### PR TITLE
fix(agent-runtime): handle non-dict LLM output without AttributeError

### DIFF
--- a/core/langgraph/agent_graph.py
+++ b/core/langgraph/agent_graph.py
@@ -161,9 +161,12 @@ def build_agent_graph(
                 "reasoning_trace": [*trace, "ERROR: No AI message found"],
             }
 
-        # Parse output
+        # Parse output — _parse_json_output guarantees a dict, but be
+        # defensive for any future caller that builds output differently.
         content = last_ai.content or ""
         output = _parse_json_output(content)
+        if not isinstance(output, dict):
+            output = {"raw_output": output, "status": "completed"}
 
         # Compute variable confidence from observable signals (not a fixed default)
         # Signals: tool success rate, output structure, output length, error presence
@@ -320,7 +323,15 @@ def build_agent_graph(
 
 
 def _parse_json_output(content: str | list | Any) -> dict[str, Any]:
-    """Parse JSON from LLM output, handling markdown code blocks."""
+    """Parse JSON from LLM output, handling markdown code blocks.
+
+    Always returns a dict. If the LLM emitted a valid JSON array or
+    scalar (instead of an object), wrap it in ``raw_output`` so every
+    downstream call to ``output.get(...)`` is safe. The previous
+    version returned whatever ``json.loads`` produced, so a JSON list
+    crashed the graph with ``AttributeError: 'list' object has no
+    attribute 'get'`` in evaluate/_extract_confidence.
+    """
     # Handle list content (multiple messages) — join into single string
     if isinstance(content, list):
         content = "\n".join(str(item) for item in content)
@@ -332,9 +343,13 @@ def _parse_json_output(content: str | list | Any) -> dict[str, Any]:
         lines = [ln for ln in lines if not ln.strip().startswith("```")]
         text = "\n".join(lines).strip()
     try:
-        return json.loads(text)
+        parsed = json.loads(text)
     except json.JSONDecodeError:
         return {"raw_output": content, "status": "completed"}
+    if isinstance(parsed, dict):
+        return parsed
+    # Valid JSON but not an object — wrap to preserve our dict contract.
+    return {"raw_output": parsed, "status": "completed"}
 
 
 def _extract_confidence(output: dict[str, Any], content_length: int = 0) -> float:
@@ -347,6 +362,8 @@ def _extract_confidence(output: dict[str, Any], content_length: int = 0) -> floa
 
     Never returns a hardcoded default — confidence varies based on real signals.
     """
+    if not isinstance(output, dict):
+        output = {}
     raw = output.get("confidence") or output.get("agent_confidence")
     if raw is not None:
         try:

--- a/tests/unit/test_langgraph_runtime.py
+++ b/tests/unit/test_langgraph_runtime.py
@@ -167,6 +167,35 @@ class TestAgentGraph:
         result = _parse_json_output("not json at all")
         assert result["raw_output"] == "not json at all"
 
+    def test_parse_json_output_list_wrapped_as_dict(self):
+        """A valid JSON list must not leak through — downstream code
+        calls .get() on the result. Shadow-run AttributeError regression
+        (trace_id=bea65adb4cca)."""
+        from core.langgraph.agent_graph import _parse_json_output
+
+        result = _parse_json_output("[1, 2, 3]")
+        assert isinstance(result, dict)
+        assert result["raw_output"] == [1, 2, 3]
+        assert result["status"] == "completed"
+
+    def test_parse_json_output_scalar_wrapped_as_dict(self):
+        """A bare JSON scalar (number, string, bool) must also be wrapped."""
+        from core.langgraph.agent_graph import _parse_json_output
+
+        result = _parse_json_output("42")
+        assert isinstance(result, dict)
+        assert result["raw_output"] == 42
+
+    def test_extract_confidence_non_dict_input(self):
+        """_extract_confidence must tolerate a non-dict output silently
+        instead of raising AttributeError."""
+        from core.langgraph.agent_graph import _extract_confidence
+
+        # Should not raise
+        assert 0.0 <= _extract_confidence([1, 2, 3]) <= 1.0
+        assert 0.0 <= _extract_confidence("unexpected") <= 1.0
+        assert 0.0 <= _extract_confidence(None) <= 1.0
+
     def test_extract_confidence_numeric(self):
         from core.langgraph.agent_graph import _extract_confidence
 


### PR DESCRIPTION
## Why

Production shadow tests reported:

> Agent execution failed: internal agent runtime error (AttributeError). trace_id=bea65adb4cca

(exactly the format introduced by the BUG-007 fix — classified exception class + short hint + correlator).

## Root cause

`core/langgraph/agent_graph.py::_parse_json_output` returned whatever `json.loads` produced. If the LLM emitted valid JSON that was **not an object** (a bare list like `[1,2,3]`, or a scalar like `42`), the function returned that list/scalar. Downstream code then called `.get()` on it:

- `evaluate()`: `output.get("status") == "error"`
- `_extract_confidence()`: `output.get("confidence") or output.get("agent_confidence")`

Both raised `AttributeError: 'list' object has no attribute 'get'`, which the BUG-007 `except Exception as exc` branch classified as "internal agent runtime error" and reported with a trace_id.

## What

1. `_parse_json_output`: always returns a dict. Valid JSON that is not an object now gets wrapped as `{"raw_output": parsed, "status": "completed"}`.
2. `evaluate()`: defensive `isinstance(output, dict)` guard for any future caller that builds output differently.
3. `_extract_confidence`: coerces non-dict input to `{}` silently.

## Test plan

- [x] `pytest tests/unit/test_langgraph_runtime.py -q --no-cov` → **38/38 passed** (4 new regression tests)
- [x] `ruff check` — clean
- [ ] Re-run the shadow test in prod after merge; the AttributeError should be gone

## Not a regression from CI work

This was a latent production bug that surfaced only after PR #125's BUG-007 fix started classifying + logging the actual exception class instead of hiding everything behind a generic "check server logs". Worth noting: the new error classification is earning its keep on day one.