### PR TITLE
test(e2e): eliminate 27 conditional skips + make Playwright blocking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -202,6 +202,25 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    services:
+      # Ephemeral Postgres used only by tests/e2e/test_cxo_flows.py,
+      # which drives the FastAPI app via TestClient and needs a real
+      # DB behind it. Cheap to start, isolated from production.
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_DB: agenticorg_e2e
+          POSTGRES_USER: e2e
+          POSTGRES_PASSWORD: e2e
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U e2e -d agenticorg_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports: ["6379:6379"]
     steps:
       - uses: actions/checkout@v6
 
@@ -223,23 +242,11 @@ jobs:
             sleep 10
           done
 
-      - name: Run Python E2E tests (against production)
-        # Global 5-minute cap — the previous fixture-teardown hang wedged
-        # a runner past 25 min (CI runs 24432641344 and 24433193853),
-        # cancel requests did not propagate. This puts a hard ceiling.
-        timeout-minutes: 5
-        run: pytest tests/e2e/ -v
-        env:
-          AGENTICORG_E2E_BASE_URL: https://app.agenticorg.ai
-          AGENTICORG_SECRET_KEY: ci-test-secret-key-minimum-16
-
-      - name: Run Synthetic Agent Quality tests (non-blocking — tests LLM behavior)
-        run: pytest tests/synthetic_data/ -v || echo "::warning::Synthetic agent tests failed — LLM behavior issue, not code bug"
-        continue-on-error: true
-        env:
-          AGENTICORG_E2E_BASE_URL: https://app.agenticorg.ai
-          AGENTICORG_SECRET_KEY: ci-test-secret-key-minimum-16
-
+      # Acquire the auth token FIRST so every downstream step (pytest e2e,
+      # synthetic tests, Playwright) sees the same AGENTICORG_E2E_TOKEN.
+      # Previously this step ran after the pytest steps, which forced the
+      # 21 token-gated test cases in tests/e2e/test_smoke.py and
+      # tests/synthetic_data/ to skip.
       - name: Get fresh E2E auth token
         id: auth
         run: |
@@ -263,24 +270,53 @@ jobs:
           echo "::error::Could not acquire E2E auth token after 5 attempts — failing pipeline"
           exit 1
 
+      - name: Seed demo tenant with an AP Processor agent (idempotent)
+        # Several synthetic tests look up an agent of type ``ap_processor``
+        # and skip if none exists. The demo tenant ships with other
+        # finance agents but not AP Processor, so the tests were always
+        # skipping. Create one here if absent; the endpoint is a no-op
+        # when a shadow agent of that type already exists (caught by the
+        # fleet-limit guard + 409 -> treated as success).
+        run: |
+          python3 scripts/seed_e2e_demo_agents.py \
+            --base-url https://app.agenticorg.ai \
+            --token "${{ steps.auth.outputs.token }}"
+
+      - name: Run Python E2E tests (against production)
+        # Global 5-minute cap — the previous fixture-teardown hang wedged
+        # a runner past 25 min (CI runs 24432641344 and 24433193853),
+        # cancel requests did not propagate. This puts a hard ceiling.
+        timeout-minutes: 5
+        run: pytest tests/e2e/ -v
+        env:
+          AGENTICORG_E2E_BASE_URL: https://app.agenticorg.ai
+          AGENTICORG_E2E_TOKEN: ${{ steps.auth.outputs.token }}
+          AGENTICORG_DATABASE_URL: postgresql+asyncpg://e2e:e2e@localhost:5432/agenticorg_e2e
+          AGENTICORG_REDIS_URL: redis://localhost:6379/0
+          AGENTICORG_SECRET_KEY: ci-test-secret-key-minimum-16
+
+      - name: Run Synthetic Agent Quality tests (LLM behavior)
+        # Now blocking. With AGENTICORG_ENABLE_LIVE_TESTS=1 + a real token
+        # + seeded AP Processor agent, every assertion should resolve.
+        # If this step starts flaking on legitimate LLM non-determinism,
+        # split the non-deterministic cases into an explicitly-marked
+        # suite — do not reintroduce ``continue-on-error``.
+        run: pytest tests/synthetic_data/ -v
+        env:
+          AGENTICORG_E2E_BASE_URL: https://app.agenticorg.ai
+          AGENTICORG_E2E_TOKEN: ${{ steps.auth.outputs.token }}
+          AGENTICORG_ENABLE_LIVE_TESTS: "1"
+          AGENTICORG_SECRET_KEY: ci-test-secret-key-minimum-16
+
       - name: Install Playwright
         run: cd ui && npm install --legacy-peer-deps && npx playwright install --with-deps chromium
 
       - name: Run ALL Playwright E2E regression suite against production
