### PR TITLE
fix(deploy): harden production API rollouts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -329,12 +329,43 @@ jobs:
 
       - name: Verify production rollout
         run: |
-          kubectl rollout status deployment/agenticorg-api \
-            --namespace agenticorg \
-            --timeout=300s
-          kubectl rollout status deployment/agenticorg-ui \
-            --namespace agenticorg \
-            --timeout=300s
+          set -euo pipefail
+
+          dump_rollout_debug() {
+            local deployment_name="$1"
+            local app_label="$2"
+
+            echo "::group::${deployment_name} rollout diagnostics"
+            kubectl get deployment "${deployment_name}" --namespace agenticorg -o wide || true
+            kubectl describe deployment "${deployment_name}" --namespace agenticorg || true
+            kubectl rollout history deployment/"${deployment_name}" --namespace agenticorg || true
+            kubectl get rs --namespace agenticorg -l "app=${app_label}" -o wide || true
+            kubectl get pods --namespace agenticorg -l "app=${app_label}" -o wide || true
+
+            for pod in $(kubectl get pods --namespace agenticorg -l "app=${app_label}" -o name); do
+              kubectl describe --namespace agenticorg "${pod}" || true
+              kubectl logs --namespace agenticorg "${pod}" --all-containers --tail=200 || true
+              kubectl logs --namespace agenticorg "${pod}" --all-containers --previous --tail=200 || true
+            done
+
+            kubectl get events --namespace agenticorg --sort-by=.metadata.creationTimestamp | tail -n 50 || true
+            echo "::endgroup::"
+          }
+
+          check_rollout() {
+            local deployment_name="$1"
+            local app_label="$2"
+
+            if ! kubectl rollout status deployment/"${deployment_name}" \
+              --namespace agenticorg \
+              --timeout=600s; then
+              dump_rollout_debug "${deployment_name}" "${app_label}"
+              exit 1
+            fi
+          }
+
+          check_rollout agenticorg-api agenticorg-api
+          check_rollout agenticorg-ui agenticorg-ui
 
       - name: Post-deploy production health check
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ USER agenticorg
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD curl -sf http://localhost:8000/api/v1/health/liveness || exit 1
-CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2", "--timeout-graceful-shutdown", "20"]

--- a/docs/PR_SUMMARY_PRODUCTION_ROLLOUT_FIX_2026-04-13.md
+++ b/docs/PR_SUMMARY_PRODUCTION_ROLLOUT_FIX_2026-04-13.md
@@ -1,0 +1,73 @@
+# PR Summary: Production Rollout Timeout Fix
+
+## Problem
+
+The `main` deployment workflow failed twice after the CA pack hardening merge:
+
+- run `24348764719`
+- rerun of `24348764719`
+
+Both failures happened in `deploy-production` during `Verify production rollout` while waiting on `deployment/agenticorg-api`.
+
+Observed failure:
+
+- `1 old replicas are pending termination...`
+- `error: timed out waiting for the condition`
+
+This left the product functionally updated on the QA tenant, but the deployment pipeline itself remained unhealthy and blocked post-deploy jobs.
+
+## Changes
+
+- Bound API shutdown time in `Dockerfile` with:
+  - `--timeout-graceful-shutdown 20`
+- Made API rollout behavior explicit in `helm/templates/deployment.yaml`:
+  - `revisionHistoryLimit: 5`
+  - `progressDeadlineSeconds: 900`
+  - `minReadySeconds: 10`
+  - rolling update strategy with `maxUnavailable: 1` and `maxSurge: 1`
+  - `terminationGracePeriodSeconds: 45`
+- Hardened `.github/workflows/deploy.yml`:
+  - increased rollout verification timeout from `300s` to `600s`
+  - added deployment/replicaset/pod/event diagnostics on rollout failure
+  - added pod describe/log capture so future failures are actionable from CI logs
+
+## Why This Fix
+
+The failure pattern points to rollout fragility, not a build or unit/integration issue:
+
+- build passed
+- unit tests passed
+- integration tests passed
+- the live tenant already showed the CA behavior after merge
+- only the API deployment rollout verification failed
+
+This patch addresses both sides of that problem:
+
+1. the pod should terminate more predictably
+2. the rollout controller has more explicit and more forgiving parameters
+3. if rollout still fails, CI will now show exactly which pod/deployment state caused it
+
+## Files
+
+- `Dockerfile`
+- `helm/templates/deployment.yaml`
+- `.github/workflows/deploy.yml`
+
+## Verification
+
+- `helm template agenticorg ./helm -f helm/values-production.yaml`
+- result: passed
+
+## Known Limits
+
+- `actionlint` is not installed in this environment, so there was no dedicated workflow linter run
+- this patch should be validated by merging and watching the next `main` deploy run
+
+## Post-Merge Check
+
+Confirm on the next `main` run that:
+
+- `deploy-production` succeeds
+- `e2e-tests` runs instead of skipping
+- `submit-indexing` runs instead of skipping
+- no API rollout timeout occurs in `Verify production rollout`

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -4,6 +4,14 @@ metadata:
   name: {{ .Release.Name }}-api
 spec:
   replicas: {{ .Values.replicaCount.api }}
+  revisionHistoryLimit: 5
+  progressDeadlineSeconds: 900
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
   selector:
     matchLabels:
       app: agenticorg-api
@@ -12,6 +20,7 @@ spec:
       labels:
         app: agenticorg-api
     spec:
+      terminationGracePeriodSeconds: 45
       containers:
         - name: api
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
## Summary

This PR addresses the current `main` deployment failure mode in production rollout verification.

Observed failure on `main`:
- workflow run `24348764719`
- rerun of `24348764719`
- both failed in `deploy-production` during `Verify production rollout`
- failing symptom: `agenticorg-api` timed out while an old replica was still pending termination

## Changes

- bound API shutdown time in `Dockerfile` with `--timeout-graceful-shutdown 20`
- made API deployment rollout behavior explicit in `helm/templates/deployment.yaml`
  - `revisionHistoryLimit: 5`
  - `progressDeadlineSeconds: 900`
  - `minReadySeconds: 10`
  - rolling update strategy with `maxUnavailable: 1`, `maxSurge: 1`
  - `terminationGracePeriodSeconds: 45`
- hardened `.github/workflows/deploy.yml`
  - increased rollout verification timeout from `300s` to `600s`
  - added deployment / rs / pod / event diagnostics on rollout failure
  - added pod describe and logs capture so future failures are actionable from CI logs
- added execution notes in `docs/PR_SUMMARY_PRODUCTION_ROLLOUT_FIX_2026-04-13.md`

## Why this patch

The product behavior is already live and working for the CA QA tenant, but the deployment pipeline is not clean because the API rollout verification is fragile. This patch targets rollout robustness and debuggability instead of masking the failure.

## Verification

- `helm template agenticorg ./helm -f helm/values-production.yaml`
- result: passed

## Known limits

- `actionlint` is not installed in the local environment, so there was no dedicated workflow lint pass
- the real proof for this PR is the next `main` deployment run after merge

## Post-merge check

On the next `main` run, confirm:
- `deploy-production` succeeds
- no API rollout timeout occurs
- `e2e-tests` runs
- `submit-indexing` runs
