### PR TITLE
fix(e2e): un-skip 5 tests + pytest-timeout safety net

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ dev = [
     "pytest>=8.3.0",
     "pytest-asyncio>=0.26.0",
     "pytest-cov>=6.3.0",
+    "pytest-timeout>=2.3.0",
     "respx>=0.23.1",
     # Pinned <4.14 because testcontainers[redis]>=4.14 transitively
     # pulls redis>=7, conflicting with celery[redis]>=5.4 (which needs
@@ -117,6 +118,11 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 testpaths = ["tests"]
 cache_dir = "codex-pytest-cache"
+# 60s per test. E2E tests that hang (see CI run 24431646301) fail with a
+# traceback pointing to the exact frame instead of stalling the CI job.
+# Integration/unit tests should complete in well under 60s each.
+timeout = 60
+timeout_method = "thread"
 addopts = "--basetemp=codex-pytest-basetemp --cov=core --cov=api --cov=auth --cov=workflows --cov=scaling --cov-report=xml --cov-report=term-missing"
 
 [tool.mypy]

--- a/tests/e2e/test_cxo_flows.py
+++ b/tests/e2e/test_cxo_flows.py
@@ -52,7 +52,14 @@ def app():
 @pytest_asyncio.fixture(scope="module")
 async def _schema_ready() -> AsyncGenerator[str, None]:
     """Point the module-level engine at the test DB, create ORM tables,
-    and seed a tenant row.
+    seed a tenant row.
+
+    All 5 previously-skipped tests only touch tables with ORM models
+    (companies, agents, kpi_cache, industry_pack_installs,
+    agent_task_results, report_schedules) — metadata.create_all is
+    sufficient. If a test hits a ``relation does not exist`` error on
+    a raw-SQL-only table, add the ORM model instead of swapping in
+    an alembic subprocess (which races asyncpg).
 
     We reconfigure the existing async_session_factory in place rather
     than reassigning the module attribute, so any module that did
@@ -107,30 +114,6 @@ async def _schema_ready() -> AsyncGenerator[str, None]:
         _db_mod.async_session_factory.configure(bind=original_engine)
 
 
-
-
-# Reason for skipping the 5 DB-write e2e tests.
-#
-# PR #125 added ORM models for kpi_cache and industry_pack_installs and
-# removed @pytest.mark.skip on these tests. With all 30 tests running in
-# the CI e2e-tests job, the run hung past 10 minutes on one of the
-# company-creation tests (previous runs: 1-3 min). The hermetic in-process
-# TestClient + AsyncClient path reaches code (e.g. pack installer) that
-# either retries indefinitely or holds a connection the NullPool engine
-# cannot release between tests.
-#
-# Re-skipping until we either (a) mock out the pack installer and other
-# non-critical side effects in the fixture, or (b) run the e2e suite
-# against a dedicated alembic-stamped test DB with a longer isolation
-# budget. The agent-runtime AttributeError fix in PR #128 is live in
-# production; these skips do not reduce production safety.
-_HANG_SKIP_REASON = (
-    "Hangs CI e2e-tests runner past 10 min on in-process TestClient + "
-    "hermetic NullPool engine. Follow-up: mock pack installer or run "
-    "against an alembic-stamped test DB."
-)
-
-
 @pytest_asyncio.fixture
 async def client(app, _schema_ready) -> AsyncGenerator[AsyncClient, None]:
     """httpx.AsyncClient with auth middleware bypassed and admin scopes granted."""
@@ -165,7 +148,6 @@ async def client(app, _schema_ready) -> AsyncGenerator[AsyncClient, None]:
 class TestCFOJourney:
     """End-to-end CFO user flow."""
 
-    @pytest.mark.skip(reason=_HANG_SKIP_REASON)
     @pytest.mark.asyncio
     async def test_cfo_kpis_return_valid_data(self, client: AsyncClient):
         """CFO KPI dashboard returns all required metrics (basic metrics shape)."""
@@ -211,7 +193,6 @@ class TestCFOJourney:
         schedule_ids = [s["id"] for s in schedules]
         assert schedule["id"] in schedule_ids
 
-    @pytest.mark.skip(reason=_HANG_SKIP_REASON)
     @pytest.mark.asyncio
     async def test_company_switcher_lists_companies(self, client: AsyncClient):
         """Company switcher returns list after creating companies."""
@@ -241,7 +222,6 @@ class TestCFOJourney:
                     "get_balance_sheet", "get_cash_position"}
         assert expected == set(DEFAULT_TOOLS)
 
-    @pytest.mark.skip(reason=_HANG_SKIP_REASON)
     @pytest.mark.asyncio
     async def test_cfo_kpis_with_company_filter(self, client: AsyncClient):
         """CFO KPIs accept company_id parameter."""
@@ -250,7 +230,6 @@ class TestCFOJourney:
         data = resp.json()
         assert data["company_id"] == "test-company"
 
-    @pytest.mark.skip(reason=_HANG_SKIP_REASON)
     @pytest.mark.asyncio
     async def test_create_and_retrieve_company(self, client: AsyncClient):
         """Full company lifecycle: create -> retrieve -> verify fields."""
@@ -278,7 +257,6 @@ class TestCFOJourney:
 class TestCMOJourney:
     """End-to-end CMO user flow."""
 
-    @pytest.mark.skip(reason=_HANG_SKIP_REASON)
     @pytest.mark.asyncio
     async def test_cmo_kpis_return_valid_data(self, client: AsyncClient):
         """CMO KPI dashboard returns all required metrics (basic metrics shape)."""


### PR DESCRIPTION
## Why

PR #129 re-applied skips on 5 e2e tests after they hung CI past 10 min. But those tests only touch tables that **have ORM models** (`companies`, `agents`, `kpi_cache`, `industry_pack_installs`, `agent_task_results`, `report_schedules`) — `metadata.create_all` covers all of them. The hang must be elsewhere (inside a test body or the request path), not in schema setup.

Rather than ship permanent skips, add a CI-level safety net so the next hang surfaces a traceback instead of stalling the runner.

## What

- `pyproject.toml`: add `pytest-timeout>=2.3.0` to dev deps, set `timeout = 60` and `timeout_method = "thread"` in `[tool.pytest.ini_options]`. Any test exceeding 60s fails with a frame-accurate traceback.
- `tests/e2e/test_cxo_flows.py`: drop the 5 `@pytest.mark.skip` markers and the `_HANG_SKIP_REASON` constant.

## Considered alternatives

- **Alembic-upgrade-head subprocess in the fixture**: more faithful to prod schema, but all 5 tests hit tables that already have ORM models after PR #125. The subprocess would race asyncpg's pool for no tangible benefit. Rejected.
- **Mock the pack installer side effects**: premature — we don't yet know the installer is the hang site. Mocking preemptively would hide the real bug.

## Worst case

If one of the un-skipped tests hangs again, CI fails quickly with a stack trace pointing to the exact frame, and we know exactly where to fix.

## Test plan

- [x] `ruff check tests/e2e/test_cxo_flows.py` — clean
- [x] `uv pip compile pyproject.toml --extra dev` — pytest-timeout 2.4.0 resolves cleanly
- [x] Local: `pytest tests/e2e/test_cxo_flows.py::TestCMOJourney::test_cmo_weekly_report_generation` — passes (a non-DB test that exercises the modified fixture path)
- [ ] Main CI: `e2e-tests` completes with all 23 tests running (0 skips)