### PR TITLE
fix(ca): reconcile pack installs and restore audit coverage

### DIFF
--- a/api/v1/companies.py
+++ b/api/v1/companies.py
@@ -211,6 +211,13 @@ def _company_to_out(c: Company) -> CompanyOut:
     )
 
 
+async def _ensure_ca_pack_ready(tenant_id: str) -> None:
+    """Keep CA pack state aligned with active or trial CA subscriptions."""
+    from core.agents.packs.installer import ensure_ca_pack_subscription_sync_async
+
+    await ensure_ca_pack_subscription_sync_async(tenant_id)
+
+
 # ---------------------------------------------------------------------------
 # LIST
 # ---------------------------------------------------------------------------
@@ -226,6 +233,7 @@ async def list_companies(
     tenant_id: str = Depends(get_current_tenant),
 ):
     """List all companies for the current tenant with optional filters."""
+    await _ensure_ca_pack_ready(tenant_id)
     tid = _uuid.UUID(tenant_id)
     async with get_tenant_session(tid) as session:
         base = select(Company).where(Company.tenant_id == tid)
@@ -344,6 +352,7 @@ async def get_company(
     tenant_id: str = Depends(get_current_tenant),
 ):
     """Get details of a specific company."""
+    await _ensure_ca_pack_ready(tenant_id)
     tid = _uuid.UUID(tenant_id)
     try:
         cid = _uuid.UUID(company_id)
@@ -1232,6 +1241,7 @@ async def get_ca_subscription(
     tenant_id: str = Depends(get_current_tenant),
 ):
     """Get the current tenant's CA subscription."""
+    await _ensure_ca_pack_ready(tenant_id)
     tid = _uuid.UUID(tenant_id)
 
     async with get_tenant_session(tid) as session:
