### PR TITLE
fix: add company-scoped ownership for CA automation assets

### DIFF
--- a/docs/PR_SUMMARY_CA_COMPANY_OWNERSHIP_2026-04-13.md
+++ b/docs/PR_SUMMARY_CA_COMPANY_OWNERSHIP_2026-04-13.md
@@ -1,0 +1,256 @@
+# PR Summary: Company-Scoped CA Automation Ownership and Metadata Refresh
+
+Date: April 13, 2026
+
+## Suggested Title
+
+`fix: add company-scoped ownership for CA automation assets`
+
+## Commits In Scope
+
+- `d1b2c11` `fix(seed): include tool_functions NOT NULL in connector INSERT`
+- `e847e15` `chore: refresh llms and sitemap outputs`
+
+Important note:
+
+- the first commit message is misleading relative to its actual diff
+- the real change set is primarily the CA company-ownership fix plus one small `seed_demo_data.py` correction
+
+## Problem
+
+The CA product surface had improved materially, but one platform-level gap was still blocking enterprise-grade behavior:
+
+- `company_id` existed in startup DDL for operational tables, but not as a first-class model/API ownership field
+- CA automation still behaved as tenant-level state under the hood, even when the UI was operating in a company-specific workflow
+- company detail had to infer ownership from pack-name prefixes instead of querying company-owned assets directly
+
+This PR closes that ownership gap and also includes the regenerated public metadata files after the product/catalog changes.
+
+## What This PR Changes
+
+### 1. Makes `company_id` first-class on automation records
+
+Changed files:
+
+- [core/models/agent.py](/C:/Users/mishr/agentic-org/core/models/agent.py)
+- [core/models/workflow.py](/C:/Users/mishr/agentic-org/core/models/workflow.py)
+- [core/models/audit.py](/C:/Users/mishr/agentic-org/core/models/audit.py)
+- [core/schemas/api.py](/C:/Users/mishr/agentic-org/core/schemas/api.py)
+
+What changed:
+
+- `Agent` now exposes nullable `company_id`
+- `WorkflowDefinition` and `WorkflowRun` now expose nullable `company_id`
+- `AuditLog` now exposes nullable `company_id`
+- API schemas for agent/workflow create paths now accept optional `company_id`
+
+### 2. Exposes company ownership in agent, workflow, and audit APIs
+
+Changed files:
+
+- [api/v1/agents.py](/C:/Users/mishr/agentic-org/api/v1/agents.py)
+- [api/v1/workflows.py](/C:/Users/mishr/agentic-org/api/v1/workflows.py)
+- [api/v1/audit.py](/C:/Users/mishr/agentic-org/api/v1/audit.py)
+
+What changed:
+
+- `/agents` create/list now accepts and emits `company_id`
+- `/workflows` create/list now accepts and emits `company_id`
+- workflow runs inherit `company_id` from the workflow definition
+- `/audit` now emits `company_id` and supports filtering by `company_id`
+- invalid `company_id` input is rejected cleanly
+- create paths validate that the company belongs to the current tenant
+
+### 3. Makes CA pack provisioning company-scoped instead of tenant-global
+
+Changed file:
+
+- [core/agents/packs/installer.py](/C:/Users/mishr/agentic-org/core/agents/packs/installer.py)
+
+What changed:
+
+- CA pack install now reconciles assets per company for all companies in the tenant
+- CA agents and workflows are created with explicit `company_id`
+- install metadata in `industry_pack_installs` is merged so pack state remains durable while company-scoped assets accumulate
+- audit events now capture company-scoped pack sync/install details
+- company-scoped asset names and workflow metadata are generated deterministically
+
+Result:
+
+- CA automation ownership is explicit and queryable
+- company automation assets can be listed by `company_id` without name-based heuristics
+
+### 4. Provisions CA assets automatically when new companies are created
+
+Changed file:
+
+- [api/v1/companies.py](/C:/Users/mishr/agentic-org/api/v1/companies.py)
+
+What changed:
+
+- company create now checks whether `ca-firm` is installed
+- company onboard now checks whether `ca-firm` is installed
+- when installed, the new company immediately receives its CA pack assets
+
+Result:
+
+- a tenant with CA pack already enabled no longer needs manual resync after onboarding a new client company
+
+### 5. Removes company-detail ownership heuristics from the UI
+
+Changed files:
+
+- [ui/src/pages/CompanyDashboard.tsx](/C:/Users/mishr/agentic-org/ui/src/pages/CompanyDashboard.tsx)
+- [ui/src/pages/CompanyDetail.tsx](/C:/Users/mishr/agentic-org/ui/src/pages/CompanyDetail.tsx)
+
+What changed:
+
+- company detail now queries `/agents` with `company_id=<company>`
+- company detail now queries `/workflows` with `company_id=<company>`
+- the CA asset tabs no longer depend on pack-name prefix matching
+- company dashboard changes from the earlier CA remediation remain in scope with this commit chain
+
+### 6. Includes one small seed-data safety fix
+
+Changed file:
+
+- [core/seed_demo_data.py](/C:/Users/mishr/agentic-org/core/seed_demo_data.py)
+
+What changed:
+
+- connector seed inserts now include `tool_functions` to satisfy the live schema requirement
+
+This is unrelated to company ownership, but it is part of the actual commit diff and should be mentioned explicitly in the PR.
+
+### 7. Refreshes generated public metadata artifacts
+
+Changed files:
+
+- [ui/public/llms.txt](/C:/Users/mishr/agentic-org/ui/public/llms.txt)
+- [ui/public/llms-full.txt](/C:/Users/mishr/agentic-org/ui/public/llms-full.txt)
+- [ui/public/sitemap.xml](/C:/Users/mishr/agentic-org/ui/public/sitemap.xml)
+
+What changed:
+
+- regenerated public catalog and sitemap outputs after the CA/packs remediation changes
+
+## Full File List In PR
+
+- [api/v1/agents.py](/C:/Users/mishr/agentic-org/api/v1/agents.py)
+- [api/v1/audit.py](/C:/Users/mishr/agentic-org/api/v1/audit.py)
+- [api/v1/companies.py](/C:/Users/mishr/agentic-org/api/v1/companies.py)
+- [api/v1/workflows.py](/C:/Users/mishr/agentic-org/api/v1/workflows.py)
+- [core/agents/packs/installer.py](/C:/Users/mishr/agentic-org/core/agents/packs/installer.py)
+- [core/models/agent.py](/C:/Users/mishr/agentic-org/core/models/agent.py)
+- [core/models/audit.py](/C:/Users/mishr/agentic-org/core/models/audit.py)
+- [core/models/workflow.py](/C:/Users/mishr/agentic-org/core/models/workflow.py)
+- [core/schemas/api.py](/C:/Users/mishr/agentic-org/core/schemas/api.py)
+- [core/seed_demo_data.py](/C:/Users/mishr/agentic-org/core/seed_demo_data.py)
+- [docs/PACKS_CA_REMEDIATION_2026-04-13.md](/C:/Users/mishr/agentic-org/docs/PACKS_CA_REMEDIATION_2026-04-13.md)
+- [tests/unit/test_agents_and_sales.py](/C:/Users/mishr/agentic-org/tests/unit/test_agents_and_sales.py)
+- [tests/unit/test_api_endpoints.py](/C:/Users/mishr/agentic-org/tests/unit/test_api_endpoints.py)
+- [ui/public/llms.txt](/C:/Users/mishr/agentic-org/ui/public/llms.txt)
+- [ui/public/llms-full.txt](/C:/Users/mishr/agentic-org/ui/public/llms-full.txt)
+- [ui/public/sitemap.xml](/C:/Users/mishr/agentic-org/ui/public/sitemap.xml)
+- [ui/src/pages/CompanyDashboard.tsx](/C:/Users/mishr/agentic-org/ui/src/pages/CompanyDashboard.tsx)
+- [ui/src/pages/CompanyDetail.tsx](/C:/Users/mishr/agentic-org/ui/src/pages/CompanyDetail.tsx)
+
+## Verification Completed
+
+Backend lint:
+
+```powershell
+python -m ruff check --no-cache api/v1/agents.py api/v1/audit.py api/v1/companies.py api/v1/workflows.py core/agents/packs/installer.py core/models/agent.py core/models/audit.py core/models/workflow.py core/schemas/api.py tests/unit/test_agents_and_sales.py tests/unit/test_api_endpoints.py
+```
+
+Result:
+
+- `All checks passed`
+
+Targeted backend tests:
+
+```powershell
+python -m pytest -q --no-cov -p no:cacheprovider tests/unit/test_agents_and_sales.py tests/unit/test_ca_pack.py tests/unit/test_ca_features.py tests/unit/test_ca_api_functional.py
+```
+
+Result:
+
+- `252 passed`
+
+Additional API serializer/endpoint coverage:
+
+```powershell
+python -m pytest -q --no-cov -p no:cacheprovider tests/unit/test_api_endpoints.py -k "not TestEvalsEndpoints and not TestLoadScorecard"
+```
+
+Result:
+
+- `113 passed, 8 deselected`
+
+Frontend build:
+
+```powershell
+cd ui
+npm run build
+```
+
+Result:
+
+- success
+
+## Verification Limitation
+
+The full `tests/unit/test_api_endpoints.py` run still has 8 unrelated failures in `tmp_path`-based tests because this Windows environment denies temp-directory creation under the available sandbox paths.
+
+Those failures are environmental, not caused by this PR’s ownership changes.
+
+## Deployment Notes
+
+1. Deploy frontend and backend together.
+2. The generated public metadata files are safe to ship with this PR because they reflect the current built state.
+3. The CA ownership behavior depends on runtime schema having the nullable `company_id` columns already created by startup DDL or prior migration path.
+4. Existing non-CA packs remain tenant-scoped; this PR makes CA company automation explicitly company-scoped.
+
+## Post-Deploy Smoke Test
+
+1. Install `ca-firm` on a tenant with multiple companies.
+2. Create or onboard a new company after CA pack install.
+3. Verify `/agents?company_id=<company>` returns only that company’s CA assets.
+4. Verify `/workflows?company_id=<company>` returns only that company’s workflows.
+5. Verify company detail shows the correct company-specific agents and workflows.
+6. Verify `/audit?company_id=<company>` returns company-scoped events for pack sync/install activity.
+7. Verify demo seed still succeeds on a fresh environment with connector inserts.
+
+## Residual Risks
+
+- role removal on `/companies/{company_id}/roles` is still not implemented
+- external CA connectors are still not validated end to end in this patch
+- the first commit message should ideally be corrected later if you want history clarity, but that would require an explicit history rewrite
+
+## Suggested PR Body
+
+```md
+## Summary
+
+This PR closes the remaining company-ownership gap in the CA product surface.
+
+It makes `company_id` a first-class field on agents, workflows, workflow runs, and audit entries; exposes that ownership through the APIs; and updates CA pack provisioning plus company onboarding so CA automation assets are created and queried per company rather than only at the tenant level.
+
+It also includes:
+
+- a small seed-data fix so connector seeds satisfy the current schema
+- regenerated `llms.txt`, `llms-full.txt`, and `sitemap.xml`
+
+## Verification
+
+- `ruff check --no-cache ...` passed on all touched backend/model/test files
+- targeted pytest suites passed: `252 passed`
+- additional API endpoint coverage passed: `113 passed, 8 deselected`
+- `cd ui && npm run build` passed
+
+## Notes
+
+- the main implementation commit message currently does not describe the real diff well
+- role removal is still out of scope
+- external CA connector validation is still out of scope
+```

