### PR TITLE
fix(billing): correct app URL default + set explicit env in helm

### DIFF
--- a/core/billing/pinelabs_client.py
+++ b/core/billing/pinelabs_client.py
@@ -49,7 +49,7 @@ _BASE_URLS = {
 
 _BASE_URL = _BASE_URLS.get(_ENV, _BASE_URLS["sandbox"])
 
-_APP_BASE_URL = os.getenv("AGENTICORG_APP_URL", "https://app.agenticorg.com")
+_APP_BASE_URL = os.getenv("AGENTICORG_APP_URL", "https://app.agenticorg.ai")
 
 _API_CALLBACK_URL = os.getenv(
     "PLURAL_CALLBACK_URL", f"{_APP_BASE_URL}/api/v1/billing/callback"

--- a/core/billing/stripe_client.py
+++ b/core/billing/stripe_client.py
@@ -45,7 +45,7 @@ PLAN_AMOUNT_USD: dict[str, int] = {
     "enterprise": 499_00,  # $499/mo
 }
 
-_APP_BASE_URL = os.getenv("AGENTICORG_APP_URL", "https://app.agenticorg.com")
+_APP_BASE_URL = os.getenv("AGENTICORG_APP_URL", "https://app.agenticorg.ai")
 
 _API_CALLBACK_URL = os.getenv(
     "STRIPE_CALLBACK_URL",

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -106,3 +106,8 @@ env:
   AGENTICORG_LLM_FALLBACK: gemini-2.5-flash-preview-05-20     # Switch to gpt-4o-2024-11-20 when needed
   # Alembic is the schema authority. init_db() skips legacy DDL when this is true.
   AGENTICORG_DDL_MANAGED_BY_ALEMBIC: "true"
+  # Public app URL — used in billing callback URLs (Stripe + Plural),
+  # invite emails, password-reset emails, etc. MUST match the actual
+  # production hostname; a wrong value silently breaks payment redirects
+  # (Stripe redirected to a non-existent .com host before this was set).
+  AGENTICORG_APP_URL: "https://app.agenticorg.ai"


### PR DESCRIPTION
## Repro

User reported: after completing payment on Stripe, instead of being returned to `/dashboard/billing/callback` with a success message, the browser lands on the login page (or a blank/404).

## Root cause

`core/billing/stripe_client.py:48` and `core/billing/pinelabs_client.py:52` both default `AGENTICORG_APP_URL` to **`https://app.agenticorg.com`** (.com) — stale from before production was on the .ai domain. Helm did **not** set this env var, so the wrong default reached production:

```python
_APP_BASE_URL = os.getenv("AGENTICORG_APP_URL", "https://app.agenticorg.com")
```

Stripe's `success_url` was constructed as `https://app.agenticorg.com/api/v1/billing/callback/stripe?session_id=…`. Stripe dutifully redirected the browser to that URL. The `.com` host has no SPA serving the callback route → user perceives "taken to login".

Other modules (`core/email.py`, `api/v1/auth.py`, `api/v1/org.py`, `api/v1/a2a.py`) had already been updated to default to `.ai`; only the two billing client files were missed.

## Fix

1. **`core/billing/stripe_client.py`**: default → `https://app.agenticorg.ai`
2. **`core/billing/pinelabs_client.py`**: default → `https://app.agenticorg.ai`
3. **`helm/values.yaml`**: set `AGENTICORG_APP_URL: "https://app.agenticorg.ai"` explicitly, with a comment about the payment-redirect blast radius so a future env-var change doesn't silently break payments.

## Test plan

- [x] `ruff check` on touched files — clean
- [ ] After deploy: complete a Stripe test payment from `/dashboard/billing` and verify the browser returns to `/dashboard/billing/callback?payment=success&...` and then auto-redirects to `/dashboard/billing` showing the active subscription.