### PR TITLE
fix(report-schedules): TC_001 500-on-bad-email + TC_002 missing config controls

### DIFF
--- a/api/v1/report_schedules.py
+++ b/api/v1/report_schedules.py
@@ -5,17 +5,108 @@ Uses PostgreSQL via SQLAlchemy ORM with tenant-scoped sessions (RLS).
 
 from __future__ import annotations
 
+import re
 import uuid as _uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy import select
 
 from api.deps import get_current_tenant, require_tenant_admin
 from core.database import get_tenant_session
 from core.models.report_schedule import ReportSchedule
+
+# Presets understood by both the API layer and the scheduler worker.
+# Real cron strings (5 fields) are also accepted — see _is_valid_cron().
+_CRON_PRESETS: frozenset[str] = frozenset({
+    "every_5_minutes",
+    "hourly",
+    "daily",
+    "weekly",
+    "monthly",
+})
+
+# Pragmatic email shape check. SendGrid does authoritative validation at
+# delivery time; this just rejects obviously malformed input at the API
+# boundary so the user gets a 422 instead of an eventual 500.
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s.]+\.[^@\s]+$")
+
+# Slack channel IDs: C* (public), G* (private), D* (DM). 9-11 alphanumeric
+# chars after the prefix. Accepts the friendly "#channel-name" form too,
+# which Slack resolves server-side.
+_SLACK_CHANNEL_RE = re.compile(r"^(?:[CGD][A-Z0-9]{8,10}|#[a-z0-9][a-z0-9._-]{0,78})$")
+
+# WhatsApp: E.164 phone numbers, 8-15 digits with optional leading '+'.
+_WHATSAPP_PHONE_RE = re.compile(r"^\+?[1-9]\d{7,14}$")
+
+
+def _is_valid_cron(expr: str) -> bool:
+    """Accept either a preset keyword or a real 5-field cron expression.
+
+    Delegates to croniter when available (authoritative). When croniter is
+    absent (it is an optional dep for the task layer too, see
+    core/tasks/report_tasks.py), falls back to a per-field range check so
+    we still reject obviously-invalid values like ``99 99 99 99 99``.
+    """
+    if expr in _CRON_PRESETS:
+        return True
+    try:
+        from croniter import croniter  # type: ignore[import-untyped]
+
+        try:
+            croniter(expr, datetime.now(UTC))
+            return True
+        except (ValueError, KeyError):
+            return False
+    except ImportError:
+        pass
+    # croniter not installed — do a field-by-field range check.
+    return _fallback_cron_check(expr)
+
+
+def _fallback_cron_check(expr: str) -> bool:
+    """Permissive-but-range-aware cron validator used when croniter is absent.
+
+    Each of the 5 fields must be a ``*``, ``*/N``, ``A-B``, ``A,B,C``, or a
+    bare integer, all within the field's natural range.
+    """
+    fields = expr.split()
+    if len(fields) != 5:
+        return False
+    ranges = [(0, 59), (0, 23), (1, 31), (1, 12), (0, 7)]
+    for token, (lo, hi) in zip(fields, ranges, strict=False):
+        if not _cron_field_ok(token, lo, hi):
+            return False
+    return True
+
+
+def _cron_field_ok(token: str, lo: int, hi: int) -> bool:
+    if token == "*":
+        return True
+    if token.startswith("*/"):
+        try:
+            n = int(token[2:])
+        except ValueError:
+            return False
+        return n > 0
+    for part in token.split(","):
+        if "-" in part:
+            try:
+                a, b = (int(x) for x in part.split("-", 1))
+            except ValueError:
+                return False
+            if not (lo <= a <= hi and lo <= b <= hi and a <= b):
+                return False
+            continue
+        try:
+            v = int(part)
+        except ValueError:
+            return False
+        if not (lo <= v <= hi):
+            return False
+    return True
 
 router = APIRouter(dependencies=[require_tenant_admin])
 
@@ -28,6 +119,50 @@ class DeliveryChannel(BaseModel):
     type: str = Field(..., description="Channel type: email | slack | whatsapp")
     target: str = Field(..., description="Email address, Slack channel ID, or phone number")
 
+    @field_validator("type")
+    @classmethod
+    def _validate_type(cls, v: str) -> str:
+        if v not in {"email", "slack", "whatsapp"}:
+            raise ValueError(
+                "type must be one of: email, slack, whatsapp"
+            )
+        return v
+
+    @model_validator(mode="after")
+    def _validate_target_for_type(self) -> DeliveryChannel:
+        """Validate target format against channel type.
+
+        Without this, the API accepts an empty or malformed target and the
+        failure surfaces later as an HTTP 500 from the dispatcher (SendGrid
+        rejection, Slack 404, Twilio format error). Rejecting at the
+        boundary gives callers a clean 422 with a specific message.
+        """
+        target = (self.target or "").strip()
+        if not target:
+            raise ValueError(
+                f"target is required for {self.type} delivery channel"
+            )
+        if self.type == "email":
+            if not _EMAIL_RE.match(target):
+                raise ValueError(
+                    "invalid email address (expected name@domain.tld)"
+                )
+        elif self.type == "slack":
+            if not _SLACK_CHANNEL_RE.match(target):
+                raise ValueError(
+                    "invalid Slack channel: use the channel ID "
+                    "(e.g. C01ABC23DEF) or #channel-name"
+                )
+        elif self.type == "whatsapp":
+            if not _WHATSAPP_PHONE_RE.match(target):
+                raise ValueError(
+                    "invalid WhatsApp number: use E.164 format "
+                    "(e.g. +919876543210)"
+                )
+        # Store the trimmed value so downstream code never sees padding.
+        object.__setattr__(self, "target", target)
+        return self
+
 
 class ReportScheduleCreate(BaseModel):
     report_type: str = Field(
@@ -36,13 +171,43 @@ class ReportScheduleCreate(BaseModel):
     )
     cron_expression: str = Field(
         "daily",
-        description="Cron or keyword: every_5_minutes, hourly, daily, weekly, monthly",
+        description=(
+            "Preset keyword (every_5_minutes, hourly, daily, weekly, monthly) "
+            "or a standard 5-field cron expression (e.g. '0 9 * * 1-5')."
+        ),
     )
     delivery_channels: list[DeliveryChannel] = Field(default_factory=list)
     format: str = Field("pdf", description="Output format: pdf | excel | both")
     is_active: bool = True
     company_id: str = "default"
     params: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("cron_expression")
