### PR TITLE
fix(truth): widen consistency sweep to mcp-server + llms.txt; scrub stale claims (PR-G1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ This repository is a multi-tenant enterprise AI platform. Optimize for correct, 
 - Do not mark a user "authenticated enough" unless the session can be validated and hydrated safely.
 - Prefer typed API helpers and explicit error states over silent fallbacks.
 - If a frontend change affects auth, routing, billing, or admin workflows, run at least targeted UI tests and a build.
+- **Design quality pass (impeccable skill):** Every UI-touching PR must invoke `/audit`, `/critique`, and `/polish` from the impeccable skill pack against the changed components before push. Record the output summary in the PR description. The skill lives at `~/.claude/skills/` (see `docs/frontend-design-workflow.md` for the playbook). This catches generic LLM aesthetic patterns (overused fonts, gray-on-colored text, nested cards, bounce easing) that Playwright correctness tests don't.
 
 ### Delivery and Release Safety
 

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ AgenticOrg implements Google's A2A protocol for cross-platform agent discovery a
 - `POST /a2a/tasks` — execute tasks via A2A protocol (JWT or Grantex auth)
 
 ### MCP (Model Context Protocol)
-Full MCP server exposing all 340+ connector tools to any MCP-compatible client:
+Full MCP server exposing the live connector tools to any MCP-compatible client (see /api/v1/product-facts.tool_count):
 - `GET /mcp/tools` — list all available MCP tools (no auth required)
 - `POST /mcp/call` — call any MCP tool (JWT or Grantex auth)
 

--- a/docs/frontend-design-workflow.md
+++ b/docs/frontend-design-workflow.md
@@ -1,0 +1,79 @@
+# Frontend design workflow — impeccable skill pack
+
+**Rule:** every UI-touching PR runs three design commands before push.
+Playwright owns correctness; these three own aesthetic quality.
+
+## One-time setup
+
+The skill pack is installed globally at `~/.claude/skills/`. Verify:
+
+```bash
+ls ~/.claude/skills/impeccable/SKILL.md  # must exist
+ls ~/.claude/skills/audit/SKILL.md
+ls ~/.claude/skills/critique/SKILL.md
+ls ~/.claude/skills/polish/SKILL.md
+```
+
+If missing, re-install from `https://github.com/pbakaus/impeccable`:
+
+```bash
+git clone --depth 1 https://github.com/pbakaus/impeccable /tmp/imp
+cp -r /tmp/imp/source/skills/* ~/.claude/skills/
+```
+
+First use ever — once per design-system context — run
+`/impeccable teach` so the skill captures your typography, color, and
+spacing baseline. Subsequent commands compare against that baseline.
+
+## Required commands per UI PR
+
+| Command | Purpose | When it runs |
+|---|---|---|
+| `/audit <area>` | technical quality report (a11y, responsive, perf) — **no edits** | before making changes |
+| `/critique <area>` | UX review (hierarchy, clarity, emotional resonance) | before push |
+| `/polish <area>` | final alignment pass + shipping readiness | last step before push |
+
+`<area>` is a short descriptor: `/audit dashboard`, `/critique governance settings`, `/polish connectors edit`.
+
+Example combined run:
+
+```
+/audit settings
+/critique settings
+/polish settings
+```
+
+Paste the resulting report summary into the PR description under a
+`## Design review` heading. Reviewers should scan it before approval.
+
+## Optional commands
+
+The pack includes 15 more (`/distill`, `/clarify`, `/optimize`,
+`/harden`, `/animate`, `/colorize`, `/bolder`, `/quieter`, `/delight`,
+`/adapt`, `/typeset`, `/layout`, `/overdrive`, `/impeccable craft`,
+`/impeccable extract`). Use when a `/critique` recommends them — don't
+run the full 18 every PR.
+
+## Anti-patterns the skill catches
+
+From impeccable's curated list — the aesthetic-bias defaults every
+LLM learned and that Playwright can't see:
+
+- Overused fonts (Inter, Arial, Helvetica, system defaults)
+- Pure black / pure gray (always tint toward a warm or cool neutral)
+- Gray text on colored backgrounds (contrast failure)
+- Cards nested in cards nested in cards
+- Bounce or elastic easing on UI motion (dated)
+- Purple gradients on everything
+
+If a `/critique` flags one of these, fix it in the same PR.
+
+## How this fits the Enterprise Readiness bar
+
+The Readiness checklist (`docs/ENTERPRISE_READINESS_CHECKLIST.md`)
+asserts every UI feature has Playwright coverage. Impeccable adds a
+second dimension: every UI feature has *aesthetic* coverage. The two
+are complementary — Playwright protects the feature from regressing
+mechanically, impeccable protects it from looking generic.
+
+Neither is a substitute for the other. Both run on every UI PR.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,6 +1,6 @@
 # agenticorg-mcp-server
 
-MCP (Model Context Protocol) server for [AgenticOrg](https://agenticorg.ai) — expose 50+ AI agents and 1000+ tools to any MCP-compatible client.
+MCP (Model Context Protocol) server for [AgenticOrg](https://agenticorg.ai) — expose every AgenticOrg AI agent and native tool to any MCP-compatible client (live counts: `/api/v1/product-facts`).
 
 ## Quick Start
 
@@ -50,8 +50,8 @@ Add to your MCP client configuration:
 | `get_agent_details` | Get full agent config and capabilities |
 | `create_agent_from_sop` | Parse SOP text → create new agent |
 | `deploy_agent` | Deploy an agent configuration |
-| `list_connectors` | List all 54 connectors and status |
-| `call_connector_tool` | Call any of 340+ connector tools |
+| `list_connectors` | List all native connectors and status |
+| `call_connector_tool` | Call any connector tool |
 | `list_mcp_tools` | Discover all available tools |
 | `discover_agents_a2a` | A2A protocol agent discovery |
 | `get_agent_card` | Get the public A2A Agent Card |

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -2,7 +2,7 @@
   "name": "agenticorg-mcp-server",
   "version": "4.0.0",
   "mcpName": "io.github.mishrasanjeev/agenticorg",
-  "description": "MCP server for AgenticOrg — expose 50+ AI agents and 340+ tools to ChatGPT, Claude, and any MCP client",
+  "description": "MCP server for AgenticOrg — expose every AgenticOrg AI agent and native tool to ChatGPT, Claude, and any MCP client",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.mishrasanjeev/agenticorg",
-  "description": "50+ AI agents, 1000+ integrations, voice, RAG, LLM routing. Finance/HR/Marketing/Ops.",
+  "description": "AgenticOrg AI agents + native connectors + 1000+ Composio integrations, voice, RAG, LLM routing. Finance/HR/Marketing/Ops.",
   "repository": {
     "url": "https://github.com/mishrasanjeev/agentic-org",
     "source": "github"
@@ -18,17 +18,17 @@
     }
   ],
   "tools": [
-    { "name": "list_agents", "description": "List 50+ AI agents across Finance, HR, Marketing, Ops — filter by domain, status, type" },
+    { "name": "list_agents", "description": "List every AgenticOrg AI agent across Finance, HR, Marketing, Ops — filter by domain, status, type" },
     { "name": "run_agent", "description": "Execute any AI agent (ap_processor, payroll_engine, campaign_pilot, support_triage, etc.) with real tool calls" },
     { "name": "get_agent_details", "description": "Get agent config, scopes, tools, confidence floor, HITL conditions, shadow status" },
     { "name": "create_agent", "description": "Create a new AI agent from natural language description or manual config" },
     { "name": "create_agent_from_sop", "description": "Parse an SOP/policy document (PDF/Word) and auto-generate an AI agent" },
-    { "name": "list_connectors", "description": "List 54 native connectors + 1000+ via Composio (SAP, Oracle, Jira, HubSpot, Salesforce, GSTN, Tally, Stripe, Gmail, Slack, Teams)" },
-    { "name": "call_connector_tool", "description": "Call any of 340+ connector tools — create Jira tickets, send emails, query CRM, file GST returns, process payments" },
+    { "name": "list_connectors", "description": "List native connectors + 1000+ via Composio (SAP, Oracle, Jira, HubSpot, Salesforce, GSTN, Tally, Stripe, Gmail, Slack, Teams)" },
+    { "name": "call_connector_tool", "description": "Call any connector tool — create Jira tickets, send emails, query CRM, file GST returns, process payments" },
     { "name": "list_workflows", "description": "List 20+ workflow templates — invoice_to_pay, month_end_close, campaign_launch, incident_response" },
     { "name": "run_workflow", "description": "Trigger a multi-step workflow with parallel agents, HITL approval gates, and adaptive replanning" },
     { "name": "search_knowledge_base", "description": "Search company documents (PDF, Word, Excel) via RAG — agents answer from your uploaded policies and SOPs" },
-    { "name": "list_mcp_tools", "description": "Discover all available MCP tools across 54 native connectors and 1000+ Composio integrations" },
+    { "name": "list_mcp_tools", "description": "Discover all available MCP tools across native connectors and 1000+ Composio integrations" },
     { "name": "get_agent_card", "description": "Get the A2A protocol Agent Card for cross-platform agent discovery" }
   ],
   "environmentVariables": [

--- a/scripts/consistency_sweep.py
+++ b/scripts/consistency_sweep.py
@@ -133,23 +133,37 @@ def check_product_facts_alignment() -> Check:
 
 
 def check_stale_public_claims() -> Check:
-    """Drift guard — the specific strings P1 eliminated shouldn't return."""
+    """Drift guard — the specific strings P1 eliminated shouldn't return.
+
+    Scans every surface that a customer, AI crawler, MCP client, or
+    package-registry consumer actually reads. If a surface is missing
+    here it won't catch drift — add it on the next incident.
+    """
     c = Check("no stale hardcoded public claims")
     targets = {
         "54 native connectors",
         "57 native connectors",
+        "50+ AI agents",
         "340+ tools",
+        "340+ connector tools",
+        "340+ native tools",
         "v4.0.0",
         "v4.3.0",
         "v4.6.0",
     }
-    # Only scan public surfaces — NOT docs/ (historical) or
-    # ENTERPRISE_READINESS_PLAN.md (which references the bad strings).
+    # Scan every externally-visible surface: README, in-app UI,
+    # AI-crawler-consumed llms.txt/llms-full.txt, MCP registry manifest
+    # + npm package metadata + its README.
     scan = [
         ROOT / "README.md",
         ROOT / "ui" / "src" / "pages" / "Landing.tsx",
         ROOT / "ui" / "src" / "pages" / "Pricing.tsx",
         ROOT / "ui" / "index.html",
+        ROOT / "ui" / "public" / "llms.txt",
+        ROOT / "ui" / "public" / "llms-full.txt",
+        ROOT / "mcp-server" / "server.json",
+        ROOT / "mcp-server" / "package.json",
+        ROOT / "mcp-server" / "README.md",
     ]
     for path in scan:
         if not path.exists():

--- a/ui/public/llms.txt
+++ b/ui/public/llms.txt
@@ -65,15 +65,15 @@ AgenticOrg is built for Indian enterprise with native connectors for: Banking Aa
 
 ## Pricing
 
-- Free ($0/month): 50+ AI agents, 20 connectors, 500 tasks/day
-- Pro ($499/month): Unlimited AI agents, 54 connectors, Unlimited tasks
-- Enterprise (Custom): Unlimited AI agents, 54 connectors, Unlimited everything
+- Free ($0/month): 20 connectors, 500 tasks/day, Community support
+- Pro ($499/month): Unlimited AI agents, Unlimited tasks, Email support
+- Enterprise (Custom): Unlimited AI agents, Unlimited everything, Dedicated support
 
 ## Developer SDKs & Integration
 
 - **Python SDK**: `pip install agenticorg` — run agents, parse SOPs, A2A/MCP access ([PyPI](https://pypi.org/project/agenticorg/))
 - **TypeScript SDK**: `npm i agenticorg-sdk` — full TypeScript client library ([npm](https://www.npmjs.com/package/agenticorg-sdk))
-- **MCP Server**: `npx agenticorg-mcp-server` — expose 50+ agents and 340+ native tools to ChatGPT, Claude Desktop, Cursor ([npm](https://www.npmjs.com/package/agenticorg-mcp-server))
+- **MCP Server**: `npx agenticorg-mcp-server` — expose every AgenticOrg agent and native tool to ChatGPT, Claude Desktop, Cursor (live counts: `/api/v1/product-facts`) ([npm](https://www.npmjs.com/package/agenticorg-mcp-server))
 - **CLI**: `agenticorg agents list`, `agenticorg agents run`, `agenticorg sop deploy`
 - **API Keys**: Generate from Settings > API Keys in the dashboard. Keys use `ao_sk_` prefix, bcrypt-hashed, scoped, revocable
 - **A2A Protocol**: Google Agent-to-Agent discovery via Agent Cards at `/api/v1/a2a/agent-card`

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -638,7 +638,7 @@ export default function Landing() {
                 <BrowserFrame
                   src="/screenshots/agents.webp"
                   title="app.agenticorg.ai/dashboard/agents"
-                  alt="Agent fleet management view showing 50+ AI agents across Finance, HR, Marketing, and Ops"
+                  alt="Agent fleet management view — AI agents across Finance, HR, Marketing, and Ops"
                 />
                 <h3 className="text-xl font-bold text-slate-900">Agent Fleet</h3>
                 <p className="text-slate-600 text-sm leading-relaxed">


### PR DESCRIPTION
## Summary (PR-G1 + addendum)

Two related truth-gate improvements.

### Part 1 — widen consistency sweep to mcp-server + llms.txt

After Enterprise Readiness finished, audit found the Phase-9 sweep only scanned README + Landing + Pricing + index.html. Drift had been quietly accumulating on surfaces a customer / AI crawler / MCP client / npm consumer actually reads.

Stale claims scrubbed:
- \`mcp-server/server.json\` — 5 hits in description + tool blurbs
- \`mcp-server/package.json\` — 1 hit
- \`mcp-server/README.md\` — 2 hits
- \`ui/public/llms.txt\` — 1 hit
- \`README.md\` — 1 leftover MCP-server blurb
- \`ui/src/pages/Landing.tsx\` — 1 stale alt text

\`scripts/consistency_sweep.py::check_stale_public_claims\` now scans 9 surfaces (adds \`llms.txt\`, \`llms-full.txt\`, \`mcp-server/*\`) and matches 3 new patterns. Any regression fails preflight gate #8.

### Part 2 — impeccable frontend design skill pack

User adopted [impeccable](https://github.com/pbakaus/impeccable) (Apache 2.0, 18 design skills) to catch generic LLM aesthetic patterns Playwright can't see. Installed globally at \`~/.claude/skills/\`.

- \`CLAUDE.md\` Frontend Integrity: every UI-touching PR must invoke \`/audit\`, \`/critique\`, \`/polish\` and paste the summary into the PR body.
- \`docs/frontend-design-workflow.md\`: playbook.
- Complements the "No feature ships without Playwright coverage" rule with "no feature ships without aesthetic coverage."

## Test plan

- [x] \`python scripts/consistency_sweep.py\` — all 4 checks pass, all 9 surfaces clean
- [x] \`ruff check\` — clean
- [ ] Branch CI green

@codex please review.