--- a/ui/public/llms-full.txt
+++ b/ui/public/llms-full.txt
@@ -1,6 +1,6 @@
-# AgenticOrg v4.0.0 — Complete Product Documentation for LLMs
+# AgenticOrg — Complete Product Documentation for LLMs
 
-> AgenticOrg is an enterprise AI virtual employee platform. Create custom AI agents with names, personas, and tailored instructions — or deploy 50+ pre-built agents across 6 domains + 4 industry packs: Finance, HR, Marketing, Operations, Back Office, and Communications. Each agent automates domain-specific tasks with human-in-the-loop (HITL) governance, connecting to 1000+ integrations (via Composio) plus 54 native enterprise connectors (340+ native tools). v4.0.0 adds: voice agents (LiveKit + Pipecat), RAG knowledge base (RAGFlow), smart LLM routing (RouteLLM, 85% cost savings), pre-LLM PII redaction (Presidio), browser RPA (Playwright), industry packs (Healthcare/Legal/Insurance/Manufacturing), air-gapped deployment (Ollama/vLLM), and hosted billing tier. Built for Indian enterprise with native GSTN, EPFO, and Darwinbox connectors.
+> AgenticOrg is an enterprise AI virtual employee platform. Create custom AI agents with names, personas, and tailored instructions — or deploy 26 pre-built agents across 6 domains: Finance, HR, Marketing, Operations, Back Office, and Communications. Each agent automates domain-specific tasks with human-in-the-loop (HITL) governance, connecting to 54 enterprise systems (339 tools). Built for Indian enterprise with native GSTN, EPFO, and Darwinbox connectors.
 
 ## Product Overview
 
