### PR TITLE
test(e2e): Phase 1 — fix auth role in 16 regression specs

### DIFF
--- a/ui/e2e/app-routes.spec.ts
+++ b/ui/e2e/app-routes.spec.ts
@@ -79,7 +79,7 @@ test.describe("Dashboard Routes — Auth Required", () => {
     await page.goto(`${APP}/login`);
     await page.evaluate((token) => {
       localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    }, E2E_TOKEN);
   });
 
   for (const route of dashboardRoutes) {
@@ -148,7 +148,7 @@ test.describe("Dashboard — Sidebar Navigation", () => {
     await page.goto(`${APP}/login`);
     await page.evaluate((token) => {
       localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    }, E2E_TOKEN);
   });
 
   for (const link of sidebarLinks) {
@@ -186,7 +186,7 @@ test.describe("Create Flows", () => {
     await page.goto(`${APP}/login`);
     await page.evaluate((token) => {
       localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    }, E2E_TOKEN);
   });
 
   test("Agents page → Create Agent button works", async ({ page }) => {
@@ -226,7 +226,7 @@ test.describe("Data Display Quality", () => {
     await page.goto(`${APP}/login`);
     await page.evaluate((token) => {
       localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    }, E2E_TOKEN);
   });
 
   const pages = [

--- a/ui/e2e/cfo-demo.spec.ts
+++ b/ui/e2e/cfo-demo.spec.ts
@@ -65,7 +65,7 @@ test.describe("CFO Demo: Dashboard (auth required)", () => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.evaluate((t) => {
       localStorage.setItem("token", t);
-      localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));
+      localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));
     }, E2E_TOKEN);
   });
 

--- a/ui/e2e/cxo-dashboards.spec.ts
+++ b/ui/e2e/cxo-dashboards.spec.ts
@@ -29,7 +29,7 @@ async function authenticate(page: Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));  }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));  }, E2E_TOKEN);
 }
 
 async function goToDashboard(page: Page, path: string): Promise<void> {

--- a/ui/e2e/error-handling.spec.ts
+++ b/ui/e2e/error-handling.spec.ts
@@ -19,7 +19,7 @@ async function ensureAuth(page: Page, baseURL: string) {
   await page.goto(baseURL, { waitUntil: "domcontentloaded" });
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    localStorage.setItem(
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    localStorage.setItem(
       "user",
       JSON.stringify({
         email: "e2e@agenticorg.ai",
@@ -188,7 +188,7 @@ test.describe("Token Expiry", () => {
     await page.goto(baseURL!, { waitUntil: "domcontentloaded" });
     await page.evaluate(() => {
       localStorage.setItem("token", "expired.invalid.token");
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));      localStorage.setItem(
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));      localStorage.setItem(
         "user",
         JSON.stringify({ email: "x@x.x", name: "X", role: "admin" }),
       );

--- a/ui/e2e/flows.spec.ts
+++ b/ui/e2e/flows.spec.ts
@@ -16,7 +16,7 @@ async function authenticate(page: import("@playwright/test").Page) {
   await page.goto(`${APP}/login`);
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));  }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));  }, E2E_TOKEN);
 }
 
 // ============================================================================

--- a/ui/e2e/full-app.spec.ts
+++ b/ui/e2e/full-app.spec.ts
@@ -14,7 +14,7 @@ async function authenticate(page: Page) {
   await page.goto(`${APP}/login`);
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));  }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));  }, E2E_TOKEN);
 }
 
 // ---------------------------------------------------------------------------

--- a/ui/e2e/helpers/auth.ts
+++ b/ui/e2e/helpers/auth.ts
@@ -1,35 +1,145 @@
 /**
- * Auth helper for Playwright E2E regression tests.
+ * Shared E2E helpers for the regression suite.
  *
- * Seeds both `localStorage.token` AND `localStorage.user` so ProtectedRoute
- * treats the session as fully hydrated. Using only `token` hits `/auth/me`,
- * which since PR #103 defaults `onboarding_complete=false` for safety —
- * redirecting the test user to `/onboarding` and breaking every dashboard
- * assertion.
+ * What goes wrong without these and what each helper prevents:
+ *   1. Hardcoding `localStorage.user` with a fake role (e.g. "ceo") breaks
+ *      Layout sidebar filtering, which gates nav items by role. The CI demo
+ *      account is `admin`, so anything else hides every CxO nav link.
+ *   2. Hardcoding company UUIDs like "c1" makes CompanyDetail render empty
+ *      against a real tenant — tabs, modals, and table rows all disappear.
+ *   3. `getByText("Approvals", {exact:true}).first()` matches the sidebar
+ *      nav link before the CompanyDetail tab. Tab clicks navigate to the
+ *      wrong page entirely.
+ *
+ * All three patterns came up in `ca-firms.spec.ts` and the fixes are
+ * generic. Use these helpers in every regression spec.
  */
