### PR TITLE
fix(deploy): tolerate kubectl rollout-status race on GKE Autopilot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -409,16 +409,41 @@ jobs:
             echo "::endgroup::"
           }
 
+          # Re-check actual deployment readiness after a rollout-status
+          # timeout. GKE Autopilot occasionally reports the watch as timed
+          # out even when the deployment has reconciled to all-new + ready.
+          deployment_is_fully_rolled() {
+            local deployment_name="$1"
+            local desired updated available
+            desired=$(kubectl get deployment "${deployment_name}" -n agenticorg \
+              -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "0")
+            updated=$(kubectl get deployment "${deployment_name}" -n agenticorg \
+              -o jsonpath='{.status.updatedReplicas}' 2>/dev/null || echo "0")
+            available=$(kubectl get deployment "${deployment_name}" -n agenticorg \
+              -o jsonpath='{.status.availableReplicas}' 2>/dev/null || echo "0")
+            [ "$desired" = "$updated" ] && [ "$desired" = "$available" ] && [ "$desired" != "0" ]
+          }
+
           check_rollout() {
             local deployment_name="$1"
             local app_label="$2"
 
-            if ! kubectl rollout status deployment/"${deployment_name}" \
+            # 900s matches the deployment's progressDeadlineSeconds in helm.
+            if kubectl rollout status deployment/"${deployment_name}" \
               --namespace agenticorg \
-              --timeout=600s; then
-              dump_rollout_debug "${deployment_name}" "${app_label}"
-              exit 1
+              --timeout=900s; then
+              echo "${deployment_name} rollout reported success"
+              return 0
             fi
+
+            echo "::warning::${deployment_name} rollout status reported timeout — re-checking actual readiness"
+            if deployment_is_fully_rolled "${deployment_name}"; then
+              echo "${deployment_name} is in fact fully rolled (replicas == updated == available); accepting"
+              return 0
+            fi
+
+            dump_rollout_debug "${deployment_name}" "${app_label}"
+            exit 1
           }
 
           check_rollout agenticorg-api agenticorg-api


### PR DESCRIPTION
## Why

PR #105's main deploy reported `deploy-production` failure even though the deployment fully reconciled — `kubectl get deployment` showed `2/2 ready` immediately after the timeout, and `https://app.agenticorg.ai/api/v1/health` returned `{"status":"healthy"}` on the new image. This false negative cascaded: `e2e-tests` and `submit-indexing` were skipped because `deploy-production.result != 'success'`, even though prod was actually live and healthy.

## What

Two changes to the `Verify production rollout` step:

1. **Bump `--timeout` from 600s to 900s** so it matches the deployment's `progressDeadlineSeconds: 900` (in `helm/templates/deployment.yaml`). The watch should never give up before the controller does.
2. **After a watch timeout, re-check the deployment's actual readiness** via `spec.replicas == status.updatedReplicas == status.availableReplicas`. If it is fully rolled, accept the deploy. Only fail if the deployment is genuinely not at the new revision.

## Out of scope

The PR #105 deploy showed one new pod with 5 restarts during warmup before settling. That's a separate pod-startup quirk worth investigating but doesn't block this fix — the deployment did reach 2/2 ready, which is what `availableReplicas` reflects.

## Test plan

- [ ] Next push to main triggers `deploy-production`. The migrate step succeeds (already verified in the PR #105 deploy). The rollout-status step either reports success directly (fast path) or, on a slow Autopilot rolling update, the post-timeout re-check accepts the deploy and prints `<deployment> is in fact fully rolled`.
- [ ] `e2e-tests` and `submit-indexing` no longer skip on transient Autopilot timing.