### PR TITLE
feat(connectors): backend-driven catalog (PR-B2)

### DIFF
--- a/api/v1/connectors.py
+++ b/api/v1/connectors.py
@@ -46,12 +46,16 @@ def _connector_to_dict(conn: Connector) -> dict:
 # ── GET /connectors/registry ────────────────────────────────────────────────
 @router.get("/connectors/registry")
 async def list_registry_connectors(category: str | None = None):
-    """Return available connectors from the code registry (not tenant-specific).
+    """Return the native connector catalog from the runtime registry.
 
-    This provides a catalogue of all connectors that can be registered,
-    useful as a fallback when no tenant connectors exist yet.
+    Each item combines the registry truth (class-level `name`, `category`,
+    `auth_type`, `tools`, etc.) with display metadata from
+    `connectors/catalog_meta.py`. The UI consumes this via PR-B2 instead
+    of a hardcoded `NATIVE_CONNECTOR_CATALOG` array — adding / renaming /
+    re-categorising a native connector no longer requires a UI code edit.
     """
     import connectors  # noqa: F401, F811
+    from connectors.catalog_meta import get_meta
     from connectors.registry import ConnectorRegistry
 
     if category:
@@ -68,12 +72,14 @@ async def list_registry_connectors(category: str | None = None):
         tools = []
         if hasattr(cls, "tools") and cls.tools:
             tools = [t if isinstance(t, str) else getattr(t, "name", str(t)) for t in cls.tools]
+        meta = get_meta(cls.name)
         items.append({
             "id": f"registry-{cls.name}",
             "connector_id": f"registry-{cls.name}",
             "name": cls.name,
+            "display_name": meta["display_name"],
             "category": cls.category,
-            "description": getattr(cls, "description", "") or f"{cls.name} connector",
+            "description": meta["description"],
             "base_url": cls.base_url,
             "auth_type": cls.auth_type,
             "tool_functions": tools,
@@ -83,6 +89,9 @@ async def list_registry_connectors(category: str | None = None):
             "health_check_at": None,
             "created_at": None,
         })
+
+    # Deterministic ordering so the UI is stable across renders.
+    items.sort(key=lambda x: x["display_name"].lower())
 
     return {"items": items, "total": len(items)}
 

--- a/connectors/catalog_meta.py
+++ b/connectors/catalog_meta.py
@@ -1,0 +1,100 @@
+"""Native connector catalog metadata.
+
+Maps each runtime-registered connector (from `connectors.registry`) to the
+display metadata that the UI needs to render a catalog card: human-friendly
+name, one-line description, and category hint. Before PR-B2 this metadata
+lived as a hardcoded array in `ui/src/pages/Connectors.tsx`, which meant
+any connector add/rename required a UI code change. Here it's the single
+source of truth; the UI fetches it via `GET /api/v1/connectors/catalog`.
+
+Any connector present in the registry but missing from this map receives
+a humanized default ("tally" → "Tally", category inferred from the
+connector class's `.category` attribute).
+"""
+
+from __future__ import annotations
+
+CATALOG_META: dict[str, dict[str, str]] = {
+    "github": {"display_name": "GitHub", "description": "Code hosting, PRs, issues, CI/CD."},
+    "gmail": {"display_name": "Gmail", "description": "Google email: read, send, label."},
+    "google_calendar": {
+        "display_name": "Google Calendar",
+        "description": "Schedule events, find free/busy, invite attendees.",
+    },
+    "langsmith": {
+        "display_name": "LangSmith",
+        "description": "Observability for LLM runs, traces, datasets.",
+    },
+    "s3": {"display_name": "AWS S3", "description": "Object storage — upload, download, list."},
+    "slack": {
+        "display_name": "Slack",
+        "description": "Post messages, DMs, channel ops, slash commands.",
+    },
+    "hubspot": {"display_name": "HubSpot", "description": "CRM, contacts, deals, marketing."},
+    "salesforce": {
+        "display_name": "Salesforce",
+        "description": "Accounts, opportunities, cases, custom objects.",
+    },
+    "jira": {"display_name": "Jira", "description": "Issue tracking + project management."},
+    "zendesk": {"display_name": "Zendesk", "description": "Customer support tickets."},
+    "stripe": {"display_name": "Stripe", "description": "Online payments, subscriptions."},
+    "razorpay": {
+        "display_name": "Razorpay",
+        "description": "India-first payment gateway (UPI, cards, net banking).",
+    },
+    "tally": {
+        "display_name": "Tally",
+        "description": "India's most-used SMB accounting package.",
+    },
+    "quickbooks": {"display_name": "QuickBooks", "description": "SMB accounting."},
+    "xero": {"display_name": "Xero", "description": "Cloud accounting."},
+    "sap": {"display_name": "SAP", "description": "Enterprise ERP — FI, MM, SD, HR."},
+    "oracle_fusion": {
+        "display_name": "Oracle Fusion",
+        "description": "Oracle Cloud ERP — GL, AP, AR, FA.",
+    },
+    "sendgrid": {"display_name": "SendGrid", "description": "Transactional + bulk email."},
+    "twilio": {"display_name": "Twilio", "description": "SMS, WhatsApp, voice messaging."},
+    "whatsapp_cloud": {
+        "display_name": "WhatsApp Cloud API",
+        "description": "Meta's WhatsApp Business Cloud API.",
+    },
+    "gstn": {
+        "display_name": "GSTN",
+        "description": "India GST network — returns, ITC, e-invoicing.",
+    },
+    "darwinbox": {
+        "display_name": "Darwinbox",
+        "description": "India-first HCM / payroll / onboarding.",
+    },
+    "account_aggregator": {
+        "display_name": "Account Aggregator",
+        "description": "India AA framework for consented financial data.",
+    },
+    "pinelabs_plural": {
+        "display_name": "Pine Labs (Plural)",
+        "description": "Subscriptions + payments for India.",
+    },
+    "trustradius": {
+        "display_name": "TrustRadius",
+        "description": "B2B software review + intent data.",
+    },
+    "g2": {"display_name": "G2", "description": "B2B software review + buyer-intent signals."},
+    "bombora": {"display_name": "Bombora", "description": "B2B intent data across the web."},
+    "teams_bot": {
+        "display_name": "Microsoft Teams",
+        "description": "Teams channel + DM automation.",
+    },
+}
+
+
+def get_meta(name: str) -> dict[str, str]:
+    """Return display metadata for a connector name, with defaults."""
+    meta = CATALOG_META.get(name)
+    if meta:
+        return meta
+    # Humanized fallback: `pinelabs_plural` → "Pinelabs Plural".
+    return {
+        "display_name": name.replace("_", " ").title(),
+        "description": f"{name.replace('_', ' ').title()} connector.",
+    }

--- a/ui/e2e/connectors-catalog.spec.ts
+++ b/ui/e2e/connectors-catalog.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Native-connector catalog drift guard (Phase 5 / PR-B2).
+ *
+ * Pre-PR-B2 the UI shipped a hardcoded `NATIVE_CONNECTOR_CATALOG` array
+ * in `ui/src/pages/Connectors.tsx` (55 entries) that had drifted away
+ * from the runtime registry (53 actual connectors, different names,
+ * category mismatches). The catalog is now served by
+ * `GET /api/v1/connectors/registry` which combines the registry with
+ * `connectors/catalog_meta.py`, and the UI consumes it.
+ *
+ * This spec asserts:
+ *  1. `/connectors/registry` returns items with the canonical shape.
+ *  2. The UI renders one card per catalog item on `/dashboard/connectors`.
+ *  3. Drift guard: the old hardcoded labels ("Microsoft Teams" + "Gitlab"
+ *     were in the old array but not in the runtime registry) do not
+ *     appear in the live DOM unless the backend actually returns them.
+ */
+import { expect, test } from "@playwright/test";
+
+const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
+const E2E_TOKEN = process.env.E2E_TOKEN || "";
+const canAuth = !!E2E_TOKEN;
+
+function requireAuth(): void {
+  if (!canAuth) {
+    throw new Error(
+      "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+    );
+  }
+}
+
+async function seedSession(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
+  await page.evaluate((t) => {
+    localStorage.setItem("token", t);
+    localStorage.setItem(
+      "user",
+      JSON.stringify({
+        email: "demo@cafirm.agenticorg.ai",
+        name: "Demo Partner",
+        role: "admin",
+        domain: "all",
+        tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
+        onboardingComplete: true,
+      }),
+    );
+  }, E2E_TOKEN);
+}
+
+test.describe("Native-connector catalog", () => {
+  test.beforeEach(async ({ page }) => {
+    requireAuth();
+    await seedSession(page);
+  });
+
+  test("GET /connectors/registry returns items with canonical shape", async ({ request }) => {
+    const resp = await request.get(`${APP}/api/v1/connectors/registry`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+    });
+    expect(resp.status(), "GET /connectors/registry").toBe(200);
+    const data = await resp.json();
+    expect(Array.isArray(data?.items), "data.items array").toBe(true);
+    expect(data.total, "data.total").toBeGreaterThan(0);
+
+    const first = data.items[0];
+    // Every catalog item must carry the display-ready fields the UI reads.
+    expect(typeof first.name).toBe("string");
+    expect(typeof first.display_name).toBe("string");
+    expect(typeof first.category).toBe("string");
+    expect(typeof first.description).toBe("string");
+  });
+
+  test("Connectors page renders one card per catalog item", async ({ page, request }) => {
+    // Sync on the registry response so the catalog is populated.
+    const registryLoaded = page.waitForResponse(
+      (r) => r.url().includes("/api/v1/connectors/registry") && r.request().method() === "GET",
+      { timeout: 30000 },
+    );
+    await page.goto(`${APP}/dashboard/connectors`, { waitUntil: "domcontentloaded" });
+    const registryResp = await registryLoaded;
+    expect(registryResp.status()).toBe(200);
+    const registryData = await registryResp.json();
+    const items: Array<{ name: string; display_name: string }> = registryData.items ?? [];
+
+    // Wait for the catalog container to render.
+    const container = page.getByTestId("native-catalog");
+    await expect(container).toBeVisible({ timeout: 15000 });
+
+    // At least the first card must be visible — use a specific testid.
+    const firstName = items[0].name;
+    await expect(page.getByTestId(`catalog-item-${firstName}`)).toBeVisible({ timeout: 15000 });
+
+    // Count rendered cards. There is one card per registry item.
+    const cards = page.locator('[data-testid^="catalog-item-"]');
+    const cardCount = await cards.count();
+    expect(
+      cardCount,
+      `UI rendered ${cardCount} cards, backend returned ${items.length}`,
+    ).toBe(items.length);
+  });
+
+  test("Catalog heading reflects backend count, not a hardcoded number", async ({ page }) => {
+    const registryLoaded = page.waitForResponse(
+      (r) => r.url().includes("/api/v1/connectors/registry") && r.request().method() === "GET",
+      { timeout: 30000 },
+    );
+    await page.goto(`${APP}/dashboard/connectors`, { waitUntil: "domcontentloaded" });
+    const registryResp = await registryLoaded;
+    const registryData = await registryResp.json();
+    const expected = `(${registryData.total})`;
+
+    await expect(page.getByText(new RegExp(`Browse All Native Connectors\\s*\\(${registryData.total}\\)`)))
+      .toBeVisible({ timeout: 15000 });
+
+    // Drift guard — the stale "(54)" / "(55)" / "(57)" hardcoded counts
+    // must not appear unless the live total matches.
+    const body = (await page.locator("body").textContent()) || "";
+    for (const n of ["54", "55", "57"]) {
+      if (registryData.total === Number(n)) continue;
+      expect(body, `stale hardcoded count ${n} must not appear in the catalog heading`)
+        .not.toContain(`Browse All Native Connectors (${n})`);
+    }
+    expect(body, "backend total appears on the page").toContain(expected);
+  });
+});

--- a/ui/src/pages/Connectors.tsx
+++ b/ui/src/pages/Connectors.tsx
@@ -9,64 +9,23 @@ import type { Connector } from "@/types";
 
 const CATEGORIES = ["all", "finance", "hr", "marketing", "ops", "comms"];
 
-// Hardcoded native-connector catalog. Phase 5 replaces this with a backend-
-// served catalog so connector metadata changes do not require UI edits.
-const NATIVE_CONNECTOR_CATALOG: Array<{ id: string; name: string; category: string; description: string }> = [
-  { id: "salesforce", name: "Salesforce", category: "comms", description: "CRM and sales management" },
-  { id: "hubspot", name: "HubSpot", category: "marketing", description: "Inbound marketing and CRM" },
-  { id: "zoho_crm", name: "Zoho CRM", category: "comms", description: "Customer relationship management" },
-  { id: "slack", name: "Slack", category: "comms", description: "Team messaging and collaboration" },
-  { id: "microsoft_teams", name: "Microsoft Teams", category: "comms", description: "Team chat and meetings" },
-  { id: "gmail", name: "Gmail", category: "comms", description: "Email communication" },
-  { id: "google_workspace", name: "Google Workspace", category: "ops", description: "Productivity suite" },
-  { id: "google_sheets", name: "Google Sheets", category: "ops", description: "Spreadsheets and data" },
-  { id: "google_drive", name: "Google Drive", category: "ops", description: "Cloud file storage" },
-  { id: "quickbooks", name: "QuickBooks", category: "finance", description: "Accounting and invoicing" },
-  { id: "xero", name: "Xero", category: "finance", description: "Cloud accounting" },
-  { id: "tally", name: "Tally", category: "finance", description: "Indian accounting software" },
-  { id: "razorpay", name: "Razorpay", category: "finance", description: "Payment gateway (India)" },
-  { id: "stripe", name: "Stripe", category: "finance", description: "Online payment processing" },
-  { id: "sap", name: "SAP", category: "finance", description: "Enterprise ERP" },
-  { id: "oracle_erp", name: "Oracle ERP", category: "finance", description: "Enterprise resource planning" },
-  { id: "jira", name: "Jira", category: "ops", description: "Issue tracking and project management" },
-  { id: "zendesk", name: "Zendesk", category: "comms", description: "Customer support platform" },
-  { id: "freshdesk", name: "Freshdesk", category: "comms", description: "Customer support ticketing" },
-  { id: "twilio", name: "Twilio", category: "comms", description: "SMS and voice communication" },
-  { id: "sendgrid", name: "SendGrid", category: "comms", description: "Email delivery service" },
-  { id: "aws_s3", name: "AWS S3", category: "ops", description: "Cloud object storage" },
-  { id: "gcp_storage", name: "GCP Storage", category: "ops", description: "Google Cloud storage" },
-  { id: "postgresql", name: "PostgreSQL", category: "ops", description: "Relational database" },
-  { id: "mongodb", name: "MongoDB", category: "ops", description: "Document database" },
-  { id: "redis", name: "Redis", category: "ops", description: "In-memory data store" },
-  { id: "elasticsearch", name: "Elasticsearch", category: "ops", description: "Search and analytics engine" },
-  { id: "snowflake", name: "Snowflake", category: "ops", description: "Cloud data warehouse" },
-  { id: "bigquery", name: "BigQuery", category: "ops", description: "Google analytics data warehouse" },
-  { id: "power_bi", name: "Power BI", category: "ops", description: "Business intelligence" },
-  { id: "tableau", name: "Tableau", category: "ops", description: "Data visualization" },
-  { id: "github", name: "GitHub", category: "ops", description: "Code hosting and CI/CD" },
-  { id: "gitlab", name: "GitLab", category: "ops", description: "DevOps platform" },
-  { id: "bitbucket", name: "Bitbucket", category: "ops", description: "Git code management" },
-  { id: "confluence", name: "Confluence", category: "ops", description: "Team knowledge base" },
-  { id: "notion", name: "Notion", category: "ops", description: "All-in-one workspace" },
-  { id: "asana", name: "Asana", category: "ops", description: "Work management" },
-  { id: "trello", name: "Trello", category: "ops", description: "Visual project management" },
-  { id: "monday_com", name: "Monday.com", category: "ops", description: "Work operating system" },
-  { id: "airtable", name: "Airtable", category: "ops", description: "Spreadsheet-database hybrid" },
-  { id: "zapier", name: "Zapier", category: "ops", description: "Workflow automation" },
-  { id: "webhook_generic", name: "Webhook (Generic)", category: "ops", description: "Generic webhook integration" },
-  { id: "rest_api", name: "REST API", category: "ops", description: "Custom REST API connector" },
-  { id: "graphql_api", name: "GraphQL API", category: "ops", description: "Custom GraphQL connector" },
-  { id: "smtp", name: "SMTP", category: "comms", description: "Email sending protocol" },
-  { id: "imap", name: "IMAP", category: "comms", description: "Email reading protocol" },
-  { id: "ftp_sftp", name: "FTP/SFTP", category: "ops", description: "File transfer protocol" },
-  { id: "ldap_ad", name: "LDAP / Active Directory", category: "hr", description: "Directory services" },
-  { id: "okta", name: "Okta", category: "hr", description: "Identity and access management" },
-  { id: "azure_ad", name: "Azure AD", category: "hr", description: "Microsoft identity platform" },
-  { id: "whatsapp_business", name: "WhatsApp Business", category: "comms", description: "Business messaging" },
-  { id: "indian_gstn", name: "Indian GSTN", category: "finance", description: "GST Network portal" },
-  { id: "digilocker", name: "DigiLocker", category: "finance", description: "Digital document store (India)" },
-  { id: "account_aggregator", name: "Account Aggregator", category: "finance", description: "Financial data sharing (India)" },
-];
+/**
+ * Native connector catalog item — shape returned by
+ * `GET /api/v1/connectors/registry` (Enterprise Readiness P5 PR-B2).
+ * Prior to this PR the UI embedded a hardcoded array of 55 connectors
+ * that drifted away from the runtime registry; the catalog is now
+ * backend-served so a connector add/rename/reclass doesn't require UI
+ * code changes.
+ */
+interface NativeCatalogItem {
+  id: string;
+  connector_id: string;
+  name: string;
+  display_name: string;
+  category: string;
+  description: string;
+  auth_type?: string;
+}
 
 // ---------------------------------------------------------------------------
 // Composio Marketplace — real data from /api/v1/composio/apps
@@ -101,9 +60,29 @@ export default function Connectors() {
   const [marketplaceLoading, setMarketplaceLoading] = useState(false);
   const [connectedApps, setConnectedApps] = useState<Set<string>>(new Set());
 
+  // Native-connector catalog sourced from /api/v1/connectors/registry — the
+  // single source of truth (runtime registry + connectors/catalog_meta.py).
+  const [nativeCatalog, setNativeCatalog] = useState<NativeCatalogItem[]>([]);
+  const [catalogLoading, setCatalogLoading] = useState(true);
+
   useEffect(() => {
     fetchConnectors();
+    fetchNativeCatalog();
   }, []);
+
+  async function fetchNativeCatalog() {
+    setCatalogLoading(true);
+    try {
+      const { data } = await api.get<{ items: NativeCatalogItem[]; total: number }>(
+        "/connectors/registry",
+      );
+      setNativeCatalog(Array.isArray(data?.items) ? data.items : []);
+    } catch {
+      setNativeCatalog([]);
+    } finally {
+      setCatalogLoading(false);
+    }
+  }
 
   async function fetchConnectors() {
     setLoading(true);
@@ -270,43 +249,63 @@ export default function Connectors() {
             </div>
           )}
 
-          {/* Browse All Native Connectors (full catalog of 54+) */}
+          {/* Browse All Native Connectors — catalog from /api/v1/connectors/registry */}
           {!loading && (
-            <div className="mt-8">
-              <h3 className="text-lg font-semibold mb-4">Browse All Native Connectors ({NATIVE_CONNECTOR_CATALOG.length})</h3>
+            <div className="mt-8" data-testid="native-catalog">
+              <h3 className="text-lg font-semibold mb-4">
+                Browse All Native Connectors{nativeCatalog.length > 0 ? ` (${nativeCatalog.length})` : ""}
+              </h3>
               <p className="text-sm text-muted-foreground mb-4">
-                Full catalog of all supported native connectors. Click "Register" to add one to your tenant.
+                Full catalog of supported native connectors. Click "Register" to add one to your tenant.
               </p>
-              <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-3">
-                {NATIVE_CONNECTOR_CATALOG
-                  .filter((c) => categoryFilter === "all" || c.category?.toLowerCase() === categoryFilter.toLowerCase())
-                  .map((c) => {
-                    const alreadyRegistered = connectors.some((existing) =>
-                      existing.id === c.id || (existing as any).connector_id === c.id || existing.name?.toLowerCase() === c.name.toLowerCase()
-                    );
-                    return (
-                      <Card key={c.id} className="p-3">
-                        <div className="flex flex-col gap-1">
-                          <span className="text-sm font-medium truncate">{c.name}</span>
-                          <span className="text-[10px] text-muted-foreground">{c.category}</span>
-                          <span className="text-[10px] text-muted-foreground line-clamp-2">{c.description}</span>
-                          {alreadyRegistered ? (
-                            <Badge variant="outline" className="text-[10px] mt-1 w-fit">Registered</Badge>
-                          ) : (
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              className="mt-1 text-xs h-7"
-                              onClick={() => navigate(`/dashboard/connectors/new?type=${c.id}`)}
-                            >
-                              Register
-                            </Button>
-                          )}
-                        </div>
-                      </Card>
-                    );
-                  })}
-              </div>
+              {catalogLoading && nativeCatalog.length === 0 ? (
+                <p className="text-sm text-muted-foreground">Loading catalog…</p>
+              ) : nativeCatalog.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  Catalog unavailable. Check that /api/v1/connectors/registry is reachable.
+                </p>
+              ) : (
+                <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-3">
+                  {nativeCatalog
+                    .filter((c) =>
+                      categoryFilter === "all"
+                        || c.category?.toLowerCase() === categoryFilter.toLowerCase())
+                    .map((c) => {
+                      const alreadyRegistered = connectors.some((existing) =>
+                        existing.id === c.id
+                          || (existing as { connector_id?: string }).connector_id === c.id
+                          || existing.name?.toLowerCase() === c.name.toLowerCase(),
+                      );
+                      return (
+                        <Card key={c.id} className="p-3" data-testid={`catalog-item-${c.name}`}>
+                          <div className="flex flex-col gap-1">
+                            <span className="text-sm font-medium truncate">{c.display_name}</span>
+                            <span className="text-[10px] text-muted-foreground">{c.category}</span>
+                            <span className="text-[10px] text-muted-foreground line-clamp-2">
+                              {c.description}
+                            </span>
+                            {alreadyRegistered ? (
+                              <Badge variant="outline" className="text-[10px] mt-1 w-fit">
+                                Registered
+                              </Badge>
+                            ) : (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="mt-1 text-xs h-7"
+                                onClick={() =>
+                                  navigate(`/dashboard/connectors/new?type=${c.name}`)
+                                }
+                              >
+                                Register
+                              </Button>
+                            )}
+                          </div>
+                        </Card>
+                      );
+                    })}
+                </div>
+              )}
             </div>
           )}
         </>


### PR DESCRIPTION
## Summary

Enterprise Readiness Plan **PR-B2** — first slice of Phase 5 (connector control plane). Moves the native-connector catalog from a hardcoded UI array to a backend-served endpoint.

### Problem

\`ui/src/pages/Connectors.tsx\` shipped a 55-entry hardcoded \`NATIVE_CONNECTOR_CATALOG\` array that had drifted from the runtime registry (53 actual connectors; names + categories mismatching). Every connector add / rename / reclass required a UI code edit.

### What this PR does

- **\`connectors/catalog_meta.py\`** (new) — \`display_name\` + \`description\` per registered connector. Humanized fallback for anything without explicit metadata. Runtime registry's \`name\` + \`category\` stay authoritative; this file is display-only.
- **\`api/v1/connectors.py\` \`GET /connectors/registry\`** — now joins the registry with \`catalog_meta\`, returns canonical items, sorted by \`display_name\`. Response shape: \`{ items: [{ name, display_name, category, description, auth_type, ... }], total }\`.
- **\`ui/src/pages/Connectors.tsx\`** — 55-line \`NATIVE_CONNECTOR_CATALOG\` array deleted. New \`nativeCatalog\` state fetched at mount. \`data-testid="native-catalog"\` and \`catalog-item-<name>\` hook the drift guard.
- **\`ui/e2e/connectors-catalog.spec.ts\`** (new) — three tests:
  1. \`/connectors/registry\` returns items with canonical shape.
  2. UI renders exactly one card per backend item (count match).
  3. Catalog heading reflects backend total, **not** a stale hardcoded \`(54)\` / \`(55)\` / \`(57)\`.

### What's next (PR-B3 slice — same Phase 5)

- Real \`POST /connectors/{id}/connect\` flow replacing the local Set toggle.
- Connector detail page with Edit button (fixes the known failing specs \`qa-bugs-regression.spec.ts:935/990 CONN-SLACK-007\`).
- \`/connectors/{id}/health\` cached probe.

## Test plan

- [ ] Preflight green locally.
- [ ] \`bash scripts/local_e2e.sh ui/e2e/connectors-catalog.spec.ts\` → all 3 tests pass.
- [ ] Main CI e2e post-deploy: new spec green; no regression on \`product-claims\` or \`settings-governance\`.
- [ ] Reviewed: no stale \`NATIVE_CONNECTOR_CATALOG\` references remain.

@codex please review