### PR TITLE
test(qa): eliminate 16 pytest skip violations — zero-skip for real (PR-D1)

### DIFF
--- a/tests/synthetic_data/test_synthetic_flows.py
+++ b/tests/synthetic_data/test_synthetic_flows.py
@@ -138,8 +138,11 @@ class TestAPInvoiceProcessing:
         """INV-SYNTH-001: Clean invoice, PO matches within tolerance."""
         inv = invoices[0]
         agent_id = _get_agent_id(headers, "ap_processor")
-        if not agent_id:
-            pytest.skip("No AP Processor agent found")
+        assert agent_id, (
+    "No AP Processor agent found — the demo tenant must have this agent seeded. "
+    "Run scripts/seed_e2e_demo_agents.py against the target environment. "
+    "Skipping this assertion would hide real product regressions."
+)
 
         result = _run_agent(headers, agent_id, "process_invoice", {
             "invoice": inv["ocr_extracted"],
@@ -160,8 +163,11 @@ class TestAPInvoiceProcessing:
         """INV-SYNTH-002: Invoice vs PO mismatch — should flag the delta."""
         inv = invoices[1]
         agent_id = _get_agent_id(headers, "ap_processor")
-        if not agent_id:
-            pytest.skip("No AP Processor agent found")
+        assert agent_id, (
+    "No AP Processor agent found — the demo tenant must have this agent seeded. "
+    "Run scripts/seed_e2e_demo_agents.py against the target environment. "
+    "Skipping this assertion would hide real product regressions."
+)
 
         result = _run_agent(headers, agent_id, "process_invoice", {
             "invoice": inv["ocr_extracted"],
@@ -187,8 +193,11 @@ class TestAPInvoiceProcessing:
         """INV-SYNTH-003: Invalid GSTIN — should fail validation."""
         inv = invoices[2]
         agent_id = _get_agent_id(headers, "ap_processor")
-        if not agent_id:
-            pytest.skip("No AP Processor agent found")
+        assert agent_id, (
+    "No AP Processor agent found — the demo tenant must have this agent seeded. "
+    "Run scripts/seed_e2e_demo_agents.py against the target environment. "
+    "Skipping this assertion would hide real product regressions."
+)
 
         result = _run_agent(headers, agent_id, "process_invoice", {
             "invoice": inv["ocr_extracted"],
@@ -209,8 +218,11 @@ class TestAPInvoiceProcessing:
         """INV-SYNTH-004: ₹29.5L invoice — should mention high value."""
         inv = invoices[3]
         agent_id = _get_agent_id(headers, "ap_processor")
-        if not agent_id:
-            pytest.skip("No AP Processor agent found")
+        assert agent_id, (
+    "No AP Processor agent found — the demo tenant must have this agent seeded. "
+    "Run scripts/seed_e2e_demo_agents.py against the target environment. "
+    "Skipping this assertion would hide real product regressions."
+)
 
         result = _run_agent(headers, agent_id, "process_invoice", {
             "invoice": inv["ocr_extracted"],
@@ -231,8 +243,11 @@ class TestAPInvoiceProcessing:
         """INV-SYNTH-005: Missing required fields — should flag incomplete."""
         inv = invoices[4]
         agent_id = _get_agent_id(headers, "ap_processor")
-        if not agent_id:
-            pytest.skip("No AP Processor agent found")
+        assert agent_id, (
+    "No AP Processor agent found — the demo tenant must have this agent seeded. "
+    "Run scripts/seed_e2e_demo_agents.py against the target environment. "
+    "Skipping this assertion would hide real product regressions."
+)
 
         result = _run_agent(headers, agent_id, "process_invoice", {
             "invoice": inv["ocr_extracted"],
@@ -253,8 +268,11 @@ class TestAPInvoiceProcessing:
         """INV-SYNTH-006: Duplicate invoice ID — should detect."""
         inv = invoices[5]
         agent_id = _get_agent_id(headers, "ap_processor")
-        if not agent_id:
-            pytest.skip("No AP Processor agent found")
+        assert agent_id, (
+    "No AP Processor agent found — the demo tenant must have this agent seeded. "
+    "Run scripts/seed_e2e_demo_agents.py against the target environment. "
+    "Skipping this assertion would hide real product regressions."
+)
 
         result = _run_agent(headers, agent_id, "process_invoice", {
             "invoice": inv["ocr_extracted"],
@@ -278,8 +296,11 @@ class TestResumeScreening:
         candidates, job, rubric = resumes
         candidate = candidates[0]
         agent_id = _get_agent_id(headers, "talent_acquisition")
-        if not agent_id:
-            pytest.skip("No Talent Acquisition agent found")
+        assert agent_id, (
+    "No Talent Acquisition agent found — the demo tenant must have this agent seeded. "
+    "Run scripts/seed_e2e_demo_agents.py against the target environment. "
+    "Skipping this assertion would hide real product regressions."
+)
 
         result = _run_agent(headers, agent_id, "screen_resume", {
             "candidate": candidate["parsed_data"],
@@ -305,8 +326,11 @@ class TestResumeScreening:
         candidates, job, rubric = resumes
         candidate = candidates[1]
         agent_id = _get_agent_id(headers, "talent_acquisition")
-        if not agent_id:
-            pytest.skip("No Talent Acquisition agent found")
+        assert agent_id, (
+    "No Talent Acquisition agent found — the demo tenant must have this agent seeded. "
+    "Run scripts/seed_e2e_demo_agents.py against the target environment. "
+    "Skipping this assertion would hide real product regressions."
+)
 
         result = _run_agent(headers, agent_id, "screen_resume", {
             "candidate": candidate["parsed_data"],
@@ -337,8 +361,11 @@ class TestResumeScreening:
         candidates, job, rubric = resumes
         candidate = candidates[2]
         agent_id = _get_agent_id(headers, "talent_acquisition")
-        if not agent_id:
-            pytest.skip("No Talent Acquisition agent found")
+        assert agent_id, (
+    "No Talent Acquisition agent found — the demo tenant must have this agent seeded. "
+    "Run scripts/seed_e2e_demo_agents.py against the target environment. "
+    "Skipping this assertion would hide real product regressions."
+)
 
         result = _run_agent(headers, agent_id, "screen_resume", {
             "candidate": candidate["parsed_data"],
@@ -364,8 +391,11 @@ class TestResumeScreening:
         candidates, job, rubric = resumes
         candidate = candidates[3]
         agent_id = _get_agent_id(headers, "talent_acquisition")
-        if not agent_id:
-            pytest.skip("No Talent Acquisition agent found")
+        assert agent_id, (
+    "No Talent Acquisition agent found — the demo tenant must have this agent seeded. "
+    "Run scripts/seed_e2e_demo_agents.py against the target environment. "
+    "Skipping this assertion would hide real product regressions."
+)
 
         result = _run_agent(headers, agent_id, "screen_resume", {
             "candidate": candidate["parsed_data"],
@@ -381,8 +411,11 @@ class TestResumeScreening:
         candidates, job, rubric = resumes
         candidate = candidates[4]
         agent_id = _get_agent_id(headers, "talent_acquisition")
-        if not agent_id:
-            pytest.skip("No Talent Acquisition agent found")
+        assert agent_id, (
+    "No Talent Acquisition agent found — the demo tenant must have this agent seeded. "
+    "Run scripts/seed_e2e_demo_agents.py against the target environment. "
+    "Skipping this assertion would hide real product regressions."
+)
 
         result = _run_agent(headers, agent_id, "screen_resume", {
             "candidate": candidate["parsed_data"],
@@ -417,8 +450,11 @@ class TestContractAnalysis:
         """CTR-SYNTH-001: Standard SaaS contract — should index without issues."""
         contract = contracts[0]
         agent_id = _get_agent_id(headers, "contract_intelligence")
-        if not agent_id:
-            pytest.skip("No Contract Intelligence agent found")
+        assert agent_id, (
+    "No Contract Intelligence agent found — the demo tenant must have this agent seeded. "
+    "Run scripts/seed_e2e_demo_agents.py against the target environment. "
+    "Skipping this assertion would hide real product regressions."
+)
 
         result = _run_agent(headers, agent_id, "analyze_contract", {
             "contract": contract["parsed_data"],
@@ -432,8 +468,11 @@ class TestContractAnalysis:
         """CTR-SYNTH-002: Unlimited indemnification + non-compete — should escalate."""
         contract = contracts[1]
         agent_id = _get_agent_id(headers, "contract_intelligence")
-        if not agent_id:
-            pytest.skip("No Contract Intelligence agent found")
+        assert agent_id, (
+    "No Contract Intelligence agent found — the demo tenant must have this agent seeded. "
+    "Run scripts/seed_e2e_demo_agents.py against the target environment. "
+    "Skipping this assertion would hide real product regressions."
+)
 
         result = _run_agent(headers, agent_id, "analyze_contract", {
             "contract": contract["parsed_data"],
@@ -457,8 +496,11 @@ class TestContractAnalysis:
         """CTR-SYNTH-003: ₹3.5Cr contract — should flag for review."""
         contract = contracts[2]
         agent_id = _get_agent_id(headers, "contract_intelligence")
-        if not agent_id:
-            pytest.skip("No Contract Intelligence agent found")
+        assert agent_id, (
+    "No Contract Intelligence agent found — the demo tenant must have this agent seeded. "
+    "Run scripts/seed_e2e_demo_agents.py against the target environment. "
+    "Skipping this assertion would hide real product regressions."
+)
 
         result = _run_agent(headers, agent_id, "analyze_contract", {
             "contract": contract["parsed_data"],
@@ -475,8 +517,11 @@ class TestContractAnalysis:
         """CTR-SYNTH-004: Contract expiring in 45 days — should flag renewal."""
         contract = contracts[3]
         agent_id = _get_agent_id(headers, "contract_intelligence")
-        if not agent_id:
-            pytest.skip("No Contract Intelligence agent found")
+        assert agent_id, (
+    "No Contract Intelligence agent found — the demo tenant must have this agent seeded. "
+    "Run scripts/seed_e2e_demo_agents.py against the target environment. "
+    "Skipping this assertion would hide real product regressions."
+)
 
         result = _run_agent(headers, agent_id, "analyze_contract", {
             "contract": contract["parsed_data"],

--- a/tests/unit/test_ca_workflows.py
+++ b/tests/unit/test_ca_workflows.py
@@ -237,8 +237,15 @@ class TestAllWorkflowsCompanyScoped:
     )
     def test_company_scoped_flag(self, filename: str):
         path = WORKFLOWS_DIR / filename
-        if not path.exists():
-            pytest.skip(f"{filename} not found")
+        # Zero-skip rule: a missing workflow template is a real product
+        # regression, not something to hide with `pytest.skip`. The CA
+        # workflow library shipped these filenames; absence means a
+        # refactor forgot one.
+        assert path.exists(), (
+            f"{filename} must exist in core/workflows/templates — "
+            "the CA pack advertises these workflows and losing one is "
+            "a silent feature deletion."
+        )
         wf = _load_yaml(path)
         assert wf.get("company_scoped") is True, (
             f"{filename} must have company_scoped: true"


### PR DESCRIPTION
## Summary

Enterprise Readiness Plan **Phase 8 / PR-D slice 1**. First batch of backend zero-skip work — the same cleanup applied to Playwright specs in #194 (\`feedback_no_skip_full_coverage\`) now extended to pytest.

### Problem

Sixteen \`pytest.skip(...)\` sites were silently pretending to pass when the preconditions they fabricated weren't met. Two categories:

- **15× "No X agent found"** in \`tests/synthetic_data/test_synthetic_flows.py\`: \`if not agent_id: pytest.skip("No AP Processor agent found")\`. A failed seed run (very plausible in CI) skipped every synthetic-flow test silently — giving the illusion of green signal while literally no agent ran.
- **1× "file not found"** in \`tests/unit/test_ca_workflows.py:241\`: a missing workflow template file skipped instead of failing.

Both are exactly what your \`feedback_no_skip_full_coverage.md\` memory warns against: a skipped test is a latent failure, not a pass.

### What this PR does

- **\`tests/synthetic_data/test_synthetic_flows.py\`** — 15 sites rewritten from \`if not agent_id: pytest.skip(...)\` to \`assert agent_id, "<seed pointer>"\`. Covers AP Processor, Talent Acquisition, and Contract Intelligence flows. Failed seed → test fails loudly with a pointer to \`scripts/seed_e2e_demo_agents.py\`.
- **\`tests/unit/test_ca_workflows.py:241\`** — converted to \`assert path.exists(), ...\` with an explanation.

### Out of scope (tracked for PR-D2)

- 12 \`skipif(not AGENTICORG_DB_URL)\` sites in unit tests — needs CI to provision the DB URL in the \`unit-tests\` job (currently only \`integration-tests\` has it).
- 4 dep-missing \`skipif\` (presidio / pypdf / PyYAML / composio-core) — needs pyproject.toml \`[project.optional-dependencies].test\` group.
- 4 E2E-token \`pytest.skip\` sites — will migrate once the fresh-E2E-token step is guaranteed in all jobs.

## Test plan

- [ ] Branch CI lint / unit / integration green.
- [ ] Main CI e2e post-deploy: synthetic-flow step now reports real pass/fail instead of silent skips.
- [ ] No regression in pytest pass count (2847 passing locally before, 2847 after minus the one Redis-env flake that's pre-existing).

@codex please review