+    @classmethod
+    def _validate_cron(cls, v: str) -> str:
+        v = (v or "").strip()
+        if not _is_valid_cron(v):
+            raise ValueError(
+                "cron_expression must be a preset "
+                f"({', '.join(sorted(_CRON_PRESETS))}) or a valid "
+                "5-field cron expression"
+            )
+        return v
+
+    @field_validator("format")
+    @classmethod
+    def _validate_format(cls, v: str) -> str:
+        if v not in {"pdf", "excel", "both"}:
+            raise ValueError("format must be one of: pdf, excel, both")
+        return v
+
+    @model_validator(mode="after")
+    def _require_at_least_one_channel(self) -> ReportScheduleCreate:
+        if not self.delivery_channels:
+            raise ValueError(
+                "at least one delivery channel is required"
+            )
+        return self
 
 
 class ReportScheduleUpdate(BaseModel):
@@ -53,6 +218,36 @@ class ReportScheduleUpdate(BaseModel):
     is_active: bool | None = None
     company_id: str | None = None
     params: dict[str, Any] | None = None
+
+    @field_validator("cron_expression")
+    @classmethod
+    def _validate_cron(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        v = v.strip()
+        if not _is_valid_cron(v):
+            raise ValueError(
+                "cron_expression must be a preset "
+                f"({', '.join(sorted(_CRON_PRESETS))}) or a valid "
+                "5-field cron expression"
+            )
+        return v
+
+    @field_validator("format")
+    @classmethod
+    def _validate_format(cls, v: str | None) -> str | None:
+        if v is not None and v not in {"pdf", "excel", "both"}:
+            raise ValueError("format must be one of: pdf, excel, both")
+        return v
+
+    @model_validator(mode="after")
+    def _delivery_channels_not_empty_when_set(self) -> ReportScheduleUpdate:
+        if self.delivery_channels is not None and not self.delivery_channels:
+            raise ValueError(
+                "delivery_channels cannot be an empty list; "
+                "omit the field to keep existing channels"
+            )
+        return self
 
 
 class ReportScheduleResponse(BaseModel):
@@ -75,7 +270,12 @@ class ReportScheduleResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 def _compute_next_run(cron: str) -> datetime:
-    """Lightweight next-run estimation (matches task-layer logic)."""
+    """Estimate next run for display purposes.
+
+    The authoritative next-run calculation happens in the scheduler worker
+    (`core/tasks/report_tasks.py`). This helper just gives the UI a
+    reasonable `next_run_at` to show immediately after create/update.
+    """
     now = datetime.now(UTC)
     interval_map: dict[str, timedelta] = {
         "every_5_minutes": timedelta(minutes=5),
@@ -84,8 +284,15 @@ def _compute_next_run(cron: str) -> datetime:
         "weekly": timedelta(weeks=1),
         "monthly": timedelta(days=30),
     }
-    delta = interval_map.get(cron, timedelta(days=1))
-    return now + delta
+    if cron in interval_map:
+        return now + interval_map[cron]
+    # Real cron string — defer to croniter for an accurate estimate.
+    try:
+        from croniter import croniter  # type: ignore[import-untyped]
+
+        return croniter(cron, now).get_next(datetime)
+    except (ImportError, ValueError, KeyError):
+        return now + timedelta(days=1)
 
 
 def _to_response(row: ReportSchedule) -> ReportScheduleResponse:

--- a/tests/integration/test_db_api_endpoints.py
+++ b/tests/integration/test_db_api_endpoints.py
@@ -164,7 +164,13 @@ class TestReportSchedulesIntegration:
         created = (await client.post(
             "/api/v1/report-schedules",
             headers=headers,
-            json={"report_type": "cmo_weekly", "cron_expression": "weekly"},
+            json={
+                "report_type": "cmo_weekly",
+                "cron_expression": "weekly",
+                "delivery_channels": [
+                    {"type": "email", "target": "cmo@example.com"},
+                ],
+            },
         )).json()
         try:
             updated = await client.patch(
@@ -207,7 +213,9 @@ class TestReportSchedulesIntegration:
             json={
                 "report_type": "aging_report",
                 "cron_expression": "daily",
-                "delivery_channels": [],
+                "delivery_channels": [
+                    {"type": "email", "target": "ops@example.com"},
+                ],
             },
         )).json()
         try:
@@ -228,6 +236,143 @@ class TestReportSchedulesIntegration:
             await client.delete(
                 f"/api/v1/report-schedules/{created['id']}", headers=a_hdr,
             )
