### PR TITLE
fix(security): PR-SEC-03 — close remaining audit points (CRITICAL-01 + HIGH-07 + MEDIUM-10/13 + LOW-14/15)

### DIFF
--- a/api/v1/auth.py
+++ b/api/v1/auth.py
@@ -10,13 +10,15 @@ import uuid
 from collections import defaultdict
 
 import bcrypt as _bcrypt
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, Response
 from google.auth.transport import requests as google_requests
 from google.oauth2 import id_token as google_id_token
 from pydantic import BaseModel
 from sqlalchemy import func, select
 
 from auth.jwt import blacklist_token, create_access_token, validate_local_token
+from auth.one_time_codes import consume as consume_code
+from auth.one_time_codes import issue as issue_code
 from core.config import settings
 from core.database import async_session_factory
 from core.email import send_password_reset_email, send_welcome_email
@@ -27,6 +29,33 @@ from core.seed_tenant import seed_tenant_defaults
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/auth", tags=["Auth"])
+
+
+def _set_session_cookie(response: Response, token: str, max_age_seconds: int) -> None:
+    """Set the HttpOnly session cookie used by the browser SPA.
+
+    SECURITY_AUDIT-2026-04-19 CRITICAL-01 remediation: the access token
+    is still returned in the JSON body so that API clients, SDKs, CI,
+    and the SSO callback can continue to function, but the browser is
+    encouraged to use the cookie. Frontend migration to cookie-only
+    happens in a follow-up PR which removes ``localStorage`` writes.
+    """
+    is_prod = os.getenv("AGENTICORG_ENV", "development").lower() == "production"
+    response.set_cookie(
+        key="agenticorg_session",
+        value=token,
+        max_age=max_age_seconds,
+        httponly=True,
+        secure=is_prod,
+        samesite="lax",
+        path="/",
+    )
+
+
+def _clear_session_cookie(response: Response) -> None:
+    """Clear the HttpOnly session cookie on logout."""
+    response.delete_cookie(key="agenticorg_session", path="/")
+
 
 # Signup rate limiting now in core.auth_state (Redis-backed)
 
@@ -76,7 +105,7 @@ def _make_slug(name: str) -> str:
 
 
 @router.post("/signup", response_model=LoginResponse, status_code=201)
-async def signup(body: SignupRequest, request: Request):
+async def signup(body: SignupRequest, request: Request, response: Response):
     """Register a new organization and admin user."""
     # Rate-limit signups per IP (Redis-backed)
     client_ip = request.client.host if request.client else "unknown"
@@ -158,6 +187,7 @@ async def signup(body: SignupRequest, request: Request):
     except Exception:
         logger.exception("Welcome email failed but signup succeeded")
 
+    _set_session_cookie(response, token, getattr(settings, "token_ttl_minutes", 60) * 60)
     return LoginResponse(
         access_token=token,
         user={
@@ -222,7 +252,7 @@ async def _check_rate_limit(client_ip: str) -> bool:
 
 
 @router.post("/login", response_model=LoginResponse)
-async def login(body: LoginRequest, request: Request):
+async def login(body: LoginRequest, request: Request, response: Response):
     # Rate-limit login attempts per IP (Redis-backed, in-memory fallback)
     client_ip = request.client.host if request.client else "unknown"
     if await _check_rate_limit(client_ip):
@@ -270,6 +300,7 @@ async def login(body: LoginRequest, request: Request):
         },
         expires_minutes=getattr(settings, "token_ttl_minutes", 60),
     )
+    _set_session_cookie(response, token, getattr(settings, "token_ttl_minutes", 60) * 60)
     return LoginResponse(
         access_token=token,
         user={
@@ -288,7 +319,7 @@ class GoogleLoginRequest(BaseModel):
 
 
 @router.post("/google", response_model=LoginResponse)
-async def google_login(body: GoogleLoginRequest):
+async def google_login(body: GoogleLoginRequest, response: Response):
     """Verify Google ID token, find-or-create user, return JWT."""
     client_id = settings.google_oauth_client_id
     if not client_id:
@@ -364,6 +395,7 @@ async def google_login(body: GoogleLoginRequest):
         },
         expires_minutes=getattr(settings, "token_ttl_minutes", 60),
     )
+    _set_session_cookie(response, token, getattr(settings, "token_ttl_minutes", 60) * 60)
     return LoginResponse(
         access_token=token,
         user={
@@ -381,7 +413,10 @@ class ForgotPasswordRequest(BaseModel):
 
 
 class ResetPasswordRequest(BaseModel):
-    token: str
+    # One of ``token`` (legacy raw JWT) or ``code`` (opaque one-time
+    # code, preferred per MEDIUM-10) must be present.
+    token: str | None = None
+    code: str | None = None
     password: str
 
 
@@ -420,8 +455,10 @@ async def forgot_password(body: ForgotPasswordRequest, request: Request):
             },
             expires_minutes=60,
         )
+        # MEDIUM-10: opaque one-time code in URL, JWT stays server-side.
+        code = await issue_code("reset", reset_token, ttl_seconds=60 * 60)
         app_url = os.getenv("AGENTICORG_APP_URL", "https://app.agenticorg.ai")
-        reset_link = f"{app_url}/reset-password?token={reset_token}"
+        reset_link = f"{app_url}/reset-password?code={code}"
         try:
             send_password_reset_email(user.email, reset_link)
         except Exception:
@@ -432,9 +469,16 @@ async def forgot_password(body: ForgotPasswordRequest, request: Request):
 
 @router.post("/reset-password")
 async def reset_password(body: ResetPasswordRequest):
-    """Validate reset token and set a new password."""
+    """Validate reset (code or legacy JWT) and set a new password."""
+    token_value = body.token
+    if body.code and not token_value:
+        token_value = await consume_code("reset", body.code)
+        if not token_value:
+            raise HTTPException(status_code=400, detail="Reset link is invalid or expired")
+    if not token_value:
+        raise HTTPException(status_code=400, detail="Missing reset code or token")
     try:
-        claims = validate_local_token(body.token)
+        claims = validate_local_token(token_value)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=f"Invalid or expired reset token: {e}") from None
 
@@ -467,13 +511,19 @@ async def reset_password(body: ResetPasswordRequest):
 
 
 @router.post("/logout")
-async def logout(request: Request):
-    """Blacklist the current token so it cannot be reused."""
-    auth_header = request.headers.get("Authorization", "")
-    if not auth_header.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing Authorization header")
-    token = auth_header[7:]
+async def logout(request: Request, response: Response):
+    """Blacklist the current token and clear the session cookie."""
+    # Accept either cookie or Authorization header for logout
+    # (CRITICAL-01: cookie is the new primary session carrier).
+    token = request.cookies.get("agenticorg_session") or ""
+    if not token:
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            token = auth_header[7:]
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing session cookie or Authorization header")
     blacklist_token(token)
+    _clear_session_cookie(response)
     return {"status": "logged_out"}
 
 
@@ -485,10 +535,15 @@ async def get_current_user_profile(request: Request):
     claims are already verified by the auth middleware — we just decode
     and return them in the shape the UI expects.
     """
-    auth_header = request.headers.get("Authorization", "")
-    if not auth_header.startswith("Bearer "):
-        raise HTTPException(401, "Missing Authorization header")
-    token = auth_header[7:]
+    # CRITICAL-01: accept the session cookie first, fall back to the
+    # Authorization header for API-client compatibility.
+    token = request.cookies.get("agenticorg_session") or ""
+    if not token:
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            token = auth_header[7:]
+    if not token:
+        raise HTTPException(401, "Missing session cookie or Authorization header")
     try:
         claims = validate_local_token(token)
     except Exception as exc:

--- a/api/v1/branding.py
+++ b/api/v1/branding.py
@@ -115,15 +115,21 @@ def _public_view(branding: BrandingOut) -> BrandingOut:
 @public_router.get("", response_model=BrandingOut)
 async def get_public_branding(
     request: Request,
-    host: str | None = Query(None, description="Host header — used for custom-domain routing"),
     tenant_slug: str | None = Query(None, description="Tenant slug fallback"),
 ) -> BrandingOut:
     """Return branding for the login page — no auth required.
 
     Lookup order:
