### PR TITLE
feat(agents): real explainer from trace data — kill the mock (PR-C1)

### DIFF
--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -1978,6 +1978,114 @@ async def list_agent_feedback(
     return {"agent_id": str(agent_id), "feedback": entries, "count": len(entries)}
 
 
+# ── GET /agents/{id}/explanation/latest ─────────────────────────────────────
+@router.get("/agents/{agent_id}/explanation/latest")
+async def get_latest_explanation(
+    agent_id: UUID,
+    tenant_id: str = Depends(get_current_tenant),
+):
+    """Derive a real, human-readable explanation of the agent's most recent
+    run from stored `AgentTaskResult` data.
+
+    Replaces the mock explanation that used to live in the UI
+    (`ui/src/pages/AgentDetail.tsx`, removed in PR-C1). Returns the empty
+    state when the agent hasn't run yet — callers must handle
+    ``has_run: false`` rather than fabricating bullets.
+
+    Response shape:
+      {
+        "has_run": bool,
+        "run_id": str | None,
+        "status": str | None,
+        "confidence": float | None,
+        "bullets": list[str],     # derived from hitl, confidence, tool usage
+        "tools_cited": list[str], # unique tool names from tool_calls
+        "hitl_required": bool,
+        "hitl_decision": str | None,
+        "duration_ms": int,
+        "completed_at": ISO str | None,
+      }
+    """
+    from core.models.agent_task_result import AgentTaskResult
+
+    tid = _uuid.UUID(tenant_id)
+    async with get_tenant_session(tid) as session:
+        row = (
+            await session.execute(
+                select(AgentTaskResult)
+                .where(
+                    AgentTaskResult.agent_id == agent_id,
+                    AgentTaskResult.tenant_id == tid,
+                )
+                .order_by(AgentTaskResult.created_at.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+    if row is None:
+        return {
+            "has_run": False,
+            "run_id": None,
+            "status": None,
+            "confidence": None,
+            "bullets": [],
+            "tools_cited": [],
+            "hitl_required": False,
+            "hitl_decision": None,
+            "duration_ms": 0,
+            "completed_at": None,
+        }
+
+    # Derive bullets from real trace — no hardcoded filler.
+    bullets: list[str] = []
+    tool_calls_list = row.tool_calls or []
+    tools_cited = sorted(
+        {
+            (tc.get("tool") if isinstance(tc, dict) else None) or ""
+            for tc in tool_calls_list
+        }
+        - {""}
+    )
+
+    if tools_cited:
+        bullets.append(
+            f"Called {len(tool_calls_list)} tool invocation"
+            f"{'s' if len(tool_calls_list) != 1 else ''} "
+            f"across {len(tools_cited)} distinct tool"
+            f"{'s' if len(tools_cited) != 1 else ''}: "
+            + ", ".join(tools_cited)
+        )
+    else:
+        bullets.append("No tool calls were required for this run.")
+
+    if row.confidence is not None:
+        pct = int(round(row.confidence * 100))
+        bullets.append(f"Confidence was {pct}% ({row.status}).")
+
+    if row.hitl_required:
+        decision = row.hitl_decision or "pending review"
+        bullets.append(f"HITL gate triggered — {decision}.")
+    else:
+        bullets.append("No HITL gate conditions were met.")
+
+    if row.error_message:
+        # Constant summary (no exception text in the response body).
+        bullets.append("The run ended with an error — see the audit log.")
+
+    return {
+        "has_run": True,
+        "run_id": str(row.id),
+        "status": row.status,
+        "confidence": row.confidence,
+        "bullets": bullets,
+        "tools_cited": tools_cited,
+        "hitl_required": row.hitl_required,
+        "hitl_decision": row.hitl_decision,
+        "duration_ms": row.duration_ms,
+        "completed_at": row.created_at.isoformat() if row.created_at else None,
+    }
+
+
 # ── POST /agents/{id}/feedback/analyze ──────────────────────────────────────
 @router.post("/agents/{agent_id}/feedback/analyze")
 async def analyze_agent_feedback(

--- a/ui/e2e/explainer-real.spec.ts
+++ b/ui/e2e/explainer-real.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Agent detail Explainer drift guard — Phase 7 P7.1 (PR-C1).
+ *
+ * Pre-PR-C1 the "Why did the agent do this?" panel in `AgentDetail.tsx`
+ * hardcoded its bullets, confidence, and tool citations. The component
+ * literally said `// Load mock explanation until real API is wired`.
+ * This spec asserts the UI now renders only values sourced from
+ * `GET /agents/{id}/explanation/latest`.
+ *
+ * Drift guard:
+ *   - If an agent has no run history, the empty state must show instead
+ *     of fabricated bullets.
+ *   - If the endpoint returns bullets, the DOM must contain them (a
+ *     subset check — the mocked strings ("Agent processed the request"
+ *     / "Confidence was above threshold") must NOT appear unless the
+ *     real response contains them).
+ */
+import { expect, test } from "@playwright/test";
+
+const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
+const E2E_TOKEN = process.env.E2E_TOKEN || "";
+const canAuth = !!E2E_TOKEN;
+
+function requireAuth(): void {
+  if (!canAuth) {
+    throw new Error(
+      "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+    );
+  }
+}
+
+async function seedSession(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
+  await page.evaluate((t) => {
+    localStorage.setItem("token", t);
+    localStorage.setItem(
+      "user",
+      JSON.stringify({
+        email: "demo@cafirm.agenticorg.ai",
+        name: "Demo Partner",
+        role: "admin",
+        domain: "all",
+        tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
+        onboardingComplete: true,
+      }),
+    );
+  }, E2E_TOKEN);
+}
+
+test.describe("Agent detail explainer — real trace data", () => {
+  test.beforeEach(async ({ page }) => {
+    requireAuth();
+    await seedSession(page);
+  });
+
+  test("GET /agents/{id}/explanation/latest returns canonical shape", async ({ request }) => {
+    // Pick the first agent for the demo tenant to exercise the endpoint.
+    const agentsResp = await request.get(`${APP}/api/v1/agents?per_page=1`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+    });
+    expect(agentsResp.status(), "GET /agents").toBe(200);
+    const agentsBody = await agentsResp.json();
+    const items = Array.isArray(agentsBody) ? agentsBody : agentsBody?.items ?? [];
+    expect(items.length, "at least one agent must exist in the demo tenant").toBeGreaterThan(0);
+
+    const agentId = items[0].id || items[0].agent_id;
+    const explResp = await request.get(
+      `${APP}/api/v1/agents/${agentId}/explanation/latest`,
+      { headers: { Authorization: `Bearer ${E2E_TOKEN}` } },
+    );
+    expect(explResp.status(), "GET /agents/{id}/explanation/latest").toBe(200);
+    const explData = await explResp.json();
+    expect(typeof explData.has_run).toBe("boolean");
+    expect(Array.isArray(explData.bullets)).toBe(true);
+    expect(Array.isArray(explData.tools_cited)).toBe(true);
+    expect(typeof explData.hitl_required).toBe("boolean");
+  });
+
+  test("Explainer panel renders no mocked strings", async ({ page, request }) => {
+    const agentsResp = await request.get(`${APP}/api/v1/agents?per_page=1`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+    });
+    const agentsBody = await agentsResp.json();
+    const items = Array.isArray(agentsBody) ? agentsBody : agentsBody?.items ?? [];
+    const agentId = items[0].id || items[0].agent_id;
+
+    await page.goto(`${APP}/dashboard/agents/${agentId}`, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle").catch(() => {});
+
+    // Expand the explainer.
+    await page.getByText(/Why did the agent do this/).first().click();
+    const body = page.getByTestId("explainer-body");
+    await expect(body).toBeVisible({ timeout: 15000 });
+
+    // Drift guard — the old hardcoded bullets from the mock must never
+    // be rendered. If the backend returns something that happens to
+    // match, the backend is the source of truth; we explicitly want
+    // these specific placeholder strings gone.
+    const bodyText = (await body.textContent()) || "";
+    expect(bodyText, "mock bullet #1 removed").not.toContain(
+      "Agent processed the request using configured tools",
+    );
+    expect(bodyText, "mock bullet #2 removed").not.toContain(
+      "Confidence was above threshold",
+    );
+    expect(bodyText, "mock bullet #3 removed").not.toContain(
+      "No HITL trigger conditions met",
+    );
+    // `get_contact` and `query` were the mocked tool names — they must
+    // only appear if this agent actually called them.
+    expect(bodyText, "mock readability grade removed").not.toContain(
+      "7.5 (Flesch-Kincaid)",
+    );
+  });
+});

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -447,22 +447,53 @@ function ExplainerPanel({ agentId }: { agentId: string }) {
   const [correcting, setCorrecting] = useState(false);
   const [correctionText, setCorrectionText] = useState("");
 
-  // Load the latest run explanation when expanded
+  // Load the latest run explanation when expanded. Real trace data
+  // from GET /agents/{id}/explanation/latest (PR-C1) — replaces the
+  // hardcoded-bullet mock that shipped pre-Enterprise-Readiness.
+  const [explanationHasRun, setExplanationHasRun] = useState<boolean | null>(null);
+
   useEffect(() => {
     if (!expanded) return;
+    let cancelled = false;
+
+    // Keep the feedback fetch so the thumbs-up/down controls still have a
+    // run_id to attach to.
     api.get(`/agents/${agentId}/feedback?limit=1`).then(({ data }) => {
+      if (cancelled) return;
       const items = Array.isArray(data) ? data : data?.items || [];
       if (items.length > 0) {
         setRunResult({ task_id: items[0].run_id, status: "completed" });
       }
     }).catch(() => {});
-    // Load mock explanation until real API is wired
-    setExplanation({
-      bullets: ["Agent processed the request using configured tools", "Confidence was above threshold", "No HITL trigger conditions met"],
-      confidence: 0.92,
-      tools_cited: ["get_contact", "query"],
-      readability_grade: 7.5,
-    });
+
+    api
+      .get(`/agents/${agentId}/explanation/latest`)
+      .then(({ data }) => {
+        if (cancelled) return;
+        if (!data?.has_run) {
+          setExplanationHasRun(false);
+          setExplanation(null);
+          return;
+        }
+        setExplanationHasRun(true);
+        setExplanation({
+          bullets: Array.isArray(data.bullets) ? data.bullets : [],
+          confidence: typeof data.confidence === "number" ? data.confidence : undefined,
+          tools_cited: Array.isArray(data.tools_cited) ? data.tools_cited : [],
+          // readability_grade is deliberately not returned — we won't
+          // fabricate it client-side.
+          readability_grade: undefined,
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setExplanationHasRun(null);
+        setExplanation(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [expanded, agentId]);
 
   async function sendFeedback(type: string) {
@@ -495,8 +526,13 @@ function ExplainerPanel({ agentId }: { agentId: string }) {
       </button>
 
       {expanded && (
-        <div className="mt-3 bg-muted/30 rounded-lg p-4 space-y-3">
-          {explanation && explanation.bullets ? (
+        <div className="mt-3 bg-muted/30 rounded-lg p-4 space-y-3" data-testid="explainer-body">
+          {explanationHasRun === false ? (
+            <p className="text-sm text-muted-foreground" data-testid="explainer-empty">
+              No explanation yet. Run the agent at least once to generate a real
+              trace.
+            </p>
+          ) : explanation && explanation.bullets ? (
             <>
               <ul className="list-disc list-inside text-sm space-y-1">
                 {explanation.bullets.map((b, i) => (


### PR DESCRIPTION
## Summary

Enterprise Readiness Plan **Phase 7 P7.1** — removes the single most damning line in the codebase:

\`\`\`jsx
// ui/src/pages/AgentDetail.tsx (pre-PR-C1)
// Load mock explanation until real API is wired
setExplanation({
  bullets: ["Agent processed the request using configured tools", ...],
  confidence: 0.92,
  tools_cited: ["get_contact", "query"],
  readability_grade: 7.5,
});
\`\`\`

Every agent's "Why did the agent do this?" panel showed the same four hardcoded bullets + fake 92 % confidence regardless of whether the agent had ever run. An enterprise buyer's first-hour review would catch this.

## What this PR does

- **Backend** \`GET /api/v1/agents/{id}/explanation/latest\` — derives a real explanation from the most recent \`AgentTaskResult\` row. Response:

  \`\`\`
  { has_run, run_id, status, confidence, bullets, tools_cited,
    hitl_required, hitl_decision, duration_ms, completed_at }
  \`\`\`

  Bullets are derived from the stored trace (tool-call count, distinct tool names, confidence, HITL state). No filler. When the agent hasn't run yet, \`has_run: false\`.

- **UI** \`ui/src/pages/AgentDetail.tsx\` — ExplainerPanel now fetches the real endpoint. Mock block removed. Empty state element (\`data-testid="explainer-empty"\`) shows "No explanation yet. Run the agent at least once…" when the endpoint reports \`has_run: false\`.

- **Drift guard** \`ui/e2e/explainer-real.spec.ts\` — asserts the canonical response shape and that the four pre-PR-C1 mock strings can never come back.

- CodeQL-safe — \`error_message\` presence flips to a constant "The run ended with an error — see the audit log" bullet; no exception-derived text flows into the response.

## Test plan

- [ ] Preflight green locally (done).
- [ ] \`bash scripts/local_e2e.sh ui/e2e/explainer-real.spec.ts\` passes.
- [ ] Branch CI lint / unit / integration green.
- [ ] Main CI e2e post-deploy: new spec passes.

@codex please review