### PR TITLE
fix(connectors): Tally health check + typed error hierarchy + bridge wheel packaging

### DIFF
--- a/connectors/finance/tally.py
+++ b/connectors/finance/tally.py
@@ -17,11 +17,72 @@ from typing import Any
 from xml.etree.ElementTree import Element, SubElement, tostring
 
 import structlog
+from defusedxml.ElementTree import ParseError as XMLParseError
 from defusedxml.ElementTree import fromstring as xml_fromstring
 
 from connectors.framework.base_connector import BaseConnector
 
 logger = structlog.get_logger()
+
+
+# UR-Bug-6 (Uday/Ramesh 2026-04-21): Tally errors used to surface as a
+# bare ``RuntimeError`` — callers couldn't distinguish a transient
+# bridge outage from a TDL-syntax bug, company-not-open, or bad XML.
+# The UI rendered a single opaque "Tally bridge error" line for every
+# case, so debugging was guesswork.
+#
+# Exception hierarchy keeps the generic catch-all working (``except
+# TallyError``) while letting finer handlers react to specific
+# failure modes. API layers should catch ``TallyError`` and map to
+# HTTP 4xx/5xx according to the subclass.
+
+
+class TallyError(RuntimeError):
+    """Base class for all Tally-originated failures.
+
+    Attributes
+    ----------
+    detail : str | None
+        Machine-readable reason from Tally's XML response or the
+        bridge envelope (e.g. "LINEERROR 01: Company not open").
+    request_id : str | None
+        Bridge request_id when the failure came through the tunnel —
+        useful for cross-referencing bridge logs.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        detail: str | None = None,
+        request_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.detail = detail
+        self.request_id = request_id
+
+
+class TallyConnectionError(TallyError):
+    """Tally endpoint is unreachable (bridge down, ngrok offline,
+    localhost:9000 closed, TCP timeout). Typically a user/ops problem
+    rather than a code bug. API layer should return 503."""
+
+
+class TallyBridgeError(TallyError):
+    """Bridge rejected the call (auth failure, unknown bridge_id,
+    bridge internal error)."""
+
+
+class TallyResponseError(TallyError):
+    """Tally itself returned an error response (TDL syntax, missing
+    company, permission denied, malformed voucher). API layer should
+    return 400 — the user's request is the problem."""
+
+
+class TallyXMLError(TallyError):
+    """Tally returned a non-XML or malformed-XML body. Usually means
+    the bridge forwarded an HTML error page (502/504) or Tally is
+    running on a port serving a non-TDL service."""
 
 
 def _tdl_request(request_type: str, collection: str, filters: dict | None = None) -> str:
@@ -83,6 +144,50 @@ def _xml_to_dict(elem: Element) -> dict[str, Any]:
     return result
 
 
