### PR TITLE
fix: Dockerfile.ui npm ci → npm install for cross-platform compat

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,7 +1,7 @@
 FROM node:25-slim AS builder
 WORKDIR /app
 COPY ui/package.json ui/package-lock.json* ./
-RUN npm ci --legacy-peer-deps
+RUN npm install --legacy-peer-deps
 ARG CACHE_BUST=1
 COPY ui/ .
 # Copy backend source for llms.txt/sitemap generators (they parse agents + connectors)


### PR DESCRIPTION
npm ci fails because lockfile from Windows lacks Linux optional deps (@rollup/rollup-linux-*, fsevents). Using npm install instead.