### PR TITLE
fix(security): CRITICAL-02 filing authz bypass + CRITICAL-03 CDC tenant leak

### DIFF
--- a/api/v1/cdc_webhooks.py
+++ b/api/v1/cdc_webhooks.py
@@ -4,24 +4,54 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, Depends, Query, Request
 
+from api.deps import get_current_tenant
 from core.cdc.receiver import get_stored_events, handle_cdc_webhook
 
 router = APIRouter()
 
 
-@router.post("/webhooks/cdc/{connector}")
-async def cdc_webhook(connector: str, request: Request) -> dict[str, Any]:
-    """Receive a CDC webhook from any connector.
+@router.post("/webhooks/cdc/{tenant_id}/{connector}")
+async def cdc_webhook(
+    tenant_id: str,
+    connector: str,
+    request: Request,
+) -> dict[str, Any]:
+    """Receive a CDC webhook for a specific tenant.
 
-    The connector name is passed as a path parameter.  Signature validation
-    uses a per-connector secret from the environment (CDC_WEBHOOK_SECRET_<CONNECTOR>).
+    The URL carries the tenant_id so cross-tenant routing is explicit
+    at the transport layer (the pre-fix `/webhooks/cdc/{connector}`
+    shape stored every event in a shared list — CRITICAL-03 in the
+    2026-04-19 security audit). Signature verification still uses the
+    per-connector secret `CDC_WEBHOOK_SECRET_<CONNECTOR>`.
+
+    Producers must update their webhook URL to include the tenant.
+    The legacy unscoped path returns 410 Gone below.
     """
     payload: dict[str, Any] = await request.json()
     signature = request.headers.get("X-CDC-Signature", "")
-    result = await handle_cdc_webhook(connector, payload, signature)
+    result = await handle_cdc_webhook(tenant_id, connector, payload, signature)
     return result
+
+
+@router.post("/webhooks/cdc/{connector}", status_code=410)
+async def cdc_webhook_legacy(connector: str) -> dict[str, Any]:
+    """Legacy unscoped CDC URL — 410 Gone.
+
+    Events posted here would land in a shared store with no tenant
+    ownership tag; rejecting keeps that leak closed. Update callers
+    to `/webhooks/cdc/{tenant_id}/{connector}`.
+    """
+    return {
+        "error": "endpoint_removed",
+        "message": (
+            "POST /webhooks/cdc/{connector} was removed for cross-tenant "
+            "isolation. Use /webhooks/cdc/{tenant_id}/{connector} "
+            "(see SECURITY_AUDIT_2026-04-19.md CRITICAL-03)."
+        ),
+        "connector": connector,
+    }
 
 
 @router.get("/cdc/events")
@@ -30,14 +60,16 @@ async def list_cdc_events(
     event_type: str | None = Query(None, description="Filter by event type"),
     page: int = Query(1, ge=1, description="Page number"),
     page_size: int = Query(50, ge=1, le=200, description="Items per page"),
+    tenant_id: str = Depends(get_current_tenant),
 ) -> dict[str, Any]:
-    """Return stored CDC events with optional filtering and pagination.
+    """Return stored CDC events for the CALLER's tenant only.
 
-    Uses the in-memory store from ``core.cdc.receiver``.
+    Enforces tenant isolation at the read layer so a global in-memory
+    store never leaks cross-tenant events (CRITICAL-03 fix).
     """
-    events = get_stored_events()
+    events = get_stored_events(tenant_id=tenant_id)
 
-    # Apply filters
+    # Apply optional filters
     if connector:
         events = [e for e in events if e.get("connector") == connector]
     if event_type:

