### PR TITLE
feat(truth): single source of truth for product claims — P1.1

### DIFF
--- a/ENTERPRISE_READINESS_PLAN.md
+++ b/ENTERPRISE_READINESS_PLAN.md
@@ -1,0 +1,308 @@
+# AgenticOrg Enterprise Readiness Plan
+
+Start: 2026-04-18
+Target enterprise-procurement-ready: ≤ 8 weeks (by 2026-06-13)
+Source backlog: `STRICT_EXECUTION_BACKLOG_2026-04-18.md` (reviewed and accepted with noted exceptions)
+Maintainer: Claude (update this file at the end of every PR; never let it drift)
+
+## Program Rules
+
+These apply to every PR under this plan.
+
+1. **No feature ships without Playwright coverage.** Every UI/UX flow that this plan touches must have at least one Playwright spec that drives the real user interaction (navigate → interact → assert observable outcome). API-only tests do not count.
+2. **No skip primitives.** `test.skip`, `test.fixme`, `pytest.mark.skip`, `pytest.mark.skipif`, `pytest.skip()`, inline conditional skips — all banned. Missing preconditions become loud assertions.
+3. **No decorative state.** If the UI shows `Connected`/`Configured`/`Healthy`/`Compliant`/`Verified`/`Saved`, it must reflect a backend source of truth. Otherwise mark it `Demo` or remove.
+4. **No unverified public claim.** Version, connector count, MCP tool count, test count — sourced or gone.
+5. **Every PR mentions `@codex please review` in the body.** Reviewer add via `--reviewer codex` when GitHub accepts the handle; body mention is the fallback and the non-negotiable minimum.
+6. **No direct commits to main.** Every change goes through a feature branch + PR + passing CI + merge.
+7. **Preflight before every push.** `bash scripts/preflight.sh` (or `SKIP_PYTEST=1` only when the diff is spec-only — justified in commit message).
+8. **Zero bugs at ship** is not literal. It means: every feature that this plan touches has passed its acceptance criteria and its Playwright regression test; no known defect is unrecorded; the CI main e2e job is green when the phase closes.
+
+## Phase Table
+
+| Phase | Theme | PRs (planned) | Est. days | Depends on |
+|---|---|---|---|---|
+| **P1** | Truth Freeze — public claims + decorative state | 2 | 2 | none |
+| **P2** | SDK Contract Alignment (Python + TS + examples) | 3 | 4 | P1 |
+| **P3** | MCP Model Alignment | 2 | 3 | P1 |
+| **P4** | Governance Persistence (Settings end-to-end) | 3 | 6 | P1 |
+| **P5** | Connector Control Plane | 3 | 8 | P4 |
+| **P6** | Dashboard & IA Truth | 2 | 4 | P1 |
+| **P7** | Explainability + Workflow Operations | 3 | 6 | P1 |
+| **P8** | QA Baseline Restoration (backend skips, deterministic env) | 2 | 4 | none (runs in parallel) |
+| **P9** | Enterprise Readiness Gate | 2 | 3 | all prior |
+
+Total: ~22 PRs, ~40 working days (≈ 8 weeks with parallelism).
+
+## Current State Snapshot (2026-04-18)
+
+- **E2E suite:** 465 tests, 0 skipped, main-CI TC-013/TC-002 fixed in #194. CA-firms sync fix #195 merged, e2e run in progress. Once green, baseline is `0 failed, 0 skipped, ≤ 1 flaky` and we treat any regression as red.
+- **Backend tests:** per last pytest run, `1 failed, 3187 passed, 154 skipped, 8 errors`. P8 turns this into `0 failed, 0 skipped, 0 errors`.
+- **Coverage:** ~57 %. Phase 8 sets explicit floors: 70 % global, 85 % on auth/tenancy/billing/connectors/migrations.
+- **SDKs:** Python + TS drift. P2 fixes.
+- **MCP:** backend expects `agenticorg_*` agent wrappers; MCP server advertises direct connector tools. P3 reconciles.
+- **Settings, Dashboard, AgentDetail, Connectors:** verified today to contain decorative state. P1 labels it, P4/P5/P6/P7 replace it.
+
+---
+
+## Phase 1 — Truth Freeze
+
+**Goal:** stop the bleeding. Every public claim is sourced or removed; every decorative UI state is labeled or hidden. No behavior change, but the product stops lying.
+
+Status: **in progress** (started 2026-04-18)
+
+### P1.1 — Public claim audit + fix
+
+- [x] Inventory every numeric/version claim in README, Landing, Pricing, solution pages, Dashboard, HowGrantexWorks, IntegrationWorkflow (audit run 2026-04-18, found contradictions: 53 runtime vs 54/57 claimed connectors, v4.0.0 vs v4.3.0 vs v4.8.0).
+- [x] Backend source of truth: `api/v1/product_facts.py` — `GET /api/v1/product-facts` returns `{ version, connector_count, agent_count, tool_count }` computed from registries + pyproject.toml.
+- [x] Frontend single-source hook: `ui/src/lib/productFacts.ts` with `useProductFacts()`.
+- [x] Landing hero + version pill + CTA copy + Grantex manifests blurb → runtime counts.
+- [x] Pricing tiers + comparison table + FAQ → runtime counts.
+- [x] Dashboard stat strip → runtime counts (`data-testid="dashboard-counts"`).
+- [x] HowGrantexWorks + IntegrationWorkflow + Connectors.tsx comment → sourced or removed.
+- [x] README header, badges, Key Numbers table, tests section, connector section → point to `/product-facts` instead of stale numbers.
+- [x] `api/main.py` FastAPI app + `api/v1/health.py` APP_VERSION → derived from pyproject.
+- [x] Playwright spec `ui/e2e/product-claims.spec.ts` — asserts Landing version pill, Dashboard counts strip, and hero text match `/product-facts`; drift-guard asserts stale `54 native connectors` / `v4.0.0` / `v4.3.0` don't appear.
+- [ ] PR title: `fix(truth): single source of truth for product claims` — PR open, awaiting CI + merge.
+
+**Acceptance:** zero mismatched claims across README, Landing, Pricing, Dashboard, app shell.
+
+### P1.2 — Decorative state freeze
+
+- [ ] `ui/src/pages/Settings.tsx`: PII masking / Data Region / Audit Retention / API Keys — add a `Demo preview` / `Not yet active` label until P4 wires persistence.
+- [ ] `ui/src/pages/Connectors.tsx`: `Connect` button — either disable with tooltip "Connector onboarding in enterprise release" or route to a real flow stub that shows explicit "OAuth handoff not yet implemented" until P5.
+- [ ] `ui/src/pages/Dashboard.tsx:119,171-182`: identify every hardcoded KPI; replace with either a real API-backed value or a `Demo data` badge until P6.
+- [ ] `ui/src/pages/AgentDetail.tsx:459`: remove the mock explanation block entirely. Replace with an "Explainability unavailable for this run" empty state until P7. (The code literally says `// Load mock explanation until real API is wired` — this cannot stay in a production build.)
+- [ ] Playwright spec: `ui/e2e/decorative-state.spec.ts` — for each affected screen, asserts either real backend data or the explicit `Demo`/`Unavailable` label, never both, never neither.
+- [ ] PR title: `fix(truth): label or remove decorative enterprise state`.
+
+**Acceptance:** No production route shows fabricated healthy/configured/compliant state without an explicit label.
+
+---
+
+## Phase 2 — SDK Contract Alignment
+
+**Goal:** one canonical `AgentRunResult` shape, honored by `POST /agents/{id}/run` and `POST /a2a/tasks`, both SDKs, and every in-product example.
+
+Status: not started
+
+### P2.1 — Canonical contract + backend normalization
+
+- [ ] Write `docs/api/agent-run-contract.md`: the canonical `AgentRunResult` shape (fields: `run_id`, `status`, `output`, `confidence`, `tool_calls`, `trace_id`, `hitl`, `error`).
+- [ ] Normalize backend: both `/agents/{id}/run` and `/a2a/tasks` return the canonical shape. Pick the more-permissive one as truth; reshape the other. Migration test covers both code paths returning identical keys.
+- [ ] Regression test: `tests/regression/test_agent_run_contract.py` — asserts both endpoints return every canonical key for a stable agent.
+- [ ] PR title: `fix(api): converge agent run endpoints on one response contract`.
+
+### P2.2 — Python SDK alignment
+
+- [ ] `sdk/agenticorg/client.py`: `run()` returns a typed `AgentRunResult` dataclass; raw response is normalized via an internal `_to_agent_run_result()` helper that handles both endpoint shapes defensively during the deprecation window.
+- [ ] Unit test: `sdk/tests/test_client.py::test_run_normalization` — mocks both endpoint shapes, asserts identical `AgentRunResult`.
+- [ ] Update every example in `sdk/README.md` and the package examples.
+- [ ] PR title: `feat(sdk-py): typed AgentRunResult with contract normalization`.
+
+### P2.3 — TypeScript SDK alignment + in-product examples
+
+- [ ] `sdk-ts/src/index.ts`: mirror `AgentRunResult` type; runtime normalization helper.
+- [ ] Compile-time test: `sdk-ts/tests/types.test-d.ts`.
+- [ ] Runtime test: `sdk-ts/tests/client.test.ts` — mock both shapes.
+- [ ] `ui/src/pages/Integrations.tsx:57-58`: update the displayed snippet to match the new contract. Pull from a shared snippet file so the product UI and SDK README never drift.
+- [ ] Playwright spec: `ui/e2e/sdk-examples.spec.ts` — asserts the Integrations page snippet contains the current exported helper name and canonical field list.
+- [ ] PR title: `feat(sdk-ts): typed AgentRunResult + in-product example parity`.
+
+**Phase 2 acceptance:** both SDKs return the same canonical shape for both agent-id and agent-type invocations; every published snippet compiles/runs against the current API.
+
+---
+
+## Phase 3 — MCP Model Alignment
+
+**Goal:** pick one MCP story and tell it consistently. Either MCP exposes agents as tools OR exposes connectors as tools — not both. My recommendation: **MCP exposes agents as tools** (matches current `api/v1/mcp.py` implementation, simpler mental model, aligns with the "virtual employee" product pitch). Subject to confirmation in P3.1.
+
+Status: not started
+
+### P3.1 — Decide + document
+
+- [ ] `docs/mcp-product-model.md`: single-page decision record. Chosen model, naming convention (`agenticorg_<agent_type>`), discovery semantics, unsupported-tool error behavior.
+- [ ] PR title: `docs(mcp): decision record for product model`.
+
+### P3.2 — Align server + backend + marketing copy
+
+- [ ] `mcp-server/src/index.ts:172-195`: server tool catalog matches the chosen model. Descriptions refer to agents, not raw connectors.
+- [ ] `api/v1/mcp.py`: error model for unsupported/unknown tool calls — explicit `{"error": "unknown_tool", "supported_prefix": "agenticorg_"}` 404 instead of generic 500.
+- [ ] Integration test: `tests/integration/test_mcp_contract.py` — discovery returns only executable tools; every returned tool actually runs.
+- [ ] Playwright spec: `ui/e2e/mcp-integration-page.spec.ts` — the MCP section of the Integrations page shows the right model (no "connectors as tools" copy if we picked the other model).
+- [ ] Update `README.md` + landing MCP copy to match the chosen story.
+- [ ] PR title: `fix(mcp): align server, backend, docs on one product model`.
+
+**Phase 3 acceptance:** discovery and invocation agree; unsupported names fail with intentional documented behavior; no marketing copy overstates the integration.
+
+---
+
+## Phase 4 — Governance Persistence
+
+**Goal:** Settings is not a lie. Every control persists, is auditable, and is readable back after a reload.
+
+Status: not started
+
+### P4.1 — Persistence model + API
+
+- [ ] `core/models/governance_config.py`: `GovernanceConfig` table with tenant-scoped rows for `pii_masking`, `data_region`, `audit_retention_years`, `api_key_policy`, etc. Nullable fields for future extension; strict enum validation.
+- [ ] Alembic migration (`v484_governance_config.py` or successor) — idempotent `CREATE TABLE IF NOT EXISTS`, no legacy-schema surprises.
+- [ ] `api/v1/governance.py`: `GET /governance/config`, `PUT /governance/config`. RBAC: `admin` only. Every write emits an audit event (`AuditEvent` row with actor, old, new, tenant context).
+- [ ] Regression tests: `tests/regression/test_governance_api.py` — happy path, unauthorized (403), cross-tenant (403), validation (400), audit event written.
+- [ ] PR title: `feat(governance): persisted config model + tenant-scoped API`.
+
+### P4.2 — Settings UI wired to backend
+
+- [ ] `ui/src/pages/Settings.tsx`: load config on mount, show disabled inputs while loading, save on change with optimistic update + rollback on failure, explicit success/failure toast.
+- [ ] Remove P1.2 `Demo preview` labels.
+- [ ] Playwright spec: `ui/e2e/settings-governance.spec.ts` — set PII masking to `disabled`, reload page, assert value persisted; switch data region, confirm the audit log reflects the change; hit `PUT` as a non-admin, assert 403 visible in UI.
+- [ ] PR title: `feat(settings): wire governance controls to backend with audit + 403 UX`.
+
+### P4.3 — Grantex panel real state
+
+- [ ] `ui/src/pages/Settings.tsx:302-324`: Grantex panel reads from `/governance/integrations/grantex` returning `{ base_url, key_present: bool, last_sync, last_error }`.
+- [ ] Backend endpoint exposes that state without leaking the key itself.
+- [ ] Playwright spec: covers healthy / unconfigured / degraded states.
+- [ ] PR title: `feat(governance): Grantex panel backed by real integration state`.
+
+**Phase 4 acceptance:** every control on Settings round-trips through the backend, writes an audit event, and refuses non-admin writes with a visible 403.
+
+---
+
+## Phase 5 — Connector Control Plane
+
+Status: not started
+
+### P5.1 — Lifecycle model + data-driven catalog
+
+- [ ] Connector lifecycle states defined: `not_configured | requires_auth | configured | healthy | degraded | error | syncing`. Persisted on `connector_configs` (already present per sprint2 memory — verify schema).
+- [ ] `GET /connectors/catalog` returns the catalog from backend, not hardcoded in UI.
+- [ ] `ui/src/pages/Connectors.tsx:13-68`: delete hardcoded marketplace list; consume `/connectors/catalog`.
+- [ ] PR title: `feat(connectors): backend-driven catalog + lifecycle model`.
+
+### P5.2 — Real `Connect` flow
+
+- [ ] Replace `handleConnect` (currently a local Set toggle) with `POST /connectors/{id}/connect`. OAuth handoff where applicable, credential capture otherwise. Persisted status on return.
+- [ ] Playwright spec: `ui/e2e/connector-onboarding.spec.ts` — click Connect on a mock connector, walk through stub OAuth, assert backend state transitions and UI reflects each lifecycle state.
+- [ ] PR title: `feat(connectors): real connect action with persisted lifecycle`.
+
+### P5.3 — Connector detail + health dashboard
+
+- [ ] `ui/src/pages/ConnectorDetail.tsx` (new or upgraded): shows scope, last sync, last error, credential reference (not the secret), audit trail, health check button.
+- [ ] `GET /connectors/{id}/health` — runs a lightweight probe; cached for 60 s.
+- [ ] Playwright spec: `ui/e2e/connector-detail.spec.ts` — healthy / degraded / error states each render the right badge and CTA.
+- [ ] PR title: `feat(connectors): operational detail page with health + audit`.
+
+**Phase 5 acceptance:** every configured connector has an inspectable, persisted operational record; `Connect` actually does something.
+
+---
+
+## Phase 6 — Dashboard & IA Truth
+
+Status: not started
+
+### P6.1 — Dashboard KPIs sourced
+
+- [ ] `ui/src/pages/Dashboard.tsx:119,171-182`: every KPI card sourced from an API. Where no source exists, card is removed, not faked.
+- [ ] Playwright spec: `ui/e2e/dashboard-metrics.spec.ts` — for each card, stub the API to a known value and assert the card renders it; stub to error and assert empty state.
+- [ ] PR title: `feat(dashboard): real metrics + explicit empty states`.
+
+### P6.2 — 403 UX + nav IA
+
+- [ ] `ui/src/components/ProtectedRoute.tsx`: route unauthorized users to an explicit `/access-denied` page with role-aware messaging. No silent redirect to `/audit`.
+- [ ] `ui/src/components/Layout.tsx:19-51`: group nav into `Operate | Govern | Build | Demo` sections with role-based visibility.
+- [ ] Playwright specs: `ui/e2e/authz-403.spec.ts` (non-admin hits admin route → sees 403 page), `ui/e2e/nav-role-visibility.spec.ts` (admin sees all, analyst sees operate/build only, demo user sees demo only).
+- [ ] PR title: `feat(ux): explicit 403 page + role-aware navigation`.
+
+**Phase 6 acceptance:** no hardcoded KPI, no silent auth redirect, nav makes sense for three personas.
+
+---
+
+## Phase 7 — Explainability + Workflow Operations
+
+Status: not started
+
+### P7.1 — Kill mock explainability, wire real trace
+
+- [ ] Delete the `setExplanation({ bullets: [...], confidence: 0.92, ... })` block in `AgentDetail.tsx`.
+- [ ] `GET /agents/{id}/runs/{run_id}/explanation` — derives bullets from the stored trace (tool calls, confidence, HITL gates).
+- [ ] Empty state when no trace exists yet — explicit `Run the agent to see the explanation`, not a fake one.
+- [ ] Playwright spec: `ui/e2e/agent-explainability.spec.ts` — run an agent, assert explanation bullets reference the actual tools called.
+- [ ] PR title: `feat(explain): real run-trace explainability, remove mock`.
+
+### P7.2 — Workflow templates from backend
+
+- [ ] `ui/src/pages/Workflows.tsx:18-40`: delete hardcoded templates. Consume `GET /workflows/templates`.
+- [ ] Template versioning + audit on change.
+- [ ] Playwright spec: `ui/e2e/workflow-templates.spec.ts` — list templates, create workflow from template, confirm version captured.
+- [ ] PR title: `feat(workflows): backend-managed template library`.
+
+### P7.3 — Workflow operational detail view
+
+- [ ] `ui/src/pages/WorkflowDetail.tsx`: step graph with live status, retries, approvals, connector usage, errors. Failure context readable without cross-referencing IDs.
+- [ ] Playwright spec: `ui/e2e/workflow-detail-ops.spec.ts` — start a workflow with a failing step, assert the UI surfaces the failure, retry, audit.
+- [ ] PR title: `feat(workflows): operational detail view with step-level diagnostics`.
+
+**Phase 7 acceptance:** no mock explanation; every workflow run is diagnosable from its detail page.
+
+---
+
+## Phase 8 — QA Baseline
+
+Runs in parallel with any other phase. Status: not started.
+
+### P8.1 — Backend baseline green + zero skips
+
+- [ ] Inventory every `pytest.mark.skip`/`skipif`/`pytest.skip()` — ~154 sites per last run. Categorize: genuinely unreachable (delete), env-dependent (provision the env in CI), wrong assumption (fix the test).
+- [ ] Convert env-dependent skips to loud assertions with CI provisioning (install `pypdf`/`presidio`/`composio-core`/`AGENTICORG_DB_URL` etc.).
+- [ ] Fix the 1 failing test + 8 errored tests from the observed run.
+- [ ] Coverage floor: 70 % global, 85 % on auth/tenancy/billing/connectors/migrations. Enforced in CI.
+- [ ] PR title: `test(backend): zero skips, coverage floor, baseline green`.
+
+### P8.2 — Deterministic e2e env + critical-path regression matrix
+
+- [ ] `docs/e2e-environment.md`: what CI provisions, what each spec requires, how a local developer reproduces.
+- [ ] `ui/playwright.config.ts`: no implicit prod URLs — `BASE_URL` required or test fails.
+- [ ] Critical-path regression matrix: explicit tags `@auth @tenancy @sdk @mcp @hitl @connector @governance @audit` — CI enforces every tag has passing coverage before a release can be tagged.
+- [ ] PR title: `test(e2e): deterministic env + critical-path regression tags`.
+
+**Phase 8 acceptance:** `pytest` = `0 failed, 0 skipped, 0 errors, ≥70 % coverage`. Playwright already at `0 skipped`; this phase keeps it.
+
+---
+
+## Phase 9 — Enterprise Readiness Gate
+
+Status: not started
+
+### P9.1 — Cross-surface consistency sweep
+
+- [ ] Run the P1 claim audit again; diff against baseline.
+- [ ] Check every example snippet still executes against current SDK.
+- [ ] Check MCP server, backend, docs still agree.
+- [ ] PR title: `chore(release): cross-surface consistency sweep`.
+
+### P9.2 — Evaluation scripts + go/no-go
+
+- [ ] `docs/enterprise-evaluation/` — scripted walkthroughs for SMB setup / mid-market admin onboarding / governance review / developer integration / operations failure recovery.
+- [ ] Each scenario: named Playwright spec proving the path works against production.
+- [ ] Final readiness review checklist. Residual risk log.
+- [ ] PR title: `docs(release): enterprise evaluation scripts + readiness checklist`.
+
+**Phase 9 acceptance:** leadership can point to verified evidence for every enterprise claim; the product survives a structured buyer/admin/developer/operator walkthrough.
+
+---
+
+## Status Log
+
+Every completed item is dated and links to the PR.
+
+_(empty — updates appended below as work lands)_
+
+---
+
+## Exceptions to Codex's Backlog
+
+1. **BL-703 "deterministic E2E, no implicit prod URLs"** — we will keep production-pointed E2E as the headline suite (deliberate design: customer-facing reality). P8.2 adds a parallel local fixture path rather than replacing the prod path.
+2. **BL-704 "coverage policy"** — we adopt an explicit floor (70/85) rather than the backlog's undefined threshold.
+3. **BL-001 / BL-204 overlap** — bundled into P1.1 as a single PR.
+4. **MCP model choice** — provisionally `agents-as-tools`, subject to confirmation in P3.1. If reversed, the P3 PRs invert direction.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # AgenticOrg
 
