### PR TITLE
test(synthetic): per-test 180s timeout to cover cold-start + LLM

### DIFF
--- a/tests/synthetic_data/test_synthetic_flows.py
+++ b/tests/synthetic_data/test_synthetic_flows.py
@@ -13,10 +13,21 @@ from pathlib import Path
 import httpx
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    os.getenv("AGENTICORG_ENABLE_LIVE_TESTS") != "1" or not os.getenv("AGENTICORG_E2E_BASE_URL"),
-    reason="live synthetic tests are opt-in; set AGENTICORG_ENABLE_LIVE_TESTS=1 and AGENTICORG_E2E_BASE_URL",
-)
+pytestmark = [
+    pytest.mark.skipif(
+        os.getenv("AGENTICORG_ENABLE_LIVE_TESTS") != "1"
+        or not os.getenv("AGENTICORG_E2E_BASE_URL"),
+        reason=(
+            "live synthetic tests are opt-in; set AGENTICORG_ENABLE_LIVE_TESTS=1"
+            " and AGENTICORG_E2E_BASE_URL"
+        ),
+    ),
+    # Each synthetic test includes a live Claude Sonnet round-trip, plus
+    # PII redaction and a possible retry on cold-start 502. 180s covers
+    # the P99 without hiding a real hang — pyproject.toml's default 60s
+    # was biting the first test after a fresh pod rollout.
+    pytest.mark.timeout(180),
+]
 
 BASE = f"{os.getenv('AGENTICORG_E2E_BASE_URL', '').rstrip('/')}/api/v1"
 DATA_DIR = Path(__file__).parent
@@ -89,13 +100,13 @@ def _run_agent(headers: dict, agent_id: str, action: str, inputs: dict) -> dict:
             f"{BASE}/agents/{agent_id}/run",
             headers=headers,
             json={"action": action, "inputs": inputs},
-            timeout=60,
+            timeout=45,
         )
         try:
             return r.json()
         except Exception:
             if attempt == 0:
-                _time.sleep(3)
+                _time.sleep(2)
                 continue
             raise
 


### PR DESCRIPTION
## Why

Post-#188 main: `test_happy_path_matched` failed with a pytest-timeout stack trace mid-HTTP-call. Root cause: `pyproject.toml` sets a blanket `timeout = 60` on every test. One synthetic call is legitimately ~30-45s (Claude Sonnet + PII redaction + JSON parse) and the retry back-off adds more on cold start, so the first synthetic test after a pod rollout blows through the 60s cap.

## Fix

- Attach `@pytest.mark.timeout(180)` to the synthetic module so each LLM test gets a realistic budget. The global 60s cap still applies to every other suite.
- Shrink the HTTP client timeout from 60s to 45s and the retry back-off from 3s to 2s so even a retried call fits comfortably inside the 180s envelope.

## Expected

Synthetic step passes end-to-end with no timeout hangs.