### PR TITLE
fix(deploy): bump API memory + drop to 1 uvicorn worker (OOM eviction)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ USER agenticorg
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD curl -sf http://localhost:8000/api/v1/health/liveness || exit 1
-CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2", "--timeout-graceful-shutdown", "20"]
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1", "--timeout-graceful-shutdown", "20"]

--- a/helm/values-lean.yaml
+++ b/helm/values-lean.yaml
@@ -23,12 +23,19 @@ imageUI:
 # ── Lean resource requests (Autopilot bills on requests, not limits) ──
 resources:
   api:
+    # Bumped from 512Mi/1Gi after OOM-eviction on 2026-04-17.
+    # spaCy + Presidio NLP pipeline pushes each uvicorn worker to
+    # ~700MB resident; with 2 workers the pod was steady-state ~1.5GB
+    # and got evicted when the node was under memory pressure.
+    # Pair this with ``--workers 1`` in the Dockerfile CMD so the pod
+    # runs a single Python process and Autopilot bills on the lower
+    # request.
     requests:
       cpu: 250m
-      memory: 512Mi
+      memory: 1Gi
     limits:
       cpu: 1000m
-      memory: 1Gi
+      memory: 2Gi
   orchestrator:
     requests:
       cpu: 250m


### PR DESCRIPTION
## Root cause

After #174 added spaCy + Presidio to the image, each uvicorn worker went from ~350 MB resident to ~700 MB. With `--workers 2` and a 1 Gi memory limit the pod steady-stated at ~1.5 GB and GKE Autopilot evicted it under node pressure:

```
Warning Evicted: The node was low on resource: memory.
Container api was using 1504652Ki, request is 1Gi
```

Once the pod was evicted the GCE Ingress had no healthy backend — every `/api/v1/*` hit the fallback path and served the marketing HTML (17 KB, content-type text/html). All 14 synthetic tests in the last main run failed with `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` and the e2e job went red.

Confirmed via `kubectl describe` + event log.

## Fix

1. **`Dockerfile`** — uvicorn now runs with `--workers 1`. Halves the per-pod Python processes so spaCy/Presidio load once. Horizontal scale-out is still available via replicas if we need more concurrency.

2. **`helm/values-lean.yaml`** — API memory request 512Mi → 1Gi, limit 1Gi → 2Gi. Keeps Autopilot billing reasonable while giving the worker headroom for PII-redaction warm-up (~900 MB transient).

## Verification

- `kubectl set resources` applied the same bump to the live cluster while this PR builds → API recovered, `/api/v1/health/liveness` returns `{"status":"alive"}` and `/auth/login` issues tokens again.
- This PR makes the config durable across redeploys.

## Test plan

- [x] live API smoke: liveness + login return 200
- [ ] PR CI green
- [ ] Post-merge main e2e — all synthetic tests return valid JSON (no more empty bodies)