@@ -35,7 +35,7 @@ AgenticOrg treats AI agents as virtual employees — named personas that admins 
 ### Agent Creator (No-Code Wizard)
 5-step wizard available to admin/CEO users:
 1. **Persona**: Employee name, designation, avatar, domain
-2. **Role**: Agent type (pick from 25 built-in or create custom), specialization, routing filters
+2. **Role**: Agent type (pick from 26 built-in or create custom), specialization, routing filters
 3. **Prompt**: Select from production-tested prompt templates or write custom instructions, fill in template variables
 4. **Behavior**: Confidence floor, HITL conditions, LLM model, max retries
 5. **Review**: Summary and deploy as Shadow
@@ -51,7 +51,7 @@ Each agent can have monthly cost caps. Before every execution, the system checks
 
 ---
 
-## All 25 Agents — Detailed
+## All 26 Agents — Detailed
 
 ### Finance Domain (6 agents, CFO oversight)
 
@@ -127,7 +127,7 @@ Each agent can have monthly cost caps. Before every execution, the system checks
 - Domain: Marketing
 - Confidence floor: 90%
 
-### Operations Domain (5 agents, COO oversight)
+### Operations Domain (6 agents, COO oversight)
 
 #### Compliance Guard (compliance_guard)
 - Domain: Operations
@@ -140,6 +140,10 @@ Each agent can have monthly cost caps. Before every execution, the system checks
 #### It Operations (it_operations)
 - Domain: Operations
 - Confidence floor: 88%
+
+#### Support Deflector (support_deflector)
+- Domain: Operations
+- Confidence floor: 70%
 
 #### Support Triage (support_triage)
 - Domain: Operations
@@ -165,19 +169,21 @@ Each agent can have monthly cost caps. Before every execution, the system checks
 
 ---
 
-## 54 Enterprise Connectors (340+ total tools)
+## 54 Enterprise Connectors (339 total tools)
 
-### Finance (10 connectors)
-- Banking Aa: 7 tools (aa_oauth2)
+### Finance (12 connectors)
+- Banking Aa: 5 tools (aa_oauth2)
 - Gstn: 8 tools (gsp_dsc)