-import type { Page } from "@playwright/test";
+import type { Page, Locator } from "@playwright/test";
 
-const E2E_USER = {
-  email: "ceo@agenticorg.local",
-  name: "CEO",
-  role: "ceo",
-  domain: "general",
-  tenant_id: "e2e-tenant",
-  onboardingComplete: true,
-};
+export const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
+export const E2E_TOKEN = process.env.E2E_TOKEN || "";
+export const canAuth = !!E2E_TOKEN;
+
+interface AuthUser {
+  email: string;
+  name: string;
+  role: string;
+  domain: string;
+  tenant_id: string;
+  onboardingComplete: boolean;
+}
+
+/** Cache the resolved profile across tests in one Playwright run. */
+let _cachedProfile: AuthUser | null = null;
+let _cachedCompanyId: string | null = null;
 
 /**
- * Seed a valid token + fully-hydrated user into localStorage.
+ * Authenticate the page by seeding the real demo profile into localStorage.
  *
- * @param page - Playwright page
- * @param token - E2E auth token from login response
+ * Resolves the profile from `/api/v1/auth/me` the first time so the seeded
+ * `user` matches what ProtectedRoute would have hydrated naturally — most
+ * critically, the real `role` so sidebar filtering works.
  */
-export async function seedAuth(page: Page, token: string): Promise<void> {
+export async function authenticate(page: Page): Promise<void> {
+  if (!E2E_TOKEN) return;
+  await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
+  const profile = await getProfile(page);
   await page.evaluate(
     ([tkn, user]) => {
       localStorage.setItem("token", tkn as string);
       localStorage.setItem("user", JSON.stringify(user));
     },
-    [token, E2E_USER],
+    [E2E_TOKEN, profile],
   );
+}
+
+/**
+ * Fetch the live profile from /auth/me using the E2E token. Cached.
+ *
+ * Falls back to a known-good admin shape if the API is unreachable so a
+ * transient network blip during test setup does not cascade across the
+ * whole regression suite.
+ */
+export async function getProfile(page: Page): Promise<AuthUser> {
+  if (_cachedProfile) return _cachedProfile;
+  try {
+    const resp = await page.request.get(`${APP}/api/v1/auth/me`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+    });
+    if (resp.ok()) {
+      const data = await resp.json();
+      _cachedProfile = {
+        email: data.email,
+        name: data.name,
+        role: data.role,
+        domain: data.domain,
+        tenant_id: data.tenant_id,
+        onboardingComplete: data.onboarding_complete ?? true,
+      };
+      return _cachedProfile;
+    }
+  } catch {
+    // fall through
+  }
+  _cachedProfile = {
+    email: "demo@cafirm.agenticorg.ai",
+    name: "Demo Partner",
+    role: "admin",
+    domain: "all",
+    tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
+    onboardingComplete: true,
+  };
+  return _cachedProfile;
+}
+
+/**
+ * Fetch the first real company id for the authed tenant. Cached.
+ *
+ * Specs MUST use this instead of hardcoding `c1` — `c1` does not exist in
+ * the demo tenant, so CompanyDetail renders an empty shell and every
+ * downstream selector fails.
+ */
+export async function getCompanyId(page: Page): Promise<string> {
+  if (_cachedCompanyId) return _cachedCompanyId;
+  try {
+    const resp = await page.request.get(
+      `${APP}/api/v1/companies?page=1&per_page=1`,
+      { headers: { Authorization: `Bearer ${E2E_TOKEN}` } },
+    );
+    if (resp.ok()) {
+      const data = await resp.json();
+      const items = Array.isArray(data) ? data : data?.items ?? [];
+      if (items.length > 0 && items[0]?.id) {
+        _cachedCompanyId = items[0].id as string;
+        return _cachedCompanyId;
+      }
+    }
+  } catch {
+    // fall through
+  }
+  // Known-good fallback so the spec can still run if the list endpoint blips.
+  return "b3611f2b-9906-4ae5-b525-c034bb823282";
+}
+
+/**
+ * Click-target locator that ignores the sidebar.
+ *
+ * `page.getByText("Approvals").first()` matches the sidebar nav link
+ * before any in-page tab button. Use this for tabs, in-page buttons, and
+ * any element that could be shadowed by an identical-named nav link.
+ */
+export function mainText(page: Page, text: string): Locator {
+  return page.locator("main").getByText(text, { exact: true }).first();
+}
+
+/** Click a CompanyDetail tab without picking up the sidebar nav link. */
+export function tabButton(page: Page, label: string | RegExp): Locator {
+  const matcher = typeof label === "string" ? new RegExp(`^${label}$`) : label;
+  return page.locator("main button").filter({ hasText: matcher }).first();
+}
+
+/** Reset the in-process cache. Useful between projects in one Playwright run. */
+export function _resetHelpersCache(): void {
+  _cachedProfile = null;
+  _cachedCompanyId = null;
 }

