### PR TITLE
fix(security): PR-SEC-02 — HIGH batch (webhooks, voice, RPA, SSRF, redirect allowlist)

### DIFF
--- a/SECURITY_AUDIT_2026-04-19.md
+++ b/SECURITY_AUDIT_2026-04-19.md
@@ -1,0 +1,392 @@
+# Security Audit - 2026-04-19
+
+## Scope
+
+Static security review of the repository at `C:\Users\mishr\agentic-org`, with targeted code inspection across:
+
+- `api/`, `auth/`, `core/`, `connectors/`
+- `ui/`
+- `sdk/`, `sdk-ts/`, `mcp-server/`
+- security-related tests and deployment config
+
+This is a source-code security review, not a live penetration test. Findings below are confirmed from code paths present in the repository. Additional runtime, infrastructure, supply-chain, and deployment issues may still exist outside what can be proven from source alone.
+
+## Executive Summary
+
+Confirmed security issues found in this review:
+
+- `3` critical
+- `6` high
+- `5` medium/low
+
+The most serious problems are:
+
+- browser bearer tokens stored in `localStorage`
+- broken authorization in company filing approval/rejection flows
+- cross-tenant event leakage through global in-memory CDC/RPA state
+- unauthenticated or fail-open webhook ingestion
+- SSRF/server-side network probing surfaces in voice and connector flows
+
+## Findings
+
+### CRITICAL-01: Bearer tokens are stored in browser `localStorage`
+
+**Evidence**
+
+- `ui/src/contexts/AuthContext.tsx:30-32`
+- `ui/src/contexts/AuthContext.tsx:48-49`
+- `ui/src/contexts/AuthContext.tsx:70-71`
+- `ui/src/contexts/AuthContext.tsx:88-89`
+- `ui/src/contexts/AuthContext.tsx:99`
+- `ui/src/contexts/AuthContext.tsx:108`
+- `ui/src/lib/api.ts:7`
+- `ui/src/pages/SSOCallback.tsx:9`
+- `ui/src/pages/SSOCallback.tsx:23-25`
+- `ui/src/pages/SSOCallback.tsx:43-48`
+- `ui/src/pages/InviteAccept.tsx:51-52`
+
+**Issue**
+
+Access tokens are persisted in `localStorage` and then read back into API requests. The SSO callback also accepts a JWT in the URL fragment and persists it to `localStorage`.
+
+**Impact**
+
+Any XSS in the SPA, third-party script compromise, browser extension compromise, or malicious injected content can steal full-session bearer tokens. Because the token is bearer-based, theft is usually equivalent to full account takeover until expiry or revocation.
+
+**Why this is severe**
+
+The repository also ships a CSP that still allows `'unsafe-inline'` and `'unsafe-eval'`, which materially weakens the browser-side mitigation posture.
+
+**Remediation direction**
+
+Move session handling to `HttpOnly`, `Secure`, `SameSite` cookies, remove token persistence from `localStorage`, and convert the SSO callback to a one-time server exchange.
+
+### CRITICAL-02: Filing approval/rejection authorization is broken
+
+**Evidence**
+
+- `api/v1/companies.py:1035-1045`
+- `api/v1/companies.py:1114-1122`
+
+**Issue**
+
+If the current caller's email is not found in `company.user_roles`, the code iterates role values and grants partner or manager authority if any company user has that role. That means the caller is effectively authorized based on another user's role entry.
+
+**Impact**
+
+An authenticated tenant user can approve or reject filings they should not control, as long as the company has at least one partner or manager entry.
+
+**Why this is severe**
+
+This is a direct authorization bypass on a compliance-sensitive workflow.
+
+**Remediation direction**
+
+Authorization must bind to the current caller's identity only. Never infer caller authority by scanning whether the company has some user with the required role.
+
+### CRITICAL-03: CDC events are stored globally and exposed without tenant isolation
+
+**Evidence**
+
+- `core/cdc/receiver.py:12-13`
+- `core/cdc/receiver.py:79`
+- `core/cdc/receiver.py:85`
+- `core/cdc/receiver.py:94`
+- `api/v1/cdc_webhooks.py:28-38`
+
+**Issue**
+
+CDC webhook events are appended to a global in-memory `_event_store`. Trigger evaluation is called with `tenant_id=""`, and the read API returns stored events with only connector and event-type filters, not tenant filters.
+
+**Impact**
+
+Users can potentially read CDC events originating from other tenants. This is a direct multi-tenant isolation failure.
+
+**Remediation direction**
+
+Persist CDC events with tenant ownership, require tenant-filtered queries, and remove all global unscoped event storage from request-serving paths.
+
+### HIGH-04: Webhook ingestion is unauthenticated or fail-open
+
+**Evidence**
+
+- `api/v1/webhooks.py:79-94`
+- `api/v1/webhooks.py:133`
+- `api/v1/webhooks.py:182-223`
+- `api/v1/webhooks.py:223-267`
+
+**Issue**
+
+- SendGrid verification returns `True` when `SENDGRID_WEBHOOK_KEY` is unset.
+- Mailchimp webhook processing does not verify a signature.
+- MoEngage webhook processing does not verify a signature.
+
+**Impact**
+
+Attackers can forge delivery/open/click/bounce events, poison campaign telemetry, and potentially trigger workflow resumes tied to those email events.
+
+**Remediation direction**
+
+Require signature verification on every externally reachable webhook endpoint. Do not ship fail-open verification logic.
+
+### HIGH-05: Any authenticated tenant user can read and overwrite tenant-wide voice secrets
+
+**Evidence**
+
+- `api/v1/voice.py:136-138`
+- `api/v1/voice.py:256-271`
+
+**Issue**
+
+Voice configuration and connection-test endpoints depend only on `get_current_tenant`. They are not admin-gated. The saved config includes sensitive telephony/API credentials and is returned back through `GET /voice/config`.
+
+**Impact**
+
+Any authenticated user inside a tenant can:
+
+- read tenant-wide voice credentials
+- replace voice credentials
+- test outbound connectivity with attacker-supplied endpoints
+
+**Remediation direction**
+
+Require explicit admin or privileged-operator scope for voice configuration and return masked secrets by default.
+
+### HIGH-06: Voice custom SIP connection testing is an SSRF/internal network probing primitive
+
+**Evidence**
+
+- `api/v1/voice.py:136`
+- `api/v1/voice.py:205`
+- `api/v1/voice.py:233`
+- `api/v1/voice.py:240-245`
+
+**Issue**
+
+`POST /voice/test-connection` accepts a custom SIP endpoint, extracts host/port, and opens a raw TCP socket from the server to that target.
+
+**Impact**
+
+Authenticated users can make the backend probe internal IPs, private services, or cloud metadata-adjacent surfaces and use response differences for port scanning or network reconnaissance.
+
+**Remediation direction**
+
+Block private/reserved IP ranges, require strict allowlists for customer-configurable voice endpoints, and move reachability tests behind privileged operations only.
+
+### HIGH-07: Knowledge-base integration appears to use a shared external dataset across tenants
+
+**Evidence**
+
+- `api/v1/knowledge.py:97-100`
+- `api/v1/knowledge.py:111`
+- `api/v1/knowledge.py:131`
+- `api/v1/knowledge.py:146`
+- `api/v1/knowledge.py:285`
+- `api/v1/knowledge.py:359`
+- `api/v1/knowledge.py:471`
+
+**Issue**
+
+RAGFlow operations are performed against `datasets/default` and searches use `dataset_ids: ["default"]`. Upload passes `tenant_id` as a query parameter, but list/search/delete paths do not partition at the dataset level.
+
+**Impact**
+
+If the backing RAGFlow deployment is shared as implied by this code, tenants may be able to search, list, or delete one another's knowledge documents through the external KB layer.
+
+**Remediation direction**
+
+Use dedicated tenant-scoped dataset IDs, not a shared `default` dataset, and enforce ownership checks on every list/search/delete path.
+
+### HIGH-08: RPA execution history is stored globally and returned without tenant filtering
+
+**Evidence**
+
+- `api/v1/rpa.py:109`
+- `api/v1/rpa.py:176-184`
+- `api/v1/rpa.py:243`
+
+**Issue**
+
+RPA execution history is appended to a global `_execution_history` list. The `list_history` endpoint explicitly notes tenant filtering is a future item, but still returns the shared in-memory history.
+
+**Impact**
+
+Users can see other tenants' RPA execution metadata. Depending on failures and script naming, this can leak sensitive operational activity.
+
+**Remediation direction**
+
+Persist execution history with tenant ownership and reject all reads that are not filtered by tenant at the data layer.
+
+### HIGH-09: Any authenticated tenant user can trigger server-side browser automation against arbitrary portals
+
+**Evidence**
+
+- `api/v1/rpa.py:65`
+- `api/v1/rpa.py:147`
+- `api/v1/rpa.py:192-197`
+- `rpa/scripts/generic_portal.py:105-132`
+- `rpa/scripts/generic_portal.py:192-193`
+- `core/rpa/executor.py:102-103`
+
+**Issue**
+
+The generic portal automation flow accepts arbitrary `portal_url`, credentials, and optional `target_url`, then launches headless Chromium from the server and browses to those destinations. The API is not admin-gated.
+
+**Impact**
+
+This creates a high-risk abuse surface for:
+
+- SSRF-like browser-based internal access
+- credential handling on untrusted destinations
+- automated interaction with attacker-controlled sites from trusted server egress
+
+**Remediation direction**
+
+Restrict RPA execution to privileged operators, enforce domain allowlists, and isolate browser automation workers from sensitive internal networks.
+
+### MEDIUM-10: Invite and password-reset bearer tokens are placed in query strings
+
+**Evidence**
+
+- `api/v1/org.py:176-203`
+- `api/v1/auth.py:415-424`
+
+**Issue**
+
+Invitation and password-reset links embed the bearer token directly in the URL query string.
+
+**Impact**
+
+Query-string tokens are more likely to leak into:
+
+- browser history
+- reverse-proxy logs
+- email security scanners
+- analytics/referrer chains
+- screenshots and support tooling
+
+**Remediation direction**
+
+Use one-time opaque codes, POST-based completion, or short-lived exchange tokens delivered through safer flows.
+
+### MEDIUM-11: Billing flows accept caller-controlled redirect/return URLs
+
+**Evidence**
+
+- `api/v1/billing.py:37-38`
+- `api/v1/billing.py:60`
+- `api/v1/billing.py:132-136`
+- `api/v1/billing.py:331-341`
+- `core/billing/stripe_client.py:130-144`
+- `core/billing/stripe_client.py:379-383`
+
+**Issue**
+
+Stripe checkout and portal helpers accept `success_url`, `cancel_url`, and `return_url` directly from the caller and pass them through without allowlist validation.
+
+**Impact**
+
+This enables open-redirect style abuse and phishing opportunities after billing actions.
+
+**Remediation direction**
+
+Validate redirect targets against a strict allowlist of first-party domains and approved paths.
+
+### MEDIUM-12: Admin-configurable connector `base_url` values can be abused for SSRF during test/connect flows
+
+**Evidence**
+
+- `api/v1/connectors.py:182`
+- `api/v1/connectors.py:194`
+- `api/v1/connectors.py:205`
+- `api/v1/connectors.py:412-413`
+- `connectors/framework/base_connector.py:42`
+- `connectors/framework/base_connector.py:44-46`
+- `connectors/framework/base_connector.py:89-90`
+- `connectors/framework/base_connector.py:108-116`
+
+**Issue**
+
+Connector registration persists an arbitrary `base_url`, connector instances honor that override, and the connector test path calls `connect()` plus `health_check()`, which makes outbound requests to that configured host.
+
+**Impact**
+
+Tenant admins can turn the platform into an SSRF client against arbitrary destinations unless outbound access is heavily fenced at the network layer.
+
+**Remediation direction**
+
+Validate connector destinations, block private address space, and enforce per-connector host allowlists.
+
+### MEDIUM-13: Production CSP still allows `'unsafe-inline'` and `'unsafe-eval'`
+
+**Evidence**
+
+- `ui/nginx.conf:43-48`
+
+**Issue**
+
+The shipped CSP allows inline scripts and `eval`-style execution.
+
+**Impact**
+
+This materially weakens XSS resistance. Combined with `localStorage` session tokens, the blast radius of any front-end injection is much higher.
+
+**Remediation direction**
+
+Adopt nonce- or hash-based CSP, remove `unsafe-eval`, and eliminate inline script dependencies.
+
+### LOW-14: Public branding lookup accepts arbitrary `host` query values, enabling tenant-domain enumeration
+
+**Evidence**
+
+- `api/v1/branding.py:116-118`
+- `api/v1/branding.py:151`
+
+**Issue**
+
+The public branding endpoint accepts `host` as a query parameter and uses it to look up `TenantBranding.custom_domain == host`.
+
+**Impact**
+
+Attackers can probe for known or guessed custom domains and enumerate whether those domains are configured in the platform.
+
+**Remediation direction**
+
+Use the actual request host/header path under trusted proxy handling, and rate-limit or anonymize existence checks.
+
+### LOW-15: Predictable development secret values are tracked in repository config
+
+**Evidence**
+
+- `docker-compose.yml:63`
+- `docker-compose.yml:87`
+- `auth/jwt.py:51`
+- `core/auth_state.py:131`
+
+**Issue**
+
+Tracked compose configuration includes predictable secret values, and some auth-supporting code paths still fall back to hard-coded default secret strings when environment configuration is absent.
+
+**Impact**
+
+This is not an immediate exploit by itself, but it increases the probability of insecure deployments using predictable secrets or derived token-blacklist keys.
+
+**Remediation direction**
+
+Remove predictable secret defaults from tracked runtime config and fail closed whenever security-critical secrets are missing.
+
+## Notes On Coverage
+
+- Existing security-oriented tests are present under `tests/security/` and `ui/e2e/security-tests.spec.ts`.
+- Those tests do not currently prevent the vulnerabilities above.
+- Several of the most serious issues are authorization, tenant-isolation, and trust-boundary defects that should be covered by explicit regression tests after remediation.
+
+## Priority Order
+
+1. Remove browser token storage and redesign session handling.
+2. Fix filing authorization logic.
+3. Eliminate global unscoped CDC/RPA stores and restore tenant isolation.
+4. Lock down webhook verification.
+5. Lock down voice/RPA privileged operations and SSRF surfaces.
+6. Re-architect knowledge-base tenant partitioning.
+7. Tighten redirect validation, CSP, and configuration hardening.

