### PR TITLE
fix(ci): 45-min hard timeout on Playwright regression step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -267,6 +267,12 @@ jobs:
         run: cd ui && npm install --legacy-peer-deps && npx playwright install --with-deps chromium
 
       - name: Run ALL Playwright E2E regression suite against production
+        # Hard 45-min cap. Regression suite has 438 tests, workers: 1,
+        # retries: 2 — typical pass completes in 20-30 min. Anything
+        # beyond 45 min is flake-loop territory and should fail fast
+        # so the team sees the signal instead of the runner wedging
+        # (see PR #132 run 24435533758 which went 1h+).
+        timeout-minutes: 45
         run: cd ui && npx playwright test --config=e2e/regression.config.ts
         env:
           BASE_URL: https://app.agenticorg.ai


### PR DESCRIPTION
## Why

PR #132's main CI went past 1 hour on the Playwright step (run 24435533758) despite every other gate being green: deploy-production ✅, build ✅, pytest e2e step ~15s ✅, integration-tests ✅. I had to force-cancel the run.

The regression suite runs 438 tests sequentially (`workers: 1`) with `retries: 2`. When even a few tests flake across all 3 attempts, the runner spins far past the typical 20–30 min envelope.

## What

Add `timeout-minutes: 45` on the **Run ALL Playwright E2E regression suite against production** step in `.github/workflows/deploy.yml`.

- 45 min is ~2x the typical pass duration — leaves headroom for modest flake.
- Beyond 45 min, the step fails fast with a clean error instead of the runner wedging until GitHub Actions' 6-hour job cap.
- Matches the pattern from PR #131 (5-min cap on the pytest step).

## Impact

- Healthy runs (20–30 min): no change.
- Unhealthy runs: surface a failure within 45 min with a `playwright-report` artifact attached, rather than consuming ~6 hours of runner time.

## Test plan

- [x] `cat .github/workflows/deploy.yml | grep -A 2 "timeout-minutes"` — confirms the cap is set
- [ ] Next main CI: Playwright completes in 20–30 min (healthy) or fails at 45 min (flake)