### PR TITLE
fix(knowledge-base): TC_005/006/010/011 display + dedup bugs

### DIFF
--- a/api/v1/knowledge.py
+++ b/api/v1/knowledge.py
@@ -13,7 +13,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 import structlog
-from fastapi import APIRouter, Depends, Query, UploadFile
+from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile
 from pydantic import BaseModel, Field
 
 from api.deps import get_current_tenant
@@ -97,6 +97,29 @@ class SearchResponse(BaseModel):
     results: list[SearchResult]
 
 
+# Canonical status values surfaced to the UI. "ready" was a legacy
+# RAGFlow-side label that leaked straight into the response; it is now
+# normalised to "indexed" before it reaches the client.
+DOC_STATUS_PROCESSING = "processing"
+DOC_STATUS_INDEXED = "indexed"
+DOC_STATUS_FAILED = "failed"
+_LEGACY_STATUS_MAP: dict[str, str] = {
+    # map everything the upload path or RAGFlow might set onto the three
+    # canonical values the frontend badge component knows about.
+    "ready": DOC_STATUS_INDEXED,
+    "done": DOC_STATUS_INDEXED,
+    "ok": DOC_STATUS_INDEXED,
+    "processed": DOC_STATUS_INDEXED,
+}
+
+
+def _normalize_status(raw: str | None) -> str:
+    """Map any incoming status string onto the canonical set."""
+    if not raw:
+        return DOC_STATUS_PROCESSING
+    return _LEGACY_STATUS_MAP.get(raw, raw)
+
+
 class DocumentOut(BaseModel):
     document_id: str
     filename: str
@@ -104,6 +127,11 @@ class DocumentOut(BaseModel):
     size_bytes: int
     status: str
     created_at: str
+    # TC_010: frontend expected `uploaded_at` but the API only returned
+    # `created_at`, so the Uploaded column rendered "-" for every row.
+    # We now expose both; `uploaded_at` is the user-facing name and
+    # `created_at` is retained for back-compat with SDK consumers.
+    uploaded_at: str
     deleted: bool = False
 
 
@@ -116,6 +144,16 @@ class StatsResponse(BaseModel):
     total_documents: int
     total_chunks: int
     index_size_mb: float
+
+
+class DuplicateDocumentError(Exception):
+    """Raised when an upload would create a filename duplicate in the
+    current tenant scope (TC_011)."""
+
+    def __init__(self, document_id: str, filename: str) -> None:
+        self.document_id = document_id
+        self.filename = filename
+        super().__init__(f"document already exists: {filename}")
 
 
 # ---------------------------------------------------------------------------
@@ -190,6 +228,38 @@ async def _ragflow_delete(tenant_id: str, doc_id: str) -> bool:
 # ---------------------------------------------------------------------------
 # PostgreSQL fallback — document metadata persistence
 # ---------------------------------------------------------------------------
+async def _db_find_existing_by_filename(
+    tenant_id: str, filename: str,
+) -> dict[str, Any] | None:
+    """Return the first non-deleted document with the given filename for
+    this tenant, or None. Used to block duplicate uploads (TC_011)."""
+    from uuid import UUID as _UUID
+
+    from sqlalchemy import select
+
+    from core.database import get_tenant_session
+    from core.models.document import Document
+
+    tid = _UUID(tenant_id)
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(Document).where(
+                Document.tenant_id == tid,
+                Document.filename == filename,
+                Document.status != "deleted",
+            ).limit(1)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return {
+            "document_id": str(row.id),
+            "filename": row.filename,
+            "size_bytes": row.size_bytes,
+            "status": _normalize_status(row.status),
+        }
+
+
 async def _db_store_doc(tenant_id: str, doc: dict[str, Any]) -> None:
     """Store document metadata in PostgreSQL (fallback when RAGFlow is down)."""
     from uuid import UUID as _UUID
@@ -251,20 +321,56 @@ async def _db_list_docs(tenant_id: str) -> list[dict[str, Any]]:
 async def upload_document(
     file: UploadFile,
     tenant_id: str = Depends(get_current_tenant),
+    allow_duplicate: bool = Query(
+        default=False,
+        description=(
+            "TC_011: when False (default), an upload whose filename already "
+            "exists in the tenant's non-deleted documents returns 409 "
+            "Conflict with the existing document_id. Set true to bypass "
+            "the check (e.g. to deliberately upload a new version)."
+        ),
+    ),
 ):
     """Upload a document to the knowledge base.
 
     Uses RAGFlow for chunking + vector indexing when available.
     Falls back to PostgreSQL metadata storage otherwise.
     """