--- a/api/v1/companies.py
+++ b/api/v1/companies.py
@@ -1030,16 +1030,19 @@ async def approve_filing(
         if not company:
             raise HTTPException(404, "Company not found")
 
-        # Check the user has partner role on this company
-        # user_roles keys can be user_id (UUID) or email — check both
+        # Check the current caller has partner role on this company.
+        # user_roles keys can be user_id (UUID) or email — check the
+        # caller's own identifiers, NEVER scan other users' entries.
+        # Prior code iterated values and promoted the caller if ANY
+        # user in the company had partner role (CRITICAL-02 authz
+        # bypass in SECURITY_AUDIT_2026-04-19.md).
         roles = company.user_roles or {}
-        user_role = roles.get(user_email)
-        if not user_role:
-            # Try matching by iterating values (key might be UUID)
-            for _key, _role in roles.items():
-                if _role == CompanyRole.partner.value:
-                    user_role = _role
-                    break
+        caller_ids = [user_email, user.get("sub", ""), user.get("user_id", "")]
+        user_role = None
+        for ident in caller_ids:
+            if ident and ident in roles:
+                user_role = roles[ident]
+                break
         # Also check if user is platform admin (role from JWT)
         jwt_role = user.get("role", "")
         if user_role != CompanyRole.partner.value and jwt_role != "admin":
@@ -1111,13 +1114,15 @@ async def reject_filing(
         if not company:
             raise HTTPException(404, "Company not found")
 
+        # Bind authz to the caller's identity only. Do NOT scan other
+        # users' role entries (CRITICAL-02 authz bypass fix).
         roles = company.user_roles or {}
-        user_role = roles.get(user_email)
-        if not user_role:
-            for _key, _role in roles.items():
-                if _role in (CompanyRole.partner.value, CompanyRole.manager.value):
-                    user_role = _role
-                    break
+        caller_ids = [user_email, user.get("sub", ""), user.get("user_id", "")]
+        user_role = None
+        for ident in caller_ids:
+            if ident and ident in roles:
+                user_role = roles[ident]
+                break
         jwt_role = user.get("role", "")
         if user_role not in (CompanyRole.partner.value, CompanyRole.manager.value) and jwt_role != "admin":
             raise HTTPException(403, "Only partners or managers can reject filings")

--- a/core/cdc/receiver.py
+++ b/core/cdc/receiver.py
@@ -9,8 +9,16 @@ import time
 from typing import Any
 
 # In-memory event store.  Replace with DB-backed store once migration exists.
+# Each entry is `{tenant_id, connector, ...}` — callers that read this
+# store MUST filter by tenant_id before returning to users. See
+# get_stored_events(tenant_id=...) below. The audit in 2026-04-19
+# (CRITICAL-03) flagged that a single shared list without tenant tags
+# leaked events across tenants through the read API.
 _event_store: list[dict[str, Any]] = []
-_seen_ids: set[str] = set()
+# Dedup set scoped by (tenant_id, connector, resource_type, resource_id,
+# event_type) — a different tenant can legitimately emit the same
+# fingerprint and we must still accept it.
+_seen_ids: set[tuple[str, str]] = set()
 
 
 def _compute_event_id(connector: str, payload: dict[str, Any]) -> str:
@@ -41,26 +49,35 @@ def _validate_signature(payload_bytes: bytes, signature: str, connector: str) ->
 
 
 async def handle_cdc_webhook(
+    tenant_id: str,
     connector: str,
     payload: dict[str, Any],
     signature: str,
 ) -> dict[str, Any]:
-    """Process an incoming CDC webhook.
+    """Process an incoming CDC webhook for a specific tenant.
 
     1. Validate signature (HMAC-SHA256 or provider-specific).
-    2. Normalize payload to CDC event format.
-    3. Deduplicate (skip if already seen).
+    2. Normalize payload to CDC event format + tag with tenant_id.
+    3. Deduplicate within the tenant (skip if already seen).
     4. Store event and trigger workflow evaluation asynchronously.
+
+    Reject the webhook (400) if no tenant_id is provided — a CDC
+    event without tenant ownership cannot be routed safely.
     """
     import json as _json
+
+    if not tenant_id:
+        return {"status": "rejected", "reason": "missing_tenant"}
 
     payload_bytes = _json.dumps(payload, sort_keys=True).encode()
 
     if not _validate_signature(payload_bytes, signature, connector):
         return {"status": "rejected", "reason": "invalid_signature"}
 
-    # Normalize to standard CDC event format
+    # Normalize to standard CDC event format. tenant_id is the first
+    # field so any downstream consumer MUST see the ownership tag.
     event: dict[str, Any] = {
+        "tenant_id": tenant_id,
         "connector": connector,
         "event_type": payload.get("event_type", payload.get("type", "unknown")),
         "resource_type": payload.get("resource_type", payload.get("object", "unknown")),
@@ -69,29 +86,37 @@ async def handle_cdc_webhook(
         "received_at": time.time(),
     }
 
-    event_id = _compute_event_id(connector, event)
+    fingerprint = _compute_event_id(connector, event)
+    dedup_key = (tenant_id, fingerprint)
 
-    # Deduplication
-    if event_id in _seen_ids:
-        return {"status": "duplicate", "event_id": event_id}
+    if dedup_key in _seen_ids:
+        return {"status": "duplicate", "event_id": fingerprint}
 
-    _seen_ids.add(event_id)
+    _seen_ids.add(dedup_key)
     _event_store.append(event)
 
-    # Trigger workflow evaluation asynchronously (best-effort)
+    # Trigger workflow evaluation asynchronously (best-effort) with
+    # the real tenant so downstream routing respects tenancy.
     try:
         from core.cdc.triggers import evaluate_triggers
 
-        evaluate_triggers(event, tenant_id="")
+        evaluate_triggers(event, tenant_id=tenant_id)
     except Exception:  # noqa: S110
         pass  # best-effort trigger evaluation
 
-    return {"status": "accepted", "event_id": event_id, "event": event}
+    return {"status": "accepted", "event_id": fingerprint, "event": event}
 
 
-def get_stored_events() -> list[dict[str, Any]]:
-    """Return all stored CDC events (for testing / inspection)."""
-    return list(_event_store)
+def get_stored_events(tenant_id: str | None = None) -> list[dict[str, Any]]:
+    """Return stored CDC events, optionally filtered by tenant.
+
+    Callers that serve user requests MUST pass a tenant_id. The
+    no-argument form (tenant_id=None) is only for tests and internal
+    diagnostics — it returns the full store.
+    """
+    if tenant_id is None:
+        return list(_event_store)
+    return [e for e in _event_store if e.get("tenant_id") == tenant_id]
 
 
 def clear_store() -> None:

--- a/tests/regression/test_security_audit_20260419.py
+++ b/tests/regression/test_security_audit_20260419.py
@@ -1,0 +1,145 @@
+"""Regression tests for the 2026-04-19 security audit fixes.
+
+Each test pins a specific finding from SECURITY_AUDIT_2026-04-19.md so
+the regression can't silently return. One test per finding where
+meaningful; combined where assertions share setup.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# CRITICAL-02 — filing-approval authorization must bind to caller identity
+# ---------------------------------------------------------------------------
+
+class TestFilingApprovalAuthz:
+    """Authz must bind to the current caller's identity, never to role
+    entries belonging to other users of the company. The pre-fix code
+    iterated role values and granted partner authority to any caller
+    if *any* user in the company had partner role.
+    """
+
+    def test_approve_filing_source_scans_caller_ids_only(self) -> None:
+        """The approve_filing handler source must not scan role values
+        looking for a partner match — authz must key off caller ids.
+        """
+        from api.v1 import companies as mod
+
+        src = inspect.getsource(mod.approve_filing)
+        # Pre-fix pattern: `for _key, _role in roles.items(): if _role == partner.value:`
+        assert "for _key, _role in roles.items()" not in src, (
+            "approve_filing must not iterate role entries to locate partner "
+            "status — caller identity MUST key the lookup. See "
+            "SECURITY_AUDIT_2026-04-19.md CRITICAL-02."
+        )
+        # Post-fix sentinel: caller-id sweep
+        assert "caller_ids" in src, (
+            "approve_filing must build a caller_ids list from the JWT and "
+            "look up the role ONLY from those identifiers."
+        )
+
+    def test_reject_filing_source_scans_caller_ids_only(self) -> None:
+        from api.v1 import companies as mod
+
+        src = inspect.getsource(mod.reject_filing)
+        assert "for _key, _role in roles.items()" not in src, (
+            "reject_filing must not iterate role entries. CRITICAL-02 fix."
+        )
+        assert "caller_ids" in src, (
+            "reject_filing must use caller_ids for the authz lookup."
+        )
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL-03 — CDC events must not leak across tenants
+# ---------------------------------------------------------------------------
+
+class TestCDCTenantIsolation:
+
+    @pytest.mark.asyncio
+    async def test_events_are_tenant_tagged_and_scoped(self) -> None:
+        """handle_cdc_webhook must tag every stored event with the
+        tenant_id it was received for, and get_stored_events(tenant_id=)
+        must never return events from a different tenant."""
+        import hashlib
+        import hmac
+        import json
+        import os
+
+        from core.cdc.receiver import (
+            clear_store,
+            get_stored_events,
+            handle_cdc_webhook,
+        )
+
+        # Per-connector HMAC secret (fail-closed path requires this).
+        os.environ["CDC_WEBHOOK_SECRET_TESTCONN"] = "sec-key"
+        try:
+            clear_store()
+            payload = {
+                "event_type": "record.updated",
+                "resource_type": "contact",
+                "resource_id": "c-42",
+            }
+            sig = hmac.new(
+                b"sec-key",
+                json.dumps(payload, sort_keys=True).encode(),
+                hashlib.sha256,
+            ).hexdigest()
+
+            # Tenant A ingests
+            result_a = await handle_cdc_webhook("tenant-a", "testconn", payload, sig)
+            assert result_a["status"] == "accepted"
+            assert result_a["event"]["tenant_id"] == "tenant-a"
+
+            # Tenant B's read must be empty — no cross-tenant leak
+            assert get_stored_events(tenant_id="tenant-b") == []
+
+            # Tenant A's read returns the event
+            a_events = get_stored_events(tenant_id="tenant-a")
+            assert len(a_events) == 1
+            assert a_events[0]["tenant_id"] == "tenant-a"
+        finally:
+            os.environ.pop("CDC_WEBHOOK_SECRET_TESTCONN", None)
+            clear_store()
+
+    @pytest.mark.asyncio
+    async def test_missing_tenant_id_is_rejected(self) -> None:
+        """A webhook with an empty tenant_id must be rejected — an
+        event without ownership cannot be routed safely."""
+        from core.cdc.receiver import handle_cdc_webhook
+
+        result = await handle_cdc_webhook("", "anyconnector", {}, "any-sig")
+        assert result["status"] == "rejected"
+        assert result["reason"] == "missing_tenant"
+
+    def test_legacy_unscoped_webhook_url_returns_410(self) -> None:
+        """The pre-fix POST /webhooks/cdc/{connector} endpoint must
+        now respond 410 Gone — any call to it was silently storing
+        events without tenant tags."""
+        from api.v1 import cdc_webhooks as mod
+
+        # Source sanity: the legacy handler decorator carries
+        # status_code=410 and a helpful redirection body.
+        src = inspect.getsource(mod.cdc_webhook_legacy)
+        assert "410" in src
+        assert "endpoint_removed" in src
+
+
+# ---------------------------------------------------------------------------
+# CDC read API tenant-filter regression
+# ---------------------------------------------------------------------------
+
+def test_cdc_list_endpoint_declares_tenant_dependency() -> None:
+    """GET /cdc/events must take tenant_id via Depends(get_current_tenant).
+    The pre-fix endpoint had no auth gate at all."""
+    from api.v1 import cdc_webhooks as mod
+
+    src = inspect.getsource(mod.list_cdc_events)
+    assert "get_current_tenant" in src, (
+        "/cdc/events must bind tenant_id via Depends(get_current_tenant). "
+        "CRITICAL-03 fix — no more unauthenticated read of the global store."
+    )

--- a/tests/unit/test_cdc.py
+++ b/tests/unit/test_cdc.py
@@ -50,12 +50,17 @@ async def test_webhook_stores_event():
         "resource_id": "c-123",
         "data": {"name": "Acme Corp"},
     }
-    result = await handle_cdc_webhook("salesforce", payload, signature=_sign(payload))
+    result = await handle_cdc_webhook(
+        "tenant-a", "salesforce", payload, signature=_sign(payload),
+    )
     assert result["status"] == "accepted"
-    events = get_stored_events()
+    events = get_stored_events(tenant_id="tenant-a")
     assert len(events) == 1
+    assert events[0]["tenant_id"] == "tenant-a"
     assert events[0]["connector"] == "salesforce"
     assert events[0]["event_type"] == "contact.updated"
+    # Cross-tenant read must NOT see it.
+    assert get_stored_events(tenant_id="tenant-b") == []
 
 
 @pytest.mark.asyncio
@@ -67,7 +72,9 @@ async def test_signature_validation():
     os.environ["CDC_WEBHOOK_SECRET_TESTCONN"] = "supersecret"
     try:
         payload = {"event_type": "record.created", "resource_type": "deal", "resource_id": "d-1"}
-        result = await handle_cdc_webhook("testconn", payload, signature="bad-signature")
+        result = await handle_cdc_webhook(
+            "tenant-a", "testconn", payload, signature="bad-signature",
+        )
         assert result["status"] == "rejected"
         assert get_stored_events() == []
     finally:
@@ -100,14 +107,21 @@ async def test_duplicate_event_skipped():
         "resource_type": "invoice",
         "resource_id": "inv-42",
     }