--- a/api/v1/billing.py
+++ b/api/v1/billing.py
@@ -14,7 +14,9 @@ Plural flow:
 
 from __future__ import annotations
 
+import os
 from typing import Any
+from urllib.parse import urlparse
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -26,6 +28,59 @@ from api.deps import get_current_tenant
 logger = structlog.get_logger()
 
 router = APIRouter(prefix="/billing", tags=["Billing"])
+
+
+def _allowed_redirect_hosts() -> set[str]:
+    """First-party domains that may receive billing redirects.
+
+    MEDIUM-11: caller-supplied success_url/cancel_url/return_url used to
+    pass through to Stripe unchecked, enabling open-redirect phishing
+    opportunities after billing actions.
+
+    The allowlist starts from ``AGENTICORG_FRONTEND_URL`` and can be
+    extended via ``AGENTICORG_BILLING_REDIRECT_ALLOWLIST`` (comma-
+    separated hostnames).
+    """
+    hosts: set[str] = set()
+    fe_url = os.getenv("AGENTICORG_FRONTEND_URL", "").strip()
+    if fe_url:
+        host = urlparse(fe_url).hostname
+        if host:
+            hosts.add(host.lower())
+    extra = os.getenv("AGENTICORG_BILLING_REDIRECT_ALLOWLIST", "").strip()
+    if extra:
+        for item in extra.split(","):
+            item = item.strip().lower()
+            if item:
+                hosts.add(item)
+    return hosts
+
+
+def _validate_redirect_url(url: str, field: str) -> str:
+    """Return ``url`` if it points at an allowlisted first-party host.
+
+    Empty strings are allowed — callers may intentionally omit the
+    redirect to let the gateway pick its default.
+    """
+    if not url:
+        return url
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(400, f"{field} must be http(s): got '{parsed.scheme}'")
+    host = (parsed.hostname or "").lower()
+    allowed = _allowed_redirect_hosts()
+    if not allowed:
+        raise HTTPException(
+            500,
+            "Billing redirect allowlist is empty. Set AGENTICORG_FRONTEND_URL "
+            "or AGENTICORG_BILLING_REDIRECT_ALLOWLIST.",
+        )
+    if host not in allowed:
+        raise HTTPException(
+            400,
+            f"{field} host '{host}' is not in the billing redirect allowlist.",
+        )
+    return url
 
 
 # ── Request / Response models ────────────────────────────────────────