+    filename = file.filename or "untitled"
+
+    # TC_011: filename-level dedup. Caller can opt out with
+    # ?allow_duplicate=true if they actually want two documents with the
+    # same filename (e.g. re-ingesting an updated file). This check is
+    # best-effort — if the DB lookup fails, we proceed with the upload
+    # rather than block legitimate usage.
+    if not allow_duplicate:
+        try:
+            existing = await _db_find_existing_by_filename(tenant_id, filename)
+        except Exception as exc:
+            logger.debug("dedup_lookup_failed_soft", error=str(exc))
+            existing = None
+        if existing is not None:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "duplicate_filename",
+                    "message": (
+                        f"A document named {filename!r} is already in the "
+                        "knowledge base. Upload with allow_duplicate=true "
+                        "to bypass this check."
+                    ),
+                    "existing_document_id": existing["document_id"],
+                },
+            )
+
     content = await file.read()
     doc_id = str(uuid.uuid4())
     doc: dict[str, Any] = {
         "document_id": doc_id,
-        "filename": file.filename or "untitled",
+        "filename": filename,
         "content_type": file.content_type,
         "size_bytes": len(content),
-        "status": "processing",
+        "status": DOC_STATUS_PROCESSING,
         "created_at": _now_iso(),
     }
 
@@ -276,13 +382,13 @@ async def upload_document(
             # RAGFlow returns its own document ID
             rf_doc_id = rf_result.get("data", {}).get("id", doc_id)
             doc["document_id"] = rf_doc_id
-            doc["status"] = "ready"
+            doc["status"] = DOC_STATUS_INDEXED
             logger.info("knowledge_upload_ragflow", doc_id=rf_doc_id, filename=doc["filename"])
         except Exception as exc:
             logger.warning("ragflow_upload_failed_fallback_db", error=str(exc))
-            doc["status"] = "ready"
+            doc["status"] = DOC_STATUS_INDEXED
     else:
-        doc["status"] = "ready"
+        doc["status"] = DOC_STATUS_INDEXED
 
     # Session 5 TC-013: always mirror metadata to Postgres so the document
     # list survives a RAGFlow outage or a RAGFlow-side search lag. Without
@@ -299,8 +405,9 @@ async def upload_document(
         filename=doc["filename"],
         content_type=doc["content_type"],
         size_bytes=doc["size_bytes"],
-        status=doc["status"],
+        status=_normalize_status(doc["status"]),
         created_at=doc["created_at"],
+        uploaded_at=doc["created_at"],
     )
 
 
@@ -381,8 +488,9 @@ async def list_documents(
             filename=d.get("filename", d.get("name", "")),
             content_type=d.get("content_type"),
             size_bytes=d.get("size_bytes", d.get("size", 0)),
-            status=d.get("status", "ready"),
+            status=_normalize_status(d.get("status")),
             created_at=d.get("created_at", ""),
+            uploaded_at=d.get("uploaded_at") or d.get("created_at", ""),
         )
         for d in page_items
     ]

