### PR TITLE
fix(e2e): revert test_cxo_flows to stable; drop DB services; hard CI timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -202,16 +202,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    services:
-      # In-process TestClient paths in tests/e2e/ need a real DB+Redis so
-      # the handlers' DB queries return 200 with zeros instead of 500.
-      postgres:
-        image: "pgvector/pgvector:pg16"
-        env: { POSTGRES_DB: test, POSTGRES_USER: test, POSTGRES_PASSWORD: test }
-        ports: ["5432:5432"]
-      redis:
-        image: "redis:7-alpine"
-        ports: ["6379:6379"]
     steps:
       - uses: actions/checkout@v6
 
@@ -234,11 +224,13 @@ jobs:
           done
 
       - name: Run Python E2E tests (against production)
+        # Global 5-minute cap — the previous fixture-teardown hang wedged
+        # a runner past 25 min (CI runs 24432641344 and 24433193853),
+        # cancel requests did not propagate. This puts a hard ceiling.
+        timeout-minutes: 5
         run: pytest tests/e2e/ -v
         env:
           AGENTICORG_E2E_BASE_URL: https://app.agenticorg.ai
-          AGENTICORG_DB_URL: postgresql+asyncpg://test:test@localhost:5432/test
-          AGENTICORG_REDIS_URL: redis://localhost:6379/0
           AGENTICORG_SECRET_KEY: ci-test-secret-key-minimum-16
 
       - name: Run Synthetic Agent Quality tests (non-blocking — tests LLM behavior)

--- a/tests/e2e/test_cxo_flows.py
+++ b/tests/e2e/test_cxo_flows.py
@@ -1,46 +1,28 @@
 """E2E tests for CFO and CMO user flows.
 
-Tests complete user journeys using an in-process ASGI client
-(httpx.AsyncClient + ASGITransport), verifying that the platform works
-end-to-end from KPIs through NL queries, report scheduling, and agent
-tool verification.
-
-Why async not sync TestClient:
-    FastAPI's sync TestClient spins up a fresh asyncio loop per request.
-    Combined with SQLAlchemy's pooled async engine, asyncpg connections
-    get bound to one loop and re-used from another, crashing with
-    'Event loop is closed'. An httpx.AsyncClient on
-    pytest_asyncio's loop keeps the engine, connections, and test
-    coroutines on a single loop for the whole session.
+Tests complete user journeys using the FastAPI TestClient, verifying
+that the platform works end-to-end from KPIs through NL queries,
+report scheduling, and agent tool verification.
 """
 
 from __future__ import annotations
 
-import os
 import uuid
-from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from unittest.mock import patch
 
 import pytest
-import pytest_asyncio
-from httpx import ASGITransport, AsyncClient
+from fastapi.testclient import TestClient
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
-# Module-scoped UUID — tenants.id is UUID, and get_tenant_session()
-# rejects anything that doesn't match the UUID format.
-_SHARED_TENANT_ID = str(uuid.uuid4())
-
-
 @pytest.fixture(scope="module")
 def app():
     from api.main import app as _app
 
-    # Replace lifespan to skip DB init — we'll create the schema in the
-    # session-scoped fixture below.
+    # Replace lifespan to skip DB init
     @asynccontextmanager
     async def _test_lifespan(app):
         yield
@@ -49,75 +31,10 @@ def app():
     return _app
 
 
