### PR TITLE
test(e2e): fix last 2 CA-firms failures — case-insensitive + render sync

### DIFF
--- a/ui/e2e/ca-firms.spec.ts
+++ b/ui/e2e/ca-firms.spec.ts
@@ -694,22 +694,17 @@ test.describe("Subscription Status", () => {
     });
     await companyLoaded;
 
-    // The company header should show a subscription status badge
-    // Valid values: Trial, Active, Expired
-    const subscriptionBadges = ["Trial", "Active", "Expired"];
-    let foundBadge = false;
-    for (const badge of subscriptionBadges) {
-      const el = page.getByText(badge, { exact: true }).first();
-      if (await el.isVisible({ timeout: 5000 }).catch(() => false)) {
-        foundBadge = true;
-        break;
-      }
-    }
-
-    // Fallback: check the header area for any subscription-related text
+    // The company header should show a subscription status badge. The
+    // backend model stores the value lowercase (`trial | active | expired`
+    // — see core/models/company.py) and the UI renders it verbatim, so
+    // match case-insensitively.
+    const subscriptionPattern = /trial|active|expired/i;
+    const badge = page.getByText(subscriptionPattern).first();
+    await expect(badge).toBeVisible({ timeout: 15000 });
     const body = (await page.locator("body").textContent()) || "";
-    const hasSubscriptionText = body.includes("Trial") || body.includes("Active") || body.includes("Expired");
-    expect(foundBadge || hasSubscriptionText).toBeTruthy();
+    expect(body, "company detail body should reference subscription state").toMatch(
+      subscriptionPattern,
+    );
   });
 });
 
@@ -766,15 +761,24 @@ test.describe("Client Health Score", () => {
     });
     await listLoaded;
 
-    // The dashboard should show company cards with status indicators
-    // At minimum, active/inactive badges should be visible
+    // Wait for React to flush the companies list into the DOM. The
+    // summary line ("N total · N active · N inactive") is rendered
+    // unconditionally once the fetch resolves, so use it as the sync
+    // point between network arrival and rendered DOM.
+    await expect(
+      page.getByText(/total.*active.*inactive/i).first(),
+    ).toBeVisible({ timeout: 15000 });
+
+    // Either an explicit status badge, a summary badge count, or the
+    // active/inactive text in the rendered body should be present.
     const statusBadges = page.locator('[class*="badge"], [class*="Badge"]');
     const badgeCount = await statusBadges.count().catch(() => 0);
-
-    // Should have at least one badge visible (status indicators)
     const body = (await page.locator("body").textContent()) || "";
-    const hasHealthIndicator = body.includes("active") || body.includes("Active") || body.includes("inactive");
-    expect(badgeCount > 0 || hasHealthIndicator).toBeTruthy();
+    const hasHealthIndicator = /\bactive\b|\binactive\b/i.test(body);
+    expect(
+      badgeCount > 0 || hasHealthIndicator,
+      "companies dashboard should render status badges or active/inactive text",
+    ).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Summary

Completes the CA-firms e2e stabilization (PR #195 fixed 4-of-6; this fixes the remaining 2). Main CI after #195 merged reported \`463 passed, 2 failed, 0 flaky, 0 skipped\`. The two residual failures were both test-expectation bugs — UI and backend are behaving correctly.

1. **\`ca-firms.spec.ts:679\` Subscription badge** — the test asserted \`body.includes("Trial" | "Active" | "Expired")\` but the backend model stores the value lowercase (\`trial | active | expired\`, per \`core/models/company.py:95\`) and the UI renders it verbatim. Changed to case-insensitive regex + visible-locator assertion.
2. **\`ca-firms.spec.ts:755\` Companies-list health indicator** — \`waitForResponse\` resolved on \`GET /companies\` correctly, but \`body.textContent()\` ran before React flushed the list into the DOM, so the \`badges / "N total · N active · N inactive"\` summary wasn't there yet. Added an explicit \`toBeVisible\` sync on the summary line before the body check.

No product code change; no skip primitives introduced; \`0 skipped\` invariant preserved.

## Test plan

- [ ] Main CI \`e2e-tests\` post-deploy reports \`465 passed, 0 failed, 0 flaky, 0 skipped\`
- [ ] No new regressions on adjacent ca-firms tests

@codex please review