@@ -128,12 +183,14 @@ async def subscribe_stripe(
     """Create a Stripe Checkout Session for subscription."""
     from core.billing.stripe_client import create_checkout_session
 
+    success_url = _validate_redirect_url(body.success_url, "success_url")
+    cancel_url = _validate_redirect_url(body.cancel_url, "cancel_url")
     try:
         result = create_checkout_session(
             tenant_id=tenant_id,
             plan=body.plan,
-            success_url=body.success_url,
-            cancel_url=body.cancel_url,
+            success_url=success_url,
+            cancel_url=cancel_url,
             customer_email=body.customer_email,
             customer_name=body.customer_name,
         )
@@ -335,10 +392,11 @@ async def create_portal(
     """Create a Stripe Customer Portal session for self-service billing."""
     from core.billing.stripe_client import create_portal_session
 
+    return_url = _validate_redirect_url(body.return_url, "return_url")
     try:
         url = create_portal_session(
             tenant_id=tenant_id,
-            return_url=body.return_url,
+            return_url=return_url,
         )
         return {"portal_url": url}
     except ValueError as exc:

--- a/api/v1/connectors.py
+++ b/api/v1/connectors.py
@@ -28,6 +28,10 @@ def _assert_public_base_url(base_url: str) -> None:
     base_url on a connector, turning connector test/health flows into an
     SSRF primitive against the cluster's internal network (including
     169.254.169.254 cloud metadata).
+
+    Unresolvable hosts are allowed through (DNS may be environment-
+    specific — CI cannot prove a production host is bad); only explicit
+    resolution to a private/reserved range is blocked.
     """
     if not base_url:
         return
@@ -37,12 +41,24 @@ def _assert_public_base_url(base_url: str) -> None:
     host = parsed.hostname or ""
     if not host:
         raise HTTPException(400, "Connector base_url is missing a host")
+
+    # Reject bare IPs in private/reserved ranges without needing DNS.
     try:
-        infos = socket.getaddrinfo(host, None)
-    except socket.gaierror as exc:
-        raise HTTPException(400, f"Connector base_url host does not resolve: {exc}") from None
-    for info in infos:
-        addr = info[4][0]
+        literal_ip: ipaddress._BaseAddress | None = ipaddress.ip_address(host)
+    except ValueError:
+        literal_ip = None
+    candidates: list[str] = []
+    if literal_ip is not None:
+        candidates.append(str(literal_ip))
+    else:
+        try:
+            infos = socket.getaddrinfo(host, None)
+            candidates = [info[4][0] for info in infos]
+        except socket.gaierror:
+            # Unresolvable — httpx will error on the real call. Don't
+            # block registration purely on a transient DNS miss.
+            return
+    for addr in candidates:
         try:
             ip = ipaddress.ip_address(addr)
         except ValueError:

--- a/api/v1/connectors.py
+++ b/api/v1/connectors.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import ipaddress
 import logging
+import socket
 import uuid as _uuid
+from urllib.parse import urlparse
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -16,6 +19,49 @@ from core.models.connector import Connector
 from core.schemas.api import ConnectorCreate, ConnectorUpdate
 
 _log = logging.getLogger(__name__)
+
+
+def _assert_public_base_url(base_url: str) -> None:
+    """Reject connector base_urls that resolve to private/reserved ranges.
+
+    SECURITY_AUDIT-2026-04-19 MEDIUM-12: admins could previously set any
+    base_url on a connector, turning connector test/health flows into an
+    SSRF primitive against the cluster's internal network (including
+    169.254.169.254 cloud metadata).
+    """
+    if not base_url:
+        return
+    parsed = urlparse(base_url)
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(400, f"Connector base_url must be http(s): got '{parsed.scheme}'")
+    host = parsed.hostname or ""
+    if not host:
+        raise HTTPException(400, "Connector base_url is missing a host")
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        raise HTTPException(400, f"Connector base_url host does not resolve: {exc}") from None
+    for info in infos:
+        addr = info[4][0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            continue
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            raise HTTPException(
+                403,
+                f"Connector base_url '{host}' resolves to a blocked "
+                f"address ({ip}). Private, loopback, link-local, "
+                "multicast, reserved, and unspecified ranges are not "
+                "allowed.",
+            )
 
 router = APIRouter(dependencies=[require_tenant_admin])
 
@@ -185,6 +231,9 @@ async def register_connector(
 ):
     tid = _uuid.UUID(tenant_id)
 
+    # MEDIUM-12: reject SSRF-capable base_urls before persisting.
+    _assert_public_base_url(body.base_url or "")
+
     # Separate secret material from non-secret config.
     # auth_config on the Connector model is deprecated for secrets —
     # new writes go to connector_configs.credentials_encrypted via
@@ -281,7 +330,11 @@ async def update_connector(
         # auth_config is deprecated for new writes — secrets go via
         # connector_configs.credentials_encrypted.
         _blocked_fields = {"id", "tenant_id", "auth_config", "secret_ref"}
-        for field, value in body.model_dump(exclude_none=True).items():
+        updates = body.model_dump(exclude_none=True)
+        # MEDIUM-12: same SSRF guard on update paths.
+        if "base_url" in updates:
+            _assert_public_base_url(updates["base_url"] or "")
+        for field, value in updates.items():
             if field in _blocked_fields:
                 continue
             setattr(connector, field, value)
@@ -377,6 +430,12 @@ async def test_connector(
     connector_cls = ConnectorRegistry.get(connector.name)
     if not connector_cls:
         return {"tested": False, "error": f"No connector class for '{connector.name}'"}
+
+    # MEDIUM-12: even if the stored base_url was valid when saved, re-check
+    # at test time so a stale DNS record flipped to a private IP can't be
+    # used as an SSRF primitive.
+    effective_base_url = (connector.base_url or getattr(connector_cls, "base_url", "") or "")
+    _assert_public_base_url(effective_base_url)
 
     # Load credentials from ENCRYPTED connector_configs first,
     # falling back to legacy plaintext auth_config for backward compat.

--- a/api/v1/rpa.py
+++ b/api/v1/rpa.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from api.deps import get_current_tenant
@@ -105,8 +105,17 @@ _BUILTIN_SCRIPTS: dict[str, dict[str, Any]] = {
     },
 }
 
-# In-memory execution history (per-process; Redis-backed in production)
-_execution_history: list[dict[str, Any]] = []
+# In-memory per-tenant execution history (per-process; Redis-backed in production).
+# SECURITY_AUDIT-2026-04-19 HIGH-08: pre-fix this was a single global list
+# shared across tenants, so any caller could read every tenant's history.
+_execution_history: dict[str, list[dict[str, Any]]] = {}
+
+
+# Generic portal RPA has no domain allowlist. It can be pointed at any
+# URL, login with arbitrary credentials, and navigate to any target —
+# SECURITY_AUDIT-2026-04-19 HIGH-09 flagged this as SSRF-like server-side
+# automation. Gate it behind tenant admin until a real allowlist lands.
+_ADMIN_ONLY_SCRIPTS: frozenset[str] = frozenset({"generic_portal"})
 
 
 # ── Schemas ──────────────────────────────────────────────────────────
@@ -177,11 +186,15 @@ async def list_history(
     limit: int = 50,
     tenant_id: str = Depends(get_current_tenant),
 ) -> list[RPAExecutionOut]:
-    """Return recent RPA execution history."""
-    # Filter by tenant (future: when executions are DB-backed)
+    """Return the caller's tenant RPA execution history.
+
+    HIGH-08 fix: the store is keyed by tenant and this endpoint will only
+    ever return entries tagged with the caller's authenticated tenant_id.
+    """
+    tenant_history = _execution_history.get(str(tenant_id), [])
     return [
         RPAExecutionOut(**h)
-        for h in reversed(_execution_history[-limit:])
+        for h in reversed(tenant_history[-limit:])
     ]
 
 
@@ -189,18 +202,40 @@ async def list_history(
 async def run_script(
     script_id: str,
     body: RPARunRequest,
+    request: Request,
     tenant_id: str = Depends(get_current_tenant),
 ) -> RPAExecutionOut:
     """Execute an RPA script and return the result.
 
     The script runs in a headless Chromium browser via Playwright.
     Requires ``playwright`` to be installed on the server.
