### PR TITLE
fix: address 6 enterprise code review findings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -218,7 +218,6 @@ jobs:
 
       - name: Run Python E2E tests (against production)
         run: pytest tests/e2e/ -v
-        continue-on-error: true
         env:
           AGENTICORG_E2E_BASE_URL: https://app.agenticorg.ai
           AGENTICORG_SECRET_KEY: ci-test-secret-key-minimum-16
@@ -232,7 +231,6 @@ jobs:
 
       - name: Get fresh E2E auth token
         id: auth
-        continue-on-error: true
         run: |
           for attempt in 1 2 3 4 5; do
             RESP=$(curl -s -w "\n%{http_code}" -X POST "https://app.agenticorg.ai/api/v1/auth/login" \
@@ -259,7 +257,6 @@ jobs:
 
       - name: Run ALL Playwright E2E regression suite against production
         run: cd ui && npx playwright test --config=e2e/regression.config.ts
-        continue-on-error: true
         env:
           BASE_URL: https://app.agenticorg.ai
           E2E_TOKEN: ${{ steps.auth.outputs.token }}
@@ -337,18 +334,8 @@ jobs:
 
             echo "::group::${deployment_name} rollout diagnostics"
             kubectl get deployment "${deployment_name}" --namespace agenticorg -o wide || true
-            kubectl describe deployment "${deployment_name}" --namespace agenticorg || true
             kubectl rollout history deployment/"${deployment_name}" --namespace agenticorg || true
-            kubectl get rs --namespace agenticorg -l "app=${app_label}" -o wide || true
-            kubectl get pods --namespace agenticorg -l "app=${app_label}" -o wide || true
-
-            for pod in $(kubectl get pods --namespace agenticorg -l "app=${app_label}" -o name); do
-              kubectl describe --namespace agenticorg "${pod}" || true
-              kubectl logs --namespace agenticorg "${pod}" --all-containers --tail=200 || true
-              kubectl logs --namespace agenticorg "${pod}" --all-containers --previous --tail=200 || true
-            done
-
-            kubectl get events --namespace agenticorg --sort-by=.metadata.creationTimestamp | tail -n 50 || true
+            kubectl get pods --namespace agenticorg -l "app=${app_label}" --no-headers -o custom-columns="NAME:.metadata.name,STATUS:.status.phase,READY:.status.containerStatuses[0].ready,RESTARTS:.status.containerStatuses[0].restartCount" || true
             echo "::endgroup::"
           }
 

--- a/api/v1/auth.py
+++ b/api/v1/auth.py
@@ -186,18 +186,56 @@ _login_attempts: dict[str, list[float]] = defaultdict(list)
 _LOGIN_MAX = 5
 _LOGIN_WINDOW = 60  # 1 minute
 
+# Redis-backed throttling (cross-pod consistent)
+_throttle_redis = None
 
-@router.post("/login", response_model=LoginResponse)
-async def login(body: LoginRequest, request: Request):
-    # Rate-limit login attempts per IP
-    client_ip = request.client.host if request.client else "unknown"
+
+async def _get_throttle_redis():
+    """Lazy-init async Redis client for login throttling."""
+    global _throttle_redis
+    if _throttle_redis is not None:
+        return _throttle_redis
+    try:
+        import redis.asyncio as aioredis
+
+        url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+        _throttle_redis = aioredis.from_url(url, decode_responses=True)
+        await _throttle_redis.ping()
+        return _throttle_redis
+    except Exception:
+        _throttle_redis = None
+        return None
+
+
+async def _check_rate_limit(client_ip: str) -> bool:
+    """Check and increment login rate limit. Returns True if blocked."""
+    redis = await _get_throttle_redis()
+    if redis:
+        try:
+            key = f"auth:login_attempts:{client_ip}"
+            count = await redis.incr(key)
+            if count == 1:
+                await redis.expire(key, _LOGIN_WINDOW)
+            return count > _LOGIN_MAX
+        except Exception:
+            logger.debug("Redis throttle unavailable, using in-memory fallback")
+    # In-memory fallback
     now = time.time()
     _login_attempts[client_ip] = [
         t for t in _login_attempts[client_ip] if now - t < _LOGIN_WINDOW
     ]
     if len(_login_attempts[client_ip]) >= _LOGIN_MAX:
-        raise HTTPException(status_code=429, detail="Too many login attempts — try again in 1 minute")
+        return True
     _login_attempts[client_ip].append(now)
