### PR TITLE
chore(mcp): align mcp-server version + add lockstep sweep (PR-G3)

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -1,0 +1,38 @@
+# agenticorg-mcp-server changelog
+
+## 4.0.2 — 2026-04-19
+
+Version alignment + truth-pass.
+
+### Changed
+- `package.json` 4.0.0 → 4.0.2 to match the MCP registry manifest
+  `server.json`. Pre-G3, the two were out of sync — the MCP registry
+  advertised 4.0.1 while npm served 4.0.0.
+- `server.json.packages[0].version` pinned to the same 4.0.2 — the
+  registry must reference the exact npm version it's shipping.
+
+### Fixed
+- Stale public claims scrubbed from tool descriptions (50+ AI agents,
+  54 native connectors, 340+ connector tools). Shipped via PR-G1
+  (#218) into main; this version bump reflects the user-visible
+  change.
+
+### Version policy
+
+- `package.json.version` and `server.json.version` always move in
+  lockstep. Bumping one without the other silently creates npm/MCP
+  drift.
+- `server.json.packages[0].version` must equal `package.json.version` —
+  the registry tells the MCP client which npm release to pull.
+- MCP server versions are independent of the main AgenticOrg app —
+  this 4.x line tracks wire-protocol compatibility with the server,
+  not the app's own `pyproject.toml` version.
+
+## 4.0.1 — prior
+
+MCP registry manifest update (server.json only; package.json unchanged
+at 4.0.0). Left the repo in a mismatched state closed by 4.0.2.
+
+## 4.0.0 — initial release
+
+First npm + MCP registry publish.

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticorg-mcp-server",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "mcpName": "io.github.mishrasanjeev/agenticorg",
   "description": "MCP server for AgenticOrg — expose 50+ AI agents and 340+ tools to ChatGPT, Claude, and any MCP client",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/mishrasanjeev/agentic-org",
     "source": "github"
   },
-  "version": "4.0.1",
+  "version": "4.0.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "agenticorg-mcp-server",
-      "version": "4.0.0",
+      "version": "4.0.2",
       "transport": {
         "type": "stdio"
       }

--- a/scripts/consistency_sweep.py
+++ b/scripts/consistency_sweep.py
@@ -160,6 +160,46 @@ def check_stale_public_claims() -> Check:
     return c
 
 
+def check_mcp_version_lockstep() -> Check:
+    """mcp-server/package.json.version MUST equal server.json.version
+    AND server.json.packages[0].version. These three moving apart
+    silently creates npm/MCP-registry drift that consumers only find
+    at install time.
+    """
+    import json as _json
+
+    c = Check("mcp-server version lockstep")
+    pkg_path = ROOT / "mcp-server" / "package.json"
+    srv_path = ROOT / "mcp-server" / "server.json"
+    if not pkg_path.exists() or not srv_path.exists():
+        c.ok = False
+        c.detail = "mcp-server/package.json or server.json missing"
+        return c
+
+    pkg = _json.loads(pkg_path.read_text(encoding="utf-8"))
+    srv = _json.loads(srv_path.read_text(encoding="utf-8"))
+    pkg_version = str(pkg.get("version", ""))
+    srv_version = str(srv.get("version", ""))
+    srv_pkg_version = ""
+    for entry in srv.get("packages", []):
+        if entry.get("registryType") == "npm":
+            srv_pkg_version = str(entry.get("version", ""))
+            break
+
+    c.subcheck("package.json.version", bool(pkg_version), pkg_version or "missing")
+    c.subcheck(
+        "server.json.version matches",
+        srv_version == pkg_version,
+        f"{srv_version} (expected {pkg_version})",
+    )
+    c.subcheck(
+        "server.json.packages[npm].version matches",
+        srv_pkg_version == pkg_version,
+        f"{srv_pkg_version} (expected {pkg_version})",
+    )
+    return c
+
+
 def check_mcp_tool_count() -> Check:
     c = Check("MCP tool list vs LangGraph tool-index")
     try:
@@ -191,6 +231,7 @@ def main() -> int:
         check_version_agreement(),
         check_product_facts_alignment(),
         check_stale_public_claims(),
+        check_mcp_version_lockstep(),
         check_mcp_tool_count(),
     ]
     print("=" * 60)


### PR DESCRIPTION
## Summary

\`mcp-server/package.json\` was at 4.0.0 while \`server.json\` advertised 4.0.1 — an install-time drift that an MCP client would only discover when the registry's advertised version didn't match what npm served.

- All three version fields (\`package.json.version\`, \`server.json.version\`, \`server.json.packages[0].version\`) pinned to 4.0.2 — a patch bump covering the stale-claim scrub that landed in PR-G1.
- \`mcp-server/CHANGELOG.md\` — new file with migration notes + explicit version policy (lockstep requirement documented).
- \`scripts/consistency_sweep.py\` adds \`check_mcp_version_lockstep\`. Preflight gate #8 now fails on drift.

Publishing 4.0.2 to npm + MCP registry is a manual step per \`docs/release-sdks.md\`.

## Test plan

- [x] \`python scripts/consistency_sweep.py\` — new check green
- [x] \`ruff check\` — clean
- [ ] Branch CI green

@codex please review.