-@pytest_asyncio.fixture(scope="module")
-async def _schema_ready() -> AsyncGenerator[str, None]:
-    """Point the module-level engine at the test DB, create ORM tables,
-    seed a tenant row.
-
-    All 5 previously-skipped tests only touch tables with ORM models
-    (companies, agents, kpi_cache, industry_pack_installs,
-    agent_task_results, report_schedules) — metadata.create_all is
-    sufficient. If a test hits a ``relation does not exist`` error on
-    a raw-SQL-only table, add the ORM model instead of swapping in
-    an alembic subprocess (which races asyncpg).
-
-    We reconfigure the existing async_session_factory in place rather
-    than reassigning the module attribute, so any module that did
-    ``from core.database import async_session_factory`` at import time
-    automatically follows us to the test engine.
-    """
-    from sqlalchemy import text as _text
-    from sqlalchemy.ext.asyncio import create_async_engine
-    from sqlalchemy.pool import NullPool
-
-    import core.database as _db_mod
-    import core.models  # noqa: F401 — register every ORM model
-    from core.models.base import BaseModel
-
-    db_url = os.getenv("AGENTICORG_DB_URL")
-    if not db_url:
-        pytest.skip("requires AGENTICORG_DB_URL for DB-backed E2E tests")
-
-    test_engine = create_async_engine(db_url, echo=False, poolclass=NullPool)
-    original_engine = _db_mod.engine
-    _db_mod.engine = test_engine
-    _db_mod.async_session_factory.configure(bind=test_engine)
-
-    try:
-        async with test_engine.begin() as conn:
-            await conn.run_sync(BaseModel.metadata.create_all)
-            await conn.execute(
-                _text(
-                    "INSERT INTO tenants (id, name, slug, plan, data_region, settings) "
-                    "VALUES (:id, :name, :slug, :plan, :region, '{}'::jsonb) "
-                    "ON CONFLICT (id) DO NOTHING"
-                ),
-                {
-                    "id": _SHARED_TENANT_ID,
-                    "name": "e2e-tenant",
-                    "slug": f"e2e-{_SHARED_TENANT_ID[:8]}",
-                    "plan": "enterprise",
-                    "region": "IN",
-                },
-            )
-    except Exception as exc:
-        await test_engine.dispose()
-        _db_mod.engine = original_engine
-        _db_mod.async_session_factory.configure(bind=original_engine)
-        pytest.skip(f"DB-backed E2E fixture unavailable: {exc}")
-
-    try:
-        yield _SHARED_TENANT_ID
-    finally:
-        await test_engine.dispose()
-        _db_mod.engine = original_engine
-        _db_mod.async_session_factory.configure(bind=original_engine)
-
-
-@pytest_asyncio.fixture
-async def client(app, _schema_ready) -> AsyncGenerator[AsyncClient, None]:
-    """httpx.AsyncClient with auth middleware bypassed and admin scopes granted."""
-    test_tenant_id = _schema_ready
+@pytest.fixture
+def client(app):
+    """TestClient with auth middleware bypassed and admin scopes granted."""
+    test_tenant_id = f"e2e-tenant-{uuid.uuid4().hex[:8]}"
 
     from api.deps import get_current_tenant
     app.dependency_overrides[get_current_tenant] = lambda: test_tenant_id
@@ -129,13 +46,13 @@ async def client(app, _schema_ready) -> AsyncGenerator[AsyncClient, None]:
             "agenticorg:scopes": ["agenticorg:admin"],
         }
 
-    with patch("auth.grantex_middleware.validate_token", side_effect=_fake_validate), \
-         patch("auth.grantex_middleware.extract_tenant_id", return_value=test_tenant_id), \
-         patch("auth.grantex_middleware.extract_scopes", return_value=["agenticorg:admin"]):
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
-            ac.headers["Authorization"] = "Bearer fake-e2e-token"
-            yield ac
+    with patch("auth.grantex_middleware.validate_token", side_effect=_fake_validate):
+        with patch("auth.grantex_middleware.extract_tenant_id", return_value=test_tenant_id):
+            with patch("auth.grantex_middleware.extract_scopes", return_value=["agenticorg:admin"]):
+                with TestClient(app, raise_server_exceptions=False) as c:
+                    c.headers["Authorization"] = "Bearer fake-e2e-token"
+                    c._test_tenant_id = test_tenant_id
+                    yield c
 
     app.dependency_overrides.pop(get_current_tenant, None)
 
@@ -148,12 +65,12 @@ async def client(app, _schema_ready) -> AsyncGenerator[AsyncClient, None]:
 class TestCFOJourney:
     """End-to-end CFO user flow."""
 
-    @pytest.mark.asyncio
-    async def test_cfo_kpis_return_valid_data(self, client: AsyncClient):
+    def test_cfo_kpis_return_valid_data(self, client):
         """CFO KPI dashboard returns all required metrics (basic metrics shape)."""
