### PR TITLE
test(e2e): stabilize last 3 regression failures keeping main red

### DIFF
--- a/ui/e2e/qa-bugs-8apr2026.spec.ts
+++ b/ui/e2e/qa-bugs-8apr2026.spec.ts
@@ -714,11 +714,14 @@ test.describe("Proactive Regression - Similar Issues", () => {
       { email: "chro@agenticorg.local", pw: "chro123!" },
       { email: "auditor@agenticorg.local", pw: "audit123!" },
     ];
-    for (const a of accounts) {
+    for (const [i, a] of accounts.entries()) {
+      // Prod login has a rate limiter; space the attempts out so a fast-running
+      // suite doesn't hit 429 on accounts 5–7.
+      if (i > 0) await new Promise((r) => setTimeout(r, 800));
       const resp = await request.post(`${APP}/api/v1/auth/login`, {
         data: { email: a.email, password: a.pw },
       });
-      expect(resp.status()).toBe(200);
+      expect(resp.status(), `login for ${a.email}`).toBe(200);
       const body = await resp.json();
       expect(body.token || body.access_token).toBeTruthy();
     }

--- a/ui/e2e/session5-bugs.spec.ts
+++ b/ui/e2e/session5-bugs.spec.ts
@@ -58,15 +58,18 @@ test.describe("Voice Setup regression", () => {
     await page.getByRole("button", { name: "Next" }).click();
 
     const phoneInput = page.locator('input[type="tel"]');
-    await phoneInput.fill("phone-number-abc");
-    // Next should be disabled or show an inline error on click.
     const nextBtn = page.getByRole("button", { name: "Next" });
-    await nextBtn.click({ trial: true }).catch(() => {});
-    // The field-level error appears after validateStep fires.
-    await nextBtn.click();
-    await expect(
-      page.locator("text=Invalid phone number").first(),
-    ).toBeVisible({ timeout: 5000 });
+
+    // Sanity: a valid E.164 number enables Next.
+    await phoneInput.fill("+919876543210");
+    await expect(nextBtn).toBeEnabled();
+
+    // The real test: a non-numeric phone must keep the user on Step 3.
+    // VoiceSetup guards forward navigation by disabling Next when
+    // validateStep(step) returns errors, so clicking would be a no-op
+    // — we assert the disabled state directly.
+    await phoneInput.fill("phone-number-abc");
+    await expect(nextBtn).toBeDisabled();
   });
 
   test("TC-011 Google TTS shows an API key field on selection", async ({ page }) => {
@@ -197,18 +200,40 @@ test.describe("Knowledge Base regression", () => {
 
     // The upload input is discoverable by its accept=".pdf,.txt..." attr.
     const uploadInput = page.locator('input[type="file"]').first();
+
+    // Sync on the actual network boundary rather than DOM polling — after
+    // upload the KB page flips into a "Loading knowledge base…" state while
+    // /knowledge/documents refreshes, so `text=` assertions race the refetch.
+    const uploadResp = page.waitForResponse(
+      (r) => r.url().includes("/knowledge/upload") && r.request().method() === "POST",
+      { timeout: 45000 },
+    );
     await uploadInput.setInputFiles({
       name: unique,
       mimeType: "text/plain",
       buffer,
     });
+    const resp = await uploadResp;
+    expect(resp.status(), "POST /knowledge/upload").toBeLessThan(400);
 
-    // Wait for the entry to appear.
+    // Now wait for the follow-up documents refetch the component issues.
+    await page
+      .waitForResponse(
+        (r) => r.url().includes("/knowledge/documents") && r.request().method() === "GET",
+        { timeout: 30000 },
+      )
+      .catch(() => {});
+
     await expect(page.locator(`text=${unique}`).first()).toBeVisible({ timeout: 30000 });
 
-    // Refresh — the document must still be there.
+    // Refresh — the document must still be there (backend persistence check).
     await page.reload({ waitUntil: "domcontentloaded" });
-    await page.waitForLoadState("networkidle").catch(() => {});
+    await page
+      .waitForResponse(
+        (r) => r.url().includes("/knowledge/documents") && r.request().method() === "GET",
+        { timeout: 30000 },
+      )
+      .catch(() => {});
     await expect(page.locator(`text=${unique}`).first()).toBeVisible({ timeout: 30000 });
   });
 });


### PR DESCRIPTION
## Summary

Three tests have been red on every push since #188, forcing the ~30-PR whack-a-mole sweep. Root causes (not flakes):

- **`qa-bugs-8apr2026.spec.ts` → `all 7 demo accounts return valid JWT`** — 7 back-to-back `POST /auth/login` trip the prod rate limiter → `429`. Space attempts 800ms apart.
- **`session5-bugs.spec.ts` → `TC-012 Phone step rejects non-numeric input`** — `ui/src/pages/VoiceSetup.tsx:458` disables Next while the phone is invalid, and the inline error only renders after `attemptNext()` fires. `await nextBtn.click()` on a disabled button waits for actionability until the 60s test timeout → "Target page… closed". Assert `toBeDisabled()` to match the real UX instead of a blocked click path.
- **`session5-bugs.spec.ts` → `TC-013 uploaded document survives page refresh`** — the KB page swaps into a full-screen "Loading knowledge base…" during `fetchData`, so `text=` races the refetch. Sync explicitly on `POST /knowledge/upload` and `GET /knowledge/documents` before each `toBeVisible`.

## Test plan

- [ ] CI `e2e-tests` job passes on this branch (watch the run after merge trigger)
- [ ] No other previously-passing specs regress (spec count unchanged: 46 in the two touched files)
- [ ] TC-012 now asserts the product behaviour: valid E.164 enables Next, invalid input disables it
- [ ] TC-013 guards against the loading-state race on both initial upload and post-reload