+
+    HIGH-09: scripts in ``_ADMIN_ONLY_SCRIPTS`` (currently just
+    ``generic_portal``) require tenant admin because they can be
+    pointed at arbitrary URLs and are therefore a server-side
+    automation/SSRF surface.
     """
     # Resolve script key
     script_key = script_id.replace("builtin-", "") if script_id.startswith("builtin-") else script_id
 
     if script_key not in _BUILTIN_SCRIPTS:
         raise HTTPException(404, f"RPA script '{script_key}' not found")
+
+    if script_key in _ADMIN_ONLY_SCRIPTS:
+        scopes = getattr(request.state, "scopes", []) or []
+        claims = getattr(request.state, "claims", {}) or {}
+        is_admin = (
+            "agenticorg:admin" in scopes
+            or any(s.startswith("agenticorg:admin") for s in scopes)
+            or claims.get("role") == "admin"
+        )
+        if not is_admin:
+            raise HTTPException(
+                403,
+                f"RPA script '{script_key}' requires tenant admin — "
+                "it can be pointed at arbitrary URLs and is gated to "
+                "privileged operators.",
+            )
 
     meta = _BUILTIN_SCRIPTS[script_key]
     execution_id = str(uuid.uuid4())
@@ -240,7 +275,7 @@ async def run_script(
             tenant_id=tenant_id,
         )
 
-    _execution_history.append(execution.model_dump())
+    _execution_history.setdefault(str(tenant_id), []).append(execution.model_dump())
 
     logger.info(
         "rpa_script_executed",

--- a/api/v1/voice.py
+++ b/api/v1/voice.py
@@ -16,16 +16,88 @@ give the user a fast pass/fail answer.
 
 from __future__ import annotations
 
+import ipaddress
 import re
+import socket
 from typing import Literal
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
-from api.deps import get_current_tenant
+from api.deps import get_current_tenant, require_tenant_admin
 
 router = APIRouter()
+
+
+def _resolve_and_block_private(host: str) -> str:
+    """Resolve a hostname and reject private/reserved/link-local targets.
+
+    SECURITY_AUDIT-2026-04-19 HIGH-06: the voice connection-test endpoint
+    was a server-side SSRF primitive. We now resolve the target host and
+    reject any address that is private, loopback, link-local, multicast,
+    reserved, or unspecified — blocking cloud metadata (169.254.169.254),
+    localhost, RFC 1918 ranges, and IPv6 equivalents.
+
+    Returns the resolved IPv4/IPv6 literal to connect to on success.
+    Raises HTTPException(400) on unresolved hosts and HTTPException(403)
+    on blocked addresses.
+    """
+    if not host:
+        raise HTTPException(400, "SIP endpoint host is empty")
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        raise HTTPException(400, f"Could not resolve SIP host: {exc}") from None
+    for info in infos:
+        addr = info[4][0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            continue
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            raise HTTPException(
+                403,
+                f"SIP endpoint resolves to a blocked address ({ip}). "
+                "Private, loopback, link-local, multicast, reserved, and "
+                "unspecified ranges are not allowed.",
+            )
+    return infos[0][4][0]
+
+
+def _mask_secret(value: str | None) -> str:
+    """Mask a sensitive credential for safe return to the client.
+
+    Keeps the last 4 characters when the secret is long enough; otherwise
+    returns a full mask. Empty/None stays empty so the UI can distinguish
+    'not configured' from 'configured but hidden'.
+    """
+    if not value:
+        return ""
+    if len(value) <= 4:
+        return "***"
+    return "***" + value[-4:]
+
+
+def _mask_voice_config(data: dict) -> dict:
+    """Return a copy of a saved voice config with credentials masked."""
+    masked = dict(data)
+    creds = dict(masked.get("credentials") or {})
+    creds["account_sid"] = _mask_secret(creds.get("account_sid", ""))
+    creds["auth_token"] = _mask_secret(creds.get("auth_token", ""))
+    masked["credentials"] = creds
+    if masked.get("tts_api_key"):
+        masked["tts_api_key"] = _mask_secret(masked["tts_api_key"])
+    if masked.get("stt_api_key"):
+        masked["stt_api_key"] = _mask_secret(masked["stt_api_key"])
+    return masked
 
 # ---------------------------------------------------------------------------
 # Validation constants
@@ -132,15 +204,20 @@ def _validate_voice_config(cfg: VoiceConfig) -> None:
 # ---------------------------------------------------------------------------
 
 
-@router.post("/voice/test-connection", response_model=VoiceTestResponse)
+@router.post(
+    "/voice/test-connection",
+    response_model=VoiceTestResponse,
+    dependencies=[require_tenant_admin],
+)
 async def test_connection(
     body: VoiceTestRequest,
     tenant_id: str = Depends(get_current_tenant),
 ):
     """Probe SIP provider credentials without persisting.
 
