### PR TITLE
chore(gitignore): ignore mcp-publisher.exe and uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,12 @@ scripts/generate_*pdf*
 scripts/generate_*doc*
 scripts/marketing*
 .tmp_lc/
+
+# MCP registry publisher binary (downloaded per-machine for publishing)
+mcp-server/mcp-publisher.exe
+mcp-server/mcp-publisher
+
+# uv (Astral package manager) lockfile — not a canonical repo tool.
+# pyproject.toml has no [tool.uv] section and no CI/Dockerfile uses uv sync.
+# If we ever adopt uv, delete this entry and commit the lockfile deliberately.
+uv.lock


### PR DESCRIPTION
## Summary

Two locally-generated artifacts should never land in the repo. Adds both to `.gitignore`.

- **`mcp-server/mcp-publisher.exe`** — 20 MB platform-specific binary the operator downloads from the `modelcontextprotocol/registry` releases page when publishing to `registry.modelcontextprotocol.io`. Installed during the 4.0.3 republish on 2026-04-19. Machine-dependent (Windows amd64 on this machine, macOS arm64 on others), so committing makes no sense.

- **`uv.lock`** — dropped in the repo root when `uv` (Astral package manager) is run against `pyproject.toml`. `uv` is **not** a canonical tool in this project:
  - `pyproject.toml` has no `[tool.uv]` section
  - No workflow, `Dockerfile`, script, or doc in the repo references `uv sync` or `uv run`
  - The only `uv*` string in `pyproject.toml` is `uvicorn` (ASGI server) — unrelated

  Committing the lockfile would silently make `uv` load-bearing without team agreement. If we later adopt `uv`, the correct move is to remove this gitignore entry and commit the lockfile deliberately as part of that decision.

## Verification

- `bash scripts/preflight.sh` — all 11 gates pass:
  branch safety, ruff, bandit, alembic revision, verify=False scan, pytest regression+unit, ui tsc, ui build, consistency sweep, module coverage floor, critical-path tags.

## Test plan

- [x] `.gitignore` diff reviewed; no accidental removals
- [x] Preflight green
- [ ] Post-merge: confirm `git status` in a fresh clone doesn't show `uv.lock` or `mcp-publisher.exe` as untracked after the publish flow

cc @codex — please review.