### PR TITLE
chore(sdks): bump Python + TS SDK to 0.2.0 for AgentRunResult contract (PR-G2)

### DIFF
--- a/docs/release-sdks.md
+++ b/docs/release-sdks.md
@@ -1,0 +1,76 @@
+# Publishing the SDKs
+
+Version is bumped in-repo by the PR that ships the API change; the
+actual PyPI / npm publish is a separate manual step (needs
+credentials, should not live in CI without a release-gating flow).
+
+## Python SDK (PyPI)
+
+**Prereqs:** `pip install build twine`. PyPI token in `~/.pypirc`.
+
+```bash
+cd sdk
+rm -rf dist
+python -m build
+twine check dist/*
+twine upload dist/*
+```
+
+**Verify:**
+
+```bash
+pip install --upgrade agenticorg
+python -c "import agenticorg; print(agenticorg.__version__)"
+# expect the version from sdk/agenticorg/__init__.py
+```
+
+The `__version__` in `sdk/agenticorg/__init__.py` must match
+`version` in `sdk/pyproject.toml`. CHANGELOG.md under `sdk/` is the
+release-notes source; keep the top entry dated.
+
+## TypeScript SDK (npm)
+
+**Prereqs:** `npm login` (or set `NODE_AUTH_TOKEN`).
+
+```bash
+cd sdk-ts
+npm run build
+npm publish --access public
+```
+
+**Verify:**
+
+```bash
+npm view agenticorg-sdk version
+# expect the version from sdk-ts/package.json
+```
+
+## MCP server (npm)
+
+```bash
+cd mcp-server
+npm run build
+npm publish --access public
+```
+
+MCP registry (`mcp-server/server.json`) points at the npm package —
+its `packages[].version` field must stay in lockstep with
+`package.json` `version`. Bump both in the same PR.
+
+## Version policy
+
+- Major bump when the wire contract breaks (e.g. field removed).
+- Minor bump when a new field is added (backward-compatible) — this
+  is what PR-A shipped (canonical `AgentRunResult`).
+- Patch bump for bugfix-only changes.
+
+SDK versions track the server's wire contract, not the app version.
+A main app at `4.8.0` is fine with SDKs at `0.2.0` — what matters is
+that the SDK can parse what the server emits.
+
+## Drift guard
+
+`scripts/consistency_sweep.py` does NOT currently cross-check SDK
+versions with published registry versions. Add it to the sweep's
+future-checks list only when there's tooling that can query PyPI /
+npm cheaply enough not to slow the preflight gate.

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -1,0 +1,29 @@
+# agenticorg-sdk changelog
+
+## 0.2.0 — 2026-04-19
+
+Canonical `AgentRunResult` contract.
+
+### Added
+- `AgentRunResult` interface with every run-contract field:
+  `run_id`, `status`, `output`, `confidence`, `reasoning_trace`,
+  `tool_calls`, `runtime`, `performance`, `explanation`,
+  `hitl_trigger`, `error`. Returned from `client.agents.run()`.
+- `toAgentRunResult()` helper that accepts legacy response shapes
+  (`task_id`, `result.output`, `result.confidence`) and normalizes
+  them to the canonical field set.
+
+### Changed
+- `client.agents.run()` now returns `AgentRunResult` (typed interface)
+  instead of the looser shape `0.1.0` exposed.
+
+### Compatibility
+- Legacy aliases (`task_id`, `result.output`, `result.confidence`)
+  are accepted as inputs and deprecated through v5.0 of the server.
+- Field names are snake_case to match the over-the-wire JSON — matches
+  Python SDK spelling and reduces translation churn for consumers
+  using both SDKs.
+
+## 0.1.0 — initial release
+
+First published to npm.

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticorg-sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "TypeScript SDK for AgenticOrg — run AI agents, create from SOP, A2A/MCP access",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,0 +1,30 @@
+# AgenticOrg Python SDK changelog
+
+## 0.2.0 — 2026-04-19
+
+Canonical `AgentRunResult` contract.
+
+### Added
+- `AgentRunResult` dataclass with every run-contract field:
+  `run_id`, `status`, `output`, `confidence`, `reasoning_trace`,
+  `tool_calls`, `runtime`, `performance`, `explanation`,
+  `hitl_trigger`, `error`. Returned from `client.agents.run()`.
+- `_to_agent_run_result()` normalizer that accepts legacy response
+  shapes (`task_id`, `result.output`, `result.confidence`) and
+  converts them — kept for compatibility with the backend's
+  pre-PR-A response shape.
+
+### Changed
+- `AgenticOrg.agents.run()` now returns `AgentRunResult` (dataclass)
+  instead of a raw dict. The dataclass is pickle-safe and iterates
+  the same way a dict does for most ergonomic callers.
+
+### Compatibility
+- Legacy aliases (`task_id`, `result.output`, `result.confidence`)
+  are accepted as inputs and deprecated through v5.0 of the server.
+- Consumers of the previous 0.1.0 dict-shaped response should access
+  fields via attribute (`result.output`) or `dataclasses.asdict(result)`.
+
+## 0.1.0 — initial release
+
+First published to PyPI.

--- a/sdk/agenticorg/__init__.py
+++ b/sdk/agenticorg/__init__.py
@@ -11,4 +11,4 @@ Quickstart:
 from agenticorg.client import AgenticOrg, AgentRunResult
 
 __all__ = ["AgenticOrg", "AgentRunResult"]
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agenticorg"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python SDK for AgenticOrg — run AI agents, create from SOP, manage connectors"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

PR-A shipped the canonical \`AgentRunResult\` contract on the backend and in both SDKs, but neither SDK version was bumped. A PyPI/npm consumer pulling 0.1.0 today gets a dict-shaped response they can't type — the TS interface + Python dataclass only exist in 0.2.0.

- \`sdk/pyproject.toml\` + \`sdk/agenticorg/__init__.py\` — 0.1.0 → 0.2.0
- \`sdk-ts/package.json\` — 0.1.0 → 0.2.0
- \`sdk/CHANGELOG.md\` + \`sdk-ts/CHANGELOG.md\` — new files with migration notes
- \`docs/release-sdks.md\` — publish procedure (Python/TS/MCP), version-policy guidance, drift-guard note

This PR does not publish — publishing is a manual step with credentials per the \`release-sdks.md\` playbook.

## Test plan

- [x] \`ruff check\` — clean
- [ ] After merge: run the manual publish procedure

@codex please review.