--- a/tests/unit/test_knowledge_normalize_status.py
+++ b/tests/unit/test_knowledge_normalize_status.py
@@ -1,0 +1,63 @@
+"""Unit tests for knowledge-base helpers that are pure and DB-free.
+
+Covers the TC_006 regression: the public document API must never leak
+the legacy "ready" label. Covers TC_010 by confirming DocumentOut
+carries both `created_at` and `uploaded_at` so the UI can read either.
+"""
+
+from __future__ import annotations
+
+from api.v1.knowledge import (
+    DOC_STATUS_FAILED,
+    DOC_STATUS_INDEXED,
+    DOC_STATUS_PROCESSING,
+    DocumentOut,
+    _normalize_status,
+)
+
+
+class TestNormalizeStatus:
+    def test_ready_maps_to_indexed(self) -> None:
+        assert _normalize_status("ready") == DOC_STATUS_INDEXED
+
+    def test_done_ok_processed_all_map_to_indexed(self) -> None:
+        for legacy in ("done", "ok", "processed"):
+            assert _normalize_status(legacy) == DOC_STATUS_INDEXED
+
+    def test_canonical_values_pass_through(self) -> None:
+        for v in (
+            DOC_STATUS_PROCESSING,
+            DOC_STATUS_INDEXED,
+            DOC_STATUS_FAILED,
+        ):
+            assert _normalize_status(v) == v
+
+    def test_empty_and_none_default_to_processing(self) -> None:
+        assert _normalize_status(None) == DOC_STATUS_PROCESSING
+        assert _normalize_status("") == DOC_STATUS_PROCESSING
+
+    def test_unknown_value_passes_through_unchanged(self) -> None:
+        """Preserving unknown values is intentional — we don't want the
+        normaliser to hide a real bug by silently remapping something
+        unexpected to 'indexed'. The UI will render it as a fallback
+        badge and a reviewer will see it."""
+        assert _normalize_status("quarantined") == "quarantined"
+
+
+class TestDocumentOutFields:
+    def test_document_out_has_both_created_at_and_uploaded_at(self) -> None:
+        """TC_010: the UI reads `uploaded_at`; back-compat keeps
+        `created_at` in the same response."""
+        doc = DocumentOut(
+            document_id="doc-1",
+            filename="a.pdf",
+            content_type="application/pdf",
+            size_bytes=100,
+            status=DOC_STATUS_INDEXED,
+            created_at="2026-04-20T10:00:00Z",
+            uploaded_at="2026-04-20T10:00:00Z",
+        )
+        as_dict = doc.model_dump()
+        assert "created_at" in as_dict
+        assert "uploaded_at" in as_dict
+        assert as_dict["created_at"] == as_dict["uploaded_at"]

