### PR TITLE
fix(kb): persist KB uploads + eliminate all test.skip primitives

### DIFF
--- a/api/v1/knowledge.py
+++ b/api/v1/knowledge.py
@@ -164,6 +164,9 @@ async def _db_store_doc(tenant_id: str, doc: dict[str, Any]) -> None:
         db_doc = Document(
             id=_UUID(doc["document_id"]),
             tenant_id=tid,
+            # `name` is the legacy NOT NULL column — mirror filename into it
+            # so rows are queryable from either generation of schema.
+            name=doc["filename"],
             filename=doc["filename"],
             content_type=doc.get("content_type"),
             size_bytes=doc["size_bytes"],

--- a/core/models/document.py
+++ b/core/models/document.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import date, datetime
 
-from sqlalchemy import TIMESTAMP, Date, ForeignKey, String, func
+from sqlalchemy import TIMESTAMP, BigInteger, Date, ForeignKey, String, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -19,10 +19,18 @@ class Document(BaseModel):
     tenant_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False
     )
+    # Legacy display name — kept for backward compat with S3-era rows.
     name: Mapped[str] = mapped_column(String(500), nullable=False)
     doc_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
-    s3_bucket: Mapped[str] = mapped_column(String(255), nullable=False)
-    s3_key: Mapped[str] = mapped_column(String(1000), nullable=False)
+    # Legacy S3 pointers — nullable since v484_docs_kb_upload_cols: KB uploads
+    # are metadata-only and carry no S3 artifact.
+    s3_bucket: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    s3_key: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    # KB upload fields (added v484_docs_kb_upload_cols).
+    filename: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    content_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    status: Mapped[str] = mapped_column(String(30), nullable=False, default="ready")
     # embedding column handled via raw SQL / pgvector extension
     metadata_: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, default=dict)
     retention_until: Mapped[date | None] = mapped_column(Date, nullable=True)

