### PR TITLE
test(e2e): fix /org/invite spec to use valid 'analyst' role

### DIFF
--- a/ui/e2e/onboarding-e2e.spec.ts
+++ b/ui/e2e/onboarding-e2e.spec.ts
@@ -205,7 +205,11 @@ test.describe("Org Management API", () => {
       data: {
         email: `invite-${UNIQUE}@test.agenticorg.local`,
         name: "Invited User",
-        role: "cfo",
+        // Allowed values on /org/invite are the system roles
+        // (admin, analyst, auditor, developer, domain_lead). The
+        // earlier "cfo" was a CxO persona, not a role — server-side
+        // role validation now rejects it with a 400.
+        role: "analyst",
         domain: "finance",
       },
     });


### PR DESCRIPTION
## Why

After #191 unblocked the CA-Firms Playwright failures, **3 previously-masked spec failures surfaced**. The first — `ui/e2e/onboarding-e2e.spec.ts:198 › POST /org/invite sends invitation` — is a spec bug, not a product bug:

The spec sends `role: "cfo"`. Server hardened validation and `/org/invite` now rejects everything except `admin / analyst / auditor / developer / domain_lead`. Verified the same request with `role: "analyst"` returns 200 `{status:"invited", invite_link:"..."}` against production.

## Fix

Change the spec's `role` to `"analyst"`. Added a comment explaining why `cfo` was wrong (it was a CxO persona, not a role).

## Remaining Playwright failures (separate scope)

- `qa-bugs-8apr2026.spec.ts:707 › all 7 demo accounts return valid JWT` — each account returns 200 on a direct probe against production, so this looks transient / retry-flaky on the test runner.
- `session5-bugs.spec.ts:52 › Voice Setup phone step rejects non-numeric input` — wizard-flow regression in the Voice Setup UI.
- `session5-bugs.spec.ts:194 › Knowledge Base uploaded document survives page refresh` — KB upload persistence regression.

Those two (voice setup, KB) look like real product regressions and need a feature-team debug — happy to pick them up as separate PRs if you want me to continue.