### PR TITLE
fix(e2e): give e2e-tests a real DB and valid UUID tenant

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -202,6 +202,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    services:
+      # In-process TestClient paths in tests/e2e/ need a real DB+Redis so
+      # the handlers' DB queries return 200 with zeros instead of 500.
+      postgres:
+        image: "pgvector/pgvector:pg16"
+        env: { POSTGRES_DB: test, POSTGRES_USER: test, POSTGRES_PASSWORD: test }
+        ports: ["5432:5432"]
+      redis:
+        image: "redis:7-alpine"
+        ports: ["6379:6379"]
     steps:
       - uses: actions/checkout@v6
 
@@ -227,6 +237,8 @@ jobs:
         run: pytest tests/e2e/ -v
         env:
           AGENTICORG_E2E_BASE_URL: https://app.agenticorg.ai
+          AGENTICORG_DB_URL: postgresql+asyncpg://test:test@localhost:5432/test
+          AGENTICORG_REDIS_URL: redis://localhost:6379/0
           AGENTICORG_SECRET_KEY: ci-test-secret-key-minimum-16
 
       - name: Run Synthetic Agent Quality tests (non-blocking — tests LLM behavior)

--- a/tests/e2e/test_cxo_flows.py
+++ b/tests/e2e/test_cxo_flows.py
@@ -31,10 +31,56 @@ def app():
     return _app
 
 
+@pytest.fixture(scope="module")
+def _schema_ready():
+    """Initialise the test DB schema + seed a tenant row once per module.
+
+    The in-process TestClient's handlers reach the real DB
+    (see AGENTICORG_DB_URL in .github/workflows/deploy.yml). Without
+    this, queries via get_tenant_session/async_session_factory bubble
+    up as 500s."""
+    import asyncio
+
+    from sqlalchemy import text as _text
+
+    import core.models  # noqa: F401 — register every ORM model
+    from core.database import async_session_factory, engine
+    from core.models.base import BaseModel
+
+    async def _setup():
+        async with engine.begin() as conn:
+            await conn.run_sync(BaseModel.metadata.create_all)
+        # Tenant row for FK and /kpis/* queries.
+        async with async_session_factory() as session:
+            await session.execute(
+                _text(
+                    "INSERT INTO tenants (id, name, slug, plan, data_region, settings) "
+                    "VALUES (:id, :name, :slug, :plan, :region, '{}'::jsonb) "
+                    "ON CONFLICT (id) DO NOTHING"
+                ),
+                {
+                    "id": _SHARED_TENANT_ID,
+                    "name": "e2e-tenant",
+                    "slug": f"e2e-{_SHARED_TENANT_ID[:8]}",
+                    "plan": "enterprise",
+                    "region": "IN",
+                },
+            )
+            await session.commit()
+
+    asyncio.run(_setup())
+    return _SHARED_TENANT_ID
+
+
+# Module-scoped UUID — tenants.id is UUID, and get_tenant_session()
+# rejects anything that doesn't match the UUID format.
+_SHARED_TENANT_ID = str(uuid.uuid4())
+
+
 @pytest.fixture
-def client(app):
+def client(app, _schema_ready):
     """TestClient with auth middleware bypassed and admin scopes granted."""
-    test_tenant_id = f"e2e-tenant-{uuid.uuid4().hex[:8]}"
+    test_tenant_id = _schema_ready  # valid UUID from the schema fixture
 
     from api.deps import get_current_tenant
     app.dependency_overrides[get_current_tenant] = lambda: test_tenant_id
@@ -229,16 +275,28 @@ class TestCMOJourney:
         output = gen.generate(report_type="cmo_weekly", params={})
         assert isinstance(output, ReportOutput)
         assert output.report_type == "cmo_weekly"
-        assert "ROAS" in output.content_html or "roas" in output.content_html.lower()
+        # The report now uses the basic-metrics contract (same shape as
+        # /kpis/cmo) — agent_count, total_tasks_30d, success_rate, etc.
+        # ROAS / channel breakdown have been out of this report since the
+        # KPI unification; don't re-require them here.
+        assert "CMO Weekly Report" in output.content_html
+        for key in ("Agents", "Tasks (30d)", "Success Rate", "Domain Breakdown"):
+            assert key in output.content_html, f"CMO report missing section: {key}"
 
     def test_campaign_report_generation(self):
-        """Campaign performance report contains marketing metrics."""
+        """Campaign performance report returns the basic-metrics contract."""
         from core.reports.generator import ReportGenerator
         gen = ReportGenerator()
         output = gen.generate(report_type="campaign_report", params={})
         data = output.content_data
-        assert "roas_by_channel" in data
-        assert "social_engagement" in data
+        # Current campaign_report uses _fetch_cmo_kpis, i.e. the unified
+        # basic-metrics shape. The legacy roas_by_channel /
+        # social_engagement fields were removed when /kpis/cmo stopped
+        # fabricating dashboards from raw task_output.
+        required = ("agent_count", "total_tasks_30d", "success_rate",
+                    "hitl_interventions", "total_cost_usd", "domain_breakdown")
+        for key in required:
+            assert key in data, f"campaign_report missing: {key}"
 
     def test_email_marketing_agent_registered(self):
         """Email marketing agent is registered in the platform."""


### PR DESCRIPTION
## Why

PR #106 stopped `deploy-production` from silently skipping `e2e-tests`. With `e2e-tests` actually running, we now see the pre-existing breakage:

| Test | Status | Root cause |
|---|---|---|
| `test_cfo_kpis_return_valid_data` | 500 | No DB behind the in-process TestClient |
| `test_cfo_kpis_with_company_filter` | 500 | Same |
| `test_cmo_kpis_return_valid_data` | 500 | Same |
| `test_company_switcher_lists_companies` | 400 | `tenant_id = "e2e-tenant-abcd1234"` isn't a UUID → `get_tenant_session` raises → handler 500→400 downstream |
| `test_create_and_retrieve_company` | 400 | Same |
| `test_report_schedule_created_successfully` | 400 | Same |
| `test_cmo_weekly_report_generation` | fail | Asserts `ROAS` in HTML; current report doesn't emit it |
| `test_campaign_report_generation` | fail | Asserts `roas_by_channel` / `social_engagement`; current contract doesn't emit them |

## What

1. Add `postgres` + `redis` service containers to the `e2e-tests` job (mirroring `integration-tests`). Wire `AGENTICORG_DB_URL` and `AGENTICORG_REDIS_URL` into the pytest env so the in-process handlers can actually query a DB.
2. Rewrite the `client` fixture in `tests/e2e/test_cxo_flows.py`:
   - Module-scoped `_schema_ready` fixture runs `BaseModel.metadata.create_all` once and seeds a tenant row with a real `uuid.uuid4()`.
   - The `client` fixture consumes that same UUID as the `get_current_tenant` override so `get_tenant_session(tid)` passes its strict regex.
3. Re-align the two CMO report assertions at what the current generator actually emits (basic-metrics keys). The legacy `ROAS` / `roas_by_channel` / `social_engagement` fields were removed when `/kpis/cmo` stopped fabricating dashboards from raw `task_output`.

## Out of scope

- The CMO report contract question (should it emit ROAS again?) is a product/PRD decision, not a CI-green question. Out of scope for this PR.
- Synthetic agent quality tests (`tests/synthetic_data/`) remain `continue-on-error: true` because they test LLM behavior, not code.

## Test plan

- [x] `ruff check tests/e2e/test_cxo_flows.py` — clean
- [x] `python -m compile` — syntax OK
- [ ] main CI: `e2e-tests` reports success (not skipped, not failed)