### PR TITLE
fix(test): alembic e2e assertion reads dynamic head

### DIFF
--- a/tests/integration/test_alembic_e2e.py
+++ b/tests/integration/test_alembic_e2e.py
@@ -108,8 +108,21 @@ def _table_names() -> set[str]:
 
 
 def test_legacy_db_gets_stamped_at_baseline():
-    """A legacy-shaped DB (no alembic_version) must be stamped and
-    leave alembic_version = v480_baseline."""
+    """A legacy-shaped DB (no alembic_version) must be stamped at the
+    baseline and then upgraded to the current head.
+
+    The wrapper runs ``stamp v480_baseline`` followed by
+    ``upgrade head``, so the resulting version is whatever the Alembic
+    head is today, not necessarily the baseline. Read the expected
+    head dynamically so this test does not regress every time a new
+    migration file is added."""
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    cfg = Config("alembic.ini")
+    expected_head = ScriptDirectory.from_config(cfg).get_current_head()
+    assert expected_head, "Alembic has no head revision"
+
     _reset_schema()
     _build_legacy_schema()
     tables = _table_names()
@@ -123,7 +136,7 @@ def test_legacy_db_gets_stamped_at_baseline():
         version = conn.execute(
             text("SELECT version_num FROM alembic_version")
         ).scalar()
-    assert version == "v480_baseline"
+    assert version == expected_head
 
 
 def test_already_managed_db_is_noop():


### PR DESCRIPTION
## Why

`tests/integration/test_alembic_e2e.py::test_legacy_db_gets_stamped_at_baseline` hardcoded the expected version as `v480_baseline`. After PR #125 added `v481_orm_sync`, the wrapper correctly does:

```
stamp v480_baseline  →  upgrade head  →  alembic_version = v481_orm_sync
```

The assertion then fails with `'v481_orm_sync' == 'v480_baseline'` — see CI run 24411613885.

## What

Read the current head dynamically via `ScriptDirectory.from_config(cfg).get_current_head()` so the assertion tracks the version chain as it grows.

## Test plan

- [x] `ruff check tests/integration/test_alembic_e2e.py` — clean
- [ ] main CI: integration-tests pass