--- a/migrations/versions/v4_8_4_documents_kb_upload_cols.py
+++ b/migrations/versions/v4_8_4_documents_kb_upload_cols.py
@@ -1,0 +1,66 @@
+"""Add KB-upload columns to the legacy documents table.
+
+Revision ID: v484_documents_kb_upload_cols
+Revises: v483_prompt_tpl_partial_uniq
+Create Date: 2026-04-18
+
+Session 5 TC-013 root cause: api/v1/knowledge.py:_db_store_doc tries to
+INSERT into `documents` with filename/content_type/size_bytes/status
+fields that don't exist on the legacy (S3-era) schema. SQLAlchemy raises,
+the upload path swallows the exception, the row is never persisted, and
+the Knowledge Base UI always shows an empty table after upload.
+
+Fix: additively add the four columns the upload path needs, and relax
+the legacy NOT NULL constraints on s3_bucket / s3_key so metadata-only
+(non-S3) uploads are representable. No existing rows are altered.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# Alembic identifiers — kept <=32 chars (alembic_version.version_num size).
+revision = "v484_docs_kb_upload_cols"
+down_revision = "v483_prompt_tpl_partial_uniq"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Additive columns used by the KB upload path.
+    op.add_column("documents", sa.Column("filename", sa.String(500), nullable=True))
+    op.add_column("documents", sa.Column("content_type", sa.String(100), nullable=True))
+    op.add_column(
+        "documents",
+        sa.Column("size_bytes", sa.BigInteger, nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "documents",
+        sa.Column("status", sa.String(30), nullable=False, server_default="ready"),
+    )
+
+    # Backfill filename from the existing `name` for any legacy rows, so a
+    # later NOT NULL tightening (if we ever need one) has a clean starting
+    # point. Cheap: `documents` is expected to be near-empty in every
+    # environment because the upload path has been silently failing.
+    op.execute("UPDATE documents SET filename = name WHERE filename IS NULL")
+
+    # Relax the legacy S3 NOT NULLs so metadata-only KB uploads (which
+    # have no S3 artifact) are representable without sentinel empty
+    # strings leaking through the schema.
+    op.alter_column("documents", "s3_bucket", nullable=True)
+    op.alter_column("documents", "s3_key", nullable=True)
+
+
+def downgrade() -> None:
+    # Reinstate NOT NULL — rollback expects any rows to have populated
+    # s3_bucket/s3_key, so if this is used in an environment with real
+    # KB uploads it will need a manual backfill first.
+    op.alter_column("documents", "s3_bucket", nullable=False)
+    op.alter_column("documents", "s3_key", nullable=False)
+
+    op.drop_column("documents", "status")
+    op.drop_column("documents", "size_bytes")
+    op.drop_column("documents", "content_type")
+    op.drop_column("documents", "filename")

--- a/migrations/versions/v4_8_4_documents_kb_upload_cols.py
+++ b/migrations/versions/v4_8_4_documents_kb_upload_cols.py
@@ -17,7 +17,6 @@ the legacy NOT NULL constraints on s3_bucket / s3_key so metadata-only
 
 from __future__ import annotations
 
-import sqlalchemy as sa
 from alembic import op
 
 # Alembic identifiers — kept <=32 chars (alembic_version.version_num size).
@@ -28,16 +27,18 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Additive columns used by the KB upload path.
-    op.add_column("documents", sa.Column("filename", sa.String(500), nullable=True))
-    op.add_column("documents", sa.Column("content_type", sa.String(100), nullable=True))
-    op.add_column(
-        "documents",
-        sa.Column("size_bytes", sa.BigInteger, nullable=False, server_default="0"),
+    # Additive columns used by the KB upload path. Use ADD COLUMN IF NOT
+    # EXISTS (repo convention — see v4_6_0_enterprise_readiness) so the
+    # migration is idempotent against environments where the updated
+    # ORM's metadata.create_all already provisioned these columns
+    # (notably the test_alembic_e2e legacy-schema fixture).
+    op.execute("ALTER TABLE documents ADD COLUMN IF NOT EXISTS filename VARCHAR(500)")
+    op.execute("ALTER TABLE documents ADD COLUMN IF NOT EXISTS content_type VARCHAR(100)")
+    op.execute(
+        "ALTER TABLE documents ADD COLUMN IF NOT EXISTS size_bytes BIGINT NOT NULL DEFAULT 0"
     )
-    op.add_column(
-        "documents",
-        sa.Column("status", sa.String(30), nullable=False, server_default="ready"),
+    op.execute(
+        "ALTER TABLE documents ADD COLUMN IF NOT EXISTS status VARCHAR(30) NOT NULL DEFAULT 'ready'"
     )
 
     # Backfill filename from the existing `name` for any legacy rows, so a
@@ -48,19 +49,20 @@ def upgrade() -> None:
 
     # Relax the legacy S3 NOT NULLs so metadata-only KB uploads (which
     # have no S3 artifact) are representable without sentinel empty
-    # strings leaking through the schema.
-    op.alter_column("documents", "s3_bucket", nullable=True)
-    op.alter_column("documents", "s3_key", nullable=True)
+    # strings leaking through the schema. DROP NOT NULL is a no-op when
+    # the column is already nullable, so no explicit guard is needed.
+    op.execute("ALTER TABLE documents ALTER COLUMN s3_bucket DROP NOT NULL")
+    op.execute("ALTER TABLE documents ALTER COLUMN s3_key DROP NOT NULL")
 
 
 def downgrade() -> None:
     # Reinstate NOT NULL — rollback expects any rows to have populated
     # s3_bucket/s3_key, so if this is used in an environment with real
     # KB uploads it will need a manual backfill first.
-    op.alter_column("documents", "s3_bucket", nullable=False)
-    op.alter_column("documents", "s3_key", nullable=False)
+    op.execute("ALTER TABLE documents ALTER COLUMN s3_bucket SET NOT NULL")
+    op.execute("ALTER TABLE documents ALTER COLUMN s3_key SET NOT NULL")
 
-    op.drop_column("documents", "status")
-    op.drop_column("documents", "size_bytes")
-    op.drop_column("documents", "content_type")
-    op.drop_column("documents", "filename")
+    op.execute("ALTER TABLE documents DROP COLUMN IF EXISTS status")
+    op.execute("ALTER TABLE documents DROP COLUMN IF EXISTS size_bytes")
+    op.execute("ALTER TABLE documents DROP COLUMN IF EXISTS content_type")
+    op.execute("ALTER TABLE documents DROP COLUMN IF EXISTS filename")

--- a/ui/e2e/app-routes.spec.ts
+++ b/ui/e2e/app-routes.spec.ts
@@ -10,6 +10,12 @@ const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
 const MARKETING = "https://agenticorg.ai";
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
+function requireAuth(): void {
+  if (!canAuth) throw new Error(
+    "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+  );
+}
+
 
 // ---------------------------------------------------------------------------
 // Public Routes — Must load without auth
@@ -75,7 +81,7 @@ test.describe("Dashboard Routes — Auth Required", () => {
   ];
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await page.goto(`${APP}/login`);
     await page.evaluate((token) => {
       localStorage.setItem("token", token);
@@ -144,7 +150,7 @@ test.describe("Dashboard — Sidebar Navigation", () => {
   ];
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await page.goto(`${APP}/login`);
     await page.evaluate((token) => {
       localStorage.setItem("token", token);
@@ -182,7 +188,7 @@ test.describe("Create Flows", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await page.goto(`${APP}/login`);
     await page.evaluate((token) => {
       localStorage.setItem("token", token);
@@ -222,7 +228,7 @@ test.describe("Data Display Quality", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await page.goto(`${APP}/login`);
     await page.evaluate((token) => {
       localStorage.setItem("token", token);

--- a/ui/e2e/ca-firms.spec.ts
+++ b/ui/e2e/ca-firms.spec.ts
@@ -17,6 +17,12 @@ const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
 const MARKETING = "https://agenticorg.ai";
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
+function requireAuth(): void {
+  if (!canAuth) throw new Error(
+    "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+  );
+}
+
 
 // -- Helper: authenticate via localStorage token --
 async function authenticate(page: Page): Promise<void> {
@@ -137,7 +143,7 @@ test.describe("CA Firms Solution Page", () => {
 
 test.describe("Company Dashboard", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -201,7 +207,7 @@ test.describe("Company Dashboard", () => {
 
 test.describe("Company Onboard Wizard", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -310,7 +316,7 @@ test.describe("Company Onboard Wizard", () => {
 
 test.describe("Company Detail", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -395,7 +401,7 @@ test.describe("Company Detail", () => {
 
 test.describe("Company Switcher", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -518,7 +524,7 @@ test.describe("CA Demo Login Flow", () => {
 
 test.describe("Filing Approvals", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -589,7 +595,7 @@ test.describe("Filing Approvals", () => {
 
 test.describe("GSTN Manual Upload", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -649,7 +655,7 @@ test.describe("GSTN Manual Upload", () => {
 
 test.describe("Subscription Status", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -685,7 +691,7 @@ test.describe("Subscription Status", () => {
 
 test.describe("Client Health Score", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -731,7 +737,7 @@ test.describe("Client Health Score", () => {
 
 test.describe("Partner Dashboard", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -810,7 +816,7 @@ test.describe("Partner Dashboard", () => {
 
 test.describe("GSTN Credential Vault", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -889,7 +895,7 @@ test.describe("GSTN Credential Vault", () => {
 
 test.describe("Tally Auto-Detect", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -917,7 +923,7 @@ test.describe("Tally Auto-Detect", () => {
 
 test.describe("Compliance Calendar", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -977,7 +983,7 @@ test.describe("Compliance Calendar", () => {
 
 test.describe("Bulk Approval", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -1036,7 +1042,7 @@ test.describe("Bulk Approval", () => {
 
 test.describe("Form Validation", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -1177,7 +1183,7 @@ test.describe("Form Validation", () => {
 
 test.describe("CompanyDetail Tab Content", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -1295,7 +1301,7 @@ test.describe("CompanyDetail Tab Content", () => {
 
 test.describe("Partner Dashboard Details", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -1368,7 +1374,7 @@ test.describe("Partner Dashboard Details", () => {
 
 test.describe("Compliance Alerts Configuration", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -1422,7 +1428,7 @@ test.describe("Compliance Alerts Configuration", () => {
 
 test.describe("CxO Dashboard Nav Links in Layout", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token -- set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 

--- a/ui/e2e/cfo-demo.spec.ts
+++ b/ui/e2e/cfo-demo.spec.ts
@@ -10,6 +10,12 @@ import { test, expect } from "@playwright/test";
 
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
+function requireAuth(): void {
+  if (!canAuth) throw new Error(
+    "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+  );
+}
+
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Public pages — no auth needed
@@ -61,7 +67,7 @@ test.describe("CFO Demo: Public Pages", () => {
 
 test.describe("CFO Demo: Dashboard (auth required)", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
+    requireAuth();
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.evaluate((t) => {
       localStorage.setItem("token", t);

--- a/ui/e2e/cxo-dashboards.spec.ts
+++ b/ui/e2e/cxo-dashboards.spec.ts
@@ -26,7 +26,7 @@
  * component change rather than keeping stale assertions around.
  */
 import { expect, test } from "@playwright/test";
-import { APP, authenticate, canAuth } from "./helpers/auth";
+import { APP, authenticate, canAuth, requireAuth } from "./helpers/auth";
 
 const DASHBOARDS = [
   { title: "CEO Dashboard", path: "/dashboard/ceo" },
@@ -48,7 +48,7 @@ const SHARED_KPIS = [
 for (const { title, path } of DASHBOARDS) {
   test.describe(title, () => {
     test.beforeEach(async ({ page }) => {
-      test.skip(!canAuth, "E2E_TOKEN required");
+      requireAuth();
       await authenticate(page);
       await page.goto(`${APP}${path}`, { waitUntil: "domcontentloaded" });
       await page.waitForLoadState("networkidle").catch(() => {});
@@ -85,7 +85,7 @@ for (const { title, path } of DASHBOARDS) {
 // test which asserted a CEO-dashboard layout the app no longer renders.
 test.describe("CxO sidebar navigation", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN required");
+    requireAuth();
     await authenticate(page);
     await page.goto(`${APP}/dashboard`, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle").catch(() => {});

--- a/ui/e2e/error-handling.spec.ts
+++ b/ui/e2e/error-handling.spec.ts
@@ -10,6 +10,12 @@ import { test, expect, Page } from "@playwright/test";
 
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
+function requireAuth(): void {
+  if (!canAuth) throw new Error(
+    "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+  );
+}
+
 
 // ---------------------------------------------------------------------------
 // Auth helper — token-based only, no hardcoded credentials
@@ -56,7 +62,7 @@ test.describe("404 Page Handling", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
 
     await page.goto(`${baseURL}/dashboard/nonexistent-page-xyz`, {
@@ -98,7 +104,7 @@ test.describe("404 Page Handling", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
 
     await page.goto(`${baseURL}/dashboard/cfo/blah`, {
@@ -219,16 +225,13 @@ test.describe("XSS Prevention", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
     await page.goto(`${baseURL}/dashboard`, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle");
 
     const input = page.locator('input[placeholder*="Ask anything"]');
-    if (!(await input.isVisible({ timeout: 5000 }).catch(() => false))) {
-      test.skip();
-      return;
-    }
+    await expect(input).toBeVisible({ timeout: 5000 });
 
     let alertCalled = false;
     page.on("dialog", (dialog) => {
@@ -248,16 +251,13 @@ test.describe("XSS Prevention", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
     await page.goto(`${baseURL}/dashboard`, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle");
 
     const input = page.locator('input[placeholder*="Ask anything"]');
-    if (!(await input.isVisible({ timeout: 5000 }).catch(() => false))) {
-      test.skip();
-      return;
-    }
+    await expect(input).toBeVisible({ timeout: 5000 });
 
     let alertCalled = false;
     page.on("dialog", (dialog) => {
@@ -304,16 +304,13 @@ test.describe("Large Input Handling", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
     await page.goto(`${baseURL}/dashboard`, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle");
 
     const input = page.locator('input[placeholder*="Ask anything"]');
-    if (!(await input.isVisible({ timeout: 5000 }).catch(() => false))) {
-      test.skip();
-      return;
-    }
+    await expect(input).toBeVisible({ timeout: 5000 });
 
     const largeInput = "A".repeat(10000);
     await input.fill(largeInput);
@@ -353,7 +350,7 @@ test.describe("Network Error Handling", () => {
   }) => {
     // Offline mode cannot be reliably tested against production.
     // Instead, verify the page loads and does not crash on reload.
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
     await page.goto(`${baseURL}/dashboard`, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle");
@@ -377,7 +374,7 @@ test.describe("No Unhandled Errors", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const consoleErrors: string[] = [];
     page.on("console", (msg) => {
       if (msg.type() === "error") {
@@ -411,7 +408,7 @@ test.describe("No Unhandled Errors", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const consoleErrors: string[] = [];
     page.on("console", (msg) => {
       if (msg.type() === "error") {

--- a/ui/e2e/flows.spec.ts
+++ b/ui/e2e/flows.spec.ts
@@ -10,6 +10,12 @@ const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
 const MARKETING = "https://agenticorg.ai";
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
+function requireAuth(): void {
+  if (!canAuth) throw new Error(
+    "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+  );
+}
+
 
 // Helper: authenticate via localStorage token
 async function authenticate(page: import("@playwright/test").Page) {
@@ -27,7 +33,7 @@ test.describe("Agents — Production Flow", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -132,7 +138,7 @@ test.describe("Workflows — Production Flow", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -195,7 +201,7 @@ test.describe("Approvals — Production Flow", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -243,7 +249,7 @@ test.describe("Connectors — Production Flow", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -296,7 +302,7 @@ test.describe("Schemas — Production Flow", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -355,7 +361,7 @@ test.describe("Audit — Production Flow", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -393,7 +399,7 @@ test.describe("Settings — Production Flow", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -421,7 +427,7 @@ test.describe("Data Integrity — All Pages", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 

--- a/ui/e2e/full-app.spec.ts
+++ b/ui/e2e/full-app.spec.ts
@@ -9,6 +9,12 @@ const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
 const MARKETING = "https://agenticorg.ai";
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
+function requireAuth(): void {
+  if (!canAuth) throw new Error(
+    "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+  );
+}
+
 
 async function authenticate(page: Page) {
   await page.goto(`${APP}/login`);
@@ -63,7 +69,7 @@ test.describe("Full App — Dashboard (Auth Required)", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 

--- a/ui/e2e/helpers/auth.ts
+++ b/ui/e2e/helpers/auth.ts
@@ -20,6 +20,22 @@ export const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
 export const E2E_TOKEN = process.env.E2E_TOKEN || "";
 export const canAuth = !!E2E_TOKEN;
 
+/**
+ * Assert that the suite has authentication available. Throws if not.
+ *
+ * Policy: we do not skip tests on missing E2E_TOKEN — skipping silently
+ * hides real coverage gaps in CI. A missing token is a configuration
+ * failure that should fail the run loudly. Call this from beforeEach or
+ * at the top of any spec that drives auth-gated flows.
+ */
+export function requireAuth(): void {
+  if (!canAuth) {
+    throw new Error(
+      "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+    );
+  }
+}
+
 interface AuthUser {
   email: string;
   name: string;
@@ -41,7 +57,7 @@ let _cachedCompanyId: string | null = null;
  * critically, the real `role` so sidebar filtering works.
  */
 export async function authenticate(page: Page): Promise<void> {
-  if (!E2E_TOKEN) return;
+  requireAuth();
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
   const profile = await getProfile(page);
   await page.evaluate(

--- a/ui/e2e/login-e2e.spec.ts
+++ b/ui/e2e/login-e2e.spec.ts
@@ -10,6 +10,12 @@ const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
 const MARKETING = "https://agenticorg.ai";
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
+function requireAuth(): void {
+  if (!canAuth) throw new Error(
+    "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+  );
+}
+
 
 test.describe("Login Page — Rendering & Validation", () => {
   test("login page renders with email and password fields", async ({ page }) => {
@@ -83,7 +89,7 @@ test.describe("Login Page — Auth Flow", () => {
   });
 
   test("authenticated user can access dashboard via token", async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await page.goto(`${APP}/login`);
     await page.evaluate((token) => {
       localStorage.setItem("token", token);

--- a/ui/e2e/negative-cases.spec.ts
+++ b/ui/e2e/negative-cases.spec.ts
@@ -11,6 +11,12 @@ import { test, expect, Page } from "@playwright/test";
 
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
+function requireAuth(): void {
+  if (!canAuth) throw new Error(
+    "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+  );
+}
+
 
 // ---------------------------------------------------------------------------
 // Auth helper — token-based only
@@ -109,7 +115,7 @@ test.describe("AUTH: Signup validation", () => {
 
 test.describe("API: 404 responses", () => {
   test("Non-existent agent does not return 500", async ({ page, baseURL }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const resp = await page.request.get(
       `${baseURL}/api/v1/agents/00000000-0000-0000-0000-000000000000`,
       { headers: { Authorization: `Bearer ${E2E_TOKEN}` } },
@@ -120,7 +126,7 @@ test.describe("API: 404 responses", () => {
   });
 
   test("Non-existent workflow does not return 500", async ({ page, baseURL }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const resp = await page.request.get(
       `${baseURL}/api/v1/workflows/00000000-0000-0000-0000-000000000000`,
       { headers: { Authorization: `Bearer ${E2E_TOKEN}` } },
@@ -129,7 +135,7 @@ test.describe("API: 404 responses", () => {
   });
 
   test("Non-existent connector returns 404", async ({ page, baseURL }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const resp = await page.request.get(
       `${baseURL}/api/v1/connectors/00000000-0000-0000-0000-000000000000`,
       { headers: { Authorization: `Bearer ${E2E_TOKEN}` } },
@@ -141,7 +147,7 @@ test.describe("API: 404 responses", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const resp = await page.request.post(
       `${baseURL}/api/v1/approvals/00000000-0000-0000-0000-000000000000/decide`,
       {
@@ -159,7 +165,7 @@ test.describe("API: 404 responses", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
     await page.goto(
       `${baseURL}/dashboard/agents/00000000-0000-0000-0000-000000000000`,
@@ -218,7 +224,7 @@ test.describe("API: 401 unauthorized", () => {
 
 test.describe("API: Input validation", () => {
   test("Workflow with empty steps returns 400", async ({ page, baseURL }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const resp = await page.request.post(`${baseURL}/api/v1/workflows`, {
       headers: {
         Authorization: `Bearer ${E2E_TOKEN}`,
@@ -235,7 +241,7 @@ test.describe("API: Input validation", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const resp = await page.request.post(`${baseURL}/api/v1/workflows`, {
       headers: {
         Authorization: `Bearer ${E2E_TOKEN}`,
@@ -247,7 +253,7 @@ test.describe("API: Input validation", () => {
   });
 
   test("Duplicate connector name returns 409", async ({ page, baseURL }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const ts = Date.now();
     const name = `dup-conn-${ts}`;
 
@@ -272,7 +278,7 @@ test.describe("API: Input validation", () => {
   });
 
   test("Invalid audit date_from returns 400", async ({ page, baseURL }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const resp = await page.request.get(
       `${baseURL}/api/v1/audit?date_from=not-a-date`,
       { headers: { Authorization: `Bearer ${E2E_TOKEN}` } },
@@ -281,7 +287,7 @@ test.describe("API: Input validation", () => {
   });
 
   test("Invalid audit agent_id returns 400", async ({ page, baseURL }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const resp = await page.request.get(
       `${baseURL}/api/v1/audit?agent_id=not-a-uuid`,
       { headers: { Authorization: `Bearer ${E2E_TOKEN}` } },
@@ -299,7 +305,7 @@ test.describe("UI: Error display", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
     await page.goto(`${baseURL}/dashboard/workflows/new`, {
       waitUntil: "domcontentloaded",

--- a/ui/e2e/onboarding-e2e.spec.ts
+++ b/ui/e2e/onboarding-e2e.spec.ts
@@ -8,6 +8,12 @@ import { test, expect, Page } from "@playwright/test";
 
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
+function requireAuth(): void {
+  if (!canAuth) throw new Error(
+    "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+  );
+}
+
 const UNIQUE = Date.now().toString(36);
 
 // ---------------------------------------------------------------------------
@@ -136,7 +142,7 @@ test.describe("Onboarding Wizard", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
 
     // Override onboardingComplete to false so onboarding page renders
@@ -170,7 +176,7 @@ test.describe("Onboarding Wizard", () => {
 
 test.describe("Org Management API", () => {
   test("GET /org/profile returns tenant info", async ({ page, baseURL }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const resp = await page.request.get(`${baseURL}/api/v1/org/profile`, {
       headers: { Authorization: `Bearer ${E2E_TOKEN}` },
     });
@@ -181,7 +187,7 @@ test.describe("Org Management API", () => {
   });
 
   test("GET /org/members returns team list", async ({ page, baseURL }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const resp = await page.request.get(`${baseURL}/api/v1/org/members`, {
       headers: { Authorization: `Bearer ${E2E_TOKEN}` },
     });
@@ -196,7 +202,7 @@ test.describe("Org Management API", () => {
   });
 
   test("POST /org/invite sends invitation", async ({ page, baseURL }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const resp = await page.request.post(`${baseURL}/api/v1/org/invite`, {
       headers: {
         Authorization: `Bearer ${E2E_TOKEN}`,
@@ -219,7 +225,7 @@ test.describe("Org Management API", () => {
   });
 
   test("PUT /org/onboarding updates state", async ({ page, baseURL }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const resp = await page.request.put(`${baseURL}/api/v1/org/onboarding`, {
       headers: {
         Authorization: `Bearer ${E2E_TOKEN}`,
@@ -237,7 +243,7 @@ test.describe("Org Management API", () => {
 
 test.describe("SLA Monitor", () => {
   test("SLA page loads for admin", async ({ page, baseURL }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
 
     await page.goto(`${baseURL}/dashboard/sla`, {
@@ -257,7 +263,7 @@ test.describe("SLA Monitor", () => {
 
 test.describe("Evidence Export", () => {
   test("Audit page has export buttons", async ({ page, baseURL }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
 
     await page.goto(`${baseURL}/dashboard/audit`, {

--- a/ui/e2e/production-full.spec.ts
+++ b/ui/e2e/production-full.spec.ts
@@ -13,6 +13,14 @@ const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
 const MARKETING = "https://agenticorg.ai";
 const HAS_AUTH = Boolean(process.env.E2E_TOKEN);
 
+function requireAuth(): void {
+  if (!HAS_AUTH) {
+    throw new Error(
+      "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+    );
+  }
+}
+
 // ── Helper: authenticate via localStorage token ──────────────────────
 async function injectAuth(page: Page): Promise<void> {
   const token = process.env.E2E_TOKEN!;
@@ -214,7 +222,7 @@ test.describe("Auth Flow", () => {
 // ═══════════════════════════════════════════════════════════════════════
 
 test.describe("Dashboard (authenticated)", () => {
-  test.skip(!HAS_AUTH, "Skipping: E2E_TOKEN not set");
+  requireAuth();
 
   test.beforeEach(async ({ page }) => {
     await injectAuth(page);
@@ -387,7 +395,7 @@ test.describe("Responsive -- Tablet (768px)", () => {
   test.use({ viewport: { width: 768, height: 1024 } });
 
   test("Dashboard at 768px -- sidebar collapses", async ({ page }) => {
-    test.skip(!HAS_AUTH, "Skipping: E2E_TOKEN not set");
+    requireAuth();
     await injectAuth(page);
     await page.goto(`${APP}/dashboard`, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle").catch(() => {});
@@ -404,7 +412,7 @@ test.describe("Responsive -- Tablet (768px)", () => {
 
 test.describe("Navigation", () => {
   test("All sidebar dashboard links resolve without 404", async ({ page }) => {
-    test.skip(!HAS_AUTH, "Skipping: E2E_TOKEN not set");
+    requireAuth();
     await injectAuth(page);
     const paths = [
       "/dashboard",

--- a/ui/e2e/qa-bugs-8apr2026.spec.ts
+++ b/ui/e2e/qa-bugs-8apr2026.spec.ts
@@ -14,6 +14,12 @@ import { test, expect, Page } from "@playwright/test";
 const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
+function requireAuth(): void {
+  if (!canAuth) throw new Error(
+    "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+  );
+}
+
 
 // ---------------------------------------------------------------------------
 // Auth helper -- localStorage token injection
@@ -57,7 +63,7 @@ async function assertNoGarbageText(page: Page): Promise<void> {
 test.describe("Ramesh Backend Regression", () => {
   // Bug #1: Connector config loaded from DB -- chat query returns agent with tools
   test("chat query returns agent with tools (not empty)", async ({ request }) => {
-    test.skip(!canAuth, "E2E_TOKEN required");
+    requireAuth();
     const resp = await request.get(`${APP}/api/v1/agents`, {
       headers: { Authorization: `Bearer ${E2E_TOKEN}` },
     });
@@ -78,7 +84,7 @@ test.describe("Ramesh Backend Regression", () => {
 
   // Bug #2: authorized_tools populated -- chat response has non-zero confidence
   test("chat response has non-zero confidence", async ({ request }) => {
-    test.skip(!canAuth, "E2E_TOKEN required");
+    requireAuth();
     const agentsResp = await request.get(`${APP}/api/v1/agents`, {
       headers: { Authorization: `Bearer ${E2E_TOKEN}` },
     });
@@ -104,7 +110,7 @@ test.describe("Ramesh Backend Regression", () => {
 
   // Bug #7: PATCH agents accepts description field
   test("PATCH /agents/{id} with description returns 200", async ({ request }) => {
-    test.skip(!canAuth, "E2E_TOKEN required");
+    requireAuth();
     const agentsResp = await request.get(`${APP}/api/v1/agents`, {
       headers: { Authorization: `Bearer ${E2E_TOKEN}` },
     });
@@ -126,7 +132,7 @@ test.describe("Ramesh Backend Regression", () => {
 
   // Bug #9: Chat button exists on agent detail page
   test("agent detail page has Chat with Agent button", async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN required");
+    requireAuth();
     await authenticate(page);
     await goTo(page, "/dashboard/agents");
 
@@ -148,7 +154,7 @@ test.describe("Ramesh Backend Regression", () => {
 
   // Bug #10: ChatPanel sends agent_id in request
   test("ChatPanel sends agent_id in request", async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN required");
+    requireAuth();
     await authenticate(page);
     await goTo(page, "/dashboard/agents");
 
@@ -204,7 +210,7 @@ test.describe("Ramesh Backend Regression", () => {
 
 test.describe("Ramesh UI Regression", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN required");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -375,7 +381,7 @@ test.describe("Ramesh UI Regression", () => {
 
 test.describe("Aishwarya Regression", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN required");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -643,7 +649,7 @@ test.describe("Aishwarya Regression", () => {
 
 test.describe("Proactive Regression - Similar Issues", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN required");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -729,7 +735,7 @@ test.describe("Proactive Regression - Similar Issues", () => {
 
   // API KPIs all return 200
   test("all 6 KPI endpoints return 200", async ({ request }) => {
-    test.skip(!canAuth, "E2E_TOKEN required");
+    requireAuth();
     const kpiPaths = [
       "/api/v1/kpis/ceo",
       "/api/v1/kpis/cfo",
@@ -807,7 +813,7 @@ test.describe("Proactive Regression - Similar Issues", () => {
 
   // Agents list API returns valid JSON array
   test("agents list API returns valid array with ids", async ({ request }) => {
-    test.skip(!canAuth, "E2E_TOKEN required");
+    requireAuth();
     const resp = await request.get(`${APP}/api/v1/agents`, {
       headers: { Authorization: `Bearer ${E2E_TOKEN}` },
     });

--- a/ui/e2e/qa-bugs-regression.spec.ts
+++ b/ui/e2e/qa-bugs-regression.spec.ts
@@ -12,6 +12,12 @@ import { test, expect, Page } from "@playwright/test";
 
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
+function requireAuth(): void {
+  if (!canAuth) throw new Error(
+    "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+  );
+}
+
 
 // ---------------------------------------------------------------------------
 // Auth helper -- token-based only
@@ -150,7 +156,7 @@ test.describe("D2: Promote & Rollback Buttons", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
 
     await page.goto(`${baseURL}/dashboard/agents`, {
@@ -162,10 +168,7 @@ test.describe("D2: Promote & Rollback Buttons", () => {
     const agentCard = page
       .locator('[class*="cursor-pointer"], [class*="card"], [class*="Card"]')
       .first();
-    if (!(await agentCard.isVisible({ timeout: 10000 }).catch(() => false))) {
-      test.skip();
-      return;
-    }
+    await expect(agentCard).toBeVisible({ timeout: 10000 });
     await agentCard.click();
     await page.waitForURL("**/agents/**", { timeout: 15000 });
     await page.waitForLoadState("networkidle");
@@ -173,14 +176,11 @@ test.describe("D2: Promote & Rollback Buttons", () => {
     const promoteBtn = page.getByRole("button", { name: /Promote/i });
     const rollbackBtn = page.getByRole("button", { name: /Rollback/i });
 
-    const hasPromote = await promoteBtn.isVisible({ timeout: 10000 }).catch(() => false);
-    const hasRollback = await rollbackBtn.isVisible({ timeout: 5000 }).catch(() => false);
-
-    if (!hasPromote && !hasRollback) {
-      // Agent detail page may not show these buttons for all agent states
-      test.skip();
-      return;
-    }
+    // The agent detail page must surface at least one of Promote/Rollback.
+    // If neither is visible the page is degraded and the test should fail.
+    await expect(promoteBtn.or(rollbackBtn).first()).toBeVisible({ timeout: 10000 });
+    const hasPromote = await promoteBtn.isVisible().catch(() => false);
+    const hasRollback = await rollbackBtn.isVisible().catch(() => false);
 
     if (hasPromote) {
       // Click Promote -- should show response (error or success)
@@ -208,7 +208,7 @@ test.describe("E1: Playground Shows Custom Agents", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
 
     await page.goto(`${baseURL}/dashboard`, {
@@ -236,7 +236,7 @@ test.describe("E2: HITL in Approvals", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
     const ts = Date.now();
 
@@ -294,7 +294,7 @@ test.describe("G4/G5: Template Edit & Delete", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
     const ts = Date.now();
 
@@ -333,7 +333,7 @@ test.describe("G4/G5: Template Edit & Delete", () => {
   });
 
   test("Edit opens textarea and Save works", async ({ page, baseURL }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
     const ts = Date.now();
 
@@ -370,7 +370,7 @@ test.describe("G4/G5: Template Edit & Delete", () => {
   });
 
   test("Delete button visible on template detail (production-safe: no actual delete)", async ({ page, baseURL }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
 
     // Just verify the template list page renders and has templates
@@ -409,7 +409,7 @@ test.describe("G6: Built-in Template Clone", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
 
     await page.goto(`${baseURL}/dashboard/prompt-templates`, {
@@ -458,7 +458,7 @@ test.describe("G6: Built-in Template Clone", () => {
   });
 
   test("Clone creates a custom copy", async ({ page, baseURL }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
 
     await page.goto(`${baseURL}/dashboard/prompt-templates`, {
@@ -611,7 +611,7 @@ test.describe("ORG-INV-002: Invite Token Issuer", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
 
     const ts = Date.now();
@@ -660,7 +660,7 @@ test.describe("AGENT-CONFIG-003: Agent Tools Auto-populate", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
 
     await page.goto(`${baseURL}/dashboard/agents/new`, {
@@ -682,7 +682,7 @@ test.describe("AGENT-CONFIG-003: Agent Tools Auto-populate", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
     const ts = Date.now();
 
@@ -724,7 +724,7 @@ test.describe("HITL-COUNT-004: Decided Tab UI", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
     const ts = Date.now();
 
@@ -811,7 +811,7 @@ test.describe("HITL-EXP-005: Expired HITL Filtering", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
 
     const pendingResp = await page.request.get(
       `${baseURL}/api/v1/approvals?status=pending`,
@@ -841,7 +841,7 @@ test.describe("WF-CONN-006: Email Trigger in Workflow UI", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
 
     await page.goto(`${baseURL}/dashboard/workflows/new`, {
@@ -871,7 +871,7 @@ test.describe("WF-CONN-006: Email Trigger in Workflow UI", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
 
     await page.goto(`${baseURL}/dashboard/workflows/new`, {
@@ -900,7 +900,7 @@ test.describe("WF-CONN-006: Email Trigger in Workflow UI", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
 
     await page.goto(`${baseURL}/dashboard/workflows/new`, {
@@ -936,7 +936,7 @@ test.describe("CONN-SLACK-007: Slack Connector Config", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
 
     await page.goto(`${baseURL}/dashboard/connectors/new`, {
@@ -960,7 +960,7 @@ test.describe("CONN-SLACK-007: Slack Connector Config", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const ts = Date.now();
 
     const createResp = await page.request.post(
@@ -991,7 +991,7 @@ test.describe("CONN-SLACK-007: Slack Connector Config", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     await ensureAuth(page, baseURL!);
     const ts = Date.now();
 
@@ -1032,7 +1032,7 @@ test.describe("CONN-SLACK-007: Slack Connector Config", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
     const ts = Date.now();
 
     const createResp = await page.request.post(
@@ -1076,18 +1076,19 @@ test.describe("CONN-SLACK-007: Slack Connector Config", () => {
     page,
     baseURL,
   }) => {
-    test.skip(!canAuth, "requires E2E_TOKEN");
+    requireAuth();
 
-    // Verify agents API is accessible and returns valid data
+    // Verify agents API is accessible and returns valid data. A 401 here
+    // means the CI E2E_TOKEN is expired — surface that as a loud failure
+    // rather than a silent skip so it gets rotated.
     const listResp = await page.request.get(
       `${baseURL}/api/v1/agents`,
       { headers: { Authorization: `Bearer ${E2E_TOKEN}` } },
     );
-    // Skip gracefully if token expired (401) — test requires valid auth
-    if (!listResp.ok()) {
-      test.skip(true, `agents API returned ${listResp.status()} — token may be expired`);
-      return;
-    }
+    expect(
+      listResp.ok(),
+      `GET /api/v1/agents returned ${listResp.status()} — token may be expired; rotate E2E_TOKEN`,
+    ).toBe(true);
     const data = await listResp.json();
     const agents = Array.isArray(data) ? data : data.agents || data.items || [];
 

--- a/ui/e2e/scope-enforcement.spec.ts
+++ b/ui/e2e/scope-enforcement.spec.ts
@@ -14,6 +14,12 @@ import { test, expect, Page } from "@playwright/test";
 const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
+function requireAuth(): void {
+  if (!canAuth) throw new Error(
+    "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+  );
+}
+
 
 async function authenticate(page: Page) {
   await page.goto(`${APP}/login`);
@@ -30,7 +36,7 @@ test.describe("Scope Enforcement — UI", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 

--- a/ui/e2e/session5-bugs.spec.ts
+++ b/ui/e2e/session5-bugs.spec.ts
@@ -7,7 +7,7 @@
  * mutate delete what they create at the end.
  */
 import { expect, test, type Page } from "@playwright/test";
-import { APP, authenticate, canAuth } from "./helpers/auth";
+import { APP, authenticate, canAuth, requireAuth } from "./helpers/auth";
 
 /**
  * Selector helper — scope to <main> so the sidebar "Voice Agents" /
@@ -24,7 +24,7 @@ function mainButton(page: Page, name: string | RegExp) {
 
 test.describe("Voice Setup regression", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN required");
+    requireAuth();
     await authenticate(page);
     await page.goto(`${APP}/dashboard/voice-setup`, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle").catch(() => {});
@@ -131,7 +131,7 @@ test.describe("Voice Setup regression", () => {
 
 test.describe("Sales Pipeline CSV import", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN required");
+    requireAuth();
     await authenticate(page);
     await page.goto(`${APP}/dashboard/sales`, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle").catch(() => {});
@@ -145,7 +145,13 @@ test.describe("Sales Pipeline CSV import", () => {
       `QA Test 2,qa2-${Date.now()}@example.invalid,AcmeCo`,
     ].join("\n");
 
-    // Set the hidden input directly — the visible button only opens a picker.
+    // Sync on the actual network boundary — the banner only appears after
+    // POST /sales/import-csv resolves, and the request can take >30s against
+    // production, so DOM-only polling flakes.
+    const importResp = page.waitForResponse(
+      (r) => r.url().includes("/sales/import-csv") && r.request().method() === "POST",
+      { timeout: 60000 },
+    );
     await page.setInputFiles(
       "#csv-import-input",
       {
@@ -154,10 +160,12 @@ test.describe("Sales Pipeline CSV import", () => {
         buffer: Buffer.from(csv, "utf-8"),
       },
     );
+    const resp = await importResp;
+    expect(resp.status(), "POST /sales/import-csv").toBeLessThan(400);
 
     // The success banner must not say "0" when we uploaded 2 rows.
     const banner = page.locator("text=/Imported \\d+ leads? from CSV/").first();
-    await expect(banner).toBeVisible({ timeout: 30000 });
+    await expect(banner).toBeVisible({ timeout: 15000 });
     const text = (await banner.textContent()) || "";
     expect(text).not.toMatch(/Imported 0 leads/);
   });
@@ -188,7 +196,7 @@ test.describe("Sales Pipeline CSV import", () => {
 
 test.describe("Knowledge Base regression", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN required");
+    requireAuth();
     await authenticate(page);
     await page.goto(`${APP}/dashboard/knowledge`, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle").catch(() => {});
@@ -244,7 +252,7 @@ test.describe("Knowledge Base regression", () => {
 
 test.describe("Tally test-connection", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN required");
+    requireAuth();
     await authenticate(page);
   });
 

--- a/ui/e2e/sop-flow.spec.ts
+++ b/ui/e2e/sop-flow.spec.ts
@@ -9,6 +9,12 @@ import { test, expect } from "@playwright/test";
 
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
+function requireAuth(): void {
+  if (!canAuth) throw new Error(
+    "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+  );
+}
+
 
 // ═══════════════════════════════════════════════════════════════════════════
 // SOP Page — Auth Required
@@ -16,7 +22,7 @@ const canAuth = !!E2E_TOKEN;
 
 test.describe("SOP: Page Access (auth required)", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
+    requireAuth();
     await page.goto("/login", { waitUntil: "domcontentloaded" });
     await page.evaluate((t) => {
       localStorage.setItem("token", t);
@@ -57,7 +63,7 @@ test.describe("SOP: Page Access (auth required)", () => {
 
 test.describe("SOP: API Parse (auth required)", () => {
   test.beforeEach(async () => {
-    test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
+    requireAuth();
   });
 
   test("parse text SOP returns draft config via API", async ({ request }) => {
@@ -143,7 +149,7 @@ test.describe("SOP: A2A + MCP Integration (public)", () => {
 
 test.describe("SOP: Dashboard v3.0 (auth required)", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
+    requireAuth();
     await page.goto("/login", { waitUntil: "domcontentloaded" });
     await page.evaluate((t) => {
       localStorage.setItem("token", t);

--- a/ui/e2e/v4-features.spec.ts
+++ b/ui/e2e/v4-features.spec.ts
@@ -19,6 +19,12 @@ const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
 const MARKETING = "https://agenticorg.ai";
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
+function requireAuth(): void {
+  if (!canAuth) throw new Error(
+    "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+  );
+}
+
 
 // ── Helper: authenticate via localStorage token ────────────────────────
 async function authenticate(page: Page): Promise<void> {
@@ -36,7 +42,7 @@ test.describe("v4 — Knowledge Base", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -109,7 +115,7 @@ test.describe("v4 — Voice Setup", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -171,7 +177,7 @@ test.describe("v4 — RPA Scripts", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -235,7 +241,7 @@ test.describe("v4 — Industry Packs", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -301,7 +307,7 @@ test.describe("v4 — Billing", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -395,7 +401,7 @@ test.describe("v4 — Sidebar Navigation", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -462,7 +468,7 @@ test.describe("v4 — Language Picker", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 
@@ -495,7 +501,7 @@ test.describe("v4 — Data Quality (no NaN / undefined)", () => {
   ];
 
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "requires auth token — set E2E_TOKEN env var");
+    requireAuth();
     await authenticate(page);
   });
 

--- a/ui/e2e/video-recordings.spec.ts
+++ b/ui/e2e/video-recordings.spec.ts
@@ -9,6 +9,12 @@ import { test, expect } from "@playwright/test";
 
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
+function requireAuth(): void {
+  if (!canAuth) throw new Error(
+    "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+  );
+}
+
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Public: Landing page (all demo videos start here)
@@ -36,7 +42,7 @@ test.describe("Video Flows: Landing Page", () => {
 
 test.describe("Video Flows: Platform Overview (auth required)", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
+    requireAuth();
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.evaluate((t) => {
       localStorage.setItem("token", t);
@@ -81,7 +87,7 @@ test.describe("Video Flows: Platform Overview (auth required)", () => {
 
 test.describe("Video Flows: CFO Finance (auth required)", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
+    requireAuth();
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.evaluate((t) => {
       localStorage.setItem("token", t);
@@ -106,7 +112,7 @@ test.describe("Video Flows: CFO Finance (auth required)", () => {
 
 test.describe("Video Flows: CHRO HR (auth required)", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
+    requireAuth();
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.evaluate((t) => {
       localStorage.setItem("token", t);
@@ -131,7 +137,7 @@ test.describe("Video Flows: CHRO HR (auth required)", () => {
 
 test.describe("Video Flows: CMO Marketing (auth required)", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
+    requireAuth();
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.evaluate((t) => {
       localStorage.setItem("token", t);
@@ -151,7 +157,7 @@ test.describe("Video Flows: CMO Marketing (auth required)", () => {
 
 test.describe("Video Flows: COO Operations (auth required)", () => {
   test.beforeEach(async ({ page }) => {
-    test.skip(!canAuth, "E2E_TOKEN not set — skipping auth-gated tests");
+    requireAuth();
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.evaluate((t) => {
       localStorage.setItem("token", t);


### PR DESCRIPTION
## Summary

Addresses two things keeping main red and/or coverage soft:

### 1. Real backend bug — every KB upload in prod silently drops the file (TC-013)

`api/v1/knowledge.py:_db_store_doc` INSERTs into the legacy `documents` table with `filename` / `content_type` / `size_bytes` / `status` — fields that don't exist on the S3-era ORM model. SQLAlchemy raises `TypeError`, the upload path swallows the exception (lines 253-254), the row never reaches the DB, and the Knowledge Base UI always shows an empty list after upload.

**Fix**
- `migrations/versions/v4_8_4_documents_kb_upload_cols.py` — additive migration: adds the four missing columns and relaxes the legacy `s3_bucket` / `s3_key` NOT NULL so metadata-only uploads are representable.
- `core/models/document.py` — ORM gains the new columns; `s3_bucket` / `s3_key` become nullable; `name` stays NOT NULL for backward compat.
- `api/v1/knowledge.py` — `_db_store_doc` mirrors `filename` into the legacy `name` column so a single INSERT satisfies both generations of the schema.

### 2. Zero-skip rule — eliminate every `test.skip` primitive in e2e specs

Per project policy (no silent skips — a missing E2E_TOKEN or a missing product feature is a loud failure, not a hidden pass), every `test.skip(!canAuth, …)` across 18 specs (122 sites), every unconditional `test.skip()`, and the one `test.skip(true, …)` are replaced.

**How**
- `ui/e2e/helpers/auth.ts` exports a new `requireAuth()` that throws on missing `E2E_TOKEN`. `authenticate(page)` now calls it instead of silently returning on no token.
- Specs that import from `helpers/auth` got `requireAuth` added to the import; specs that define `canAuth` locally got a local `requireAuth()` helper inline.
- Inline "skip when feature not visible" guards in `error-handling.spec.ts` and `qa-bugs-regression.spec.ts` become `expect(…).toBeVisible(…)` — if the NL query input or the Promote/Rollback buttons go missing, the test fails loudly.
- `production-full.spec.ts` gains a `requireAuth()` scoped to its own `HAS_AUTH` flag.

### 3. TC-002 CSV import stabilization

Flaky (passed on retry in the last run) — the "Imported N leads" banner raced the POST /sales/import-csv response. Now synced on the response explicitly: 60s HTTP wait, 15s banner wait.

## Test plan

- [ ] CI `e2e-tests` goes green on main post-deploy (this is the only environment that runs the e2e job — branch CI skips it by design)
- [ ] `0 skipped` in the Playwright summary (previously `1 skipped`)
- [ ] KB upload via `/dashboard/knowledge` shows the file after refresh (was broken before this PR)
- [ ] Preflight passed locally: branch-safety, ruff, bandit, alembic, verify=False scan, pytest unit+regression (`-k knowledge or document` = 8 passed), tsc, ui build

@codex please review