### PR TITLE
fix: address Codex review feedback on #150 + #151

### DIFF
--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -1102,31 +1102,43 @@ async def run_agent(
     authorized_tools = agent_config.get("authorized_tools", []) or []
     correlation_id = f"run_{_uuid.uuid4().hex[:12]}"
 
-    # Pre-flight: surface unresolvable tools before the graph runs so callers
-    # get an actionable 400 instead of a runtime AttributeError / silent tool
-    # failure (Session 4 BUGs 013/014/015). The tool index is built from
-    # connector manifests; a tool missing here means the required connector
-    # is not registered for this deployment.
+    # Pre-flight: filter out unresolvable tools so the graph runs with what
+    # the registry can actually dispatch (Session 4 BUGs 013/014/015). Many
+    # auto-populated defaults in _AGENT_TYPE_DEFAULT_TOOLS are not registered
+    # as connector tools today, so a hard 400 on any missing name would
+    # regress newly-created default agents. Only fail if *every* authorized
+    # tool is unresolvable and the agent had some to begin with — an empty
+    # toolset after filtering means the agent genuinely can't do its job.
     if authorized_tools:
         try:
             missing_tools = _validate_authorized_tools(authorized_tools)
         except Exception:  # noqa: BLE001 - validation is best-effort
             missing_tools = []
         if missing_tools:
-            linked_connectors = agent_config.get("connector_ids") or []
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": "tools_unavailable",
-                    "message": (
-                        "Agent authorized_tools cannot be resolved because the "
-                        "underlying connector is not linked. Link the required "
-                        "connector to this agent before running it."
-                    ),
-                    "missing_tools": missing_tools,
-                    "linked_connector_ids": linked_connectors,
-                },
+            resolvable = [t for t in authorized_tools if t not in set(missing_tools)]
+            logger.warning(
+                "agent_run_tools_filtered",
+                agent_id=str(agent_id),
+                missing=missing_tools,
+                kept=resolvable,
             )
+            if not resolvable:
+                linked_connectors = agent_config.get("connector_ids") or []
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": "tools_unavailable",
+                        "message": (
+                            "Agent has no resolvable tools — every entry in "
+                            "authorized_tools is missing from the connector "
+                            "registry. Link a connector or update the tool list."
+                        ),
+                        "missing_tools": missing_tools,
+                        "linked_connector_ids": linked_connectors,
+                    },
+                )
+            authorized_tools = resolvable
+            agent_config["authorized_tools"] = resolvable
 
     # Resolve system prompt — custom text or load from prompt file
     system_prompt = agent_config.get("system_prompt_text") or ""

--- a/ui/e2e/helpers/auth.ts
+++ b/ui/e2e/helpers/auth.ts
@@ -54,11 +54,12 @@ export async function authenticate(page: Page): Promise<void> {
 }
 
 /**
- * Fetch the live profile from /auth/me using the E2E token. Cached.
+ * Fetch the live profile from /auth/me using the E2E token.
  *
- * Falls back to a known-good admin shape if the API is unreachable so a
- * transient network blip during test setup does not cascade across the
- * whole regression suite.
+ * Only caches on successful API response. A transient network blip returns
+ * the fallback without poisoning subsequent calls, so the next test (or
+ * retry) still gets a fresh shot at the real profile — otherwise one bad
+ * request at setup time could lock the whole run to the wrong identity.
  */
 export async function getProfile(page: Page): Promise<AuthUser> {
   if (_cachedProfile) return _cachedProfile;
@@ -79,9 +80,9 @@ export async function getProfile(page: Page): Promise<AuthUser> {
       return _cachedProfile;
     }
   } catch {
-    // fall through
+    // fall through to fallback, but don't cache — next call retries the API.
   }
-  _cachedProfile = {
+  return {
     email: "demo@cafirm.agenticorg.ai",
     name: "Demo Partner",
     role: "admin",
@@ -89,15 +90,16 @@ export async function getProfile(page: Page): Promise<AuthUser> {
     tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
     onboardingComplete: true,
   };
-  return _cachedProfile;
 }
 
 /**
- * Fetch the first real company id for the authed tenant. Cached.
+ * Fetch the first real company id for the authed tenant.
  *
- * Specs MUST use this instead of hardcoding `c1` — `c1` does not exist in
- * the demo tenant, so CompanyDetail renders an empty shell and every
- * downstream selector fails.
+ * Only caches on successful API response with a non-empty list. A
+ * hardcoded UUID fallback would be wrong for any other tenant/environment
+ * and would turn a transient list-endpoint blip into persistent false
+ * negatives across the suite. When the API cannot answer, throw — the
+ * caller's spec fails cleanly and retries on the next attempt.
  */
 export async function getCompanyId(page: Page): Promise<string> {
   if (_cachedCompanyId) return _cachedCompanyId;
@@ -115,10 +117,13 @@ export async function getCompanyId(page: Page): Promise<string> {
       }
     }
   } catch {
-    // fall through
+    // Fall through — we'd rather raise a clean error than silently
+    // return a cross-tenant UUID.
   }
