### PR TITLE
feat(ui): impeccable design pass 1 — typography + anti-patterns (PR-H1)

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,99 @@
+# Design Context — AgenticOrg
+
+**Read by the impeccable skill pack (`~/.claude/skills/`) before every
+`/audit`, `/critique`, `/polish`, etc. If you add or change design
+direction, update this file.**
+
+## Target audience
+
+- **Primary:** Enterprise finance, HR, marketing, and operations
+  leaders (CFO, CHRO, CMO, COO) in Indian mid-market companies and CA
+  firms. High trust bar, compliance-sensitive, allergic to toys.
+- **Secondary:** Platform engineers integrating via the Python/TS SDK
+  or MCP server — expect typed APIs, canonical contracts, no
+  magic.
+
+## Use cases
+
+- Deploy 26+ pre-built AI agents that execute real enterprise
+  actions (file GST returns, reconcile bank statements, process
+  payroll) through tool-calls against 1000+ integrations.
+- Multi-tenant control plane: governance persistence, audit log,
+  scoped API keys, HITL approval queues.
+- Self-service: create a new agent from a PDF SOP, deploy via
+  5-step wizard, observe in an agent observatory.
+
+## Brand personality / tone
+
+- **Enterprise-grade, not demo-grade.** Truth over marketing: every
+  number on the page is fetched from `/product-facts`. No decorative
+  healthy badges. "Demo" labels where OAuth handoff isn't wired.
+- **Restrained confidence.** Product is ambitious, copy is plain. No
+  emoji unless asked. No bounce easing. No purple gradients.
+- **Indian market first.** Tax terminology (GST, TDS, 44AB), INR
+  pricing (₹4,999/client), government-portal literacy (EPFO, MCA,
+  CBIC) — all appear in copy without translation.
+
+## Visual direction
+
+- **Refined minimalism.** Lots of whitespace. Typography carries
+  most of the weight. Accent color rare (~10% of pixels), used only
+  on CTAs and focus states.
+- **Tinted neutrals.** Pure black / pure gray are banned — every
+  neutral carries a sliver of blue chroma (0.005–0.015) so UI
+  surfaces feel cohesive with the primary brand color.
+- **No AI defaults.** Specifically avoid: Inter as primary typeface,
+  purple-to-pink gradients, lavender `from-purple-500 to-pink-600`,
+  bounce/elastic easing, cards nested in cards nested in cards.
+
+## Constraints
+
+- React 19 + TypeScript + Vite + Tailwind CSS + shadcn/ui
+  (Radix primitives under the hood).
+- Playwright correctness tests on every UI flow
+  (`feedback_no_skip_full_coverage.md`) — design changes must keep
+  existing selectors working or update the spec in the same PR.
+- WCAG 2.1 AA required (contrast ≥ 4.5:1 body text, ≥ 44×44px touch
+  targets, keyboard-navigable, visible focus ring). Already baked
+  into `ui/src/globals.css`.
+
+## Color tokens
+
+Current (HSL, shadcn default). Target palette on future refactor:
+
+| Role | Light | Dark | Notes |
+|---|---|---|---|
+| primary | `222 47% 11%` | `210 40% 98%` | Near-black slate + near-white |
+| muted | `210 40% 96%` | `217 33% 17%` | |
+| muted-foreground | `215 16% 47%` | `215 20% 65%` | |
+| destructive | `0 84% 60%` | — | |
+| accent brand | `slate-900` / `blue-600` | Used for CTAs + focus |
+
+Future: migrate to OKLCH with explicit chroma-tinting (see
+`~/.claude/skills/impeccable/reference/color-and-contrast.md`).
+
+## Typography
+
+Currently `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+'Helvetica Neue', Arial, sans-serif` (system stack). Swap to a
+specific modern typeface (Geist, Söhne, or Inter Tight) in a
+follow-up — it's the single highest-impact change for feel.
+
+`font-mono` uses the system stack too; use `JetBrains Mono` or
+`Geist Mono`.
+
+## What this document is for
+
+When `/audit`, `/critique`, `/polish` run, they read this file to
+know:
+
+- who the user is (enterprise Indian CFOs, not consumer
+  prosumers)
+- what tone is acceptable (restrained, not playful)
+- what anti-patterns matter for THIS project (purple gradients,
+  Inter, pure gray)
+- what existing infrastructure (WCAG base, shadcn, HSL tokens)
+  they must not break
+
+Keep this file short. If it grows past one screen, split by topic
+into separate files next to it.