@@ -1314,6 +1324,7 @@ async def activate_ca_subscription(
         await session.refresh(sub)
         out = _subscription_to_out(sub)
 
+    await _ensure_ca_pack_ready(tenant_id)
     return out
 
 
@@ -2010,6 +2021,7 @@ async def get_partner_dashboard(
     Queries companies, filing_approvals (pending count), and
     compliance_deadlines (upcoming + overdue).
     """
+    await _ensure_ca_pack_ready(tenant_id)
     tid = _uuid.UUID(tenant_id)
     today = datetime.now(tz=UTC).date()
 

--- a/api/v1/packs.py
+++ b/api/v1/packs.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from api.deps import get_current_tenant, require_tenant_admin
 from core.agents.packs.installer import (
+    ensure_ca_pack_subscription_sync_async,
     get_installed_packs_async,
     get_pack_detail,
     install_pack_async,
@@ -25,6 +26,7 @@ async def list_available_packs():
 @router.get("/packs/installed")
 async def list_installed(tenant_id: str = Depends(get_current_tenant)):
     """List packs installed for the current tenant."""
+    await ensure_ca_pack_subscription_sync_async(tenant_id)
     return {"installed": await get_installed_packs_async(tenant_id)}
 
 

--- a/core/agents/packs/installer.py
+++ b/core/agents/packs/installer.py
@@ -24,6 +24,7 @@ from core.models.agent import (
     ShadowComparison,
 )
 from core.models.audit import AuditLog
+from core.models.ca_subscription import CASubscription
 from core.models.company import Company
 from core.models.hitl import HITLQueue
 from core.models.prompt_template import PromptEditHistory
@@ -650,6 +651,30 @@ async def is_pack_installed_for_session(session, tid: UUID, pack_name: str) -> b
         {"tenant_id": tid, "pack_name": pack_name},
     )
     return existing.scalar_one_or_none() is not None
+
+
+async def ensure_ca_pack_subscription_sync_async(tenant_id: str) -> bool:
+    """Install the CA pack when an active or trial CA subscription exists.
+
+    Returns ``True`` when a missing ``ca-firm`` install was repaired, otherwise
+    ``False``. This heals tenants that were provisioned with CA subscription
+    state before the pack install lifecycle became durable.
+    """
+    tid = UUID(tenant_id)
+
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(CASubscription).where(CASubscription.tenant_id == tid)
+        )
+        subscription = result.scalar_one_or_none()
+        if not subscription or subscription.status not in {"trial", "active"}:
+            return False
+
+        if await is_pack_installed_for_session(session, tid, _ca_id):
+            return False
+
+    await install_pack_async(_ca_id, tenant_id)
+    return True
 
 
 async def _merge_install_assets(

--- a/docs/PR_SUMMARY_CA_PACK_E2E_HARDENING_2026-04-13.md
+++ b/docs/PR_SUMMARY_CA_PACK_E2E_HARDENING_2026-04-13.md
@@ -1,0 +1,80 @@
+# PR Summary: CA Pack E2E Hardening
+
+## Problem
+
+The CA pack flow still had two enterprise-grade gaps even after the earlier pack provisioning work:
+
+1. Tenants could have an active or trial CA subscription but no durable `ca-firm` install state, leaving `/packs/installed` empty and risking missing company-scoped CA assets until someone manually reinstalled the pack.
+2. The company detail UI did not surface the real company audit feed, so the CA pack provisioning trail and later company-scoped automation events were invisible in the actual product.
+
+There was also a testability gap:
+
+3. The CA UI spec lived outside the active Vitest include path, so CI did not enforce the company-detail audit behavior.
+4. The UI dependency graph was inconsistent: `vite` was on `8.x` while `@vitejs/plugin-react` remained on `4.7.0`, and local `react-dom` was stale. That blocked clean frontend test execution.
+
+## Changes
+
+- Added `ensure_ca_pack_subscription_sync_async()` in `core/agents/packs/installer.py`.
+- Reconcile CA subscription/install drift from:
+  - `GET /packs/installed`
+  - `GET /companies`
+  - `GET /companies/{company_id}`
+  - `GET /ca-subscription`
+  - `POST /ca-subscription/activate`
+  - `GET /partner-dashboard`
+- Updated `CompanyDetail` to:
+  - fetch `/audit?company_id=...`
+  - expose an `Audit Log` tab
+  - merge real audit entries into the recent activity view
+  - keep company-scoped agents/workflows/audit requests explicit
+- Added an active Vitest regression at `ui/src/__tests__/CompanyDetail.test.tsx`.
+- Upgraded `@vitejs/plugin-react` to `^5.2.0` to match the existing Vite 8 toolchain.
+
+## Files
+
+- `api/v1/companies.py`
+- `api/v1/packs.py`
+- `core/agents/packs/installer.py`
+- `tests/unit/test_ca_api_functional.py`
+- `tests/unit/test_industry_packs.py`
+- `ui/src/pages/CompanyDetail.tsx`
+- `ui/src/__tests__/CompanyDetail.test.tsx`
+- `ui/package.json`
+- `ui/package-lock.json`
+
+## Verification
+
+Backend:
+
+- `python -m ruff check --no-cache api/v1/packs.py api/v1/companies.py core/agents/packs/installer.py tests/unit/test_ca_api_functional.py tests/unit/test_industry_packs.py`
+- result: passed
+
+- `python -m pytest -q --no-cov -p no:cacheprovider tests/unit/test_ca_api_functional.py tests/unit/test_industry_packs.py tests/unit/test_ca_pack.py tests/unit/test_ca_features.py tests/unit/test_company_model.py tests/unit/test_company_isolation.py tests/regression/test_ca_regression.py tests/regression/test_ca_bugs.py tests/e2e/test_ca_firm_workflow.py`
+- result: `304 passed, 3 skipped`
+
+Frontend:
+
+- `cd ui && npm run test -- src/__tests__/CompanyDetail.test.tsx`
+- result: `1 passed, 2 tests passed`
+
+- `cd ui && npm run build`
+- result: passed
+
+## Known Out-Of-Scope Failures
+
+Running the entire active frontend unit suite after the dependency fix exposed older non-CA failures in:
+
+- `src/__tests__/CFODashboard.test.tsx`
+- `src/__tests__/CMODashboard.test.tsx`
+- `src/__tests__/NLQueryBar.test.tsx`
+
+Those regressions predate this CA patch scope and should be handled separately.
+
+## Deploy Notes
+
+- Deploy backend and frontend together.
+- Re-run production validation on:
+  - `/dashboard/packs`
+  - `/dashboard/partner`
+  - `/dashboard/companies/{company_id}`
+- Explicitly confirm that a tenant with an active CA subscription but no historical `industry_pack_installs` row self-heals on first access.

--- a/tests/unit/test_ca_api_functional.py
+++ b/tests/unit/test_ca_api_functional.py
@@ -536,6 +536,13 @@ class TestSubscriptionEndpoints:
         assert '"expired"' in source
         assert '"active"' in source
 
+    def test_activate_reconciles_ca_pack_install(self):
+        """activate_ca_subscription repairs missing ca-firm install state."""
+        from api.v1.companies import activate_ca_subscription
+
+        source = inspect.getsource(activate_ca_subscription)
+        assert "_ensure_ca_pack_ready" in source
+
     def test_subscription_model_defaults(self):
         """CASubscription model has correct defaults."""
         from core.models.ca_subscription import CASubscription
@@ -604,6 +611,31 @@ class TestPartnerDashboardSchemas:
         source = inspect.getsource(get_partner_dashboard)
         assert "4999" in source
         assert "revenue_per_month_inr" in source
+
+    def test_partner_dashboard_reconciles_ca_pack_install(self):
+        """get_partner_dashboard repairs missing ca-firm install state."""
+        from api.v1.companies import get_partner_dashboard
+
+        source = inspect.getsource(get_partner_dashboard)
+        assert "_ensure_ca_pack_ready" in source
+
+
+class TestCACompanyEndpointReconciliation:
+    """Verify CA company endpoints self-heal pack install drift."""
+
+    def test_list_companies_reconciles_ca_pack_install(self):
+        """list_companies repairs missing ca-firm install state."""
+        from api.v1.companies import list_companies
+
+        source = inspect.getsource(list_companies)
+        assert "_ensure_ca_pack_ready" in source
+
+    def test_get_company_reconciles_ca_pack_install(self):
+        """get_company repairs missing ca-firm install state."""
+        from api.v1.companies import get_company
+
+        source = inspect.getsource(get_company)
+        assert "_ensure_ca_pack_ready" in source
 
 
 # ============================================================================

--- a/tests/unit/test_industry_packs.py
+++ b/tests/unit/test_industry_packs.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
 from core.agents.packs.installer import (
@@ -84,3 +86,11 @@ def test_installed_packs_per_tenant():
 
     assert "legal" in get_installed_packs("tenant-B")
     assert "healthcare" not in get_installed_packs("tenant-B")
+
+
+def test_list_installed_repairs_ca_subscription_drift():
+    """The packs API self-heals missing ca-firm installs for active CA tenants."""
+    from api.v1.packs import list_installed
+
+    source = inspect.getsource(list_installed)
+    assert "ensure_ca_pack_subscription_sync_async" in source

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -40,7 +40,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^4.7.0",
+        "@vitejs/plugin-react": "^5.2.0",
         "autoprefixer": "^10.4.0",
         "eslint": "^10.2.0",
         "jsdom": "^29.0.2",
@@ -2004,9 +2004,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -2459,24 +2459,24 @@
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.0",
+        "@babel/core": "^7.29.0",
         "@babel/plugin-transform-react-jsx-self": "^7.27.1",
         "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
         "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
+        "react-refresh": "^0.18.0"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -5145,9 +5145,9 @@
       }
     },
     "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -50,7 +50,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^4.7.0",
+    "@vitejs/plugin-react": "^5.2.0",
     "autoprefixer": "^10.4.0",
     "eslint": "^10.2.0",
     "jsdom": "^29.0.2",

--- a/ui/src/__tests__/CompanyDetail.test.tsx
+++ b/ui/src/__tests__/CompanyDetail.test.tsx
@@ -1,0 +1,203 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+const mockPatch = vi.fn();
+const mockPut = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock("../lib/api", () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    patch: (...args: unknown[]) => mockPatch(...args),
+    put: (...args: unknown[]) => mockPut(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+  },
+  extractApiError: () => "request failed",
+}));
+
+vi.mock("react-helmet-async", () => ({
+  Helmet: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  HelmetProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import CompanyDetail from "@/pages/CompanyDetail";
+
+const COMPANY_ID = "company-001";
+
+const companyResponse = {
+  id: COMPANY_ID,
+  name: "Acme Manufacturing Pvt Ltd",
+  gstin: "29AABCU9603R1ZM",
+  subscription_status: "trial",
+  client_health_score: 92,
+  gst_auto_file: true,
+  document_vault_enabled: true,
+};
+
+const approvalsResponse = [
+  {
+    id: "approval-1",
+    company_id: COMPANY_ID,
+    filing_type: "GSTR-1",
+    filing_period: "2026-04",
+    status: "pending",
+    requested_by: "partner@agenticorg.ai",
+    created_at: "2026-04-13T09:00:00Z",
+  },
+];
+
+const deadlinesResponse = [
+  {
+    id: "deadline-1",
+    company_id: COMPANY_ID,
+    deadline_type: "GST Filing",
+    filing_period: "2026-04",
+    due_date: "2099-04-20",
+    filed: false,
+    created_at: "2026-04-13T09:00:00Z",
+  },
+];
+
+const uploadsResponse = [
+  {
+    id: "upload-1",
+    company_id: COMPANY_ID,
+    upload_type: "GSTR-2B",
+    filing_period: "2026-04",
+    file_name: "gstr2b-apr.json",
+    status: "uploaded",
+    uploaded_at: "2026-04-13T10:00:00Z",
+    uploaded_by: "associate@agenticorg.ai",
+    created_at: "2026-04-13T10:00:00Z",
+  },
+];
+
+const rolesResponse = {
+  roles: [{ user_id: "partner@agenticorg.ai", role: "partner" }],
+  valid_roles: ["partner", "manager", "associate", "audit_reviewer"],
+};
+
+const credentialsResponse = [
+  {
+    id: "cred-1",
+    company_id: COMPANY_ID,
+    gstin: "29AABCU9603R1ZM",
+    username: "gst-ops",
+    portal_type: "gstn",
+    is_active: true,
+    last_verified_at: "2026-04-13T10:00:00Z",
+    created_at: "2026-04-13T10:00:00Z",
+  },
+];
+
+const agentsResponse = {
+  items: [
+    {
+      id: "agent-1",
+      employee_name: "GST Filing Specialist",
+      domain: "finance",
+      status: "active",
+      designation: "GST Agent",
+    },
+  ],
+};
+
+const workflowsResponse = {
+  items: [
+    {
+      id: "workflow-1",
+      name: "GST Return Filing",
+      description: "Prepare and file GST return",
+      is_active: true,
+      created_at: "2026-04-13T10:00:00Z",
+    },
+  ],
+};
+
+const auditResponse = {
+  items: [
+    {
+      id: "audit-1",
+      created_at: "2026-04-13T11:00:00Z",
+      action: "Synchronized Chartered Accountant Firm Pack assets for Acme Manufacturing Pvt Ltd",
+      actor_type: "system",
+      outcome: "success",
+    },
+  ],
+};
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/dashboard/companies/${COMPANY_ID}`]}>
+      <Routes>
+        <Route path="/dashboard/companies/:id" element={<CompanyDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("CompanyDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockImplementation((url: string, config?: { params?: Record<string, unknown> }) => {
+      if (url === `/companies/${COMPANY_ID}`) return Promise.resolve({ data: companyResponse });
+      if (url === `/companies/${COMPANY_ID}/approvals`) return Promise.resolve({ data: approvalsResponse });
+      if (url === `/companies/${COMPANY_ID}/deadlines`) return Promise.resolve({ data: deadlinesResponse });
+      if (url === `/companies/${COMPANY_ID}/gstn-uploads`) return Promise.resolve({ data: uploadsResponse });
+      if (url === `/companies/${COMPANY_ID}/roles`) return Promise.resolve({ data: rolesResponse });
+      if (url === `/companies/${COMPANY_ID}/credentials`) return Promise.resolve({ data: credentialsResponse });
+      if (url === "/agents") return Promise.resolve({ data: agentsResponse });
+      if (url === "/workflows") return Promise.resolve({ data: workflowsResponse });
+      if (url === "/audit") return Promise.resolve({ data: auditResponse });
+      throw new Error(`Unexpected GET ${url} ${JSON.stringify(config?.params || {})}`);
+    });
+  });
+
+  it("renders the audit log tab and shows real audit events", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Acme Manufacturing Pvt Ltd")).toBeInTheDocument();
+    });
+
+    const auditTab = screen.getByText("Audit Log");
+    expect(auditTab).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(auditTab);
+    });
+
+    expect(
+      screen.getByText("Synchronized Chartered Accountant Firm Pack assets for Acme Manufacturing Pvt Ltd"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("success")).toBeInTheDocument();
+  });
+
+  it("requests company-scoped agents, workflows, and audit records", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith(
+        "/agents",
+        expect.objectContaining({ params: expect.objectContaining({ company_id: COMPANY_ID }) }),
+      );
+    });
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/workflows",
+      expect.objectContaining({ params: expect.objectContaining({ company_id: COMPANY_ID }) }),
+    );
+    expect(mockGet).toHaveBeenCalledWith(
+      "/audit",
+      expect.objectContaining({ params: expect.objectContaining({ company_id: COMPANY_ID }) }),
+    );
+  });
+});

--- a/ui/src/pages/CompanyDetail.tsx
+++ b/ui/src/pages/CompanyDetail.tsx
@@ -128,7 +128,7 @@ type TabKey =
   | "compliance"
   | "agents"
   | "workflows"
-  | "activity"
+  | "audit"
   | "approvals"
   | "settings";
 
@@ -204,6 +204,7 @@ export default function CompanyDetail() {
   const [credentials, setCredentials] = useState<Credential[]>([]);
   const [agents, setAgents] = useState<AutomationAgent[]>([]);
   const [workflows, setWorkflows] = useState<AutomationWorkflow[]>([]);
+  const [auditEntries, setAuditEntries] = useState<ActivityEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -261,6 +262,7 @@ export default function CompanyDetail() {
       credentialsResult,
       agentsResult,
       workflowsResult,
+      auditResult,
     ] = await Promise.allSettled([
       api.get(`/companies/${id}`),
       api.get(`/companies/${id}/approvals`),
@@ -270,6 +272,7 @@ export default function CompanyDetail() {
       api.get(`/companies/${id}/credentials`),
       api.get("/agents", { params: { page: 1, per_page: 200, domain: "finance", company_id: id } }),
       api.get("/workflows", { params: { page: 1, per_page: 200, company_id: id } }),
+      api.get("/audit", { params: { page: 1, per_page: 200, company_id: id } }),
     ]);
 
     if (companyResult.status === "rejected") {
@@ -365,6 +368,21 @@ export default function CompanyDetail() {
       setWorkflows([]);
     }
 
+    if (auditResult.status === "fulfilled") {
+      const auditItems = itemsFromResponse<Record<string, unknown>>(auditResult.value.data);
+      setAuditEntries(
+        auditItems.map((record) => ({
+          id: `audit-${String(record.id || crypto.randomUUID())}`,
+          timestamp: String(record.created_at || record.timestamp || ""),
+          action: String(record.action || record.event_type || "Audit event"),
+          actor: String(record.actor_id || record.actor_type || "system"),
+          outcome: String(record.outcome || "recorded"),
+        })),
+      );
+    } else {
+      setAuditEntries([]);
+    }
+
     setLoading(false);
   }, [id]);
 
@@ -403,17 +421,19 @@ export default function CompanyDetail() {
       outcome: upload.status,
     }));
 
-    return [...approvalActivity, ...deadlineActivity, ...uploadActivity].sort(
+    const merged = [...auditEntries, ...approvalActivity, ...deadlineActivity, ...uploadActivity];
+    const deduped = merged.filter((entry, index, items) => items.findIndex((candidate) => candidate.id === entry.id) === index);
+    return deduped.sort(
       (left, right) => new Date(right.timestamp).getTime() - new Date(left.timestamp).getTime(),
     );
-  }, [approvals, deadlines, uploads]);
+  }, [approvals, auditEntries, deadlines, uploads]);
 
   const tabs: { key: TabKey; label: string }[] = [
     { key: "overview", label: "Overview" },
     { key: "compliance", label: "Compliance" },
     { key: "agents", label: "Agents" },
     { key: "workflows", label: "Workflows" },
-    { key: "activity", label: "Activity" },
+    { key: "audit", label: "Audit Log" },
     { key: "approvals", label: "Approvals" },
     { key: "settings", label: "Settings" },
   ];
@@ -714,11 +734,11 @@ export default function CompanyDetail() {
 
             <Card>
               <CardHeader>
-                <CardTitle className="text-base">Recent Compliance Activity</CardTitle>
+                <CardTitle className="text-base">Recent Audit & Activity</CardTitle>
               </CardHeader>
               <CardContent>
                 {activities.length === 0 ? (
-                  <p className="text-sm text-muted-foreground">No company activity recorded yet.</p>
+                  <p className="text-sm text-muted-foreground">No company audit events recorded yet.</p>
                 ) : (
                   <div className="space-y-3">
                     {activities.slice(0, 5).map((activity) => (
@@ -907,13 +927,13 @@ export default function CompanyDetail() {
         </div>
       )}
 
-      {activeTab === "activity" && (
-        <Card>
-          <CardContent className="pt-4">
-            {activities.length === 0 ? (
-              <p className="text-sm text-muted-foreground">No activity recorded yet.</p>
-            ) : (
-              <div className="overflow-x-auto">
+        {activeTab === "audit" && (
+          <Card>
+            <CardContent className="pt-4">
+              {activities.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No audit events recorded yet.</p>
+              ) : (
+                <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b">


### PR DESCRIPTION
## Summary

This PR closes the remaining CA-pack gaps found in the end-to-end validation pass:

1. tenants could have an active or trial CA subscription but no durable `ca-firm` install state
2. company detail did not surface the real company audit feed, so CA pack provisioning and later automation events were invisible in the product
3. the CA company-detail UI regression was not in the active Vitest include path
4. the UI dependency graph was inconsistent (`vite` 8 with `@vitejs/plugin-react` 4.7), which blocked clean frontend test execution

## Changes

- add `ensure_ca_pack_subscription_sync_async()` in `core/agents/packs/installer.py`
- self-heal CA pack install drift from:
  - `GET /packs/installed`
  - `GET /companies`
  - `GET /companies/{company_id}`
  - `GET /ca-subscription`
  - `POST /ca-subscription/activate`
  - `GET /partner-dashboard`
- update `CompanyDetail` to:
  - fetch `/audit?company_id=...`
  - expose an `Audit Log` tab
  - merge real audit entries into recent activity
  - keep company-scoped agents/workflows/audit requests explicit
- add an active Vitest regression at `ui/src/__tests__/CompanyDetail.test.tsx`
- align `@vitejs/plugin-react` with the existing Vite 8 toolchain
- include execution notes in `docs/PR_SUMMARY_CA_PACK_E2E_HARDENING_2026-04-13.md`

## Verification

Backend
- `python -m ruff check --no-cache api/v1/packs.py api/v1/companies.py core/agents/packs/installer.py tests/unit/test_ca_api_functional.py tests/unit/test_industry_packs.py`
- `python -m pytest -q --no-cov -p no:cacheprovider tests/unit/test_ca_api_functional.py tests/unit/test_industry_packs.py tests/unit/test_ca_pack.py tests/unit/test_ca_features.py tests/unit/test_company_model.py tests/unit/test_company_isolation.py tests/regression/test_ca_regression.py tests/regression/test_ca_bugs.py tests/e2e/test_ca_firm_workflow.py`
- result: `304 passed, 3 skipped`

Frontend
- `cd ui && npm run test -- src/__tests__/CompanyDetail.test.tsx`
- result: `1 passed, 2 tests passed`
- `cd ui && npm run build`
- result: passed

## Known Out-Of-Scope Failures

Running the entire active frontend unit suite after the dependency fix exposed older non-CA failures in:
- `src/__tests__/CFODashboard.test.tsx`
- `src/__tests__/CMODashboard.test.tsx`
- `src/__tests__/NLQueryBar.test.tsx`

Those regressions predate this CA patch scope and should be handled separately.

## Deploy Notes

- deploy backend and frontend together
- after deploy, revalidate:
  - `/dashboard/packs`
  - `/dashboard/partner`
  - `/dashboard/companies/{company_id}`
- explicitly confirm that a tenant with an active CA subscription but no historical `industry_pack_installs` row self-heals on first access