-        resp = await client.get("/api/v1/kpis/cfo")
-        assert resp.status_code == 200, resp.text
+        resp = client.get("/api/v1/kpis/cfo")
+        assert resp.status_code == 200
         data = resp.json()
+        # Current KPI contract uses basic metrics shape
         required_keys = [
             "agent_count", "total_tasks_30d", "success_rate",
             "hitl_interventions", "total_cost_usd", "domain_breakdown",
@@ -161,49 +78,48 @@ class TestCFOJourney:
         for key in required_keys:
             assert key in data, f"CFO KPI missing: {key}"
 
-    @pytest.mark.asyncio
-    async def test_nl_query_finance_routes_correctly(self, client: AsyncClient):
+    def test_nl_query_finance_routes_correctly(self, client):
         """NL query with finance question routes to finance domain."""
-        resp = await client.post("/api/v1/chat/query", json={
-            "query": "What is our accounts receivable aging and cash flow position?",
+        resp = client.post("/api/v1/chat/query", json={
+            "query": "What is our accounts receivable aging and cash flow position?"
         })
-        assert resp.status_code == 200, resp.text
+        assert resp.status_code == 200
         data = resp.json()
         assert data["domain"] == "finance"
         assert data["confidence"] >= 0.7
 
-    @pytest.mark.asyncio
-    async def test_report_schedule_created_successfully(self, client: AsyncClient):
+    def test_report_schedule_created_successfully(self, client):
         """CFO can create a report schedule that persists."""
-        resp = await client.post("/api/v1/report-schedules", json={
+        resp = client.post("/api/v1/report-schedules", json={
             "report_type": "cfo_daily",
             "cron_expression": "daily",
             "delivery_channels": [{"type": "email", "target": "cfo@company.com"}],
             "format": "pdf",
             "is_active": True,
         })
-        assert resp.status_code == 201, resp.text
+        assert resp.status_code == 201
         schedule = resp.json()
         assert schedule["report_type"] == "cfo_daily"
         assert schedule["is_active"] is True
 
-        list_resp = await client.get("/api/v1/report-schedules")
+        # Verify it appears in the list
+        list_resp = client.get("/api/v1/report-schedules")
         assert list_resp.status_code == 200
         schedules = list_resp.json()
         schedule_ids = [s["id"] for s in schedules]
         assert schedule["id"] in schedule_ids
 
-    @pytest.mark.asyncio
-    async def test_company_switcher_lists_companies(self, client: AsyncClient):
+    def test_company_switcher_lists_companies(self, client):
         """Company switcher returns list after creating companies."""
-        await client.post("/api/v1/companies", json={
+        # Create companies with required fields (pan is mandatory)
+        client.post("/api/v1/companies", json={
             "name": "Test Corp A", "pan": "AABCA0001A", "industry": "IT",
         })
-        await client.post("/api/v1/companies", json={
+        client.post("/api/v1/companies", json={
             "name": "Test Corp B", "pan": "AABCB0002B", "industry": "Finance",
         })
-        resp = await client.get("/api/v1/companies")
-        assert resp.status_code == 200, resp.text
+        resp = client.get("/api/v1/companies")
+        assert resp.status_code == 200
         data = resp.json()
         items = data if isinstance(data, list) else data.get("items", [])
         assert len(items) >= 2
@@ -222,27 +138,25 @@ class TestCFOJourney:
                     "get_balance_sheet", "get_cash_position"}
         assert expected == set(DEFAULT_TOOLS)
 
-    @pytest.mark.asyncio
-    async def test_cfo_kpis_with_company_filter(self, client: AsyncClient):
+    def test_cfo_kpis_with_company_filter(self, client):
         """CFO KPIs accept company_id parameter."""
-        resp = await client.get("/api/v1/kpis/cfo?company_id=test-company")
-        assert resp.status_code == 200, resp.text
+        resp = client.get("/api/v1/kpis/cfo?company_id=test-company")
+        assert resp.status_code == 200
         data = resp.json()
         assert data["company_id"] == "test-company"
 
-    @pytest.mark.asyncio
-    async def test_create_and_retrieve_company(self, client: AsyncClient):
+    def test_create_and_retrieve_company(self, client):
         """Full company lifecycle: create -> retrieve -> verify fields."""
-        create_resp = await client.post("/api/v1/companies", json={
+        create_resp = client.post("/api/v1/companies", json={
             "name": "Sharma Manufacturing",
             "gstin": "27AABCS9999F1Z5",
             "pan": "AABCS9999F",
             "industry": "Manufacturing",
         })
-        assert create_resp.status_code == 201, create_resp.text
+        assert create_resp.status_code == 201
         company = create_resp.json()
 
-        get_resp = await client.get(f"/api/v1/companies/{company['id']}")
+        get_resp = client.get(f"/api/v1/companies/{company['id']}")
         assert get_resp.status_code == 200
         fetched = get_resp.json()
         assert fetched["name"] == "Sharma Manufacturing"
@@ -257,11 +171,10 @@ class TestCFOJourney:
 class TestCMOJourney:
     """End-to-end CMO user flow."""
 
-    @pytest.mark.asyncio
-    async def test_cmo_kpis_return_valid_data(self, client: AsyncClient):
+    def test_cmo_kpis_return_valid_data(self, client):
         """CMO KPI dashboard returns all required metrics (basic metrics shape)."""
-        resp = await client.get("/api/v1/kpis/cmo")
-        assert resp.status_code == 200, resp.text
+        resp = client.get("/api/v1/kpis/cmo")
+        assert resp.status_code == 200
         data = resp.json()
         required_keys = [
             "agent_count", "total_tasks_30d", "success_rate",
@@ -270,13 +183,12 @@ class TestCMOJourney:
         for key in required_keys:
             assert key in data, f"CMO KPI missing: {key}"
 
-    @pytest.mark.asyncio
-    async def test_nl_query_marketing_routes_correctly(self, client: AsyncClient):
+    def test_nl_query_marketing_routes_correctly(self, client):
         """NL query with marketing question routes to marketing domain."""
-        resp = await client.post("/api/v1/chat/query", json={
-            "query": "Show me the latest SEO rankings and campaign conversion rates",
+        resp = client.post("/api/v1/chat/query", json={
+            "query": "Show me the latest SEO rankings and campaign conversion rates"
         })
-        assert resp.status_code == 200, resp.text
+        assert resp.status_code == 200
         data = resp.json()
         assert data["domain"] == "marketing"
         assert data["confidence"] >= 0.7
@@ -317,28 +229,16 @@ class TestCMOJourney:
         output = gen.generate(report_type="cmo_weekly", params={})
         assert isinstance(output, ReportOutput)
         assert output.report_type == "cmo_weekly"
-        # The report now uses the basic-metrics contract (same shape as
-        # /kpis/cmo) — agent_count, total_tasks_30d, success_rate, etc.
-        # ROAS / channel breakdown have been out of this report since the
-        # KPI unification; don't re-require them here.
-        assert "CMO Weekly Report" in output.content_html
-        for key in ("Agents", "Tasks (30d)", "Success Rate", "Domain Breakdown"):
-            assert key in output.content_html, f"CMO report missing section: {key}"
+        assert "ROAS" in output.content_html or "roas" in output.content_html.lower()
 
     def test_campaign_report_generation(self):
-        """Campaign performance report returns the basic-metrics contract."""
+        """Campaign performance report contains marketing metrics."""
         from core.reports.generator import ReportGenerator
         gen = ReportGenerator()
         output = gen.generate(report_type="campaign_report", params={})
         data = output.content_data
-        # Current campaign_report uses _fetch_cmo_kpis, i.e. the unified
-        # basic-metrics shape. The legacy roas_by_channel /
-        # social_engagement fields were removed when /kpis/cmo stopped
-        # fabricating dashboards from raw task_output.
-        required = ("agent_count", "total_tasks_30d", "success_rate",
-                    "hitl_interventions", "total_cost_usd", "domain_breakdown")
-        for key in required:
-            assert key in data, f"campaign_report missing: {key}"
+        assert "roas_by_channel" in data
+        assert "social_engagement" in data
 
     def test_email_marketing_agent_registered(self):
         """Email marketing agent is registered in the platform."""
@@ -370,21 +270,19 @@ class TestCMOJourney:
 class TestCrossDomainIntegration:
     """Verify cross-domain features work together."""
 
-    @pytest.mark.asyncio
-    async def test_a2a_agent_card_returns_skills(self, client: AsyncClient):
+    def test_a2a_agent_card_returns_skills(self, client):
         """A2A agent card lists available agent skills."""
-        resp = await client.get("/api/v1/a2a/.well-known/agent.json")
-        assert resp.status_code == 200, resp.text
+        resp = client.get("/api/v1/a2a/.well-known/agent.json")
+        assert resp.status_code == 200
         data = resp.json()
         assert "skills" in data
         assert isinstance(data["skills"], list)
         assert len(data["skills"]) > 0
 
-    @pytest.mark.asyncio
-    async def test_a2a_agent_list(self, client: AsyncClient):
+    def test_a2a_agent_list(self, client):
         """A2A agents endpoint lists all available agents."""
-        resp = await client.get("/api/v1/a2a/agents")
-        assert resp.status_code == 200, resp.text
+        resp = client.get("/api/v1/a2a/agents")
+        assert resp.status_code == 200
         data = resp.json()
         assert "agents" in data
 
@@ -404,6 +302,7 @@ class TestCrossDomainIntegration:
         }
         for domain, module_path in domain_connectors.items():
             mod = importlib.import_module(module_path)
+            # Find the connector class in the module
             connector_cls = None
             for attr_name in dir(mod):
                 attr = getattr(mod, attr_name)


### PR DESCRIPTION
## Why

PR #107 → #120 → #125 → #128 → #130 progressively replaced the original sync `TestClient` e2e fixture with an `httpx.AsyncClient` + NullPool + hermetic-DB pattern. That path has an **uninterruptible asyncpg deadlock at module-fixture teardown** that:

- Wedged PR #129's CI for 26+ min (run 24432641344).
- Wedged PR #130's CI for 25+ min (run 24433193853) — even with `pytest-timeout = 60`, because the hang is at fixture teardown, not a test body.
- Both cancel requests failed to propagate.

## What

Three parts of a single revert:

1. **`tests/e2e/test_cxo_flows.py`**: restore to commit `7c99062` (the last known stable shape) — sync `fastapi.testclient.TestClient`, no engine swap, no NullPool. Tests that touch DB endpoints now return 500 from the handler and may skip/fail cleanly; no fixture deadlock is possible.
2. **`.github/workflows/deploy.yml`**:
   - Remove the `postgres`/`redis` service containers on the `e2e-tests` job (introduced PR #107).
   - Remove `AGENTICORG_DB_URL` / `AGENTICORG_REDIS_URL` env vars from the pytest step.
   - Add `timeout-minutes: 5` as a hard ceiling so any future fixture hang cannot wedge the runner.

## Impact

- **Production**: zero. PR #128's agent-runtime `AttributeError` fix is already deployed and serving on prod.
- **Test coverage**: the DB-backed paths are still covered by `integration-tests` (which has working Postgres+Redis services with the `tests/integration/conftest.py` pattern). `e2e-tests` is limited to what works without a live DB — registry/tool checks, report generator, NL routing without write, etc. — exactly how it was before PR #107.

## Follow-up (tracked)

A proper hermetic e2e suite needs to either (a) run against the real deployed prod URL with a service-account token (not this repo's approach), or (b) reuse the working `tests/integration/conftest.py` fixture pattern and move these tests under `tests/integration/`. Either is a deliberate follow-up rather than more iteration on the wedged-fixture path.

## Test plan

- [x] `ruff check tests/e2e/test_cxo_flows.py` — clean
- [ ] Main CI: `e2e-tests` completes under 5 minutes (or fails fast on timeout, but does not hang)