### PR TITLE
revert: fastembed >=0.8.0 — Pillow conflict with composio-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     "authlib>=1.7.0",
     "reportlab>=4.4.10",
     "google-cloud-kms>=3.12.0",
-    "fastembed>=0.8.0",
+    "fastembed>=0.7.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Reverts #253 (`c47a1b0`). Fastembed 0.8.0 merged cleanly on its own PR CI but broke main's Docker build with an unsolvable pip constraint.

## Failure seen on main

```
ERROR: Cannot install agenticorg because these package versions have conflicting dependencies.
The conflict is caused by:
    composio-core 0.7.21 depends on Pillow<11 and >=10.2.0
    fastembed 0.8.0 depends on pillow<13.0 and >=12.0.0; python_version >= "3.14"

Additionally, some packages in these conflicts have no matching distributions available for your environment:
    pillow

ERROR: ResolutionImpossible
```

pip has no intersection between `[10.2, 11)` and `[12.0, 13.0)`, so `pip install .[v4]` fails inside the API Dockerfile. This broke #254's build, #256's build, and every subsequent main push.

## Why PR-level CI didn't catch it

PR #253's own build ran with its PR-merge-base constraint set. The combined set (composio-core + fastembed 0.8.0) only materialises once both land on main. No matrix tests the full resolver on the PR branch.

## Scope

Only reverts `pyproject.toml`:
```
-    "fastembed>=0.8.0",
+    "fastembed>=0.7.0",
```

Everything else from the 11 Dependabot merges stays in.

## Retry path

Options for landing the 0.8.0 bump later:
1. Wait for composio-core to widen its Pillow range to include 12.x, then retry.
2. Upstream coordinate a joint bump of composio-core + fastembed.
3. Pin an older fastembed tail that keeps Pillow 10.x compatibility on py3.14.

Flagged to Dependabot's ignore list for fastembed 0.8.x until composio catches up.

## Verification

- `bash scripts/preflight.sh` — all 11 gates pass (the revert is a single-line change to pyproject.toml; local Docker build wasn't exercised, but the reverted constraint is identical to the pre-#253 state which was green on main for weeks)

cc @codex

---

Emergency revert to unbreak main's build job.