--- a/ui/e2e/login-e2e.spec.ts
+++ b/ui/e2e/login-e2e.spec.ts
@@ -87,7 +87,7 @@ test.describe("Login Page — Auth Flow", () => {
     await page.goto(`${APP}/login`);
     await page.evaluate((token) => {
       localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    }, E2E_TOKEN);
     await page.goto(`${APP}/dashboard`, { waitUntil: "networkidle" });
     await expect(page.getByText("Dashboard").first()).toBeVisible({ timeout: 10000 });
   });

--- a/ui/e2e/negative-cases.spec.ts
+++ b/ui/e2e/negative-cases.spec.ts
@@ -20,7 +20,7 @@ async function ensureAuth(page: Page, baseURL: string) {
   await page.goto(baseURL, { waitUntil: "domcontentloaded" });
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    localStorage.setItem(
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    localStorage.setItem(
       "user",
       JSON.stringify({
         email: "e2e@agenticorg.ai",

--- a/ui/e2e/onboarding-e2e.spec.ts
+++ b/ui/e2e/onboarding-e2e.spec.ts
@@ -18,7 +18,7 @@ async function ensureAuth(page: Page, baseURL: string) {
   await page.goto(baseURL, { waitUntil: "domcontentloaded" });
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    localStorage.setItem(
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    localStorage.setItem(
       "user",
       JSON.stringify({
         email: "e2e@agenticorg.ai",

--- a/ui/e2e/production-full.spec.ts
+++ b/ui/e2e/production-full.spec.ts
@@ -19,7 +19,7 @@ async function injectAuth(page: Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
   await page.evaluate((t) => {
     localStorage.setItem("token", t);
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));  }, token);
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));  }, token);
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/ui/e2e/qa-bugs-8apr2026.spec.ts
+++ b/ui/e2e/qa-bugs-8apr2026.spec.ts
@@ -23,7 +23,7 @@ async function authenticate(page: Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    localStorage.setItem(
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    localStorage.setItem(
       "user",
       JSON.stringify({
         email: "e2e@agenticorg.ai",

--- a/ui/e2e/qa-bugs-regression.spec.ts
+++ b/ui/e2e/qa-bugs-regression.spec.ts
@@ -21,7 +21,7 @@ async function ensureAuth(page: Page, baseURL: string) {
   await page.goto(baseURL, { waitUntil: "domcontentloaded" });
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));    localStorage.setItem(
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    localStorage.setItem(
       "user",
       JSON.stringify({
         email: "e2e@agenticorg.ai",

--- a/ui/e2e/scope-enforcement.spec.ts
+++ b/ui/e2e/scope-enforcement.spec.ts
@@ -19,7 +19,7 @@ async function authenticate(page: Page) {
   await page.goto(`${APP}/login`);
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));  }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));  }, E2E_TOKEN);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/ui/e2e/sop-flow.spec.ts
+++ b/ui/e2e/sop-flow.spec.ts
@@ -20,7 +20,7 @@ test.describe("SOP: Page Access (auth required)", () => {
     await page.goto("/login", { waitUntil: "domcontentloaded" });
     await page.evaluate((t) => {
       localStorage.setItem("token", t);
-      localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));
+      localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));
     }, E2E_TOKEN);
   });
 
@@ -147,7 +147,7 @@ test.describe("SOP: Dashboard v3.0 (auth required)", () => {
     await page.goto("/login", { waitUntil: "domcontentloaded" });
     await page.evaluate((t) => {
       localStorage.setItem("token", t);
-      localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));
+      localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));
     }, E2E_TOKEN);
   });
 

--- a/ui/e2e/v4-features.spec.ts
+++ b/ui/e2e/v4-features.spec.ts
@@ -25,7 +25,7 @@ async function authenticate(page: Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
   await page.evaluate((token) => {
     localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));  }, E2E_TOKEN);