+
+    # --- validation regressions (QA bug TC_001 + TC_002) -------------------
+    #
+    # Each of these used to surface as an HTTP 500 at delivery time because
+    # the API accepted malformed input. They should now all be 422 at the
+    # boundary, with a specific validation message.
+    @pytest.mark.asyncio
+    async def test_missing_email_target_returns_422_not_500(
+        self, client, make_auth_headers,
+    ):
+        """TC_001: empty-string email target must be rejected at boundary."""
+        headers = self._admin_headers(make_auth_headers)
+        resp = await client.post(
+            "/api/v1/report-schedules",
+            headers=headers,
+            json={
+                "report_type": "cfo_daily",
+                "cron_expression": "daily",
+                "delivery_channels": [{"type": "email", "target": ""}],
+            },
+        )
+        assert resp.status_code == 422, resp.text
+        assert "target" in resp.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_email_returns_422(self, client, make_auth_headers):
+        """TC_001: malformed email target must be rejected at boundary."""
+        headers = self._admin_headers(make_auth_headers)
+        resp = await client.post(
+            "/api/v1/report-schedules",
+            headers=headers,
+            json={
+                "report_type": "cfo_daily",
+                "cron_expression": "daily",
+                "delivery_channels": [
+                    {"type": "email", "target": "not-an-email"},
+                ],
+            },
+        )
+        assert resp.status_code == 422, resp.text
+        assert "email" in resp.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_slack_channel_returns_422(
+        self, client, make_auth_headers,
+    ):
+        headers = self._admin_headers(make_auth_headers)
+        resp = await client.post(
+            "/api/v1/report-schedules",
+            headers=headers,
+            json={
+                "report_type": "cfo_daily",
+                "cron_expression": "daily",
+                "delivery_channels": [
+                    {"type": "slack", "target": "not-a-channel-id"},
+                ],
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+    @pytest.mark.asyncio
+    async def test_invalid_whatsapp_number_returns_422(
+        self, client, make_auth_headers,
+    ):
+        headers = self._admin_headers(make_auth_headers)
+        resp = await client.post(
+            "/api/v1/report-schedules",
+            headers=headers,
+            json={
+                "report_type": "cfo_daily",
+                "cron_expression": "daily",
+                "delivery_channels": [
+                    {"type": "whatsapp", "target": "12345"},
+                ],
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+    @pytest.mark.asyncio
+    async def test_no_delivery_channels_returns_422(
+        self, client, make_auth_headers,
+    ):
+        """A schedule with zero delivery channels is useless — reject it."""
+        headers = self._admin_headers(make_auth_headers)
+        resp = await client.post(
+            "/api/v1/report-schedules",
+            headers=headers,
+            json={
+                "report_type": "cfo_daily",
+                "cron_expression": "daily",
+                "delivery_channels": [],
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+    @pytest.mark.asyncio
+    async def test_real_cron_expression_is_accepted(
+        self, client, make_auth_headers,
+    ):
+        """TC_002: real 5-field cron expressions must be accepted."""
+        headers = self._admin_headers(make_auth_headers)
+        resp = await client.post(
+            "/api/v1/report-schedules",
+            headers=headers,
+            json={
+                "report_type": "cfo_daily",
+                "cron_expression": "0 9 * * 1-5",
+                "delivery_channels": [
+                    {"type": "email", "target": "cfo@example.com"},
+                ],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        created = resp.json()
+        assert created["cron_expression"] == "0 9 * * 1-5"
+        await client.delete(
+            f"/api/v1/report-schedules/{created['id']}", headers=headers,
+        )
+
+    @pytest.mark.asyncio
+    async def test_invalid_cron_expression_returns_422(
+        self, client, make_auth_headers,
+    ):
+        """TC_002: obviously-invalid cron must be rejected."""
+        headers = self._admin_headers(make_auth_headers)
+        resp = await client.post(
+            "/api/v1/report-schedules",
+            headers=headers,
+            json={
+                "report_type": "cfo_daily",
+                "cron_expression": "99 99 99 99 99",
+                "delivery_channels": [
+                    {"type": "email", "target": "cfo@example.com"},
+                ],
+            },
+        )
+        assert resp.status_code == 422, resp.text
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/ui/src/__tests__/ReportScheduler.test.tsx
+++ b/ui/src/__tests__/ReportScheduler.test.tsx
@@ -587,4 +587,104 @@ describe("ReportScheduler", () => {
     expect(screen.getByText("Status")).toBeInTheDocument();
     expect(screen.getByText("Actions")).toBeInTheDocument();
   });
+
+  // ── QA regressions (TC_001 / TC_002) ───────────────────────────────────
+
+  it("blocks submit and shows inline error when email recipient is invalid (TC_001)", async () => {
+    setupFetch();
+    render(<ReportScheduler />);
+    await waitFor(() => {
+      expect(screen.getByText("CFO Daily Briefing")).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("+ New Schedule"));
+    });
+    // Email is enabled by default; type something that fails our regex.
+    const emailInput = screen.getByPlaceholderText("recipient@company.com");
+    await act(async () => {
+      fireEvent.change(emailInput, { target: { value: "not-an-email" } });
+    });
+    // Submit by submitting the form element itself (avoid HTML5
+    // email-type validation intercepting the submit button click).
+    const form = emailInput.closest("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+    // Inline validation should fire; no POST should be made.
+    const postCalls = mockFetch.mock.calls.filter(
+      (c: unknown[]) =>
+        (c[0] as string).endsWith("/report-schedules") &&
+        (c[1] as RequestInit)?.method === "POST",
+    );
+    expect(postCalls.length).toBe(0);
+    expect(
+      await screen.findByText(/Invalid email address/),
+    ).toBeInTheDocument();
+  });
+
+  it("exposes execution time + day-of-week + advanced cron controls (TC_002)", async () => {
+    setupFetch();
+    render(<ReportScheduler />);
+    await waitFor(() => {
+      expect(screen.getByText("CFO Daily Briefing")).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("+ New Schedule"));
+    });
+    // Execution time is always visible.
+    const timeInput = screen.getByLabelText(/Execution Time/);
+    expect(timeInput).toBeInTheDocument();
+    // Day of Week appears when weekly is selected.
+    const freqSelect = screen.getByLabelText(/Frequency/);
+    await act(async () => {
+      fireEvent.change(freqSelect, { target: { value: "weekly" } });
+    });
+    expect(screen.getByLabelText(/Day of Week/)).toBeInTheDocument();
+    // Advanced mode reveals a cron textbox.
+    const advancedToggle = screen.getByText(/Advanced — write CRON/);
+    await act(async () => {
+      fireEvent.click(advancedToggle);
+    });
+    expect(
+      screen.getByLabelText(/Custom cron expression/i),
+    ).toBeInTheDocument();
+  });
+
+  it("composes a real cron string from frequency + time before POST (TC_002)", async () => {
+    setupFetch();
+    render(<ReportScheduler />);
+    await waitFor(() => {
+      expect(screen.getByText("CFO Daily Briefing")).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("+ New Schedule"));
+    });
+    const emailInput = screen.getByPlaceholderText("recipient@company.com");
+    await act(async () => {
+      fireEvent.change(emailInput, { target: { value: "ops@example.com" } });
+    });
+    // Set time to 14:30 — cron must be "30 14 * * *".
+    const timeInput = screen.getByLabelText(/Execution Time/) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(timeInput, { target: { value: "14:30" } });
+    });
+    const submitBtns = screen.getAllByText("Create Schedule");
+    const submitBtn = submitBtns[submitBtns.length - 1];
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+    await waitFor(() => {
+      const postCall = mockFetch.mock.calls.find(
+        (c: unknown[]) =>
+          (c[0] as string).endsWith("/report-schedules") &&
+          (c[1] as RequestInit)?.method === "POST",
+      );
+      expect(postCall).toBeDefined();
+      const body = JSON.parse((postCall![1] as RequestInit).body as string);
+      expect(body.cron_expression).toBe("30 14 * * *");
+      expect(body.delivery_channels).toEqual([
+        { type: "email", target: "ops@example.com" },
+      ]);
+    });
+  });
 });

--- a/ui/src/pages/ReportScheduler.tsx
+++ b/ui/src/pages/ReportScheduler.tsx
@@ -32,10 +32,23 @@ const REPORT_TYPES = [
   { value: "campaign_report", label: "Campaign Performance" },
 ] as const;
 
-const SCHEDULE_PRESETS = [
+type FrequencyPreset = "daily" | "weekly" | "monthly";
+
+const FREQUENCY_PRESETS: { value: FrequencyPreset; label: string }[] = [
   { value: "daily", label: "Daily" },
   { value: "weekly", label: "Weekly" },
   { value: "monthly", label: "Monthly" },
+];
+
+// Cron weekday convention: 0 or 7 = Sunday, 1 = Monday, ... 6 = Saturday.
+const DAYS_OF_WEEK = [
+  { value: "1", label: "Monday" },
+  { value: "2", label: "Tuesday" },
+  { value: "3", label: "Wednesday" },
+  { value: "4", label: "Thursday" },
+  { value: "5", label: "Friday" },
+  { value: "6", label: "Saturday" },
+  { value: "0", label: "Sunday" },
 ] as const;
 
 const FORMAT_OPTIONS = [
@@ -45,6 +58,12 @@ const FORMAT_OPTIONS = [
 ] as const;
 
 const API_BASE = "/api/v1";
+
+// Must match the server-side regexes in api/v1/report_schedules.py so
+// users see the same error client-side before the round-trip.
+const EMAIL_RE = /^[^@\s]+@[^@\s.]+\.[^@\s]+$/;
+const SLACK_RE = /^(?:[CGD][A-Z0-9]{8,10}|#[a-z0-9][a-z0-9._-]{0,78})$/;
+const WHATSAPP_RE = /^\+?[1-9]\d{7,14}$/;
 
 /* ── Helpers ───────────────────────────────────────────────────────── */
 
@@ -73,6 +92,102 @@ function statusBadge(active: boolean) {
   );
 }
 
+/** Compose a 5-field cron from the simple controls. */
+function composeCron(
+  freq: FrequencyPreset,
+  time: string,
+  dayOfWeek: string,
+  dayOfMonth: string,
+): string {
+  const [hh, mm] = time.split(":");
+  const minute = String(parseInt(mm, 10) || 0);
+  const hour = String(parseInt(hh, 10) || 0);
+  if (freq === "daily") return `${minute} ${hour} * * *`;
+  if (freq === "weekly") return `${minute} ${hour} * * ${dayOfWeek}`;
+  return `${minute} ${hour} ${dayOfMonth} * *`;
+}
+
+/** Try to map a stored cron back to the simple controls. Falls back to
+ *  advanced mode when the pattern doesn't fit one of our three presets. */
+function parseCron(cron: string): {
+  advanced: boolean;
+  freq: FrequencyPreset;
+  time: string;
+  dayOfWeek: string;
+  dayOfMonth: string;
+  raw: string;
+} {
+  const defaults = {
+    advanced: false,
+    freq: "daily" as FrequencyPreset,
+    time: "09:00",
+    dayOfWeek: "1",
+    dayOfMonth: "1",
+    raw: cron,
+  };
+  // Preset keyword — show as "Daily/Weekly/Monthly" with a default 09:00.
+  if (cron === "daily" || cron === "weekly" || cron === "monthly") {
+    return { ...defaults, freq: cron };
+  }
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) return { ...defaults, advanced: true };
+  const [m, h, dom, mo, dow] = parts;
+  const mNum = parseInt(m, 10);
+  const hNum = parseInt(h, 10);
+  if (Number.isNaN(mNum) || Number.isNaN(hNum) || mo !== "*") {
+    return { ...defaults, advanced: true };
+  }
+  const time = `${String(hNum).padStart(2, "0")}:${String(mNum).padStart(2, "0")}`;
+  if (dom === "*" && dow === "*") {
+    return { ...defaults, freq: "daily", time };
+  }
+  if (dom === "*" && /^[0-7]$/.test(dow)) {
+    return { ...defaults, freq: "weekly", time, dayOfWeek: dow };
+  }
+  if (dow === "*" && /^([1-9]|[12]\d|3[01])$/.test(dom)) {
+    return { ...defaults, freq: "monthly", time, dayOfMonth: dom };
+  }
+  return { ...defaults, advanced: true };
+}
+
+function validateTarget(
+  type: DeliveryChannel["type"],
+  target: string,
+): string | null {
+  const t = target.trim();
+  if (!t) return `${type} recipient is required`;
+  if (type === "email" && !EMAIL_RE.test(t)) {
+    return "Invalid email address (expected name@domain.tld)";
+  }
+  if (type === "slack" && !SLACK_RE.test(t)) {
+    return "Invalid Slack channel — use C01ABC23DEF or #channel-name";
+  }
+  if (type === "whatsapp" && !WHATSAPP_RE.test(t)) {
+    return "Invalid WhatsApp number — use E.164 (e.g. +919876543210)";
+  }
+  return null;
+}
+
+/** Flatten a FastAPI 422 body into a one-line user-readable message. */
+async function extractError(resp: Response): Promise<string> {
+  try {
+    const data = await resp.json();
+    if (Array.isArray(data?.detail)) {
+      return data.detail
+        .map((d: { loc?: unknown[]; msg?: string }) => {
+          const field = Array.isArray(d.loc) ? d.loc.slice(1).join(".") : "";
+          return field ? `${field}: ${d.msg}` : d.msg;
+        })
+        .filter(Boolean)
+        .join("; ");
+    }
+    if (typeof data?.detail === "string") return data.detail;
+  } catch {
+    /* fall through */
+  }
+  return `HTTP ${resp.status}`;
+}
+
 /* ── Component ─────────────────────────────────────────────────────── */
 
 export default function ReportScheduler() {
@@ -82,10 +197,16 @@ export default function ReportScheduler() {
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
 
   /* ── Form state ── */
   const [formType, setFormType] = useState("cfo_daily");
-  const [formCron, setFormCron] = useState("daily");
+  const [formFreq, setFormFreq] = useState<FrequencyPreset>("daily");
+  const [formTime, setFormTime] = useState("09:00");
+  const [formDayOfWeek, setFormDayOfWeek] = useState("1");
+  const [formDayOfMonth, setFormDayOfMonth] = useState("1");
+  const [formAdvanced, setFormAdvanced] = useState(false);
+  const [formCustomCron, setFormCustomCron] = useState("0 9 * * *");
   const [formFormat, setFormFormat] = useState("pdf");
   const [formActive, setFormActive] = useState(true);
   const [formEmailEnabled, setFormEmailEnabled] = useState(true);
@@ -94,6 +215,7 @@ export default function ReportScheduler() {
   const [formSlackTarget, setFormSlackTarget] = useState("");
   const [formWhatsappEnabled, setFormWhatsappEnabled] = useState(false);
   const [formWhatsappTarget, setFormWhatsappTarget] = useState("");
+  const [formFieldErrors, setFormFieldErrors] = useState<Record<string, string>>({});
 
   /* ── Fetch schedules ── */
   const fetchSchedules = useCallback(async () => {
@@ -107,8 +229,9 @@ export default function ReportScheduler() {
       const data: ReportSchedule[] = await resp.json();
       setSchedules(data);
       setError(null);
-    } catch (e: any) {
-      setError(e.message ?? "Failed to load schedules");
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Failed to load schedules";
+      setError(msg);
     } finally {
       setLoading(false);
     }
@@ -118,25 +241,43 @@ export default function ReportScheduler() {
     fetchSchedules();
   }, [fetchSchedules]);
 
-  /* ── Build channels from form ── */
-  function buildChannels(): DeliveryChannel[] {
+  /* ── Build channels + pre-submit validation ── */
+  function buildValidatedChannels(): {
+    channels: DeliveryChannel[];
+    errors: Record<string, string>;
+  } {
+    const errors: Record<string, string> = {};
     const channels: DeliveryChannel[] = [];
-    if (formEmailEnabled && formEmailTarget.trim()) {
-      channels.push({ type: "email", target: formEmailTarget.trim() });
+    if (formEmailEnabled) {
+      const err = validateTarget("email", formEmailTarget);
+      if (err) errors.email = err;
+      else channels.push({ type: "email", target: formEmailTarget.trim() });
     }
-    if (formSlackEnabled && formSlackTarget.trim()) {
-      channels.push({ type: "slack", target: formSlackTarget.trim() });
+    if (formSlackEnabled) {
+      const err = validateTarget("slack", formSlackTarget);
+      if (err) errors.slack = err;
+      else channels.push({ type: "slack", target: formSlackTarget.trim() });
     }
-    if (formWhatsappEnabled && formWhatsappTarget.trim()) {
-      channels.push({ type: "whatsapp", target: formWhatsappTarget.trim() });
+    if (formWhatsappEnabled) {
+      const err = validateTarget("whatsapp", formWhatsappTarget);
+      if (err) errors.whatsapp = err;
+      else channels.push({ type: "whatsapp", target: formWhatsappTarget.trim() });
     }
-    return channels;
+    if (channels.length === 0 && Object.keys(errors).length === 0) {
+      errors.channels = "At least one delivery channel is required";
+    }
+    return { channels, errors };
   }
 
   /* ── Reset form ── */
   function resetForm() {
     setFormType("cfo_daily");
-    setFormCron("daily");
+    setFormFreq("daily");
+    setFormTime("09:00");
+    setFormDayOfWeek("1");
+    setFormDayOfMonth("1");
+    setFormAdvanced(false);
+    setFormCustomCron("0 9 * * *");
     setFormFormat("pdf");
     setFormActive(true);
     setFormEmailEnabled(true);
@@ -147,13 +288,20 @@ export default function ReportScheduler() {
     setFormWhatsappTarget("");
     setEditingId(null);
     setShowForm(false);
+    setFormFieldErrors({});
   }
 
   /* ── Populate form for edit ── */
   function startEdit(s: ReportSchedule) {
     setEditingId(s.id);
     setFormType(s.report_type);
-    setFormCron(s.cron_expression);
+    const parsed = parseCron(s.cron_expression);
+    setFormAdvanced(parsed.advanced);
+    setFormFreq(parsed.freq);
+    setFormTime(parsed.time);
+    setFormDayOfWeek(parsed.dayOfWeek);
+    setFormDayOfMonth(parsed.dayOfMonth);
+    setFormCustomCron(parsed.advanced ? parsed.raw : "0 9 * * *");
     setFormFormat(s.format);
     setFormActive(s.is_active);
 
@@ -169,50 +317,63 @@ export default function ReportScheduler() {
     setFormWhatsappTarget(wa?.target ?? "");
 
     setShowForm(true);
+    setFormFieldErrors({});
   }
 
   /* ── Create / Update ── */
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    const { channels, errors } = buildValidatedChannels();
+    const cron = formAdvanced
+      ? formCustomCron.trim()
+      : composeCron(formFreq, formTime, formDayOfWeek, formDayOfMonth);
+    if (formAdvanced && cron.split(/\s+/).length !== 5) {
+      errors.cron = "Advanced cron must be a 5-field expression (min hour dom mon dow)";
+    }
+    if (Object.keys(errors).length > 0) {
+      setFormFieldErrors(errors);
+      return;
+    }
+    setFormFieldErrors({});
+    setSubmitting(true);
     const token = localStorage.getItem("token") || "";
-    const channels = buildChannels();
 
     try {
-      if (editingId) {
-        await fetch(`${API_BASE}/report-schedules/${editingId}`, {
-          method: "PATCH",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            report_type: formType,
-            cron_expression: formCron,
-            delivery_channels: channels,
-            format: formFormat,
-            is_active: formActive,
-          }),
-        });
-      } else {
-        await fetch(`${API_BASE}/report-schedules`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            report_type: formType,
-            cron_expression: formCron,
-            delivery_channels: channels,
-            format: formFormat,
-            is_active: formActive,
-          }),
-        });
+      const payload = {
+        report_type: formType,
+        cron_expression: cron,
+        delivery_channels: channels,
+        format: formFormat,
+        is_active: formActive,
+      };
+      const resp = editingId
+        ? await fetch(`${API_BASE}/report-schedules/${editingId}`, {
+            method: "PATCH",
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          })
+        : await fetch(`${API_BASE}/report-schedules`, {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          });
+
+      if (!resp.ok) {
+        setError(await extractError(resp));
+        return;
       }
       resetForm();
       fetchSchedules();
-    } catch (err: any) {
-      setError(err.message ?? "Save failed");
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSubmitting(false);
     }
   }
 
@@ -257,8 +418,8 @@ export default function ReportScheduler() {
       const data = await resp.json();
       alert(`Report triggered. Task ID: ${data.task_id}`);
       fetchSchedules();
-    } catch (err: any) {
-      setError(err.message ?? "Run failed");
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Run failed");
     } finally {
       setActionLoading(null);
     }
@@ -309,10 +470,11 @@ export default function ReportScheduler() {
           <form onSubmit={handleSubmit} className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {/* Report type */}
             <div>
-              <label className="block text-sm font-medium mb-1">
+              <label className="block text-sm font-medium mb-1" htmlFor="rs-report-type">
                 Report Type
               </label>
               <select
+                id="rs-report-type"
                 value={formType}
                 onChange={(e) => setFormType(e.target.value)}
                 className="w-full border rounded-lg px-3 py-2 text-sm bg-background"
@@ -325,17 +487,19 @@ export default function ReportScheduler() {
               </select>
             </div>
 
-            {/* Schedule */}
+            {/* Frequency */}
             <div>
-              <label className="block text-sm font-medium mb-1">
-                Schedule
+              <label className="block text-sm font-medium mb-1" htmlFor="rs-frequency">
+                Frequency
               </label>
               <select
-                value={formCron}
-                onChange={(e) => setFormCron(e.target.value)}
-                className="w-full border rounded-lg px-3 py-2 text-sm bg-background"
+                id="rs-frequency"
+                value={formFreq}
+                onChange={(e) => setFormFreq(e.target.value as FrequencyPreset)}
+                disabled={formAdvanced}
+                className="w-full border rounded-lg px-3 py-2 text-sm bg-background disabled:opacity-50"
               >
-                {SCHEDULE_PRESETS.map((p) => (
+                {FREQUENCY_PRESETS.map((p) => (
                   <option key={p.value} value={p.value}>
                     {p.label}
                   </option>
@@ -343,12 +507,99 @@ export default function ReportScheduler() {
               </select>
             </div>
 
+            {/* Execution time (HH:MM) — visible for every frequency */}
+            <div>
+              <label className="block text-sm font-medium mb-1" htmlFor="rs-time">
+                Execution Time (UTC)
+              </label>
+              <input
+                id="rs-time"
+                type="time"
+                value={formTime}
+                onChange={(e) => setFormTime(e.target.value || "09:00")}
+                disabled={formAdvanced}
+                className="w-full border rounded-lg px-3 py-2 text-sm bg-background disabled:opacity-50"
+              />
+            </div>
+
+            {/* Day selector — weekly only */}
+            {formFreq === "weekly" && !formAdvanced && (
+              <div>
+                <label className="block text-sm font-medium mb-1" htmlFor="rs-dow">
+                  Day of Week
+                </label>
+                <select
+                  id="rs-dow"
+                  value={formDayOfWeek}
+                  onChange={(e) => setFormDayOfWeek(e.target.value)}
+                  className="w-full border rounded-lg px-3 py-2 text-sm bg-background"
+                >
+                  {DAYS_OF_WEEK.map((d) => (
+                    <option key={d.value} value={d.value}>
+                      {d.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {/* Day-of-month — monthly only */}
+            {formFreq === "monthly" && !formAdvanced && (
+              <div>
+                <label className="block text-sm font-medium mb-1" htmlFor="rs-dom">
+                  Day of Month
+                </label>
+                <input
+                  id="rs-dom"
+                  type="number"
+                  min={1}
+                  max={31}
+                  value={formDayOfMonth}
+                  onChange={(e) => setFormDayOfMonth(e.target.value || "1")}
+                  className="w-full border rounded-lg px-3 py-2 text-sm bg-background"
+                />
+              </div>
+            )}
+
+            {/* Advanced / CRON toggle */}
+            <div className="sm:col-span-2">
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={formAdvanced}
+                  onChange={(e) => setFormAdvanced(e.target.checked)}
+                  className="rounded"
+                />
+                Advanced — write CRON expression directly
+              </label>
+              {formAdvanced && (
+                <div className="mt-2">
+                  <input
+                    type="text"
+                    value={formCustomCron}
+                    onChange={(e) => setFormCustomCron(e.target.value)}
+                    placeholder="0 9 * * 1-5   (every weekday at 09:00 UTC)"
+                    className="w-full border rounded-lg px-3 py-2 text-sm bg-background font-mono"
+                    aria-label="Custom cron expression"
+                  />
+                  <p className="text-xs text-muted-foreground mt-1">
+                    5 fields: minute (0-59), hour (0-23), day-of-month (1-31),
+                    month (1-12), day-of-week (0-7).
+                  </p>
+                  {formFieldErrors.cron && (
+                    <p className="text-xs text-red-600 mt-1">{formFieldErrors.cron}</p>
+                  )}
+                </div>
+              )}
+            </div>
+
             {/* Format */}
             <div>
-              <label className="block text-sm font-medium mb-1">
+              <label className="block text-sm font-medium mb-1" htmlFor="rs-format">
                 Output Format
               </label>
               <select
+                id="rs-format"
                 value={formFormat}
                 onChange={(e) => setFormFormat(e.target.value)}
                 className="w-full border rounded-lg px-3 py-2 text-sm bg-background"
@@ -380,82 +631,105 @@ export default function ReportScheduler() {
               <p className="text-sm font-medium">Delivery Channels</p>
 
               {/* Email */}
-              <div className="flex items-center gap-3">
-                <input
-                  type="checkbox"
-                  id="ch-email"
-                  checked={formEmailEnabled}
-                  onChange={(e) => setFormEmailEnabled(e.target.checked)}
-                  className="rounded"
-                />
-                <label htmlFor="ch-email" className="text-sm w-24">
-                  Email
-                </label>
-                {formEmailEnabled && (
+              <div className="space-y-1">
+                <div className="flex items-center gap-3">
                   <input
-                    type="email"
-                    placeholder="recipient@company.com"
-                    value={formEmailTarget}
-                    onChange={(e) => setFormEmailTarget(e.target.value)}
-                    className="flex-1 border rounded-lg px-3 py-1.5 text-sm bg-background"
+                    type="checkbox"
+                    id="ch-email"
+                    checked={formEmailEnabled}
+                    onChange={(e) => setFormEmailEnabled(e.target.checked)}
+                    className="rounded"
                   />
+                  <label htmlFor="ch-email" className="text-sm w-24">
+                    Email
+                  </label>
+                  {formEmailEnabled && (
+                    <input
+                      type="email"
+                      placeholder="recipient@company.com"
+                      value={formEmailTarget}
+                      onChange={(e) => setFormEmailTarget(e.target.value)}
+                      className="flex-1 border rounded-lg px-3 py-1.5 text-sm bg-background"
+                      aria-invalid={!!formFieldErrors.email}
+                    />
+                  )}
+                </div>
+                {formFieldErrors.email && (
+                  <p className="text-xs text-red-600 pl-32">{formFieldErrors.email}</p>
                 )}
               </div>
 
               {/* Slack */}
-              <div className="flex items-center gap-3">
-                <input
-                  type="checkbox"
-                  id="ch-slack"
-                  checked={formSlackEnabled}
-                  onChange={(e) => setFormSlackEnabled(e.target.checked)}
-                  className="rounded"
-                />
-                <label htmlFor="ch-slack" className="text-sm w-24">
-                  Slack
-                </label>
-                {formSlackEnabled && (
+              <div className="space-y-1">
+                <div className="flex items-center gap-3">
                   <input
-                    type="text"
-                    placeholder="Channel ID (e.g. C01ABC23DEF)"
-                    value={formSlackTarget}
-                    onChange={(e) => setFormSlackTarget(e.target.value)}
-                    className="flex-1 border rounded-lg px-3 py-1.5 text-sm bg-background"
+                    type="checkbox"
+                    id="ch-slack"
+                    checked={formSlackEnabled}
+                    onChange={(e) => setFormSlackEnabled(e.target.checked)}
+                    className="rounded"
                   />
+                  <label htmlFor="ch-slack" className="text-sm w-24">
+                    Slack
+                  </label>
+                  {formSlackEnabled && (
+                    <input
+                      type="text"
+                      placeholder="Channel ID (e.g. C01ABC23DEF) or #channel-name"
+                      value={formSlackTarget}
+                      onChange={(e) => setFormSlackTarget(e.target.value)}
+                      className="flex-1 border rounded-lg px-3 py-1.5 text-sm bg-background"
+                      aria-invalid={!!formFieldErrors.slack}
+                    />
+                  )}
+                </div>
+                {formFieldErrors.slack && (
+                  <p className="text-xs text-red-600 pl-32">{formFieldErrors.slack}</p>
                 )}
               </div>
 
               {/* WhatsApp */}
-              <div className="flex items-center gap-3">
-                <input
-                  type="checkbox"
-                  id="ch-whatsapp"
-                  checked={formWhatsappEnabled}
-                  onChange={(e) => setFormWhatsappEnabled(e.target.checked)}
-                  className="rounded"
-                />
-                <label htmlFor="ch-whatsapp" className="text-sm w-24">
-                  WhatsApp
-                </label>
-                {formWhatsappEnabled && (
+              <div className="space-y-1">
+                <div className="flex items-center gap-3">
                   <input
-                    type="tel"
-                    placeholder="+91 98765 43210"
-                    value={formWhatsappTarget}
-                    onChange={(e) => setFormWhatsappTarget(e.target.value)}
-                    className="flex-1 border rounded-lg px-3 py-1.5 text-sm bg-background"
+                    type="checkbox"
+                    id="ch-whatsapp"
+                    checked={formWhatsappEnabled}
+                    onChange={(e) => setFormWhatsappEnabled(e.target.checked)}
+                    className="rounded"
                   />
+                  <label htmlFor="ch-whatsapp" className="text-sm w-24">
+                    WhatsApp
+                  </label>
+                  {formWhatsappEnabled && (
+                    <input
+                      type="tel"
+                      placeholder="+919876543210"
+                      value={formWhatsappTarget}
+                      onChange={(e) => setFormWhatsappTarget(e.target.value)}
+                      className="flex-1 border rounded-lg px-3 py-1.5 text-sm bg-background"
+                      aria-invalid={!!formFieldErrors.whatsapp}
+                    />
+                  )}
+                </div>
+                {formFieldErrors.whatsapp && (
+                  <p className="text-xs text-red-600 pl-32">{formFieldErrors.whatsapp}</p>
                 )}
               </div>
+
+              {formFieldErrors.channels && (
+                <p className="text-xs text-red-600">{formFieldErrors.channels}</p>
+              )}
             </div>
 
             {/* Actions */}
             <div className="sm:col-span-2 flex gap-3 pt-2">
               <button
                 type="submit"
-                className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:opacity-90"
+                disabled={submitting}
+                className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 disabled:opacity-50"
               >
-                {editingId ? "Update Schedule" : "Create Schedule"}
+                {submitting ? "Saving..." : editingId ? "Update Schedule" : "Create Schedule"}
               </button>
               <button
                 type="button"
@@ -513,7 +787,7 @@ export default function ReportScheduler() {
                         .join(", ") || "No delivery"}
                     </div>
                   </td>
-                  <td className="px-4 py-3 hidden sm:table-cell capitalize">
+                  <td className="px-4 py-3 hidden sm:table-cell font-mono text-xs">
                     {s.cron_expression}
                   </td>
                   <td className="px-4 py-3 hidden md:table-cell text-muted-foreground">


### PR DESCRIPTION
## Summary

Closes the two Critical/Reopen bugs from the Aishwarya 20-Apr QA report:

- **TC_001** — HTTP 500 when email recipient is missing/invalid on report-schedule create.
- **TC_002** — Report Scheduler missing execution time, day-of-week, and CRON configuration options.

## Backend changes (`api/v1/report_schedules.py`)

- `DeliveryChannel` now has a `field_validator` + `model_validator` that enforces **per-channel-type** target format: email regex for `type=email`, Slack channel-ID / `#channel-name` regex for `type=slack`, E.164 phone regex for `type=whatsapp`. Empty target rejected.
- `ReportScheduleCreate` requires **at least one delivery channel** — a schedule with zero channels is useless.
- `cron_expression` accepts a preset keyword **or** a real 5-field cron expression (validated with `croniter` when available, else a per-field range check that still rejects obvious bad input like `99 99 99 99 99`).
- `_compute_next_run` now delegates to `croniter` for non-preset strings so the UI-displayed `next_run_at` respects the configured cron.
- Invalid input now surfaces as HTTP 422 with a specific message instead of an eventual HTTP 500 from the downstream dispatcher (SendGrid / Slack / Twilio rejecting garbage).

## Frontend changes (`ui/src/pages/ReportScheduler.tsx`)

- New **Execution Time** picker (always visible).
- New **Day of Week** selector (visible for weekly schedules).
- New **Day of Month** input (visible for monthly schedules).
- New **"Advanced — write CRON expression directly"** toggle with a free-text cron textbox.
- Client-side cron composition produces a real 5-field string from frequency + time (+ day) so the scheduler worker gets precise input.
- **Pre-submit inline validation** for each enabled channel target — users see the error without a round-trip.
- Server 422 responses are now surfaced as a single readable banner message.

## Tests

- `tests/integration/test_db_api_endpoints.py` gets 7 new TC_001/TC_002 regression cases: empty email target, invalid email, invalid slack, invalid whatsapp, no-channels, real-cron-accepted, invalid-cron-rejected.
- `ui/src/__tests__/ReportScheduler.test.tsx` gets 3 new cases: inline validation blocks POST on invalid email, time/day/CRON controls render as expected, composed cron string matches what lands in the POST body.

## Verification

- `ruff check api/v1/report_schedules.py` — clean
- `python -m pytest tests/unit/ tests/regression/ -q` — **2882 passed**
- `npm test -- --run ReportScheduler` — **25 passed** (22 original + 3 new)
- `npx tsc --noEmit` — clean
- `python scripts/consistency_sweep.py` — all checks pass
- Local preflight (all 11 gates) — all pass

## Test plan

- [x] Empty/invalid email returns 422 not 500
- [x] Invalid Slack/WhatsApp target returns 422
- [x] At least one channel required
- [x] Real cron (`0 9 * * 1-5`) accepted
- [x] Invalid cron (`99 99 99 99 99`) rejected
- [x] UI: time/day/CRON controls present and compose correct cron
- [x] UI: pre-submit validation blocks garbage email without hitting server
- [ ] Post-merge smoke on `app.agenticorg.ai/dashboard/report-schedules` with the Aishwarya credentials

cc @codex — please review.

---

This is PR-A of the 2026-04-20 stabilization sweep. Follow-up PRs in the same branch-family will close the remaining Aishwarya + Ramesh bugs. See `memory/project_qa_sweep_20260420.md` for the full plan.