-    Session 5 TC-006 root cause: this endpoint did not exist, so the
-    wizard's Test Connection button always returned HTTP 404.
+    HIGH-05/HIGH-06 hardening: admin-only, custom SIP targets are
+    resolved and filtered against private/reserved IP ranges before
+    any TCP connect.
     """
     ok, msg = _validate_provider_credentials(body.provider, body.credentials)
     if not ok:
@@ -199,7 +276,6 @@ async def test_connection(
     # No SSL bypass / no HTTP request — the real SIP handshake happens
     # via the voice connector when the agent starts.
     import asyncio as _asyncio
-    import socket
     import urllib.parse
 
     target = body.credentials.custom_url.strip()
@@ -219,18 +295,22 @@ async def test_connection(
         host = host_part
         port = 5061 if target.startswith("sips:") else 5060
 
+    host = urllib.parse.unquote(host)
     if not host:
         return VoiceTestResponse(
             status="invalid_credentials",
             message="SIP endpoint could not be parsed — missing host.",
         )
 
+    # SSRF guard: resolve and reject private/reserved ranges before connect.
+    safe_addr = _resolve_and_block_private(host)
+
     loop = _asyncio.get_event_loop()
 
     def _probe_tcp() -> str:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.settimeout(5)
-            s.connect((urllib.parse.unquote(host), port))
+            s.connect((safe_addr, port))
         return "ok"
 
     try:
@@ -256,19 +336,34 @@ async def test_connection(
 _VOICE_CONFIG: dict[str, dict] = {}
 
 
-@router.post("/voice/config", response_model=VoiceConfig)
+@router.post(
+    "/voice/config",
+    response_model=VoiceConfig,
+    dependencies=[require_tenant_admin],
+)
 async def save_voice_config(
     body: VoiceConfig,
     tenant_id: str = Depends(get_current_tenant),
 ):
+    """Save tenant voice config. Admin-only (HIGH-05)."""
     _validate_voice_config(body)
     _VOICE_CONFIG[str(tenant_id)] = body.model_dump()
-    return body
+    # Return masked copy so secrets aren't echoed back in the response.
+    return VoiceConfig(**_mask_voice_config(body.model_dump()))
 
 
-@router.get("/voice/config", response_model=VoiceConfig | None)
+@router.get(
+    "/voice/config",
+    response_model=VoiceConfig | None,
+    dependencies=[require_tenant_admin],
+)
 async def get_voice_config(tenant_id: str = Depends(get_current_tenant)):
+    """Return the saved tenant voice config with credentials masked.
+
+    HIGH-05 fix — pre-fix any authenticated tenant user could read the
+    full credentials. Now admin-only, and secrets are masked on return.
+    """
     data = _VOICE_CONFIG.get(str(tenant_id))
     if not data:
         return None
-    return VoiceConfig(**data)
+    return VoiceConfig(**_mask_voice_config(data))

--- a/api/v1/webhooks.py
+++ b/api/v1/webhooks.py
@@ -1,10 +1,17 @@
-"""Webhook endpoints for email event tracking (open/click/bounce)."""
+"""Webhook endpoints for email event tracking (open/click/bounce).
+
+Every externally reachable webhook handler here fails closed when the
+provider's verification secret is missing, per SECURITY_AUDIT-2026-04-19
+HIGH-04. Set ``AGENTICORG_WEBHOOK_ALLOW_UNSIGNED=1`` only in local dev.
+"""
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import hmac
 import json
+import os
 from typing import Any
 
 import structlog
@@ -13,6 +20,10 @@ from fastapi import APIRouter, HTTPException, Request
 logger = structlog.get_logger()
 
 router = APIRouter()
+
+
+def _dev_allow_unsigned() -> bool:
+    return os.getenv("AGENTICORG_WEBHOOK_ALLOW_UNSIGNED") == "1"
 
 
 def _get_redis():
@@ -84,20 +95,93 @@ def _verify_sendgrid_signature(
 ) -> bool:
     """Verify SendGrid Event Webhook signature.
 
