### PR TITLE
fix(playwright): seed user alongside token so dashboard tests pass

### DIFF
--- a/ui/e2e/app-routes.spec.ts
+++ b/ui/e2e/app-routes.spec.ts
@@ -79,7 +79,7 @@ test.describe("Dashboard Routes — Auth Required", () => {
     await page.goto(`${APP}/login`);
     await page.evaluate((token) => {
       localStorage.setItem("token", token);
-    }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    }, E2E_TOKEN);
   });
 
   for (const route of dashboardRoutes) {
@@ -148,7 +148,7 @@ test.describe("Dashboard — Sidebar Navigation", () => {
     await page.goto(`${APP}/login`);
     await page.evaluate((token) => {
       localStorage.setItem("token", token);
-    }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    }, E2E_TOKEN);
   });
 
   for (const link of sidebarLinks) {
@@ -186,7 +186,7 @@ test.describe("Create Flows", () => {
     await page.goto(`${APP}/login`);
     await page.evaluate((token) => {
       localStorage.setItem("token", token);
-    }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    }, E2E_TOKEN);
   });
 
   test("Agents page → Create Agent button works", async ({ page }) => {
@@ -226,7 +226,7 @@ test.describe("Data Display Quality", () => {
     await page.goto(`${APP}/login`);
     await page.evaluate((token) => {
       localStorage.setItem("token", token);
-    }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    }, E2E_TOKEN);
   });
 
   const pages = [

--- a/ui/e2e/ca-firms.spec.ts
+++ b/ui/e2e/ca-firms.spec.ts
@@ -23,7 +23,7 @@ async function authenticate(page: Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-  }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));  }, E2E_TOKEN);
 }
 
 // ==========================================================================

--- a/ui/e2e/cfo-demo.spec.ts
+++ b/ui/e2e/cfo-demo.spec.ts
@@ -63,7 +63,10 @@ test.describe("CFO Demo: Dashboard (auth required)", () => {
   test.beforeEach(async ({ page }) => {
     test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
     await page.goto("/", { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => localStorage.setItem("token", t), E2E_TOKEN);
+    await page.evaluate((t) => {
+      localStorage.setItem("token", t);
+      localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));
+    }, E2E_TOKEN);
   });
 
   test("agent fleet page loads", async ({ page }) => {

--- a/ui/e2e/cxo-dashboards.spec.ts
+++ b/ui/e2e/cxo-dashboards.spec.ts
@@ -29,7 +29,7 @@ async function authenticate(page: Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-  }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));  }, E2E_TOKEN);
 }
 
 async function goToDashboard(page: Page, path: string): Promise<void> {

--- a/ui/e2e/error-handling.spec.ts
+++ b/ui/e2e/error-handling.spec.ts
@@ -19,7 +19,7 @@ async function ensureAuth(page: Page, baseURL: string) {
   await page.goto(baseURL, { waitUntil: "domcontentloaded" });
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-    localStorage.setItem(
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    localStorage.setItem(
       "user",
       JSON.stringify({
         email: "e2e@agenticorg.ai",
@@ -188,7 +188,7 @@ test.describe("Token Expiry", () => {
     await page.goto(baseURL!, { waitUntil: "domcontentloaded" });
     await page.evaluate(() => {
       localStorage.setItem("token", "expired.invalid.token");
-      localStorage.setItem(
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));      localStorage.setItem(
         "user",
         JSON.stringify({ email: "x@x.x", name: "X", role: "admin" }),
       );

--- a/ui/e2e/flows.spec.ts
+++ b/ui/e2e/flows.spec.ts
@@ -16,7 +16,7 @@ async function authenticate(page: import("@playwright/test").Page) {
   await page.goto(`${APP}/login`);
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-  }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));  }, E2E_TOKEN);
 }
 
 // ============================================================================

--- a/ui/e2e/full-app.spec.ts
+++ b/ui/e2e/full-app.spec.ts
@@ -14,7 +14,7 @@ async function authenticate(page: Page) {
   await page.goto(`${APP}/login`);
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-  }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));  }, E2E_TOKEN);
 }
 
 // ---------------------------------------------------------------------------

