### PR TITLE
fix(e2e): run init_db and reconfigure session factory in place

### DIFF
--- a/tests/e2e/test_cxo_flows.py
+++ b/tests/e2e/test_cxo_flows.py
@@ -51,20 +51,25 @@ def app():
 
 @pytest_asyncio.fixture(scope="module")
 async def _schema_ready() -> AsyncGenerator[str, None]:
-    """Swap core.database.engine for a NullPool engine, create tables
-    against the test DB, seed a tenant row.
+    """Point the module-level engine/factory at the test DB, run
+    init_db() to get every table (including the ones only defined in
+    raw SQL — kpi_cache, industry_pack_installs, etc.), and seed a
+    tenant row.
 
-    Running the setup on pytest_asyncio's module event loop means the
-    engine, all handler queries, and the httpx.AsyncClient share a
-    single loop — no cross-loop asyncpg reuse.
+    We reconfigure the existing async_session_factory in place rather
+    than reassigning the module attribute, so any module that did
+    ``from core.database import async_session_factory`` at import time
+    automatically follows us to the test engine. Without that, those
+    callers would keep using the original pooled engine, whose asyncpg
+    connections end up on a different loop from the test and raise
+    "Future attached to a different loop".
     """
     from sqlalchemy import text as _text
-    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from sqlalchemy.ext.asyncio import create_async_engine
     from sqlalchemy.pool import NullPool
 
     import core.database as _db_mod
     import core.models  # noqa: F401 — register every ORM model
-    from core.models.base import BaseModel
 
     db_url = os.getenv("AGENTICORG_DB_URL")
     if not db_url:
@@ -72,15 +77,27 @@ async def _schema_ready() -> AsyncGenerator[str, None]:
 
     test_engine = create_async_engine(db_url, echo=False, poolclass=NullPool)
     original_engine = _db_mod.engine
-    original_factory = _db_mod.async_session_factory
-    _db_mod.engine = test_engine
-    _db_mod.async_session_factory = async_sessionmaker(
-        test_engine, expire_on_commit=False
-    )
 
+    # Point core.database.engine at the test engine and reconfigure the
+    # sessionmaker in place so cached imports of async_session_factory
+    # start using the test engine too.
+    _db_mod.engine = test_engine
+    _db_mod.async_session_factory.configure(bind=test_engine)
+
+    # Run init_db() to produce the raw-SQL tables (kpi_cache,
+    # industry_pack_installs, approval_* , tenant_branding, etc.) on
+    # top of what ORM metadata.create_all would give us. init_db()
+    # short-circuits when AGENTICORG_DDL_MANAGED_BY_ALEMBIC is truthy,
+    # so clear it for this setup.
+    prior_flag = os.environ.pop("AGENTICORG_DDL_MANAGED_BY_ALEMBIC", None)
     try:
+        from core.models.base import BaseModel
+
         async with test_engine.begin() as conn:
             await conn.run_sync(BaseModel.metadata.create_all)
+        # init_db writes to tenants/companies/etc. and assumes they exist.
+        await _db_mod.init_db()
+        async with test_engine.begin() as conn:
             await conn.execute(
                 _text(
                     "INSERT INTO tenants (id, name, slug, plan, data_region, settings) "
@@ -98,15 +115,20 @@ async def _schema_ready() -> AsyncGenerator[str, None]:
     except Exception as exc:
         await test_engine.dispose()
         _db_mod.engine = original_engine
-        _db_mod.async_session_factory = original_factory
+        _db_mod.async_session_factory.configure(bind=original_engine)
+        if prior_flag is not None:
+            os.environ["AGENTICORG_DDL_MANAGED_BY_ALEMBIC"] = prior_flag
         pytest.skip(f"DB-backed E2E fixture unavailable: {exc}")
+    finally:
+        if prior_flag is not None:
+            os.environ["AGENTICORG_DDL_MANAGED_BY_ALEMBIC"] = prior_flag
 
     try:
         yield _SHARED_TENANT_ID
     finally:
         await test_engine.dispose()
         _db_mod.engine = original_engine
-        _db_mod.async_session_factory = original_factory
+        _db_mod.async_session_factory.configure(bind=original_engine)
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
## Why

Main CI after PR #120 gets 25/30 e2e tests passing (async conversion worked) but 5 still fail with two distinct errors:

1. `relation "kpi_cache" does not exist` / `relation "industry_pack_installs" does not exist`
2. `Future attached to a different loop` on `test_cfo_kpis_with_company_filter`

## Root cause

- `BaseModel.metadata.create_all` only creates ORM-modelled tables. `kpi_cache`, `industry_pack_installs`, and several others are defined only in `core.database.init_db()`'s raw SQL — they have no ORM model.
- Reassigning `_db_mod.async_session_factory = new_factory` doesn't reach modules that did `from core.database import async_session_factory` at import time. Those held a snapshot bound to the **original** pooled engine, whose asyncpg connections landed on a different loop from the test.

## What

- Temporarily clear `AGENTICORG_DDL_MANAGED_BY_ALEMBIC` and run `init_db()` in the fixture setup so the raw-SQL tables exist in the test DB too.
- Call `async_session_factory.configure(bind=test_engine)` instead of reassigning the module attribute. `configure()` mutates the existing sessionmaker object in place, so cached references (e.g. `from core.database import async_session_factory` in `core/kpi_cache.py`, `api/v1/auth.py`, `api/v1/api_keys.py`) now follow us to the test engine.
- Teardown restores the original engine and the prior value of the flag.

## Test plan

- [x] `ruff check tests/e2e/test_cxo_flows.py` — clean
- [x] `python -m compile` — syntax OK
- [ ] main CI: all `test_cxo_flows.py` tests pass