-    Uses HMAC-SHA256 with the webhook verification key.
+    Uses HMAC-SHA256 with the webhook verification key. Fails closed
+    when no key is configured — pre-fix this returned True (dev-mode
+    bypass) which allowed forged events in production. Per
+    SECURITY_AUDIT_2026-04-19.md HIGH-04.
     """
-    import os
-
     verification_key = public_key or os.getenv("SENDGRID_WEBHOOK_KEY", "")
     if not verification_key:
-        # If no key configured, skip verification (dev mode)
-        logger.warning("sendgrid_webhook_key_not_configured")
-        return True
+        if _dev_allow_unsigned():
+            logger.warning("sendgrid_webhook_key_not_configured_allowed_by_dev_flag")
+            return True
+        logger.error(
+            "sendgrid_webhook_key_not_configured",
+            hint="Set SENDGRID_WEBHOOK_KEY in env. HIGH-04 fail-closed.",
+        )
+        return False
 
     signed_payload = f"{timestamp}{payload.decode('utf-8')}"
     expected = hmac.new(
         verification_key.encode("utf-8"),
         signed_payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature)
+
+
+def _verify_mailchimp_signature(
+    url: str,
+    form: dict[str, str],
+    signature: str,
+) -> bool:
+    """Verify Mandrill/Mailchimp webhook signature.
+
+    Mandrill signs the webhook URL concatenated with each POST field name
+    and value (in the order the fields were defined for the webhook),
+    then base64-encodes HMAC-SHA1 of that with the webhook key.
+    Ref: https://mailchimp.com/developer/transactional/guides/track-respond-activity-webhooks/#authenticating-webhook-requests
+
+    Fails closed when MAILCHIMP_WEBHOOK_KEY is not set. Set
+    ``AGENTICORG_WEBHOOK_ALLOW_UNSIGNED=1`` only for local dev.
+    """
+    verification_key = os.getenv("MAILCHIMP_WEBHOOK_KEY", "")
+    if not verification_key:
+        if _dev_allow_unsigned():
+            logger.warning("mailchimp_webhook_key_not_configured_allowed_by_dev_flag")
+            return True
+        logger.error(
+            "mailchimp_webhook_key_not_configured",
+            hint="Set MAILCHIMP_WEBHOOK_KEY in env. HIGH-04 fail-closed.",
+        )
+        return False
+
+    # Concatenate URL + sorted(key + value) to produce a stable signed string.
+    # Mandrill's docs describe preserving the field order from the webhook
+    # definition, but since we don't have that here we sort by key — the
+    # sender must match this ordering. For strict Mandrill interop, ops
+    # can override by signing in the same sorted-by-key order on their end.
+    signed_parts = [url]
+    for key in sorted(form.keys()):
+        signed_parts.append(key)
+        signed_parts.append(form[key])
+    signed_data = "".join(signed_parts).encode("utf-8")
+    expected = base64.b64encode(
+        hmac.new(verification_key.encode("utf-8"), signed_data, hashlib.sha1).digest()
+    ).decode("utf-8")
+    return hmac.compare_digest(expected, signature)
+
+
+def _verify_moengage_signature(payload: bytes, signature: str) -> bool:
+    """Verify MoEngage webhook signature.
+
+    MoEngage webhooks carry an HMAC-SHA256 of the raw request body signed
+    with a shared secret in the ``X-MoEngage-Signature`` header (hex).
+    Fails closed when MOENGAGE_WEBHOOK_KEY is not set.
+    """
+    verification_key = os.getenv("MOENGAGE_WEBHOOK_KEY", "")
+    if not verification_key:
+        if _dev_allow_unsigned():
+            logger.warning("moengage_webhook_key_not_configured_allowed_by_dev_flag")
+            return True
+        logger.error(
+            "moengage_webhook_key_not_configured",
+            hint="Set MOENGAGE_WEBHOOK_KEY in env. HIGH-04 fail-closed.",
+        )
+        return False
+    expected = hmac.new(
+        verification_key.encode("utf-8"),
+        payload,
         hashlib.sha256,
     ).hexdigest()
     return hmac.compare_digest(expected, signature)
@@ -185,7 +269,13 @@ async def mailchimp_webhook(request: Request) -> dict[str, Any]:
     Mailchimp sends form-encoded data with: type (subscribe/unsubscribe/campaign),
     fired_at, and nested data fields.
     """
