### PR TITLE
Clear per‑IP auth failure counters on successful auth; add test and audit report

### DIFF
--- a/auth/middleware.py
+++ b/auth/middleware.py
@@ -65,6 +65,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             return JSONResponse(
                 status_code=401, content={"detail": "Invalid or expired token"}
             )
+        self._clear_failures(client_ip)
 
         # Set request state
         tenant_id = extract_tenant_id(claims)
@@ -92,3 +93,6 @@ class AuthMiddleware(BaseHTTPMiddleware):
         _failed_attempts[ip].append(now)
         if len(_failed_attempts[ip]) >= MAX_FAILURES:
             _blocked_ips[ip] = now + BLOCK_DURATION
+
+    def _clear_failures(self, ip: str) -> None:
+        _failed_attempts.pop(ip, None)

--- a/docs/CODE_AUDIT_2026-04-01.md
+++ b/docs/CODE_AUDIT_2026-04-01.md
@@ -1,0 +1,38 @@
+# Code Audit — April 1, 2026
+
+## Scope
+- Reviewed authentication middleware and JWT validation paths for abuse resistance and tenant-isolation behavior.
+- Executed targeted auth/security tests that do not require async pytest plugins.
+- Performed focused static review for high-impact security and reliability concerns.
+
+## Findings
+
+### 1) Failure counter was not reset after successful authentication (fixed)
+**Severity:** Medium
+
+`AuthMiddleware` tracked failed attempts by IP and blocked after repeated failures, but successful authentication did not clear prior failures. This allowed stale failures to accumulate and could cause avoidable lockouts for legitimate clients after intermittent auth errors.
+
+**Fix applied:**
+- Added `_clear_failures(ip)` and call it immediately after successful token validation.
+- Added unit test coverage for the behavior in the middleware test suite.
+
+### 2) Async test plugin dependency drift in local environment (open)
+**Severity:** Low (test infra)
+
+The repo's test configuration expects async pytest support and coverage options, but the local environment lacks the necessary plugins (`pytest-asyncio` and `pytest-cov`).
+
+**Impact:**
+- Direct execution of async-marked test modules fails in this environment unless options are overridden.
+
+**Recommendation:**
+- Ensure CI and local developer bootstrap include `pytest-asyncio` and `pytest-cov` to keep test behavior consistent.
+
+## Additional observations
+- JWT validation correctly rejects `alg=none` and enforces `aud`/`iss` for both local and JWKS paths.
+- Token blacklist lookup checks memory and Redis before validation.
+- Tenant mismatch guard is present and returns `E4004` on tenant/path mismatch.
+
+## Validation commands run
+- `pytest -q tests/security/test_auth_security.py tests/unit/test_auth.py` (fails here due to missing pytest-cov addopts plugin)
+- `pytest -q -o addopts='' tests/security/test_auth_security.py tests/unit/test_auth.py` (passes)
+- `pytest -q -o addopts='' tests/unit/test_auth_and_core.py::TestAuthMiddleware` (fails here due to missing async pytest plugin)

--- a/tests/unit/test_auth_and_core.py
+++ b/tests/unit/test_auth_and_core.py
@@ -798,6 +798,24 @@ class TestAuthMiddleware:
             call_next.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_successful_auth_clears_prior_failures(self):
+        from auth.middleware import AuthMiddleware, _blocked_ips, _failed_attempts
+        _failed_attempts.clear()
+        _blocked_ips.clear()
+        client_ip = "10.0.0.51"
+        _failed_attempts[client_ip] = [time.time() - 10, time.time() - 5]
+
+        middleware = AuthMiddleware(app=MagicMock())
+        mock_claims = {"sub": "u@t.io", "agenticorg:tenant_id": TENANT_ID, "grantex:scopes": []}
+        request = self._make_request(auth_header="Bearer token", client_ip=client_ip)
+        call_next = AsyncMock(return_value=MagicMock(status_code=200))
+
+        with patch("auth.middleware.validate_token", new_callable=AsyncMock, return_value=mock_claims):
+            await middleware.dispatch(request, call_next)
+            assert client_ip not in _failed_attempts
+            call_next.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_tenant_mismatch_returns_403(self):
         from auth.middleware import AuthMiddleware, _blocked_ips, _failed_attempts
         _failed_attempts.clear()


### PR DESCRIPTION
### Motivation
- Prevent stale failed-attempt counters from causing avoidable client lockouts after intermittent authentication successes by clearing per-IP failure state on successful token validation.
- Add a unit test to guard against regression of the failure-clearing behavior.
- Record findings and validation steps from a focused auth/security audit for future reference.

### Description
- Call `self._clear_failures(client_ip)` immediately after a successful `validate_token(...)` in `auth/middleware.py` to reset prior failure history for that IP.
- Add a new helper method `AuthMiddleware._clear_failures(ip: str)` which removes the IP from `_failed_attempts`.
- Add `test_successful_auth_clears_prior_failures` to `tests/unit/test_auth_and_core.py` that seeds prior failures and asserts they are cleared on successful dispatch.
- Add a focused audit document `docs/CODE_AUDIT_2026-04-01.md` summarizing findings and recommendations.

### Testing
- Ran `pytest -q -o addopts='' tests/security/test_auth_security.py tests/unit/test_auth.py`, which completed successfully (`5 passed`).
- Ran `pytest -q -o addopts='' tests/unit/test_auth_and_core.py::TestAuthMiddleware`, which failed in this environment because async test execution requires an async pytest plugin (for example, `pytest-asyncio`) that is not installed here.
- Noted that running `pytest` without overriding repo `addopts` in this environment initially failed due to missing coverage plugins (`pytest-cov`) so `-o addopts=''` was used for validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd0e255d78832a830318abc8b6ba04)