--- a/ui/e2e/helpers/auth.ts
+++ b/ui/e2e/helpers/auth.ts
@@ -1,0 +1,35 @@
+/**
+ * Auth helper for Playwright E2E regression tests.
+ *
+ * Seeds both `localStorage.token` AND `localStorage.user` so ProtectedRoute
+ * treats the session as fully hydrated. Using only `token` hits `/auth/me`,
+ * which since PR #103 defaults `onboarding_complete=false` for safety —
+ * redirecting the test user to `/onboarding` and breaking every dashboard
+ * assertion.
+ */
+import type { Page } from "@playwright/test";
+
+const E2E_USER = {
+  email: "ceo@agenticorg.local",
+  name: "CEO",
+  role: "ceo",
+  domain: "general",
+  tenant_id: "e2e-tenant",
+  onboardingComplete: true,
+};
+
+/**
+ * Seed a valid token + fully-hydrated user into localStorage.
+ *
+ * @param page - Playwright page
+ * @param token - E2E auth token from login response
+ */
+export async function seedAuth(page: Page, token: string): Promise<void> {
+  await page.evaluate(
+    ([tkn, user]) => {
+      localStorage.setItem("token", tkn as string);
+      localStorage.setItem("user", JSON.stringify(user));
+    },
+    [token, E2E_USER],
+  );
+}

--- a/ui/e2e/login-e2e.spec.ts
+++ b/ui/e2e/login-e2e.spec.ts
@@ -87,7 +87,7 @@ test.describe("Login Page — Auth Flow", () => {
     await page.goto(`${APP}/login`);
     await page.evaluate((token) => {
       localStorage.setItem("token", token);
-    }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    }, E2E_TOKEN);
     await page.goto(`${APP}/dashboard`, { waitUntil: "networkidle" });
     await expect(page.getByText("Dashboard").first()).toBeVisible({ timeout: 10000 });
   });