-  // Known-good fallback so the spec can still run if the list endpoint blips.
-  return "b3611f2b-9906-4ae5-b525-c034bb823282";
+  throw new Error(
+    "getCompanyId: /api/v1/companies returned no usable id. " +
+      "Seed the demo tenant with at least one company before running the suite.",
+  );
 }
 
 /**

--- a/ui/src/pages/CompanyDetail.tsx
+++ b/ui/src/pages/CompanyDetail.tsx
@@ -973,7 +973,17 @@ export default function CompanyDetail() {
           });
           const exportCsv = () => {
             const header = ["Timestamp", "Action", "Actor", "Outcome"];
-            const csvEscape = (v: string) => `"${v.replace(/"/g, '""')}"`;
+            // Neutralize CSV formula injection: any cell whose first
+            // character can be interpreted as a spreadsheet formula
+            // (=, +, -, @, CR, LF, TAB) is prefixed with a single quote
+            // so Excel/Sheets render it as text. Action and Actor fields
+            // carry user-controlled strings (filing types, emails), so
+            // without this an exported audit log could execute formulas
+            // on the reviewer's machine.
+            const csvEscape = (v: string) => {
+              const guarded = /^[=+\-@\r\n\t]/.test(v) ? `'${v}` : v;
+              return `"${guarded.replace(/"/g, '""')}"`;
+            };
             const rows = filteredActivities.map((a) => [
               a.timestamp,
               a.action,


### PR DESCRIPTION
## Summary

Four review items from the Codex bot on #150 and #151. All legitimate and actionable.

### P1 — `api/v1/agents.py` run_agent pre-flight too aggressive

**Comment:** The 400-on-any-missing check regresses newly-created default agents, because `_AGENT_TYPE_DEFAULT_TOOLS` contains names that are not registered in the connector registry (e.g. `check_order_status`, `schedule_social_post`, `search_content_fulltext`). `create_agent` skips validation for auto-populated defaults, so these agents get persisted and then fail at runtime.

**Fix:** Filter unresolvable tools and only reject the run when every authorized tool is missing. Agents with some working tools now run with what's available; fully unresolvable agents still get a clear 400. Logs a warning with the filtered/kept sets so it's observable.

### P2 — `ui/src/pages/CompanyDetail.tsx` CSV formula injection

**Comment:** Audit CSV export only escapes quotes. A cell starting with `=`, `+`, `-`, or `@` is still emitted as an executable formula by Excel/Sheets. Action / Actor fields carry user-controlled strings, so an exported audit log could execute formulas on the reviewer's machine.

**Fix:** Prefix any cell starting with `=+-@\r\n\t` with a single quote before quoting, so the spreadsheet renders it as text.

### P2 — `ui/e2e/helpers/auth.ts` `getProfile` caches fallback

**Comment:** A transient `/auth/me` failure cached the hardcoded fallback identity for the rest of the run, locking the suite to the wrong role/tenant.

**Fix:** Only populate `_cachedProfile` on a 2xx response. On failure, return the fallback without caching so the next call retries.

### P2 — `ui/e2e/helpers/auth.ts` `getCompanyId` cross-tenant fallback

**Comment:** The fixed UUID fallback is wrong for any non-demo tenant. A transient list-endpoint blip turns into persistent false negatives.

**Fix:** Throw instead of returning the hardcoded UUID. Specs fail cleanly and retry on the next attempt.

## Verification

- `ruff check api/v1/agents.py` — clean
- `tsc --noEmit` — clean
- `pytest tests/unit/test_agents_and_sales.py -q --no-cov` — **107 passed**

## Test plan
- [ ] Merge, watch the next `unit-tests` / `integration-tests` jobs on main pass.
- [ ] Next e2e regression run: agent-run no longer 400s for default agents.
- [ ] Spot-check the audit CSV export with a row whose action starts with `=` — opens as text, not a formula.