### PR TITLE
feat(governance): persist per-tenant Compliance & Data controls (PR-B1)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -37,6 +37,7 @@ from api.v1 import (
     departments,
     evals,
     feature_flags,
+    governance,
     health,
     invoices,
     knowledge,
@@ -178,6 +179,7 @@ app.include_router(schemas.router, prefix="/api/v1", tags=["Schemas"])
 app.include_router(connectors.router, prefix="/api/v1", tags=["Connectors"])
 app.include_router(compliance.router, prefix="/api/v1", tags=["Compliance"])
 app.include_router(config.router, prefix="/api/v1", tags=["Config"])
+app.include_router(governance.router, prefix="/api/v1", tags=["Governance"])
 app.include_router(v1_demo.router, prefix="/api/v1", tags=["Demo"])
 app.include_router(v1_org.router, prefix="/api/v1", tags=["Organization"])
 app.include_router(api_keys.router, prefix="/api/v1", tags=["API Keys"])

--- a/api/v1/governance.py
+++ b/api/v1/governance.py
@@ -1,0 +1,169 @@
+"""Per-tenant governance configuration API.
+
+GET  /api/v1/governance/config   — read the tenant's governance settings.
+PUT  /api/v1/governance/config   — update them (admin only, audit-logged).
+
+See Enterprise Readiness Plan Phase 4 and
+docs/mcp-product-model.md for context. Before PR-B the Settings page's
+PII/region/retention controls were UI-only React state — this module
+persists them and closes the compliance story.
+"""
+
+from __future__ import annotations
+
+import uuid as _uuid
+from typing import Any, Literal
+
+import structlog
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel, Field
+
+from api.deps import get_current_tenant, require_tenant_admin
+from core.database import get_tenant_session
+from core.models.audit import AuditLog
+from core.models.governance_config import GovernanceConfig
+
+router = APIRouter(prefix="/governance", tags=["Governance"])
+logger = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+DataRegion = Literal["IN", "EU", "US"]
+
+
+class GovernanceConfigOut(BaseModel):
+    pii_masking: bool
+    data_region: DataRegion
+    audit_retention_years: int = Field(ge=1, le=10)
+    updated_by: str | None = None
+    updated_at: str | None = None
+
+
+class GovernanceConfigUpdate(BaseModel):
+    """Partial update — any omitted field keeps its current value."""
+
+    pii_masking: bool | None = None
+    data_region: DataRegion | None = None
+    audit_retention_years: int | None = Field(default=None, ge=1, le=10)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+@router.get("/config", response_model=GovernanceConfigOut)
+async def get_config(tenant_id: str = Depends(get_current_tenant)) -> GovernanceConfigOut:
+    """Return this tenant's governance config. Creates a defaulted row on
+    first read so every tenant has a stable persisted baseline."""
+    tid = _uuid.UUID(tenant_id)
+    async with get_tenant_session(tid) as session:
+        row = await session.get(GovernanceConfig, tid)
+        if row is None:
+            row = GovernanceConfig(tenant_id=tid)
+            session.add(row)
+            await session.flush()
+            # server_default fires on the actual INSERT — pull the populated
+            # values back so the response is accurate on first read.
+            await session.refresh(row)
+        return GovernanceConfigOut(
+            pii_masking=row.pii_masking,
+            data_region=row.data_region,  # type: ignore[arg-type]
+            audit_retention_years=row.audit_retention_years,
+            updated_by=str(row.updated_by) if row.updated_by else None,
+            updated_at=row.updated_at.isoformat() if row.updated_at else None,
+        )
+
+
+@router.put(
+    "/config",
+    response_model=GovernanceConfigOut,
+    dependencies=[require_tenant_admin],
+)
+async def put_config(
+    body: GovernanceConfigUpdate,
+    request: Request,
+    tenant_id: str = Depends(get_current_tenant),
+) -> GovernanceConfigOut:
+    """Update this tenant's governance config. Admin-only.
+
+    Each changed field writes an AuditLog row (event_type=
+    'governance_config.change') with old + new values in ``details``, in
+    the same transaction as the update itself.
+    """
+    tid = _uuid.UUID(tenant_id)
+    claims = getattr(request.state, "claims", {}) or {}
+    actor_id = str(claims.get("sub") or claims.get("user_id") or "unknown")
+
+    async with get_tenant_session(tid) as session:
+        row = await session.get(GovernanceConfig, tid)
+        if row is None:
+            row = GovernanceConfig(tenant_id=tid)
+            session.add(row)
+            await session.flush()
+
+        old_values: dict[str, Any] = {
+            "pii_masking": row.pii_masking,
+            "data_region": row.data_region,
+            "audit_retention_years": row.audit_retention_years,
+        }
+
+        new_values = old_values.copy()
+        if body.pii_masking is not None:
+            new_values["pii_masking"] = body.pii_masking
+        if body.data_region is not None:
+            new_values["data_region"] = body.data_region
+        if body.audit_retention_years is not None:
+            new_values["audit_retention_years"] = body.audit_retention_years
+
+        changed = {k: (old_values[k], new_values[k]) for k in new_values if old_values[k] != new_values[k]}
+        if not changed:
+            # No-op; still refresh + return current state.
+            return GovernanceConfigOut(
+                pii_masking=row.pii_masking,
+                data_region=row.data_region,  # type: ignore[arg-type]
+                audit_retention_years=row.audit_retention_years,
+                updated_by=str(row.updated_by) if row.updated_by else None,
+                updated_at=row.updated_at.isoformat() if row.updated_at else None,
+            )
+
+        # Apply + audit in the same transaction so a failed audit write
+        # rolls back the config change.
+        row.pii_masking = new_values["pii_masking"]
+        row.data_region = new_values["data_region"]
+        row.audit_retention_years = new_values["audit_retention_years"]
+        try:
+            row.updated_by = _uuid.UUID(actor_id)
+        except (ValueError, TypeError):
+            row.updated_by = None
+
+        session.add(
+            AuditLog(
+                tenant_id=tid,
+                event_type="governance_config.change",
+                actor_type="user",
+                actor_id=actor_id,
+                resource_type="governance_config",
+                resource_id=str(tid),
+                action="update",
+                outcome="success",
+                details={"changes": {k: {"old": v[0], "new": v[1]} for k, v in changed.items()}},
+            )
+        )
+        await session.flush()
+        await session.refresh(row)
+
+    logger.info(
+        "governance_config_updated",
+        tenant_id=str(tid),
+        actor_id=actor_id,
+        changed_fields=list(changed.keys()),
+    )
+
+    return GovernanceConfigOut(
+        pii_masking=row.pii_masking,
+        data_region=row.data_region,  # type: ignore[arg-type]
+        audit_retention_years=row.audit_retention_years,
+        updated_by=str(row.updated_by) if row.updated_by else None,
+        updated_at=row.updated_at.isoformat() if row.updated_at else None,
+    )

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -26,6 +26,7 @@ from core.models.delegation import UserDelegation as UserDelegation
 from core.models.document import Document as Document
 from core.models.feature_flag import FeatureFlag as FeatureFlag
 from core.models.filing_approval import FilingApproval as FilingApproval
+from core.models.governance_config import GovernanceConfig as GovernanceConfig
 from core.models.gstn_credential import GSTNCredential as GSTNCredential
 from core.models.gstn_upload import GSTNUpload as GSTNUpload
 from core.models.hitl import HITLQueue as HITLQueue

--- a/core/models/governance_config.py
+++ b/core/models/governance_config.py
@@ -1,0 +1,54 @@
+"""Per-tenant governance configuration.
+
+Stores the compliance / data-region / retention controls that the Settings
+page exposes. Before PR-B these were UI-only React state and the admin's
+choices evaporated on reload — see docs/mcp-product-model.md and the
+Enterprise Readiness Plan Phase 4.
+
+One row per tenant. Every write goes through the governance API which
+emits an audit event (actor, old value, new value, tenant) in the same
+transaction.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, Boolean, ForeignKey, Integer, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.models.base import BaseModel
+
+
+class GovernanceConfig(BaseModel):
+    """One row per tenant — the persisted Settings page controls."""
+
+    __tablename__ = "governance_config"
+
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+
+    # PII masking in logs/traces/audit. Default true — production requires it.
+    pii_masking: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    # Data-region residency. Enum-ish string (IN | EU | US) — validated at API layer.
+    data_region: Mapped[str] = mapped_column(String(8), nullable=False, default="IN")
+
+    # Audit log retention in years. Bounded [1, 10].
+    audit_retention_years: Mapped[int] = mapped_column(Integer, nullable=False, default=7)
+
+    # Last-writer stamps.
+    updated_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/migrations/versions/v4_8_5_governance_config.py
+++ b/migrations/versions/v4_8_5_governance_config.py
@@ -1,0 +1,43 @@
+"""Add per-tenant governance_config table.
+
+Revision ID: v485_governance_config
+Revises: v484_docs_kb_upload_cols
+Create Date: 2026-04-18
+
+Enterprise Readiness Plan P4 — persists the Settings page's compliance
+controls (PII masking, data region, audit retention) so they survive a
+reload. Pre-PR-B those values were UI-only React state.
+
+Idempotent: CREATE TABLE IF NOT EXISTS so a legacy-schema build (which
+goes through ORM create_all + alembic) doesn't DuplicateTable.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# Alembic identifiers — kept <=32 chars (alembic_version.version_num size).
+revision = "v485_governance_config"
+down_revision = "v484_docs_kb_upload_cols"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS governance_config (
+            tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+            pii_masking BOOLEAN NOT NULL DEFAULT TRUE,
+            data_region VARCHAR(8) NOT NULL DEFAULT 'IN',
+            audit_retention_years INTEGER NOT NULL DEFAULT 7,
+            updated_by UUID REFERENCES users(id) ON DELETE SET NULL,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            PRIMARY KEY (tenant_id),
+            CHECK (data_region IN ('IN', 'EU', 'US')),
+            CHECK (audit_retention_years BETWEEN 1 AND 10)
+        )
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS governance_config")

--- a/ui/e2e/settings-governance.spec.ts
+++ b/ui/e2e/settings-governance.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * Settings → Compliance & Data governance persistence (Phase 4).
+ *
+ * Verifies the three controls on the Compliance card (PII masking,
+ * data region, audit retention) round-trip through /governance/config:
+ *  1. GET populates initial values.
+ *  2. Changing a value + Save persists.
+ *  3. Reload pulls the persisted value back.
+ *  4. Every write writes an audit event readable via /audit.
+ *
+ * Drift guard: pre-PR-B this card was decorative — local React state
+ * only. If that regresses, the "reload" assertion fails because the
+ * page returns to the default.
+ */
+import { expect, test } from "@playwright/test";
+
+const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
+const E2E_TOKEN = process.env.E2E_TOKEN || "";
+const canAuth = !!E2E_TOKEN;
+
+function requireAuth(): void {
+  if (!canAuth) {
+    throw new Error(
+      "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+    );
+  }
+}
+
+async function seedSession(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
+  await page.evaluate((t) => {
+    localStorage.setItem("token", t);
+    localStorage.setItem(
+      "user",
+      JSON.stringify({
+        email: "demo@cafirm.agenticorg.ai",
+        name: "Demo Partner",
+        role: "admin",
+        domain: "all",
+        tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
+        onboardingComplete: true,
+      }),
+    );
+  }, E2E_TOKEN);
+}
+
+test.describe("Settings → Compliance & Data governance", () => {
+  test.beforeEach(async ({ page }) => {
+    requireAuth();
+    await seedSession(page);
+  });
+
+  test("GET /governance/config returns populated values", async ({ request }) => {
+    const resp = await request.get(`${APP}/api/v1/governance/config`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+    });
+    expect(resp.status(), "GET /governance/config").toBe(200);
+    const data = await resp.json();
+    expect(typeof data.pii_masking).toBe("boolean");
+    expect(["IN", "EU", "US"]).toContain(data.data_region);
+    expect(data.audit_retention_years).toBeGreaterThanOrEqual(1);
+    expect(data.audit_retention_years).toBeLessThanOrEqual(10);
+  });
+
+  test("Toggling PII masking + Save persists across reload", async ({ page }) => {
+    // Sync on the initial GET so the inputs are hydrated.
+    const initialLoaded = page.waitForResponse(
+      (r) => r.url().includes("/api/v1/governance/config") && r.request().method() === "GET",
+      { timeout: 30000 },
+    );
+    await page.goto(`${APP}/dashboard/settings`, { waitUntil: "domcontentloaded" });
+    await initialLoaded;
+
+    const card = page.getByTestId("governance-card");
+    await expect(card).toBeVisible({ timeout: 15000 });
+
+    // Read current value, flip it, then save.
+    const select = page.getByTestId("governance-pii-masking");
+    const currentValue = await select.inputValue();
+    const flipped = currentValue === "enabled" ? "disabled" : "enabled";
+
+    const saved = page.waitForResponse(
+      (r) => r.url().includes("/api/v1/governance/config") && r.request().method() === "PUT",
+      { timeout: 30000 },
+    );
+    await select.selectOption(flipped);
+    await page.getByTestId("governance-save").click();
+    const putResp = await saved;
+    expect(putResp.status(), "PUT /governance/config").toBeLessThan(300);
+
+    await expect(page.getByTestId("governance-saved")).toBeVisible({ timeout: 10000 });
+
+    // Reload and confirm the persisted value came back.
+    const reloaded = page.waitForResponse(
+      (r) => r.url().includes("/api/v1/governance/config") && r.request().method() === "GET",
+      { timeout: 30000 },
+    );
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await reloaded;
+    await expect(page.getByTestId("governance-pii-masking")).toHaveValue(flipped, { timeout: 15000 });
+
+    // Flip back so the test is idempotent for the next run.
+    const saveBack = page.waitForResponse(
+      (r) => r.url().includes("/api/v1/governance/config") && r.request().method() === "PUT",
+      { timeout: 30000 },
+    );
+    await page.getByTestId("governance-pii-masking").selectOption(currentValue);
+    await page.getByTestId("governance-save").click();
+    await saveBack;
+  });
+
+  test("Audit log records governance_config.change", async ({ request, page }) => {
+    const initialLoaded = page.waitForResponse(
+      (r) => r.url().includes("/api/v1/governance/config") && r.request().method() === "GET",
+      { timeout: 30000 },
+    );
+    await page.goto(`${APP}/dashboard/settings`, { waitUntil: "domcontentloaded" });
+    await initialLoaded;
+
+    // Make any change.
+    const years = page.getByTestId("governance-audit-retention");
+    const current = Number(await years.inputValue());
+    const next = current === 10 ? 9 : current + 1;
+
+    const saved = page.waitForResponse(
+      (r) => r.url().includes("/api/v1/governance/config") && r.request().method() === "PUT",
+      { timeout: 30000 },
+    );
+    await years.fill(String(next));
+    await page.getByTestId("governance-save").click();
+    await saved;
+    await expect(page.getByTestId("governance-saved")).toBeVisible({ timeout: 10000 });
+
+    // Query the audit endpoint directly.
+    const auditResp = await request.get(
+      `${APP}/api/v1/audit?event_type=governance_config.change&limit=5`,
+      { headers: { Authorization: `Bearer ${E2E_TOKEN}` } },
+    );
+    expect(auditResp.status(), "GET /audit").toBe(200);
+    const body = await auditResp.json();
+    const entries = Array.isArray(body) ? body : body?.items ?? [];
+    expect(
+      entries.length,
+      "at least one governance_config.change audit entry should exist",
+    ).toBeGreaterThan(0);
+
+    // Flip back.
+    const back = page.waitForResponse(
+      (r) => r.url().includes("/api/v1/governance/config") && r.request().method() === "PUT",
+      { timeout: 30000 },
+    );
+    await years.fill(String(current));
+    await page.getByTestId("governance-save").click();
+    await back;
+  });
+});

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -28,11 +28,25 @@ const DEFAULT_LIMITS: FleetLimits = {
   max_replicas_per_type: 20,
 };
 
+type DataRegion = "IN" | "EU" | "US";
+
+interface GovernanceConfig {
+  pii_masking: boolean;
+  data_region: DataRegion;
+  audit_retention_years: number;
+  updated_by: string | null;
+  updated_at: string | null;
+}
+
 export default function Settings() {
   const [limits, setLimits] = useState<FleetLimits>(DEFAULT_LIMITS);
   const [piiMasking, setPiiMasking] = useState(true);
-  const [dataRegion, setDataRegion] = useState("IN");
+  const [dataRegion, setDataRegion] = useState<DataRegion>("IN");
   const [auditRetention, setAuditRetention] = useState(7);
+  const [governanceLoading, setGovernanceLoading] = useState(true);
+  const [governanceSaving, setGovernanceSaving] = useState(false);
+  const [governanceSaved, setGovernanceSaved] = useState(false);
+  const [governanceError, setGovernanceError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -48,6 +62,7 @@ export default function Settings() {
 
   useEffect(() => {
     fetchSettings();
+    fetchGovernance();
     fetchApiKeys();
   }, []);
 
@@ -57,6 +72,44 @@ export default function Settings() {
       if (data.max_active_agents) setLimits(data);
     } catch {
       // Use defaults
+    }
+  }
+
+  async function fetchGovernance() {
+    setGovernanceLoading(true);
+    try {
+      const { data } = await api.get<GovernanceConfig>("/governance/config");
+      setPiiMasking(!!data.pii_masking);
+      setDataRegion(data.data_region);
+      setAuditRetention(data.audit_retention_years);
+    } catch {
+      // Keep local defaults — the PUT endpoint will create the row on first write.
+    } finally {
+      setGovernanceLoading(false);
+    }
+  }
+
+  async function saveGovernance() {
+    setGovernanceSaving(true);
+    setGovernanceSaved(false);
+    setGovernanceError(null);
+    try {
+      await api.put<GovernanceConfig>("/governance/config", {
+        pii_masking: piiMasking,
+        data_region: dataRegion,
+        audit_retention_years: auditRetention,
+      });
+      setGovernanceSaved(true);
+      setTimeout(() => setGovernanceSaved(false), 3000);
+    } catch (e: unknown) {
+      const resp = (e as { response?: { status?: number; data?: { detail?: string } } })?.response;
+      if (resp?.status === 403) {
+        setGovernanceError("You must be a tenant admin to change governance settings.");
+      } else {
+        setGovernanceError(resp?.data?.detail || "Failed to save governance settings.");
+      }
+    } finally {
+      setGovernanceSaving(false);
     }
   }
 
@@ -154,20 +207,32 @@ export default function Settings() {
         </CardContent>
       </Card>
 
-      <Card>
+      <Card data-testid="governance-card">
         <CardHeader><CardTitle>Compliance & Data</CardTitle></CardHeader>
         <CardContent className="space-y-4">
           <div className="grid grid-cols-3 gap-4">
             <div>
               <label className="text-sm font-medium">PII Masking</label>
-              <select value={piiMasking ? "enabled" : "disabled"} onChange={(e) => setPiiMasking(e.target.value === "enabled")} className="border rounded px-3 py-2 text-sm w-full mt-1">
+              <select
+                data-testid="governance-pii-masking"
+                disabled={governanceLoading || governanceSaving}
+                value={piiMasking ? "enabled" : "disabled"}
+                onChange={(e) => setPiiMasking(e.target.value === "enabled")}
+                className="border rounded px-3 py-2 text-sm w-full mt-1"
+              >
                 <option value="enabled">Enabled (required for production)</option>
                 <option value="disabled">Disabled (dev only)</option>
               </select>
             </div>
             <div>
               <label className="text-sm font-medium">Data Region</label>
-              <select value={dataRegion} onChange={(e) => setDataRegion(e.target.value)} className="border rounded px-3 py-2 text-sm w-full mt-1">
+              <select
+                data-testid="governance-data-region"
+                disabled={governanceLoading || governanceSaving}
+                value={dataRegion}
+                onChange={(e) => setDataRegion(e.target.value as DataRegion)}
+                className="border rounded px-3 py-2 text-sm w-full mt-1"
+              >
                 <option value="IN">India (asia-south1)</option>
                 <option value="EU">EU (europe-west1)</option>
                 <option value="US">US (us-central1)</option>
@@ -175,8 +240,36 @@ export default function Settings() {
             </div>
             <div>
               <label className="text-sm font-medium">Audit Retention (years)</label>
-              <input type="number" value={auditRetention} onChange={(e) => setAuditRetention(Number(e.target.value))} min={1} max={10} className="border rounded px-3 py-2 text-sm w-full mt-1" />
+              <input
+                data-testid="governance-audit-retention"
+                disabled={governanceLoading || governanceSaving}
+                type="number"
+                value={auditRetention}
+                onChange={(e) => setAuditRetention(Number(e.target.value))}
+                min={1}
+                max={10}
+                className="border rounded px-3 py-2 text-sm w-full mt-1"
+              />
             </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <Button
+              data-testid="governance-save"
+              onClick={saveGovernance}
+              disabled={governanceLoading || governanceSaving}
+            >
+              {governanceSaving ? "Saving…" : "Save Compliance Settings"}
+            </Button>
+            {governanceSaved && (
+              <span data-testid="governance-saved" className="text-sm text-emerald-600">
+                Saved — audit entry written.
+              </span>
+            )}
+            {governanceError && (
+              <span data-testid="governance-error" className="text-sm text-red-600">
+                {governanceError}
+              </span>
+            )}
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary

Enterprise Readiness Plan **Phase 4 (governance persistence)** — first half of PR-B, splitting the batched PR into B1 (governance) and B2 (connector control plane, follow-up) so each stays reviewable at ≤ 500 lines.

### Problem

Settings → Compliance & Data (PII masking, data region, audit retention) was **UI-only React state** before this PR. The admin's choices evaporated on reload, and there was no enterprise compliance story.

### What this PR does

- **Backend model** \`core/models/governance_config.py\` — one row per tenant, PII masking / data region (\`IN|EU|US\`) / audit retention (\`1-10\` years), stamped with \`updated_by\` + \`updated_at\`.
- **Migration** \`v4_8_5_governance_config.py\` — idempotent \`CREATE TABLE IF NOT EXISTS\` (repo convention); CHECK constraints on \`data_region\` and \`audit_retention_years\` so the DB rejects garbage.
- **API** \`api/v1/governance.py\`
  - \`GET /api/v1/governance/config\` — any authed user; creates a defaulted row on first read so every tenant has a persisted baseline.
  - \`PUT /api/v1/governance/config\` — admin-only via \`require_tenant_admin\` (scope \`agenticorg:admin\`). Every write emits an \`AuditLog\` entry (\`event_type=governance_config.change\`) in the **same transaction** as the update — a failed audit rolls back the config change.
- **UI** \`ui/src/pages/Settings.tsx\` — Compliance card wired end-to-end: fetches on mount, Save-button commits, disables inputs while loading/saving, shows \`Saved — audit entry written.\` on success or \`You must be a tenant admin…\` on 403. \`data-testid\` hooks on the card, each input, save button, saved, and error surfaces drive the drift guard.
- **Playwright drift guard** \`ui/e2e/settings-governance.spec.ts\` — three tests:
  1. \`GET /governance/config\` returns populated values.
  2. Toggle PII masking + Save; reload; assert persisted value comes back (the decorative-state drift guard).
  3. \`PUT\` writes an \`AuditLog\` entry visible via \`/audit?event_type=governance_config.change\`.

### Scope

- No other features touched; no existing test modified.
- No zero-skip primitives introduced (the spec uses \`requireAuth()\`).
- PR-B2 (connector control plane) follows as a separate PR under the same plan entry.

## Test plan

- [ ] CI branch lint / unit / integration green.
- [ ] \`bash scripts/local_e2e.sh ui/e2e/settings-governance.spec.ts\` passes (governance persists round-trip).
- [ ] Main CI e2e green post-deploy — \`settings-governance.spec.ts\` joins the regression tag set.

@codex please review