-    form = await request.form()
+    form_data = await request.form()
+    form = {str(k): str(v) for k, v in form_data.items()}
+    signature = request.headers.get("X-Mandrill-Signature", "")
+    webhook_url = str(request.url)
+    if not _verify_mailchimp_signature(webhook_url, form, signature):
+        raise HTTPException(status_code=403, detail="Invalid webhook signature")
+
     webhook_type = form.get("type", "")
     fired_at = form.get("fired_at", "")
     data_email = form.get("data[email]", "")
@@ -226,9 +316,14 @@ async def moengage_webhook(request: Request) -> dict[str, Any]:
     MoEngage sends JSON with: event_type, email, campaign_id, timestamp,
     and additional metadata.
     """
+    body = await request.body()
+    signature = request.headers.get("X-MoEngage-Signature", "")
+    if not _verify_moengage_signature(body, signature):
+        raise HTTPException(status_code=403, detail="Invalid webhook signature")
+
     try:
-        payload = await request.json()
-    except Exception:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
         raise HTTPException(status_code=400, detail="Invalid JSON payload") from None
 
     event_type = payload.get("event_type", payload.get("type", ""))

--- a/tests/regression/test_security_audit_20260419_high.py
+++ b/tests/regression/test_security_audit_20260419_high.py
@@ -1,0 +1,188 @@
+"""Regression tests for HIGH findings in SECURITY_AUDIT_2026-04-19.md.
+
+Covers:
+  - HIGH-04: Webhook signature verification fails closed.
+  - HIGH-05: Voice config endpoints are admin-gated and mask secrets.
+  - HIGH-06: Voice SIP test rejects private/reserved IP ranges.
+  - HIGH-08: RPA execution history is tenant-scoped.
+  - HIGH-09: RPA generic_portal requires tenant admin.
+  - MEDIUM-11: Billing redirect URLs validated against allowlist.
+  - MEDIUM-12: Connector base_url SSRF guard rejects private IPs.
+
+These tests read the source files and assert the remediation is present,
+rather than depending on the full FastAPI runtime. Source-level assertions
+are intentionally strict: if the fix is refactored the test will flag it
+for re-review.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _read(path: str) -> str:
+    return (REPO / path).read_text(encoding="utf-8")
+
+
+# ── HIGH-04 ─────────────────────────────────────────────────────────
+
+
+def test_high04_sendgrid_fail_closed():
+    src = _read("api/v1/webhooks.py")
+    assert "AGENTICORG_WEBHOOK_ALLOW_UNSIGNED" in src
+    # Must not blindly return True when key missing
+    assert "_verify_sendgrid_signature" in src
+    assert "sendgrid_webhook_key_not_configured" in src
+
+
+def test_high04_mailchimp_signature_verified():
+    src = _read("api/v1/webhooks.py")
+    assert "_verify_mailchimp_signature" in src
+    assert "X-Mandrill-Signature" in src
+    assert "MAILCHIMP_WEBHOOK_KEY" in src
+
+
+def test_high04_moengage_signature_verified():
+    src = _read("api/v1/webhooks.py")
+    assert "_verify_moengage_signature" in src
+    assert "X-MoEngage-Signature" in src
+    assert "MOENGAGE_WEBHOOK_KEY" in src
+
+
+def test_high04_webhook_functions_fail_closed_callsites():
+    """Each provider handler must reject on missing signature."""
+    from api.v1 import webhooks
+
+    sg = inspect.getsource(webhooks.sendgrid_webhook)
+    assert "_verify_sendgrid_signature" in sg
+    assert "Invalid webhook signature" in sg
+
+    mc = inspect.getsource(webhooks.mailchimp_webhook)
+    assert "_verify_mailchimp_signature" in mc
+
+    mo = inspect.getsource(webhooks.moengage_webhook)
+    assert "_verify_moengage_signature" in mo
+
+
+# ── HIGH-05 / HIGH-06 ────────────────────────────────────────────────
+
+
+def test_high05_voice_config_admin_gated():
+    src = _read("api/v1/voice.py")
+    # Both save and get config must list require_tenant_admin in deps.
+    assert src.count("require_tenant_admin") >= 3  # import + 3 endpoints
+    assert "_mask_voice_config" in src
+    assert "_mask_secret" in src
+
+
+def test_high06_voice_sip_private_ip_blocked():
+    src = _read("api/v1/voice.py")
+    assert "_resolve_and_block_private" in src
+    # The function must cover major blocked categories
+    assert "is_private" in src
+    assert "is_loopback" in src
+    assert "is_link_local" in src
+
+
+def test_high06_resolver_rejects_private_range():
+    """Unit-test the private-IP resolver directly."""
+    from fastapi import HTTPException
+
+    from api.v1.voice import _resolve_and_block_private
+
+    with pytest.raises(HTTPException) as excinfo:
+        _resolve_and_block_private("127.0.0.1")
+    assert excinfo.value.status_code == 403
+
+    with pytest.raises(HTTPException) as excinfo:
+        _resolve_and_block_private("169.254.169.254")  # AWS/GCP metadata
+    assert excinfo.value.status_code == 403
+
+    with pytest.raises(HTTPException) as excinfo:
+        _resolve_and_block_private("10.0.0.1")
+    assert excinfo.value.status_code == 403
+
+
+# ── HIGH-08 / HIGH-09 ────────────────────────────────────────────────
+
+
+def test_high08_rpa_history_tenant_scoped():
+    src = _read("api/v1/rpa.py")
+    # Shared global list must be gone; per-tenant dict in its place.
+    assert "_execution_history: dict[str, list[dict[str, Any]]]" in src
+    assert "_execution_history.get(str(tenant_id)" in src
+    assert "_execution_history.setdefault(str(tenant_id)" in src
+
+
+def test_high09_rpa_generic_portal_admin_gated():
+    src = _read("api/v1/rpa.py")
+    assert "_ADMIN_ONLY_SCRIPTS" in src
+    assert "generic_portal" in src
+    # Must reject non-admins with 403
+    assert "requires tenant admin" in src
+
+
+# ── MEDIUM-11 ────────────────────────────────────────────────────────
+
+
+def test_medium11_billing_redirect_allowlist():
+    src = _read("api/v1/billing.py")
+    assert "_validate_redirect_url" in src
+    assert "_allowed_redirect_hosts" in src
+    assert "success_url" in src and "cancel_url" in src
+
+
+def test_medium11_validate_redirect_blocks_offsite(monkeypatch):
+    from fastapi import HTTPException
+
+    from api.v1.billing import _validate_redirect_url
+
+    monkeypatch.setenv("AGENTICORG_FRONTEND_URL", "https://app.example.com")
+    monkeypatch.setenv("AGENTICORG_BILLING_REDIRECT_ALLOWLIST", "")
+    # Same-origin is fine
+    assert _validate_redirect_url(
+        "https://app.example.com/billing/done",
+        "success_url",
+    ) == "https://app.example.com/billing/done"
+    # Different origin is rejected
+    with pytest.raises(HTTPException) as excinfo:
+        _validate_redirect_url("https://attacker.example.net/phish", "success_url")
+    assert excinfo.value.status_code == 400
+    # Empty is allowed (caller opts into gateway default)
+    assert _validate_redirect_url("", "success_url") == ""
+
+
+# ── MEDIUM-12 ────────────────────────────────────────────────────────
+
+
+def test_medium12_connector_base_url_guard():
+    src = _read("api/v1/connectors.py")
+    assert "_assert_public_base_url" in src
+    # Must be called on register, update, and test paths.
+    assert src.count("_assert_public_base_url(") >= 3
+
+
+def test_medium12_base_url_blocks_private():
+    from fastapi import HTTPException
+
+    from api.v1.connectors import _assert_public_base_url
+
+    with pytest.raises(HTTPException) as excinfo:
+        _assert_public_base_url("http://127.0.0.1:8080")
+    assert excinfo.value.status_code == 403
+
+    with pytest.raises(HTTPException) as excinfo:
+        _assert_public_base_url("http://169.254.169.254/latest/meta-data/")
+    assert excinfo.value.status_code == 403
+
+    with pytest.raises(HTTPException) as excinfo:
+        _assert_public_base_url("ftp://example.com/")
+    assert excinfo.value.status_code == 400
+
+    # Empty is a no-op — class-level base_url still applies.
+    _assert_public_base_url("")

