### PR TITLE
test(regression): critical-path Playwright tags + enforcement (PR-F3)

### DIFF
--- a/docs/ENTERPRISE_READINESS_CHECKLIST.md
+++ b/docs/ENTERPRISE_READINESS_CHECKLIST.md
@@ -115,9 +115,12 @@ scheduled.
   today. PR-D3 shipped the staging infra (re-exports, migration-check
   allowlist, no-op conftest); the follow-up rewrites these to own their
   async lifecycle + asserts real shapes.
-- [ ] **Critical-path regression tags** (`@auth @tenancy @sdk @mcp
-  @hitl @connector @governance @audit`). Deferred from PR-D4 — once
-  applied, CI enforces that every release has coverage on each tag.
+- [x] **Critical-path regression tags — shipped 2026-04-19 (PR-F3).**
+  `@auth @tenancy @sdk @mcp @hitl @connector @governance @audit` are
+  applied to existing describes (`login-e2e`, `dashboard-403`,
+  `sdk-examples`, `ca-firms` Filing Approvals, `connectors-catalog`,
+  `settings-governance`). `scripts/check_critical_path_tags.py`
+  asserts every tag appears in at least one spec (preflight gate).
 - [ ] **bge-m3 multilingual embeddings upgrade.** bge-small is English+
   only; bge-m3 is 2.3 GB multilingual. Deferred until the pipeline has
   proven itself in CI.

--- a/scripts/check_critical_path_tags.py
+++ b/scripts/check_critical_path_tags.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Enforce that every critical-path Playwright tag appears in ≥1 test.
+
+The Enterprise Readiness plan pins these as the must-have regression
+tags. If the test suite ever stops covering one — because a spec was
+deleted, a describe was re-worded, or nobody tagged the replacement —
+we fail before CI, not after a customer hits the gap.
+
+Usage:
+
+    python scripts/check_critical_path_tags.py [ui/e2e]
+
+Exits 0 if every tag has ≥1 occurrence. Non-zero on first miss.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEFAULT_SPEC_DIR = ROOT / "ui" / "e2e"
+
+CRITICAL_TAGS: list[str] = [
+    "@auth",
+    "@tenancy",
+    "@sdk",
+    "@mcp",
+    "@hitl",
+    "@connector",
+    "@governance",
+    "@audit",
+]
+
+
+def _scan(spec_dir: pathlib.Path) -> dict[str, list[pathlib.Path]]:
+    """Return {tag: [files where it appears]}."""
+    hits: dict[str, list[pathlib.Path]] = {t: [] for t in CRITICAL_TAGS}
+    for path in spec_dir.rglob("*.spec.ts"):
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for tag in CRITICAL_TAGS:
+            # Match @tag as a whole word — not @tagsomething.
+            if re.search(rf"{re.escape(tag)}\b", text):
+                hits[tag].append(path)
+    return hits
+
+
+def main() -> int:
+    spec_dir = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_SPEC_DIR
+    if not spec_dir.exists():
+        print(f"[tags] no such directory: {spec_dir}", file=sys.stderr)
+        return 2
+    print("=" * 60)
+    print(f"Critical-path Playwright tag coverage (spec dir: {spec_dir})")
+    print("=" * 60)
+    hits = _scan(spec_dir)
+    missing: list[str] = []
+    for tag in CRITICAL_TAGS:
+        files = hits[tag]
+        if files:
+            print(f"[OK  ] {tag:<14} in {len(files)} file(s): "
+                  f"{', '.join(f.name for f in files[:3])}"
+                  f"{' ...' if len(files) > 3 else ''}")
+        else:
+            print(f"[FAIL] {tag:<14} not found")
+            missing.append(tag)
+    print("=" * 60)
+    if missing:
+        print(f"{len(missing)} tag(s) uncovered:")
+        for tag in missing:
+            print(f"  - {tag}")
+        return 1
+    print("all critical-path tags covered")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -178,6 +178,18 @@ consistency_sweep() {
 }
 
 # ---------------------------------------------------------------------------
+# 9b. Critical-path Playwright tags — every tag must appear in ≥1 spec
+# so a deleted/renamed describe can't silently drop coverage.
+# ---------------------------------------------------------------------------
+critical_tag_check() {
+  if [[ "$SKIP_TAG_CHECK" == "1" || ! -d "$REPO_ROOT/ui/e2e" ]]; then
+    echo "[preflight] skipped (SKIP_TAG_CHECK=1 or no ui/e2e/)"
+    return 0
+  fi
+  python scripts/check_critical_path_tags.py
+}
+
+# ---------------------------------------------------------------------------
 # Run
 # ---------------------------------------------------------------------------
 run_step "branch safety"          branch_check