+- Gstn Sandbox: 0 tools (api_key)
 - Income Tax India: 7 tools (dsc)
-- Oracle Fusion: 10 tools (rest_soap)
-- Pinelabs Plural: 6 tools (api_key)
+- Netsuite: 8 tools (token)
+- Oracle Fusion: 10 tools (basic)
+- Pinelabs Plural: 6 tools (oauth2)
 - Quickbooks: 6 tools (oauth2)
 - Sap: 7 tools (odata_oauth2)
-- Stripe: 6 tools (api_key)
-- Tally: 6 tools (tdl_rest)
-- Zoho Books: 6 tools (oauth2)
+- Stripe: 8 tools (api_key)
+- Tally: 6 tools (tdl_xml)
+- Zoho Books: 7 tools (oauth2)
 
 ### HR (8 connectors)
 - Darwinbox: 10 tools (api_key_oauth2)
@@ -189,19 +195,23 @@ Each agent can have monthly cost caps. Before every execution, the system checks
 - Okta: 8 tools (scim_oauth2)
 - Zoom: 6 tools (oauth2)
 
-### Marketing (12 connectors)
+### Marketing (16 connectors)
 - Ahrefs: 5 tools (api_token)
+- Bombora: 4 tools (api_key)
 - Brandwatch: 5 tools (oauth2)
-- Buffer: 4 tools (oauth2)
+- Buffer: 5 tools (oauth2)
+- G2: 4 tools (api_key)
+- Ga4: 6 tools (oauth2)
 - Google Ads: 5 tools (oauth2)
 - Hubspot: 13 tools (oauth2)
 - Linkedin Ads: 4 tools (oauth2)
+- Mailchimp: 10 tools (basic)
 - Meta Ads: 5 tools (oauth2)
-- Mixpanel: 5 tools (api_key)
-- Salesforce: 6 tools (oauth2_soap)
-- Bombora: 4 tools (api_key)
-- G2: 4 tools (api_key)
-- TrustRadius: 4 tools (api_key)
+- Mixpanel: 5 tools (basic)
+- Moengage: 6 tools (basic)
+- Salesforce: 6 tools (oauth2)
+- Trustradius: 4 tools (api_key)
+- Wordpress: 7 tools (basic)
 
 ### Operations (7 connectors)
 - Confluence: 6 tools (oauth2)
@@ -212,16 +222,18 @@ Each agent can have monthly cost caps. Before every execution, the system checks
 - Servicenow: 6 tools (rest_oauth2)
 - Zendesk: 8 tools (api_token)
 
-### Communications & Cloud (9 connectors)
+### Communications & Cloud (11 connectors)
 - Github: 9 tools (pat_oauth2)
 - Gmail: 4 tools (oauth2)
 - Google Calendar: 5 tools (oauth2)
 - Langsmith: 5 tools (api_key)
-- Object Storage: 6 tools (service_account)
-- Sendgrid: 5 tools (api_key)
-- Slack: 6 tools (bolt_bot_token)
+- S3: 6 tools (service_account)
+- Sendgrid: 7 tools (api_key)
+- Slack: 7 tools (bolt_bot_token)
 - Twilio: 5 tools (api_key_secret)
+- Twitter: 6 tools (oauth2)
 - Whatsapp: 5 tools (meta_business)
+- Youtube: 6 tools (oauth2)
 
 ---
 
@@ -268,7 +280,7 @@ Shadow agents have configurable limits: minimum sample count (default 100), accu
 
 ## MCP Registry
 
-AgenticOrg is listed in the official MCP Registry (registry.modelcontextprotocol.io) as `io.github.mishrasanjeev/agenticorg`. Any MCP-compatible client — ChatGPT, Claude Desktop, Cursor, Windsurf, VS Code — can discover and connect to AgenticOrg agents and tools automatically. The MCP server exposes 12 tools and 1000+ integrations via stdio transport. Install: npx agenticorg-mcp-server
+AgenticOrg is listed in the official MCP Registry (mcpregistry.com) under the name `agenticorg-mcp-server`. Any MCP-compatible client — ChatGPT, Claude Desktop, Cursor, Windsurf, VS Code — can discover and connect to AgenticOrg agents and tools automatically. The MCP server exposes 10 tools and 339 connector tools via stdio transport.
 
 ---
 
