### PR TITLE
fix: 6 bugs from Bug Report v2 (Apr 14)

### DIFF
--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -1195,8 +1195,28 @@ async def run_agent(
             connector_config=agent_config.get("config"),
         )
     except Exception as exc:
-        logger.error("agent_run_error", agent_id=str(agent_id), error=str(exc))
-        raise HTTPException(500, "Agent execution failed. Check server logs for details.") from None
+        # Surface enough information for the caller to act on without
+        # leaking secrets from the exception message. The full traceback
+        # stays server-side, correlated by trace_id.
+        trace_id = _uuid.uuid4().hex[:12]
+        logger.exception(
+            "agent_run_error",
+            agent_id=str(agent_id),
+            trace_id=trace_id,
+            error_type=type(exc).__name__,
+        )
+        # Classify to a short, safe hint.
+        err_type = type(exc).__name__
+        hint = {
+            "TimeoutError": "upstream LLM or tool timed out",
+            "PermissionError": "agent lacks permission for a required tool",
+            "ValueError": "invalid task input",
+            "KeyError": "missing required configuration",
+        }.get(err_type, "internal agent runtime error")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Agent execution failed: {hint} ({err_type}). trace_id={trace_id}",
+        ) from None
 
     task_status = lg_result.get("status", "completed")
     task_confidence = lg_result.get("confidence", 0.0)

--- a/api/v1/companies.py
+++ b/api/v1/companies.py
@@ -103,7 +103,10 @@ class CompanyOnboard(BaseModel):
     pan: str = Field(..., max_length=10)
     tan: str | None = Field(None, max_length=10)
     cin: str | None = Field(None, max_length=21)
-    state_code: str | None = Field(None, max_length=50)
+    # Must match the companies.state_code VARCHAR(2) column; accepting a
+    # longer string here silently passed a full state name to the DB and
+    # failed the insert at the column-length boundary.
+    state_code: str | None = Field(None, max_length=2)
     industry: str | None = Field(None, max_length=100)
     registered_address: str | None = None
     signatory_name: str | None = Field(None, max_length=255)

