### PR TITLE
fix(e2e): seed a pending filing approval for the demo company

### DIFF
--- a/scripts/seed_e2e_demo_agents.py
+++ b/scripts/seed_e2e_demo_agents.py
@@ -234,22 +234,25 @@ def _ensure_agent(
     resp.raise_for_status()
 
 
-def _ensure_company(client: httpx.Client) -> None:
+def _ensure_company(client: httpx.Client) -> str | None:
     """Idempotently ensure at least one company exists in the demo tenant.
 
-    Playwright's ``getCompanyId`` raises when the list is empty. Without a
-    company the entire CompanyDetail suite fails before it can assert.
+    Returns the company id so callers can seed company-scoped data
+    (pending approvals, etc.). Playwright's ``getCompanyId`` raises when
+    the list is empty, which would make the entire CompanyDetail suite
+    fail before any assertion.
     """
     resp = client.get("/api/v1/companies", params={"page": 1, "per_page": 1})
     try:
         data = resp.json()
     except Exception:
         print(f"[seed] company list returned non-JSON: {resp.text[:200]}")
-        return
+        return None
     items = data.get("items") if isinstance(data, dict) else data
     if items:
-        print(f"[seed] company already present (id={items[0].get('id')}) — skipping")
-        return
+        cid = items[0].get("id")
+        print(f"[seed] company already present (id={cid}) — skipping create")
+        return cid
     payload: dict[str, Any] = {
         "name": "Acme Industries E2E",
         "gstin": "27AAACE1234F1Z5",
@@ -258,9 +261,42 @@ def _ensure_company(client: httpx.Client) -> None:
     }
     r = client.post("/api/v1/companies", json=payload)
     if r.status_code in (200, 201):
-        print(f"[seed] created company id={r.json().get('id', 'unknown')}")
-        return
+        cid = r.json().get("id")
+        print(f"[seed] created company id={cid}")
+        return cid
     print(f"[seed] company create returned {r.status_code}, continuing: {r.text[:200]}")
+    return None
+
+
+def _ensure_pending_approval(client: httpx.Client, company_id: str) -> None:
+    """Ensure the company has at least one pending filing approval.
+
+    The Playwright ``Approve button visible on pending items`` test needs
+    an ``Approve`` button or a ``pending`` badge on the CompanyDetail
+    Approvals tab — both only render when an approval row exists with
+    status='pending'. Create one if missing.
+    """
+    resp = client.get(
+        f"/api/v1/companies/{company_id}/approvals",
+        params={"page": 1, "per_page": 5, "status": "pending"},
+    )
+    try:
+        data = resp.json()
+    except Exception:
+        print(f"[seed] approvals list returned non-JSON: {resp.text[:200]}")
+        return
+    items = data.get("items") if isinstance(data, dict) else data
+    if items:
+        print(f"[seed] pending approval already present (count={len(items)}) — skipping")
+        return
+    r = client.post(
+        f"/api/v1/companies/{company_id}/approvals",
+        json={"filing_type": "GSTR-1", "filing_period": "2026-04", "filing_data": {}},
+    )
+    if r.status_code in (200, 201):
+        print(f"[seed] created pending approval id={r.json().get('id', 'unknown')}")
+        return
+    print(f"[seed] approval create returned {r.status_code}, continuing: {r.text[:200]}")
 
 
 def main() -> int:
@@ -278,7 +314,9 @@ def main() -> int:
         # CompanyDetail suite calls ``getCompanyId`` which throws on an
         # empty list — a freshly cleaned demo tenant otherwise fails
         # every CompanyDetail test before the first assertion.
-        _ensure_company(client)
+        company_id = _ensure_company(client)
+        if company_id:
+            _ensure_pending_approval(client, company_id)
 
         resp = client.get("/api/v1/agents", params={"page": 1, "per_page": 200})
         resp.raise_for_status()


### PR DESCRIPTION
## Why

Post-#190 main: Playwright 460/461. Only remaining failure is `ca-firms.spec.ts:561 › Filing Approvals › Approve button visible on pending items`. The test looks for an `Approve` button or a `pending` badge on the Approvals tab — both only render when a `FilingApproval` row exists with `status='pending'`. The seeded demo company has none.

## Fix

Extend `scripts/seed_e2e_demo_agents.py` with `_ensure_pending_approval` — POSTs `{filing_type:"GSTR-1", filing_period:"2026-04"}` for the seeded company if no pending approval exists. Idempotent — re-running the seed is a no-op.

Verified live against production: row created with `status: "pending"`.

## Expected

Main CI: **Playwright 461/461, Python E2E 41/41, synthetic 15/15** — fully green.