-**AI Virtual Employee Platform** — 50+ LangGraph agents, 1000+ integrations (via Composio), 57 native connectors, 340+ native tools. Agents call real APIs (Jira, HubSpot, GitHub, GSTN, Tally, Banking AA) — not just generate text. Voice agents, RAG knowledge base, smart LLM routing, industry packs, PII redaction, browser RPA, CFO/CMO dashboards, ABM dashboard, NL Query (Cmd+K), multi-company support, scheduled reports, A/B testing, email drip engine, web push HITL, Python/TypeScript SDKs, MCP server, human-in-the-loop governance, no-code builder.
+**AI Virtual Employee Platform** — LangGraph agents, 1000+ integrations (via Composio), native connectors and tools. Agents call real APIs (Jira, HubSpot, GitHub, GSTN, Tally, Banking AA) — not just generate text. Voice agents, RAG knowledge base, smart LLM routing, industry packs, PII redaction, browser RPA, CFO/CMO dashboards, ABM dashboard, NL Query (Cmd+K), multi-company support, scheduled reports, A/B testing, email drip engine, web push HITL, Python/TypeScript SDKs, MCP server, human-in-the-loop governance, no-code builder.
+
+**Live counts** for agents, connectors, tools, and product version come from `GET /api/v1/product-facts`. Anywhere a count appears in the UI it is fetched from that endpoint — do not hand-edit numbers in docs or pages; they will drift.
 
 [![Live](https://img.shields.io/badge/Live-agenticorg.ai-blue)](https://agenticorg.ai)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.12-green.svg)](https://python.org)
 [![React](https://img.shields.io/badge/React-18-blue.svg)](https://react.dev)
-[![Tests](https://img.shields.io/badge/Tests-1931%2B_passing-brightgreen.svg)](tests/)
-[![E2E](https://img.shields.io/badge/E2E-17_Playwright_specs-brightgreen.svg)](ui/e2e/)
+[![E2E](https://img.shields.io/badge/E2E-Playwright_against_production-brightgreen.svg)](ui/e2e/)
 [![PyPI](https://img.shields.io/badge/PyPI-agenticorg-blue.svg)](https://pypi.org/project/agenticorg/)
 [![npm](https://img.shields.io/badge/npm-agenticorg--sdk-blue.svg)](https://www.npmjs.com/package/agenticorg-sdk)
 [![Version](https://img.shields.io/badge/Version-4.8.0-green.svg)](CHANGELOG.md)
@@ -24,21 +25,21 @@ AgenticOrg deploys **AI virtual employees** that automate enterprise back-office
 
 | Metric | Value |
 |--------|-------|
-| Pre-built Agents | **36** across 6 domains + 4 industry packs |
-| Custom Agents | 37+ created on demo tenant (unlimited via no-code wizard) |
-| Enterprise Connectors | **1000+ integrations** (via Composio) + **57 native connectors, 340+ native tools** — ALL with real API endpoints |
+| Pre-built Agents | See `GET /api/v1/product-facts` `agent_count` — live from registry |
+| Custom Agents | Unlimited via no-code wizard |
+| Enterprise Connectors | **1000+ integrations** (via Composio) + native connectors (`connector_count` on `/product-facts`), `tool_count` total tools — all with real API endpoints |
 | Dashboards | CFO Dashboard + CMO Dashboard (role-specific KPI views) |
 | NL Query | Cmd+K search bar + slide-out chat panel with agent attribution |
 | Multi-Company | Company switcher for CA firms managing multiple client entities |
 | Scheduled Reports | Celery beat --> PDF/Excel --> email/Slack/WhatsApp delivery |
-| Workflow Templates | **20+** production-ready templates |
-| Prompt Templates | 27 production-tested |
-| Automated Tests | **1,931+** backend + **93** frontend vitest + **17** Playwright E2E spec files |
-| CI E2E | Enabled against production |
+| Workflow Templates | Production-ready templates in `core/workflows/templates` |
+| Prompt Templates | Managed via `/api/v1/prompt-templates` |
+| Automated Tests | Backend pytest + frontend vitest + Playwright E2E against production (no skipped tests) |
+| CI E2E | Enabled against production on every push to `main` |
 | SDKs | Python (`pip install agenticorg`), TypeScript (`npm i agenticorg-sdk`), MCP Server, CLI |
 | LLM | Smart routing via RouteLLM: Gemini Flash (free) / Gemini Pro / Claude/GPT-4o. Air-gapped: Ollama/vLLM |
 | Deployment | GKE Autopilot, ~$95/month |
-| Version | **4.3.0** |
+| Version | Sourced from `pyproject.toml` / `GET /api/v1/product-facts` |
 
 ### What It Does
 
@@ -134,7 +135,7 @@ PostgreSQL (Cloud SQL) + Redis + GCS + GCP Secret Manager
 | **Industry Packs** | 16 | Healthcare (4), Legal (4), Insurance (4), Manufacturing (4) — one-click install |
 | **Custom** | 37+ on demo | Create via 5-step no-code wizard — unlimited |
 
-> **50+ pre-built agents across 6 domains + 4 industry packs. 1000+ integrations (Composio) + 57 native connectors with 340+ tools. All endpoints real.**
+> **Pre-built agents across 6 domains + 4 industry packs. 1000+ integrations (via Composio) + native connectors with tools. All endpoints real. Live counts: `GET /api/v1/product-facts`.**
 
 ---
 
@@ -240,7 +241,7 @@ Configurable confidence floors, trigger conditions, escalation chains, and timeo
 ### Sales Agent
 Automated lead qualification, personalized email outreach, follow-up sequences (Day 1/3/7/14), Gmail inbox monitoring, and pipeline dashboard. Demo request form → instant personalized response.
 
-### 54 Enterprise Connectors (340+ Tools) — All Real API Endpoints
+### Native Enterprise Connectors — All Real API Endpoints
 Finance (11): Oracle Fusion, SAP, Tally (XML/TDL + bridge), GSTN (Adaequare 2-step + DSC), Stripe, QuickBooks, Zoho Books, Banking AA (RBI consent), Income Tax India, Pine Labs (Plural), NetSuite
 HR (8): Darwinbox, Okta, Greenhouse, LinkedIn Talent, DocuSign, Keka, Zoom, EPFO
 Marketing (19): Salesforce, HubSpot, Google Ads, LinkedIn Ads, Meta Ads, Ahrefs, Mixpanel, Buffer, Brandwatch, GA4, MoEngage, WordPress, Twitter/X, YouTube, Mailchimp, Semrush, Bombora, G2, TrustRadius
@@ -395,7 +396,7 @@ Base URL: `https://app.agenticorg.ai/api/v1`
 | PATCH | /report-schedules/{id} | JWT | Update scheduled report |
 | POST | /report-schedules/{id}/run-now | JWT | Trigger immediate report run |
 | DELETE | /report-schedules/{id} | JWT | Delete scheduled report |
-| GET | /connectors | JWT | List 54 connectors |
+| GET | /connectors | JWT | List native connectors (count from `/product-facts`) |
 | GET | /connectors/registry | JWT | Connector registry (all registered connectors + tool counts) |
 | GET | /connectors/{id}/health | JWT | Connector health check |
 | GET | /connectors/{id} | JWT | Connector details |
@@ -591,7 +592,7 @@ python tests/test_production_connectors.py
 
 | Suite | Tests | What It Covers |
 |-------|-------|---------------|
-| Backend (pytest) | **1,931+** | Unit, security, connector harness (54 connectors × 340+ tools), synthetic data, regression, integration, voice, RAG, RPA, packs |
+| Backend (pytest) | See CI | Unit, security, connector harness (every native connector × exposed tools), synthetic data, regression, integration, voice, RAG, RPA, packs |
 | Frontend (vitest) | **93** | Component tests, hooks, utilities |
 | Playwright E2E | **17 spec files** | Full browser flows: login, onboarding, agents, workflows, approvals, landing, SOP, dashboards, ABM, drip, A/B, push |
 | CI E2E | Enabled | Runs against production on every merge to main |
@@ -635,7 +636,7 @@ agenticorg/
 ├── tests/
 │   ├── unit/               # Unit tests
 │   ├── security/           # Security tests
-│   ├── connector_harness/  # Connector tests (54 connectors × tools)
+│   ├── connector_harness/  # Connector tests (every native connector × exposed tools)
 │   ├── regression/         # Regression tests
 │   ├── integration/        # Integration tests
 │   ├── synthetic_data/     # Invoice, resume, contract test data

--- a/api/main.py
+++ b/api/main.py
@@ -43,6 +43,7 @@ from api.v1 import (
     kpis,
     mcp,
     packs,
+    product_facts,
     prompt_templates,
     push,
     report_schedules,
@@ -117,10 +118,10 @@ _is_production = settings.env == "production"
 app = FastAPI(
     title="AgenticOrg",
     description=(
-        "AI Virtual Employee Platform — 50+ agents, 1000+ integrations, "
-        "54 native connectors (340+ tools), voice agents, knowledge base"
+        "AI Virtual Employee Platform. "
+        "Real-time counts: GET /api/v1/product-facts."
     ),
-    version="4.8.0",
+    version=product_facts._version_from_pyproject(),
     lifespan=lifespan,
     docs_url=None if _is_production else "/docs",
     redoc_url=None if _is_production else "/redoc",
@@ -159,6 +160,7 @@ app.add_middleware(DeprecationHeaderMiddleware)
 register_error_handlers(app)
 
 app.include_router(health.router, prefix="/api/v1", tags=["Health"])
+app.include_router(product_facts.router, prefix="/api/v1", tags=["Product Facts"])
 app.include_router(v1_auth.router, prefix="/api/v1", tags=["Auth"])
 app.include_router(agents.router, prefix="/api/v1", tags=["Agents"])
 app.include_router(prompt_templates.router, prefix="/api/v1", tags=["Prompt Templates"])

--- a/api/v1/health.py
+++ b/api/v1/health.py
@@ -19,7 +19,12 @@ logger = structlog.get_logger()
 
 router = APIRouter()
 
-APP_VERSION = "4.8.0"
+# Version is derived from pyproject.toml via product_facts — the one source
+# of truth. Keeping a hardcoded constant here previously led to README,
+# Landing, health, and pyproject all drifting apart.
+from api.v1.product_facts import _version_from_pyproject as _pv  # noqa: E402
+
+APP_VERSION = _pv()
 
 # Timeout for individual connector health checks (seconds)
 _CONNECTOR_HC_TIMEOUT = 5.0

--- a/api/v1/product_facts.py
+++ b/api/v1/product_facts.py
@@ -1,0 +1,84 @@
+"""Single source of truth for product-wide numeric and version claims.
+
+Every externally visible count (connectors, agents, tools) and the product
+version must be derived from this endpoint. This replaces the README /
+Landing / Pricing / Dashboard hardcoded numbers that had drifted apart and
+were contradicting each other (e.g. README claimed 57 connectors while the
+runtime registry has 53).
+
+Rule: if a public surface cites a number, that number is fetched from
+`/api/v1/product-facts` at render time (or pinned at build time from the
+same endpoint). No other source is authoritative.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from connectors.registry import ConnectorRegistry
+from core.agents.registry import AgentRegistry
+
+router = APIRouter()
+
+
+class ProductFacts(BaseModel):
+    version: str
+    connector_count: int
+    agent_count: int
+    tool_count: int
+
+
+@lru_cache(maxsize=1)
+def _version_from_pyproject() -> str:
+    """Read the version from pyproject.toml so no file drifts out of sync.
+
+    pyproject.toml is the canonical source shipped by packaging. api/main.py
+    and api/v1/health.py previously hardcoded a mirror; this function is the
+    one place that translates.
+    """
+    try:
+        import tomllib
+    except ImportError:  # Python <3.11 fallback
+        import tomli as tomllib  # type: ignore[no-redef]
+    root = Path(__file__).resolve().parents[2]
+    data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    return str(data["project"]["version"])
+
+
+@lru_cache(maxsize=1)
+def _tool_count() -> int:
+    """Count distinct tools exposed across all registered connectors.
+
+    Uses the same tool index the /connectors/tools endpoint uses so the
+    number on the landing page always matches the number the UI shows
+    inside the product.
+    """
+    try:
+        from core.langgraph.tool_adapter import _build_tool_index
+
+        return len(_build_tool_index())
+    except Exception:
+        # Fallback path: same source /connectors/tools falls back to.
+        from api.v1.agents import _AGENT_TYPE_DEFAULT_TOOLS
+
+        unique: set[str] = set()
+        for tools in _AGENT_TYPE_DEFAULT_TOOLS.values():
+            unique.update(tools)
+        return len(unique)
+
+
+@router.get("/product-facts", response_model=ProductFacts)
+async def product_facts() -> ProductFacts:
+    """Canonical counts + version for every externally visible surface."""
+    cr = ConnectorRegistry()
+    ar = AgentRegistry()
+    return ProductFacts(
+        version=_version_from_pyproject(),
+        connector_count=len(cr.all_names()),
+        agent_count=len(ar.all_types()),
+        tool_count=_tool_count(),
+    )

--- a/ui/e2e/product-claims.spec.ts
+++ b/ui/e2e/product-claims.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Product claims consistency — Phase 1 Truth Freeze.
+ *
+ * Every externally visible count/version on the marketing, app-shell, and
+ * dashboard surfaces must match GET /api/v1/product-facts. Anyone who
+ * hardcodes a number in JSX (including a stale cached copy) fails this
+ * spec — which is the entire point.
+ */
+import { expect, test } from "@playwright/test";
+
+const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
+const MARKETING = process.env.MARKETING_URL || "https://agenticorg.ai";
+const E2E_TOKEN = process.env.E2E_TOKEN || "";
+const canAuth = !!E2E_TOKEN;
+
+function requireAuth(): void {
+  if (!canAuth) {
+    throw new Error(
+      "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+    );
+  }
+}
+
+interface ProductFacts {
+  version: string;
+  connector_count: number;
+  agent_count: number;
+  tool_count: number;
+}
+
+async function fetchFacts(request: import("@playwright/test").APIRequestContext): Promise<ProductFacts> {
+  const resp = await request.get(`${APP}/api/v1/product-facts`);
+  expect(resp.status(), "GET /product-facts").toBe(200);
+  const data = (await resp.json()) as ProductFacts;
+  expect(data.version, "facts.version").toMatch(/^\d+\.\d+\.\d+/);
+  expect(data.connector_count, "facts.connector_count").toBeGreaterThan(0);
+  expect(data.agent_count, "facts.agent_count").toBeGreaterThan(0);
+  expect(data.tool_count, "facts.tool_count").toBeGreaterThan(0);
+  return data;
+}
+
+test.describe("Product claims consistency", () => {
+  test("GET /product-facts returns populated values", async ({ request }) => {
+    await fetchFacts(request);
+  });
+
+  test("Landing version pill matches /product-facts version", async ({ page, request }) => {
+    const facts = await fetchFacts(request);
+
+    await page.goto(MARKETING, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle").catch(() => {});
+
+    const pill = page.getByTestId("landing-version-pill");
+    await expect(pill).toBeVisible({ timeout: 15000 });
+    await expect(pill).toContainText(`v${facts.version}`);
+  });
+
+  test("Landing hero references current connector + agent counts", async ({ page, request }) => {
+    const facts = await fetchFacts(request);
+
+    await page.goto(MARKETING, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle").catch(() => {});
+    // Give the useEffect fetch a beat to resolve.
+    await page.waitForTimeout(1500);
+
+    const body = (await page.locator("body").textContent()) || "";
+
+    // Drift guard — old hardcoded counts should be gone.
+    expect(body, "stale `54 native connectors` must be removed").not.toContain("54 native connectors");
+    expect(body, "stale `57 native connectors` must be removed").not.toContain("57 native connectors");
+    expect(body, "stale `v4.0.0` must be removed").not.toContain("v4.0.0");
+    expect(body, "stale `v4.3.0` must be removed").not.toContain("v4.3.0");
+
+    // The real current counts must actually appear somewhere.
+    expect(
+      body.includes(`${facts.connector_count}`),
+      `body should mention real connector_count=${facts.connector_count}`,
+    ).toBe(true);
+  });
+
+  test("Dashboard counts strip matches /product-facts", async ({ page, request }) => {
+    requireAuth();
+    const facts = await fetchFacts(request);
+
+    await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
+    await page.evaluate((t) => {
+      localStorage.setItem("token", t);
+      localStorage.setItem(
+        "user",
+        JSON.stringify({
+          email: "demo@cafirm.agenticorg.ai",
+          name: "Demo Partner",
+          role: "admin",
+          domain: "all",
+          tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
+          onboardingComplete: true,
+        }),
+      );
+    }, E2E_TOKEN);
+
+    await page.goto(`${APP}/dashboard`, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle").catch(() => {});
+
+    const counts = page.getByTestId("dashboard-counts");
+    await expect(counts).toBeVisible({ timeout: 15000 });
+    await expect(counts).toContainText(`${facts.connector_count}`);
+    await expect(counts).toContainText(`${facts.agent_count}`);
+    await expect(counts).toContainText(`${facts.tool_count}`);
+  });
+});

--- a/ui/src/lib/productFacts.ts
+++ b/ui/src/lib/productFacts.ts
@@ -1,0 +1,66 @@
+/**
+ * Canonical source for every externally visible product count or version.
+ *
+ * Every UI surface that cites a connector count, agent count, tool count,
+ * or version number must read it through {@link useProductFacts} or the
+ * build-time fallback in {@link PRODUCT_FACTS_FALLBACK}. Hardcoding a
+ * number inside a page is a regression and will fail the product-claims
+ * Playwright spec.
+ */
+import { useEffect, useState } from "react";
+import api from "@/lib/api";
+
+export interface ProductFacts {
+  version: string;
+  connector_count: number;
+  agent_count: number;
+  tool_count: number;
+}
+
+/**
+ * Safe fallback used before the API responds. Values are deliberately
+ * conservative ("50+"-style) so they cannot overpromise; the real numbers
+ * land as soon as /api/v1/product-facts resolves.
+ */
+export const PRODUCT_FACTS_FALLBACK: ProductFacts = {
+  version: "",
+  connector_count: 0,
+  agent_count: 0,
+  tool_count: 0,
+};
+
+export function useProductFacts(): {
+  facts: ProductFacts;
+  loading: boolean;
+  error: boolean;
+} {
+  const [facts, setFacts] = useState<ProductFacts>(PRODUCT_FACTS_FALLBACK);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .get("/product-facts")
+      .then(({ data }) => {
+        if (cancelled) return;
+        setFacts({
+          version: String(data.version ?? ""),
+          connector_count: Number(data.connector_count ?? 0),
+          agent_count: Number(data.agent_count ?? 0),
+          tool_count: Number(data.tool_count ?? 0),
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { facts, loading, error };
+}

--- a/ui/src/pages/Connectors.tsx
+++ b/ui/src/pages/Connectors.tsx
@@ -9,7 +9,8 @@ import type { Connector } from "@/types";
 
 const CATEGORIES = ["all", "finance", "hr", "marketing", "ops", "comms"];
 
-// Full catalog of all 54+ native connectors
+// Hardcoded native-connector catalog. Phase 5 replaces this with a backend-
+// served catalog so connector metadata changes do not require UI edits.
 const NATIVE_CONNECTOR_CATALOG: Array<{ id: string; name: string; category: string; description: string }> = [
   { id: "salesforce", name: "Salesforce", category: "comms", description: "CRM and sales management" },
   { id: "hubspot", name: "HubSpot", category: "marketing", description: "Inbound marketing and CRM" },

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import api from "@/lib/api";
 import type { Agent, HITLItem, AuditEntry } from "@/types";
+import { useProductFacts } from "@/lib/productFacts";
 import {
   PieChart, Pie, Cell,
   BarChart, Bar, XAxis, YAxis, Tooltip,
@@ -39,6 +40,7 @@ export default function Dashboard() {
   const [auditEntries, setAuditEntries] = useState<AuditEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [fetchWarnings, setFetchWarnings] = useState<string[]>([]);
+  const { facts } = useProductFacts();
 
   useEffect(() => {
     fetchAll();
@@ -171,7 +173,13 @@ export default function Dashboard() {
               <span className="text-lg font-bold">LangGraph</span>
               <span className="text-xs text-muted-foreground">v1.1</span>
             </div>
-            <p className="text-xs text-muted-foreground mt-1">50+ agents, 54 native connectors + 1000+ via Composio, 340+ tools</p>
+            <p className="text-xs text-muted-foreground mt-1" data-testid="dashboard-counts">
+              {facts.agent_count > 0 ? `${facts.agent_count} agents` : "Agents"}
+              {", "}
+              {facts.connector_count > 0 ? `${facts.connector_count} native connectors` : "Native connectors"}
+              {" + 1000+ via Composio, "}
+              {facts.tool_count > 0 ? `${facts.tool_count} tools` : "Tools"}
+            </p>
           </CardContent>
         </Card>
         <Card>

--- a/ui/src/pages/HowGrantexWorks.tsx
+++ b/ui/src/pages/HowGrantexWorks.tsx
@@ -671,7 +671,7 @@ export default function HowGrantexWorks() {
                       { text: "Manifest-based: each tool declares its required permission", detail: "No guessing. delete_contact = DELETE. Period." },
                       { text: "Offline JWT verification at the LangGraph boundary", detail: "No network call needed. Tokens are self-contained." },
                       { text: "Sub-millisecond enforcement on every tool call", detail: "<1ms overhead. Your agents stay fast." },
-                      { text: "53 connector manifests covering 269 tools", detail: "Every tool in every connector is mapped and enforced." },
+                      { text: "Connector manifests for every native integration", detail: "Every tool in every connector is mapped and enforced." },
                     ].map((item, i) => (
                       <div key={i} className="flex gap-3">
                         <CheckCircle className="w-5 h-5 text-emerald-500 flex-shrink-0 mt-0.5" />

--- a/ui/src/pages/IntegrationWorkflow.tsx
+++ b/ui/src/pages/IntegrationWorkflow.tsx
@@ -109,7 +109,7 @@ const ARCHITECTURE_LAYERS = [
   { label: "Auth Layer", desc: "API Key (ao_sk_) / Grantex Token / JWT", color: "bg-orange-100 border-orange-300 text-orange-800" },
   { label: "Agent Runtime", desc: "LangGraph executor + Gemini LLM", color: "bg-red-100 border-red-300 text-red-800" },
   { label: "HITL Gateway", desc: "Human approval via Slack / Email / Dashboard", color: "bg-yellow-100 border-yellow-300 text-yellow-800" },
-  { label: "Connectors", desc: "54 connectors, 340+ tools (Amazon, Jira, SAP...)", color: "bg-indigo-100 border-indigo-300 text-indigo-800" },
+  { label: "Connectors", desc: "Native connectors + Composio (Amazon, Jira, SAP...)", color: "bg-indigo-100 border-indigo-300 text-indigo-800" },
 ];
 
 export default function IntegrationWorkflow() {

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -7,6 +7,7 @@ import AgentsInAction from "../components/AgentsInAction";
 import WorkflowAnimation from "../components/WorkflowAnimation";
 import InteractiveDemo from "../components/InteractiveDemo";
 import SocialProof from "../components/SocialProof";
+import { useProductFacts } from "@/lib/productFacts";
 
 /* ------------------------------------------------------------------ */
 /*  useInView — Intersection Observer hook for scroll animations       */
@@ -322,6 +323,11 @@ export default function Landing() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [showDemo, setShowDemo] = useState(false);
   const location = useLocation();
+  const { facts } = useProductFacts();
+  const connectorsText = facts.connector_count > 0 ? `${facts.connector_count}` : "50+";
+  const agentsText = facts.agent_count > 0 ? `${facts.agent_count}` : "25+";
+  const toolsText = facts.tool_count > 0 ? `${facts.tool_count}+` : "250+";
+  const versionText = facts.version ? `v${facts.version}` : "";
 
   // Scroll to hash anchor on navigation (e.g. /#developers from another page)
   useEffect(() => {
@@ -434,7 +440,9 @@ export default function Landing() {
             {/* Badge */}
             <div className="inline-flex items-center gap-2 bg-slate-800/80 border border-slate-700 rounded-full px-4 py-1.5 mb-6">
               <span className="w-2 h-2 bg-emerald-400 rounded-full animate-pulse" />
-              <span className="text-slate-300 text-sm">v4.0.0 &mdash; 1000+ Integrations, 50+ AI Agents, Voice, Knowledge Base, Industry Packs</span>
+              <span className="text-slate-300 text-sm" data-testid="landing-version-badge">
+                {versionText ? `${versionText} — ` : ""}1000+ Integrations, {agentsText} AI Agents, Voice, Knowledge Base, Industry Packs
+              </span>
             </div>
 
             <h1 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-white leading-tight tracking-tight">
@@ -497,9 +505,9 @@ export default function Landing() {
           >
             <div className="relative flex flex-col sm:flex-row items-center gap-3 sm:gap-6 rounded-[15px] bg-slate-900/95 backdrop-blur px-5 py-3">
               {/* Version badge */}
-              <span className="shrink-0 inline-flex items-center gap-1.5 bg-gradient-to-r from-blue-500 to-violet-600 text-white text-xs font-bold px-3 py-1 rounded-full shadow-lg shadow-blue-500/30 animate-pulse">
+              <span className="shrink-0 inline-flex items-center gap-1.5 bg-gradient-to-r from-blue-500 to-violet-600 text-white text-xs font-bold px-3 py-1 rounded-full shadow-lg shadow-blue-500/30 animate-pulse" data-testid="landing-version-pill">
                 <span className="w-1.5 h-1.5 bg-white rounded-full" />
-                v4.0.0
+                {versionText || "v…"}
               </span>
 
               {/* Description */}
@@ -618,7 +626,7 @@ export default function Landing() {
             <div className="text-center mb-16">
               <h2 className="text-3xl sm:text-4xl font-bold text-slate-900">One Platform. Unlimited AI Employees. Complete Automation.</h2>
               <p className="mt-4 text-lg text-slate-500 max-w-2xl mx-auto">
-                50+ pre-built agents across 6 domains that reason with Gemini AND execute real actions &mdash; creating Jira tickets, reading CRM data, querying repos. 54 native connectors + 1000+ via Composio (340+ native tools), A/B testing, email drip, ABM with intent data, SDK/MCP/API access. Not chatbots. Virtual employees.
+                {agentsText} pre-built agents across 6 domains that reason with Gemini AND execute real actions &mdash; creating Jira tickets, reading CRM data, querying repos. {connectorsText} native connectors + 1000+ via Composio ({toolsText} native tools), A/B testing, email drip, ABM with intent data, SDK/MCP/API access. Not chatbots. Virtual employees.
               </p>
             </div>
           </FadeIn>
@@ -898,8 +906,8 @@ export default function Landing() {
 
             <div className="grid md:grid-cols-3 gap-12">
               {[
-                { num: "1", title: "Create or pick your agents", desc: "Choose from 50+ pre-built agents, or create custom AI virtual employees with names, specializations, and tool access — all through a guided wizard." },
-                { num: "2", title: "Connect your systems", desc: "54 connectors with 340+ tools — SAP, Oracle, Jira, HubSpot, GitHub, GSTN, Darwinbox, Slack, Salesforce, and more. Configure auth, secrets, and health checks from the UI. Trigger workflows on email, schedule, webhook, or API events." },
+                { num: "1", title: "Create or pick your agents", desc: `Choose from ${agentsText} pre-built agents, or create custom AI virtual employees with names, specializations, and tool access — all through a guided wizard.` },
+                { num: "2", title: "Connect your systems", desc: `${connectorsText} connectors with ${toolsText} tools — SAP, Oracle, Jira, HubSpot, GitHub, GSTN, Darwinbox, Slack, Salesforce, and more. Configure auth, secrets, and health checks from the UI. Trigger workflows on email, schedule, webhook, or API events.` },
                 { num: "3", title: "Agents work, you approve", desc: "Agents reason with Gemini, execute tool calls, then return results. You approve critical decisions via HITL governance. Access from dashboard, Python SDK (pip install agenticorg), TypeScript SDK (npm i agenticorg-sdk), CLI, or ChatGPT/Claude via MCP Server." },
               ].map((step, i) => (
                 <FadeIn key={step.num} delay={i * 150}>
@@ -1423,14 +1431,14 @@ $ agenticorg sop deploy \\
                   <svg className="w-6 h-6 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" /></svg>
                 </div>
                 <h3 className="font-bold text-white mb-2">MCP (Model Context Protocol)</h3>
-                <p className="text-sm text-slate-400">Anthropic's MCP. Expose 340+ tools to ChatGPT, Claude Desktop, Cursor, Windsurf, or any MCP client.</p>
+                <p className="text-sm text-slate-400">Anthropic's MCP. Expose {toolsText} tools to ChatGPT, Claude Desktop, Cursor, Windsurf, or any MCP client.</p>
               </div>
               <div className="bg-slate-800/50 border border-slate-700 rounded-xl p-6 text-center">
                 <div className="w-12 h-12 rounded-full bg-emerald-500/20 flex items-center justify-center mx-auto mb-4">
                   <svg className="w-6 h-6 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" /></svg>
                 </div>
                 <h3 className="font-bold text-white mb-2">Grantex Scope Enforcement</h3>
-                <p className="text-sm text-slate-400">Manifest-based permission enforcement with offline JWT verification. Every tool call checked against 53 connector manifests in &lt;1ms. Permission hierarchy: admin &gt; delete &gt; write &gt; read. Now with 1000+ tool manifests, voice agent security, and PII redaction before LLM.</p>
+                <p className="text-sm text-slate-400">Manifest-based permission enforcement with offline JWT verification. Every tool call checked against {connectorsText} connector manifests in &lt;1ms. Permission hierarchy: admin &gt; delete &gt; write &gt; read. Now with 1000+ tool manifests, voice agent security, and PII redaction before LLM.</p>
                 <Link to="/how-grantex-works" className="inline-flex items-center gap-1 text-sm text-emerald-400 hover:text-emerald-300 font-medium mt-2 transition-colors">
                   Learn how it works <span aria-hidden="true">&rarr;</span>
                 </Link>
@@ -1536,7 +1544,7 @@ $ agenticorg sop deploy \\
               Stop paying people to do what AI virtual employees can do better.
             </h2>
             <p className="text-lg text-slate-400 mb-10">
-              50+ agents that act. 1000+ integrations. 340+ native tools. 855+ tests passing. Free to start.
+              {agentsText} agents that act. 1000+ integrations. {toolsText} native tools. Free to start.
             </p>
 
             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">

--- a/ui/src/pages/Pricing.tsx
+++ b/ui/src/pages/Pricing.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
+import { useProductFacts } from "@/lib/productFacts";
 
 /* ------------------------------------------------------------------ */
 /*  CheckIcon                                                          */
@@ -119,67 +120,71 @@ function DemoModal({ onClose }: { onClose: () => void }) {
 /* ------------------------------------------------------------------ */
 /*  Tier data                                                          */
 /* ------------------------------------------------------------------ */
-const TIERS = [
-  {
-    name: "Free",
-    price: "$0",
-    period: "/month",
-    description: "Get started with core AI agents and see results immediately.",
-    highlight: false,
-    cta: "Start Free",
-    ctaLink: "/login",
-    features: [
-      "50+ AI agents",
-      "20 connectors",
-      "500 tasks/day",
-      "Community support",
-      "Shadow mode testing",
-      "Basic audit log",
-      "Single workspace",
-    ],
-  },
-  {
-    name: "Pro",
-    price: "$499",
-    period: "/month",
-    description: "Scale your operations with advanced agents and priority support.",
-    highlight: true,
-    cta: "Start Pro",
-    ctaLink: "demo",
-    features: [
-      "Unlimited AI agents",
-      "54 connectors",
-      "Unlimited tasks",
-      "Email support",
-      "Custom workflows",
-      "Priority HITL queue",
-      "Advanced analytics",
-      "API access",
-      "Team workspaces",
-    ],
-  },
-  {
-    name: "Enterprise",
-    price: "Custom",
-    period: "",
-    description: "Full platform with dedicated support, SLA, and custom deployments.",
-    highlight: false,
-    cta: "Contact Sales",
-    ctaLink: "demo",
-    features: [
-      "Unlimited AI agents",
-      "54 connectors",
-      "Unlimited everything",
-      "Dedicated support",
-      "99.9% SLA guarantee",
-      "Custom connectors",
-      "On-premise option",
-      "SSO / SAML",
-      "Custom integrations",
-      "Dedicated CSM",
-    ],
-  },
-];
+// Tier content parametrized on runtime connector/agent counts so it never
+// drifts from the backend registry.
+function buildTiers(agentsText: string, connectorsText: string) {
+  return [
+    {
+      name: "Free",
+      price: "$0",
+      period: "/month",
+      description: "Get started with core AI agents and see results immediately.",
+      highlight: false,
+      cta: "Start Free",
+      ctaLink: "/login",
+      features: [
+        `${agentsText} AI agents`,
+        "20 connectors",
+        "500 tasks/day",
+        "Community support",
+        "Shadow mode testing",
+        "Basic audit log",
+        "Single workspace",
+      ],
+    },
+    {
+      name: "Pro",
+      price: "$499",
+      period: "/month",
+      description: "Scale your operations with advanced agents and priority support.",
+      highlight: true,
+      cta: "Start Pro",
+      ctaLink: "demo",
+      features: [
+        "Unlimited AI agents",
+        `${connectorsText} connectors`,
+        "Unlimited tasks",
+        "Email support",
+        "Custom workflows",
+        "Priority HITL queue",
+        "Advanced analytics",
+        "API access",
+        "Team workspaces",
+      ],
+    },
+    {
+      name: "Enterprise",
+      price: "Custom",
+      period: "",
+      description: "Full platform with dedicated support, SLA, and custom deployments.",
+      highlight: false,
+      cta: "Contact Sales",
+      ctaLink: "demo",
+      features: [
+        "Unlimited AI agents",
+        `${connectorsText} connectors`,
+        "Unlimited everything",
+        "Dedicated support",
+        "99.9% SLA guarantee",
+        "Custom connectors",
+        "On-premise option",
+        "SSO / SAML",
+        "Custom integrations",
+        "Dedicated CSM",
+      ],
+    },
+  ];
+}
 
 /* ------------------------------------------------------------------ */
 /*  Feature comparison table data                                      */
@@ -191,9 +196,10 @@ interface ComparisonRow {
   enterprise: string | boolean;
 }
 
-const COMPARISON: ComparisonRow[] = [
-  { feature: "AI Agents", free: "35", pro: "Unlimited", enterprise: "Unlimited" },
-  { feature: "Connectors", free: "20", pro: "43", enterprise: "43" },
+function buildComparison(agentsText: string, connectorsText: string): ComparisonRow[] {
+  return [
+  { feature: "AI Agents", free: agentsText, pro: "Unlimited", enterprise: "Unlimited" },
+  { feature: "Connectors", free: "20", pro: connectorsText, enterprise: connectorsText },
   { feature: "Tasks per day", free: "500", pro: "Unlimited", enterprise: "Unlimited" },
   { feature: "Shadow mode", free: true, pro: true, enterprise: true },
   { feature: "Custom workflows", free: false, pro: true, enterprise: true },
@@ -207,7 +213,8 @@ const COMPARISON: ComparisonRow[] = [
   { feature: "SLA guarantee", free: false, pro: false, enterprise: "99.9%" },
   { feature: "Support", free: "Community", pro: "Email", enterprise: "Dedicated" },
   { feature: "Dedicated CSM", free: false, pro: false, enterprise: true },
-];
+  ];
+}
 
 /* ------------------------------------------------------------------ */
 /*  FAQ data                                                           */
@@ -227,7 +234,7 @@ const FAQS = [
   },
   {
     q: "What connectors are included?",
-    a: "Free includes 20 core connectors (Oracle, SAP, Salesforce, Slack, GSTN, and more). Pro and Enterprise include all 54 connectors (Darwinbox, Stripe, HubSpot, EPFO, Jira, and more). Enterprise adds custom integrations.",
+    a: "Free includes 20 core connectors (Oracle, SAP, Salesforce, Slack, GSTN, and more). Pro and Enterprise include every native connector (Darwinbox, Stripe, HubSpot, EPFO, Jira, and more). Enterprise adds custom integrations.",
   },
   {
     q: "Is my data secure?",
@@ -281,6 +288,11 @@ function CellValue({ value }: { value: string | boolean }) {
 /* ================================================================== */
 export default function Pricing() {
   const [showDemo, setShowDemo] = useState(false);
+  const { facts } = useProductFacts();
+  const connectorsText = facts.connector_count > 0 ? `${facts.connector_count}` : "50+";
+  const agentsText = facts.agent_count > 0 ? `${facts.agent_count}` : "25+";
+  const TIERS = buildTiers(agentsText, connectorsText);
+  const COMPARISON = buildComparison(agentsText, connectorsText);
 
   return (
     <div className="min-h-screen bg-white">


### PR DESCRIPTION
## Summary

Kickoff of the **Enterprise Readiness Plan** (`ENTERPRISE_READINESS_PLAN.md`). Addresses WS-0 / BL-001 / BL-204 of the strict execution backlog: every externally visible count and version was drifted (README said 57 native connectors, Landing said 54, HowGrantexWorks said 53, runtime registry has **53**; version spanned v4.0.0 / v4.3.0 / v4.8.0 across the same surfaces).

### Single source of truth
- **Backend:** `GET /api/v1/product-facts` returns `{ version, connector_count, agent_count, tool_count }` computed live from `connectors.registry`, `core.agents.registry`, the tool index, and `pyproject.toml`.
- **Frontend:** `ui/src/lib/productFacts.ts` / `useProductFacts()`.
- **Version:** `api/main.py` and `api/v1/health.py` no longer hardcode — both read pyproject.

### Surfaces wired
- Landing hero description, version pill (`data-testid="landing-version-pill"`), three-step onboarding, MCP blurb, Grantex manifests, final CTA.
- Pricing tiers + comparison table + FAQ (parametrized on counts).
- Dashboard stat strip (`data-testid="dashboard-counts"`).
- HowGrantexWorks, IntegrationWorkflow, Connectors comment.
- README header, Key Numbers table, tests section, connector section — counts replaced by pointer to `/product-facts`; stale Tests/E2E badges removed.

### Drift guard (Playwright — `ui/e2e/product-claims.spec.ts`)
- Asserts `/product-facts` returns populated values.
- Landing version pill must contain `v${facts.version}`.
- Landing body must **not** contain `54 native connectors`, `57 native connectors`, `v4.0.0`, or `v4.3.0`.
- Landing body must contain the current real `connector_count`.
- Dashboard counts strip must contain live connector/agent/tool counts.

No behavior change outside of copy. No SDK, API contract, or DB migration.

## Test plan

- [ ] CI `e2e-tests` green on main post-deploy
- [ ] `product-claims.spec.ts` passes (Landing pill + body + Dashboard strip match `/product-facts`)
- [ ] Preflight passed locally: branch-safety, ruff, bandit, alembic, verify=False, pytest unit+regression (`-k` knowledge / product-facts), tsc, ui build
- [ ] Zero-skip rule preserved — no new skip primitives introduced

@codex please review