+    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));  }, E2E_TOKEN);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/ui/e2e/video-recordings.spec.ts
+++ b/ui/e2e/video-recordings.spec.ts
@@ -40,7 +40,7 @@ test.describe("Video Flows: Platform Overview (auth required)", () => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.evaluate((t) => {
       localStorage.setItem("token", t);
-      localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));
+      localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));
     }, E2E_TOKEN);
   });
 
@@ -85,7 +85,7 @@ test.describe("Video Flows: CFO Finance (auth required)", () => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.evaluate((t) => {
       localStorage.setItem("token", t);
-      localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));
+      localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));
     }, E2E_TOKEN);
   });
 
@@ -110,7 +110,7 @@ test.describe("Video Flows: CHRO HR (auth required)", () => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.evaluate((t) => {
       localStorage.setItem("token", t);
-      localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));
+      localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));
     }, E2E_TOKEN);
   });
 
@@ -135,7 +135,7 @@ test.describe("Video Flows: CMO Marketing (auth required)", () => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.evaluate((t) => {
       localStorage.setItem("token", t);
-      localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));
+      localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));
     }, E2E_TOKEN);
   });
 
@@ -155,7 +155,7 @@ test.describe("Video Flows: COO Operations (auth required)", () => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.evaluate((t) => {
       localStorage.setItem("token", t);
-      localStorage.setItem("user", JSON.stringify({ email: "ceo@agenticorg.local", name: "CEO", role: "ceo", domain: "general", tenant_id: "e2e-tenant", onboardingComplete: true }));
+      localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));
     }, E2E_TOKEN);
   });
 


### PR DESCRIPTION
## Summary

Every regression spec seeded `localStorage.user` with role `"ceo"` (a fake value), but `Layout.tsx` filters sidebar nav by role and the real CI demo account is role `"admin"`. Result: all CxO Dashboard nav links were hidden and anything asserting them failed — a test-fixture bug, not a product bug.

This is the mechanical half of the e2e stabilization plan (Phase 1). Remaining Playwright failures after this lands are **pure content drift** (Phase 2) — specs asserting UI strings the shipped app no longer renders ("Revenue MTD", "Recent Escalations", "View Details" quadrant links, etc.).

## What changed

- **`ui/e2e/helpers/auth.ts`** — rewritten as a shared helper module. Replaces the lone `seedAuth()` with:
  - `authenticate(page)` — seeds token + profile, fetches `/auth/me` live so the seeded `user` always matches what `ProtectedRoute` would hydrate.
  - `getProfile(page)` — cached profile lookup with safe fallback.
  - `getCompanyId(page)` — cached, replaces hardcoded UUIDs.
  - `mainText(page, text)` / `tabButton(page, label)` — selectors scoped to `<main>` so sidebar nav links don't shadow in-page tabs.

- **16 spec files** — swapped the inline fake-`ceo` user JSON for the real CA demo profile (`role="admin"`, `tenant_id=58483c90-…`). Purely mechanical replacement, no logic changes.

Specs touched: `app-routes`, `cfo-demo`, `cxo-dashboards`, `error-handling`, `flows`, `full-app`, `login-e2e`, `negative-cases`, `onboarding-e2e`, `production-full`, `qa-bugs-8apr2026`, `qa-bugs-regression`, `scope-enforcement`, `sop-flow`, `v4-features`, `video-recordings`.

`ca-firms.spec.ts` is **not** touched — it was already fixed in PR #150 with its own inline helpers and is the only spec currently passing (56/58 against prod).

## Verification

- `tsc --noEmit` — clean.
- Canary: `cxo-dashboards.spec.ts` against `https://app.agenticorg.ai` with the real demo token. Confirmed:
  - Pages load for the seeded user (sidebar shows CEO/CFO/CHRO links; dashboard routes no longer redirect to `/onboarding`).
  - Failures that remain are content assertions on CEO-dashboard UI that no longer exists in the shipped app — that's Phase 2.

## What's out of scope (Phase 2)

- Rewriting spec assertions to match the shipped UI strings.
- Seeding deterministic fixture data in the demo tenant so tests like "7 client rows" / "specific INR amount" can assert precisely.
- Sharding the regression suite (currently `workers: 1`, 45-min timeout).
- Flipping `continue-on-error: true` → `false` once Phase 2 is green.

I'll open those as separate PRs once this lands and we confirm the pass-rate bump in CI.

## Test plan
- [ ] Merge, observe the next `e2e-tests` job on main — before: auth redirected every test to onboarding; after: tests reach the dashboard pages and fail only on content drift.
- [ ] Confirm `ca-firms.spec.ts` still passes unchanged.