-        # Non-blocking. The suite is a 438-test post-deploy canary against
-        # live production. It runs for every deploy, uploads a report as
-        # an artifact, and surfaces drift — but it does not gate CI.
-        #
-        # Why non-blocking: the suite has accumulated contract-drift
-        # against the current UI over many releases (expected KPI card
-        # counts, specific INR amounts, demo tenant seed rows, etc.),
-        # and fixing every spec is a dedicated multi-week effort, not
-        # a deploy-time concern. Production safety is enforced by the
-        # blocking gates above: lint, unit, security, integration,
-        # build, deploy-production's rollout check, and the post-deploy
-        # pytest e2e step (5-min cap).
+        # Blocking. PR #151 (Phase 1 auth role) and #152 (Phase 2 cxo
+        # rewrite) fixed the systemic drift that had been hidden by
+        # continue-on-error. If a spec fails here, fix the spec or the
+        # product — do not reintroduce continue-on-error.
         timeout-minutes: 45
-        continue-on-error: true
         run: cd ui && npx playwright test --config=e2e/regression.config.ts
         env:
           BASE_URL: https://app.agenticorg.ai

--- a/scripts/seed_e2e_demo_agents.py
+++ b/scripts/seed_e2e_demo_agents.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Idempotently seed the demo tenant with agents required by the E2E suite.
+
+Currently ensures:
+  - at least one agent of type ``ap_processor`` in ``shadow`` state
+
+``tests/synthetic_data/test_synthetic_flows.py`` looks up an agent of
+that type and skips when one is not present. The demo tenant ships with
+a different finance agent mix (ar_collections, bank_reconciliation,
+gst_filing, tds_compliance), so the AP Processor tests always skipped
+in CI. Running this script before the pytest step turns those skips
+into real assertions.
+
+Idempotent: a second invocation is a no-op. Exits non-zero only on
+network failure or a 5xx from the API.
+
+Usage:
+  python3 scripts/seed_e2e_demo_agents.py \
+      --base-url https://app.agenticorg.ai \
+      --token "$E2E_TOKEN"
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+import httpx
+
+
+def _ensure_ap_processor(client: httpx.Client) -> None:
+    resp = client.get("/api/v1/agents", params={"page": 1, "per_page": 200})
+    resp.raise_for_status()
+    items = resp.json().get("items", [])
+    existing = [a for a in items if a.get("agent_type") == "ap_processor"]
+    if existing:
+        print(f"[seed] ap_processor already present (id={existing[0]['id']}) — skipping create")
+        return
+
+    payload: dict[str, Any] = {
+        "name": "E2E AP Processor",
+        "agent_type": "ap_processor",
+        "domain": "finance",
+        "employee_name": "E2E AP Processor",
+        "designation": "AP Processor (E2E)",
+        "initial_status": "shadow",
+        "system_prompt_text": (
+            "You are an AP Processor agent. Given an invoice plus matching "
+            "PO and GRN data, decide whether to approve the invoice and "
+            "return a JSON object with status, confidence, and "
+            "processing_trace."
+        ),
+    }
+    resp = client.post("/api/v1/agents", json=payload)
+    if resp.status_code in (200, 201):
+        print(f"[seed] created ap_processor agent id={resp.json().get('id', 'unknown')}")
+        return
+    if resp.status_code == 409:
+        # Shadow fleet limit reached or duplicate — treat as benign.
+        print(f"[seed] ap_processor create returned 409, continuing: {resp.text[:200]}")
+        return
+    resp.raise_for_status()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--token", required=True)
+    args = parser.parse_args()
+
+    headers = {
+        "Authorization": f"Bearer {args.token}",
+        "Content-Type": "application/json",
+    }
+    with httpx.Client(base_url=args.base_url.rstrip("/"), headers=headers, timeout=30) as client:
+        _ensure_ap_processor(client)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e/test_cxo_flows.py
+++ b/tests/e2e/test_cxo_flows.py
@@ -57,16 +57,11 @@ def client(app):
     app.dependency_overrides.pop(get_current_tenant, None)
 
 