--- a/ui/src/__tests__/KnowledgeBase.test.tsx
+++ b/ui/src/__tests__/KnowledgeBase.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * KnowledgeBase component — regression tests for the 20-Apr QA bugs:
+ *   TC_005  Deleting one file no longer wipes the whole list.
+ *   TC_006  "ready" is normalised (server-side) and shows a green badge.
+ *   TC_010  Uploaded column renders a real timestamp, not "-".
+ *   TC_011  Duplicate filename upload triggers a confirm dialog and,
+ *           when the user cancels, does not call POST.
+ */
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}));
+
+import KnowledgeBase from "@/pages/KnowledgeBase";
+
+const THREE_DOCS = [
+  {
+    document_id: "doc-a",
+    filename: "alpha.pdf",
+    status: "indexed",
+    size_bytes: 12345,
+    created_at: "2026-04-20T09:15:00Z",
+    uploaded_at: "2026-04-20T09:15:00Z",
+  },
+  {
+    document_id: "doc-b",
+    filename: "beta.pdf",
+    status: "indexed",
+    size_bytes: 56789,
+    created_at: "2026-04-20T09:20:00Z",
+    uploaded_at: "2026-04-20T09:20:00Z",
+  },
+  {
+    document_id: "doc-c",
+    filename: "gamma.pdf",
+    status: "processing",
+    size_bytes: 9999,
+    created_at: "2026-04-20T09:25:00Z",
+    uploaded_at: "2026-04-20T09:25:00Z",
+  },
+];
+
+const STATS = {
+  total_documents: 3,
+  total_chunks: 42,
+  index_size_mb: 1.2,
+};
+
+function armFetches(docs = THREE_DOCS) {
+  mockGet.mockImplementation((url: string) => {
+    if (url === "/knowledge/documents") {
+      return Promise.resolve({ data: { items: docs, total: docs.length } });
+    }
+    if (url === "/knowledge/stats") {
+      return Promise.resolve({ data: STATS });
+    }
+    return Promise.resolve({ data: null });
+  });
+  mockPost.mockResolvedValue({ data: { document_id: "new" } });
+  mockDelete.mockResolvedValue({ data: { ok: true } });
+}
+
+describe("KnowledgeBase", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    vi.spyOn(window, "alert").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the uploaded date from uploaded_at (TC_010)", async () => {
+    armFetches();
+    render(<KnowledgeBase />);
+    await waitFor(() => {
+      expect(screen.getByText("alpha.pdf")).toBeInTheDocument();
+    });
+    // The dash is what we used to render. A real timestamp should
+    // contain digits (localised; don't assert exact format).
+    const row = screen.getByText("alpha.pdf").closest("tr")!;
+    const cells = row.querySelectorAll("td");
+    const uploadedCell = cells[3]; // Filename, Status, Size, Uploaded, Actions
+    expect(uploadedCell.textContent).not.toBe("-");
+    expect(uploadedCell.textContent).toMatch(/\d/);
+  });
+
+  it("deletes only the targeted row and does NOT wipe the list (TC_005)", async () => {
+    armFetches();
+    render(<KnowledgeBase />);
+    await waitFor(() => {
+      expect(screen.getByText("alpha.pdf")).toBeInTheDocument();
+      expect(screen.getByText("beta.pdf")).toBeInTheDocument();
+      expect(screen.getByText("gamma.pdf")).toBeInTheDocument();
+    });
+
+    // Clicking Delete on alpha should DELETE /knowledge/documents/doc-a
+    // and then refetch. Arm the next GET to return only beta + gamma.
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/knowledge/documents") {
+        return Promise.resolve({
+          data: { items: THREE_DOCS.slice(1), total: 2 },
+        });
+      }
+      if (url === "/knowledge/stats") return Promise.resolve({ data: STATS });
+      return Promise.resolve({ data: null });
+    });
+
+    const alphaRow = screen.getByText("alpha.pdf").closest("tr")!;
+    const deleteBtn = alphaRow.querySelector("button")!;
+    await act(async () => {
+      fireEvent.click(deleteBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith(
+        "/knowledge/documents/doc-a",
+      );
+    });
+    // After refetch, beta and gamma still present; alpha gone.
+    await waitFor(() => {
+      expect(screen.queryByText("alpha.pdf")).not.toBeInTheDocument();
+      expect(screen.getByText("beta.pdf")).toBeInTheDocument();
+      expect(screen.getByText("gamma.pdf")).toBeInTheDocument();
+    });
+  });
+
+  it("maps legacy status='ready' from older server builds to a known badge (TC_006)", async () => {
+    // A server that hasn't rolled out the _normalize_status fix may still
+    // send 'ready'. The frontend normaliser in fetchData must not leave
+    // the row in a broken badge state.
+    const legacy = [
+      { ...THREE_DOCS[0], status: "ready" },
+    ];
+    armFetches(legacy);
+    render(<KnowledgeBase />);
+    await waitFor(() => {
+      expect(screen.getByText("alpha.pdf")).toBeInTheDocument();
+    });
+    // Non-canonical statuses are coerced to 'indexed' (green/success badge),
+    // not rendered raw.
+    expect(screen.queryByText("ready")).not.toBeInTheDocument();
+    expect(screen.getByText("indexed")).toBeInTheDocument();
+  });
+
+  it("warns on duplicate filename upload and skips POST when user cancels (TC_011)", async () => {
+    armFetches();
+    render(<KnowledgeBase />);
+    await waitFor(() => {
+      expect(screen.getByText("alpha.pdf")).toBeInTheDocument();
+    });
+
+    // Simulate uploading a new file with the same filename as an existing doc.
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const dupFile = new File(["..."], "alpha.pdf", { type: "application/pdf" });
+    Object.defineProperty(fileInput, "files", {
+      value: { 0: dupFile, length: 1, item: (i: number) => [dupFile][i] },
+    });
+
+    await act(async () => {
+      fireEvent.change(fileInput);
+    });
+
+    // User clicked Cancel on the confirm dialog (beforeEach returns false)
+    expect(window.confirm).toHaveBeenCalled();
+    // No POST should be made because the user cancelled.
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("sends allow_duplicate=true when user confirms the overwrite (TC_011)", async () => {
+    armFetches();
+    vi.spyOn(window, "confirm").mockReturnValue(true); // user clicks OK
+    render(<KnowledgeBase />);
+    await waitFor(() => {
+      expect(screen.getByText("alpha.pdf")).toBeInTheDocument();
+    });
+
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const dupFile = new File(["..."], "alpha.pdf", { type: "application/pdf" });
+    Object.defineProperty(fileInput, "files", {
+      value: { 0: dupFile, length: 1, item: (i: number) => [dupFile][i] },
+    });
+
+    await act(async () => {
+      fireEvent.change(fileInput);
+    });
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        "/knowledge/upload?allow_duplicate=true",
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/ui/src/pages/KnowledgeBase.tsx
+++ b/ui/src/pages/KnowledgeBase.tsx
@@ -9,11 +9,19 @@ import api from "@/lib/api";
 /* ------------------------------------------------------------------ */
 
 interface KBDocument {
-  id: string;
+  // TC_005 fix: backend returns `document_id`, frontend used `id` → every
+  // row had `id === undefined`, so `filter(d => d.id !== id)` kept nothing
+  // on delete (all records dropped from the UI). Now we read the canonical
+  // field from the backend directly.
+  document_id: string;
   filename: string;
   status: "processing" | "indexed" | "failed";
   size_bytes: number;
+  // TC_010 fix: backend was returning `created_at`, UI rendered
+  // `doc.uploaded_at` (undefined) → "-". Backend now sends both fields;
+  // we read the user-facing name.
   uploaded_at: string;
+  created_at?: string;
 }
 
 interface KBStats {
@@ -35,7 +43,22 @@ function formatBytes(bytes: number | undefined | null): string {
   return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
 }
 
-const STATUS_BADGE: Record<string, "success" | "warning" | "destructive"> = {
+function formatUploadedDate(iso: string | null | undefined): string {
+  // TC_010/TC_015-style guard: never render `new Date(null)`, which
+  // produces an epoch-1970 string; fall back to a neutral dash instead.
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString();
+}
+
+// Status badges for the three canonical states. Backend normalises the
+// legacy "ready" label to "indexed" (see _normalize_status in
+// api/v1/knowledge.py) so we don't have to keep a fallback here.
+const STATUS_BADGE: Record<
+  KBDocument["status"],
+  "success" | "warning" | "destructive"
+> = {
   indexed: "success",
   processing: "warning",
   failed: "destructive",
@@ -61,10 +84,29 @@ export default function KnowledgeBase() {
         api.get("/knowledge/documents"),
         api.get("/knowledge/stats"),
       ]);
-      const docs =
+      const rawDocs =
         docsRes.status === "fulfilled"
           ? Array.isArray(docsRes.value.data) ? docsRes.value.data : docsRes.value.data?.items || []
           : [];
+      // Normalise on read so the rest of the component can assume
+      // document_id and uploaded_at are present even if a given server
+      // build still ships the legacy field shape.
+      const docs: KBDocument[] = rawDocs.map(
+        (d: Record<string, unknown>): KBDocument => ({
+          document_id: String(d.document_id ?? d.id ?? ""),
+          filename: String(d.filename ?? d.name ?? ""),
+          status: (["processing", "indexed", "failed"].includes(
+            d.status as string,
+          )
+            ? d.status
+            : "indexed") as KBDocument["status"],
+          size_bytes: Number(d.size_bytes ?? 0),
+          uploaded_at: String(
+            d.uploaded_at ?? d.created_at ?? "",
+          ),
+          created_at: typeof d.created_at === "string" ? d.created_at : undefined,
+        }),
+      );
       const s = statsRes.status === "fulfilled" ? statsRes.value.data : null;
 
       setDocuments(docs);
@@ -87,16 +129,49 @@ export default function KnowledgeBase() {
     if (!files || files.length === 0) return;
     setUploading(true);
     try {
+      const existing = new Set(
+        documents.map((d) => d.filename.toLowerCase()),
+      );
       for (const file of Array.from(files)) {
+        // TC_011 client-side dedup: warn on same filename before the
+        // round-trip. The backend also returns 409 for this case — this
+        // check just saves the user a server error.
+        const isDuplicate = existing.has(file.name.toLowerCase());
+        if (isDuplicate) {
+          const proceed = window.confirm(
+            `"${file.name}" is already in the knowledge base. ` +
+              "Upload a new copy anyway?",
+          );
+          if (!proceed) continue;
+        }
         const fd = new FormData();
         fd.append("file", file);
-        await api.post("/knowledge/upload", fd);
+        try {
+          const url = isDuplicate
+            ? "/knowledge/upload?allow_duplicate=true"
+            : "/knowledge/upload";
+          await api.post(url, fd);
+          existing.add(file.name.toLowerCase());
+        } catch (err: unknown) {
+          // If the server rejects a specific file (e.g. 409), keep going
+          // with the rest instead of aborting the whole batch.
+          const status = (err as { response?: { status?: number } })?.response
+            ?.status;
+          if (status === 409) {
+            window.alert(
+              `"${file.name}" already exists on the server. ` +
+                "Check the duplicate box to replace it.",
+            );
+            continue;
+          }
+          throw err;
+        }
       }
       await fetchData();
     } catch {
-      // fallback: add locally
+      // Best-effort local preview if the whole batch failed.
       const newDocs: KBDocument[] = Array.from(files).map((f, i) => ({
-        id: `new-${Date.now()}-${i}`,
+        document_id: `pending-${Date.now()}-${i}`,
         filename: f.name,
         status: "processing" as const,
         size_bytes: f.size,
@@ -108,13 +183,23 @@ export default function KnowledgeBase() {
     }
   };
 
-  const handleDelete = async (id: string) => {
+  const handleDelete = async (documentId: string) => {
+    // TC_005 fix: previously we filtered local state optimistically on
+    // `d.id !== id`, but frontend docs had no `id` (only `document_id`),
+    // so `undefined !== undefined` was always false → every row fell out
+    // of the filter. Now we pass the canonical id, await the response,
+    // and refetch from the server when the DELETE succeeds. The refetch
+    // ensures an eventual-consistency outcome: if the backend reports a
+    // failure, the document reappears naturally.
+    if (!documentId) return;
     try {
-      await api.delete(`/knowledge/documents/${id}`);
-    } catch {
-      // remove locally even if API fails
+      await api.delete(`/knowledge/documents/${documentId}`);
+    } catch (err) {
+      // Surface the failure but don't mutate local state — refetch will
+      // reconcile with whatever the server currently believes.
+      console.error("delete failed", err);
     }
-    setDocuments((prev) => prev.filter((d) => d.id !== id));
+    await fetchData();
   };
 
   const handleSearch = async () => {
@@ -249,15 +334,19 @@ export default function KnowledgeBase() {
             </thead>
             <tbody>
               {documents.map((doc) => (
-                <tr key={doc.id} className="border-t hover:bg-muted/50">
+                <tr key={doc.document_id} className="border-t hover:bg-muted/50">
                   <td className="p-3 font-medium">{doc.filename}</td>
                   <td className="p-3">
                     <Badge variant={STATUS_BADGE[doc.status] || "secondary"}>{doc.status}</Badge>
                   </td>
                   <td className="p-3">{formatBytes(doc.size_bytes ?? 0)}</td>
-                  <td className="p-3">{doc.uploaded_at ? new Date(doc.uploaded_at).toLocaleDateString() : "-"}</td>
+                  <td className="p-3">{formatUploadedDate(doc.uploaded_at)}</td>
                   <td className="p-3">
-                    <Button variant="destructive" size="sm" onClick={() => handleDelete(doc.id)}>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => handleDelete(doc.document_id)}
+                    >
                       Delete
                     </Button>
                   </td>


### PR DESCRIPTION
## Summary

Four display/state bugs from the Aishwarya 20-Apr QA report that all sat on the boundary between `api/v1/knowledge.py` and `ui/src/pages/KnowledgeBase.tsx`.

## Fixes

- **TC_005** — Deleting one file wiped the entire list. Root cause: frontend used `id`, backend sent `document_id`; `filter(d => d.id !== id)` dropped nothing because both sides were `undefined`. Fixed by reading `document_id` and refetching after DELETE completes.
- **TC_006** — Status column showed legacy `"ready"` label. Backend now normalises `ready/done/ok/processed` → `indexed`; frontend coerces unknown values too.
- **TC_010** — Uploaded column showed `"-"`. `DocumentOut` now carries both `created_at` and `uploaded_at` (same value); UI formatter null-guards invalid dates.
- **TC_011** — Same file uploaded repeatedly. Backend returns HTTP 409 on `(tenant_id, filename)` collision with the existing `document_id`; caller can set `?allow_duplicate=true` to proceed. Frontend prompts before sending the override.

## Tests

- `tests/unit/test_knowledge_normalize_status.py` (new, 6 cases)
- `ui/src/__tests__/KnowledgeBase.test.tsx` (new, 5 cases)

## Verification

- `ruff check api/v1/knowledge.py` — clean
- `python -m pytest tests/unit/test_knowledge_normalize_status.py` — 6 passed
- `npx tsc --noEmit` — clean
- `npm test` — 79 passed (7 files)
- Local preflight — all 11 gates pass

## Back-compat

No breaking changes: `DocumentOut.created_at` still present (uploaded_at is additive). Frontend accepts legacy `id` as fallback.

## Test plan

- [x] Delete only the targeted row
- [x] Legacy `ready` status shows indexed badge
- [x] Uploaded column shows real timestamp
- [x] Duplicate-filename upload prompts confirmation
- [ ] Post-merge smoke on production

cc @codex — please review.

---

PR-B of the 2026-04-20 stabilization sweep.