### PR TITLE
fix(truth): Grantex status + marketplace Connect decorative freeze (PR-D4)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -39,6 +39,7 @@ from api.v1 import (
     feature_flags,
     governance,
     health,
+    integrations_status,
     invoices,
     knowledge,
     kpis,
@@ -162,6 +163,7 @@ register_error_handlers(app)
 
 app.include_router(health.router, prefix="/api/v1", tags=["Health"])
 app.include_router(product_facts.router, prefix="/api/v1", tags=["Product Facts"])
+app.include_router(integrations_status.router, prefix="/api/v1", tags=["Integrations"])
 app.include_router(v1_auth.router, prefix="/api/v1", tags=["Auth"])
 app.include_router(agents.router, prefix="/api/v1", tags=["Agents"])
 app.include_router(prompt_templates.router, prefix="/api/v1", tags=["Prompt Templates"])

--- a/api/v1/integrations_status.py
+++ b/api/v1/integrations_status.py
@@ -1,0 +1,39 @@
+"""Integration configuration status — backs the Settings page status badges.
+
+Returns boolean flags for each third-party integration indicating whether
+the environment is configured. NEVER returns the secret values themselves.
+
+Prior to this endpoint, `ui/src/pages/Settings.tsx` rendered a hardcoded
+green "Configured" dot next to Grantex regardless of actual config state.
+The P1.2 decorative-state rule requires either a real source of truth or
+an explicit "Not configured" label — this endpoint provides the former.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class IntegrationsStatus(BaseModel):
+    grantex_configured: bool
+    composio_configured: bool
+    ragflow_configured: bool
+
+
+def _env_set(name: str) -> bool:
+    return bool((os.getenv(name) or "").strip())
+
+
+@router.get("/integrations/status", response_model=IntegrationsStatus)
+async def integrations_status() -> IntegrationsStatus:
+    """Boolean config-state report for each third-party integration."""
+    return IntegrationsStatus(
+        grantex_configured=_env_set("GRANTEX_API_KEY"),
+        composio_configured=_env_set("COMPOSIO_API_KEY"),
+        ragflow_configured=_env_set("RAGFLOW_API_URL"),
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,10 @@ cache_dir = "codex-pytest-cache"
 timeout = 60
 timeout_method = "thread"
 addopts = "--basetemp=codex-pytest-basetemp --cov=core --cov=api --cov=auth --cov=workflows --cov=scaling --cov-report=xml --cov-report=term-missing"
+# Coverage floor not enforced here yet — current measured coverage is ~57%
+# and PR-D4 ships the decorative-state work without the floor to avoid a
+# repo-wide CI block. A follow-up will add `--cov-fail-under` once we
+# have a CI run that establishes the real baseline.
 
 [tool.mypy]
 python_version = "3.12"

--- a/ui/e2e/decorative-state.spec.ts
+++ b/ui/e2e/decorative-state.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Decorative-state freeze (Phase 1.2).
+ *
+ * Every screen that previously rendered a hardcoded healthy/configured/
+ * compliant badge must now either reflect a real backend source of truth
+ * OR carry an explicit "Demo" / "Not configured" label. Never both,
+ * never neither.
+ *
+ * Covers:
+ *   - Settings → Grantex Integration → API Key Status:
+ *       reflects /integrations/status.grantex_configured.
+ *   - Connectors → Marketplace tab → Connect button:
+ *       labelled as a Demo preview (UI state only, no OAuth handoff).
+ *
+ * Drift guard: if a regressing PR re-introduces a hardcoded "Configured"
+ * dot or drops the Demo label, these assertions fail.
+ */
+import { expect, test } from "@playwright/test";
+
+const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
+const E2E_TOKEN = process.env.E2E_TOKEN || "";
+const canAuth = !!E2E_TOKEN;
+
+function requireAuth(): void {
+  if (!canAuth) {
+    throw new Error(
+      "E2E_TOKEN is required for this spec. Set the E2E_TOKEN env var — the suite runs against production and must have credentials.",
+    );
+  }
+}
+
+async function seedSession(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
+  await page.evaluate((t) => {
+    localStorage.setItem("token", t);
+    localStorage.setItem(
+      "user",
+      JSON.stringify({
+        email: "demo@cafirm.agenticorg.ai",
+        name: "Demo Partner",
+        role: "admin",
+        domain: "all",
+        tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
+        onboardingComplete: true,
+      }),
+    );
+  }, E2E_TOKEN);
+}
+
+test.describe("Decorative-state freeze (P1.2)", () => {
+  test.beforeEach(async ({ page }) => {
+    requireAuth();
+    await seedSession(page);
+  });
+
+  test("Settings Grantex API Key Status reflects /integrations/status", async ({
+    page,
+    request,
+  }) => {
+    const statusResp = await request.get(`${APP}/api/v1/integrations/status`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+    });
+    expect(statusResp.status(), "GET /integrations/status").toBe(200);
+    const integrations = await statusResp.json();
+
+    await page.goto(`${APP}/dashboard/settings`, { waitUntil: "networkidle" });
+    const badge = page.getByTestId("grantex-api-key-status");
+    await expect(badge, "grantex status badge must render").toBeVisible();
+
+    const text = (await badge.textContent()) || "";
+    if (integrations.grantex_configured) {
+      expect(
+        text.toLowerCase().includes("configured"),
+        `expected 'configured' in badge when grantex_configured=true, got: ${text}`,
+      ).toBe(true);
+    } else {
+      expect(
+        text.toLowerCase().includes("not configured"),
+        `expected 'not configured' in badge when grantex_configured=false, got: ${text}`,
+      ).toBe(true);
+    }
+  });
+
+  test("Connectors Marketplace Connect button is labelled as Demo", async ({
+    page,
+  }) => {
+    await page.goto(`${APP}/dashboard/connectors`, { waitUntil: "networkidle" });
+    await page.getByTestId("tab-marketplace").click();
+
+    // Wait for marketplace cards to render. We don't assert a specific app
+    // name (Composio catalog rotates) — we just need one connect button.
+    const firstConnect = page
+      .locator('[data-testid^="marketplace-connect-"]')
+      .first();
+    await expect(
+      firstConnect,
+      "at least one marketplace Connect button must render",
+    ).toBeVisible({ timeout: 15_000 });
+
+    const label = (await firstConnect.textContent()) || "";
+    expect(
+      label.includes("Demo"),
+      `Connect button must be labelled as Demo, got: '${label}'`,
+    ).toBe(true);
+  });
+});

--- a/ui/src/pages/Connectors.tsx
+++ b/ui/src/pages/Connectors.tsx
@@ -206,7 +206,7 @@ export default function Connectors() {
           onClick={() => setActiveTab("marketplace")}
           className={`px-6 py-3 text-sm font-medium border-b-2 transition-colors ${activeTab === "marketplace" ? "border-primary text-primary" : "border-transparent text-muted-foreground hover:text-primary hover:border-primary/50"}`}
         >
-          Marketplace ({marketplaceTotal || "1000+"})
+          Marketplace{marketplaceTotal > 0 ? ` (${marketplaceTotal})` : ""}
         </button>
       </div>
 
@@ -366,9 +366,13 @@ export default function Connectors() {
                       variant={connectedApps.has(app.key) ? "outline" : "default"}
                       className="w-full"
                       onClick={() => handleConnect(app.key)}
+                      data-testid={`marketplace-connect-${app.key}`}
                     >
-                      {connectedApps.has(app.key) ? "Connected" : "Connect"}
+                      {connectedApps.has(app.key) ? "Connected (Demo)" : "Connect (Demo)"}
                     </Button>
+                    <p className="text-[10px] text-muted-foreground text-center mt-1">
+                      OAuth handoff pending — UI state only
+                    </p>
                   </CardContent>
                 </Card>
               ))}

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -38,6 +38,12 @@ interface GovernanceConfig {
   updated_at: string | null;
 }
 
+interface IntegrationsStatus {
+  grantex_configured: boolean;
+  composio_configured: boolean;
+  ragflow_configured: boolean;
+}
+
 export default function Settings() {
   const [limits, setLimits] = useState<FleetLimits>(DEFAULT_LIMITS);
   const [piiMasking, setPiiMasking] = useState(true);
@@ -50,6 +56,11 @@ export default function Settings() {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Integration status (Grantex/Composio/RAGFlow) — loaded from
+  // /integrations/status so the badges reflect real deployment config
+  // instead of a hardcoded "Configured" dot.
+  const [integrations, setIntegrations] = useState<IntegrationsStatus | null>(null);
 
   // API Keys state
   const [apiKeys, setApiKeys] = useState<ApiKeyRecord[]>([]);
@@ -64,7 +75,17 @@ export default function Settings() {
     fetchSettings();
     fetchGovernance();
     fetchApiKeys();
+    fetchIntegrations();
   }, []);
+
+  async function fetchIntegrations() {
+    try {
+      const { data } = await api.get<IntegrationsStatus>("/integrations/status");
+      setIntegrations(data);
+    } catch {
+      setIntegrations(null);
+    }
+  }
 
   async function fetchSettings() {
     try {
@@ -406,9 +427,26 @@ npx agenticorg-mcp-server`}</code></pre>
             </div>
             <div>
               <label className="text-sm font-medium">API Key Status</label>
-              <div className="flex items-center gap-2 mt-2">
-                <span className="w-2.5 h-2.5 rounded-full bg-green-500" />
-                <span className="text-sm">Configured (stored in GCP Secret Manager)</span>
+              <div
+                className="flex items-center gap-2 mt-2"
+                data-testid="grantex-api-key-status"
+              >
+                {integrations === null ? (
+                  <>
+                    <span className="w-2.5 h-2.5 rounded-full bg-slate-300" />
+                    <span className="text-sm text-muted-foreground">Checking…</span>
+                  </>
+                ) : integrations.grantex_configured ? (
+                  <>
+                    <span className="w-2.5 h-2.5 rounded-full bg-green-500" />
+                    <span className="text-sm">Configured (GRANTEX_API_KEY set)</span>
+                  </>
+                ) : (
+                  <>
+                    <span className="w-2.5 h-2.5 rounded-full bg-amber-500" />
+                    <span className="text-sm">Not configured — set GRANTEX_API_KEY to enable</span>
+                  </>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Phase 1.2 decorative-state freeze, continued. Two UI surfaces still rendered hardcoded "healthy" state without a backend source of truth:

- **Settings → Grantex Integration → API Key Status** — green dot + 'Configured (stored in GCP Secret Manager)' regardless of actual deployment config.
- **Connectors → Marketplace → Connect button** — flipped local React state to 'Connected' with zero OAuth handoff.

### Changes

- \`api/v1/integrations_status.py\` — new \`GET /integrations/status\` returning \`{grantex_configured, composio_configured, ragflow_configured}\`, booleans from env presence. Never leaks secret values.
- \`Settings.tsx\` — fetches on mount, renders live green/amber badge matching actual config state.
- \`Connectors.tsx\` — marketplace Connect button relabelled 'Connect (Demo)' / 'Connected (Demo)' with 'OAuth handoff pending — UI state only' note. Tab label drops the \`|| "1000+"\` fallback so the count is only shown when real.
- \`ui/e2e/decorative-state.spec.ts\` — Playwright drift guard that asserts the Grantex badge matches the API and the marketplace Connect button carries the Demo label.

### Deferred

Coverage floor \`--cov-fail-under\` is intentionally NOT enabled here — current measured coverage is ~57%, and a single cut-off would block every in-flight PR (#203, #205, #206, #207, #208, #209). A follow-up lands the floor once a CI-measured baseline is pinned.

## Test plan

- [x] \`ruff check\` — green
- [x] \`tsc --noEmit\` — green
- [x] \`bash scripts/preflight.sh\` (SKIP_UI/SKIP_PYTEST for speed) — all gates pass
- [ ] Branch CI — unit/lint/security all green
- [ ] \`ui/e2e/decorative-state.spec.ts\` — Playwright drift guard green against local or staging

@codex please review.