### PR TITLE
test(synthetic): remove overly-broad skip patterns

### DIFF
--- a/tests/synthetic_data/test_synthetic_flows.py
+++ b/tests/synthetic_data/test_synthetic_flows.py
@@ -96,21 +96,14 @@ def _run_agent(headers: dict, agent_id: str, action: str, inputs: dict) -> dict:
         return {"error": "empty_or_invalid_response", "raw": r.text, "status_code": r.status_code}
 
 
-# Textual markers that indicate the agent in this environment isn't
-# configured to handle the test's action (wrong tool list, wrong prompt,
-# missing connector). The test skips rather than asserting, because we're
-# validating agent behavior, not the seeded demo-tenant config.
-_TOOLS_NOT_CONFIGURED_PATTERNS = (
-    "cannot fulfill",
-    "tools lack",
-    # Claude / GPT phrasing when the requested action isn't in the
-    # agent's allowed-actions list (seeded demo agents often ship with a
-    # narrower action surface than the synthetic tests exercise).
-    "not a supported action",
-    "not a valid action",
-    "is not supported",
-    "allowed list",
-)
+# Narrow set of markers that indicate the agent explicitly said it cannot
+# carry out the task with its current tool set. Previously we also
+# skipped on "not a supported action" / "is not supported" / "allowed
+# list", but those phrases appear in a false-positive way inside the
+# signed response envelope (base64 substrings and LLM self-narrative),
+# which caused ``test_renewal_approaching`` to skip spuriously even
+# though the agent had produced a valid answer.
+_TOOLS_NOT_CONFIGURED_PATTERNS = ("cannot fulfill", "tools lack")
 
 
 def _skip_if_tools_missing(result: dict) -> None:
@@ -124,13 +117,6 @@ def _skip_if_tools_missing(result: dict) -> None:
     # Also skip on empty / unparseable responses
     if result.get("error") == "empty_or_invalid_response":
         pytest.skip("Agent returned empty or non-JSON response")
-    # Skip when the server-side exception handler wraps any runtime error
-    # into a 500 detail. These are infrastructure issues (e.g. missing
-    # deps, LLM provider outage) — legitimate tests should not be the ones
-    # to report them, they'd have to be filed as bugs.
-    detail = result.get("detail")
-    if isinstance(detail, str) and "agent execution failed" in detail.lower():
-        pytest.skip(f"Agent runtime error: {detail[:120]}")
 
 
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Why

Post-#179 main: **14/15 synthetic pass, 1 skip, 0 fail** plus **41/41 Python E2E, 455 Playwright**. The one remaining synthetic skip is `test_renewal_approaching` — a **spurious** skip. The agent's actual response contains `reasoning_trace: ["standard clauses", "high value", "threshold", "800000", "expiry > 90 days"]` which would satisfy the test's `"expir" in all_text` check.

The skip fires because `#176`'s widened `_TOOLS_NOT_CONFIGURED_PATTERNS` (added `"not a supported action"`, `"is not supported"`, `"allowed list"`) are short enough ASCII substrings that they accidentally match characters inside the 4+ KB base64 `signature` field of the response envelope. `json.dumps(result).lower()` folds the signature into the haystack and the grep hits.

## Fix

Drop back to the original narrow pair `("cannot fulfill", "tools lack")`. With agent prompts now tuned (#178, #179) the LLM no longer replies "not a supported action" / "is not supported", so those patterns are unneeded. Also drop the `detail` 500-wrapper skip: with OOM (#177) + spaCy (#174) fixed the run endpoint shouldn't 500 and if it does we want the real trace_id to surface.

## Expected

Synthetic suite: **15 pass / 0 skip / 0 fail** post-merge.