### PR TITLE
Harden settings secret handling and add full audit report

### DIFF
--- a/AUDIT_REPORT_2026-04-01.md
+++ b/AUDIT_REPORT_2026-04-01.md
@@ -1,0 +1,53 @@
+# Full Code Audit Report
+
+Date: 2026-04-01
+Repository: `agentic-org`
+Auditor: Codex (GPT-5.3-Codex)
+
+## Scope
+- Static code quality checks
+- Test-suite health checks
+- Configuration and runtime boot safety review
+
+## Commands Executed
+1. `ruff check .`
+2. `pytest -q`
+3. `pytest -q -o addopts=''`
+4. `python --version`
+5. `bandit -q -r core api auth connectors workflows scaling observability audit schemas -x tests`
+
+## Executive Summary
+- **Lint status:** Passed (`ruff check .`).
+- **Test status:** Could not fully execute in this environment due missing optional test dependencies (`pytest-cov`, `pytest-asyncio`), missing runtime env var (`AGENTICORG_SECRET_KEY`), and Python version mismatch (runtime is 3.10 while project targets >=3.11).
+- **High-impact improvement implemented:** Hardened configuration boot behavior so local/dev import paths do not crash when `AGENTICORG_SECRET_KEY` is unset, while still enforcing explicit secret configuration in staging/production.
+
+## Findings
+
+### 1) Import-time settings initialization caused broad failures in non-prod dev/test startup
+- **Severity:** High (availability / developer ergonomics)
+- **Where observed:** `core/config.py`
+- **Issue:** Settings were instantiated at import time and `secret_key` had no default, causing global module import failure in many codepaths when env vars were absent.
+- **Evidence:** Multiple test collection failures showed `ValidationError: secret_key Field required` from `core/config.py`.
+- **Fix applied:**
+  - Added a safe dev default secret (`dev-only-change-me`) for local/dev startup.
+  - Added post-validation guard to reject this default in `production` and `staging`.
+- **Security rationale:** Prevents accidental insecure deployments while preserving local operability.
+
+### 2) Test environment currently not aligned with project runtime requirements
+- **Severity:** Medium
+- **Issue:** The container runs Python 3.10.19, but project requires Python >=3.11 and uses 3.11+ APIs (e.g., `datetime.UTC`, `enum.StrEnum`).
+- **Impact:** Extensive test collection import errors unrelated to application logic.
+- **Recommendation:** Run CI and local checks on Python 3.12 as specified in `pyproject.toml`.
+
+### 3) Security scanner unavailable in current environment
+- **Severity:** Low (process gap)
+- **Issue:** `bandit` command not installed.
+- **Recommendation:** Ensure dev dependencies are installed (`pip install .[dev]`) in CI jobs that claim full security scanning.
+
+## Recommendations (Next Steps)
+1. Standardize CI test matrix with Python 3.12 and include `.[dev]` extras.
+2. Keep strict production secret enforcement and add a dedicated unit test for settings validation by env.
+3. Add a lightweight `make audit` target that runs lint + tests + security scan consistently.
+
+## Audit Conclusion
+The codebase lint posture is clean. Primary reliability issue identified during audit was configuration initialization strictness for local/dev contexts, now remediated with environment-sensitive validation.

--- a/core/config.py
+++ b/core/config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings
 
 
@@ -14,7 +14,7 @@ class Settings(BaseSettings):
     # Environment
     env: str = "development"
     log_level: str = "INFO"
-    secret_key: str = Field(min_length=16)
+    secret_key: str = Field(default="dev-only-change-me", min_length=16)
 
     # Database
     db_url: str = "postgresql+asyncpg://agenticorg:agenticorg_dev@localhost:5432/agenticorg"
@@ -52,6 +52,13 @@ class Settings(BaseSettings):
     default_hitl_threshold_inr: int = 500_000
     default_confidence_floor: float = 0.88
     max_agent_retries: int = 3
+
+    @model_validator(mode="after")
+    def validate_production_secrets(self) -> Settings:
+        """Prevent unsafe default secrets outside local/dev environments."""
+        if self.env.lower() in {"production", "staging"} and self.secret_key == "dev-only-change-me":
+            raise ValueError("AGENTICORG_SECRET_KEY must be set for staging/production environments")
+        return self
 
 
 class ExternalKeys(BaseSettings):


### PR DESCRIPTION
### Motivation
- Prevent import-time startup failures in development when required secrets are not set, while still enforcing secure configuration in staging/production.
- Record the results of a focused code audit (lint, tests, and config/runtime checks) into the repository for visibility.

### Description
- Provide a safe development default for the application secret by setting `secret_key` to `dev-only-change-me` in `Settings` so imports do not crash in local/dev contexts.
- Add an environment-aware post-validation using `@model_validator(mode="after")` that raises an error if the dev default secret is still present when `env` is `production` or `staging`.
- Add `AUDIT_REPORT_2026-04-01.md` containing the audit scope, commands executed, findings, and recommendations from the scan performed in this environment.

### Testing
- Ran `ruff check .`, which passed with no lint errors.
- Performed a Python sanity check that confirmed `Settings()` initializes in development without an explicit `AGENTICORG_SECRET_KEY` and that `Settings()` raises a `ValidationError` in production when the dev default is used.
- Attempted `pytest -q` which failed due to unavailable test plugins/options (CI config in `pyproject.toml` adds `--cov` flags but `pytest-cov` is not present), and `pytest -q -o addopts=''` which produced collection errors in this environment because the runtime is Python 3.10 while the project requires Python >=3.11 (tests/imports use 3.11+ APIs like `datetime.UTC` and `enum.StrEnum`) and `pytest-asyncio` was also missing.
- Security scanner `bandit` was not installed in this environment, so the security scan step was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd0e255d78832a830318abc8b6ba04)