### PR TITLE
[codex] fix post-deploy jobs being skipped on main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,7 +185,13 @@ jobs:
 
   e2e-tests:
     needs: deploy-production
-    if: github.ref == 'refs/heads/main'
+    # deploy-production can still succeed when approval-gate is skipped on main
+    # pushes, so gate these jobs on the actual deploy result instead of the
+    # default implicit status chain.
+    if: |
+      always() &&
+      github.ref == 'refs/heads/main' &&
+      needs.deploy-production.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -348,7 +354,10 @@ jobs:
 
   submit-indexing:
     needs: deploy-production
-    if: github.ref == 'refs/heads/main'
+    if: |
+      always() &&
+      github.ref == 'refs/heads/main' &&
+      needs.deploy-production.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

This PR fixes the GitHub Actions workflow bug where `e2e-tests` and `submit-indexing` were being skipped on successful `main` deploys even though `deploy-production` had completed successfully.

## Root Cause

`deploy-production` is explicitly allowed to proceed when `approval-gate` is skipped on normal `main` pushes. However, the downstream jobs were still using a plain `if: github.ref == 'refs/heads/main'` condition, which left them subject to the default implicit status chain and caused them to be skipped in practice.

This was visible in recent successful `main` runs, where:
- `lint`, `unit-tests`, `integration-tests`, `security-scan`, `build`, and `deploy-production` all succeeded
- `e2e-tests` and `submit-indexing` were still marked `skipped`

## Change

- gate `e2e-tests` on:
  - `always()`
  - `github.ref == 'refs/heads/main'`
  - `needs.deploy-production.result == 'success'`
- gate `submit-indexing` on the same explicit conditions
- add a short comment explaining why the downstream jobs cannot rely on the default implicit status chain here

## Validation

- inspected recent successful `main` workflow runs and confirmed the skip pattern
- patched `.github/workflows/deploy.yml`
- reviewed the exact workflow diff and final YAML block layout locally

## Notes

- `actionlint` is not installed in the local environment, so I did not run a dedicated workflow linter
- this PR only changes the workflow conditions for post-deploy jobs; it does not change the deploy steps themselves
