### PR TITLE
fix(lint): auto-fix import sorting on main

### DIFF
--- a/api/v1/cron.py
+++ b/api/v1/cron.py
@@ -10,6 +10,7 @@ import logging
 import os
 
 from fastapi import APIRouter, Header, HTTPException
+
 from core.config import settings
 
 router = APIRouter()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 
-
 _TEST_TMPDIR = Path.cwd() / "codex-pytest-temp"
 _TEST_TMPDIR.mkdir(parents=True, exist_ok=True)
 tempfile.tempdir = str(_TEST_TMPDIR)

--- a/tests/unit/test_report_engine.py
+++ b/tests/unit/test_report_engine.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-
 _ARTIFACT_DIR = Path.cwd() / "codex-pytest-artifacts"
 _ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Why

Main lint has been failing since PR #108 (respx bump) landed — `ruff check .` reports 3 `I001` import-sort errors on:

- `api/v1/cron.py`
- `tests/conftest.py`
- `tests/unit/test_report_engine.py`

The dependency merges (#108/#109/#110/#111/#112/#114/#115/#116/#117/#118/#119) each individually passed CI on their dependabot branches, but the combined merge ordering left these three files out of sort order.

## What

`ruff check . --fix`. 3-line import reorder, no behavior change.

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy --ignore-missing-imports .` — no new issues (547 source files)