### PR TITLE
fix(e2e): add ORM models for kpi_cache and industry_pack_installs

### DIFF
--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -29,7 +29,9 @@ from core.models.filing_approval import FilingApproval as FilingApproval
 from core.models.gstn_credential import GSTNCredential as GSTNCredential
 from core.models.gstn_upload import GSTNUpload as GSTNUpload
 from core.models.hitl import HITLQueue as HITLQueue
+from core.models.industry_pack_install import IndustryPackInstall as IndustryPackInstall
 from core.models.invoice import Invoice as Invoice
+from core.models.kpi_cache import KPICache as KPICache
 from core.models.lead_pipeline import EmailSequence as EmailSequence
 from core.models.lead_pipeline import LeadPipeline as LeadPipeline
 from core.models.organization import CostCenter as CostCenter

--- a/core/models/industry_pack_install.py
+++ b/core/models/industry_pack_install.py
@@ -1,0 +1,38 @@
+"""ORM model for industry_pack_installs.
+
+Mirror of the table created in ``core.database.init_db()``. Existed
+for a long time in raw SQL only; this model lets ``BaseModel.metadata
+.create_all`` produce the same schema for hermetic tests.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.models.base import BaseModel
+
+
+class IndustryPackInstall(BaseModel):
+    __tablename__ = "industry_pack_installs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False, index=True
+    )
+    pack_name: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    installed_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    agent_ids: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, default=list
+    )
+    workflow_ids: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, default=list
+    )

--- a/core/models/kpi_cache.py
+++ b/core/models/kpi_cache.py
@@ -1,0 +1,44 @@
+"""ORM model for kpi_cache.
+
+Mirror of the table created in ``core.database.init_db()``. Existed for
+a long time in raw SQL only; this model lets ``BaseModel.metadata
+.create_all`` produce the same schema for hermetic tests.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import TIMESTAMP, Boolean, ForeignKey, Integer, String, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.models.base import BaseModel
+
+
+class KPICache(BaseModel):
+    __tablename__ = "kpi_cache"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False, index=True
+    )
+    company_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("companies.id"), nullable=True
+    )
+    role: Mapped[str] = mapped_column(String(20), nullable=False)
+    metric_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    metric_value: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    source: Mapped[str] = mapped_column(String(50), nullable=False, default="agent")
+    computed_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    ttl_seconds: Mapped[int] = mapped_column(Integer, nullable=False, default=3600)
+    stale: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/migrations/versions/v4_8_1_orm_sync.py
+++ b/migrations/versions/v4_8_1_orm_sync.py
@@ -1,0 +1,34 @@
+"""v4.8.1 — ORM sync for pre-existing tables
+
+No-op migration. Documents that ``core.models.kpi_cache.KPICache`` and
+``core.models.industry_pack_install.IndustryPackInstall`` were added
+to mirror tables that have always existed in this repo via raw DDL:
+
+  - kpi_cache — created in v480_baseline (and originally in init_db())
+  - industry_pack_installs — created in v400_apex
+
+These ORM models let ``BaseModel.metadata.create_all`` produce the
+full schema for hermetic tests (tests/e2e/test_cxo_flows.py). No DDL
+changes are required in production — the tables are already there on
+every deployed environment.
+
+Revision ID: v481_orm_sync
+Revises: v480_baseline
+Create Date: 2026-04-14
+"""
+
+revision = "v481_orm_sync"
+down_revision = "v480_baseline"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # No DDL. The ORM models added in core/models/kpi_cache.py and
+    # core/models/industry_pack_install.py describe tables that
+    # already exist in every deployed environment.
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/tests/e2e/test_cxo_flows.py
+++ b/tests/e2e/test_cxo_flows.py
@@ -107,18 +107,6 @@ async def _schema_ready() -> AsyncGenerator[str, None]:
         _db_mod.async_session_factory.configure(bind=original_engine)
 
 