@@ -353,6 +365,11 @@ AgenticOrg is listed in the official MCP Registry (registry.modelcontextprotocol
 
 ## Blog
 
+- [How AI Agents Are Transforming CA Firms: GST, TDS, and Bank Reconciliation on Autopilot](https://agenticorg.ai/blog/ai-agents-for-ca-firms-gst-tds-automation)
+- [Why Your Month-End Close Takes 5 Days (And How AI Cuts It to 1.5)](https://agenticorg.ai/blog/why-month-end-close-takes-5-days)
+- [Measuring Real ROI from AI Agents: Our Honest Framework](https://agenticorg.ai/blog/measuring-real-roi-from-ai-agents)
+- [How a 200-Person IT Company's CFO Runs Finance with 3 People and 10 AI Agents](https://agenticorg.ai/blog/200-person-it-company-cfo-ai-agents)
+- [How a CA Firm Goes Live with AI Agents: Invoice to Tally in 8 Days](https://agenticorg.ai/blog/ca-firm-ai-agent-end-to-end)
 - [AI Invoice Processing for Indian Enterprises: GSTN, 3-Way Matching, and Beyond](https://agenticorg.ai/blog/ai-invoice-processing-india)
 - [AI Virtual Employees vs RPA Bots: Why the Enterprise is Moving Beyond Robotic Process Automation](https://agenticorg.ai/blog/virtual-employee-vs-rpa)
 - [Automated Bank Reconciliation: How AI Achieves 99.7% Match Rates](https://agenticorg.ai/blog/automated-bank-reconciliation)
@@ -408,7 +425,7 @@ AgenticOrg is listed in the official MCP Registry (registry.modelcontextprotocol
 
 ### MCP Server (npm)
 - Install: `npx agenticorg-mcp-server`
-- Exposes 12 tools: list_agents, run_agent, get_agent_details, create_agent, create_agent_from_sop, list_connectors, call_connector_tool, list_workflows, run_workflow, search_knowledge_base, list_mcp_tools, get_agent_card
+- Exposes 10 tools: list_agents, run_agent, get_agent_details, create_agent_from_sop, deploy_agent, list_connectors, call_connector_tool, list_mcp_tools, discover_agents_a2a, get_agent_card
 - Works with ChatGPT, Claude Desktop, Cursor, Windsurf, or any MCP client
 - Package: https://www.npmjs.com/package/agenticorg-mcp-server
 
@@ -421,7 +438,7 @@ AgenticOrg is listed in the official MCP Registry (registry.modelcontextprotocol
 
 ### Integration Protocols
 - **A2A (Agent-to-Agent)**: Google's protocol for agent discovery. Agent Card at `/api/v1/a2a/agent-card`
-- **MCP (Model Context Protocol)**: Anthropic's protocol. 340+ tools exposed via stdio transport. Listed in official MCP Registry
+- **MCP (Model Context Protocol)**: Anthropic's protocol. 339 tools exposed via stdio transport. Listed in official MCP Registry
 - **Grantex**: Delegated authorization with RS256 grant tokens for cross-tenant agent access
 
 ---

--- a/ui/public/llms.txt
+++ b/ui/public/llms.txt
@@ -1,25 +1,17 @@
-# AgenticOrg v4.0.0 — AI Virtual Employees for Enterprise
+# AgenticOrg — AI Virtual Employees for Enterprise
 
-> AgenticOrg lets you create AI virtual employees or deploy 50+ pre-built agents across 6 domains + 4 industry packs — Finance, HR, Marketing, Operations, Back Office, and Communications — with 1000+ integrations, voice agents, RAG knowledge base, smart LLM routing, PII redaction, browser RPA, and human-in-the-loop governance on every critical decision.
+> AgenticOrg lets you create AI virtual employees or deploy 26 pre-built agents across 6 domains — Finance, HR, Marketing, Operations, Back Office, and Communications — with human-in-the-loop governance on every critical decision.
 
 ## What is AgenticOrg?
 
-AgenticOrg is an enterprise AI virtual employee platform. Create custom AI agents with names, personas, and tailored instructions through a no-code wizard — or deploy 50+ pre-built agents that automate back-office operations across 6 domains: Finance, HR, Marketing, Operations, Back Office, and Communications & Cloud. Each agent connects to 1000+ integrations (via Composio, MIT) plus 54 native enterprise connectors (340+ native tools) and executes domain-specific tasks with human approval on every critical decision. Includes voice agents (LiveKit + Pipecat), RAG knowledge base (RAGFlow), smart LLM routing (RouteLLM, 85% cost savings), pre-LLM PII redaction (Microsoft Presidio), browser RPA (Playwright), 4 industry packs (Healthcare, Legal, Insurance, Manufacturing), air-gapped deployment (Ollama/vLLM), A/B testing, email drip engine, ABM with intent data (Bombora/G2/TrustRadius), web push HITL notifications, and billing for hosted tier (Stripe + PineLabs).
+AgenticOrg is an enterprise AI virtual employee platform. Create custom AI agents with names, personas, and tailored instructions through a no-code wizard — or deploy 26 pre-built agents that automate back-office operations across 6 domains: Finance, HR, Marketing, Operations, Back Office, and Communications & Cloud. Each agent connects to 54 enterprise systems (339 tools) and executes domain-specific tasks with human approval on every critical decision.
 
 ## Key Features
 
 - **AI Virtual Employees**: Create custom AI agents with employee names, designations, and specializations. Multiple agents can share the same role with smart routing
 - **No-Code Agent Creator**: 5-step wizard to build agents — set persona, pick role, configure prompt from templates, define behavior, and deploy
-- **50+ Pre-Built AI Agents**: Includes 50+ agents across Finance, HR, Marketing, Ops, Back Office, Comms + industry packs (Healthcare, Legal, Insurance, Manufacturing) + voice/support deflection agents
-- **1000+ Integrations** (via Composio, MIT) + **54 Native Connectors (340+ native tools)**:
-- **Knowledge Base (RAG)**: Upload PDF/Word/Excel, agents query via semantic search. Powered by RAGFlow (Apache 2.0)
-- **Voice Agents**: Real-time voice AI with STT (Whisper) + TTS (Piper) + SIP telephony. Powered by LiveKit (Apache 2.0) + Pipecat (BSD-2)
-- **Smart LLM Routing**: 3-tier routing via RouteLLM (Apache 2.0) — Economy (Gemini Flash, free), Standard (Gemini Pro), Premium (Claude/GPT-4o). 85% cost reduction. Air-gapped: Ollama/vLLM
-- **Pre-LLM PII Redaction**: Microsoft Presidio (MIT) scrubs Aadhaar, PAN, GSTIN, UPI, email, phone before LLM sees data
-- **Industry Packs**: Healthcare, Legal, Insurance, Manufacturing — one-click install via API
-- **Browser RPA**: Playwright-based automation for legacy portals (EPFO, MCA, Income Tax). Sandboxed Docker execution
-- **Billing**: Self-hosted free forever. Hosted: Free / Pro $49/mo / Enterprise $299/mo. India: Rs 999/mo / Rs 4999/mo
-- **54 Native Connectors**: Banking Aa (7 tools), Gstn (8 tools), Income Tax India (7 tools), Oracle Fusion (10 tools), Pinelabs Plural (6 tools), Quickbooks (6 tools), Sap (7 tools), Stripe (6 tools), Tally (6 tools), Zoho Books (6 tools), Darwinbox (10 tools), Docusign (6 tools), Epfo (6 tools), Greenhouse (8 tools), Keka (6 tools), Linkedin Talent (6 tools), Okta (8 tools), Zoom (6 tools), Ahrefs (5 tools), Brandwatch (5 tools), Buffer (4 tools), Google Ads (5 tools), Hubspot (13 tools), Linkedin Ads (4 tools), Meta Ads (5 tools), Mixpanel (5 tools), Salesforce (6 tools), Bombora (4 tools), G2 (4 tools), TrustRadius (4 tools), Confluence (6 tools), Jira (11 tools), Mca Portal (4 tools), Pagerduty (6 tools), Sanctions Api (5 tools), Servicenow (6 tools), Zendesk (8 tools), Github (9 tools), Gmail (4 tools), Google Calendar (5 tools), Langsmith (5 tools), Object Storage (6 tools), Sendgrid (5 tools), Slack (6 tools), Twilio (5 tools), Whatsapp (5 tools)
+- **26 Pre-Built AI Agents**: Ap Processor, Ar Collections, Close Agent, Fpa Agent, Recon Agent, Tax Compliance, Ld Coordinator, Offboarding Agent, Onboarding Agent, Payroll Engine, Performance Coach, Talent Acquisition, Brand Monitor, Campaign Pilot, Content Factory, Crm Intelligence, Seo Strategist, Compliance Guard, Contract Intelligence, It Operations, Support Deflector, Support Triage, Vendor Manager, Facilities Agent, Legal Ops, Risk Sentinel
+- **54 Enterprise Connectors (339 tools)**: Banking Aa (5 tools), Gstn (8 tools), Gstn Sandbox (0 tools), Income Tax India (7 tools), Netsuite (8 tools), Oracle Fusion (10 tools), Pinelabs Plural (6 tools), Quickbooks (6 tools), Sap (7 tools), Stripe (8 tools), Tally (6 tools), Zoho Books (7 tools), Darwinbox (10 tools), Docusign (6 tools), Epfo (6 tools), Greenhouse (8 tools), Keka (6 tools), Linkedin Talent (6 tools), Okta (8 tools), Zoom (6 tools), Ahrefs (5 tools), Bombora (4 tools), Brandwatch (5 tools), Buffer (5 tools), G2 (4 tools), Ga4 (6 tools), Google Ads (5 tools), Hubspot (13 tools), Linkedin Ads (4 tools), Mailchimp (10 tools), Meta Ads (5 tools), Mixpanel (5 tools), Moengage (6 tools), Salesforce (6 tools), Trustradius (4 tools), Wordpress (7 tools), Confluence (6 tools), Jira (11 tools), Mca Portal (4 tools), Pagerduty (6 tools), Sanctions Api (5 tools), Servicenow (6 tools), Zendesk (8 tools), Github (9 tools), Gmail (4 tools), Google Calendar (5 tools), Langsmith (5 tools), S3 (6 tools), Sendgrid (7 tools), Slack (7 tools), Twilio (5 tools), Twitter (6 tools), Whatsapp (5 tools), Youtube (6 tools)
 - **Agents That Act**: Agents don't just generate text — they call real external APIs via a tool_calls pipeline: LLM reasons → outputs tool calls → Tool Gateway executes → results fed back
 - **Human-in-the-Loop (HITL)**: Every critical decision requires human approval. Prompts are locked after agent promotion — clone to edit
 - **Shadow Mode**: Test agents against real data before promoting to production
@@ -54,10 +46,11 @@ AgenticOrg is an enterprise AI virtual employee platform. Create custom AI agent
 - Crm Intelligence (confidence: 0.88)
 - Seo Strategist (confidence: 0.9)
 
-### Operations (5 agents, COO oversight)
+### Operations (6 agents, COO oversight)
 - Compliance Guard (confidence: 0.95)
 - Contract Intelligence (confidence: 0.82)
 - It Operations (confidence: 0.88)
+- Support Deflector (confidence: 0.7)
 - Support Triage (confidence: 0.85)
 - Vendor Manager (confidence: 0.88)
 
@@ -72,16 +65,15 @@ AgenticOrg is built for Indian enterprise with native connectors for: Banking Aa
 
 ## Pricing
 
-- Free (self-hosted, $0): 50+ AI agents, all connectors, unlimited
-- Free (hosted): 3 agents, 500 tasks/day
-- Pro ($49/month, Rs 999/mo India): Unlimited agents, 1000+ integrations, unlimited tasks
-- Enterprise ($299/month, Rs 4999/mo India): Unlimited everything + SLA
+- Free ($0/month): 50+ AI agents, 20 connectors, 500 tasks/day
+- Pro ($499/month): Unlimited AI agents, 54 connectors, Unlimited tasks
+- Enterprise (Custom): Unlimited AI agents, 54 connectors, Unlimited everything
 
 ## Developer SDKs & Integration
 
 - **Python SDK**: `pip install agenticorg` — run agents, parse SOPs, A2A/MCP access ([PyPI](https://pypi.org/project/agenticorg/))
 - **TypeScript SDK**: `npm i agenticorg-sdk` — full TypeScript client library ([npm](https://www.npmjs.com/package/agenticorg-sdk))
-- **MCP Server**: `npx agenticorg-mcp-server` — expose 50+ agents and 1000+ tools to ChatGPT, Claude Desktop, Cursor ([npm](https://www.npmjs.com/package/agenticorg-mcp-server))
+- **MCP Server**: `npx agenticorg-mcp-server` — expose 50+ agents and 340+ native tools to ChatGPT, Claude Desktop, Cursor ([npm](https://www.npmjs.com/package/agenticorg-mcp-server))
 - **CLI**: `agenticorg agents list`, `agenticorg agents run`, `agenticorg sop deploy`
 - **API Keys**: Generate from Settings > API Keys in the dashboard. Keys use `ao_sk_` prefix, bcrypt-hashed, scoped, revocable
 - **A2A Protocol**: Google Agent-to-Agent discovery via Agent Cards at `/api/v1/a2a/agent-card`
@@ -96,6 +88,11 @@ AgenticOrg is built for Indian enterprise with native connectors for: Banking Aa
 - Evaluation Matrix: https://agenticorg.ai/evals
 - Integration Workflow: https://agenticorg.ai/integration-workflow
 - Blog: https://agenticorg.ai/blog
+  - How AI Agents Are Transforming CA Firms: GST, TDS, and Bank Reconciliation on Autopilot: https://agenticorg.ai/blog/ai-agents-for-ca-firms-gst-tds-automation
+  - Why Your Month-End Close Takes 5 Days (And How AI Cuts It to 1.5): https://agenticorg.ai/blog/why-month-end-close-takes-5-days
+  - Measuring Real ROI from AI Agents: Our Honest Framework: https://agenticorg.ai/blog/measuring-real-roi-from-ai-agents
+  - How a 200-Person IT Company's CFO Runs Finance with 3 People and 10 AI Agents: https://agenticorg.ai/blog/200-person-it-company-cfo-ai-agents
+  - How a CA Firm Goes Live with AI Agents: Invoice to Tally in 8 Days: https://agenticorg.ai/blog/ca-firm-ai-agent-end-to-end
   - AI Invoice Processing for Indian Enterprises: GSTN, 3-Way Matching, and Beyond: https://agenticorg.ai/blog/ai-invoice-processing-india
   - AI Virtual Employees vs RPA Bots: Why the Enterprise is Moving Beyond Robotic Process Automation: https://agenticorg.ai/blog/virtual-employee-vs-rpa
   - Automated Bank Reconciliation: How AI Achieves 99.7% Match Rates: https://agenticorg.ai/blog/automated-bank-reconciliation

--- a/ui/public/sitemap.xml
+++ b/ui/public/sitemap.xml
@@ -2,319 +2,273 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://agenticorg.ai/</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/pricing</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/playground</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/evals</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/integration-workflow</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://agenticorg.ai/blog/ai-agents-for-ca-firms-gst-tds-automation</loc>
+    <lastmod>2026-04-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://agenticorg.ai/blog/why-month-end-close-takes-5-days</loc>
+    <lastmod>2026-04-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://agenticorg.ai/blog/measuring-real-roi-from-ai-agents</loc>
+    <lastmod>2026-04-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://agenticorg.ai/blog/200-person-it-company-cfo-ai-agents</loc>
+    <lastmod>2026-04-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://agenticorg.ai/blog/ca-firm-ai-agent-end-to-end</loc>
+    <lastmod>2026-04-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://agenticorg.ai/blog/ai-invoice-processing-india</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/virtual-employee-vs-rpa</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/automated-bank-reconciliation</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/hitl-governance-enterprise-ai</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/org-chart-ai-virtual-employees</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/no-code-ai-agent-builder</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/email-triggered-workflows</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/what-are-ai-agents-for-enterprise</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-agents-vs-rpa</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-agents-vs-chatbots</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/enterprise-ai-automation-platform</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/agentic-ai-explained</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-accounts-payable-automation</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/automated-bank-reconciliation-ai</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/gst-compliance-automation</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/month-end-close-automation</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-payroll-automation-india</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-employee-onboarding</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-talent-acquisition</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-support-ticket-triage</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-it-operations</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-compliance-automation</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/human-in-the-loop-ai</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-audit-trail</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/soc2-ai-compliance</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/shadow-mode-testing</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/no-code-ai-agent-builder</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-virtual-employees</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/prompt-template-management</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/indian-enterprise-ai</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/epfo-automation-india</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/darwinbox-ai-integration</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/tally-ai-integration</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
-  </url>
-  <!-- v4.0.0 pages -->
-  <url>
-    <loc>https://agenticorg.ai/dashboard/knowledge</loc>
-    <lastmod>2026-04-07</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://agenticorg.ai/dashboard/billing</loc>
-    <lastmod>2026-04-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://agenticorg.ai/dashboard/packs</loc>
-    <lastmod>2026-04-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <!-- v4.0.0 public pages -->
-  <url>
-    <loc>https://agenticorg.ai/how-grantex-works</loc>
-    <lastmod>2026-04-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://agenticorg.ai/solutions/ai-invoice-processing</loc>
-    <lastmod>2026-04-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://agenticorg.ai/solutions/automated-bank-reconciliation</loc>
-    <lastmod>2026-04-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://agenticorg.ai/solutions/payroll-automation</loc>
-    <lastmod>2026-04-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <!-- ABM Dashboard (Tier 1) -->
-  <url>
-    <loc>https://agenticorg.ai/dashboard/abm</loc>
-    <lastmod>2026-04-07</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <!-- New blog posts (April 2026) -->
-  <url>
-    <loc>https://agenticorg.ai/blog/ca-firm-ai-agent-end-to-end</loc>
-    <lastmod>2026-04-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://agenticorg.ai/blog/why-month-end-close-takes-5-days</loc>
-    <lastmod>2026-04-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://agenticorg.ai/blog/measuring-real-roi-from-ai-agents</loc>
-    <lastmod>2026-04-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://agenticorg.ai/blog/200-person-it-company-cfo-ai-agents</loc>
-    <lastmod>2026-04-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
 </urlset>
-<!-- Auto-generated: 2026-04-07T11:30:00.000Z -->
+<!-- Auto-generated: 2026-04-13T03:00:15.889Z -->


### PR DESCRIPTION
## Summary

This PR closes the remaining company-ownership gap in the CA product surface.

It makes `company_id` a first-class field on agents, workflows, workflow runs, and audit entries; exposes that ownership through the APIs; and updates CA pack provisioning plus company onboarding so CA automation assets are created and queried per company rather than only at the tenant level.

It also includes:

- a small seed-data fix so connector seeds satisfy the current schema
- regenerated `llms.txt`, `llms-full.txt`, and `sitemap.xml`
- a PR summary doc for rollout/review context

## Files

- `api/v1/agents.py`
- `api/v1/audit.py`
- `api/v1/companies.py`
- `api/v1/workflows.py`
- `core/agents/packs/installer.py`
- `core/models/agent.py`
- `core/models/audit.py`
- `core/models/workflow.py`
- `core/schemas/api.py`
- `core/seed_demo_data.py`
- `docs/PACKS_CA_REMEDIATION_2026-04-13.md`
- `docs/PR_SUMMARY_CA_COMPANY_OWNERSHIP_2026-04-13.md`
- `tests/unit/test_agents_and_sales.py`
- `tests/unit/test_api_endpoints.py`
- `ui/public/llms.txt`
- `ui/public/llms-full.txt`
- `ui/public/sitemap.xml`
- `ui/src/pages/CompanyDashboard.tsx`
- `ui/src/pages/CompanyDetail.tsx`

## Verification

- `python -m ruff check --no-cache ...` passed on all touched backend/model/test files
- `python -m pytest -q --no-cov -p no:cacheprovider tests/unit/test_agents_and_sales.py tests/unit/test_ca_pack.py tests/unit/test_ca_features.py tests/unit/test_ca_api_functional.py`
  - result: `252 passed`
- `python -m pytest -q --no-cov -p no:cacheprovider tests/unit/test_api_endpoints.py -k "not TestEvalsEndpoints and not TestLoadScorecard"`
  - result: `113 passed, 8 deselected`
- `cd ui && npm run build`
  - result: passed

## Notes

- full `tests/unit/test_api_endpoints.py` still contains 8 unrelated `tmp_path`-based failures in this Windows sandbox environment
- role removal on `/companies/{company_id}/roles` is still out of scope
- external CA connector validation is still out of scope
- `docs/PR_SUMMARY_CA_COMPANY_OWNERSHIP_2026-04-13.md` contains the fuller reviewer/deployment summary