-    first = await handle_cdc_webhook("xero", payload, signature=_sign(payload))
+    first = await handle_cdc_webhook("tenant-a", "xero", payload, signature=_sign(payload))
     assert first["status"] == "accepted"
 
-    second = await handle_cdc_webhook("xero", payload, signature=_sign(payload))
+    second = await handle_cdc_webhook("tenant-a", "xero", payload, signature=_sign(payload))
     assert second["status"] == "duplicate"
 
-    # Only one event stored
-    assert len(get_stored_events()) == 1
+    # Only one event stored for tenant-a
+    assert len(get_stored_events(tenant_id="tenant-a")) == 1
+
+    # A DIFFERENT tenant sending the same fingerprint must NOT dedupe —
+    # the per-tenant dedup scope fixes a previous cross-tenant collision
+    # where tenant-b would see tenant-a's event count as "duplicate".
+    third = await handle_cdc_webhook("tenant-b", "xero", payload, signature=_sign(payload))
+    assert third["status"] == "accepted"
+    assert len(get_stored_events(tenant_id="tenant-b")) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two **CRITICAL** findings from \`SECURITY_AUDIT_2026-04-19.md\` patched with surgical changes + regression tests.

### CRITICAL-02 — filing approve/reject authorization bypass

**Before:** \`api/v1/companies.py\` approve_filing / reject_filing handlers — if the caller's email wasn't in \`company.user_roles\`, the code scanned \`roles.values()\` and granted partner/manager authority based on *another user's* role entry. Any authenticated tenant user could approve/reject filings as long as the company had at least one partner entry for someone else.

**After:** build a caller-id list from the JWT (\`email\`, \`sub\`, \`user_id\`), look up the role ONLY from those identifiers. No one else's entry contributes.

### CRITICAL-03 — CDC cross-tenant leakage

**Before:** global \`_event_store\` list, no tenant tags, GET \`/cdc/events\` unauthenticated, trigger evaluation called with \`tenant_id=""\`.

**After:**
- \`handle_cdc_webhook(tenant_id, …)\` tags every stored event, scopes dedup by \`(tenant_id, fingerprint)\`.
- \`get_stored_events(tenant_id=…)\` — scoped reads.
- \`POST /webhooks/cdc/{tenant_id}/{connector}\` — tenant in URL.
- \`POST /webhooks/cdc/{connector}\` — **410 Gone** with pointer to new URL.
- \`GET /cdc/events\` — binds tenant via \`Depends(get_current_tenant)\`.

### Regression coverage

\`tests/regression/test_security_audit_20260419.py\` — 5 tests pinning both fixes so the bypass can't silently return.

### Deferred (tracked)

- CRITICAL-01 (localStorage tokens → HttpOnly cookies) needs backend cookie issuance + SSO callback rework + client helper rewrite. Separate PR.
- HIGH-04..09 (webhooks fail-open, voice SSRF + admin gate, RPA isolation + admin gate, KB tenant partitioning) — next PR in series.
- MEDIUM-10..15 — follow-up.

## Test plan

- [x] \`ruff check\` clean
- [x] \`pytest tests/regression/test_security_audit_20260419.py tests/unit/test_cdc.py -q\` → 11 passed
- [ ] Branch CI green

@codex please review.