### PR TITLE
fix(prod): resolve startup deadlock + probe timeout (outage recovery)

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -93,6 +93,15 @@ async def init_db() -> None:
         return
 
     async with engine.begin() as conn:
+        # Serialize startup DDL across concurrently-booting pods with a
+        # transaction-scoped advisory lock. Without this, a rolling deploy
+        # that restarts N pods at once has them racing on ALTER TABLE ...
+        # ENABLE ROW LEVEL SECURITY (AccessExclusiveLock) and deadlocking
+        # against each other — the April 16 outage. The lock is released
+        # automatically when this BEGIN..COMMIT transaction ends. Any
+        # magic int64 works; the constant below is arbitrary but stable.
+        await conn.execute(text("SELECT pg_advisory_xact_lock(4815162342);"))
+
         # v4.0.0: Ensure prompt_amendments column exists on agents table.
         # Safe to run every startup (IF NOT EXISTS check).
         await conn.execute(text("""

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -36,20 +36,38 @@ spec:
             {{- end }}
           resources:
             {{- toYaml (.Values.resources.api | default dict) | nindent 12 }}
+          # Startup probe: allows up to ~3 minutes for the 3.2 GB image to
+          # import LangGraph + 54 connectors and bind port 8000 on cold-
+          # started Autopilot nodes. While this probe is passing, the
+          # livenessProbe is disabled — kubelet cannot kill the container
+          # for slow startup. Once startup succeeds, liveness takes over.
+          # Prior config (initialDelaySeconds: 10, failureThreshold: 3)
+          # gave only 100s before kubelet SIGKILLed the container, which
+          # took production offline during the April 16 deploy storm.
+          startupProbe:
+            httpGet:
+              path: /api/v1/health/liveness
+              port: 8000
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 18
           livenessProbe:
             httpGet:
               path: /api/v1/health/liveness
               port: 8000
-            initialDelaySeconds: 10
+            initialDelaySeconds: 90
             periodSeconds: 30
-            timeoutSeconds: 3
+            timeoutSeconds: 5
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /api/v1/health
               port: 8000
-            initialDelaySeconds: 5
+            initialDelaySeconds: 20
             periodSeconds: 10
             timeoutSeconds: 5
+            failureThreshold: 3
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/migrations/versions/v4_8_2_init_db_advisory_lock.py
+++ b/migrations/versions/v4_8_2_init_db_advisory_lock.py
@@ -1,0 +1,37 @@
+"""No-op migration — documents init_db advisory lock for the CI migration guard.
+
+Revision ID: v482_init_db_advisory_lock
+Revises: v481_orm_sync
+Create Date: 2026-04-16
+
+This revision intentionally does not change any schema. It exists so the CI
+``check_migration_required`` guard is satisfied when ``core/database.py`` is
+edited purely for runtime behavior changes.
+
+The accompanying code change in ``core/database.py`` serializes the startup
+DDL block with ``SELECT pg_advisory_xact_lock(...)``. Concurrent pod boots
+during a rolling deploy were deadlocking each other on
+``ALTER TABLE ... ENABLE ROW LEVEL SECURITY`` (``AccessExclusiveLock``),
+which took production down on 2026-04-16. The lock is transaction-scoped,
+released automatically at COMMIT, and has no persistent effect on the
+database schema — hence no up/down DDL here.
+
+See ``core/database.py::init_db`` for the lock call, and PR #154 for the
+full write-up of the outage and fix.
+"""
+
+from __future__ import annotations
+
+# Alembic identifiers
+revision = "v482_init_db_advisory_lock"
+down_revision = "v481_orm_sync"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """No-op. See module docstring."""
+
+
+def downgrade() -> None:
+    """No-op. See module docstring."""


### PR DESCRIPTION
## Summary

**Production outage recovery.** April 16, during a deploy storm (8 PRs merging within an hour), every api pod entered CrashLoopBackOff and production returned HTTP 502 across app.agenticorg.ai.

## Root cause (found in pod logs)

Multiple pods booting concurrently race each other in `init_db()`:

```
sqlalchemy.exc.DBAPIError: DeadlockDetectedError
DETAIL: Process 897141 waits for AccessExclusiveLock on relation 18430;
        blocked by process 897140.
Process 897140 waits for AccessExclusiveLock on relation 18415;
        blocked by process 897141.
[SQL: ALTER TABLE sso_configs ENABLE ROW LEVEL SECURITY;]
ERROR: Application startup failed. Exiting.
```

`ALTER TABLE ... ENABLE ROW LEVEL SECURITY` takes an `AccessExclusiveLock`. Two pods acquiring locks on different tables in different order deadlock, Postgres aborts one, FastAPI startup fails, pod crashloops. Enough pods looping like that fill the replica set and the LB returns 502.

## Fix (two changes)

### 1. `core/database.py` — serialize startup DDL

Wrap the `init_db()` DDL transaction in `SELECT pg_advisory_xact_lock(...);`. Only one pod at a time runs the section; the lock is released when the transaction commits. Subsequent pods observe idempotent DDL (`IF NOT EXISTS` / `DO` blocks) and no-op quickly. **This is the actual bug fix.**

### 2. `helm/templates/deployment.yaml` — startupProbe + longer liveness

The old probe config (`initialDelaySeconds: 10`, `failureThreshold: 3`, `period: 30s`) gave the container only ~100s to bind port 8000 before kubelet SIGKILLed it. On cold-started Autopilot nodes the 3.2 GB image + 54 connectors + LangGraph imports can take longer. This was not the root cause (the DB deadlock was), but it turned a recoverable error into a pure crashloop. Safety net:

| Probe | Before | After |
|------|--------|-------|
| `startupProbe` | — | `initialDelay 20s`, `period 10s`, `failureThreshold 18` (~180s) |
| `livenessProbe.initialDelaySeconds` | 10s | 90s |
| `livenessProbe.failureThreshold` | 3 | 5 |
| `readinessProbe.initialDelaySeconds` | 5s | 20s |

## Status

- Live production was patched via `kubectl patch` at ~12:33 UTC to unblock the outage — the probe timing patch stopped the kubelet from SIGKILLing a pod that was winning the DB-lock race, and one pod came up clean.
- **Production is HTTP 200 again.**
- This PR makes both fixes durable in Helm and code so they survive the next deploy.

## Verification
- [ ] `ruff check core/database.py` — clean.
- [ ] Merge → deploy-production rolls the new image + deployment. With the advisory lock, new pods should start cleanly even if the rolling update schedules them concurrently.
- [ ] `/api/v1/health` stays HTTP 200 during and after rollout.
- [ ] All api pods 1/1 Ready; no CrashLoopBackOff in `kubectl get pods -n agenticorg`.

## Residual risk

Memory limit (2Gi) on a 3.2 GB image is still tight. Not the root cause today, but a follow-up should (a) trim the image via multistage build or (b) bump memory + raise autoscaler minReplicas.