+# UR-Bug-6: inspect the parsed XML for Tally's inline error markers.
+# Tally reports business-logic failures *inside* a 2xx response body
+# rather than via HTTP status, so a naive caller that only checks the
+# transport succeeds when the voucher actually failed.
+_TALLY_ERROR_KEYS = frozenset({
+    "LINEERROR",
+    "EXCEPTIONS",
+    "ERROR",
+    "DESC",  # inside <STATUS><DESC> for some TDL errors
+})
+
+
+def _extract_tally_error(parsed: dict[str, Any]) -> str | None:
+    """Return the first error message found anywhere in a parsed Tally
+    response, or None if the response looks clean.
+
+    Scans recursively because Tally nests errors at varying depths
+    depending on the request type (Export vs Import vs TDL dump).
+    """
+    status = parsed.get("STATUS") if isinstance(parsed, dict) else None
+    if isinstance(status, dict):
+        # Success responses typically carry STATUS=1 as the text payload.
+        # Anything else is suspicious; dig for DESC.
+        desc = status.get("DESC")
+        if isinstance(desc, str) and desc.strip():
+            return desc.strip()
+    for key in _TALLY_ERROR_KEYS:
+        value = parsed.get(key) if isinstance(parsed, dict) else None
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, dict):
+            nested = _extract_tally_error(value)
+            if nested:
+                return nested
+    # Depth-first walk for deeply nested IMPORTRESULT / LINEERROR blocks.
+    if isinstance(parsed, dict):
+        for v in parsed.values():
+            if isinstance(v, dict):
+                nested = _extract_tally_error(v)
+                if nested:
+                    return nested
+    return None
+
+
 class TallyConnector(BaseConnector):
     """Tally connector with optional bridge routing for remote instances.
 
@@ -119,6 +224,53 @@ class TallyConnector(BaseConnector):
         api_key = self._get_secret("api_key")
         self._auth_headers = {"X-Tally-Key": api_key} if api_key else {}
 
+    async def health_check(self) -> dict[str, Any]:
+        """Tally-specific health check.
+
+        UR-Bug-4 (Uday/Ramesh 2026-04-21): the inherited BaseConnector
+        default issues an HTTP GET to ``/`` — Tally Prime only serves
+        HTTP POST with an XML envelope and returns 405 on GET, so the
+        default always reported "unhealthy". Override sends the
+        smallest possible TDL probe (``CompanyInfo`` export) through
+        whichever path is configured (bridge or direct) and treats a
+        parseable XML response as healthy.
+        """
+        probe = _tdl_request("Export", "CompanyInfo")
+        try:
+            if self._use_bridge:
+                await self._send_via_bridge(probe)
+                return {"status": "healthy", "transport": "bridge"}
+            # Direct localhost / LAN call. Swallow the dict — we only
+            # care that the request cycle completes and the response
+            # parses as XML.
+            resp = await self._post_xml(probe)
+            if resp is None:
+                return {"status": "unhealthy", "error": "empty XML response"}
+            return {"status": "healthy", "transport": "direct"}
+        except TallyConnectionError as exc:
+            # Upstream is unreachable — ops-level failure, not an auth
+            # or data issue. Report as "unreachable" not "unhealthy" so
+            # the UI can phrase it correctly.
+            return {
+                "status": "unreachable",
+                "error": str(exc),
+                "detail": exc.detail,
+            }
+        except TallyBridgeError as exc:
+            return {
+                "status": "bridge_error",
+                "error": str(exc),
+                "detail": exc.detail,
+            }
+        except TallyError as exc:
+            return {
+                "status": "unhealthy",
+                "error": str(exc),
+                "detail": exc.detail,
+            }
+        except Exception as exc:  # defensive — connector health must never raise
+            return {"status": "unhealthy", "error": str(exc)}
+
     async def _send_xml(self, xml_body: str) -> dict[str, Any]:
         """Send XML to Tally — directly or via bridge tunnel.
 
@@ -132,7 +284,12 @@ class TallyConnector(BaseConnector):
         return _xml_to_dict(resp)
 
     async def _send_via_bridge(self, xml_body: str) -> dict[str, Any]:
-        """Route XML through the cloud bridge to a remote Tally instance."""
+        """Route XML through the cloud bridge to a remote Tally instance.
+
+        UR-Bug-6: each failure mode now maps to a specific Tally*Error
+        subclass so the API layer can pick the right HTTP status and
+        surface a user-actionable message instead of a generic 500.
+        """
         import httpx
 
         request_id = str(uuid.uuid4())
@@ -150,26 +307,102 @@ class TallyConnector(BaseConnector):
             bridge_id=self._bridge_id,
         )
 
