### PR TITLE
feat(ux): real Dashboard KPIs + explicit /access-denied page (PR-C2)

### DIFF
--- a/ui/e2e/dashboard-403.spec.ts
+++ b/ui/e2e/dashboard-403.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Dashboard KPIs + 403 UX drift guard — PR-C2.
+ *
+ * Two Phase-6 invariants:
+ *
+ *  1. Dashboard metrics strip carries no hardcoded KPIs. Specifically,
+ *     the old "Deflection Rate 73%" card (fabricated, no backing API)
+ *     must never come back. "Approvals Resolved" replaces it and is
+ *     computed from `/approvals`.
+ *
+ *  2. Unauthorized role → explicit `/dashboard/access-denied` page,
+ *     not a silent redirect to `/dashboard/audit`. The page tells the
+ *     user what was blocked and why.
+ */
+import { expect, test } from "@playwright/test";
+
+const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
+const E2E_TOKEN = process.env.E2E_TOKEN || "";
+const canAuth = !!E2E_TOKEN;
+
+function requireAuth(): void {
+  if (!canAuth) {
+    throw new Error(
+      "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+    );
+  }
+}
+
+async function seedSession(
+  page: import("@playwright/test").Page,
+  role: string,
+): Promise<void> {
+  await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
+  await page.evaluate(
+    ([t, r]) => {
+      localStorage.setItem("token", t);
+      localStorage.setItem(
+        "user",
+        JSON.stringify({
+          email: "demo@cafirm.agenticorg.ai",
+          name: "Demo Partner",
+          role: r,
+          domain: r === "admin" ? "all" : "finance",
+          tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
+          onboardingComplete: true,
+        }),
+      );
+    },
+    [E2E_TOKEN, role],
+  );
+}
+
+test.describe("Dashboard metrics — no hardcoded KPIs", () => {
+  test.beforeEach(async ({ page }) => {
+    requireAuth();
+    await seedSession(page, "admin");
+  });
+
+  test("Deflection Rate 73% hardcoded KPI is gone", async ({ page }) => {
+    await page.goto(`${APP}/dashboard`, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle").catch(() => {});
+    const body = (await page.textContent("body")) || "";
+    expect(body, "stale hardcoded 'Deflection Rate' card removed").not.toContain(
+      "Deflection Rate",
+    );
+    expect(body, "stale hardcoded '73%' KPI removed").not.toMatch(/\b73%\b.*Auto-resolved/);
+    expect(body, "stale hardcoded Auto-resolved subtitle removed").not.toContain(
+      "Auto-resolved support tickets",
+    );
+  });
+
+  test("Approvals Resolved KPI is sourced — not a fabricated constant", async ({
+    page,
+  }) => {
+    await page.goto(`${APP}/dashboard`, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle").catch(() => {});
+    // "Approvals Resolved" card must exist. Its value is either a
+    // percentage derived from the live count or "—" when there are
+    // no approvals at all. Crucially it is NOT a fixed number.
+    const label = page.getByText("Approvals Resolved").first();
+    await expect(label).toBeVisible({ timeout: 15000 });
+  });
+});
+
+test.describe("403 Access Denied page", () => {
+  test("Non-auditor role hitting /dashboard/audit lands on /dashboard/access-denied", async ({
+    page,
+  }) => {
+    requireAuth();
+    // The CFO role isn't in the audit page's allowedRoles for this
+    // test's purposes — we seed CFO and navigate to a route that only
+    // admin/auditor can reach. Using settings since settings only
+    // admits admin.
+    await seedSession(page, "cfo");
+    await page.goto(`${APP}/dashboard/settings`, { waitUntil: "domcontentloaded" });
+
+    // Expect the explicit access-denied page to render; NOT a silent
+    // redirect to /dashboard/audit (the pre-PR-C2 behaviour).
+    await expect(page).toHaveURL(/\/dashboard\/access-denied/);
+    const card = page.getByTestId("access-denied");
+    await expect(card).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId("access-denied-role")).toContainText("cfo");
+  });
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -52,6 +52,7 @@ const Schemas = lazyRetry(() => import("./pages/Schemas"));
 const Audit = lazyRetry(() => import("./pages/Audit"));
 const Observatory = lazyRetry(() => import("./pages/Observatory"));
 const Settings = lazyRetry(() => import("./pages/Settings"));
+const AccessDenied = lazyRetry(() => import("./pages/AccessDenied"));
 const Onboarding = lazyRetry(() => import("./pages/Onboarding"));
 const SLAMonitor = lazyRetry(() => import("./pages/SLAMonitor"));
 const PromptTemplates = lazyRetry(() => import("./pages/PromptTemplates"));
@@ -478,6 +479,16 @@ export default function App() {
           <ProtectedRoute allowedRoles={["admin", "cfo", "chro", "cmo", "coo", "auditor"]}>
             <Layout>
               <Audit />
+            </Layout>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/dashboard/access-denied"
+        element={
+          <ProtectedRoute>
+            <Layout>
+              <AccessDenied />
             </Layout>
           </ProtectedRoute>
         }

--- a/ui/src/components/ProtectedRoute.tsx
+++ b/ui/src/components/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 
 interface ProtectedRouteProps {
@@ -8,6 +8,8 @@ interface ProtectedRouteProps {
 
 export default function ProtectedRoute({ children, allowedRoles }: ProtectedRouteProps) {
   const { isAuthenticated, user } = useAuth();
+  const location = useLocation();
+
   if (!isAuthenticated) return <Navigate to="/login" replace />;
   // Fail closed: if the session has a token but no hydrated user
   // object (e.g. after SSO flow where /auth/me failed), treat the
@@ -15,7 +17,21 @@ export default function ProtectedRoute({ children, allowedRoles }: ProtectedRout
   // accessing role-gated routes.
   if (allowedRoles && !user) return <Navigate to="/login" replace />;
   if (allowedRoles && user && !allowedRoles.includes(user.role)) {
-    return <Navigate to="/dashboard/audit" replace />;
+    // PR-C2: explicit 403 page instead of silently redirecting to
+    // /dashboard/audit. The old redirect confused users ("why am I on
+    // the audit page?") and masked RBAC behaviour. The access-denied
+    // page tells them what was blocked and why.
+    return (
+      <Navigate
+        to="/dashboard/access-denied"
+        replace
+        state={{
+          attemptedPath: location.pathname,
+          allowedRoles,
+          currentRole: user.role,
+        }}
+      />
+    );
   }
   return <>{children}</>;
 }

--- a/ui/src/pages/AccessDenied.tsx
+++ b/ui/src/pages/AccessDenied.tsx
@@ -1,0 +1,102 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { Helmet } from "react-helmet-async";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/contexts/AuthContext";
+
+/**
+ * AccessDenied — explicit 403 UX for role-gated routes.
+ *
+ * Before Enterprise Readiness PR-C2, `ProtectedRoute` silently redirected
+ * unauthorized users to `/dashboard/audit`. That was confusing ("why am I
+ * on the audit page?") and masked RBAC behavior. Now unauthorized access
+ * lands here with the actual reason, the user's current role, and the
+ * required role(s).
+ *
+ * The router passes the attempted path + allowed roles via location
+ * state so the page can explain what was denied and why.
+ */
+interface AccessDeniedState {
+  attemptedPath?: string;
+  allowedRoles?: string[];
+  currentRole?: string;
+}
+
+export default function AccessDenied() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const state = (location.state as AccessDeniedState | null) || {};
+
+  const attemptedPath = state.attemptedPath || "this page";
+  const allowedRoles = state.allowedRoles || [];
+  const currentRole = state.currentRole || user?.role || "unknown";
+
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center p-6">
+      <Helmet>
+        <title>Access Denied — AgenticOrg</title>
+      </Helmet>
+      <Card className="max-w-xl w-full" data-testid="access-denied">
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-full bg-red-100 text-red-600 flex items-center justify-center text-xl font-bold">
+              403
+            </div>
+            <div>
+              <CardTitle>Access denied</CardTitle>
+              <p className="text-sm text-muted-foreground mt-1">
+                Your current role can't view{" "}
+                <code className="text-xs bg-muted px-1 rounded">{attemptedPath}</code>.
+              </p>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <span className="text-xs text-muted-foreground uppercase tracking-wide">
+                Your role
+              </span>
+              <p
+                data-testid="access-denied-role"
+                className="font-mono text-sm mt-1"
+              >
+                {currentRole}
+              </p>
+            </div>
+            <div>
+              <span className="text-xs text-muted-foreground uppercase tracking-wide">
+                Required role{allowedRoles.length > 1 ? "s" : ""}
+              </span>
+              <p
+                data-testid="access-denied-required"
+                className="font-mono text-sm mt-1"
+              >
+                {allowedRoles.length > 0 ? allowedRoles.join(" | ") : "admin"}
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+            <p>
+              RBAC is enforced server-side. Even if the UI could show this
+              route, the API would reject writes from your role. If you
+              need access, ask a tenant admin to grant the required role
+              or a matching scope.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button onClick={() => navigate("/dashboard")} variant="default">
+              Back to dashboard
+            </Button>
+            <Button onClick={() => navigate(-1)} variant="outline">
+              Go back
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -113,12 +113,31 @@ export default function Dashboard() {
   // Pending approval items
   const pendingItems = approvals.filter((a) => a.status === "pending");
 
+  // P6.1 (Enterprise Readiness): every metric is derived from real data
+  // pulled above. The old hardcoded "Deflection Rate 73%" card was removed
+  // — it was a fabricated KPI with no backing API, exactly the decorative
+  // state the plan bans. "Approvals Resolved" is a real ratio computed
+  // from the approvals we already fetched.
+  const resolvedApprovals = approvals.filter(
+    (a) => a.status !== "pending" && a.status !== "expired",
+  ).length;
+  const resolvedPct = approvals.length > 0
+    ? Math.round((resolvedApprovals / approvals.length) * 100)
+    : 0;
+
   const metrics = [
     { label: "Total Agents", value: totalAgents, color: "text-foreground", subtitle: "" },
     { label: "Active Agents", value: activeAgents, color: "text-green-600", subtitle: "" },
     { label: "Pending Approvals", value: pendingApprovals, color: "text-red-600", subtitle: "" },
     { label: "Shadow Agents", value: shadowAgents, color: "text-yellow-600", subtitle: "" },
-    { label: "Deflection Rate", value: "73%", color: "text-green-600", subtitle: "Auto-resolved support tickets" },
+    {
+      label: "Approvals Resolved",
+      value: approvals.length > 0 ? `${resolvedPct}%` : "—",
+      color: "text-green-600",
+      subtitle: approvals.length > 0
+        ? `${resolvedApprovals}/${approvals.length} decisions`
+        : "No approvals logged",
+    },
   ];
 
   if (loading) {


### PR DESCRIPTION
## Summary

Enterprise Readiness Plan **Phase 6** (Dashboard & IA truth). Two decorative-state violations fixed.

### 1. Hardcoded "Deflection Rate 73%" card — removed

\`ui/src/pages/Dashboard.tsx\` shipped a fabricated KPI with no backing API (\`{ label: "Deflection Rate", value: "73%", ... }\`). Replaced with **Approvals Resolved** — computed live from \`/approvals\` data already in state. Shows \`N% (X/Y decisions)\` when there are approvals, \`—\` (em-dash) when none.

### 2. Silent 403 redirect — replaced with explicit page

\`ProtectedRoute\` used to redirect unauthorized roles to \`/dashboard/audit\` (a random unrelated page). Users saw the audit log and thought the app was broken, not that RBAC had blocked them. Now unauthorized access lands on **\`/dashboard/access-denied\`** — new \`ui/src/pages/AccessDenied.tsx\` renders:
- Attempted path (in code tag)
- Your current role
- Required role(s)
- Reminder that RBAC is enforced server-side too
- "Back to dashboard" + "Go back" actions

Location state carries \`{ attemptedPath, allowedRoles, currentRole }\` so the page can explain the specific denial.

### Drift guard (\`ui/e2e/dashboard-403.spec.ts\`)

1. Dashboard body must not contain "Deflection Rate" / "73% Auto-resolved" / "Auto-resolved support tickets" — ever.
2. "Approvals Resolved" label is visible.
3. CFO role hitting \`/dashboard/settings\` (admin-only) lands on \`/dashboard/access-denied\`, shows the AccessDenied card, and the "Your role" field reads \`cfo\`.

### Scope

- No backend change, no migration.
- No skip primitives introduced.
- Existing Dashboard behaviour preserved for all other cards.

## Test plan

- [ ] Preflight green locally (done).
- [ ] Branch CI lint / unit / integration green.
- [ ] \`bash scripts/local_e2e.sh ui/e2e/dashboard-403.spec.ts\` passes.
- [ ] Main CI e2e post-deploy: new spec green; existing dashboard specs unchanged.

@codex please review