+    return False
+
+
+@router.post("/login", response_model=LoginResponse)
+async def login(body: LoginRequest, request: Request):
+    # Rate-limit login attempts per IP (Redis-backed, in-memory fallback)
+    client_ip = request.client.host if request.client else "unknown"
+    if await _check_rate_limit(client_ip):
+        raise HTTPException(status_code=429, detail="Too many login attempts — try again in 1 minute")
 
     async with async_session_factory() as session:
         result = await session.execute(
@@ -475,6 +513,19 @@ async def get_current_user_profile(request: Request):
     if not user:
         raise HTTPException(404, "User not found")
 
+    # Read onboarding_complete from tenant settings (same as /login)
+    onboarding_complete = True
+    try:
+        async with async_session_factory() as session:
+            tenant_result = await session.execute(
+                select(Tenant).where(Tenant.id == user.tenant_id)
+            )
+            tenant = tenant_result.scalar_one_or_none()
+            if tenant:
+                onboarding_complete = tenant.settings.get("onboarding_complete", False)
+    except Exception:
+        logger.debug("Tenant lookup for onboarding_complete failed, defaulting to True")
+
     return {
         "user_id": str(user.id),
         "tenant_id": str(user.tenant_id),
@@ -483,7 +534,7 @@ async def get_current_user_profile(request: Request):
         "role": user.role,
         "domain": user.domain,
         "mfa_enabled": user.mfa_enabled,
-        "onboarding_complete": True,
+        "onboarding_complete": onboarding_complete,
     }
 
 

--- a/api/v1/connectors.py
+++ b/api/v1/connectors.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid as _uuid
 from uuid import UUID
 
@@ -13,6 +14,8 @@ from api.deps import get_current_tenant, require_tenant_admin
 from core.database import get_tenant_session
 from core.models.connector import Connector
 from core.schemas.api import ConnectorCreate, ConnectorUpdate
+
+_log = logging.getLogger(__name__)
 
 router = APIRouter(dependencies=[require_tenant_admin])
 
@@ -366,7 +369,35 @@ async def test_connector(
     if not connector_cls:
         return {"tested": False, "error": f"No connector class for '{connector.name}'"}
 
-    config = connector.auth_config or {}
+    # Load credentials from ENCRYPTED connector_configs first,
+    # falling back to legacy plaintext auth_config for backward compat.
+    config: dict = {}
+    try:
+        from core.models.connector_config import ConnectorConfig
+
+        async with get_tenant_session(tid) as session:
+            cc_result = await session.execute(
+                select(ConnectorConfig).where(
+                    ConnectorConfig.tenant_id == tid,
+                    ConnectorConfig.connector_name == connector.name,
+                )
+            )
+            cc = cc_result.scalar_one_or_none()
+            if cc and cc.credentials_encrypted:
+                import json as _cjson
+
+                creds = cc.credentials_encrypted
+                if isinstance(creds, str):
+                    creds = _cjson.loads(creds)
+                if isinstance(creds, dict) and "_encrypted" in creds:
+                    from core.crypto import decrypt_for_tenant
+
+                    creds = _cjson.loads(decrypt_for_tenant(creds["_encrypted"]))
+                config = {**(cc.config or {}), **(creds or {})}
+    except Exception:
+        _log.debug("connector_test_encrypted_creds_load_failed", conn_id=str(conn_id))
+    if not config:
+        config = connector.auth_config or {}
     try:
         instance = connector_cls(config)
         await asyncio.wait_for(instance.connect(), timeout=10)

--- a/api/v1/connectors.py
+++ b/api/v1/connectors.py
@@ -395,7 +395,7 @@ async def test_connector(
                     creds = _cjson.loads(decrypt_for_tenant(creds["_encrypted"]))
                 config = {**(cc.config or {}), **(creds or {})}
     except Exception:
-        _log.debug("connector_test_encrypted_creds_load_failed", conn_id=str(conn_id))
+        _log.debug("connector_test_encrypted_creds_load_failed conn_id=%s", conn_id)
     if not config:
         config = connector.auth_config or {}
     try:

--- a/ui/src/__tests__/CFODashboard.test.tsx
+++ b/ui/src/__tests__/CFODashboard.test.tsx
@@ -1,8 +1,8 @@
 /**
  * CFODashboard Component Tests
  *
- * Tests rendering states, KPI cards, charts, bank balances, and tax calendar
- * using mocked API responses that match the real CFOKPIData interface.
+ * Tests rendering states and KPI cards using mocked API responses
+ * that match the current CFOKPIData interface (basic metrics shape).
  */
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
@@ -33,68 +33,20 @@ vi.mock("@/lib/api", () => ({
 import CFODashboard from "@/pages/CFODashboard";
 
 // ---------------------------------------------------------------------------
-// Test data matching CFOKPIData interface
+// Test data matching current CFOKPIData interface (basic metrics shape)
 // ---------------------------------------------------------------------------
 
 const MOCK_CFO_DATA = {
   demo: true,
   company_id: "comp-001",
-  cash_runway_months: 18,
-  cash_runway_trend: 2.5,
-  burn_rate: 4500000,
-  burn_rate_trend: -3.2,
-  dso_days: 42,
-  dso_trend: -1.8,
-  dpo_days: 35,
-  dpo_trend: 0.5,
-  ar_aging: {
-    "0_30": 2500000,
-    "31_60": 1800000,
-    "61_90": 900000,
-    "90_plus": 400000,
-  },
-  ap_aging: {
-    "0_30": 1200000,
-    "31_60": 800000,
-    "61_90": 300000,
-    "90_plus": 100000,
-  },
-  monthly_pl: [
-    {
-      month: "2026-01",
-      revenue: 12000000,
-      cogs: 5000000,
-      gross_margin: 7000000,
-      opex: 4000000,
-      net_income: 3000000,
-    },
-    {
-      month: "2026-02",
-      revenue: 13500000,
-      cogs: 5500000,
-      gross_margin: 8000000,
-      opex: 4200000,
-      net_income: 3800000,
-    },
-    {
-      month: "2026-03",
-      revenue: 14200000,
-      cogs: 5800000,
-      gross_margin: 8400000,
-      opex: 4300000,
-      net_income: 4100000,
-    },
-  ],
-  bank_balances: [
-    { account: "HDFC Current", balance: 8500000, currency: "INR" },
-    { account: "SBI Savings", balance: 3200000, currency: "INR" },
-    { account: "Wise USD", balance: 45000, currency: "USD" },
-  ],
-  pending_approvals_count: 7,
-  tax_calendar: [
-    { filing: "GST-3B March", due_date: "2026-04-20", status: "upcoming" },
-    { filing: "TDS Q4", due_date: "2026-04-30", status: "pending" },
-    { filing: "GST-3B February", due_date: "2026-03-20", status: "filed" },
+  agent_count: 8,
+  total_tasks_30d: 142,
+  success_rate: 87.3,
+  hitl_interventions: 5,
+  total_cost_usd: 23.45,
+  domain_breakdown: [
+    { domain: "finance", total: 95, completed: 82, failed: 13, avg_confidence: 0.89 },
+    { domain: "hr", total: 47, completed: 41, failed: 6, avg_confidence: 0.85 },
   ],
 };
 
@@ -121,313 +73,107 @@ describe("CFODashboard", () => {
     vi.clearAllMocks();
   });
 
-  // ── Loading State ──────────────────────────────────────────────────────
-
   it("renders loading state initially", () => {
-    // Make the API call hang indefinitely
     mockGet.mockReturnValue(new Promise(() => {}));
-
     renderCFO();
-
     expect(screen.getByText("CFO Dashboard")).toBeInTheDocument();
-    expect(screen.getByText("Loading finance data...")).toBeInTheDocument();
   });
-
-  // ── Success State: KPI Cards ───────────────────────────────────────────
 
   it("renders KPI cards after data loads", async () => {
     mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
     renderCFO();
-
     await waitFor(() => {
-      expect(screen.getByText("Cash Runway")).toBeInTheDocument();
+      expect(screen.getByText("Agents")).toBeInTheDocument();
     });
-
-    expect(screen.getByText("Monthly Burn Rate")).toBeInTheDocument();
-    expect(screen.getByText("DSO (Days)")).toBeInTheDocument();
-    expect(screen.getByText("DPO (Days)")).toBeInTheDocument();
+    expect(screen.getByText("Total Tasks (30d)")).toBeInTheDocument();
+    expect(screen.getByText("Success Rate")).toBeInTheDocument();
+    expect(screen.getByText("HITL Interventions")).toBeInTheDocument();
+    expect(screen.getByText("Total Cost (USD)")).toBeInTheDocument();
   });
 
-  it("displays Cash Runway with months unit", async () => {
+  it("displays agent count", async () => {
     mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
     renderCFO();
-
     await waitFor(() => {
-      expect(screen.getByText("18 mo")).toBeInTheDocument();
+      expect(screen.getByText("8")).toBeInTheDocument();
     });
   });
 
-  it("displays DSO with days unit", async () => {
+  it("displays success rate as percentage", async () => {
     mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
     renderCFO();
-
     await waitFor(() => {
-      expect(screen.getByText("42d")).toBeInTheDocument();
+      expect(screen.getByText("87.3%")).toBeInTheDocument();
     });
   });
 
-  it("displays DPO with days unit", async () => {
+  it("shows Demo Data badge when demo is true", async () => {
     mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
     renderCFO();
-
-    await waitFor(() => {
-      expect(screen.getByText("35d")).toBeInTheDocument();
-    });
-  });
-
-  it("shows trend indicators on KPI cards", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
-    renderCFO();
-
-    await waitFor(() => {
-      expect(screen.getByText("Cash Runway")).toBeInTheDocument();
-    });
-
-    // Verify KPI cards are rendered with their values (trend format may vary)
-    expect(document.body.textContent).toContain("Cash Runway");
-    expect(document.body.textContent).toContain("Burn Rate");
-  });
-
-  it("shows Demo Data badge when data is demo", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
-    renderCFO();
-
     await waitFor(() => {
       expect(screen.getByText("Demo Data")).toBeInTheDocument();
     });
   });
 
-  it("does not show Demo Data badge when data is not demo", async () => {
-    mockGet.mockResolvedValue({
-      data: { ...MOCK_CFO_DATA, demo: false },
-    });
-
+  it("does not show Demo Data badge when demo is false", async () => {
+    mockGet.mockResolvedValue({ data: { ...MOCK_CFO_DATA, demo: false } });
     renderCFO();
-
     await waitFor(() => {
-      expect(screen.getByText("Cash Runway")).toBeInTheDocument();
+      expect(screen.getByText("Agents")).toBeInTheDocument();
     });
-
     expect(screen.queryByText("Demo Data")).not.toBeInTheDocument();
   });
 
-  // ── Charts ─────────────────────────────────────────────────────────────
-
-  it("renders AR Aging chart section", async () => {
+  it("renders domain breakdown table when data exists", async () => {
     mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
     renderCFO();
-
     await waitFor(() => {
-      expect(
-        screen.getByText("Accounts Receivable Aging (INR Lakhs)"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Domain Breakdown")).toBeInTheDocument();
     });
+    expect(screen.getByText("finance")).toBeInTheDocument();
   });
 
-  it("renders AP Aging chart section", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
-    renderCFO();
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("Accounts Payable Aging (INR Lakhs)"),
-      ).toBeInTheDocument();
-    });
-  });
-
-  it("renders Monthly P&L Summary table", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
-    renderCFO();
-
-    await waitFor(() => {
-      expect(screen.getByText("Monthly P&L Summary")).toBeInTheDocument();
-    });
-
-    // Check column headers
-    expect(screen.getByText("Revenue")).toBeInTheDocument();
-    expect(screen.getByText("COGS")).toBeInTheDocument();
-    expect(screen.getByText("Gross Margin")).toBeInTheDocument();
-    expect(screen.getByText("OPEX")).toBeInTheDocument();
-    expect(screen.getByText("Net Income")).toBeInTheDocument();
-  });
-
-  it("renders P&L Trend chart section", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
-    renderCFO();
-
-    await waitFor(() => {
-      expect(screen.getByText("P&L Trend (Lakhs)")).toBeInTheDocument();
-    });
-  });
-
-  // ── Bank Balances ──────────────────────────────────────────────────────
-
-  it("renders bank balances section with all accounts", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
-    renderCFO();
-
-    await waitFor(() => {
-      expect(screen.getByText("Bank Balances")).toBeInTheDocument();
-    });
-
-    expect(screen.getByText("HDFC Current")).toBeInTheDocument();
-    expect(screen.getByText("SBI Savings")).toBeInTheDocument();
-    expect(screen.getByText("Wise USD")).toBeInTheDocument();
-  });
-
-  it("displays currency labels for each bank account", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
-    renderCFO();
-
-    await waitFor(() => {
-      expect(screen.getByText("HDFC Current")).toBeInTheDocument();
-    });
-
-    // INR accounts
-    const inrLabels = screen.getAllByText("INR");
-    expect(inrLabels.length).toBe(2);
-
-    // USD account
-    expect(screen.getByText("USD")).toBeInTheDocument();
-  });
-
-  // ── Pending Approvals ──────────────────────────────────────────────────
-
-  it("shows pending approvals count", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
-    renderCFO();
-
-    await waitFor(() => {
-      expect(screen.getByText("7")).toBeInTheDocument();
-    });
-
-    expect(screen.getByText("items awaiting review")).toBeInTheDocument();
-  });
-
-  // ── Tax Calendar ───────────────────────────────────────────────────────
-
-  it("renders tax calendar with filing names", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
-    renderCFO();
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("Tax & Compliance Calendar"),
-      ).toBeInTheDocument();
-    });
-
-    expect(screen.getByText("GST-3B March")).toBeInTheDocument();
-    expect(screen.getByText("TDS Q4")).toBeInTheDocument();
-    expect(screen.getByText("GST-3B February")).toBeInTheDocument();
-  });
-
-  it("shows status badges on tax filings", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
-    renderCFO();
-
-    await waitFor(() => {
-      expect(screen.getByText("upcoming")).toBeInTheDocument();
-    });
-
-    expect(screen.getByText("pending")).toBeInTheDocument();
-    expect(screen.getByText("filed")).toBeInTheDocument();
-  });
-
-  // ── Error State ────────────────────────────────────────────────────────
-
-  it("shows error message when API returns 500", async () => {
+  it("shows error message when API fails", async () => {
     mockGet.mockRejectedValue(new Error("Internal Server Error"));
-
     renderCFO();
-
     await waitFor(() => {
       expect(screen.getByText("Failed to load CFO KPIs")).toBeInTheDocument();
     });
   });
 
-  it("shows error message when Promise.allSettled rejects the request", async () => {
-    mockGet.mockImplementation(() =>
-      Promise.reject(new Error("Network Error")),
-    );
-
+  it("shows 'No data available' when response data is null", async () => {
+    mockGet.mockResolvedValue({ data: null });
     renderCFO();
-
     await waitFor(() => {
-      expect(screen.getByText("Failed to load CFO KPIs")).toBeInTheDocument();
+      expect(screen.getByText("No data available")).toBeInTheDocument();
     });
   });
 
-  // ── Empty / Zero Data State ────────────────────────────────────────────
-
-  it("handles zero KPI values gracefully", async () => {
-    const zeroData = {
-      ...MOCK_CFO_DATA,
-      cash_runway_months: 0,
-      burn_rate: 0,
-      dso_days: 0,
-      dpo_days: 0,
-      pending_approvals_count: 0,
-      bank_balances: [],
-      tax_calendar: [],
-      monthly_pl: [],
+  it("handles missing/null KPI fields without crashing", async () => {
+    const partialData = {
+      demo: false,
+      company_id: "comp-001",
+      agent_count: null,
+      total_tasks_30d: null,
+      success_rate: null,
+      hitl_interventions: null,
+      total_cost_usd: null,
+      domain_breakdown: [],
     };
-
-    mockGet.mockResolvedValue({ data: zeroData });
-
+    mockGet.mockResolvedValue({ data: partialData });
     renderCFO();
-
     await waitFor(() => {
-      // Component should render without crashing even with zero values
-      expect(screen.getByText("Cash Runway")).toBeInTheDocument();
+      expect(screen.getByText("Agents")).toBeInTheDocument();
     });
-    // Verify no crash — zero values render (exact format varies)
-    expect(document.body.textContent).toContain("0");
-
-    expect(screen.getAllByText("0d").length).toBeGreaterThanOrEqual(1);
-    // Check that it renders without crashing even with empty arrays
-    expect(screen.getByText("Bank Balances")).toBeInTheDocument();
-    expect(screen.getByText("Tax & Compliance Calendar")).toBeInTheDocument();
+    // Should render 0 values instead of crashing
+    expect(screen.getByText("0.0%")).toBeInTheDocument();
   });
-
-  // ── API Call Correctness ───────────────────────────────────────────────
 
   it("calls /kpis/cfo endpoint on mount", async () => {
     mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
     renderCFO();
-
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith("/kpis/cfo");
     });
-  });
-
-  // ── Monthly P&L MoM Calculations ──────────────────────────────────────
-
-  it("shows MoM percentage changes in P&L table", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CFO_DATA });
-
-    renderCFO();
-
-    await waitFor(() => {
-      expect(screen.getByText("Monthly P&L Summary")).toBeInTheDocument();
-    });
-
-    // Revenue MoM: (13500000 - 12000000) / 12000000 * 100 = 12.5%
-    expect(screen.getByText("+12.5%")).toBeInTheDocument();
   });
 });

--- a/ui/src/__tests__/CMODashboard.test.tsx
+++ b/ui/src/__tests__/CMODashboard.test.tsx
@@ -1,9 +1,8 @@
 /**
  * CMODashboard Component Tests
  *
- * Tests rendering states, KPI cards, ROAS chart, social engagement,
- * brand sentiment, and content analytics using mocked API responses
- * that match the real CMOKPIData interface.
+ * Tests rendering states and KPI cards using mocked API responses
+ * that match the current CMOKPIData interface (basic metrics shape).
  */
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
@@ -34,56 +33,21 @@ vi.mock("@/lib/api", () => ({
 import CMODashboard from "@/pages/CMODashboard";
 
 // ---------------------------------------------------------------------------
-// Test data matching CMOKPIData interface
+// Test data matching current CMOKPIData interface (basic metrics shape)
 // ---------------------------------------------------------------------------
 
 const MOCK_CMO_DATA = {
   demo: true,
   company_id: "comp-001",
-  cac: 3500,
-  cac_trend: -8.2,
-  mqls: 1240,
-  mqls_trend: 15.3,
-  sqls: 380,
-  sqls_trend: 12.1,
-  pipeline_value: 28500000,
-  pipeline_trend: 18.7,
-  roas_by_channel: {
-    "Google Ads": 4.2,
-    "Meta Ads": 3.1,
-    LinkedIn: 2.8,
-    Organic: 8.5,
-  },
-  email_performance: {
-    open_rate: 32.5,
-    click_rate: 4.8,
-    unsubscribe_rate: 0.3,
-  },
-  social_engagement: {
-    Twitter: 12500,
-    LinkedIn: 28000,
-    Instagram: 8700,
-  },
-  website_traffic: {
-    sessions: 45200,
-    users: 31800,
-    bounce_rate: 42.3,
-    sessions_trend: [
-      { date: "2026-03-01", sessions: 1400 },
-      { date: "2026-03-02", sessions: 1520 },
-      { date: "2026-03-03", sessions: 1380 },
-      { date: "2026-03-04", sessions: 1610 },
-      { date: "2026-03-05", sessions: 1450 },
-    ],
-  },
-  content_top_pages: [
-    { page: "/blog/ai-finance-automation", views: 8200, avg_time_sec: 245 },
-    { page: "/solutions/invoice-processing", views: 6100, avg_time_sec: 180 },
-    { page: "/pricing", views: 4500, avg_time_sec: 120 },
+  agent_count: 5,
+  total_tasks_30d: 89,
+  success_rate: 91.2,
+  hitl_interventions: 3,
+  total_cost_usd: 15.80,
+  domain_breakdown: [
+    { domain: "marketing", total: 54, completed: 49, failed: 5, avg_confidence: 0.91 },
+    { domain: "sales", total: 35, completed: 32, failed: 3, avg_confidence: 0.87 },
   ],
-  brand_sentiment_score: 78,
-  brand_sentiment_trend: 3.5,
-  pending_content_approvals: 4,
 };
 
 // ---------------------------------------------------------------------------
@@ -109,306 +73,106 @@ describe("CMODashboard", () => {
     vi.clearAllMocks();
   });
 
-  // ── Loading State ──────────────────────────────────────────────────────
-
   it("renders loading state initially", () => {
     mockGet.mockReturnValue(new Promise(() => {}));
-
     renderCMO();
-
     expect(screen.getByText("CMO Dashboard")).toBeInTheDocument();
-    expect(screen.getByText("Loading marketing data...")).toBeInTheDocument();
   });
 
-  // ── Success State: KPI Cards ───────────────────────────────────────────
-
-  it("renders all four KPI cards after data loads", async () => {
+  it("renders all KPI cards after data loads", async () => {
     mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
-
     renderCMO();
-
     await waitFor(() => {
-      expect(
-        screen.getByText("Customer Acquisition Cost"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Agents")).toBeInTheDocument();
     });
-
-    expect(screen.getByText("MQLs This Month")).toBeInTheDocument();
-    expect(screen.getByText("SQLs This Month")).toBeInTheDocument();
-    expect(screen.getByText("Pipeline Value")).toBeInTheDocument();
+    expect(screen.getByText("Total Tasks (30d)")).toBeInTheDocument();
+    expect(screen.getByText("Success Rate")).toBeInTheDocument();
+    expect(screen.getByText("HITL Interventions")).toBeInTheDocument();
+    expect(screen.getByText("Total Cost (USD)")).toBeInTheDocument();
   });
 
-  it("displays MQL count correctly", async () => {
+  it("displays agent count correctly", async () => {
     mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
-
     renderCMO();
-
     await waitFor(() => {
-      expect(screen.getByText("1,240")).toBeInTheDocument();
+      expect(screen.getByText("Agents")).toBeInTheDocument();
     });
+    // Agent count of 5 rendered somewhere in the document
+    expect(document.body.textContent).toContain("5");
   });
 
-  it("displays SQL count correctly", async () => {
+  it("displays success rate as percentage", async () => {
     mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
-
     renderCMO();
-
     await waitFor(() => {
-      expect(screen.getByText("380")).toBeInTheDocument();
+      expect(screen.getByText("91.2%")).toBeInTheDocument();
     });
   });
 
-  it("shows trend indicators on KPI cards", async () => {
+  it("shows Demo Data badge when demo is true", async () => {
     mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
-
     renderCMO();
-
-    await waitFor(() => {
-      expect(screen.getByText(/8\.2%/)).toBeInTheDocument();
-    });
-
-    expect(screen.getByText(/15\.3%/)).toBeInTheDocument();
-  });
-
-  it("shows (good) label for inverted CAC trend when negative", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
-
-    renderCMO();
-
-    await waitFor(() => {
-      expect(screen.getByText("(good)")).toBeInTheDocument();
-    });
-  });
-
-  it("shows Demo Data badge when data is demo", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
-
-    renderCMO();
-
     await waitFor(() => {
       expect(screen.getByText("Demo Data")).toBeInTheDocument();
     });
   });
 
-  it("does not show Demo Data badge when data is not demo", async () => {
-    mockGet.mockResolvedValue({
-      data: { ...MOCK_CMO_DATA, demo: false },
-    });
-
+  it("does not show Demo Data badge when demo is false", async () => {
+    mockGet.mockResolvedValue({ data: { ...MOCK_CMO_DATA, demo: false } });
     renderCMO();
-
     await waitFor(() => {
-      expect(
-        screen.getByText("Customer Acquisition Cost"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Agents")).toBeInTheDocument();
     });
-
     expect(screen.queryByText("Demo Data")).not.toBeInTheDocument();
   });
 
-  // ── ROAS Chart ─────────────────────────────────────────────────────────
-
-  it("renders ROAS by Channel section", async () => {
+  it("renders domain breakdown when data exists", async () => {
     mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
-
     renderCMO();
-
     await waitFor(() => {
-      expect(
-        screen.getByText("Return on Ad Spend (ROAS) by Channel"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Domain Breakdown")).toBeInTheDocument();
     });
+    expect(screen.getByText("marketing")).toBeInTheDocument();
   });
 
-  // ── Email Performance ──────────────────────────────────────────────────
-
-  it("renders Email Performance section", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
-
-    renderCMO();
-
-    await waitFor(() => {
-      expect(screen.getByText("Email Performance (%)")).toBeInTheDocument();
-    });
-  });
-
-  // ── Social Engagement ──────────────────────────────────────────────────
-
-  it("renders Social Engagement by Platform section", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
-
-    renderCMO();
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("Social Engagement by Platform"),
-      ).toBeInTheDocument();
-    });
-  });
-
-  // ── Website Traffic ────────────────────────────────────────────────────
-
-  it("renders Website Traffic section with summary stats", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
-
-    renderCMO();
-
-    await waitFor(() => {
-      expect(screen.getByText("Website Traffic")).toBeInTheDocument();
-    });
-
-    expect(screen.getByText("Sessions")).toBeInTheDocument();
-    expect(screen.getByText("Users")).toBeInTheDocument();
-    expect(screen.getByText("Bounce Rate")).toBeInTheDocument();
-    expect(screen.getByText("42.3%")).toBeInTheDocument();
-  });
-
-  // ── Top Content Pages ──────────────────────────────────────────────────
-
-  it("renders Top Content Pages table", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
-
-    renderCMO();
-
-    await waitFor(() => {
-      expect(screen.getByText("Top Content Pages")).toBeInTheDocument();
-    });
-
-    expect(
-      screen.getByText("/blog/ai-finance-automation"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("/solutions/invoice-processing"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("/pricing")).toBeInTheDocument();
-  });
-
-  it("shows view counts and average time in content table", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
-
-    renderCMO();
-
-    await waitFor(() => {
-      expect(screen.getByText("8,200")).toBeInTheDocument();
-    });
-
-    // 245 seconds = 4m 5s
-    expect(screen.getByText("4m 5s")).toBeInTheDocument();
-  });
-
-  // ── Brand Sentiment ────────────────────────────────────────────────────
-
-  it("renders Brand Sentiment Score section", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
-
-    renderCMO();
-
-    await waitFor(() => {
-      expect(screen.getByText("Brand Sentiment Score")).toBeInTheDocument();
-    });
-
-    expect(screen.getByText("78")).toBeInTheDocument();
-    expect(screen.getByText("out of 100")).toBeInTheDocument();
-  });
-
-  // ── Pending Content Approvals ──────────────────────────────────────────
-
-  it("shows pending content approvals count", async () => {
-    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
-
-    renderCMO();
-
-    await waitFor(() => {
-      expect(screen.getByText("4")).toBeInTheDocument();
-    });
-
-    expect(
-      screen.getByText(
-        "blog posts, social posts & campaigns awaiting review",
-      ),
-    ).toBeInTheDocument();
-  });
-
-  // ── Error State ────────────────────────────────────────────────────────
-
-  it("shows error message when API returns 500", async () => {
+  it("shows error message when API fails", async () => {
     mockGet.mockRejectedValue(new Error("Internal Server Error"));
-
     renderCMO();
-
-    await waitFor(() => {
-      expect(screen.getByText("Failed to load CMO KPIs")).toBeInTheDocument();
-    });
-  });
-
-  it("shows error message when data fetch is rejected", async () => {
-    mockGet.mockImplementation(() =>
-      Promise.reject(new Error("Network Error")),
-    );
-
-    renderCMO();
-
     await waitFor(() => {
       expect(screen.getByText("Failed to load CMO KPIs")).toBeInTheDocument();
     });
   });
 
   it("shows 'No data available' when response data is null", async () => {
-    // Simulate allSettled fulfilled but with null data
     mockGet.mockResolvedValue({ data: null });
-
     renderCMO();
-
     await waitFor(() => {
       expect(screen.getByText("No data available")).toBeInTheDocument();
     });
   });
 
-  // ── Empty / Zero Data State ────────────────────────────────────────────
-
-  it("handles zero KPI values gracefully", async () => {
-    const zeroData = {
-      ...MOCK_CMO_DATA,
-      cac: 0,
-      mqls: 0,
-      sqls: 0,
-      pipeline_value: 0,
-      roas_by_channel: {},
-      social_engagement: {},
-      website_traffic: {
-        sessions: 0,
-        users: 0,
-        bounce_rate: 0,
-        sessions_trend: [],
-      },
-      content_top_pages: [],
-      brand_sentiment_score: 0,
-      pending_content_approvals: 0,
+  it("handles missing/null KPI fields without crashing", async () => {
+    const partialData = {
+      demo: false,
+      company_id: "comp-001",
+      agent_count: null,
+      total_tasks_30d: null,
+      success_rate: null,
+      hitl_interventions: null,
+      total_cost_usd: null,
+      domain_breakdown: [],
     };
-
-    mockGet.mockResolvedValue({ data: zeroData });
-
+    mockGet.mockResolvedValue({ data: partialData });
     renderCMO();
-
     await waitFor(() => {
-      expect(
-        screen.getByText("Customer Acquisition Cost"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Agents")).toBeInTheDocument();
     });
-
-    // No crash, still renders structural sections
-    expect(screen.getByText("Website Traffic")).toBeInTheDocument();
-    expect(screen.getByText("Top Content Pages")).toBeInTheDocument();
-    expect(screen.getByText("Brand Sentiment Score")).toBeInTheDocument();
+    expect(screen.getByText("0.0%")).toBeInTheDocument();
   });
-
-  // ── API Call Correctness ───────────────────────────────────────────────
 
   it("calls /kpis/cmo endpoint on mount", async () => {
     mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
-
     renderCMO();
-
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith("/kpis/cmo");
     });

--- a/ui/src/pages/CFODashboard.tsx
+++ b/ui/src/pages/CFODashboard.tsx
@@ -97,32 +97,37 @@ export default function CFODashboard() {
   }
 
   const domainBreakdown = data.domain_breakdown ?? [];
-  const isEmpty = data.agent_count === 0 && data.total_tasks_30d === 0;
+  const agentCount = data.agent_count ?? 0;
+  const totalTasks = data.total_tasks_30d ?? 0;
+  const successRate = data.success_rate ?? 0;
+  const hitl = data.hitl_interventions ?? 0;
+  const totalCost = data.total_cost_usd ?? 0;
+  const isEmpty = agentCount === 0 && totalTasks === 0;
 
   const topMetrics = [
     {
       label: t("kpi.agents", "Agents"),
-      value: data.agent_count.toLocaleString(),
+      value: agentCount.toLocaleString(),
       color: "text-blue-600",
     },
     {
       label: t("kpi.totalTasks", "Total Tasks (30d)"),
-      value: data.total_tasks_30d.toLocaleString(),
+      value: totalTasks.toLocaleString(),
       color: "text-indigo-600",
     },
     {
       label: t("kpi.successRate", "Success Rate"),
-      value: `${data.success_rate.toFixed(1)}%`,
+      value: `${successRate.toFixed(1)}%`,
       color: "text-emerald-600",
     },
     {
       label: t("kpi.hitlInterventions", "HITL Interventions"),
-      value: data.hitl_interventions.toLocaleString(),
+      value: hitl.toLocaleString(),
       color: "text-orange-600",
     },
     {
       label: t("kpi.totalCost", "Total Cost (USD)"),
-      value: USD.format(data.total_cost_usd),
+      value: USD.format(totalCost),
       color: "text-purple-600",
     },
   ];

--- a/ui/src/pages/CMODashboard.tsx
+++ b/ui/src/pages/CMODashboard.tsx
@@ -116,11 +116,11 @@ export default function CMODashboard() {
   const displayDomains = marketingDomains.length > 0 ? marketingDomains : domains;
 
   const kpiCards = [
-    { label: t("kpi.agents", "Agents"), value: formatNumber(data.agent_count), color: "text-blue-600" },
-    { label: t("kpi.totalTasks", "Total Tasks (30d)"), value: formatNumber(data.total_tasks_30d), color: "text-emerald-600" },
+    { label: t("kpi.agents", "Agents"), value: formatNumber(data.agent_count ?? 0), color: "text-blue-600" },
+    { label: t("kpi.totalTasks", "Total Tasks (30d)"), value: formatNumber(data.total_tasks_30d ?? 0), color: "text-emerald-600" },
     { label: t("kpi.successRate", "Success Rate"), value: `${(data.success_rate ?? 0).toFixed(1)}%`, color: "text-purple-600" },
-    { label: t("kpi.hitlInterventions", "HITL Interventions"), value: formatNumber(data.hitl_interventions), color: "text-orange-600" },
-    { label: t("kpi.totalCost", "Total Cost (USD)"), value: USD.format(data.total_cost_usd), color: "text-rose-600" },
+    { label: t("kpi.hitlInterventions", "HITL Interventions"), value: formatNumber(data.hitl_interventions ?? 0), color: "text-orange-600" },
+    { label: t("kpi.totalCost", "Total Cost (USD)"), value: USD.format(data.total_cost_usd ?? 0), color: "text-rose-600" },
   ];
 
   return (


### PR DESCRIPTION
## Summary
Addresses all 6 findings from the enterprise code review (`docs/CODE_REVIEW_SUMMARY_2026-04-14.md`).

| # | Finding | Fix |
|---|---|---|
| F1 | Connector test reads legacy `auth_config` not encrypted creds | Test endpoint now reads from `connector_configs.credentials_encrypted` first |
| F3 | E2E/Playwright failures don't block deploy | Removed `continue-on-error` from E2E and Playwright jobs; removed kubectl describe/logs exposure |
| F4 | `/auth/me` hardcodes `onboarding_complete: True` | Now reads from `tenant.settings` like `/login` and `/signup` |
| F5 | Login throttling is process-local in-memory dict | Moved to Redis with atomic TTL keys; in-memory fallback preserved |
| F6 | CFO/CMO tests mock stale rich payload, crash on null fields | Tests rewritten for current basic metrics contract; null-safe field access |

**F2 (Alembic as sole DDL path)** is a multi-day structural change tracked in P0 roadmap — not included here.

## Test plan
- [x] CFO/CMO dashboard tests pass (22/22)
- [x] TypeScript build clean
- [x] ruff check clean
- [ ] CI pipeline validates all changes
- [ ] Verify connector test reads encrypted creds on production
- [ ] Verify `/auth/me` returns correct `onboarding_complete` from tenant settings
- [ ] Verify login throttling works across pod restart