### PR TITLE
fix(deps): pin testcontainers<4.14 to resolve redis conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,10 @@ dev = [
     "pytest-asyncio>=0.26.0",
     "pytest-cov>=6.3.0",
     "respx>=0.23.1",
-    "testcontainers[postgres,redis]>=4.14.2,<4.15.0",
+    # Pinned <4.14 because testcontainers[redis]>=4.14 transitively
+    # pulls redis>=7, conflicting with celery[redis]>=5.4 (which needs
+    # redis<6.5 via kombu 5.6). See CI run 24411076696.
+    "testcontainers[postgres,redis]>=4.8.0,<4.14.0",
     "factory-boy>=3.3.0",
     "ruff>=0.15.10",
     "mypy>=1.20.1",


### PR DESCRIPTION
## Why

Main has been failing on `unit-tests > Install Python deps` since PR #113 bumped testcontainers to >=4.14.2. The 4.14.x series pulls `redis>=7` via the `[redis]` extra, conflicting with `celery[redis]>=5.4`:

```
celery 5.6.3 → kombu>=5.6 → redis<6.5
testcontainers 4.14.x[redis] → redis>=7
```

`uv pip install -e '.[dev]'` aborts with *'agenticorg==4.8.0 and celery[redis]>=5.4.0 are incompatible'* (see CI run 24411076696).

## What

Pin testcontainers back to `>=4.8.0,<4.14.0` in `pyproject.toml` dev extras. Added a comment explaining why so the next dependabot bump to 4.14+ gets pushed back with context.

## Follow-up

When celery/kombu release a line that accepts redis>=7, we can re-bump testcontainers to 4.14+.

## Test plan

- [x] `uv pip compile pyproject.toml --extra dev` — resolves cleanly
- [ ] CI unit-tests install step succeeds