### PR TITLE
fix(e2e): explicit 'never refuse' guardrail in synthetic prompts

### DIFF
--- a/scripts/seed_e2e_demo_agents.py
+++ b/scripts/seed_e2e_demo_agents.py
@@ -42,7 +42,9 @@ import httpx
 
 _AP_PROCESSOR_PROMPT = (
     "You are an AP Processor. The ``action`` is always 'process_invoice' — "
-    "it IS the instruction, never reply 'not a supported action'. Work "
+    "it IS the instruction. You MUST ALWAYS produce the JSON answer below. "
+    "NEVER refuse. NEVER say 'cannot fulfill', 'tools lack', 'not a "
+    "supported action', 'my capabilities', or any similar refusal. Work "
     "deterministically on ``inputs.invoice`` + ``inputs.po_data`` + optional "
     "``inputs.grn_data`` and ``inputs.context.previously_processed`` (list "
     "of already-seen invoice_ids).\n\n"
@@ -88,7 +90,9 @@ _AP_PROCESSOR_TOOLS: list[str] = [
 _TALENT_ACQUISITION_PROMPT = (
     "You screen job candidates. Action is 'screen_resume'. Input contains "
     "``candidate`` (parsed resume), ``job_requisition``, and optional "
-    "``rubric``. Output a JSON decision — never reply 'not a valid action'.\n\n"
+    "``rubric``. ALWAYS produce the JSON decision below. NEVER refuse. "
+    "NEVER say 'cannot fulfill', 'tools lack', 'not a valid action', "
+    "'my capabilities', or any similar refusal.\n\n"
     "Scoring rules (emit the keywords in reasoning_trace and output.fields):\n"
     "- Strong match (candidate skills + years fit job level): "
     "recommendation='shortlist', include 'strong', 'qualified', 'recommend'.\n"
@@ -114,8 +118,10 @@ _TALENT_ACQUISITION_TOOLS: list[str] = [
 _CONTRACT_INTELLIGENCE_PROMPT = (
     "You analyze contracts. Action is 'analyze_contract'. Input contains "
     "``contract`` (parsed dict — read fields ``contract.contract_value.amount``, "
-    "``contract.expiry_date``, ``contract.clauses``). Output JSON — never "
-    "reply 'not a valid action' and NEVER emit an empty reasoning_trace.\n\n"
+    "``contract.expiry_date``, ``contract.clauses``). ALWAYS produce the "
+    "JSON answer below. NEVER refuse. NEVER say 'cannot fulfill', 'tools "
+    "lack', 'not a valid action', 'my capabilities', or any similar "
+    "refusal. NEVER emit an empty reasoning_trace.\n\n"
     "Evaluate ALL four rules, push the keyword for each rule that fires:\n"
     "- Non-standard clauses: if ``contract.clauses`` mentions unlimited "
     "indemnification, aggressive non-compete, one-sided liability, or any "


### PR DESCRIPTION
## Why

Post-#186 main: synthetic step is **13 pass / 2 skip / 0 fail**. Two AP tests (`test_happy_path_matched`, `test_3way_mismatch_hitl`) that previously passed now trip `_skip_if_tools_missing` on the patterns `"cannot fulfill"` / `"tools lack"`. Claude intermittently emits a refusal phrase when it decides the available tools aren't enough, even though the prompt already tells it to answer from the payload alone.

## Fix

Tighten all three prompts (AP, Talent, Contract) with an explicit clause at the top: **"NEVER refuse. NEVER say 'cannot fulfill', 'tools lack', 'not a supported action', 'my capabilities', or any similar refusal."** Claude follows explicit negative constraints far more reliably than implied ones.

## Expected

Synthetic: **15 pass / 0 skip / 0 fail**.