--- a/tests/unit/test_tier1_features.py
+++ b/tests/unit/test_tier1_features.py
@@ -331,7 +331,12 @@ class TestWebhookParsing:
             yield c
 
     @pytest.fixture(autouse=True)
-    def _mock_redis(self):
+    def _mock_redis(self, monkeypatch):
+        # These tests exercise payload PARSING. Signature fail-closed
+        # behavior is covered by tests/regression/test_security_audit_20260419_high.py
+        # (HIGH-04). Flip the dev bypass so parsing tests are unaffected
+        # by the new verification gate.
+        monkeypatch.setenv("AGENTICORG_WEBHOOK_ALLOW_UNSIGNED", "1")
         mock_redis = AsyncMock()
         mock_redis.hset = AsyncMock()
         mock_redis.scan = AsyncMock(return_value=(0, []))


### PR DESCRIPTION
## Summary

Addresses the HIGH-severity + adjacent MEDIUM findings from `SECURITY_AUDIT_2026-04-19.md` (static review by Codex). SEC-01 (PR #232, CRITICAL-02 + CRITICAL-03) is in flight separately.

| ID | Fix |
|---|---|
| HIGH-04 | SendGrid / Mailchimp / MoEngage webhooks verify HMAC signatures. All three fail-closed when the provider secret is missing. Dev bypass only via `AGENTICORG_WEBHOOK_ALLOW_UNSIGNED=1`. |
| HIGH-05 | `/voice/config` GET + POST and `/voice/test-connection` now require `require_tenant_admin`. Returned configs mask `account_sid`, `auth_token`, `tts_api_key`, `stt_api_key`. |
| HIGH-06 | Voice SIP custom-URL probe resolves the host and rejects private, loopback, link-local, multicast, reserved, and unspecified ranges before connecting. |
| HIGH-08 | RPA execution history is per-tenant; `/rpa/history` only returns caller's tenant entries. |
| HIGH-09 | RPA `generic_portal` script is admin-only (can be pointed at arbitrary URLs). Built-in compliance scripts (EPFO, MCA) remain accessible to normal users. |
| MEDIUM-11 | Stripe `success_url` / `cancel_url` / `return_url` validated against an allowlist seeded from `AGENTICORG_FRONTEND_URL` (+ optional `AGENTICORG_BILLING_REDIRECT_ALLOWLIST`). Off-allowlist hosts rejected with 400. |
| MEDIUM-12 | Connector `base_url` is resolved and private/reserved ranges rejected at register, update, and test time. Admins can no longer turn connector flows into an SSRF primitive. |

Regression coverage pinned in `tests/regression/test_security_audit_20260419_high.py` (13 tests, all passing).

## Test plan

- [x] `python -m pytest tests/regression/ -q --no-cov` — 257 passed
- [x] `python -m pytest tests/unit/test_tier1_features.py::TestWebhookParsing -q --no-cov` — 7 passed (parsing tests still green via dev-bypass flag; new regression tests assert fail-closed behavior independently)
- [x] `ruff check` on `api/v1/{webhooks,voice,rpa,connectors,billing}.py` — clean
- [x] `bandit -ll -iii` on api/auth/core — no issues
- [ ] Full CI — running
- [ ] E2E `session5-bugs.spec.ts` (voice test-connection) — may need admin scope on the seed user; if E2E fails, follow-up will mint admin scope on the voice-setup test account rather than relaxing the gate

## Residual risks

- SEC-01 (CRITICAL-02/03) still in review as PR #232 — this branch is orthogonal and does not depend on that merge.
- CRITICAL-01 (localStorage tokens → HttpOnly cookies), HIGH-07 (RAGFlow tenant dataset partitioning), MEDIUM-10 (invite/reset tokens in query strings), MEDIUM-13 (CSP unsafe-inline/unsafe-eval), LOW-14/15 — tracked for a follow-up PR.
- Mandrill signature algorithm expects fields in the order they were declared on the webhook. This implementation sorts alphabetically; ops will sign in the same sorted order on the sender side.

@codex please re-review with the remediated source for signature verification, admin gating, SSRF blocks, redirect allowlist, and tenant-scoped RPA history.