### PR TITLE
Harden settings secret key defaults and production validation

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings
 
 
@@ -14,7 +14,7 @@ class Settings(BaseSettings):
     # Environment
     env: str = "development"
     log_level: str = "INFO"
-    secret_key: str = Field(min_length=16)
+    secret_key: str = Field(default="dev-only-secret-key", min_length=16)
 
     # Database
     db_url: str = "postgresql+asyncpg://agenticorg:agenticorg_dev@localhost:5432/agenticorg"
@@ -52,6 +52,14 @@ class Settings(BaseSettings):
     default_hitl_threshold_inr: int = 500_000
     default_confidence_floor: float = 0.88
     max_agent_retries: int = 3
+
+    @model_validator(mode="after")
+    def validate_production_secret(self) -> "Settings":
+        """Prevent accidental use of the development fallback in production."""
+        if self.env.lower() == "production" and self.secret_key == "dev-only-secret-key":
+            msg = "AGENTICORG_SECRET_KEY must be explicitly set in production"
+            raise ValueError(msg)
+        return self
 
 
 class ExternalKeys(BaseSettings):

--- a/core/config.py
+++ b/core/config.py
@@ -54,7 +54,7 @@ class Settings(BaseSettings):
     max_agent_retries: int = 3
 
     @model_validator(mode="after")
-    def validate_production_secret(self) -> "Settings":
+    def validate_production_secret(self) -> Settings:
         """Prevent accidental use of the development fallback in production."""
         if self.env.lower() == "production" and self.secret_key == "dev-only-secret-key":
             msg = "AGENTICORG_SECRET_KEY must be explicitly set in production"

--- a/tests/security/test_data_infra_security.py
+++ b/tests/security/test_data_infra_security.py
@@ -99,6 +99,18 @@ class TestSECDATA002:
         with pytest.raises(ValidationError):
             Settings(secret_key="short")
 
+    def test_development_default_secret_key_exists(self):
+        """SEC-DATA-002: Development config should load without requiring env vars."""
+        s = Settings()
+        assert len(s.secret_key) >= 16
+
+    def test_production_rejects_default_secret_key(self):
+        """SEC-DATA-002: Production must not run with the development fallback key."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            Settings(env="production")
+
     def test_audit_signature_uses_hmac_sha256(self):
         """SEC-DATA-002: Audit log entries must be signed with HMAC-SHA256,
         providing integrity protection for data at rest.


### PR DESCRIPTION
### Motivation
- Prevent module import and local/test failures when `AGENTICORG_SECRET_KEY` is not set while keeping an enforced minimum secret length.
- Ensure insecure development fallback cannot accidentally be used in production deployments.
- Add tests to assert both the development-friendly behavior and production enforcement.

### Description
- Set `Settings.secret_key` to a safe development fallback value (`"dev-only-secret-key"`) with `min_length=16` to avoid import-time failures; file: `core/config.py`.
- Add a post-init `@model_validator(mode="after")` validator `validate_production_secret` that raises if `env=="production"` while the secret still equals the development fallback; file: `core/config.py`.
- Add two security unit tests to `tests/security/test_data_infra_security.py` to verify that development loads without env vars and that production rejects the fallback secret.

### Testing
- Ran `pytest -q -o addopts='' tests/unit/test_tool_gateway.py` which passed (10 passed, 0 failed).
- Attempted `pytest -q tests/unit/test_auth.py tests/unit/test_tool_gateway.py` but the repo `addopts` required `pytest-cov`, causing `pytest` to error when run in the environment with missing plugins.
- Attempted `pytest -q -o addopts='' tests/security/test_data_infra_security.py tests/unit/test_tool_gateway.py` which failed during test collection due to an `ImportError` importing `datetime.UTC` (test environment uses Python 3.10 while the project targets Python >=3.11); this is an environment/runtime incompatibility, not a functional regression.
- Ran `python -m compileall core/config.py tests/security/test_data_infra_security.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd0e255d78832a830318abc8b6ba04)