### PR TITLE
chore(dependabot): ignore fastembed 0.8.x — Pillow conflict with composio-core

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,19 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
+      # fastembed 0.8.x bumps Pillow to >=12.0.0 (py3.14 wheels).
+      # composio-core 0.7.21 pins Pillow<11, so the combined resolver
+      # fails with ResolutionImpossible inside the API Docker build.
+      # Ignore 0.8.x until composio-core widens its Pillow range or
+      # fastembed ships a py3.14 wheel that stays compatible with
+      # Pillow 10.x.
+      #
+      # Context: PR #253 (fastembed >=0.8.0) merged CLEAN on PR-level
+      # CI but broke main's `build` job + cascaded to #254 and #256.
+      # Emergency revert shipped as #263 (cfd841c).
+      - dependency-name: "fastembed"
+        versions: ["0.8.x"]
+
   # npm — frontend dependencies
   - package-ecosystem: "npm"
     directory: "/ui"


### PR DESCRIPTION
## Summary

One-line addition to `.github/dependabot.yml` so Dependabot stops re-proposing the fastembed 0.8.x bump that broke main on 2026-04-21.

## Why

PR #253 (fastembed >= 0.8.0) passed its own PR-level CI as CLEAN but failed the `build` job on main once it combined with composio-core's Pillow pin:

```
composio-core 0.7.21 requires  Pillow >=10.2.0, <11
fastembed 0.8.0 (py3.14) requires  pillow >=12.0.0, <13
```

These ranges don't overlap, so `pip install .[v4]` hit `ResolutionImpossible` inside the API Dockerfile. #254 (langgraph) and #256 (pydantic-settings) also failed `build` while the conflict sat on main.

Emergency revert shipped as PR #263 (`cfd841c`).

## What this adds

```yaml
- dependency-name: "fastembed"
  versions: ["0.8.x"]
```

Dependabot will keep checking for 0.9+ and back-ported 0.7.x patches, but won't re-open the same bad 0.8.x PR.

## Retry path

Revisit when either:
1. composio-core widens its Pillow range to include 12.x, or
2. fastembed ships a py3.14 wheel that stays on Pillow 10.x.

## Verification

- `python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` — parses clean
- Local preflight — all 11 gates pass (config-only change, no code path affected)

cc @codex