-# Tests that require a real DB behind the FastAPI TestClient.
-# The e2e-tests job intentionally runs without Postgres/Redis service
-# containers (PR #131 diagnosis: the hermetic DB fixture wedged the
-# runner). DB-backed paths are covered by tests/integration/ and the
-# post-deploy Playwright regression against production. These six
-# tests are kept for local development and future hermetic-DB work.
-_DB_SKIP_REASON = (
-    "Requires a Postgres-backed FastAPI TestClient. Covered by "
-    "tests/integration/ + post-deploy Playwright suite."
-)
+# Tests in this module drive the FastAPI TestClient and expect a real
+# Postgres+Redis behind it. The e2e-tests CI job now provides both via
+# service containers (see .github/workflows/deploy.yml), so these run
+# unconditionally. For local development, bring up compose or export
+# AGENTICORG_DATABASE_URL / AGENTICORG_REDIS_URL to point at any pair.
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -77,7 +72,6 @@ _DB_SKIP_REASON = (
 class TestCFOJourney:
     """End-to-end CFO user flow."""
 
-    @pytest.mark.skip(reason=_DB_SKIP_REASON)
     def test_cfo_kpis_return_valid_data(self, client):
         """CFO KPI dashboard returns all required metrics (basic metrics shape)."""
         resp = client.get("/api/v1/kpis/cfo")
@@ -101,7 +95,6 @@ class TestCFOJourney:
         assert data["domain"] == "finance"
         assert data["confidence"] >= 0.7
 
-    @pytest.mark.skip(reason=_DB_SKIP_REASON)
     def test_report_schedule_created_successfully(self, client):
         """CFO can create a report schedule that persists."""
         resp = client.post("/api/v1/report-schedules", json={
@@ -123,7 +116,6 @@ class TestCFOJourney:
         schedule_ids = [s["id"] for s in schedules]
         assert schedule["id"] in schedule_ids
 
-    @pytest.mark.skip(reason=_DB_SKIP_REASON)
     def test_company_switcher_lists_companies(self, client):
         """Company switcher returns list after creating companies."""
         # Create companies with required fields (pan is mandatory)
@@ -153,7 +145,6 @@ class TestCFOJourney:
                     "get_balance_sheet", "get_cash_position"}
         assert expected == set(DEFAULT_TOOLS)
 
-    @pytest.mark.skip(reason=_DB_SKIP_REASON)
     def test_cfo_kpis_with_company_filter(self, client):
         """CFO KPIs accept company_id parameter."""
         resp = client.get("/api/v1/kpis/cfo?company_id=test-company")
@@ -161,7 +152,6 @@ class TestCFOJourney:
         data = resp.json()
         assert data["company_id"] == "test-company"
 
-    @pytest.mark.skip(reason=_DB_SKIP_REASON)
     def test_create_and_retrieve_company(self, client):
         """Full company lifecycle: create -> retrieve -> verify fields."""
         create_resp = client.post("/api/v1/companies", json={
@@ -188,7 +178,6 @@ class TestCFOJourney:
 class TestCMOJourney:
     """End-to-end CMO user flow."""
 
-    @pytest.mark.skip(reason=_DB_SKIP_REASON)
     def test_cmo_kpis_return_valid_data(self, client):
         """CMO KPI dashboard returns all required metrics (basic metrics shape)."""
         resp = client.get("/api/v1/kpis/cmo")


### PR DESCRIPTION
## Summary

The e2e-tests CI job silently lost most of its coverage over time:

- `tests/e2e/`: **9 skips** — 6 tests skipped with `@pytest.mark.skip("Requires Postgres-backed TestClient")`, 3 skipped because `AGENTICORG_E2E_TOKEN` wasn't wired into the env.
- `tests/synthetic_data/`: **18 skips** — module-level skip on `AGENTICORG_ENABLE_LIVE_TESTS`, plus token-gated and agent-lookup skips.
- `ui/e2e/*.spec.ts`: the 438-test Playwright regression was non-blocking via `continue-on-error: true`.

Net: the job reported "green" while measuring a small fraction of what it claimed to measure.

## Changes

### `.github/workflows/deploy.yml` — restructure the `e2e-tests` job

1. **Move `Get fresh E2E auth token` step before the pytest steps** so every downstream step sees `AGENTICORG_E2E_TOKEN`. Unskips 3 smoke + 15 synthetic token-gated tests.
2. **Add Postgres + Redis service containers.** Wire `AGENTICORG_DATABASE_URL` / `AGENTICORG_REDIS_URL` to the service hosts. Unskips the 6 `tests/e2e/test_cxo_flows.py` DB-backed tests.
3. **Set `AGENTICORG_ENABLE_LIVE_TESTS=1`** on the synthetic step so the module-level `skipif` unblocks.
4. **Pre-step: seed AP Processor agent** in the demo tenant (via `scripts/seed_e2e_demo_agents.py`) so the 6 synthetic AP tests find what they look up.
5. **Promote Playwright regression to blocking** (remove `continue-on-error: true`). PR #151 (auth role fix) and #152 (cxo-dashboards rewrite) fixed the systemic drift that had been hidden — no justification left for non-blocking.

### `scripts/seed_e2e_demo_agents.py` (new)

Idempotent helper. Lists existing agents; creates one `ap_processor` shadow agent if none exists. Returns 0 on success or benign 409 (fleet-limit/duplicate).

### `tests/e2e/test_cxo_flows.py`

Remove the 6 `@pytest.mark.skip` decorators. Module docstring updated to point at the workflow's service-container wiring.

## Verification

Local smoke run with a real token:

```
tests/e2e/test_smoke.py::TestSmoke::test_health_endpoint PASSED          [ 14%]
tests/e2e/test_smoke.py::TestSmoke::test_liveness_probe PASSED           [ 28%]
tests/e2e/test_smoke.py::TestSmoke::test_openapi_docs_accessible PASSED  [ 42%]
tests/e2e/test_smoke.py::TestSmoke::test_agents_list_requires_auth PASSED [ 57%]
tests/e2e/test_smoke.py::TestSmoke::test_agents_list_with_auth PASSED    [ 71%]
tests/e2e/test_smoke.py::TestSmoke::test_workflows_list_with_auth PASSED [ 85%]
tests/e2e/test_smoke.py::TestSmoke::test_schemas_list_with_auth PASSED   [100%]

============================== 7 passed in 3.45s ==============================
```

Previous run had 4 passed + 3 skipped. Seed script also verified idempotent.

`ruff check scripts/seed_e2e_demo_agents.py tests/e2e/test_cxo_flows.py`: clean.

## Residual risk

- The synthetic tests call real agents on production. Individual cases may still fail on legitimately LLM-non-deterministic output (e.g. confidence sometimes < expected threshold). If that happens post-merge, **fix the test assertion** (loosen / add xfail) rather than reintroducing `continue-on-error`.
- The Playwright regression is now blocking. If a test fails after merge, fix the spec or the product. Do **not** flip the flag back.

## Test plan
- [ ] Merge → watch the next `e2e-tests` job on main show 0 skips in pytest and a real pass count for Playwright.
- [ ] All 438 Playwright tests pass, or PR follows to fix the failure. 
- [ ] `ca-firms.spec.ts` and rewritten `cxo-dashboards.spec.ts` remain green.