### PR TITLE
fix(tests): dispose engine after setup to unblock 4 KPI e2e failures

### DIFF
--- a/tests/e2e/test_cxo_flows.py
+++ b/tests/e2e/test_cxo_flows.py
@@ -41,12 +41,6 @@ def app():
             await conn.run_sync(BaseModel.metadata.create_all)
         await init_db()
         # Seed a single tenants row that every test client will reuse.
-        # Include every NOT NULL column with a safe default — missing
-        # `slug` previously caused NotNullViolationError at every test.
-        # Doing this once in the module fixture (which runs asyncio.run
-        # exactly once) avoids "Future attached to a different loop"
-        # errors that hit us when the per-test client tried to call
-        # asyncio.run() again with the shared engine.
         async with engine.begin() as conn:
             await conn.execute(
                 _sql_text(
@@ -62,6 +56,14 @@ def app():
             )
 
     asyncio.run(_setup())
+
+    # ``asyncio.run`` closed its event loop on exit, and the async engine's
+    # pool still holds connections that were created inside that loop.  The
+    # next request comes in via Starlette's TestClient on a brand-new loop,
+    # and asyncpg will refuse to reuse those connections with
+    # "Future attached to a different loop". Dispose the pool synchronously
+    # so every subsequent request opens a fresh connection on its own loop.
+    asyncio.run(engine.dispose())
 
     @asynccontextmanager
     async def _test_lifespan(app):


### PR DESCRIPTION
## Summary

The last 4 e2e-tests failures on main had real tracebacks after #166 flipped TestClient to `raise_server_exceptions=True`:

```
RuntimeError: Task <Task pending ... BaseHTTPMiddleware...> got Future <Future pending>
attached to a different loop
```

Root cause:
- The module-scoped `app()` fixture calls `asyncio.run(_setup())` which creates a temporary event loop, opens DB connections on it, then closes the loop when `asyncio.run` exits.
- The async engine's pool keeps those dead-loop connections.
- `TestClient` then runs the request on a brand-new loop. asyncpg refuses to reuse a connection whose Future is bound to a different loop.

Fix: `asyncio.run(engine.dispose())` immediately after setup. Subsequent requests open fresh connections on their own loop. One-line semantic fix; no behavioural change in production (the shipped app never double-runs `asyncio.run`).

## Verification

Preflight (whole-tree ruff, bandit, pytest regression+unit, alembic id, verify=False scan) passed locally — pre-push hook enforced that before this PR could push.

Expected result after merge: the 4 `TestCFOJourney` / `TestCMOJourney` KPI tests pass, e2e-tests goes green, main CI finally green-end-to-end with zero skips.