### PR TITLE
feat(workflows): backend-driven template catalog (PR-C3)

### DIFF
--- a/api/v1/workflows.py
+++ b/api/v1/workflows.py
@@ -181,6 +181,23 @@ async def generate_workflow_endpoint(
     }
 
 
+# ── GET /workflows/templates ────────────────────────────────────────────────
+@router.get("/workflows/templates")
+async def list_workflow_templates(domain: str | None = None):
+    """Return the workflow-template catalog, optionally filtered by domain.
+
+    Source of truth is `core/workflows/template_catalog.py`. Before
+    PR-C3 (Enterprise Readiness Phase 7.2) this catalog was a
+    hardcoded array in `ui/src/pages/Workflows.tsx`; the UI now fetches
+    from here so adding / renaming a template no longer needs a UI
+    code change and a deploy.
+    """
+    from core.workflows.template_catalog import list_templates
+
+    items = list_templates(domain=domain)
+    return {"items": items, "total": len(items)}
+
+
 # ── GET /workflows ───────────────────────────────────────────────────────────
 @router.get("/workflows", response_model=PaginatedResponse)
 async def list_workflows(

--- a/core/workflows/template_catalog.py
+++ b/core/workflows/template_catalog.py
@@ -1,0 +1,115 @@
+"""Workflow template catalog — single source of truth for the
+"Templates" tab on the Workflows page.
+
+Before PR-C3 this catalog lived as a hardcoded 21-entry array in
+`ui/src/pages/Workflows.tsx`. That meant adding or renaming a template
+required a UI code change and a deploy. The catalog is now served by
+`GET /api/v1/workflows/templates` and the UI consumes it.
+
+Each template here is metadata only — name, description, domain, step
+count, trigger kind. The actual workflow graph is produced when the
+user picks a template and the UI routes to the Create Workflow page
+with the template id.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class WorkflowTemplate:
+    id: str
+    name: str
+    description: str
+    domain: str  # finance | hr | marketing | ops
+    steps: int
+    trigger: str  # schedule | api_event | manual | email_received
+
+
+TEMPLATES: list[WorkflowTemplate] = [
+    # Finance
+    WorkflowTemplate("tpl-invoice-processing", "Invoice Processing",
+                     "Automatically extract, validate, and route invoices for approval based on amount thresholds.",
+                     "finance", 5, "api_event"),
+    WorkflowTemplate("tpl-bank-reconciliation", "Bank Reconciliation",
+                     "Match bank statement entries with ledger transactions and flag discrepancies for review.",
+                     "finance", 4, "schedule"),
+    WorkflowTemplate("tpl-month-end-close", "Month-End Close",
+                     "Orchestrate journal entries, accruals, reconciliations, and reporting for month-end close.",
+                     "finance", 8, "schedule"),
+    WorkflowTemplate("tpl-gst-filing", "GST Filing",
+                     "Collect sales and purchase data, compute GST liability, and prepare GSTR-1/3B filings.",
+                     "finance", 6, "schedule"),
+    WorkflowTemplate("tpl-expense-approval", "Expense Approval",
+                     "Route expense reports through policy checks and multi-level approval chains.",
+                     "finance", 4, "api_event"),
+    # HR
+    WorkflowTemplate("tpl-payroll-processing", "Payroll Processing",
+                     "Calculate salaries, deductions, taxes, and generate payslips for all employees.",
+                     "hr", 6, "schedule"),
+    WorkflowTemplate("tpl-employee-onboarding", "Employee Onboarding",
+                     "Provision accounts, assign equipment, schedule orientation, and notify stakeholders in parallel.",
+                     "hr", 7, "api_event"),
+    WorkflowTemplate("tpl-leave-approval", "Leave Approval",
+                     "Validate leave balance, check team coverage, and route to manager for approval.",
+                     "hr", 3, "api_event"),
+    WorkflowTemplate("tpl-performance-review", "Performance Review Cycle",
+                     "Initiate self-assessments, collect manager ratings, calibrate scores, and finalize reviews.",
+                     "hr", 6, "schedule"),
+    WorkflowTemplate("tpl-talent-screening", "Talent Screening",
+                     "Parse resumes, score candidates against job requirements, and shortlist for interviews.",
+                     "hr", 5, "api_event"),
+    # Marketing
+    WorkflowTemplate("tpl-campaign-launch", "Campaign Launch",
+                     "Coordinate creative assets, audience targeting, channel setup, and launch across platforms.",
+                     "marketing", 6, "manual"),
+    WorkflowTemplate("tpl-lead-scoring", "Lead Scoring",
+                     "Evaluate inbound leads using firmographic, behavioral, and engagement signals.",
+                     "marketing", 4, "api_event"),
+    WorkflowTemplate("tpl-content-publishing", "Content Publishing",
+                     "Draft, review, optimize for SEO, and publish content across blog and social channels.",
+                     "marketing", 5, "manual"),
+    WorkflowTemplate("tpl-social-media-calendar", "Social Media Calendar",
+                     "Plan, schedule, and auto-publish posts across social media platforms on a weekly cadence.",
+                     "marketing", 4, "schedule"),
+    WorkflowTemplate("tpl-email-drip-campaign", "Email Drip Campaign",
+                     "Enroll contacts, send sequenced emails, track engagement, and branch based on actions.",
+                     "marketing", 5, "api_event"),
+    # Ops
+    WorkflowTemplate("tpl-support-ticket-triage", "Support Ticket Triage",
+                     "Classify incoming tickets by urgency and topic, then route to the appropriate support tier.",
+                     "ops", 4, "api_event"),
+    WorkflowTemplate("tpl-it-asset-provisioning", "IT Asset Provisioning",
+                     "Allocate laptops, software licenses, and cloud accounts for new hires or role changes.",
+                     "ops", 5, "api_event"),
+    WorkflowTemplate("tpl-vendor-onboarding", "Vendor Onboarding",
+                     "Collect vendor documents, verify compliance, set up payment details, and approve registration.",
+                     "ops", 5, "manual"),
+    WorkflowTemplate("tpl-contract-renewal", "Contract Renewal",
+                     "Track contract expiry dates, notify stakeholders, negotiate terms, and execute renewals.",
+                     "ops", 5, "schedule"),
+    WorkflowTemplate("tpl-compliance-audit", "Compliance Audit",
+                     "Gather evidence, run control checks, flag exceptions, and generate audit reports.",
+                     "ops", 6, "schedule"),
+    WorkflowTemplate("tpl-report-generation", "Report Generation",
+                     "Aggregate data from multiple sources, generate formatted reports, "
+                     "and distribute to stakeholders.",
+                     "ops", 4, "schedule"),
+]
+
+
+def list_templates(domain: str | None = None) -> list[dict]:
+    """Return the catalog, optionally filtered by domain."""
+    items = [t for t in TEMPLATES if domain is None or t.domain == domain]
+    return [
+        {
+            "id": t.id,
+            "name": t.name,
+            "description": t.description,
+            "domain": t.domain,
+            "steps": t.steps,
+            "trigger": t.trigger,
+        }
+        for t in items
+    ]

--- a/ui/e2e/workflow-templates.spec.ts
+++ b/ui/e2e/workflow-templates.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Workflow template catalog drift guard — Phase 7 P7.2 (PR-C3).
+ *
+ * Pre-PR-C3 `ui/src/pages/Workflows.tsx` embedded a 21-entry hardcoded
+ * WORKFLOW_TEMPLATES array. The backend now owns the catalog via
+ * `GET /api/v1/workflows/templates` (single source:
+ * `core/workflows/template_catalog.py`).
+ *
+ * Asserts:
+ *  1. The endpoint returns items with the canonical shape.
+ *  2. The Templates tab renders exactly one card per backend item.
+ */
+import { expect, test } from "@playwright/test";
+
+const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
+const E2E_TOKEN = process.env.E2E_TOKEN || "";
+const canAuth = !!E2E_TOKEN;
+
+function requireAuth(): void {
+  if (!canAuth) {
+    throw new Error(
+      "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+    );
+  }
+}
+
+async function seedSession(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
+  await page.evaluate((t) => {
+    localStorage.setItem("token", t);
+    localStorage.setItem(
+      "user",
+      JSON.stringify({
+        email: "demo@cafirm.agenticorg.ai",
+        name: "Demo Partner",
+        role: "admin",
+        domain: "all",
+        tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
+        onboardingComplete: true,
+      }),
+    );
+  }, E2E_TOKEN);
+}
+
+test.describe("Workflow templates — backend-driven catalog", () => {
+  test.beforeEach(async ({ page }) => {
+    requireAuth();
+    await seedSession(page);
+  });
+
+  test("GET /workflows/templates returns canonical items", async ({ request }) => {
+    const resp = await request.get(`${APP}/api/v1/workflows/templates`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+    });
+    expect(resp.status(), "GET /workflows/templates").toBe(200);
+    const data = await resp.json();
+    expect(Array.isArray(data?.items), "data.items array").toBe(true);
+    expect(data.total, "data.total").toBeGreaterThan(0);
+
+    const first = data.items[0];
+    for (const key of ["id", "name", "description", "domain", "steps", "trigger"]) {
+      expect(first, `template item missing '${key}'`).toHaveProperty(key);
+    }
+  });
+
+  test("Templates tab renders one card per backend item", async ({ page, request }) => {
+    const registryLoaded = page.waitForResponse(
+      (r) => r.url().includes("/api/v1/workflows/templates") && r.request().method() === "GET",
+      { timeout: 30000 },
+    );
+    await page.goto(`${APP}/dashboard/workflows`, { waitUntil: "domcontentloaded" });
+    const registryResp = await registryLoaded;
+    const registryData = await registryResp.json();
+    const items: Array<{ id: string }> = registryData.items ?? [];
+
+    // Switch to Templates tab.
+    await page.getByRole("button", { name: /Templates/i }).first().click();
+
+    const grid = page.getByTestId("templates-grid");
+    await expect(grid).toBeVisible({ timeout: 15000 });
+
+    const cards = page.locator('[data-testid^="use-template-"]');
+    const cardCount = await cards.count();
+    expect(
+      cardCount,
+      `UI rendered ${cardCount} cards, backend returned ${items.length}`,
+    ).toBe(items.length);
+  });
+});

--- a/ui/src/pages/Workflows.tsx
+++ b/ui/src/pages/Workflows.tsx
@@ -6,6 +6,13 @@ import { Badge } from "@/components/ui/badge";
 import api from "@/lib/api";
 import type { Workflow } from "@/types";
 
+/**
+ * Workflow template catalog item — shape returned by
+ * `GET /api/v1/workflows/templates` (Enterprise Readiness P7.2 / PR-C3).
+ * Pre-PR-C3 the UI embedded a 21-entry hardcoded array that drifted
+ * away from the backend. The catalog is now backend-served so adding
+ * / renaming a template doesn't require a UI code change.
+ */
 interface WorkflowTemplate {
   id: string;
   name: string;
@@ -14,30 +21,6 @@ interface WorkflowTemplate {
   steps: number;
   trigger: string;
 }
-
-const WORKFLOW_TEMPLATES: WorkflowTemplate[] = [
-  { id: "tpl-invoice-processing", name: "Invoice Processing", description: "Automatically extract, validate, and route invoices for approval based on amount thresholds.", domain: "finance", steps: 5, trigger: "api_event" },
-  { id: "tpl-bank-reconciliation", name: "Bank Reconciliation", description: "Match bank statement entries with ledger transactions and flag discrepancies for review.", domain: "finance", steps: 4, trigger: "schedule" },
-  { id: "tpl-month-end-close", name: "Month-End Close", description: "Orchestrate journal entries, accruals, reconciliations, and reporting for month-end close.", domain: "finance", steps: 8, trigger: "schedule" },
-  { id: "tpl-gst-filing", name: "GST Filing", description: "Collect sales and purchase data, compute GST liability, and prepare GSTR-1/3B filings.", domain: "finance", steps: 6, trigger: "schedule" },
-  { id: "tpl-expense-approval", name: "Expense Approval", description: "Route expense reports through policy checks and multi-level approval chains.", domain: "finance", steps: 4, trigger: "api_event" },
-  { id: "tpl-payroll-processing", name: "Payroll Processing", description: "Calculate salaries, deductions, taxes, and generate payslips for all employees.", domain: "hr", steps: 6, trigger: "schedule" },
-  { id: "tpl-employee-onboarding", name: "Employee Onboarding", description: "Provision accounts, assign equipment, schedule orientation, and notify stakeholders in parallel.", domain: "hr", steps: 7, trigger: "api_event" },
-  { id: "tpl-leave-approval", name: "Leave Approval", description: "Validate leave balance, check team coverage, and route to manager for approval.", domain: "hr", steps: 3, trigger: "api_event" },
-  { id: "tpl-performance-review", name: "Performance Review Cycle", description: "Initiate self-assessments, collect manager ratings, calibrate scores, and finalize reviews.", domain: "hr", steps: 6, trigger: "schedule" },
-  { id: "tpl-talent-screening", name: "Talent Screening", description: "Parse resumes, score candidates against job requirements, and shortlist for interviews.", domain: "hr", steps: 5, trigger: "api_event" },
-  { id: "tpl-campaign-launch", name: "Campaign Launch", description: "Coordinate creative assets, audience targeting, channel setup, and launch across platforms.", domain: "marketing", steps: 6, trigger: "manual" },
-  { id: "tpl-lead-scoring", name: "Lead Scoring", description: "Evaluate inbound leads using firmographic, behavioral, and engagement signals.", domain: "marketing", steps: 4, trigger: "api_event" },
-  { id: "tpl-content-publishing", name: "Content Publishing", description: "Draft, review, optimize for SEO, and publish content across blog and social channels.", domain: "marketing", steps: 5, trigger: "manual" },
-  { id: "tpl-social-media-calendar", name: "Social Media Calendar", description: "Plan, schedule, and auto-publish posts across social media platforms on a weekly cadence.", domain: "marketing", steps: 4, trigger: "schedule" },
-  { id: "tpl-email-drip-campaign", name: "Email Drip Campaign", description: "Enroll contacts, send sequenced emails, track engagement, and branch based on actions.", domain: "marketing", steps: 5, trigger: "api_event" },
-  { id: "tpl-support-ticket-triage", name: "Support Ticket Triage", description: "Classify incoming tickets by urgency and topic, then route to the appropriate support tier.", domain: "ops", steps: 4, trigger: "api_event" },
-  { id: "tpl-it-asset-provisioning", name: "IT Asset Provisioning", description: "Allocate laptops, software licenses, and cloud accounts for new hires or role changes.", domain: "ops", steps: 5, trigger: "api_event" },
-  { id: "tpl-vendor-onboarding", name: "Vendor Onboarding", description: "Collect vendor documents, verify compliance, set up payment details, and approve registration.", domain: "ops", steps: 5, trigger: "manual" },
-  { id: "tpl-contract-renewal", name: "Contract Renewal", description: "Track contract expiry dates, notify stakeholders, negotiate terms, and execute renewals.", domain: "ops", steps: 5, trigger: "schedule" },
-  { id: "tpl-compliance-audit", name: "Compliance Audit", description: "Gather evidence, run control checks, flag exceptions, and generate audit reports.", domain: "ops", steps: 6, trigger: "schedule" },
-  { id: "tpl-report-generation", name: "Report Generation", description: "Aggregate data from multiple sources, generate formatted reports, and distribute to stakeholders.", domain: "ops", steps: 4, trigger: "schedule" },
-];
 
 type WorkflowsTab = "my-workflows" | "templates";
 
@@ -48,8 +31,13 @@ export default function Workflows() {
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<WorkflowsTab>("my-workflows");
 
+  // PR-C3: template catalog now sourced from GET /workflows/templates.
+  const [templates, setTemplates] = useState<WorkflowTemplate[]>([]);
+  const [templatesLoading, setTemplatesLoading] = useState(true);
+
   useEffect(() => {
     fetchWorkflows();
+    fetchTemplates();
   }, []);
 
   async function fetchWorkflows() {
@@ -62,6 +50,20 @@ export default function Workflows() {
       setWorkflows([]);
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function fetchTemplates() {
+    setTemplatesLoading(true);
+    try {
+      const { data } = await api.get<{ items: WorkflowTemplate[]; total: number }>(
+        "/workflows/templates",
+      );
+      setTemplates(Array.isArray(data?.items) ? data.items : []);
+    } catch {
+      setTemplates([]);
+    } finally {
+      setTemplatesLoading(false);
     }
   }
 
@@ -166,9 +168,19 @@ export default function Workflows() {
       )}
 
       {/* Templates tab */}
-      {activeTab === "templates" && (
+      {activeTab === "templates" && templatesLoading && templates.length === 0 && (
+        <p className="text-sm text-muted-foreground" data-testid="templates-loading">
+          Loading templates…
+        </p>
+      )}
+      {activeTab === "templates" && !templatesLoading && templates.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          No templates available. Check that /api/v1/workflows/templates is reachable.
+        </p>
+      )}
+      {activeTab === "templates" && templates.length > 0 && (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" data-testid="templates-grid">
-          {WORKFLOW_TEMPLATES.map((tpl) => (
+          {templates.map((tpl) => (
             <Card key={tpl.id} className="hover:shadow-md transition-shadow flex flex-col">
               <CardHeader className="pb-2">
                 <div className="flex justify-between items-start">


### PR DESCRIPTION
## Summary

Enterprise Readiness Phase 7.2. Pre-PR-C3, \`ui/src/pages/Workflows.tsx\` shipped a 21-entry hardcoded \`WORKFLOW_TEMPLATES\` array; any template add/rename/reclass needed a UI code change + deploy. Same pattern as the P1.1 product-facts + PR-B2 connector catalog work — source of truth moves to backend.

### Changes

- **\`core/workflows/template_catalog.py\`** (new): the 21 templates as \`WorkflowTemplate\` dataclasses; \`list_templates(domain=None)\` returns the list as dicts.
- **\`api/v1/workflows.py\`** — \`GET /workflows/templates\` returns \`{items, total}\` with \`id, name, description, domain, steps, trigger\`. Optional \`?domain=\` filter.
- **\`ui/src/pages/Workflows.tsx\`** — hardcoded array gone. New \`templates\` state + \`fetchTemplates()\` at mount. Render handles loading / empty / grid with test ids \`templates-loading\`, \`templates-grid\`, \`use-template-<id>\`.
- **\`ui/e2e/workflow-templates.spec.ts\`** (new) — two drift guards:
  1. \`/workflows/templates\` returns canonical shape.
  2. Templates tab renders exactly one card per backend item (count match).

### Scope

- No backend data migration.
- No workflow-run path changed.
- No skip primitives introduced.

## Test plan

- [ ] Preflight green locally (done).
- [ ] Branch CI lint / unit / integration green.
- [ ] Main CI e2e post-deploy: new spec green.

@codex please review