### PR TITLE
fix(e2e): invite-accept test reads ?code= (MEDIUM-10 URL change)

### DIFF
--- a/ui/e2e/qa-bugs-regression.spec.ts
+++ b/ui/e2e/qa-bugs-regression.spec.ts
@@ -634,15 +634,25 @@ test.describe("ORG-INV-002: Invite Token Issuer", () => {
     const inviteLink = inviteData.invite_link;
     expect(inviteLink).toBeTruthy();
 
-    const inviteToken = new URL(inviteLink).searchParams.get("token");
-    expect(inviteToken).toBeTruthy();
+    // MEDIUM-10: invite URLs now carry an opaque ?code= instead of a raw
+    // JWT ?token=. Legacy ?token= links still work, so accept either.
+    const linkParams = new URL(inviteLink).searchParams;
+    const inviteCode = linkParams.get("code");
+    const inviteToken = linkParams.get("token");
+    expect(inviteCode || inviteToken).toBeTruthy();
 
     // Accept the invite -- should NOT return "Invalid issuer"
+    const acceptPayload: Record<string, string> = {
+      password: "TestPass@2026",
+    };
+    if (inviteCode) acceptPayload.code = inviteCode;
+    else if (inviteToken) acceptPayload.token = inviteToken;
+
     const acceptResp = await page.request.post(
       `${baseURL}/api/v1/org/accept-invite`,
       {
         headers: { "Content-Type": "application/json" },
-        data: { token: inviteToken, password: "TestPass@2026" },
+        data: acceptPayload,
       },
     );
     expect(acceptResp.ok()).toBeTruthy();


### PR DESCRIPTION
## Summary

ORG-INV-002 e2e regression started failing after PR #235 (SEC-03) merged. Root cause: MEDIUM-10 replaced the raw-JWT \`?token=\` in invite links with an opaque \`?code=\`. The test extracts the query param to replay against \`/org/accept-invite\` and \`searchParams.get("token")\` now returns null.

Fix: try \`?code=\` first, fall back to \`?token=\` for any still-in-flight legacy links. Mirrors the backend's dual-path accept logic.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [ ] e2e-tests on this branch — ORG-INV-002 should pass