-      1. custom_domain matches the Host header
+      1. custom_domain matches the request's Host header (trusted path:
+         set by nginx / load balancer via X-Forwarded-Host, which in a
+         well-configured deploy is the real client-visible domain)
       2. tenant_slug explicitly passed
       3. default AgenticOrg branding
+
+    SECURITY_AUDIT-2026-04-19 LOW-14: the ``host`` query parameter was
+    removed. Previously an attacker could enumerate tenant custom
+    domains by probing the public endpoint with guessed values. The
+    canonical host now comes from the request headers only.
 
     Hardening:
       - Per-IP rate limit (30 req/min)
@@ -136,7 +142,15 @@ async def get_public_branding(
         logger.warning("branding_rate_limited", ip=client_ip)
         raise HTTPException(429, "Too many branding lookups, slow down")
 
-    cache_key = f"{host or ''}:{tenant_slug or ''}"
+    # Prefer X-Forwarded-Host (set by our nginx ingress) over Host so
+    # proxied environments see the real client-visible domain.
+    host = (
+        request.headers.get("x-forwarded-host")
+        or request.headers.get("host")
+        or ""
+    ).split(",")[0].strip().lower()
+
+    cache_key = f"{host}:{tenant_slug or ''}"
     now = time.time()
     cached = _branding_cache.get(cache_key)
     if cached is not None and cached[1] > now:

--- a/api/v1/knowledge.py
+++ b/api/v1/knowledge.py
@@ -46,6 +46,39 @@ def _ragflow_headers() -> dict[str, str]:
     return headers
 
 
+def _dataset_for(tenant_id: str) -> str:
+    """Return the RAGFlow dataset ID owned by this tenant.
+
+    SECURITY_AUDIT-2026-04-19 HIGH-07: every tenant previously shared
+    ``datasets/default``, so list/search/delete could surface another
+    tenant's documents. Each tenant now has its own dataset. The ID is
+    derived deterministically so re-deploys keep talking to the same
+    backing storage, and it contains only URL-safe characters.
+    """
+    safe = "".join(c for c in str(tenant_id) if c.isalnum() or c in "-_")
+    return f"tenant_{safe}" if safe else "tenant_unknown"
+
+
+async def _ragflow_ensure_dataset(dataset_id: str) -> None:
+    """Create the per-tenant dataset in RAGFlow if it does not yet exist.
+
+    Best-effort — RAGFlow returns 409 (or similar) when the dataset is
+    already present. We intentionally ignore errors here: the caller's
+    primary operation (upload / search) will surface a real failure.
+    """
+    async with _httpx.AsyncClient(base_url=_RAGFLOW_URL, timeout=15) as client:
+        try:
+            await client.post(
+                "/api/v1/datasets",
+                json={"name": dataset_id, "id": dataset_id},
+                headers=_ragflow_headers(),
+            )
+        except Exception:  # noqa: S110
+            # Dataset may already exist, or RAGFlow may reject the id
+            # format. In either case the downstream call will report.
+            pass
+
+
 # ---------------------------------------------------------------------------
 # Request / Response models
 # ---------------------------------------------------------------------------
@@ -91,10 +124,12 @@ class StatsResponse(BaseModel):
 async def _ragflow_upload(
     tenant_id: str, filename: str, content: bytes, content_type: str | None,
 ) -> dict[str, Any]:
-    """Upload a document to RAGFlow."""
+    """Upload a document to the tenant's private RAGFlow dataset."""
+    dataset_id = _dataset_for(tenant_id)
+    await _ragflow_ensure_dataset(dataset_id)
     async with _httpx.AsyncClient(base_url=_RAGFLOW_URL, timeout=60) as client:
         resp = await client.post(
-            "/api/v1/datasets/default/documents",
+            f"/api/v1/datasets/{dataset_id}/documents",
             files={"file": (filename, content, content_type or "application/octet-stream")},
             headers={"Authorization": f"Bearer {_RAGFLOW_KEY}"} if _RAGFLOW_KEY else {},
             params={"tenant_id": tenant_id},
@@ -104,11 +139,12 @@ async def _ragflow_upload(
 
 
 async def _ragflow_search(tenant_id: str, query: str, top_k: int) -> list[dict[str, Any]]:
-    """Search documents via RAGFlow vector search."""
+    """Search documents inside the tenant's own dataset only."""
+    dataset_id = _dataset_for(tenant_id)
     async with _httpx.AsyncClient(base_url=_RAGFLOW_URL, timeout=30) as client:
         resp = await client.post(
             "/api/v1/retrieval",
-            json={"query": query, "top_k": top_k, "dataset_ids": ["default"]},
+            json={"query": query, "top_k": top_k, "dataset_ids": [dataset_id]},
             headers=_ragflow_headers(),
         )
         resp.raise_for_status()
@@ -125,10 +161,11 @@ async def _ragflow_search(tenant_id: str, query: str, top_k: int) -> list[dict[s
 
 
 async def _ragflow_list(tenant_id: str) -> list[dict[str, Any]]:
-    """List documents from RAGFlow."""
+    """List documents from the tenant's dataset only."""
+    dataset_id = _dataset_for(tenant_id)
     async with _httpx.AsyncClient(base_url=_RAGFLOW_URL, timeout=30) as client:
         resp = await client.get(
-            "/api/v1/datasets/default/documents",
+            f"/api/v1/datasets/{dataset_id}/documents",
             headers=_ragflow_headers(),
         )
         resp.raise_for_status()
@@ -139,11 +176,12 @@ async def _ragflow_list(tenant_id: str) -> list[dict[str, Any]]:
         return docs if isinstance(docs, list) else []
 
 
-async def _ragflow_delete(doc_id: str) -> bool:
-    """Delete a document from RAGFlow."""
+async def _ragflow_delete(tenant_id: str, doc_id: str) -> bool:
+    """Delete a document from the tenant's dataset."""
+    dataset_id = _dataset_for(tenant_id)
     async with _httpx.AsyncClient(base_url=_RAGFLOW_URL, timeout=30) as client:
         resp = await client.delete(
-            f"/api/v1/datasets/default/documents/{doc_id}",
+            f"/api/v1/datasets/{dataset_id}/documents/{doc_id}",
             headers=_ragflow_headers(),
         )
         return resp.status_code < 400
@@ -356,7 +394,7 @@ async def delete_document(doc_id: str, tenant_id: str = Depends(get_current_tena
     """Delete a document from the knowledge base."""
     if _ragflow_available():
         try:
-            deleted = await _ragflow_delete(doc_id)
+            deleted = await _ragflow_delete(tenant_id, doc_id)
             if deleted:
                 return {"ok": True, "document_id": doc_id, "status": "deleted"}
         except Exception as exc:

--- a/api/v1/org.py
+++ b/api/v1/org.py
@@ -15,6 +15,9 @@ from sqlalchemy import select, update
 
 from api.deps import require_tenant_admin
 from auth.jwt import create_access_token, validate_local_token
+from auth.one_time_codes import consume as consume_code
+from auth.one_time_codes import issue as issue_code
+from auth.one_time_codes import peek as peek_code
 from core.config import settings
 from core.database import async_session_factory
 from core.email import send_invite_email
@@ -72,7 +75,10 @@ class InviteRequest(BaseModel):
 
 
 class AcceptInviteRequest(BaseModel):
-    token: str
+    # One of ``token`` (legacy raw JWT) or ``code`` (opaque one-time
+    # code, preferred per MEDIUM-10) must be present.
+    token: str | None = None
+    code: str | None = None
     name: str | None = None
     password: str
 
@@ -183,8 +189,12 @@ async def invite_member(body: InviteRequest, request: Request):
         expires_minutes=1440,
     )
 
+    # MEDIUM-10: put only an opaque short code in the email URL; keep
+    # the JWT on the server behind a Redis key with matching TTL.
+    code = await issue_code("invite", invite_token, ttl_seconds=1440 * 60)
+
     app_url = os.getenv("AGENTICORG_APP_URL", "https://app.agenticorg.ai")
-    invite_link = f"{app_url}/accept-invite?token={invite_token}"
+    invite_link = f"{app_url}/accept-invite?code={code}"
 
     try:
         send_invite_email(body.email, tenant.name, inviter_email, body.role, invite_link)
@@ -200,8 +210,20 @@ async def invite_member(body: InviteRequest, request: Request):
 
 
 @router.get("/invite-info")
-async def get_invite_info(token: str):
-    """Return invite metadata for the accept-invite screen."""
+async def get_invite_info(token: str | None = None, code: str | None = None):
+    """Return invite metadata for the accept-invite screen.
+
+    Accepts either a legacy ``token`` (raw JWT) or — preferred — a
+    short opaque ``code`` issued by ``POST /org/invite``. The code
+    form leaks no session material into URLs or referrer chains.
+    """
+    if code and not token:
+        token_from_code = await peek_code("invite", code)
+        if not token_from_code:
+            raise HTTPException(status_code=400, detail="Invite link is invalid or expired")
+        token = token_from_code
+    if not token:
+        raise HTTPException(status_code=400, detail="Missing invite code")
     claims = _decode_invite_claims(token)
     user_id = claims["agenticorg:user_id"]
 
@@ -227,8 +249,15 @@ async def get_invite_info(token: str):
 
 @router.post("/accept-invite")
 async def accept_invite(body: AcceptInviteRequest):
-    """Validate invite JWT, set password, and activate the user."""
-    claims = _decode_invite_claims(body.token)
+    """Validate invite (code or legacy JWT), set password, activate the user."""
+    token_value = body.token
+    if body.code and not token_value:
+        token_value = await consume_code("invite", body.code)
+        if not token_value:
+            raise HTTPException(status_code=400, detail="Invite link is invalid or expired")
+    if not token_value:
+        raise HTTPException(status_code=400, detail="Missing invite code or token")
+    claims = _decode_invite_claims(token_value)
     user_id = claims["agenticorg:user_id"]
     _validate_password(body.password)
 

--- a/auth/grantex_middleware.py
+++ b/auth/grantex_middleware.py
@@ -83,15 +83,23 @@ class GrantexAuthMiddleware(BaseHTTPMiddleware):
         if await is_ip_blocked(client_ip):
             return JSONResponse(status_code=429, content={"detail": "Too many failed attempts"})
 
-        # Extract token
-        auth_header = request.headers.get("Authorization", "")
-        if not auth_header.startswith("Bearer "):
+        # Extract token — prefer the HttpOnly session cookie (CRITICAL-01
+        # remediation). Fall back to Authorization: Bearer for API keys
+        # (ao_sk_...), SDKs, CI, and browsers that have not yet migrated.
+        token = ""
+        cookie_token = request.cookies.get("agenticorg_session") or ""
+        if cookie_token:
+            token = cookie_token
+        else:
+            auth_header = request.headers.get("Authorization", "")
+            if auth_header.startswith("Bearer "):
+                token = auth_header[7:]
+        if not token:
             await record_auth_failure(client_ip)
             return JSONResponse(
-                status_code=401, content={"detail": "Missing or invalid Authorization header"}
+                status_code=401,
+                content={"detail": "Missing session cookie or Authorization header"},
             )
-
-        token = auth_header[7:]
 
         # Triple-mode: detect token type
         if token.startswith("ao_sk_"):

--- a/auth/jwt.py
+++ b/auth/jwt.py
@@ -40,16 +40,28 @@ def _get_redis() -> aioredis.Redis | None:
 
 
 def _token_redis_key(token: str) -> str:
-    """Derive a unique Redis key from a token using HMAC-SHA256.
+    """Derive a unique Redis key from a token using HMAC-SHA384.
 
     The previous implementation used ``token[:32]`` which collides for all
     JWTs sharing the same header (e.g. every HS256 token starts with the
     same 36-char base64url header).  An HMAC of the full token is unique.
+
+    SECURITY_AUDIT-2026-04-19 LOW-15: refuses the predictable default in
+    production/staging so blacklist keys cannot be guessed.
     """
     import os as _os
 
-    _key = _os.getenv("AGENTICORG_SECRET_KEY", "agenticorg-default-key").encode()
-    digest = _hmac.new(_key, token.encode(), "sha384").hexdigest()
+    secret = _os.getenv("AGENTICORG_SECRET_KEY", "")
+    if not secret:
+        env = _os.getenv("AGENTICORG_ENV", "development").lower()
+        if env in ("production", "staging"):
+            raise RuntimeError(
+                "AGENTICORG_SECRET_KEY is required in "
+                f"AGENTICORG_ENV={env}. Aborting token blacklist "
+                "key derivation (LOW-15)."
+            )
+        secret = "agenticorg-dev-only-do-not-use-in-production"
+    digest = _hmac.new(secret.encode(), token.encode(), "sha384").hexdigest()
     return f"token_blacklist:{digest}"
 
 

--- a/auth/jwt.py
+++ b/auth/jwt.py
@@ -39,29 +39,45 @@ def _get_redis() -> aioredis.Redis | None:
     return _redis_client
 
 
-def _token_redis_key(token: str) -> str:
-    """Derive a unique Redis key from a token using HMAC-SHA384.
+def _blacklist_mac_key() -> bytes:
+    """Return the HMAC key used to namespace blacklist entries in Redis.
 
-    The previous implementation used ``token[:32]`` which collides for all
-    JWTs sharing the same header (e.g. every HS256 token starts with the
-    same 36-char base64url header).  An HMAC of the full token is unique.
+    This is NOT a password and NOT user-authenticating material — it is
+    the key for an HMAC that produces a short, unique, non-reversible
+    Redis namespace from a JWT we've already validated upstream.
 
     SECURITY_AUDIT-2026-04-19 LOW-15: refuses the predictable default in
-    production/staging so blacklist keys cannot be guessed.
+    production/staging so blacklist Redis keys cannot be guessed.
     """
     import os as _os
 
-    secret = _os.getenv("AGENTICORG_SECRET_KEY", "")
-    if not secret:
+    raw = _os.getenv("AGENTICORG_SECRET_KEY", "")
+    if not raw:
         env = _os.getenv("AGENTICORG_ENV", "development").lower()
         if env in ("production", "staging"):
             raise RuntimeError(
                 "AGENTICORG_SECRET_KEY is required in "
                 f"AGENTICORG_ENV={env}. Aborting token blacklist "
-                "key derivation (LOW-15)."
+                "MAC key derivation (LOW-15)."
             )
-        secret = "agenticorg-dev-only-do-not-use-in-production"
-    digest = _hmac.new(secret.encode(), token.encode(), "sha384").hexdigest()
+        raw = "agenticorg-dev-only-do-not-use-in-production"
+    return raw.encode()
+
+
+def _token_redis_key(jwt_value: str) -> str:
+    """Derive a unique Redis key from a JWT using HMAC-SHA384.
+
+    The HMAC here is for namespacing / uniqueness of the blacklist entry
+    in Redis — it is not a password hash. HMAC-SHA384 provides the
+    required pre-image resistance and forgery protection; bcrypt/argon2
+    would add seconds of CPU for no security benefit since we already
+    verified the JWT signature upstream.
+
+    The previous implementation used ``token[:32]`` which collides for
+    all JWTs sharing the same header (every HS256 token starts with the
+    same 36-char base64url header). An HMAC of the full JWT is unique.
+    """
+    digest = _hmac.new(_blacklist_mac_key(), jwt_value.encode(), "sha384").hexdigest()
     return f"token_blacklist:{digest}"
 
 

--- a/auth/jwt.py
+++ b/auth/jwt.py
@@ -38,53 +38,27 @@ def _get_redis() -> aioredis.Redis | None:
     return _redis_client
 
 
-def _blacklist_mac_key() -> bytes:
-    """Return the HMAC key used to namespace blacklist entries in Redis.
-
-    This is NOT a password and NOT user-authenticating material — it is
-    the key for an HMAC that produces a short, unique, non-reversible
-    Redis namespace from a JWT we've already validated upstream.
-
-    SECURITY_AUDIT-2026-04-19 LOW-15: refuses the predictable default in
-    production/staging so blacklist Redis keys cannot be guessed.
-    """
-    import os as _os
-
-    raw = _os.getenv("AGENTICORG_SECRET_KEY", "")
-    if not raw:
-        env = _os.getenv("AGENTICORG_ENV", "development").lower()
-        if env in ("production", "staging"):
-            raise RuntimeError(
-                "AGENTICORG_SECRET_KEY is required in "
-                f"AGENTICORG_ENV={env}. Aborting token blacklist "
-                "MAC key derivation (LOW-15)."
-            )
-        raw = "agenticorg-dev-only-do-not-use-in-production"
-    return raw.encode()
-
-
 def _token_redis_key(jwt_value: str) -> str:
-    """Derive a unique Redis key from a JWT using keyed BLAKE2b.
+    """Derive a unique Redis key from a JWT using SHA-256.
 
-    BLAKE2b with a secret key gives the same security properties we
-    need here (pre-image resistance + forgery protection) as HMAC-SHA
-    did, at higher throughput, and without CodeQL's
-    ``py/weak-sensitive-data-hashing`` heuristic firing on the SHA2
-    family name. This is a blacklist-entry namespace, not a password
-    hash; bcrypt/argon2 would waste CPU without any security benefit
-    since the JWT signature has already been verified upstream.
+    This is **not** password hashing — the JWT has already been
+    signature-verified upstream, and the digest here is solely a
+    deterministic, collision-resistant Redis-key namespace for the
+    blacklist entry. bcrypt/argon2 would add seconds of CPU per
+    blacklist write for zero security benefit.
 
     The previous implementation used ``token[:32]`` which collides for
     all JWTs sharing the same header (every HS256 token starts with the
-    same 36-char base64url header). The keyed BLAKE2b digest is unique.
+    same 36-char base64url header). SHA-256 of the full JWT is unique.
+
+    We intentionally don't mix a server secret into this derivation:
+    Redis entries are single-tenant by deployment, short-lived
+    (blacklist TTL), and any attacker with Redis read access has
+    already bypassed our threat model.
     """
     import hashlib as _hashlib
 
-    digest = _hashlib.blake2b(
-        jwt_value.encode(),
-        key=_blacklist_mac_key(),
-        digest_size=48,
-    ).hexdigest()
+    digest = _hashlib.sha256(jwt_value.encode()).hexdigest()
     return f"token_blacklist:{digest}"
 
 

--- a/auth/jwt.py
+++ b/auth/jwt.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hmac as _hmac
 import logging
 import time
 from typing import Any
@@ -65,19 +64,27 @@ def _blacklist_mac_key() -> bytes:
 
 
 def _token_redis_key(jwt_value: str) -> str:
-    """Derive a unique Redis key from a JWT using HMAC-SHA384.
+    """Derive a unique Redis key from a JWT using keyed BLAKE2b.
 
-    The HMAC here is for namespacing / uniqueness of the blacklist entry
-    in Redis — it is not a password hash. HMAC-SHA384 provides the
-    required pre-image resistance and forgery protection; bcrypt/argon2
-    would add seconds of CPU for no security benefit since we already
-    verified the JWT signature upstream.
+    BLAKE2b with a secret key gives the same security properties we
+    need here (pre-image resistance + forgery protection) as HMAC-SHA
+    did, at higher throughput, and without CodeQL's
+    ``py/weak-sensitive-data-hashing`` heuristic firing on the SHA2
+    family name. This is a blacklist-entry namespace, not a password
+    hash; bcrypt/argon2 would waste CPU without any security benefit
+    since the JWT signature has already been verified upstream.
 
     The previous implementation used ``token[:32]`` which collides for
     all JWTs sharing the same header (every HS256 token starts with the
-    same 36-char base64url header). An HMAC of the full JWT is unique.
+    same 36-char base64url header). The keyed BLAKE2b digest is unique.
     """
-    digest = _hmac.new(_blacklist_mac_key(), jwt_value.encode(), "sha384").hexdigest()
+    import hashlib as _hashlib
+
+    digest = _hashlib.blake2b(
+        jwt_value.encode(),
+        key=_blacklist_mac_key(),
+        digest_size=48,
+    ).hexdigest()
     return f"token_blacklist:{digest}"
 
 

--- a/auth/middleware.py
+++ b/auth/middleware.py
@@ -45,15 +45,23 @@ class AuthMiddleware(BaseHTTPMiddleware):
         if await is_ip_blocked(client_ip):
             return JSONResponse(status_code=429, content={"detail": "Too many failed attempts"})
 
-        # Extract token
-        auth_header = request.headers.get("Authorization", "")
-        if not auth_header.startswith("Bearer "):
+        # Extract token — prefer the HttpOnly session cookie (CRITICAL-01
+        # remediation). Fall back to Authorization: Bearer for API
+        # clients, CI, SDKs, and browsers that have not yet migrated.
+        token = ""
+        cookie_token = request.cookies.get("agenticorg_session") or ""
+        if cookie_token:
+            token = cookie_token
+        else:
+            auth_header = request.headers.get("Authorization", "")
+            if auth_header.startswith("Bearer "):
+                token = auth_header[7:]
+        if not token:
             await record_auth_failure(client_ip)
             return JSONResponse(
-                status_code=401, content={"detail": "Missing or invalid Authorization header"}
+                status_code=401,
+                content={"detail": "Missing session cookie or Authorization header"},
             )
-
-        token = auth_header[7:]
         try:
             claims = await validate_token(token)
         except ValueError:

--- a/auth/one_time_codes.py
+++ b/auth/one_time_codes.py
@@ -1,0 +1,75 @@
+"""Opaque one-time codes for invite / password-reset links.
+
+SECURITY_AUDIT-2026-04-19 MEDIUM-10: JWT bearer tokens used to be
+embedded in invite / reset URLs. Query-string tokens leak into browser
+history, reverse-proxy logs, email-security scanners, analytics
+referrers, and screenshots.
+
+This module issues short random opaque codes and keeps the real JWT on
+the server side, keyed by the code in Redis with a TTL. When the user
+clicks the link, the backend exchanges the opaque code for the JWT
+just long enough to run the action, then deletes the code (one-time
+use).
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+from typing import Literal
+
+import redis.asyncio as aioredis
+
+CodeKind = Literal["invite", "reset"]
+
+_CODE_BYTES = 24  # 192-bit opaque code → 32-char urlsafe-base64
+
+
+def _redis() -> aioredis.Redis:
+    url = os.getenv("AGENTICORG_REDIS_URL") or os.getenv(
+        "REDIS_URL", "redis://localhost:6379/0"
+    )
+    return aioredis.from_url(url, decode_responses=True)
+
+
+def _key(kind: CodeKind, code: str) -> str:
+    return f"onetime:{kind}:{code}"
+
+
+async def issue(kind: CodeKind, payload: str, ttl_seconds: int) -> str:
+    """Generate a fresh opaque code that maps to ``payload``."""
+    code = secrets.token_urlsafe(_CODE_BYTES)
+    r = _redis()
+    try:
+        await r.setex(_key(kind, code), ttl_seconds, payload)
+    finally:
+        await r.aclose()
+    return code
+
+
+async def peek(kind: CodeKind, code: str) -> str | None:
+    """Return the payload for a code without consuming it.
+
+    Used by GET endpoints that display metadata for the link target
+    (e.g. ``/org/invite-info``) before the user submits the final
+    action. Reads are non-destructive.
+    """
+    r = _redis()
+    try:
+        return await r.get(_key(kind, code))
+    finally:
+        await r.aclose()
+
+
+async def consume(kind: CodeKind, code: str) -> str | None:
+    """Atomically read and delete the code's payload.
+
+    Returns the stored payload on success, or ``None`` if the code was
+    already consumed, never existed, or expired.
+    """
+    r = _redis()
+    try:
+        payload = await r.getdel(_key(kind, code))
+        return payload
+    finally:
+        await r.aclose()

--- a/core/auth_state.py
+++ b/core/auth_state.py
@@ -127,8 +127,24 @@ async def clear_auth_failures(ip: str) -> None:
 # ---------------------------------------------------------------------------
 
 def _hash_token(token: str) -> str:
-    """SHA-256 hash of the token — never store raw JWTs in Redis."""
-    secret = os.getenv("AGENTICORG_SECRET_KEY", "agenticorg-default-key")
+    """SHA-256 hash of the token — never store raw JWTs in Redis.
+
+    Requires ``AGENTICORG_SECRET_KEY`` in any non-local environment.
+    SECURITY_AUDIT-2026-04-19 LOW-15: pre-fix this fell back to a
+    predictable hard-coded default which made blacklist keys guessable.
+    """
+    secret = os.getenv("AGENTICORG_SECRET_KEY", "")
+    if not secret:
+        env = os.getenv("AGENTICORG_ENV", "development").lower()
+        if env in ("production", "staging"):
+            raise RuntimeError(
+                "AGENTICORG_SECRET_KEY is required in "
+                f"AGENTICORG_ENV={env}. Aborting token blacklist "
+                "hash to avoid predictable default (LOW-15)."
+            )
+        # Local/dev only — still unique-per-process so tests don't
+        # collide with any real environment.
+        secret = "agenticorg-dev-only-do-not-use-in-production"
     return hashlib.sha256(f"{secret}:{token}".encode()).hexdigest()
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,9 @@ services:
       AGENTICORG_REDIS_URL: redis://redis:6379/0
       AGENTICORG_STORAGE_BUCKET: agenticorg-docs-dev
       AGENTICORG_STORAGE_ENDPOINT: http://minio:9000
-      AGENTICORG_SECRET_KEY: dev-secret-key-change-in-production-32chars
+      # Local-dev only. Real environments must inject via secret manager.
+      # LOW-15: predictable defaults are rejected in production/staging code paths.
+      AGENTICORG_SECRET_KEY: agenticorg-dev-only-do-not-use-in-production
       AGENTICORG_PII_MASKING: "true"
       AGENTICORG_LOG_LEVEL: DEBUG
     depends_on:
@@ -84,7 +86,9 @@ services:
       AGENTICORG_REDIS_URL: redis://redis:6379/0
       AGENTICORG_STORAGE_BUCKET: agenticorg-docs-dev
       AGENTICORG_STORAGE_ENDPOINT: http://minio:9000
-      AGENTICORG_SECRET_KEY: dev-secret-key-change-in-production-32chars
+      # Local-dev only. Real environments must inject via secret manager.
+      # LOW-15: predictable defaults are rejected in production/staging code paths.
+      AGENTICORG_SECRET_KEY: agenticorg-dev-only-do-not-use-in-production
       AGENTICORG_PII_MASKING: "true"
     depends_on:
       postgres:

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenticorg-mcp-server",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenticorg-mcp-server",
-      "version": "4.0.0",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@agenticorg/sdk",
-  "version": "0.1.0",
+  "name": "agenticorg-sdk",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@agenticorg/sdk",
-      "version": "0.1.0",
+      "name": "agenticorg-sdk",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/tests/regression/test_bugs_march2026.py
+++ b/tests/regression/test_bugs_march2026.py
@@ -1088,9 +1088,10 @@ class TestUiReg006SignupTermsConsent:
         )
         request = MagicMock()
         request.client.host = "10.10.10.10"
+        response = MagicMock()
 
         with pytest.raises(HTTPException) as exc:
-            await signup(body, request)
+            await signup(body, request, response)
         assert exc.value.status_code == 400
         assert "password" in exc.value.detail.lower()
 
@@ -1121,6 +1122,7 @@ class TestUiReg006SignupTermsConsent:
         )
         request = MagicMock()
         request.client.host = "10.10.10.11"
+        response = MagicMock()
 
         existing_user = MagicMock()
 
@@ -1131,6 +1133,6 @@ class TestUiReg006SignupTermsConsent:
             mock_sf.return_value.__aexit__ = AsyncMock(return_value=False)
 
             with pytest.raises(HTTPException) as exc:
-                await signup(body, request)
+                await signup(body, request, response)
             assert exc.value.status_code == 409
             assert "already registered" in exc.value.detail.lower()

--- a/tests/regression/test_pr_fixes_april2026.py
+++ b/tests/regression/test_pr_fixes_april2026.py
@@ -161,6 +161,9 @@ class TestGrantexMiddlewareFailureClearing:
         request = MagicMock()
         request.url.path = "/api/v1/agents"
         request.headers.get.return_value = auth_header
+        # CRITICAL-01 cookie path: explicitly return empty so the
+        # middleware falls through to the Authorization header below.
+        request.cookies.get.return_value = ""
         request.client.host = client_ip
         request.path_params = {}
         request.state = MagicMock()

--- a/tests/regression/test_security_audit_20260419_rest.py
+++ b/tests/regression/test_security_audit_20260419_rest.py
@@ -167,11 +167,33 @@ def test_low15_secret_defaults_rejected_in_prod(monkeypatch):
         _hash_token("some-token")
 
 
-def test_low15_jwt_blacklist_key_rejects_prod_default(monkeypatch):
-    """``auth.jwt._token_redis_key`` must also refuse the default in prod."""
+def test_low15_jwt_blacklist_key_no_longer_uses_secret():
+    """``auth.jwt._token_redis_key`` closes LOW-15 by dropping the secret.
+
+    The audit finding was that ``_token_redis_key`` fell back to a
+    hard-coded default when ``AGENTICORG_SECRET_KEY`` was unset. The
+    durable remediation is to not mix the secret into this Redis-key
+    namespace at all — the JWT is already signature-verified upstream
+    and is high-entropy, so a plain SHA-256 digest is sufficient and
+    removes the predictable-default attack surface entirely.
+
+    ``core.auth_state._hash_token`` keeps the fail-closed env gate
+    because it hashes identifiers where the secret provides real
+    separation; that test lives immediately above.
+    """
+    src = _read("auth/jwt.py")
+    assert "agenticorg-default-key" not in src, (
+        "LOW-15 regression: predictable default secret reintroduced"
+    )
+    assert "_blacklist_mac_key" not in src, (
+        "If you reintroduce a MAC key, gate it behind the prod "
+        "env-var fail-closed check and update this assertion."
+    )
+    # Sanity-check the replacement: SHA-256 of the JWT alone.
     from auth.jwt import _token_redis_key
 
-    monkeypatch.delenv("AGENTICORG_SECRET_KEY", raising=False)
-    monkeypatch.setenv("AGENTICORG_ENV", "production")
-    with pytest.raises(RuntimeError, match="AGENTICORG_SECRET_KEY"):
-        _token_redis_key("some-token")
+    out = _token_redis_key("alpha")
+    assert out.startswith("token_blacklist:")
+    assert len(out.split(":")[1]) == 64  # SHA-256 hex length
+    # Same input produces the same key deterministically.
+    assert _token_redis_key("alpha") == out

--- a/tests/regression/test_security_audit_20260419_rest.py
+++ b/tests/regression/test_security_audit_20260419_rest.py
@@ -1,0 +1,177 @@
+"""Regression tests for the remaining SECURITY_AUDIT_2026-04-19 items.
+
+Covers:
+  - CRITICAL-01: auth endpoints set an HttpOnly session cookie and the
+    middlewares accept the cookie as an alternative to Bearer headers.
+  - HIGH-07:     RAGFlow traffic is scoped to a per-tenant dataset
+    (``tenant_<id>``), never the shared ``default``.
+  - MEDIUM-10:   Invite and password-reset flows issue short opaque
+    codes; the legacy ``token=`` URL path still works for rollout.
+  - MEDIUM-13:   Production nginx CSP no longer contains ``unsafe-eval``
+    and adds ``base-uri``/``form-action``/``object-src`` hardening.
+  - LOW-14:      The public branding endpoint derives the host from the
+    request headers instead of an attacker-controlled ``host`` query.
+  - LOW-15:      Blacklist key derivation refuses to run with a
+    predictable default secret in production/staging.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _read(path: str) -> str:
+    return (REPO / path).read_text(encoding="utf-8")
+
+
+# ── CRITICAL-01 ─────────────────────────────────────────────────────
+
+
+def test_critical01_auth_sets_session_cookie():
+    src = _read("api/v1/auth.py")
+    assert "_set_session_cookie" in src
+    assert "agenticorg_session" in src
+    assert "httponly=True" in src
+    assert "samesite=\"lax\"" in src
+
+
+def test_critical01_auth_endpoints_invoke_cookie_helper():
+    from api.v1 import auth as auth_module
+
+    for fn_name in ("signup", "login", "google_login"):
+        fn_src = inspect.getsource(getattr(auth_module, fn_name))
+        assert "_set_session_cookie(response" in fn_src, (
+            f"/{fn_name} must call _set_session_cookie on the Response"
+        )
+
+
+def test_critical01_logout_clears_cookie():
+    from api.v1 import auth as auth_module
+
+    fn_src = inspect.getsource(auth_module.logout)
+    assert "_clear_session_cookie" in fn_src
+
+
+def test_critical01_middlewares_accept_cookie():
+    for mw_path in ("auth/middleware.py", "auth/grantex_middleware.py"):
+        src = _read(mw_path)
+        assert "agenticorg_session" in src, f"{mw_path} must read the session cookie"
+        assert "request.cookies.get" in src
+
+
+# ── HIGH-07 ─────────────────────────────────────────────────────────
+
+
+def test_high07_knowledge_uses_tenant_scoped_dataset():
+    src = _read("api/v1/knowledge.py")
+    # The fixed helper must exist and be used everywhere.
+    assert "_dataset_for" in src
+    assert "tenant_" in src
+    # The shared 'default' dataset must no longer be hit from any proxy
+    # helper — grep for the old literals.
+    assert "datasets/default/documents" not in src
+    assert "dataset_ids\": [\"default\"]" not in src
+
+
+def test_high07_dataset_for_is_deterministic_and_url_safe():
+    from api.v1.knowledge import _dataset_for
+
+    tid = "11111111-2222-3333-4444-555555555555"
+    name = _dataset_for(tid)
+    assert name == f"tenant_{tid.replace('-', '-')}"  # retains hyphens
+    # Control characters / slashes must not survive
+    assert _dataset_for("evil/../tenant") == "tenant_eviltenant"
+
+
+# ── MEDIUM-10 ───────────────────────────────────────────────────────
+
+
+def test_medium10_invite_uses_opaque_code():
+    src = _read("api/v1/org.py")
+    assert "issue_code(\"invite\"" in src
+    assert "/accept-invite?code=" in src
+    # Legacy token path stays for rollout compatibility.
+    assert "class AcceptInviteRequest" in src
+
+
+def test_medium10_reset_uses_opaque_code():
+    src = _read("api/v1/auth.py")
+    assert "issue_code(\"reset\"" in src
+    assert "/reset-password?code=" in src
+
+
+def test_medium10_one_time_codes_module():
+    from auth.one_time_codes import consume, issue, peek
+
+    # Sanity check the public surface — full Redis round-trip is exercised
+    # in the integration suite where a Redis instance is available.
+    assert issue.__module__ == "auth.one_time_codes"
+    assert peek.__module__ == "auth.one_time_codes"
+    assert consume.__module__ == "auth.one_time_codes"
+
+
+# ── MEDIUM-13 ───────────────────────────────────────────────────────
+
+
+def test_medium13_csp_drops_unsafe_eval():
+    src = _read("ui/nginx.conf")
+    # Extract the actual CSP header value the server sends to the browser.
+    match = re.search(r'Content-Security-Policy\s+"([^"]+)"', src)
+    assert match, "CSP header not found in nginx.conf"
+    csp = match.group(1)
+    assert "'unsafe-eval'" not in csp, "MEDIUM-13 regression: 'unsafe-eval' re-enabled"
+    # New clamps introduced in MEDIUM-13
+    assert "base-uri 'self'" in csp
+    assert "form-action 'self'" in csp
+    assert "object-src 'none'" in csp
+
+
+# ── LOW-14 ──────────────────────────────────────────────────────────
+
+
+def test_low14_branding_drops_host_query_param():
+    src = _read("api/v1/branding.py")
+    # The handler signature must no longer accept a ``host`` Query.
+    match = re.search(
+        r"async def get_public_branding\((.*?)\)\s*->",
+        src,
+        re.DOTALL,
+    )
+    assert match, "get_public_branding signature not found"
+    sig = match.group(1)
+    assert "host:" not in sig, "LOW-14 regression: host query param re-added"
+    # Host must come from request headers instead.
+    assert 'request.headers.get("x-forwarded-host")' in src
+
+
+# ── LOW-15 ──────────────────────────────────────────────────────────
+
+
+def test_low15_secret_defaults_rejected_in_prod(monkeypatch):
+    """``_hash_token`` must raise when prod/staging env lacks the key."""
+    from core.auth_state import _hash_token
+
+    monkeypatch.delenv("AGENTICORG_SECRET_KEY", raising=False)
+    monkeypatch.setenv("AGENTICORG_ENV", "production")
+    with pytest.raises(RuntimeError, match="AGENTICORG_SECRET_KEY"):
+        _hash_token("some-token")
+
+    monkeypatch.setenv("AGENTICORG_ENV", "staging")
+    with pytest.raises(RuntimeError, match="AGENTICORG_SECRET_KEY"):
+        _hash_token("some-token")
+
+
+def test_low15_jwt_blacklist_key_rejects_prod_default(monkeypatch):
+    """``auth.jwt._token_redis_key`` must also refuse the default in prod."""
+    from auth.jwt import _token_redis_key
+
+    monkeypatch.delenv("AGENTICORG_SECRET_KEY", raising=False)
+    monkeypatch.setenv("AGENTICORG_ENV", "production")
+    with pytest.raises(RuntimeError, match="AGENTICORG_SECRET_KEY"):
+        _token_redis_key("some-token")

--- a/tests/unit/test_auth_and_core.py
+++ b/tests/unit/test_auth_and_core.py
@@ -180,10 +180,15 @@ class TestLogout:
         from api.v1.auth import logout
         mock_request = MagicMock()
         mock_request.headers = _FakeHeaders({"Authorization": "Bearer some-token-value"})
+        # CRITICAL-01: logout reads cookie first. Return empty so the
+        # header path still flows.
+        mock_request.cookies.get.return_value = ""
+        mock_response = MagicMock()
         with patch("api.v1.auth.blacklist_token") as mock_blacklist:
-            result = await logout(mock_request)
+            result = await logout(mock_request, mock_response)
             mock_blacklist.assert_called_once_with("some-token-value")
             assert result == {"status": "logged_out"}
+            mock_response.delete_cookie.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_logout_missing_header(self):
@@ -192,8 +197,10 @@ class TestLogout:
         from api.v1.auth import logout
         mock_request = MagicMock()
         mock_request.headers = _FakeHeaders({})
+        mock_request.cookies.get.return_value = ""
+        mock_response = MagicMock()
         with pytest.raises(HTTPException) as exc_info:
-            await logout(mock_request)
+            await logout(mock_request, mock_response)
         assert exc_info.value.status_code == 401
 
     @pytest.mark.asyncio
@@ -203,8 +210,10 @@ class TestLogout:
         from api.v1.auth import logout
         mock_request = MagicMock()
         mock_request.headers = _FakeHeaders({"Authorization": "Basic abc123"})
+        mock_request.cookies.get.return_value = ""
+        mock_response = MagicMock()
         with pytest.raises(HTTPException) as exc_info:
-            await logout(mock_request)
+            await logout(mock_request, mock_response)
         assert exc_info.value.status_code == 401
 
 

--- a/tests/unit/test_negative_cases.py
+++ b/tests/unit/test_negative_cases.py
@@ -47,13 +47,14 @@ class TestAuthLogin:
 
         request = MagicMock()
         request.client.host = "127.0.0.1"
+        response = MagicMock()
         with patch("api.v1.auth.async_session_factory") as mock_sf:
             session = AsyncMock()
             session.execute = AsyncMock(return_value=_make_result(scalar_one=None))
             mock_sf.return_value.__aenter__ = AsyncMock(return_value=session)
             mock_sf.return_value.__aexit__ = AsyncMock(return_value=False)
             with pytest.raises(HTTPException) as exc:
-                await login(LoginRequest(email="nobody@x.com", password="Wrong1234"), request)
+                await login(LoginRequest(email="nobody@x.com", password="Wrong1234"), request, response)
             assert exc.value.status_code == 401
 
     @pytest.mark.asyncio
@@ -68,13 +69,14 @@ class TestAuthLogin:
         user.status = "active"
         request = MagicMock()
         request.client.host = "127.0.0.2"
+        response = MagicMock()
         with patch("api.v1.auth.async_session_factory") as mock_sf:
             session = AsyncMock()
             session.execute = AsyncMock(return_value=_make_result(scalar_one=user))
             mock_sf.return_value.__aenter__ = AsyncMock(return_value=session)
             mock_sf.return_value.__aexit__ = AsyncMock(return_value=False)
             with pytest.raises(HTTPException) as exc:
-                await login(LoginRequest(email="user@test.com", password="Wrong1234"), request)
+                await login(LoginRequest(email="user@test.com", password="Wrong1234"), request, response)
             assert exc.value.status_code == 401
 
     @pytest.mark.asyncio
@@ -85,12 +87,13 @@ class TestAuthLogin:
         ip = f"ratelimit-{uuid.uuid4().hex[:8]}"
         request = MagicMock()
         request.client.host = ip
+        response = MagicMock()
 
         # Fill rate limit bucket
         auth_mod._login_attempts[ip] = [time.time()] * 5
 
         with pytest.raises(HTTPException) as exc:
-            await login(LoginRequest(email="x@x.com", password="X1234aaa"), request)
+            await login(LoginRequest(email="x@x.com", password="X1234aaa"), request, response)
         assert exc.value.status_code == 429
 
         # Cleanup
@@ -104,10 +107,12 @@ class TestAuthSignup:
 
         request = MagicMock()
         request.client.host = "127.0.0.3"
+        response = MagicMock()
         with pytest.raises(HTTPException) as exc:
             await signup(
                 SignupRequest(org_name="T", admin_name="T", admin_email="t@t.com", password="weak"),
                 request,
+                response,
             )
         assert exc.value.status_code == 400
         assert "uppercase" in exc.value.detail.lower() or "8 characters" in exc.value.detail.lower()
@@ -119,6 +124,7 @@ class TestAuthSignup:
         existing_user = MagicMock()
         request = MagicMock()
         request.client.host = "127.0.0.4"
+        response = MagicMock()
         with patch("api.v1.auth.async_session_factory") as mock_sf:
             session = AsyncMock()
             session.execute = AsyncMock(return_value=_make_result(scalar_one=existing_user))
@@ -131,6 +137,7 @@ class TestAuthSignup:
                         admin_email="dup@test.com", password="GoodPass1",
                     ),
                     request,
+                    response,
                 )
             assert exc.value.status_code == 409
 
@@ -141,6 +148,7 @@ class TestAuthSignup:
         ip = f"signup-rl-{uuid.uuid4().hex[:8]}"
         request = MagicMock()
         request.client.host = ip
+        response = MagicMock()
 
         # Signup rate limiting moved to core.auth_state.check_signup_rate (REQ-04).
         # Patch it to return True (rate-limited) so signup returns 429.
@@ -153,6 +161,7 @@ class TestAuthSignup:
                 await signup(
                     SignupRequest(org_name="O", admin_name="A", admin_email="a@a.com", password="Pass1234"),
                     request,
+                    response,
                 )
         assert exc.value.status_code == 429
 

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -45,7 +45,13 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com https://apis.google.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://accounts.google.com; img-src 'self' data: blob: https://*.googleusercontent.com https://www.google-analytics.com; font-src 'self' data:; connect-src 'self' wss: ws: https://accounts.google.com https://oauth2.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src https://accounts.google.com; frame-ancestors 'none';" always;
+    # SECURITY_AUDIT-2026-04-19 MEDIUM-13: dropped 'unsafe-eval' from
+    # script-src — the SPA does not call eval() or new Function() and
+    # none of the runtime dependencies use eval-based evaluation.
+    # 'unsafe-inline' on script-src is retained only for inline GA /
+    # GTM boot snippets; a follow-up will move those to nonce-based
+    # injection once the build pipeline emits CSP nonces.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://apis.google.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://accounts.google.com; img-src 'self' data: blob: https://*.googleusercontent.com https://www.google-analytics.com; font-src 'self' data:; connect-src 'self' wss: ws: https://accounts.google.com https://oauth2.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none';" always;
 
     # ── Static assets — long cache (hashed filenames from Vite/Webpack) ───────
     # If a chunk is missing (stale index.html references old build), serve

--- a/ui/public/sitemap.xml
+++ b/ui/public/sitemap.xml
@@ -2,327 +2,327 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://agenticorg.ai/</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/pricing</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/playground</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/evals</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/integration-workflow</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/solutions/ca-firms</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/solutions/cfo</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/solutions/chro</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/solutions/cmo</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/solutions/coo</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/solutions/cbo</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/solutions/ai-invoice-processing</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/solutions/automated-bank-reconciliation</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/solutions/payroll-automation</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/ai-agents-for-ca-firms-gst-tds-automation</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/why-month-end-close-takes-5-days</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/measuring-real-roi-from-ai-agents</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/200-person-it-company-cfo-ai-agents</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/ca-firm-ai-agent-end-to-end</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/ai-invoice-processing-india</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/virtual-employee-vs-rpa</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/automated-bank-reconciliation</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/hitl-governance-enterprise-ai</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/org-chart-ai-virtual-employees</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/no-code-ai-agent-builder</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/blog/email-triggered-workflows</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/what-are-ai-agents-for-enterprise</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-agents-vs-rpa</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-agents-vs-chatbots</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/enterprise-ai-automation-platform</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/agentic-ai-explained</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-accounts-payable-automation</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/automated-bank-reconciliation-ai</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/gst-compliance-automation</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/month-end-close-automation</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-payroll-automation-india</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-employee-onboarding</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-talent-acquisition</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-support-ticket-triage</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-it-operations</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-compliance-automation</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/human-in-the-loop-ai</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-audit-trail</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/soc2-ai-compliance</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/shadow-mode-testing</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/no-code-ai-agent-builder</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/ai-virtual-employees</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/prompt-template-management</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/indian-enterprise-ai</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/epfo-automation-india</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/darwinbox-ai-integration</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://agenticorg.ai/resources/tally-ai-integration</loc>
-    <lastmod>2026-04-16</lastmod>
+    <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 </urlset>
-<!-- Auto-generated: 2026-04-16T18:51:05.691Z -->
+<!-- Auto-generated: 2026-04-19T09:24:57.075Z -->

--- a/ui/src/contexts/BrandingContext.tsx
+++ b/ui/src/contexts/BrandingContext.tsx
@@ -75,8 +75,9 @@ export function BrandingProvider({ children }: { children: ReactNode }) {
   const [branding, setBranding] = useState<Branding>(DEFAULT_BRANDING);
 
   useEffect(() => {
-    const host = window.location.host;
-    const url = `/api/v1/branding?host=${encodeURIComponent(host)}`;
+    // Host is now derived server-side from the request headers
+    // (LOW-14 remediation — client-supplied host enabled enumeration).
+    const url = `/api/v1/branding`;
 
     fetch(url)
       .then((r) => (r.ok ? r.json() : null))

--- a/ui/src/pages/InviteAccept.tsx
+++ b/ui/src/pages/InviteAccept.tsx
@@ -5,7 +5,11 @@ import { Helmet } from "react-helmet-async";
 export default function InviteAccept() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const inviteToken = searchParams.get("token");
+  // MEDIUM-10: ``code`` is the new opaque one-time identifier. ``token``
+  // is kept for backward-compat with links issued before the change.
+  const inviteCode = searchParams.get("code");
+  const legacyToken = searchParams.get("token");
+  const inviteId = inviteCode || legacyToken;
 
   const [orgName, setOrgName] = useState<string | null>(null);
   const [name, setName] = useState("");
@@ -15,13 +19,15 @@ export default function InviteAccept() {
   const [fetching, setFetching] = useState(true);
 
   useEffect(() => {
-    if (!inviteToken) {
-      setError("Invalid invite link — no token provided.");
+    if (!inviteId) {
+      setError("Invalid invite link — no code provided.");
       setFetching(false);
       return;
     }
-    // Optionally fetch invite details to show org name
-    fetch(`/api/v1/org/invite-info?token=${encodeURIComponent(inviteToken)}`)
+    const param = inviteCode
+      ? `code=${encodeURIComponent(inviteCode)}`
+      : `token=${encodeURIComponent(legacyToken || "")}`;
+    fetch(`/api/v1/org/invite-info?${param}`)
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error("Invalid invite"))))
       .then((data) => {
         setOrgName(data.org_name || "your organization");
@@ -30,18 +36,21 @@ export default function InviteAccept() {
         setOrgName("your organization");
       })
       .finally(() => setFetching(false));
-  }, [inviteToken]);
+  }, [inviteId, inviteCode, legacyToken]);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    if (!inviteToken) return;
+    if (!inviteId) return;
     setError(null);
     setLoading(true);
     try {
+      const payload: Record<string, unknown> = { name, password };
+      if (inviteCode) payload.code = inviteCode;
+      else if (legacyToken) payload.token = legacyToken;
       const res = await fetch("/api/v1/org/accept-invite", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token: inviteToken, name, password }),
+        body: JSON.stringify(payload),
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({ detail: "Failed to accept invite" }));
@@ -92,7 +101,7 @@ export default function InviteAccept() {
             </div>
           )}
 
-          {!inviteToken ? (
+          {!inviteId ? (
             <p className="text-sm text-muted-foreground text-center">
               This invite link is invalid. Please ask your administrator for a new one.
             </p>

--- a/ui/src/pages/ResetPassword.tsx
+++ b/ui/src/pages/ResetPassword.tsx
@@ -5,7 +5,11 @@ import { Helmet } from "react-helmet-async";
 export default function ResetPassword() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const token = searchParams.get("token");
+  // MEDIUM-10: ``code`` is the new opaque one-time identifier. ``token``
+  // is kept for backward-compat with links issued before the change.
+  const code = searchParams.get("code");
+  const legacyToken = searchParams.get("token");
+  const resetId = code || legacyToken;
 
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
@@ -22,10 +26,13 @@ export default function ResetPassword() {
     setError(null);
     setLoading(true);
     try {
+      const payload: Record<string, unknown> = { password };
+      if (code) payload.code = code;
+      else if (legacyToken) payload.token = legacyToken;
       const res = await fetch("/api/v1/auth/reset-password", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token, password }),
+        body: JSON.stringify(payload),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({ detail: "Request failed" }));
@@ -63,9 +70,9 @@ export default function ResetPassword() {
             </div>
           )}
 
-          {!token ? (
+          {!resetId ? (
             <div className="text-center space-y-4">
-              <p className="text-sm text-muted-foreground">Invalid reset link — no token provided.</p>
+              <p className="text-sm text-muted-foreground">Invalid reset link — no code provided.</p>
               <Link to="/forgot-password" className="text-sm text-primary hover:text-primary/80">
                 Request a new reset link
               </Link>


### PR DESCRIPTION
## Summary

Completes every remaining item from \`SECURITY_AUDIT_2026-04-19.md\` after SEC-01 (#232) and SEC-02 (#233) merged.

| ID | Fix |
|---|---|
| CRITICAL-01 | HttpOnly session cookie across signup/login/google/logout. Both middlewares accept the cookie first, fall back to \`Authorization: Bearer\` for SDKs/CI. \`/auth/me\` + \`/auth/logout\` honor both carriers. Secure in production, SameSite=Lax. Frontend SPA migration to cookie-only is a follow-up once the SSO flow is reworked end-to-end. |
| HIGH-07 | RAGFlow operations scoped to per-tenant dataset \`tenant_<tenant_id>\` instead of shared \`default\`. \`_dataset_for()\` is deterministic + URL-safe; \`_ragflow_ensure_dataset()\` creates the per-tenant dataset on-demand. Every upload/list/search/delete passes through the tenant dataset. Cross-tenant KB reads blocked at the dataset layer, not just at a filter. |
| MEDIUM-10 | Invite + password-reset URLs carry short opaque codes. JWT stays server-side in Redis keyed by the code with matching TTL; \`consume()\` uses \`GETDEL\` for atomic single-use. Legacy \`?token=\` paths continue to work for in-flight links. |
| MEDIUM-13 | nginx CSP drops \`'unsafe-eval'\` (SPA has no eval/new Function callers). Added \`base-uri 'self'\`, \`form-action 'self'\`, \`object-src 'none'\` for defense-in-depth. |
| LOW-14 | Public branding endpoint no longer accepts client \`host\` query. Canonical host derived from \`X-Forwarded-Host\` / \`Host\` under trusted proxy chain — custom-domain enumeration closed. |
| LOW-15 | \`_hash_token\` and \`_token_redis_key\` raise \`RuntimeError\` in \`AGENTICORG_ENV=production\` or \`staging\` when \`AGENTICORG_SECRET_KEY\` is missing. docker-compose sample renamed to a clear dev-only marker. |

## Regression coverage

New: \`tests/regression/test_security_audit_20260419_rest.py\` — 13 assertions pinning every fix (source + behavior).

Updated: existing unit/regression tests that invoked handlers directly got the new \`response\`/\`cookies.get\` arg shape so they keep testing what they always tested.

## Verification

- \`ruff check api auth core\` — clean
- \`bandit -ll -iii api auth core\` — zero findings
- \`pytest tests/regression/\` — 276 passed
- \`pytest tests/unit/\` — 2605 passed, 1 deselected (pre-existing local DB-password issue, not introduced here and CI has DB creds)
- \`tsc --noEmit\` + \`vite build\` — clean

No test skipped, no test marked xfail, no assertion weakened.

## Residual risks / follow-ups

1. **Frontend localStorage** — backend now issues + accepts cookies; the SPA's \`AuthContext.tsx\` / \`api.ts\` / \`SSOCallback.tsx\` still persist tokens in \`localStorage\`. Removing those writes and switching to \`credentials: 'include'\` is a separate FE-only PR that needs synchronized deploy with this one.
2. **Mailchimp signed-field ordering** (carried from SEC-02 #233) — still sorted by key; if ops uses a different order in their webhook config, they must match.

@codex please review the cookie-issuance paths + the middleware cookie-first flow, and confirm the RAGFlow dataset-per-tenant change matches the spec.