### PR TITLE
fix: Dockerfile site-packages path python3.12 → 3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM python:3.14-slim
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 RUN useradd -m agenticorg
 WORKDIR /app
-COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY . .
 USER agenticorg


### PR DESCRIPTION
## Summary
- Dependabot PR #12 bumped the base image to `python:3.14-slim` but the multi-stage `COPY` still referenced `python3.12/site-packages`
- Build fails with: `"/usr/local/lib/python3.12/site-packages": not found`
- Fix: update the path to `python3.14`

## Test plan
- [ ] Docker build succeeds in CI (build job)
- [ ] Deploy + E2E tests pass