-        async with httpx.AsyncClient(timeout=30) as client:
-            resp = await client.post(
-                self._bridge_url,
-                json=payload,
-                headers=headers,
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(
+                    self._bridge_url,
+                    json=payload,
+                    headers=headers,
+                )
+        except (httpx.ConnectError, httpx.ReadTimeout, httpx.ConnectTimeout) as exc:
+            raise TallyConnectionError(
+                "Could not reach the Tally bridge at "
+                f"{self._bridge_url} — check that the AgenticOrg Tally "
+                "Bridge is running on the client's machine and the ngrok "
+                "tunnel is live.",
+                detail=str(exc),
+                request_id=request_id,
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise TallyBridgeError(
+                f"Tally bridge HTTP error: {exc}",
+                detail=str(exc),
+                request_id=request_id,
+            ) from exc
+
+        if resp.status_code == 401 or resp.status_code == 403:
+            raise TallyBridgeError(
+                "Tally bridge rejected our token. Regenerate bridge "
+                "credentials in Settings → Tally Connection.",
+                detail=f"HTTP {resp.status_code}",
+                request_id=request_id,
             )
-            resp.raise_for_status()
+        if resp.status_code >= 500:
+            raise TallyBridgeError(
+                f"Tally bridge returned HTTP {resp.status_code} — "
+                "the bridge itself may be in a bad state; try restarting "
+                "the agenticorg-bridge process.",
+                detail=resp.text[:500],
+                request_id=request_id,
+            )
+        if resp.status_code >= 400:
+            raise TallyBridgeError(
+                f"Tally bridge rejected the request (HTTP "
+                f"{resp.status_code}).",
+                detail=resp.text[:500],
+                request_id=request_id,
+            )
+
+        try:
             result = resp.json()
+        except ValueError as exc:
+            raise TallyBridgeError(
+                "Tally bridge returned a non-JSON response — most likely "
+                "an HTML error page from an upstream proxy.",
+                detail=resp.text[:500],
+                request_id=request_id,
+            ) from exc
 
         if result.get("status") == "error":
-            raise RuntimeError(
-                f"Tally bridge error: {result.get('error', 'unknown')}"
+            raise TallyBridgeError(
+                f"Tally bridge error: {result.get('error', 'unknown')}",
+                detail=result.get("error"),
+                request_id=request_id,
             )
 
         xml_response = result.get("xml_response", "")
         if not xml_response:
-            raise RuntimeError("Tally bridge returned empty response")
+            raise TallyResponseError(
+                "Tally returned an empty response — usually means no "
+                "company is open on the client's Tally instance.",
+                request_id=request_id,
+            )
 
-        elem = xml_fromstring(xml_response)
-        return _xml_to_dict(elem)
+        try:
+            elem = xml_fromstring(xml_response)
+        except XMLParseError as exc:
+            raise TallyXMLError(
+                "Tally returned a non-XML body. Check that the Tally "
+                "instance is actually Tally Prime / ERP 9 and not "
+                "another service listening on the port.",
+                detail=str(exc),
+                request_id=request_id,
+            ) from exc
+
+        parsed = _xml_to_dict(elem)
+
+        # Tally surfaces business-logic failures inline in the response
+        # (LINEERROR, EXCEPTIONS, etc.). Lift those into TallyResponseError
+        # so callers don't treat a failed voucher as a success.
+        err_msg = _extract_tally_error(parsed)
+        if err_msg:
+            raise TallyResponseError(
+                f"Tally rejected the request: {err_msg}",
+                detail=err_msg,
+                request_id=request_id,
+            )
+
+        return parsed
 
     async def post_voucher(self, **params) -> dict[str, Any]:
         """Import a voucher into Tally via TDL XML."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,12 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["core", "api", "auth", "connectors", "workflows", "scaling", "observability", "audit", "schemas"]
+# UR-Bug-5 (Uday/Ramesh 2026-04-21): `bridge/` ships the on-prem Tally
+# WebSocket agent but was missing from the wheel packages list, so
+# `pip install agenticorg` gave CA-firm sites the server code with no
+# way to install the bridge client. `bridge` now ships in the wheel
+# and the `agenticorg-bridge` console script works after pip install.
+packages = ["core", "api", "auth", "bridge", "connectors", "workflows", "scaling", "observability", "audit", "schemas"]
 
 [project]
 name = "agenticorg"
@@ -104,6 +109,12 @@ dev = [
     "presidio-anonymizer>=2.2.0",
     "composio-core>=0.7.21",
 ]
+
+[project.scripts]
+# UR-Bug-5: CA-firm sites run `agenticorg-bridge` on the client machine
+# to tunnel Tally XML calls to the cloud. Exposing the console script
+# here so `pip install agenticorg` lands a working entrypoint.
+agenticorg-bridge = "bridge.cli:main"
 
 [tool.ruff]
 target-version = "py312"

--- a/tests/unit/test_production_components.py
+++ b/tests/unit/test_production_components.py
@@ -175,6 +175,7 @@ class TestTallyConnectorBridgeRouting:
         })
 
         mock_resp = MagicMock()
+        mock_resp.status_code = 200
         mock_resp.json.return_value = {
             "status": "ok",
             "xml_response": "<ENVELOPE><BODY><CREATED>1</CREATED></BODY></ENVELOPE>",
@@ -196,6 +197,7 @@ class TestTallyConnectorBridgeRouting:
         })
 
         mock_resp = MagicMock()
+        mock_resp.status_code = 200
         mock_resp.json.return_value = {
             "status": "error",
             "error": "Tally not reachable",
@@ -203,6 +205,8 @@ class TestTallyConnectorBridgeRouting:
         mock_resp.raise_for_status = MagicMock()
 
         with patch("httpx.AsyncClient.post", return_value=mock_resp):
+            # Post-UR-Bug-6: TallyBridgeError (a RuntimeError subclass) —
+            # the caller can still catch RuntimeError for backward compat.
             with pytest.raises(RuntimeError, match="Tally bridge error"):
                 await connector._send_via_bridge("<ENVELOPE/>")
 

--- a/tests/unit/test_tally_connector_health_and_errors.py
+++ b/tests/unit/test_tally_connector_health_and_errors.py
@@ -1,0 +1,170 @@
+"""Unit tests for TallyConnector health check + error hierarchy
+(UR-Bug-4 / UR-Bug-6, Uday/Ramesh 2026-04-21).
+
+Pins:
+- ``health_check`` POSTs XML instead of the inherited base-class GET.
+- The exception hierarchy is in place so API callers can distinguish
+  connection / bridge / response / XML failures.
+- ``_extract_tally_error`` finds Tally's inline error markers at
+  varying depths in a parsed response.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from connectors.finance.tally import (
+    TallyBridgeError,
+    TallyConnectionError,
+    TallyConnector,
+    TallyError,
+    TallyResponseError,
+    TallyXMLError,
+    _extract_tally_error,
+)
+
+
+class TestTallyExceptionHierarchy:
+    def test_all_subclasses_inherit_from_tally_error(self) -> None:
+        for cls in (
+            TallyConnectionError,
+            TallyBridgeError,
+            TallyResponseError,
+            TallyXMLError,
+        ):
+            assert issubclass(cls, TallyError), f"{cls.__name__} is not TallyError"
+
+    def test_tally_error_carries_detail_and_request_id(self) -> None:
+        exc = TallyResponseError(
+            "Tally rejected it",
+            detail="LINEERROR: Company not open",
+            request_id="req-123",
+        )
+        assert str(exc) == "Tally rejected it"
+        assert exc.detail == "LINEERROR: Company not open"
+        assert exc.request_id == "req-123"
+
+
+class TestExtractTallyError:
+    def test_returns_line_error(self) -> None:
+        assert (
+            _extract_tally_error({"LINEERROR": "Company not open"})
+            == "Company not open"
+        )
+
+    def test_returns_exceptions_nested(self) -> None:
+        parsed = {"EXCEPTIONS": {"ERROR": "LEDGER missing"}}
+        assert _extract_tally_error(parsed) == "LEDGER missing"
+
+    def test_returns_status_desc(self) -> None:
+        parsed = {"STATUS": {"DESC": "Invalid voucher"}}
+        assert _extract_tally_error(parsed) == "Invalid voucher"
+
+    def test_clean_response_returns_none(self) -> None:
+        assert _extract_tally_error({"DATA": {"VOUCHERS": "ok"}}) is None
+
+    def test_deeply_nested_error_is_found(self) -> None:
+        parsed = {
+            "IMPORTDATA": {
+                "REQUESTDESC": {
+                    "EXCEPTIONS": "no company selected",
+                }
+            }
+        }
+        assert _extract_tally_error(parsed) == "no company selected"
+
+
+class TestTallyHealthCheckBridge:
+    @pytest.mark.asyncio
+    async def test_health_check_uses_xml_post_via_bridge_not_get(self) -> None:
+        """UR-Bug-4: the base-class default GET against Tally returns
+        405 every time because Tally only accepts POST. TallyConnector
+        must override and send an XML POST instead."""
+        connector = TallyConnector({
+            "bridge_url": "http://bridge.test/api",
+            "bridge_id": "bid-1",
+            "bridge_token": "tok-1",
+        })
+        with patch(
+            "connectors.finance.tally.TallyConnector._send_via_bridge",
+            AsyncMock(return_value={"ENVELOPE": {}}),
+        ):
+            result = await connector.health_check()
+        assert result["status"] == "healthy"
+        assert result["transport"] == "bridge"
+
+    @pytest.mark.asyncio
+    async def test_health_check_reports_unreachable_when_bridge_is_down(self) -> None:
+        connector = TallyConnector({
+            "bridge_url": "http://unreachable.test/api",
+            "bridge_id": "bid-1",
+            "bridge_token": "tok-1",
+        })
+        with patch(
+            "connectors.finance.tally.TallyConnector._send_via_bridge",
+            AsyncMock(side_effect=TallyConnectionError(
+                "ngrok offline", detail="ECONNREFUSED",
+            )),
+        ):
+            result = await connector.health_check()
+        assert result["status"] == "unreachable"
+        assert "ngrok offline" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_health_check_reports_bridge_error_separately(self) -> None:
+        connector = TallyConnector({
+            "bridge_url": "http://bridge.test/api",
+            "bridge_id": "bid-1",
+            "bridge_token": "tok-1",
+        })
+        with patch(
+            "connectors.finance.tally.TallyConnector._send_via_bridge",
+            AsyncMock(side_effect=TallyBridgeError(
+                "bad token", detail="HTTP 401",
+            )),
+        ):
+            result = await connector.health_check()
+        assert result["status"] == "bridge_error"
+
+    @pytest.mark.asyncio
+    async def test_health_check_never_raises(self) -> None:
+        """Connector health must return a status dict no matter what —
+        the dashboard's connector-health poller crashes otherwise."""
+        connector = TallyConnector({
+            "bridge_url": "http://bridge.test/api",
+            "bridge_id": "bid-1",
+            "bridge_token": "tok-1",
+        })
+        with patch(
+            "connectors.finance.tally.TallyConnector._send_via_bridge",
+            AsyncMock(side_effect=RuntimeError("anything can happen")),
+        ):
+            result = await connector.health_check()
+        assert "status" in result  # just must not raise
+
+
+class TestTallyHealthCheckDirect:
+    """Health check without a bridge — hits Tally directly over XML."""
+
+    @pytest.mark.asyncio
+    async def test_direct_healthy_when_xml_parses(self) -> None:
+        connector = TallyConnector({})
+        connector._use_bridge = False
+        # Fake _post_xml to return a non-None element.
+        fake_elem = MagicMock()
+        fake_elem.tag = "ENVELOPE"
+        with patch.object(connector, "_post_xml", AsyncMock(return_value=fake_elem)):
+            result = await connector.health_check()
+        assert result["status"] == "healthy"
+        assert result["transport"] == "direct"
+
+    @pytest.mark.asyncio
+    async def test_direct_unhealthy_when_empty_response(self) -> None:
+        connector = TallyConnector({})
+        connector._use_bridge = False
+        with patch.object(connector, "_post_xml", AsyncMock(return_value=None)):
+            result = await connector.health_check()
+        assert result["status"] == "unhealthy"
+        assert "empty XML" in result["error"]


### PR DESCRIPTION
## Summary

Uday/Ramesh 21-Apr-2026 sweep — four Tally-related bugs:

- **UR-Bug-3**: opaque HTTP 500s on Tally failures → typed `TallyError` hierarchy (`TallyConnectionError`, `TallyBridgeError`, `TallyResponseError`, `TallyXMLError`) so the API layer can map each to the correct HTTP status and surface an actionable message.
- **UR-Bug-4**: `health_check()` always red → protocol was HTTP GET, Tally only accepts POST-XML. Rewrote to POST `_tdl_request("Export", "CompanyInfo")`. The health check is now a true smoke test and never raises.
- **UR-Bug-5**: business-logic failures treated as successes → `_extract_tally_error()` depth-walks `{LINEERROR, EXCEPTIONS, ERROR, DESC}` inside the response envelope and raises `TallyResponseError` on hit.
- **UR-Bug-6**: `agenticorg-bridge` CLI not installable → added `bridge` to `[tool.hatch.build.targets.wheel].packages` and `agenticorg-bridge = "bridge.cli:main"` to `[project.scripts]`.

## Test plan

- [x] `tests/unit/test_tally_connector_health_and_errors.py` — 13 new cases (exception hierarchy + detail/request_id carriage; `_extract_tally_error` at 5 depths; bridge health check XML path; status mapping; never-raises guarantee).
- [x] `tests/unit/test_production_components.py::TestTallyConnectorBridgeRouting` — updated to set `status_code=200` on the MagicMock response (new code reads status_code before json()).
- [x] Local preflight gate `bash scripts/preflight.sh` — all 11 gates green (branch safety, ruff, bandit, alembic, verify=False scan, pytest regression+unit, ui tsc, ui build, consistency sweep, module coverage, critical-path tags).

## Similar Pattern Check

Grepped all 48 connector `health_check` implementations (`connectors/**/*.py`). Tally was the only one using a bare GET against a POST-only protocol and the only one that could raise on a transport failure. No other sibling instances.

@codex — please review the error hierarchy + bridge/transport mapping.