### PR TITLE
fix(mcp): server.json description fits 100-char registry limit; document real publish

### DIFF
--- a/docs/release-sdks.md
+++ b/docs/release-sdks.md
@@ -45,7 +45,13 @@ npm view agenticorg-sdk version
 # expect the version from sdk-ts/package.json
 ```
 
-## MCP server (npm)
+## MCP server (npm + MCP registry)
+
+**Two separate publishes.** An npm push does NOT propagate to the
+MCP registry. They are independent stores, one for the artifact, one
+for the discovery metadata. Both steps are required.
+
+### Step 1 — publish the npm tarball
 
 ```bash
 cd mcp-server
@@ -53,9 +59,35 @@ npm run build
 npm publish --access public
 ```
 
-MCP registry (`mcp-server/server.json`) points at the npm package —
-its `packages[].version` field must stay in lockstep with
-`package.json` `version`. Bump both in the same PR.
+### Step 2 — publish to registry.modelcontextprotocol.io
+
+Install `mcp-publisher` CLI once per machine. PowerShell:
+
+```powershell
+$arch = if ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -eq "Arm64") { "arm64" } else { "amd64" }
+Invoke-WebRequest -Uri "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_windows_$arch.tar.gz" -OutFile mcp-publisher.tar.gz
+tar xf mcp-publisher.tar.gz mcp-publisher.exe
+```
+
+Then from `mcp-server/`:
+
+```bash
+mcp-publisher validate       # catch schema failures (desc <=100 chars, etc.)
+mcp-publisher login github   # device-flow OAuth, needs the GitHub account
+                             # that owns the `io.github.<user>/*` namespace
+mcp-publisher publish        # pushes server.json to the registry
+```
+
+The registry validates `description` length (<=100 chars), `version`,
+`packages[].version`, and the `$schema` URL. `scripts/consistency_sweep.py`
+catches the description-length constraint locally so a preflight fails
+instead of a `mcp-publisher validate` later.
+
+### Lockstep rule
+
+`mcp-server/package.json.version`, `server.json.version`, and
+`server.json.packages[0].version` must always move together. The
+sweep fails if any drifts.
 
 ## Version policy
 

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.mishrasanjeev/agenticorg",
-  "description": "AgenticOrg AI agents + native connectors + 1000+ Composio integrations, voice, RAG, LLM routing. Finance/HR/Marketing/Ops.",
+  "description": "AgenticOrg AI agents + native connectors + 1000+ via Composio. Finance/HR/Marketing/Ops.",
   "repository": {
     "url": "https://github.com/mishrasanjeev/agentic-org",
     "source": "github"

--- a/scripts/consistency_sweep.py
+++ b/scripts/consistency_sweep.py
@@ -174,6 +174,32 @@ def check_stale_public_claims() -> Check:
     return c
 
 
+def check_mcp_registry_schema() -> Check:
+    """Fields that the MCP registry (registry.modelcontextprotocol.io)
+    validates on publish. Catch violations locally instead of during
+    the publish step.
+
+    Known constraints (discovered via mcp-publisher validate):
+      - description length <= 100 chars
+    """
+    import json as _json
+
+    c = Check("mcp-server registry-schema")
+    srv_path = ROOT / "mcp-server" / "server.json"
+    if not srv_path.exists():
+        c.ok = False
+        c.detail = "mcp-server/server.json missing"
+        return c
+    srv = _json.loads(srv_path.read_text(encoding="utf-8"))
+    desc = str(srv.get("description", ""))
+    c.subcheck(
+        "description <= 100 chars",
+        len(desc) <= 100,
+        f"{len(desc)} chars",
+    )
+    return c
+
+
 def check_mcp_version_lockstep() -> Check:
     """mcp-server/package.json.version MUST equal server.json.version
     AND server.json.packages[0].version. These three moving apart
@@ -245,6 +271,7 @@ def main() -> int:
         check_version_agreement(),
         check_product_facts_alignment(),
         check_stale_public_claims(),
+        check_mcp_registry_schema(),
         check_mcp_version_lockstep(),
         check_mcp_tool_count(),
     ]


### PR DESCRIPTION
## Summary

User spot-checked the MCP registry claim and was right — my earlier docs claim that \"the registry auto-syncs from npm\" was wrong.

### Actual state

\`registry.modelcontextprotocol.io\` has \`io.github.mishrasanjeev/agenticorg\` at versions 0.1.1, 4.0.0, 4.0.1 — **not** 4.0.2. npm publish and registry publish are separate operations.

### Also broken

\`mcp-publisher validate\` against 4.0.2's \`server.json\` failed:

    validation failed: expected length <= 100, body.description (122 chars)

Shortened the description from 122 → 88 chars (kept the product claims we still have, dropped the less-useful enumerations):

    "AgenticOrg AI agents + native connectors + 1000+ via Composio. Finance/HR/Marketing/Ops."

### Changes

- \`mcp-server/server.json\` — description trimmed, validates now
- \`scripts/consistency_sweep.py\` — new \`check_mcp_registry_schema\` asserts description <= 100 chars (catches this class of failure in preflight)
- \`docs/release-sdks.md\` — MCP section rewritten with the real two-step flow: \`npm publish\` + \`mcp-publisher validate\` + \`mcp-publisher login github\` + \`mcp-publisher publish\`. Includes the PowerShell install for \`mcp-publisher.exe\` and the GitHub-OAuth requirement for the \`io.github.*\` namespace.

## Test plan

- [x] \`python scripts/consistency_sweep.py\` — 5 checks green, new one passes at 88 chars
- [x] \`mcp-publisher validate\` — ✅ server.json is valid
- [ ] Branch CI green

@codex please review.