--- a/ui/index.html
+++ b/ui/index.html
@@ -310,9 +310,24 @@
   <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
   <link rel="dns-prefetch" href="https://accounts.google.com" />
 
-  <!-- Font strategy: system fonts with swap -->
+  <!-- Typography: Geist for UI, JetBrains Mono for code. Chosen over the
+       generic system stack / Inter default per the impeccable design
+       skill (docs/frontend-design-workflow.md). -->
+  <link rel="preconnect" href="https://rsms.me/" />
+  <link
+    rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+  />
   <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; }
+    body {
+      font-family: "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI",
+        "Helvetica Neue", sans-serif;
+      font-feature-settings: "ss01" on, "cv11" on;
+    }
+    code, pre, .font-mono {
+      font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo,
+        Consolas, monospace;
+    }
     @font-face { font-display: swap; }
   </style>
 

--- a/ui/src/globals.css
+++ b/ui/src/globals.css
@@ -62,7 +62,11 @@
   :root {
     --background: 0 0% 100%; --foreground: 222 84% 5%;
     --primary: 222 47% 11%; --primary-foreground: 210 40% 98%;
-    --muted: 210 40% 96%; --muted-foreground: 215 16% 47%;
+    /* muted-foreground: tinted toward the brand slate/blue hue (chroma
+       up from 16% → 18%, lightness 47% → 42% for AA body-text contrast).
+       Per impeccable/color-and-contrast: pure gray is dead, tint
+       toward the brand hue. */
+    --muted: 210 40% 96%; --muted-foreground: 215 18% 42%;
     --accent: 210 40% 96%; --accent-foreground: 222 47% 11%;
     --destructive: 0 84% 60%; --destructive-foreground: 210 40% 98%;
     --border: 214 32% 91%; --radius: 0.5rem;

--- a/ui/src/pages/ABMDashboard.tsx
+++ b/ui/src/pages/ABMDashboard.tsx
@@ -368,7 +368,7 @@ export default function ABMDashboard() {
 
       {/* Campaign launch modal */}
       {campaignAccountId && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60">
           <div className="bg-background rounded-xl border shadow-xl w-full max-w-md p-6 space-y-4">
             <h2 className="text-lg font-bold">Launch Campaign</h2>
 

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -282,7 +282,7 @@ export default function AgentDetail() {
       </Suspense>
 
       {runDialogOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60">
           <div className="w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
             <h3 className="text-lg font-semibold mb-1">
               Run {agent?.employee_name || agent?.name || "agent"}

--- a/ui/src/pages/CAFirmsSolution.tsx
+++ b/ui/src/pages/CAFirmsSolution.tsx
@@ -155,7 +155,7 @@ function DemoModal({ onClose }: { onClose: () => void }) {
 
   return (
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/70 backdrop-blur-sm px-4"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
       role="dialog"
       aria-modal="true"

--- a/ui/src/pages/CBOSolution.tsx
+++ b/ui/src/pages/CBOSolution.tsx
@@ -159,7 +159,7 @@ function DemoModal({ onClose }: { onClose: () => void }) {
 
   return (
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/70 backdrop-blur-sm px-4"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
       role="dialog"
       aria-modal="true"

--- a/ui/src/pages/CFOSolution.tsx
+++ b/ui/src/pages/CFOSolution.tsx
@@ -159,7 +159,7 @@ function DemoModal({ onClose }: { onClose: () => void }) {
 
   return (
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/70 backdrop-blur-sm px-4"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
       role="dialog"
       aria-modal="true"

--- a/ui/src/pages/CHROSolution.tsx
+++ b/ui/src/pages/CHROSolution.tsx
@@ -159,7 +159,7 @@ function DemoModal({ onClose }: { onClose: () => void }) {
 
   return (
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/70 backdrop-blur-sm px-4"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
       role="dialog"
       aria-modal="true"

--- a/ui/src/pages/CMOSolution.tsx
+++ b/ui/src/pages/CMOSolution.tsx
@@ -159,7 +159,7 @@ function DemoModal({ onClose }: { onClose: () => void }) {
 
   return (
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/70 backdrop-blur-sm px-4"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
       role="dialog"
       aria-modal="true"

--- a/ui/src/pages/COOSolution.tsx
+++ b/ui/src/pages/COOSolution.tsx
@@ -159,7 +159,7 @@ function DemoModal({ onClose }: { onClose: () => void }) {
 
   return (
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/70 backdrop-blur-sm px-4"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
       role="dialog"
       aria-modal="true"

--- a/ui/src/pages/CompanyDetail.tsx
+++ b/ui/src/pages/CompanyDetail.tsx
@@ -1434,7 +1434,7 @@ export default function CompanyDetail() {
       {/* Agent detail modal */}
       {agentDetail && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60"
           onClick={() => setAgentDetail(null)}
         >
           <div
@@ -1470,7 +1470,7 @@ export default function CompanyDetail() {
       {/* Workflow detail modal */}
       {workflowDetail && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60"
           onClick={() => setWorkflowDetail(null)}
         >
           <div
@@ -1507,7 +1507,7 @@ export default function CompanyDetail() {
 
       {/* Rejection reason dialog (replaces window.prompt) */}
       {rejectDialogId && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60">
           <div className="w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
             <h3 className="text-lg font-semibold mb-3">Rejection Reason</h3>
             <textarea

--- a/ui/src/pages/IndustryPacks.tsx
+++ b/ui/src/pages/IndustryPacks.tsx
@@ -292,7 +292,7 @@ export default function IndustryPacks() {
 
       {/* Detail panel */}
       {selectedPack && (
-        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center" onClick={() => setSelectedPack(null)}>
+        <div className="fixed inset-0 bg-slate-950/60 z-50 flex items-center justify-center" onClick={() => setSelectedPack(null)}>
           <div className="bg-background border rounded-lg p-6 w-full max-w-2xl shadow-lg max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
             <div className="flex items-start justify-between mb-4">
               <div className="flex items-center gap-3">

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -113,7 +113,7 @@ const ROLE_CARDS = [
   },
   {
     role: "CMO",
-    gradient: "from-purple-500 to-pink-600",
+    gradient: "from-blue-600 to-emerald-500",
     pain: "Launch campaigns while you sleep",
     description: "9 marketing agents run Campaign Management, A/B Testing, Email Drip Sequences, ABM with Intent Data (Bombora/G2/TrustRadius), Content Generation, SEO Optimization, CRM Nurturing, Brand Monitoring, and Competitive Intel.",
     agents: ["Campaign Mgmt", "A/B Testing", "Email Drip", "ABM + Intent", "Content Gen", "SEO", "CRM Nurture", "Brand Monitor", "Competitive Intel"],
@@ -190,7 +190,7 @@ function DemoModal({ onClose }: { onClose: () => void }) {
 
   return (
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/70 backdrop-blur-sm px-4"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
       role="dialog"
       aria-modal="true"
@@ -357,7 +357,7 @@ export default function Landing() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
           {/* Logo */}
           <div className="flex items-center gap-2">
-            <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center text-white font-bold text-sm">
+            <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-blue-500 to-teal-500 flex items-center justify-center text-white font-bold text-sm">
               AO
             </div>
             <span className="text-white font-semibold text-lg">AgenticOrg</span>
@@ -728,8 +728,8 @@ export default function Landing() {
             </FadeIn>
 
             <FadeIn delay={300}>
-              <div className="bg-gradient-to-br from-slate-50 to-purple-50 rounded-2xl p-6 border border-slate-200 hover:shadow-lg transition-all duration-300 h-full">
-                <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-purple-500 to-pink-600 flex items-center justify-center mb-4">
+              <div className="bg-gradient-to-br from-slate-50 to-teal-50 rounded-2xl p-6 border border-slate-200 hover:shadow-lg transition-all duration-300 h-full">
+                <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-blue-600 to-emerald-500 flex items-center justify-center mb-4">
                   <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
                   </svg>
@@ -1126,7 +1126,7 @@ export default function Landing() {
       <section className="py-24 bg-slate-50 scroll-mt-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <FadeIn>
-            <div className="bg-gradient-to-br from-blue-50 via-white to-purple-50 rounded-3xl border border-slate-200 overflow-hidden p-8 sm:p-12">
+            <div className="bg-gradient-to-br from-blue-50 via-white to-teal-50 rounded-3xl border border-slate-200 overflow-hidden p-8 sm:p-12">
               <div className="grid lg:grid-cols-2 gap-12 items-center">
                 <div>
                   <div className="inline-flex items-center gap-2 bg-blue-100 text-blue-700 rounded-full px-4 py-1.5 text-sm font-medium mb-4">
@@ -1246,7 +1246,7 @@ export default function Landing() {
                 role: "CHRO",
                 title: "Virtual HR Team",
                 description: "Screen 500 resumes/hr, day-1 onboarding, zero-error payroll, and EPFO/ESI compliance.",
-                gradient: "from-violet-500 to-purple-600",
+                gradient: "from-blue-500 to-teal-600",
                 icon: "M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z",
                 link: "/solutions/chro",
               },
@@ -1254,7 +1254,7 @@ export default function Landing() {
                 role: "CMO",
                 title: "Virtual Marketing Team",
                 description: "3.2x ROAS, 42% lower CAC, AI content factory, and multi-channel campaign automation.",
-                gradient: "from-pink-500 to-rose-600",
+                gradient: "from-emerald-500 to-teal-600",
                 icon: "M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z",
                 link: "/solutions/cmo",
               },
@@ -1384,7 +1384,7 @@ $ agenticorg sop deploy \\
   }
 }`,
                 link: "https://www.npmjs.com/package/agenticorg-mcp-server",
-                color: "from-purple-500 to-purple-600",
+                color: "from-blue-500 to-blue-600",
               },
             ].map((sdk, i) => (
               <FadeIn key={sdk.title} delay={i * 100}>
@@ -1456,7 +1456,7 @@ $ agenticorg sop deploy \\
                 </div>
                 <Link
                   to="/integration-workflow"
-                  className="inline-flex items-center gap-2 bg-gradient-to-r from-purple-500 to-pink-600 text-white px-6 py-3 rounded-xl text-sm font-semibold hover:from-purple-600 hover:to-pink-700 transition-all shadow-lg whitespace-nowrap"
+                  className="inline-flex items-center gap-2 bg-gradient-to-r from-blue-600 to-emerald-500 text-white px-6 py-3 rounded-xl text-sm font-semibold hover:from-blue-700 hover:to-emerald-600 transition-all shadow-lg whitespace-nowrap"
                 >
                   View Full Workflow
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
@@ -1574,7 +1574,7 @@ $ agenticorg sop deploy \\
             {/* Brand */}
             <div className="lg:col-span-1">
               <div className="flex items-center gap-2 mb-4">
-                <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center text-white font-bold text-sm">
+                <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-blue-500 to-teal-500 flex items-center justify-center text-white font-bold text-sm">
                   AO
                 </div>
                 <span className="text-white font-semibold">AgenticOrg</span>

--- a/ui/src/pages/Pricing.tsx
+++ b/ui/src/pages/Pricing.tsx
@@ -55,7 +55,7 @@ function DemoModal({ onClose }: { onClose: () => void }) {
 
   return (
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/70 backdrop-blur-sm px-4"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
       <div className="relative w-full max-w-md rounded-2xl bg-white shadow-2xl p-8">

--- a/ui/src/pages/RPAScripts.tsx
+++ b/ui/src/pages/RPAScripts.tsx
@@ -182,7 +182,7 @@ export default function RPAScripts() {
       {/* Run dialog */}
       {dialogScript && (
         <div
-          className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center"
+          className="fixed inset-0 bg-slate-950/60 z-50 flex items-center justify-center"
           onClick={() => setDialogScript(null)}
         >
           <div


### PR DESCRIPTION
## Summary

First concrete application of the impeccable skill pack (installed in #218). User asked "how do I see the impact?" — this PR shows it.

### What changed

**Typography** — \`ui/index.html\` swaps the system-default stack (\`-apple-system, …, Arial\`) for **Geist + JetBrains Mono** via Google Fonts. Geist is a modern, UI-tuned, open-source typeface from Vercel. impeccable explicitly calls out Inter + the system stack as AI-default and says pick a distinctive typeface.

**Gradient anti-patterns — Landing.tsx** — 10 purple/pink gradients replaced with on-brand pairs. Before/after:

| Before | After | Context |
|---|---|---|
| \`from-blue-500 to-purple-600\` | \`from-blue-500 to-teal-500\` | Hero logo + footer |
| \`from-purple-500 to-pink-600\` | \`from-blue-600 to-emerald-500\` | Voice agents callout, Shopify pill CTA |
| \`from-violet-500 to-purple-600\` | \`from-blue-500 to-teal-600\` | Dashboard bullet icon |
| \`from-pink-500 to-rose-600\` | \`from-emerald-500 to-teal-600\` | Enterprise-scale bullet |
| \`from-blue-50 via-white to-purple-50\` | \`from-blue-50 via-white to-teal-50\` | Integration hub panel |
| \`from-slate-50 to-purple-50\` | \`from-slate-50 to-teal-50\` | Voice agents card bg |

**Modal scrim tinting** — 14 pages had \`bg-black/50\` or \`/60\`. Swapped to \`bg-slate-950/60\` / \`/70\`. Pure black reads as lifeless next to a colored brand; tinted scrim matches the neutral palette.

**\`--muted-foreground\` tinted** — \`215 16% 47%\` → \`215 18% 42%\`. Higher chroma pulls secondary-text hue toward brand slate/blue; lower lightness preserves AA contrast.

**\`.impeccable.md\`** — design-context file (audience, use cases, brand personality). Every future \`/audit\`, \`/critique\`, \`/polish\` run reads this instead of re-running \`/impeccable teach\`.

### What it doesn't do

Visual impact you can see:
- Typography change is the biggest — compare before/after on the Landing hero.
- Gradients feel more cohesive (no purple).
- Modal backdrops warmer (tinted vs pure black).

Visual impact that's subtle:
- \`muted-foreground\` tint is almost imperceptible at a glance but makes the whole page feel less neutral-cool / more brand-cohesive.

### Test plan

- [x] \`tsc --noEmit\` — clean
- [x] \`vite build\` — 2.5s, 235 kB (index bundle size unchanged — no new deps)
- [x] \`python scripts/consistency_sweep.py\` — 6/6 checks green
- [x] No Playwright \`data-testid\` or role selectors touched
- [ ] Branch CI green
- [ ] Manual visual sanity — load Landing, Pricing, Settings, Dashboard in browser and confirm nothing looks worse

@codex please review — specifically on color choices (blue→teal vs blue→emerald) and whether we should also swap the \`from-blue-500 to-teal-500\` hero logo gradient for something even more distinctive.