--- a/scripts/gen_bug_fix_summary_v2.py
+++ b/scripts/gen_bug_fix_summary_v2.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Generate the bug-fix summary XLSX for AgenticOrg_Bug_Report_v2.xlsx."""
+
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Font, PatternFill
+
+OUT = r"C:\Users\mishr\Downloads\AgenticOrg_Bug_Fix_Summary_v2.xlsx"
+
+wb = Workbook()
+ws = wb.active
+ws.title = "Bug Fix Summary"
+
+headers = [
+    "Bug ID", "Severity", "Title", "Original Location",
+    "Root Cause", "Fix", "Files Changed", "Verification", "Status",
+]
+ws.append(headers)
+for cell in ws[1]:
+    cell.font = Font(bold=True, color="FFFFFF")
+    cell.fill = PatternFill(start_color="1F4E78", end_color="1F4E78", fill_type="solid")
+    cell.alignment = Alignment(vertical="center", horizontal="left")
+
+rows = [
+    (
+        "BUG-005", "Critical",
+        "Onboard Wizard 500 Error: State Name Too Long",
+        "/dashboard/companies/new (Step 6)",
+        "UI <select> used the full state name as its value; CompanyOnboard "
+        "schema allowed 50 chars but the companies.state_code column is "
+        "VARCHAR(2). The full name reached the DB and failed the insert.",
+        "Added ui/src/lib/indianStates.ts with code+name pairs. Select now "
+        "uses the 2-char code as its value and displays the name. "
+        "CompanyOnboard.state_code tightened to max_length=2 so a future "
+        "regression fails at the API boundary, not the DB.",
+        "ui/src/lib/indianStates.ts (new), ui/src/pages/CompanyOnboard.tsx, "
+        "api/v1/companies.py",
+        "tsc clean; 74/74 UI tests pass; vite build OK; ruff clean.",
+        "Fixed",
+    ),
+    (
+        "BUG-002", "High",
+        "Run/Reject Button Uses window.prompt()",
+        "/dashboard/agents/:id (Run Agent); also class applies to "
+        "Approvals reject flow which was already replaced with a modal.",
+        "window.prompt() and alert() are blocked in embedded browsers and "
+        "some desktop shells; they also cannot be styled or "
+        "accessibility-tested.",
+        "Replaced window.prompt in AgentDetail Run flow with an in-app "
+        "modal (runDialog) matching the existing rejectDialog pattern in "
+        "CompanyDetail. alert() replaced with an inline success banner.",
+        "ui/src/pages/AgentDetail.tsx",
+        "tsc clean; UI build OK.",
+        "Fixed",
+    ),
+    (
+        "BUG-003", "Medium",
+        "Chat Agent Returns Raw JSON",
+        "Chat panel",
+        "Some LangGraph agents returned a JSON-shaped string in the answer "
+        "field (e.g. a JSON object with answer and signature keys). The "
+        "backend _format_agent_output could not fully unwrap every path.",
+        "Added a defensive extractReadableText() in ChatPanel.tsx that "
+        "recognises JSON-shaped strings and pulls the first readable key "
+        "(answer/response/message/summary/result) before rendering. "
+        "Non-JSON strings pass through unchanged.",
+        "ui/src/components/ChatPanel.tsx",
+        "tsc clean; 74/74 UI tests pass; build OK.",
+        "Fixed",
+    ),
+    (
+        "BUG-001", "Low",
+        "State Displays as Code",
+        "/dashboard/companies/:id (Overview tab)",
+        "Company detail rendered company.state_code directly (e.g. MH) "
+        "instead of mapping back to the state name.",
+        "Company Overview now uses stateNameFromCode() from the new "
+        "ui/src/lib/indianStates.ts so MH displays as Maharashtra. Falls "
+        "back to the raw code if mapping is missing.",
+        "ui/src/pages/CompanyDetail.tsx, ui/src/lib/indianStates.ts",
+        "tsc clean; UI build OK.",
+        "Fixed",
+    ),
+    (
+        "BUG-006", "Low",
+        "Header Search Enter Misnavigation",
+        "Header search (NLQueryBar)",
+        "detectNavigationIntent had an aggressive keyword router: any "
+        "query containing finance/invoice/hr/etc. was redirected to the "
+        "matching CxO dashboard, swallowing the user query.",
+        "Dropped the keyword router. Explicit patterns (go to finance "
+        "dashboard, open hr dashboard) are kept. A free-form question "
+        "that merely mentions a finance keyword now falls through to "
+        "the chat endpoint as expected.",
+        "ui/src/components/NLQueryBar.tsx",
+        "tsc clean; 15/15 NLQueryBar tests pass; 74/74 UI overall.",
+        "Fixed",
+    ),
+    (
+        "BUG-007", "High",
+        "Agent Execution Failed Error in Shadow Testing",
+        "POST /agents/:id/run (backend)",
+        "api/v1/agents.py raised a single generic HTTPException(500) with "
+        "'Agent execution failed. Check server logs for details.' for "
+        "every failure mode. Users could not distinguish a timeout from "
+        "a misconfigured tool.",
+        "Classified exception types into short safe hints (timeout, "
+        "permission, invalid input, missing config, internal). Added a "
+        "trace_id correlator so ops can join UI errors to structured "
+        "server logs. logger.exception preserves the full traceback "
+        "server-side; nothing sensitive leaks to the caller.",
+        "api/v1/agents.py",
+        "ruff clean; backend unit tests 170/170 pass.",
+        "Fixed",
+    ),
+]
+for r in rows:
+    ws.append(r)
+
+widths = [10, 10, 48, 42, 60, 70, 55, 45, 10]
+for i, w in enumerate(widths, start=1):
+    ws.column_dimensions[chr(64 + i)].width = w
+
+for row in ws.iter_rows(min_row=2):
+    for cell in row:
+        cell.alignment = Alignment(wrap_text=True, vertical="top")
+
+ws2 = wb.create_sheet("Summary")
+ws2["A1"] = "AgenticOrg Bug Report v2 — Fix Summary"
+ws2["A1"].font = Font(bold=True, size=14)
+pairs = [
+    ("Date", "2026-04-14"),
+    ("Branch", "fix/bug-report-v2-apr14"),
+    ("Total Bugs", 6),
+    ("Fixed", 6),
+    ("Remaining", 0),
+    ("", ""),
+    ("By Severity", ""),
+    ("Critical", 1),
+    ("High", 2),
+    ("Medium", 1),
+    ("Low", 2),
+    ("", ""),
+    ("Verification", ""),
+    ("Backend unit tests", "170/170 pass"),
+    ("UI tests", "74/74 pass"),
+    ("UI build", "OK (tsc clean, vite build success)"),
+    ("Backend lint", "ruff clean"),
+]
+for i, (k, v) in enumerate(pairs, start=3):
+    ws2.cell(row=i, column=1, value=k)
+    ws2.cell(row=i, column=2, value=v)
+    if k in ("By Severity", "Verification"):
+        ws2.cell(row=i, column=1).font = Font(bold=True)
+
+ws2.column_dimensions["A"].width = 32
+ws2.column_dimensions["B"].width = 42
+
+wb.save(OUT)
+print("Saved:", OUT)

--- a/ui/src/components/ChatPanel.tsx
+++ b/ui/src/components/ChatPanel.tsx
@@ -18,6 +18,31 @@ interface ChatQueryResponse {
   domain: string;
 }
 
+// Some LangGraph agents return a JSON-shaped answer (e.g.
+// `{"answer":"...", "signature":"abc..."}`) as a raw string. The
+// backend tries to unwrap this but a few paths still slip through.
+// Unwrap defensively before rendering so users never see raw JSON.
+const READABLE_KEYS = ["answer", "response", "message", "summary", "result"] as const;
+
+function extractReadableText(raw: unknown): string {
+  if (typeof raw !== "string") return String(raw ?? "");
+  const trimmed = raw.trim();
+  if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return raw;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      for (const key of READABLE_KEYS) {
+        const v = (parsed as Record<string, unknown>)[key];
+        if (typeof v === "string" && v.trim()) return v;
+      }
+    }
+    // Structured data without a readable key — fall back to the original.
+    return raw;
+  } catch {
+    return raw;
+  }
+}
+
 export default function ChatPanel({
   open,
   onClose,
@@ -96,7 +121,7 @@ export default function ChatPanel({
       const agentMsg: Message = {
         id: crypto.randomUUID(),
         role: "agent",
-        text: res.data.answer,
+        text: extractReadableText(res.data.answer),
         agent: res.data.agent,
         confidence: res.data.confidence,
         domain: res.data.domain,

--- a/ui/src/components/NLQueryBar.tsx
+++ b/ui/src/components/NLQueryBar.tsx
@@ -55,17 +55,22 @@ function detectNavigationIntent(text: string): NavIntent | null {
     return { path: "/dashboard/settings" };
   }
 
-  // Domain-specific queries → route to CxO dashboards (TC-002)
-  const domainRoutes: [RegExp, string][] = [
-    [/\b(?:finance|invoice|payment|cash|revenue|p&l|gst|tax|reconcil|budget|expense|billing)\b/i, "/dashboard/cfo"],
-    [/\b(?:employee|hr|payroll|leave|attendance|hiring|recruit|onboard|offboard|talent|performance)\b/i, "/dashboard/chro"],
-    [/\b(?:marketing|campaign|lead|seo|content|social|brand|crm|email\s*market|abm)\b/i, "/dashboard/cmo"],
-    [/\b(?:operations|support|ticket|vendor|compliance|incident|sla|procurement)\b/i, "/dashboard/coo"],
-  ];
-  for (const [pattern, path] of domainRoutes) {
-    if (pattern.test(q)) {
-      return { path };
-    }
+  // Explicit CxO dashboard navigation only (e.g. "go to finance dashboard",
+  // "open hr dashboard"). A free-form query that happens to contain a
+  // finance keyword must fall through to chat — redirecting on any mention
+  // of "invoice" or "employee" ate the user's question.
+  const cxoMatch = q.match(
+    /^(?:show\s+(?:me\s+)?|go\s+to\s+|open\s+)(?:the\s+)?(finance|cfo|hr|chro|marketing|cmo|operations|coo)\s*dashboard$/,
+  );
+  if (cxoMatch) {
+    const role = cxoMatch[1];
+    const roleToPath: Record<string, string> = {
+      finance: "/dashboard/cfo", cfo: "/dashboard/cfo",
+      hr: "/dashboard/chro", chro: "/dashboard/chro",
+      marketing: "/dashboard/cmo", cmo: "/dashboard/cmo",
+      operations: "/dashboard/coo", coo: "/dashboard/coo",
+    };
+    return { path: roleToPath[role] };
   }
 
   return null;

--- a/ui/src/lib/indianStates.ts
+++ b/ui/src/lib/indianStates.ts
@@ -1,0 +1,60 @@
+// Indian state codes (2-char) and display names.
+// Backend `companies.state_code` column is VARCHAR(2); the UI must send the
+// code and render the name.
+
+export interface IndianState {
+  code: string;
+  name: string;
+}
+
+export const INDIAN_STATES: readonly IndianState[] = [
+  { code: "AN", name: "Andaman & Nicobar" },
+  { code: "AP", name: "Andhra Pradesh" },
+  { code: "AR", name: "Arunachal Pradesh" },
+  { code: "AS", name: "Assam" },
+  { code: "BR", name: "Bihar" },
+  { code: "CG", name: "Chhattisgarh" },
+  { code: "CH", name: "Chandigarh" },
+  { code: "DL", name: "Delhi" },
+  { code: "GA", name: "Goa" },
+  { code: "GJ", name: "Gujarat" },
+  { code: "HP", name: "Himachal Pradesh" },
+  { code: "HR", name: "Haryana" },
+  { code: "JH", name: "Jharkhand" },
+  { code: "JK", name: "Jammu & Kashmir" },
+  { code: "KA", name: "Karnataka" },
+  { code: "KL", name: "Kerala" },
+  { code: "LA", name: "Ladakh" },
+  { code: "LD", name: "Lakshadweep" },
+  { code: "MH", name: "Maharashtra" },
+  { code: "ML", name: "Meghalaya" },
+  { code: "MN", name: "Manipur" },
+  { code: "MP", name: "Madhya Pradesh" },
+  { code: "MZ", name: "Mizoram" },
+  { code: "NL", name: "Nagaland" },
+  { code: "OD", name: "Odisha" },
+  { code: "PB", name: "Punjab" },
+  { code: "PY", name: "Puducherry" },
+  { code: "RJ", name: "Rajasthan" },
+  { code: "SK", name: "Sikkim" },
+  { code: "TG", name: "Telangana" },
+  { code: "TN", name: "Tamil Nadu" },
+  { code: "TR", name: "Tripura" },
+  { code: "UK", name: "Uttarakhand" },
+  { code: "UP", name: "Uttar Pradesh" },
+  { code: "WB", name: "West Bengal" },
+] as const;
+
+const BY_CODE: Readonly<Record<string, string>> = Object.freeze(
+  INDIAN_STATES.reduce<Record<string, string>>((acc, s) => {
+    acc[s.code] = s.name;
+    return acc;
+  }, {}),
+);
+
+/** Resolve a 2-char state code to its display name, falling back to the code. */
+export function stateNameFromCode(code: string | null | undefined): string {
+  if (!code) return "";
+  const upper = code.toUpperCase();
+  return BY_CODE[upper] ?? code;
+}

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -40,6 +40,12 @@ export default function AgentDetail() {
 
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [actionNotice, setActionNotice] = useState<string | null>(null);
+
+  // Run-task dialog (replaces window.prompt, which is blocked in
+  // embedded browsers and some desktop shells).
+  const [runDialogOpen, setRunDialogOpen] = useState(false);
+  const [runTask, setRunTask] = useState("");
 
   async function handlePromote() {
     setActionLoading("promote");
@@ -98,24 +104,27 @@ export default function AgentDetail() {
     }
   }
 
-  async function handleRun() {
-    // BUG-08: Show input prompt before running — the API requires an
-    // action + inputs body. Running without it always 422'd.
-    const task = window.prompt(
-      `What should ${agent?.employee_name || agent?.name || "the agent"} do?\n\n` +
-      "Describe the task (e.g., 'Process today's invoices', 'Generate sales report'):"
-    );
-    if (!task) return; // user cancelled
+  function openRunDialog() {
+    setRunTask("");
+    setActionError(null);
+    setActionNotice(null);
+    setRunDialogOpen(true);
+  }
 
+  async function submitRun() {
+    const task = runTask.trim();
+    if (!task) return;
+
+    setRunDialogOpen(false);
     setActionLoading("run");
     setActionError(null);
+    setActionNotice(null);
     try {
       await api.post(`/agents/${id}/run`, {
         action: "run",
         inputs: { task },
       });
-      setActionError(null);
-      alert("Agent run started successfully.");
+      setActionNotice("Agent run started successfully.");
     } catch (err: any) {
       setActionError(err.response?.data?.detail || "Run failed");
     } finally {
@@ -213,7 +222,7 @@ export default function AgentDetail() {
             <Button
               variant="default"
               size="sm"
-              onClick={handleRun}
+              onClick={openRunDialog}
               disabled={actionLoading !== null}
             >
               {actionLoading === "run" ? "Running..." : "Run Agent"}
@@ -227,6 +236,7 @@ export default function AgentDetail() {
             </Button>
           </div>
           {actionError && <p className="text-xs text-destructive">{actionError}</p>}
+          {actionNotice && <p className="text-xs text-emerald-600">{actionNotice}</p>}
         </div>
       </div>
 
@@ -270,6 +280,40 @@ export default function AgentDetail() {
           />
         )}
       </Suspense>
+
+      {runDialogOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
+            <h3 className="text-lg font-semibold mb-1">
+              Run {agent?.employee_name || agent?.name || "agent"}
+            </h3>
+            <p className="text-sm text-muted-foreground mb-3">
+              Describe the task (e.g., &ldquo;Process today&apos;s invoices&rdquo;,
+              &ldquo;Generate sales report&rdquo;).
+            </p>
+            <textarea
+              value={runTask}
+              onChange={(e) => setRunTask(e.target.value)}
+              placeholder="What should the agent do?"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm min-h-[100px] focus:outline-none focus:ring-1 focus:ring-primary"
+              autoFocus
+            />
+            <div className="flex justify-end gap-2 mt-4">
+              <Button variant="outline" size="sm" onClick={() => setRunDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button
+                variant="default"
+                size="sm"
+                onClick={() => void submitRun()}
+                disabled={!runTask.trim()}
+              >
+                Run
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/pages/CompanyDetail.tsx
+++ b/ui/src/pages/CompanyDetail.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import api, { extractApiError } from "@/lib/api";
+import { stateNameFromCode } from "@/lib/indianStates";
 
 interface CompanyInfo {
   id: string;
@@ -731,7 +732,7 @@ export default function CompanyDetail() {
                   <div><span className="text-muted-foreground">PAN:</span> <span className="font-mono">{company.pan || "-"}</span></div>
                   <div><span className="text-muted-foreground">TAN:</span> <span className="font-mono">{company.tan || "-"}</span></div>
                   <div><span className="text-muted-foreground">CIN:</span> <span className="font-mono">{company.cin || "-"}</span></div>
-                  <div><span className="text-muted-foreground">State:</span> {company.state_code || "-"}</div>
+                  <div><span className="text-muted-foreground">State:</span> {stateNameFromCode(company.state_code) || "-"}</div>
                   <div className="col-span-2"><span className="text-muted-foreground">Address:</span> {company.registered_address || "-"}</div>
                   <div><span className="text-muted-foreground">Signatory:</span> {company.signatory_name || "-"}</div>
                   <div><span className="text-muted-foreground">Compliance Email:</span> {company.compliance_email || "-"}</div>

--- a/ui/src/pages/CompanyOnboard.tsx
+++ b/ui/src/pages/CompanyOnboard.tsx
@@ -5,6 +5,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import api from "@/lib/api";
+import { INDIAN_STATES, stateNameFromCode } from "@/lib/indianStates";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -63,16 +64,6 @@ const STEPS = [
   "Banking",
   "Tally Connection",
   "Review & Confirm",
-];
-
-const INDIAN_STATES = [
-  "Andhra Pradesh", "Arunachal Pradesh", "Assam", "Bihar", "Chhattisgarh",
-  "Goa", "Gujarat", "Haryana", "Himachal Pradesh", "Jharkhand",
-  "Karnataka", "Kerala", "Madhya Pradesh", "Maharashtra", "Manipur",
-  "Meghalaya", "Mizoram", "Nagaland", "Odisha", "Punjab",
-  "Rajasthan", "Sikkim", "Tamil Nadu", "Telangana", "Tripura",
-  "Uttar Pradesh", "Uttarakhand", "West Bengal", "Delhi", "Jammu & Kashmir",
-  "Ladakh", "Chandigarh", "Puducherry", "Lakshadweep", "Andaman & Nicobar",
 ];
 
 const INDUSTRIES = [
@@ -331,7 +322,7 @@ export default function CompanyOnboard() {
                 <label className={labelClass}>State <span className="text-red-500">*</span></label>
                 <select value={form.state} onChange={(e) => update("state", e.target.value)} className={fieldClass("state")}>
                   <option value="">Select state</option>
-                  {INDIAN_STATES.map((s) => <option key={s} value={s}>{s}</option>)}
+                  {INDIAN_STATES.map((s) => <option key={s.code} value={s.code}>{s.name}</option>)}
                 </select>
                 {errors.state && <p className="text-xs text-red-500 mt-1">{errors.state}</p>}
               </div>
@@ -513,7 +504,7 @@ export default function CompanyOnboard() {
                   <div><span className="text-muted-foreground">GSTIN:</span> <span className="font-mono">{form.gstin || "—"}</span></div>
                   <div><span className="text-muted-foreground">PAN:</span> <span className="font-mono">{form.pan || "—"}</span></div>
                   <div><span className="text-muted-foreground">TAN:</span> <span className="font-mono">{form.tan || "—"}</span></div>
-                  <div><span className="text-muted-foreground">State:</span> {form.state || "—"}</div>
+                  <div><span className="text-muted-foreground">State:</span> {stateNameFromCode(form.state) || "—"}</div>
                   <div><span className="text-muted-foreground">Industry:</span> {form.industry || "—"}</div>
                   <div className="sm:col-span-2"><span className="text-muted-foreground">Address:</span> {form.address || "—"}</div>
                 </div>


### PR DESCRIPTION
## Summary

Addresses all 6 bugs in `AgenticOrg_Bug_Report_v2.xlsx`. Summary XLSX written to `C:\Users\mishr\Downloads\AgenticOrg_Bug_Fix_Summary_v2.xlsx`.

| ID | Sev | Bug | Fix |
|---|---|---|---|
| BUG-005 | Critical | Onboard wizard 500 on state | UI select now submits 2-char code; new `indianStates.ts` lib; `CompanyOnboard` schema tightened to `max_length=2` |
| BUG-007 | High | Generic "Agent execution failed" | Classified exception types into safe hints + `trace_id` correlator; full traceback stays server-side |
| BUG-002 | High | `window.prompt()` in Run Agent | Replaced with in-app modal matching the existing `rejectDialog` pattern; `alert()` replaced with inline banner |
| BUG-003 | Medium | Chat shows raw JSON | Defensive `extractReadableText()` in `ChatPanel` parses JSON-shaped answers and extracts the first readable key |
| BUG-001 | Low | Company Overview state as code | `stateNameFromCode()` maps `MH` → `Maharashtra` |
| BUG-006 | Low | Header search Enter redirects to dashboard | Dropped keyword-based domain router; kept explicit `"go to X dashboard"` patterns |

## Enterprise notes

- BUG-005 fixed at **both** layers: UI sends the right value, backend schema rejects a wrong value before the DB does. Defense in depth.
- BUG-007 does not leak exception messages to the caller — only exception class + short safe hint + correlator. Full traceback logged via `logger.exception` server-side.
- No schema changes (no migration required). `state_code` column is already VARCHAR(2).

## Test plan

- [x] `ruff check api auth core connectors workflows` — clean
- [x] `pytest tests/unit/test_auth_and_core.py tests/unit/test_v490_reqs.py --no-cov` → 170/170
- [x] `cd ui && npx tsc --noEmit` — clean
- [x] `cd ui && npm test` → 74/74 passed
- [x] `cd ui && npm run build` — OK
- [ ] Manual: run onboarding wizard end-to-end with "Maharashtra" → expect success
- [ ] Manual: Run Agent from `/dashboard/agents/:id` in embedded Electron shell → expect modal, not `prompt()` error
- [ ] Manual: header search "what are my finance invoices" → expect chat answer, NOT redirect to CFO dashboard