### PR TITLE
fix(synthetic): retry on httpx.ReadTimeout + 60s timeout

### DIFF
--- a/tests/synthetic_data/test_synthetic_flows.py
+++ b/tests/synthetic_data/test_synthetic_flows.py
@@ -87,12 +87,16 @@ def _get_agent_id(headers: dict, agent_type: str) -> str:
 def _run_agent(headers: dict, agent_id: str, action: str, inputs: dict) -> dict:
     """Run an agent and return the full response.
 
-    Retries up to 3 times on two distinct transient-flake classes:
-      1. JSONDecodeError — cold-worker 502 on the first call after a
+    Retries up to 3 times on three distinct transient-flake classes:
+      1. httpx.ReadTimeout / httpx.ConnectError — cold-worker, or the
+         LLM took longer than the per-request 45s window. Back off
+         longer than on other classes since the upstream likely needs
+         time to recover.
+      2. JSONDecodeError — cold-worker 502 on the first call after a
          pod rollout (FastAPI not yet up).
-      2. `raw_output == ""` AND `reasoning_trace` empty — LLM-side
+      3. `raw_output == ""` AND `reasoning_trace` empty — LLM-side
          empty-response flake we see once every ~30 runs. A single
-         retry with back-off clears both without hiding real
+         retry with back-off clears this without hiding real
          regressions: repeated empties still bubble up as a failing
          assertion downstream.
     """
@@ -100,12 +104,20 @@ def _run_agent(headers: dict, agent_id: str, action: str, inputs: dict) -> dict:
 
     last: dict = {}
     for attempt in range(3):
-        r = httpx.post(
-            f"{BASE}/agents/{agent_id}/run",
-            headers=headers,
-            json={"action": action, "inputs": inputs},
-            timeout=45,
-        )
+        try:
+            r = httpx.post(
+                f"{BASE}/agents/{agent_id}/run",
+                headers=headers,
+                json={"action": action, "inputs": inputs},
+                timeout=60,  # bumped 45→60 for LLM latency ceiling
+            )
+        except (httpx.ReadTimeout, httpx.ConnectError, httpx.RemoteProtocolError):
+            if attempt < 2:
+                # Back off 5s / 10s — upstream LLM or worker needs
+                # breathing room, not just a fast retry.
+                _time.sleep(5 * (attempt + 1))
+                continue
+            raise
         try:
             result = r.json()
         except Exception:


### PR DESCRIPTION
## Summary

Main-CI e2e on the CSP-fix deploy (#229) unblocked public-routes, surfaced a third flake class the \`_run_agent\` retry loop wasn't catching:

    FAILED tests/synthetic_data/test_synthetic_flows.py::TestAPInvoiceProcessing
        ::test_happy_path_matched — httpx.ReadTimeout
    FAILED …::test_3way_mismatch_hitl — httpx.ReadTimeout

The existing retry wraps \`r.json()\` but not \`httpx.post()\` itself — a ReadTimeout raised during POST propagated out before the retry could see it.

### Fix

- Wrap the POST in try/except catching \`httpx.ReadTimeout\`, \`httpx.ConnectError\`, \`httpx.RemoteProtocolError\`
- Back-off 5s/10s (longer than the 2s/4s on JSONDecode) since upstream LLM needs more than a fast retry to recover
- Bump per-call timeout 45s → 60s for cold-worker + large-prompt cases

Three total attempts, persistent timeouts still bubble up — real regressions aren't hidden.

## Test plan

- [x] \`ruff check\` — clean
- [ ] Branch CI green
- [ ] Next main-CI e2e run avoids the ReadTimeout class

@codex please review.