@@ -189,6 +201,7 @@ run_step "pytest regression+unit" pytest_check
 run_step "ui tsc"                 ui_check
 run_step "ui build"               ui_build
 run_step "consistency sweep"      consistency_sweep
+run_step "critical-path tags"     critical_tag_check
 
 summary
 echo -e "${GRN}[preflight] all gates passed. Safe to push.${NC}"

--- a/ui/e2e/ca-firms.spec.ts
+++ b/ui/e2e/ca-firms.spec.ts
@@ -525,7 +525,7 @@ test.describe("CA Demo Login Flow", () => {
 //  Filing Approvals
 // ==========================================================================
 
-test.describe("Filing Approvals", () => {
+test.describe("Filing Approvals @hitl", () => {
   test.beforeEach(async ({ page }) => {
     requireAuth();
     await authenticate(page);

--- a/ui/e2e/connectors-catalog.spec.ts
+++ b/ui/e2e/connectors-catalog.spec.ts
@@ -47,7 +47,7 @@ async function seedSession(page: import("@playwright/test").Page): Promise<void>
   }, E2E_TOKEN);
 }
 
-test.describe("Native-connector catalog", () => {
+test.describe("Native-connector catalog @connector", () => {
   test.beforeEach(async ({ page }) => {
     requireAuth();
     await seedSession(page);

--- a/ui/e2e/dashboard-403.spec.ts
+++ b/ui/e2e/dashboard-403.spec.ts
@@ -82,7 +82,7 @@ test.describe("Dashboard metrics — no hardcoded KPIs", () => {
   });
 });
 
-test.describe("403 Access Denied page", () => {
+test.describe("403 Access Denied page @tenancy", () => {
   test("Non-auditor role hitting /dashboard/audit lands on /dashboard/access-denied", async ({
     page,
   }) => {

--- a/ui/e2e/login-e2e.spec.ts
+++ b/ui/e2e/login-e2e.spec.ts
@@ -17,7 +17,7 @@ function requireAuth(): void {
 }
 
 
-test.describe("Login Page — Rendering & Validation", () => {
+test.describe("Login Page — Rendering & Validation @auth", () => {
   test("login page renders with email and password fields", async ({ page }) => {
     await page.goto(`${APP}/login`, { waitUntil: "networkidle" });
     await expect(page.locator('input[type="email"]')).toBeVisible({ timeout: 10000 });
@@ -79,7 +79,7 @@ test.describe("Login Page — Rendering & Validation", () => {
   });
 });
 
-test.describe("Login Page — Auth Flow", () => {
+test.describe("Login Page — Auth Flow @auth", () => {
   test.describe.configure({ mode: "serial" });
 
   test("unauthenticated /dashboard redirects to /login", async ({ page }) => {

--- a/ui/e2e/sdk-examples.spec.ts
+++ b/ui/e2e/sdk-examples.spec.ts
@@ -21,7 +21,7 @@ function requireAuth(): void {
   }
 }
 
-test.describe("Integrations page SDK snippet", () => {
+test.describe("Integrations page SDK snippet @sdk @mcp", () => {
   test("Python snippet references AgentRunResult and canonical fields", async ({ page }) => {
     requireAuth();
 

--- a/ui/e2e/settings-governance.spec.ts
+++ b/ui/e2e/settings-governance.spec.ts
@@ -44,7 +44,7 @@ async function seedSession(page: import("@playwright/test").Page): Promise<void>
   }, E2E_TOKEN);
 }
 
-test.describe("Settings → Compliance & Data governance", () => {
+test.describe("Settings → Compliance & Data governance @governance @audit", () => {
   test.beforeEach(async ({ page }) => {
     requireAuth();
     await seedSession(page);


### PR DESCRIPTION
## Summary

Closes "Critical-path regression tags" residual risk.

- Tags applied to existing describes:
  - \`@auth\` — login-e2e.spec.ts (2 describes)
  - \`@tenancy\` — dashboard-403.spec.ts (403 Access Denied)
  - \`@sdk\` \`@mcp\` — sdk-examples.spec.ts
  - \`@hitl\` — ca-firms.spec.ts (Filing Approvals)
  - \`@connector\` — connectors-catalog.spec.ts
  - \`@governance\` \`@audit\` — settings-governance.spec.ts
- New: \`scripts/check_critical_path_tags.py\` — fails when any of the 8 critical tags drops out of the suite. Preflight gate; \`SKIP_TAG_CHECK=1\` opts out.
- Tag syntax: Playwright's title-@tag convention, so \`npx playwright test --grep @governance\` works.

## Test plan

- [x] \`python scripts/check_critical_path_tags.py\` — all 8 tags covered
- [x] \`ruff check\` — clean
- [ ] Branch CI green

@codex please review.