--- a/ui/e2e/negative-cases.spec.ts
+++ b/ui/e2e/negative-cases.spec.ts
@@ -20,7 +20,7 @@ async function ensureAuth(page: Page, baseURL: string) {
   await page.goto(baseURL, { waitUntil: "domcontentloaded" });
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-    localStorage.setItem(
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    localStorage.setItem(
       "user",
       JSON.stringify({
         email: "e2e@agenticorg.ai",

--- a/ui/e2e/onboarding-e2e.spec.ts
+++ b/ui/e2e/onboarding-e2e.spec.ts
@@ -18,7 +18,7 @@ async function ensureAuth(page: Page, baseURL: string) {
   await page.goto(baseURL, { waitUntil: "domcontentloaded" });
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-    localStorage.setItem(
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    localStorage.setItem(
       "user",
       JSON.stringify({
         email: "e2e@agenticorg.ai",

--- a/ui/e2e/production-full.spec.ts
+++ b/ui/e2e/production-full.spec.ts
@@ -19,7 +19,7 @@ async function injectAuth(page: Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
   await page.evaluate((t) => {
     localStorage.setItem("token", t);
-  }, token);
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));  }, token);
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/ui/e2e/qa-bugs-8apr2026.spec.ts
+++ b/ui/e2e/qa-bugs-8apr2026.spec.ts
@@ -23,7 +23,7 @@ async function authenticate(page: Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-    localStorage.setItem(
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    localStorage.setItem(
       "user",
       JSON.stringify({
         email: "e2e@agenticorg.ai",

--- a/ui/e2e/qa-bugs-regression.spec.ts
+++ b/ui/e2e/qa-bugs-regression.spec.ts
@@ -21,7 +21,7 @@ async function ensureAuth(page: Page, baseURL: string) {
   await page.goto(baseURL, { waitUntil: "domcontentloaded" });
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-    localStorage.setItem(
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    localStorage.setItem(
       "user",
       JSON.stringify({
         email: "e2e@agenticorg.ai",

--- a/ui/e2e/scope-enforcement.spec.ts
+++ b/ui/e2e/scope-enforcement.spec.ts
@@ -19,7 +19,7 @@ async function authenticate(page: Page) {
   await page.goto(`${APP}/login`);
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-  }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));  }, E2E_TOKEN);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/ui/e2e/sop-flow.spec.ts
+++ b/ui/e2e/sop-flow.spec.ts
@@ -18,7 +18,10 @@ test.describe("SOP: Page Access (auth required)", () => {
   test.beforeEach(async ({ page }) => {
     test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
     await page.goto("/login", { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => localStorage.setItem("token", t), E2E_TOKEN);
+    await page.evaluate((t) => {
+      localStorage.setItem("token", t);
+      localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));
+    }, E2E_TOKEN);
   });
 
   test("SOP upload page renders heading and description", async ({ page }) => {
@@ -142,7 +145,10 @@ test.describe("SOP: Dashboard v3.0 (auth required)", () => {
   test.beforeEach(async ({ page }) => {
     test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
     await page.goto("/login", { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => localStorage.setItem("token", t), E2E_TOKEN);
+    await page.evaluate((t) => {
+      localStorage.setItem("token", t);
+      localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));
+    }, E2E_TOKEN);
   });
 
   test("Dashboard shows LangGraph + Grantex + External Access cards", async ({ page }) => {

--- a/ui/e2e/v4-features.spec.ts
+++ b/ui/e2e/v4-features.spec.ts
@@ -25,7 +25,7 @@ async function authenticate(page: Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-  }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));  }, E2E_TOKEN);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/ui/e2e/video-recordings.spec.ts
+++ b/ui/e2e/video-recordings.spec.ts
@@ -38,7 +38,10 @@ test.describe("Video Flows: Platform Overview (auth required)", () => {
   test.beforeEach(async ({ page }) => {
     test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
     await page.goto("/", { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => localStorage.setItem("token", t), E2E_TOKEN);
+    await page.evaluate((t) => {
+      localStorage.setItem("token", t);
+      localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));
+    }, E2E_TOKEN);
   });
 
   test("dashboard loads", async ({ page }) => {
@@ -80,7 +83,10 @@ test.describe("Video Flows: CFO Finance (auth required)", () => {
   test.beforeEach(async ({ page }) => {
     test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
     await page.goto("/", { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => localStorage.setItem("token", t), E2E_TOKEN);
+    await page.evaluate((t) => {
+      localStorage.setItem("token", t);
+      localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));
+    }, E2E_TOKEN);
   });
 
   test("agents page loads with agent content", async ({ page }) => {
@@ -102,7 +108,10 @@ test.describe("Video Flows: CHRO HR (auth required)", () => {
   test.beforeEach(async ({ page }) => {
     test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
     await page.goto("/", { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => localStorage.setItem("token", t), E2E_TOKEN);
+    await page.evaluate((t) => {
+      localStorage.setItem("token", t);
+      localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));
+    }, E2E_TOKEN);
   });
 
   test("agents page loads", async ({ page }) => {
@@ -124,7 +133,10 @@ test.describe("Video Flows: CMO Marketing (auth required)", () => {
   test.beforeEach(async ({ page }) => {
     test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
     await page.goto("/", { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => localStorage.setItem("token", t), E2E_TOKEN);
+    await page.evaluate((t) => {
+      localStorage.setItem("token", t);
+      localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));
+    }, E2E_TOKEN);
   });
 
   test("agents page loads for marketing agents", async ({ page }) => {
@@ -141,7 +153,10 @@ test.describe("Video Flows: COO Operations (auth required)", () => {
   test.beforeEach(async ({ page }) => {
     test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
     await page.goto("/", { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => localStorage.setItem("token", t), E2E_TOKEN);
+    await page.evaluate((t) => {
+      localStorage.setItem("token", t);
+      localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));
+    }, E2E_TOKEN);
   });
 
   test("agents page loads for ops agents", async ({ page }) => {


### PR DESCRIPTION
## Why

PR #134 main CI (run 24438380803) had e2e-tests finally hit the 45-min Playwright cap (PR #133's fix worked — no more wedged runners). But the failures exposed a real bug:

Every `/dashboard/*` Playwright test timed out at 18s waiting for "Dashboard" text:

```
✘ 7 Dashboard Routes — Auth Required › Dashboard (/dashboard) loads without error (18.0s)
✘ 19 retry #1 (18.9s)
✘ 31 retry #2 (18.0s)
```

**Root cause**: the Playwright specs only do `localStorage.setItem("token", token)`. When the app loads a protected route, AuthContext hits `/auth/me` to hydrate `user`. Since PR #103's code review fix, `/auth/me` defaults `onboarding_complete=false` (fail-closed). The app then routes the test user to `/onboarding` and the "Dashboard" assertion never matches.

This is the exact pattern the repo CLAUDE.md warned about:

> **E2E auth helpers that only set a token**: Role-gated routes now fail closed when `user` hydration is missing. If Playwright stores only `localStorage.token`, protected pages can redirect or render false negatives even though the backend session is valid.

## What

Seed a complete `user` object next to every `localStorage.setItem("token", ...)` across all spec files — 27 sites in 17 files. Object shape matches `AuthContext`'s `AuthUser` interface:

```json
{
  "email": "ceo@agenticorg.local",
  "name": "CEO",
  "role": "ceo",
  "domain": "general",
  "tenant_id": "e2e-tenant",
  "onboardingComplete": true
}
```

Also added `ui/e2e/helpers/auth.ts` with a reusable `seedAuth(page, token)` helper so future specs can use a single canonical pattern instead of inlining.

## Verification

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [ ] main CI: Playwright dashboard specs pass

## Production impact

Zero. This is test-only. Production `/auth/me` behavior is unchanged (still fail-closed per PR #103 — that's the correct behavior).