-# Tests that depend on tables only defined in raw SQL (kpi_cache,
-# industry_pack_installs, etc.) or that traverse the packs installer
-# code path. The hermetic fixture above only creates ORM-modelled
-# tables. Running init_db() inside the fixture to pick up the raw-SQL
-# tables caused a hang (see CI run 24408376921). Mark these as skip
-# until a dedicated follow-up either (a) adds ORM models for the
-# raw-SQL tables or (b) stands up an alembic-stamped test DB.
-_HANG_SKIP_REASON = (
-    "Requires raw-SQL tables (kpi_cache, industry_pack_installs) not "
-    "covered by BaseModel.metadata.create_all. Follow-up: add ORM "
-    "models or run alembic upgrade in the fixture."
-)
 
 
 @pytest_asyncio.fixture
@@ -155,7 +143,6 @@ async def client(app, _schema_ready) -> AsyncGenerator[AsyncClient, None]:
 class TestCFOJourney:
     """End-to-end CFO user flow."""
 
-    @pytest.mark.skip(reason=_HANG_SKIP_REASON)
     @pytest.mark.asyncio
     async def test_cfo_kpis_return_valid_data(self, client: AsyncClient):
         """CFO KPI dashboard returns all required metrics (basic metrics shape)."""
@@ -201,7 +188,6 @@ class TestCFOJourney:
         schedule_ids = [s["id"] for s in schedules]
         assert schedule["id"] in schedule_ids
 
-    @pytest.mark.skip(reason=_HANG_SKIP_REASON)
     @pytest.mark.asyncio
     async def test_company_switcher_lists_companies(self, client: AsyncClient):
         """Company switcher returns list after creating companies."""
@@ -231,7 +217,6 @@ class TestCFOJourney:
                     "get_balance_sheet", "get_cash_position"}
         assert expected == set(DEFAULT_TOOLS)
 
-    @pytest.mark.skip(reason=_HANG_SKIP_REASON)
     @pytest.mark.asyncio
     async def test_cfo_kpis_with_company_filter(self, client: AsyncClient):
         """CFO KPIs accept company_id parameter."""
@@ -240,7 +225,6 @@ class TestCFOJourney:
         data = resp.json()
         assert data["company_id"] == "test-company"
 
-    @pytest.mark.skip(reason=_HANG_SKIP_REASON)
     @pytest.mark.asyncio
     async def test_create_and_retrieve_company(self, client: AsyncClient):
         """Full company lifecycle: create -> retrieve -> verify fields."""
@@ -268,7 +252,6 @@ class TestCFOJourney:
 class TestCMOJourney:
     """End-to-end CMO user flow."""
 
-    @pytest.mark.skip(reason=_HANG_SKIP_REASON)
     @pytest.mark.asyncio
     async def test_cmo_kpis_return_valid_data(self, client: AsyncClient):
         """CMO KPI dashboard returns all required metrics (basic metrics shape)."""


### PR DESCRIPTION
## Why

PR #123 landed 5 `@pytest.mark.skip`s on `tests/e2e/test_cxo_flows.py` with a follow-up note: *add ORM models for kpi_cache and industry_pack_installs, or stand up an alembic-stamped test DB*. This is that follow-up.

Both tables already exist in every deployed environment:
- `industry_pack_installs` — `migrations/versions/v4_0_0_project_apex_tables.py`
- `kpi_cache` — `migrations/versions/v4_8_0_baseline.py`

They were missing only as **ORM models**, so `BaseModel.metadata.create_all()` in the hermetic e2e fixture never produced them, and the handler queries failed with `UndefinedTableError`.

## What

- `core/models/kpi_cache.py` — `KPICache` mirroring the existing DDL.
- `core/models/industry_pack_install.py` — `IndustryPackInstall` mirroring the existing DDL.
- Register both in `core/models/__init__.py`.
- `migrations/versions/v4_8_1_orm_sync.py` — no-op migration so the CI migration guard passes and the version chain stays linear (`v480_baseline → v481_orm_sync`).
- Remove the 5 `@pytest.mark.skip`s in `test_cxo_flows.py` now that `metadata.create_all` produces the missing tables.

## Not a schema change

No `ALTER TABLE`, no `CREATE TABLE`. Production DBs already have these tables. The migration is intentionally `pass` in both `upgrade()` and `downgrade()`.

## Test plan

- [x] `ruff check` — clean
- [x] `alembic history` — chain valid, head is `v481_orm_sync`
- [ ] main CI: all 30 tests in `test_cxo_flows.py` pass (no skips)