### PR TITLE
fix(qa): 23-Apr sweep — Aishwarya TC_001..008 + Uday shadow/connector-delete + Codex signoff wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,11 @@ AGENTICORG_SECRET_KEY=change-me-to-32-char-random-string
 
 # Auth
 AGENTICORG_AUTH_PROVIDER=grantex
+# Enforce Redis-backed auth state across replicas (Codex K-E). When "1",
+# token blacklist + login throttle refuse to degrade to per-pod memory.
+# REQUIRED for enterprise multi-replica deploys; leave unset for
+# single-replica dev/local testing.
+AGENTICORG_AUTH_STATE_STRICT=1
 GRANTEX_API_KEY=gx_key_...                          # Required — Grantex SDK API key for enforce() and manifest loading
 GRANTEX_BASE_URL=https://api.grantex.dev             # Optional — Grantex API base URL (default: https://api.grantex.dev)
 GRANTEX_CLIENT_ID=gx_prod_...

--- a/api/v1/connectors.py
+++ b/api/v1/connectors.py
@@ -241,8 +241,24 @@ async def list_connectors(
     per_page = min(max(per_page, 1), 100)
     tid = _uuid.UUID(tenant_id)
     async with get_tenant_session(tid) as session:
-        query = select(Connector).where(Connector.tenant_id == tid)
-        count_query = select(func.count()).select_from(Connector).where(Connector.tenant_id == tid)
+        # Uday 2026-04-23: soft-deleted connectors ("archived") must
+        # stay out of the default listing, otherwise the Connectors
+        # page continues to show them and the user can't distinguish
+        # "archived, can recreate" from "active". Filter on status to
+        # hide them by default; they re-enter on re-registration (the
+        # POST /connectors auto-restore path).
+        query = select(Connector).where(
+            Connector.tenant_id == tid,
+            func.coalesce(Connector.status, "active") != "deleted",
+        )
+        count_query = (
+            select(func.count())
+            .select_from(Connector)
+            .where(
+                Connector.tenant_id == tid,
+                func.coalesce(Connector.status, "active") != "deleted",
+            )
+        )
         if category:
             query = query.where(Connector.category == category)
             count_query = count_query.where(Connector.category == category)
@@ -299,7 +315,49 @@ async def register_connector(
         try:
             await session.flush()
         except IntegrityError:
-            raise HTTPException(409, f"Connector '{body.name}' already exists") from None
+            # Uday 2026-04-23: a row with the same (tenant_id, name) may
+            # already exist. If that row is status="deleted" (soft-delete
+            # via DELETE /connectors/{id}), the prior flow surfaced a
+            # hard 409 "already exists" — confusing, because the user
+            # had just archived it and expected re-registration to
+            # work. Instead, reactivate the soft-deleted twin in place
+            # so audit history is preserved on a single row. If the
+            # existing row is still active, we still 409 honestly.
+            existing = None
+            try:
+                await session.rollback()
+                existing_result = await session.execute(
+                    select(Connector).where(
+                        Connector.tenant_id == tid,
+                        Connector.name == body.name,
+                    )
+                )
+                candidate = existing_result.scalar_one_or_none()
+                # Guard: real ORM row will have a .status string; a
+                # broken / mock Result may return a coroutine-like
+                # object. Only treat as an existing row when we can
+                # safely read .status.
+                if hasattr(candidate, "status") and isinstance(candidate.status, str | type(None)):
+                    existing = candidate
+            except Exception:
+                existing = None
+
+            if existing is not None and (existing.status or "").lower() == "deleted":
+                existing.status = "active"
+                existing.category = body.category
+                existing.base_url = body.base_url
+                existing.auth_type = body.auth_type
+                existing.auth_config = {}
+                existing.secret_ref = body.secret_ref
+                existing.tool_functions = body.tool_functions
+                existing.data_schema_ref = body.data_schema_ref
+                existing.rate_limit_rpm = body.rate_limit_rpm
+                connector = existing
+                await session.flush()
+            else:
+                raise HTTPException(
+                    409, f"Connector '{body.name}' already exists"
+                ) from None
 
         # Store secrets in the encrypted connector_configs table
         if secret_fields:
@@ -532,6 +590,42 @@ async def test_connector(
                 config = {**(cc.config or {}), **(creds or {})}
     except Exception:
         _log.debug("connector_test_encrypted_creds_load_failed conn_id=%s", conn_id)
+    # TC_006 (Aishwarya 2026-04-23): CA-firms store GSTN credentials
+    # in the per-company Credential Vault (GSTNCredential) via
+    # /companies/{id}/credentials. That vault exists for multi-company
+    # firms and shows "Verified" in the UI. Historically the connector
+    # test only looked in ConnectorConfig.credentials_encrypted and
+    # ignored the vault, so testers saw "test failed" even though the
+    # vault was clearly populated. Bridge the two stores for the GSTN
+    # connector: if ConnectorConfig has no creds, try the active
+    # GSTNCredential for this tenant.
+    if not config and connector.name.lower() in ("gstn", "gst"):
+        try:
+            from core.crypto import decrypt_for_tenant
+            from core.models.gstn_credential import GSTNCredential
+
+            async with get_tenant_session(tid) as session:
+                gstn_result = await session.execute(
+                    select(GSTNCredential)
+                    .where(
+                        GSTNCredential.tenant_id == tid,
+                        GSTNCredential.is_active.is_(True),
+                    )
+                    .order_by(GSTNCredential.last_verified_at.desc())
+                    .limit(1)
+                )
+                gstn_cred = gstn_result.scalar_one_or_none()
+            if gstn_cred and gstn_cred.password_encrypted:
+                decrypted_pw = decrypt_for_tenant(gstn_cred.password_encrypted)
+                config = {
+                    "gstin": gstn_cred.gstin,
+                    "username": gstn_cred.username,
+                    "password": decrypted_pw,
+                    "portal_type": gstn_cred.portal_type or "gstn",
+                }
+        except Exception:
+            _log.debug("connector_test_gstn_vault_bridge_failed conn_id=%s", conn_id)
+
     if not config:
         # Codex 2026-04-23 re-verification blocker G: runtime execution
         # (core/tool_gateway/gateway.py) refuses to fall back to the
@@ -542,16 +636,24 @@ async def test_connector(
         # encrypted credentials are present. Admins must re-register
         # the connector through the create/update path, which writes
         # to connector_configs.credentials_encrypted via encrypt_for_tenant.
+        hint = (
+            "Connector has no encrypted credentials. Re-register the "
+            "connector via POST/PUT /connectors so credentials land "
+            "in the encrypted vault (connector_configs.credentials_"
+            "encrypted). Plaintext auth_config is no longer accepted "
+            "by either runtime execution or this test path."
+        )
+        if connector.name.lower() in ("gstn", "gst"):
+            hint += (
+                " For GSTN: if you used the per-company Credential Vault "
+                "(Company → Settings → GSTN Credentials), ensure the "
+                "credential is marked Active — the connector test "
+                "automatically uses the most recent active vault entry."
+            )
         return {
             "tested": False,
             "name": connector.name,
-            "error": (
-                "Connector has no encrypted credentials. Re-register the "
-                "connector via POST/PUT /connectors so credentials land "
-                "in the encrypted vault (connector_configs.credentials_"
-                "encrypted). Plaintext auth_config is no longer accepted "
-                "by either runtime execution or this test path."
-            ),
+            "error": hint,
         }
     try:
         instance = connector_cls(config)
@@ -577,7 +679,49 @@ async def test_connector(
             "health": health,
         }
     except TimeoutError:
-        return {"tested": False, "name": connector.name, "error": "Connection timed out (10s)"}
-    except Exception:
+        # TC_007 (Aishwarya 2026-04-23): "Connection timed out (10s)" is
+        # specific; return a hint about what to check.
+        return {
+            "tested": False,
+            "name": connector.name,
+            "error": (
+                "Connection timed out after 10s. The connector's base URL "
+                "did not respond — check that the endpoint is reachable "
+                "from the platform network and that no upstream proxy is "
+                "blocking outbound traffic."
+            ),
+        }
+    except Exception as exc:
+        # TC_007 (Aishwarya 2026-04-23): the route used to always return
+        # "Connector test failed" regardless of the actual cause (401,
+        # SSL, DNS, auth token expired, etc.). Surface a specific,
+        # actionable message derived from the exception so operators can
+        # debug without tailing server logs. Still suppresses secrets by
+        # never echoing the raw request payload.
         _log.exception("connector_test_failed conn_id=%s name=%s", conn_id, connector.name)
-        return {"tested": False, "name": connector.name, "error": "Connector test failed"}
+        err_name = type(exc).__name__
+        err_msg = str(exc)[:240]
+        # Map common failure classes to actionable hints.
+        lowered = (err_name + " " + err_msg).lower()
+        if "401" in lowered or "unauthor" in lowered or "invalid credentials" in lowered:
+            hint = "Invalid credentials — verify username/password or API key in the credential vault."
+        elif "403" in lowered or "forbidden" in lowered:
+            hint = "Authentication succeeded but the account is not authorized for this resource."
+        elif "ssl" in lowered or "certificate" in lowered:
+            hint = "SSL / certificate validation failed. Check base URL protocol and peer certificate."
+        elif "dns" in lowered or "name resolution" in lowered or "nodename" in lowered:
+            hint = "DNS lookup failed for the connector base URL."
+        elif "connectionrefused" in lowered or "connection refused" in lowered:
+            hint = "Target refused the connection — host is up but the port is not accepting traffic."
+        elif "token" in lowered and ("expired" in lowered or "refresh" in lowered):
+            hint = "Authentication token expired — refresh the OAuth grant or re-authorize."
+        elif "timeout" in lowered:
+            hint = "Request timed out — endpoint is slow or unreachable from the platform."
+        else:
+            hint = f"{err_name}: {err_msg}" if err_msg else f"{err_name} (no detail)"
+        return {
+            "tested": False,
+            "name": connector.name,
+            "error": hint,
+            "error_class": err_name,
+        }

--- a/api/v1/health.py
+++ b/api/v1/health.py
@@ -26,6 +26,21 @@ from api.v1.product_facts import _version_from_pyproject as _pv  # noqa: E402
 
 APP_VERSION = _pv()
 
+
+def _deployed_commit() -> str:
+    """Resolve the git commit SHA of the running deploy.
+
+    Codex 2026-04-23 prod re-verification: /health exposed only version
+    (e.g. "4.8.0"), which can't prove which commit SHA is live. Helm +
+    Cloud Run can inject this via AGENTICORG_GIT_SHA / K_REVISION env
+    vars at deploy time. Fall back to "unknown" when not provided.
+    """
+    for key in ("AGENTICORG_GIT_SHA", "GIT_SHA", "GIT_COMMIT", "K_REVISION"):
+        v = os.getenv(key, "").strip()
+        if v:
+            return v
+    return "unknown"
+
 # Timeout for individual connector health checks (seconds)
 _CONNECTOR_HC_TIMEOUT = 5.0
 
@@ -76,6 +91,7 @@ async def health_readiness():
     return {
         "status": "healthy" if core_healthy else "unhealthy",
         "version": APP_VERSION,
+        "commit": _deployed_commit(),
         "checks": checks,
     }
 

--- a/auth/middleware.py
+++ b/auth/middleware.py
@@ -22,6 +22,14 @@ class AuthMiddleware(BaseHTTPMiddleware):
         "/api/v1/billing/callback",  # Plural redirect callback
         "/api/v1/billing/callback/stripe",  # Stripe redirect callback
         "/api/v1/billing/plans",  # Public pricing page
+        # Codex 2026-04-23 prod re-verification: the billing + knowledge
+        # health probes were declared auth-free in their route files but
+        # the global AuthMiddleware still required a token before the
+        # handler could run, so ops smoke tests could not use them. Add
+        # the explicit paths to EXEMPT_PATHS so the /health endpoints
+        # are actually callable from CI / Deploy / Uptime probes.
+        "/api/v1/billing/health",
+        "/api/v1/knowledge/health",
         "/api/v1/branding",  # Public tenant branding for the login page
         "/api/v1/status",  # Public status page
         "/api/v1/product-facts",  # Public product counts/version for README, Landing, Pricing

--- a/core/models/agent.py
+++ b/core/models/agent.py
@@ -72,7 +72,13 @@ class Agent(BaseModel):
     shadow_comparison_agent_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("agents.id"), nullable=True
     )
-    shadow_min_samples: Mapped[int] = mapped_column(Integer, nullable=False, default=20)
+    # Uday 2026-04-23 Bug 1: default target was 20 samples which
+    # stretched shadow-mode validation into a 20-click / one-bulk-batch
+    # flow. A quick reviewable batch is better for day-to-day QA: 10
+    # samples gives a representative accuracy signal without blocking
+    # the user on a long run. Existing rows keep their admin-set value;
+    # only new agents inherit the new default (no migration needed).
+    shadow_min_samples: Mapped[int] = mapped_column(Integer, nullable=False, default=10)
     # BUG-012 (Ramesh 2026-04-20): default floor was 0.950 — unrealistic
     # for LLM-driven agents whose per-task confidence typically lands in
     # the 0.70-0.85 band even on clean runs. A 95% average is effectively

--- a/helm/values-production.yaml
+++ b/helm/values-production.yaml
@@ -152,6 +152,12 @@ env:
   AGENTICORG_DEFAULT_CONFIDENCE_FLOOR: "0.88"
   AGENTICORG_LLM_PRIMARY: gemini-2.5-flash
   AGENTICORG_LLM_FALLBACK: gemini-2.5-flash-preview-05-20
+  # Codex round-4 blocker K-E + 2026-04-23 prod re-verification: enforce
+  # Redis-backed auth state so token-blacklist writes/reads and the
+  # login-throttle counter are consistent across replicas. Without
+  # strict mode a revocation on replica A still validates on replica B.
+  # Enterprise multi-replica deploys must set this to "1".
+  AGENTICORG_AUTH_STATE_STRICT: "1"
   GRANTEX_BASE_URL: https://api.grantex.dev
 
 # ── Secrets from GCP Secret Manager ─────────────────────────────────────────

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -106,6 +106,10 @@ env:
   AGENTICORG_LLM_FALLBACK: gemini-2.5-flash-preview-05-20     # Switch to gpt-4o-2024-11-20 when needed
   # Alembic is the schema authority. init_db() skips legacy DDL when this is true.
   AGENTICORG_DDL_MANAGED_BY_ALEMBIC: "true"
+  # Codex round-4 blocker K-E: enforce Redis-backed auth state across
+  # replicas. Without strict mode, token revocations + login-throttle
+  # counters silently fall back to per-pod memory.
+  AGENTICORG_AUTH_STATE_STRICT: "1"
   # Public app URL — used in billing callback URLs (Stripe + Plural),
   # invite emails, password-reset emails, etc. MUST match the actual
   # production hostname; a wrong value silently breaks payment redirects

--- a/migrations/versions/v4_9_0_shadow_samples_default.py
+++ b/migrations/versions/v4_9_0_shadow_samples_default.py
@@ -1,0 +1,64 @@
+"""Update shadow_min_samples default from 20 to 10 on new agents.
+
+Revision ID: v490_shadow_samples_def
+Revises: v489_tpl_edit_history
+Create Date: 2026-04-23
+
+Uday 2026-04-23 Bug 1: the shadow tab "Generate Test Samples" target
+defaulted to 20, producing a long bulk batch that testers read as a
+single parallel run. The UI now defaults to 10 and the ORM default
+on ``core/models/agent.py`` is 10. For the DB to match ORM intent
+when callers don't pass the column explicitly, also change the
+server-side default here. Existing rows keep their admin-set value
+(we only touch DEFAULT, not the stored data), so it's a non-
+destructive change.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# Alembic identifiers — kept <=32 chars per preflight gate.
+revision = "v490_shadow_samples_def"
+down_revision = "v489_tpl_edit_history"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Only touch the DEFAULT expression. Use DO-block so the migration
+    # survives a rerun on databases where the column doesn't exist yet
+    # (e.g. ephemeral CI / fresh minions).
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'agents'
+                  AND column_name = 'shadow_min_samples'
+            ) THEN
+                ALTER TABLE agents
+                    ALTER COLUMN shadow_min_samples SET DEFAULT 10;
+            END IF;
+        END$$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'agents'
+                  AND column_name = 'shadow_min_samples'
+            ) THEN
+                ALTER TABLE agents
+                    ALTER COLUMN shadow_min_samples SET DEFAULT 20;
+            END IF;
+        END$$;
+        """
+    )

--- a/tests/regression/test_codex_round4_blockers.py
+++ b/tests/regression/test_codex_round4_blockers.py
@@ -237,6 +237,55 @@ def test_k_f_billing_async_routes_wrap_sync_calls() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_k_e_strict_mode_wired_in_prod_manifests() -> None:
+    """Codex 2026-04-23 prod re-verification: the strict-mode env var
+    must be wired into the production Helm values — otherwise the code
+    fix is dormant in production.
+    """
+    for rel in ("helm/values.yaml", "helm/values-production.yaml"):
+        src = _read(rel)
+        assert "AGENTICORG_AUTH_STATE_STRICT" in src, (
+            f"{rel} must set AGENTICORG_AUTH_STATE_STRICT so the K-E "
+            "fail-closed auth state is active in prod"
+        )
+        # Must be truthy ("1" / "true" / "yes")
+        m = re.search(
+            r"AGENTICORG_AUTH_STATE_STRICT\s*:\s*\"?([^\"\n]+)\"?",
+            src,
+        )
+        assert m, f"couldn't parse strict-mode value in {rel}"
+        assert m.group(1).strip().lower() in ("1", "true", "yes"), (
+            f"{rel}: AGENTICORG_AUTH_STATE_STRICT must be truthy, got "
+            f"{m.group(1)!r}"
+        )
+
+
+def test_k_e_health_probes_are_public() -> None:
+    """Codex 2026-04-23 prod re-verification: /billing/health and
+    /knowledge/health were declared auth-free in their route files but
+    the global AuthMiddleware still required a token, so ops could not
+    call them as smoke probes. They must be in EXEMPT_PATHS.
+    """
+    src = _read("auth/middleware.py")
+    assert "/api/v1/billing/health" in src, (
+        "AuthMiddleware.EXEMPT_PATHS must include /api/v1/billing/health "
+        "so deploy smoke checks can reach it unauthenticated"
+    )
+    assert "/api/v1/knowledge/health" in src, (
+        "AuthMiddleware.EXEMPT_PATHS must include /api/v1/knowledge/health"
+    )
+
+
+def test_k_e_health_endpoint_exposes_commit_sha() -> None:
+    """/health must expose the deployed commit SHA so Codex + ops can
+    prove which commit is actually live (version alone is ambiguous).
+    """
+    src = _read("api/v1/health.py")
+    assert "_deployed_commit" in src
+    assert "AGENTICORG_GIT_SHA" in src
+    assert "\"commit\"" in src
+
+
 def test_k_g_connectors_test_endpoint_refuses_plaintext() -> None:
     """api/v1/connectors.py test path must not read Connector.auth_config."""
     src = _read("api/v1/connectors.py")

--- a/tests/regression/test_qa_23apr_sweep.py
+++ b/tests/regression/test_qa_23apr_sweep.py
@@ -1,0 +1,218 @@
+"""Regression tests for the 23-Apr-2026 QA sweep.
+
+Pins the contracts the Aishwarya + Uday bug sheets asked for:
+- TC_002: Knowledge Base search uses extractApiError, not a canned
+  "API offline" message; a zero-result response shows a dedicated
+  no-results state.
+- TC_003 + TC_004: Schemas page exposes name/version/description form
+  fields and an explicit Save/Create button wired to
+  POST/PUT /schemas.
+- TC_005: Connectors page no longer positions the three action
+  buttons absolutely on top of the card content.
+- TC_006: connector test endpoint falls back to the per-company GSTN
+  Credential Vault for the GSTN connector.
+- TC_007: connector test surfaces specific error hints (401/SSL/DNS/
+  timeout/token-expired) instead of "Connector test failed".
+- TC_008: basic auth uses username + password keys end-to-end; the
+  Edit screen renders a Username input alongside Password.
+- Uday Bug 1/2: shadow tab target defaults to 10 with a Samples
+  generated / Promotion target split; loop emits per-sample status.
+- Uday connector-delete: POST /connectors reactivates the
+  soft-deleted twin instead of 409.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    return (REPO / rel).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# TC_002 — Knowledge Base search surfaces real errors + no-results state
+# ---------------------------------------------------------------------------
+
+
+def test_tc_002_knowledge_base_uses_extract_api_error() -> None:
+    src = _read("ui/src/pages/KnowledgeBase.tsx")
+    assert "extractApiError" in src, (
+        "KnowledgeBase must import extractApiError; previously the "
+        "catch block showed a blanket 'API offline' message"
+    )
+    # The old rendered fallback (arg to setSearchResults) must be gone.
+    # Code comments that document the history are fine to keep.
+    assert 'setSearchResults(["(Search unavailable' not in src, (
+        "The old canned 'Search unavailable — API offline' array item "
+        "must be removed — it misled testers into filing bugs against "
+        "a working search"
+    )
+    # The new error-state bucket must be rendered
+    assert "setSearchError" in src
+    assert "data-testid=\"kb-search-error\"" in src
+
+
+# ---------------------------------------------------------------------------
+# TC_003 + TC_004 — Schema create + edit have Save/Create buttons
+# ---------------------------------------------------------------------------
+
+
+def test_tc_003_tc_004_schema_form_has_save_button() -> None:
+    src = _read("ui/src/pages/Schemas.tsx")
+    assert "handleSaveSchema" in src, (
+        "Schemas page must wire a save handler for both Create and Edit"
+    )
+    assert "data-testid=\"schema-save-button\"" in src
+    # Name + version + description inputs must exist so the payload
+    # matches SchemaCreate on the backend
+    assert "id=\"schema-name\"" in src
+    assert "id=\"schema-version\"" in src
+    assert "id=\"schema-description\"" in src
+    # Must POST for new and PUT for edit
+    assert "api.post(\"/schemas\"" in src
+    assert "api.put(" in src and "/schemas/" in src
+
+
+# ---------------------------------------------------------------------------
+# TC_005 — Connectors page action buttons no longer absolutely positioned
+# ---------------------------------------------------------------------------
+
+
+def test_tc_005_connectors_no_absolute_action_buttons() -> None:
+    src = _read("ui/src/pages/Connectors.tsx")
+    # The old structure wrapped the ConnectorCard in a relative
+    # container with an `absolute bottom-3 right-3` button bar — that
+    # is what caused the overlap. The replacement uses a flex column.
+    assert "absolute bottom-3 right-3" not in src, (
+        "Action buttons must no longer use absolute positioning over "
+        "the card content (TC_005 overlap fix)"
+    )
+    # Responsive grid: at least one breakpoint below lg
+    assert re.search(r"grid-cols-1\s+sm:grid-cols-2\s+lg:grid-cols-3", src)
+
+
+# ---------------------------------------------------------------------------
+# TC_006 — connector test bridges GSTN Credential Vault
+# ---------------------------------------------------------------------------
+
+
+def test_tc_006_connector_test_bridges_gstn_vault() -> None:
+    src = _read("api/v1/connectors.py")
+    assert "GSTNCredential" in src, (
+        "test_connector must try the per-company GSTN Credential Vault "
+        "for the GSTN connector when no ConnectorConfig rows exist"
+    )
+    assert "password_encrypted" in src
+    assert "is_active" in src
+
+
+# ---------------------------------------------------------------------------
+# TC_007 — connector test emits specific error hints
+# ---------------------------------------------------------------------------
+
+
+def test_tc_007_connector_test_has_specific_error_hints() -> None:
+    src = _read("api/v1/connectors.py")
+    # The route must discriminate between common failure classes
+    # rather than returning a single "Connector test failed" blob.
+    for needle in ("Invalid credentials", "SSL", "DNS", "timed out", "token"):
+        assert needle.lower() in src.lower(), (
+            f"connector test error hints must include a {needle!r} branch"
+        )
+    # The generic "Connector test failed" string is no longer the only
+    # value the route can return — we allow it nowhere except inside a
+    # comment describing history.
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if node.value == "Connector test failed":
+                raise AssertionError(
+                    "The generic 'Connector test failed' literal must be "
+                    "removed in favor of discriminated hints (TC_007)"
+                )
+
+
+# ---------------------------------------------------------------------------
+# TC_008 — basic auth field parity between Create and Edit
+# ---------------------------------------------------------------------------
+
+
+def test_tc_008_basic_auth_uses_username_password_keys() -> None:
+    """Create + Edit + buildBasicAuthConfig use the same key names."""
+    create_src = _read("ui/src/pages/ConnectorCreate.tsx")
+    consts_src = _read("ui/src/lib/connector-constants.ts")
+    detail_src = _read("ui/src/pages/ConnectorDetail.tsx")
+
+    # Create now uses username + password (not api_key + api_secret)
+    assert 'key: "username"' in create_src
+    assert 'key: "password"' in create_src
+    assert 'key: "api_key", label: "Username"' not in create_src, (
+        "Create form must not route Username into api_key anymore"
+    )
+
+    # connector-constants exposes a basic-auth helper
+    assert "buildBasicAuthConfig" in consts_src
+    assert "username" in consts_src and "password" in consts_src
+
+    # Edit screen renders an explicit Username input for basic auth
+    assert "buildBasicAuthConfig" in detail_src
+    assert "basicUsername" in detail_src
+    assert re.search(r"authType\s*===\s*\"basic\"", detail_src), (
+        "Edit screen must branch on basic auth to render the Username "
+        "input alongside Password"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Uday connector delete — reregistration revives soft-deleted twin
+# ---------------------------------------------------------------------------
+
+
+def test_uday_connector_soft_delete_reregistration() -> None:
+    src = _read("api/v1/connectors.py")
+    # The POST /connectors route must check for an existing
+    # soft-deleted row with the same name and reactivate it in place.
+    assert re.search(r"existing\.status\s*=\s*\"active\"", src), (
+        "POST /connectors must reactivate a soft-deleted twin instead "
+        "of 409-ing on the same name"
+    )
+    # List must filter out deleted entries by default
+    assert "!= \"deleted\"" in src or "!= 'deleted'" in src
+
+
+# ---------------------------------------------------------------------------
+# Uday Bug 1 + 2 — shadow tab defaults, display split, sequential loop
+# ---------------------------------------------------------------------------
+
+
+def test_uday_shadow_tab_defaults_and_display() -> None:
+    agent_detail = _read("ui/src/pages/AgentDetail.tsx")
+    # Target default is 10 (not 20) in the UI fallback
+    assert "?? 10" in agent_detail
+    # Display shows both the generated count AND the target
+    assert "Samples generated" in agent_detail
+    assert "Promotion target" in agent_detail
+    # Loop emits a per-sample status line so testers see sequential progress
+    assert "Generating sample" in agent_detail
+    assert "sequential_index" in agent_detail
+
+    # Backend default dropped from 20 to 10
+    agent_model = _read("core/models/agent.py")
+    assert "shadow_min_samples" in agent_model
+    # The whole mapped_column(...) expression lives on a single line.
+    # Extract that line and assert both the column name and default.
+    mapped_col_lines = [
+        line
+        for line in agent_model.splitlines()
+        if "shadow_min_samples" in line and "mapped_column" in line
+    ]
+    assert mapped_col_lines, "shadow_min_samples mapped_column line not found"
+    assert any("default=10" in line for line in mapped_col_lines), (
+        "shadow_min_samples ORM default must be 10 per Uday 2026-04-23 "
+        "Bug 1 — existing rows keep their admin-set value"
+    )

--- a/ui/src/lib/connector-constants.ts
+++ b/ui/src/lib/connector-constants.ts
@@ -23,6 +23,25 @@ export function buildAuthConfig(authType: string, token: string): Record<string,
   if (authType === "bolt_bot_token") return { bot_token: t };
   if (authType === "api_key") return { api_key: t };
   if (authType === "oauth2") return { client_secret: t };
+  // TC_008 (Aishwarya 2026-04-23): basic auth is username + password,
+  // but this single-token helper only had a slot for password. The
+  // ConnectorDetail edit flow now uses buildBasicAuthConfig explicitly
+  // to pass both. This helper is preserved for the single-field auth
+  // types and keeps "password" as a back-compat slot for flows that
+  // want to update the password without touching the username.
   if (authType === "basic") return { password: t };
   return { token: t };
+}
+
+/** Build an auth_config payload for basic auth (username + password). */
+export function buildBasicAuthConfig(
+  username: string,
+  password: string,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  const u = username.trim();
+  const p = password.trim();
+  if (u) out.username = u;
+  if (p) out.password = p;
+  return out;
 }

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1108,7 +1108,12 @@ function ShadowTab({ agent }: { agent: Agent }) {
   const [genResult, setGenResult] = useState<{ type: "success" | "error"; msg: string } | null>(null);
 
   const sampleCount = agent.shadow_sample_count ?? 0;
-  const minSamples = agent.shadow_min_samples ?? 20;
+  // Uday 2026-04-23 Bug 1/2: the default target was 20 samples which
+  // produced long bulk runs and a "13 / 20" display that made users
+  // think generation wasn't finished. Drop the default to 10 so a
+  // fresh agent fills in a quick, reviewable batch, and use the
+  // per-agent field verbatim when the server provides it.
+  const minSamples = agent.shadow_min_samples ?? 10;
   const sampleProgress = minSamples > 0 ? Math.min((sampleCount / minSamples) * 100, 100) : 0;
 
   const accuracyCurrent = agent.shadow_accuracy_current != null ? agent.shadow_accuracy_current * 100 : 0;
@@ -1127,22 +1132,28 @@ function ShadowTab({ agent }: { agent: Agent }) {
     setGenerating(true);
     setGenResult(null);
     try {
-      // TC_014 (Aishwarya 2026-04-22): a single /run emits a single
-      // sample, so users clicking once saw the progress bar jump from
-      // 35% to 40% and stop — they expected the button to fill the
-      // gap to minSamples in one click. Call /run in a loop to make
-      // up the shortfall. Cap the batch so a bad config can't DOS
-      // the agent; if more than 5 runs fail in a row, surface the
-      // error instead of silently continuing.
-      const gap = Math.max(0, (agent.shadow_min_samples ?? 20) - sampleCount);
-      const plannedRuns = Math.min(gap > 0 ? gap : 1, 25);
+      // Uday 2026-04-23 Bug 1: the earlier loop awaited each call but
+      // without a visible pause between requests the batch felt like a
+      // parallel bulk run — the progress counter jumped several samples
+      // at once so testers couldn't tell each sample had actually
+      // completed before the next one started. Cap the default batch
+      // at 10 (per the 2026-04-23 spec), run each sample strictly
+      // sequentially, and push an intermediate status after each so
+      // the UI shows "Sample 3/10…" progress in real time.
+      const target = Math.max(1, agent.shadow_min_samples ?? 10);
+      const gap = Math.max(0, target - sampleCount);
+      const plannedRuns = Math.min(gap > 0 ? gap : 1, 10);
       let successes = 0;
       let consecutiveFailures = 0;
       for (let i = 0; i < plannedRuns; i++) {
+        setGenResult({
+          type: "success",
+          msg: `Generating sample ${i + 1}/${plannedRuns}…`,
+        });
         try {
           await api.post(`/agents/${agent.id}/run`, {
             action: "shadow_sample",
-            inputs: { mode: "test", generate_sample: true },
+            inputs: { mode: "test", generate_sample: true, sequential_index: i + 1 },
           });
           successes += 1;
           consecutiveFailures = 0;
@@ -1156,7 +1167,7 @@ function ShadowTab({ agent }: { agent: Agent }) {
       setGenResult({
         type: "success",
         msg:
-          `Generated ${successes} shadow sample${successes === 1 ? "" : "s"}. ` +
+          `Generated ${successes} shadow sample${successes === 1 ? "" : "s"} (of ${plannedRuns} attempted). ` +
           "Refresh to see updated count and accuracy.",
       });
     } catch (err: any) {
@@ -1219,9 +1230,19 @@ function ShadowTab({ agent }: { agent: Agent }) {
               {genResult.msg}
             </div>
           )}
+          {/* Uday 2026-04-23 Bug 2: the display used to show a single
+              "{collected} / {target}" row which made a partial run look
+              like incomplete success ("13 generated, 20 total" read
+              like 7 missing). Split the two signals so testers see
+              how many samples actually exist (generated) separately
+              from the promotion target. */}
           <div className="flex justify-between text-sm">
-            <span className="text-muted-foreground">Samples collected</span>
-            <span className="font-medium">{sampleCount} / {minSamples}</span>
+            <span className="text-muted-foreground">Samples generated</span>
+            <span className="font-medium">{sampleCount}</span>
+          </div>
+          <div className="flex justify-between text-sm">
+            <span className="text-muted-foreground">Promotion target</span>
+            <span className="font-medium">{minSamples}</span>
           </div>
           <div className="w-full bg-gray-200 rounded-full h-4 overflow-hidden">
             <div

--- a/ui/src/pages/ConnectorCreate.tsx
+++ b/ui/src/pages/ConnectorCreate.tsx
@@ -18,8 +18,14 @@ const AUTH_TYPE_FIELDS: Record<string, { key: string; label: string; placeholder
     { key: "refresh_token", label: "Refresh Token", placeholder: "Enter refresh token (optional)" },
   ],
   basic: [
-    { key: "api_key", label: "Username", placeholder: "Enter username" },
-    { key: "api_secret", label: "Password", placeholder: "Enter password" },
+    // TC_008 (Aishwarya 2026-04-23): basic-auth creates were landing
+    // username/password into api_key/api_secret keys, but the native
+    // connector classes (e.g. connectors/ops/servicenow.py,
+    // connectors/marketing/salesforce.py) read config["username"] /
+    // config["password"] — so credentials saved via Create never made
+    // it to the connector. Use the keys the connectors actually read.
+    { key: "username", label: "Username", placeholder: "Enter username" },
+    { key: "password", label: "Password", placeholder: "Enter password" },
   ],
   bolt_bot_token: [
     { key: "api_key", label: "Bot Token", placeholder: "xoxb-..." },

--- a/ui/src/pages/ConnectorDetail.tsx
+++ b/ui/src/pages/ConnectorDetail.tsx
@@ -4,7 +4,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import api, { extractApiError } from "@/lib/api";
-import { AUTH_TYPES, authTypeLabel, buildAuthConfig } from "@/lib/connector-constants";
+import { AUTH_TYPES, authTypeLabel, buildAuthConfig, buildBasicAuthConfig } from "@/lib/connector-constants";
 
 interface ConnectorDetail {
   connector_id: string;
@@ -42,6 +42,10 @@ export default function ConnectorDetailPage() {
   const [oauth2ClientId, setOauth2ClientId] = useState("");
   const [oauth2TokenUrl, setOauth2TokenUrl] = useState("");
   const [oauth2RedirectUri, setOauth2RedirectUri] = useState("");
+  // TC_008 (Aishwarya 2026-04-23): basic auth needs its own
+  // username field in edit — the single-token flow above couldn't
+  // carry it and the tester saw missing Username during Edit.
+  const [basicUsername, setBasicUsername] = useState("");
   const [testing, setTesting] = useState(false);
 
   function validateBaseUrl(url: string): boolean {
@@ -83,7 +87,13 @@ export default function ConnectorDetailPage() {
         rate_limit_rpm: rateLimitRpm,
       };
       if (secretRef.trim()) update.secret_ref = secretRef.trim();
-      const authConfig = buildAuthConfig(authType, authToken);
+      // TC_008 (Aishwarya 2026-04-23): basic auth takes two fields; the
+      // single-field helper didn't carry username. Use the basic-auth
+      // helper so both username and password flow through.
+      const authConfig =
+        authType === "basic"
+          ? buildBasicAuthConfig(basicUsername, authToken)
+          : buildAuthConfig(authType, authToken);
       // Add OAuth2-specific fields
       if (authType === "oauth2") {
         if (oauth2ClientId.trim()) authConfig.client_id = oauth2ClientId.trim();
@@ -228,9 +238,36 @@ export default function ConnectorDetailPage() {
                         </div>
                       </>
                     )}
+                    {/* TC_008 (Aishwarya 2026-04-23): basic auth
+                        previously rendered ONLY a single Password
+                        input on the Edit screen — the matching
+                        Username field was missing, and the label
+                        fell through to the generic "Password" helper.
+                        Add an explicit Username input so Edit mirrors
+                        the Create form. */}
+                    {authType === "basic" && (
+                      <div>
+                        <label className="text-sm font-medium">Username</label>
+                        <input
+                          type="text"
+                          value={basicUsername}
+                          onChange={(e) => setBasicUsername(e.target.value)}
+                          placeholder="Enter username (leave blank to keep existing)"
+                          className="border rounded px-3 py-2 text-sm w-full mt-1"
+                          autoComplete="username"
+                        />
+                      </div>
+                    )}
                     <div>
                       <label className="text-sm font-medium">{authTypeLabel(authType)}</label>
-                      <input type="password" value={authToken} onChange={(e) => setAuthToken(e.target.value)} placeholder="Enter new credential (leave blank to keep existing)" className="border rounded px-3 py-2 text-sm w-full mt-1" />
+                      <input
+                        type="password"
+                        value={authToken}
+                        onChange={(e) => setAuthToken(e.target.value)}
+                        placeholder="Enter new credential (leave blank to keep existing)"
+                        className="border rounded px-3 py-2 text-sm w-full mt-1"
+                        autoComplete={authType === "basic" ? "new-password" : "off"}
+                      />
                     </div>
                     <div>
                       <label className="text-sm font-medium">Secret Reference</label>
@@ -244,7 +281,7 @@ export default function ConnectorDetailPage() {
                 </div>
                 <div className="flex gap-2 pt-2">
                   <Button size="sm" onClick={handleSave} disabled={saving}>{saving ? "Saving..." : "Save"}</Button>
-                  <Button size="sm" variant="outline" onClick={() => { setEditing(false); setAuthToken(""); setSecretRef(""); }}>Cancel</Button>
+                  <Button size="sm" variant="outline" onClick={() => { setEditing(false); setAuthToken(""); setSecretRef(""); setBasicUsername(""); }}>Cancel</Button>
                 </div>
               </div>
             ) : (

--- a/ui/src/pages/Connectors.tsx
+++ b/ui/src/pages/Connectors.tsx
@@ -253,16 +253,22 @@ export default function Connectors() {
             </select>
           </div>
 
+          {/* TC_005 (Aishwarya 2026-04-23): the three action buttons
+              (Edit / Health Check / Archive) were absolutely
+              positioned at bottom-right of each card, which caused
+              them to overlap the card content (category/auth/rate
+              row) at 100% zoom and on narrower viewports. Render
+              them in a dedicated flex row below the card. */}
           {loading ? (
             <p className="text-muted-foreground">Loading connectors...</p>
           ) : filtered.length === 0 ? (
             <p className="text-muted-foreground">No connectors found.</p>
           ) : (
-            <div className="grid grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {filtered.map((connector) => (
-                <div key={connector.id} className="relative">
+                <div key={connector.id} className="flex flex-col gap-2">
                   <ConnectorCard connector={connector} />
-                  <div className="absolute bottom-3 right-3 flex gap-2">
+                  <div className="flex flex-wrap gap-2">
                     <Button
                       variant="outline"
                       size="sm"

--- a/ui/src/pages/KnowledgeBase.tsx
+++ b/ui/src/pages/KnowledgeBase.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import api from "@/lib/api";
+import api, { extractApiError } from "@/lib/api";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -134,6 +134,9 @@ export default function KnowledgeBase() {
   const [dragActive, setDragActive] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<string[]>([]);
+  // TC_002 (Aishwarya 2026-04-23): surface real backend errors to the user
+  // instead of a blanket "API offline" line.
+  const [searchError, setSearchError] = useState<string | null>(null);
   // Modal state for the duplicate-file decision flow.
   const [dupPrompt, setDupPrompt] = useState<{
     filename: string;
@@ -298,11 +301,26 @@ export default function KnowledgeBase() {
 
   const handleSearch = async () => {
     if (!searchQuery.trim()) return;
+    setSearchError(null);
     try {
       const res = await api.post("/knowledge/search", { query: searchQuery });
-      setSearchResults(Array.isArray(res.data?.results) ? res.data.results : []);
-    } catch {
-      setSearchResults(["(Search unavailable — API offline. Results will appear once the backend is running.)"]);
+      const results = Array.isArray(res.data?.results) ? res.data.results : [];
+      setSearchResults(results);
+      // TC_002 (Aishwarya 2026-04-23): when the backend returns zero
+      // results, show a dedicated empty state — not the previous
+      // "API offline" line, which misled testers into filing bugs
+      // against a working search.
+      if (results.length === 0) {
+        setSearchError(t("knowledge.search.noResults", "No matching chunks in the knowledge base for this query."));
+      }
+    } catch (e) {
+      // TC_002 (Aishwarya 2026-04-23): the bare catch previously
+      // showed "(Search unavailable — API offline...)" for ANY error,
+      // which is why the tester filed "Something went wrong". Surface
+      // the backend's structured error detail so testers and operators
+      // see what actually failed.
+      setSearchResults([]);
+      setSearchError(extractApiError(e, t("knowledge.search.failed", "Search failed — please try again.")));
     }
   };
 
@@ -414,6 +432,16 @@ export default function KnowledgeBase() {
           {searchResults.map((r, i) => (
             <p key={i} className="text-sm text-muted-foreground">{r}</p>
           ))}
+        </div>
+      )}
+      {searchError && searchResults.length === 0 && (
+        <div
+          className="border border-amber-200 bg-amber-50 text-amber-900 rounded-lg p-3 text-sm"
+          role="alert"
+          aria-live="polite"
+          data-testid="kb-search-error"
+        >
+          {searchError}
         </div>
       )}
 

--- a/ui/src/pages/Schemas.tsx
+++ b/ui/src/pages/Schemas.tsx
@@ -4,7 +4,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import SchemaEditor from "@/components/SchemaEditor";
-import api from "@/lib/api";
+import api, { extractApiError } from "@/lib/api";
 
 interface SchemaEntry {
   name: string;
@@ -234,6 +234,19 @@ export default function Schemas() {
   // backend returns 404 (platform-default schemas, for demos).
   const [editorSchema, setEditorSchema] = useState<object | null>(null);
 
+  // TC_003 / TC_004 (Aishwarya 2026-04-23): the page rendered a
+  // SchemaEditor but never exposed a Save/Create button, so the UI
+  // was view-only — users couldn't actually persist a new schema or
+  // an edit. Add an explicit form (name / version / description) and
+  // Save/Create actions that call POST or PUT /schemas.
+  const [editorJson, setEditorJson] = useState<string>("");
+  const [formName, setFormName] = useState<string>("");
+  const [formVersion, setFormVersion] = useState<string>("1");
+  const [formDescription, setFormDescription] = useState<string>("");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [formNotice, setFormNotice] = useState<string | null>(null);
+  const [saving, setSaving] = useState<boolean>(false);
+
   useEffect(() => {
     fetchSchemas();
   }, []);
@@ -241,6 +254,10 @@ export default function Schemas() {
   useEffect(() => {
     if (!selectedSchema) {
       setEditorSchema(null);
+      setFormName("");
+      setFormVersion("1");
+      setFormDescription("");
+      setEditorJson("");
       return;
     }
     (async () => {
@@ -248,6 +265,10 @@ export default function Schemas() {
         const { data } = await api.get(`/schemas/${encodeURIComponent(selectedSchema)}`);
         if (data && typeof data === "object" && data.json_schema) {
           setEditorSchema(data.json_schema as object);
+          setFormName(data.name || selectedSchema);
+          setFormVersion(data.version || "1");
+          setFormDescription(data.description || "");
+          setEditorJson(JSON.stringify(data.json_schema, null, 2));
           return;
         }
       } catch {
@@ -255,9 +276,95 @@ export default function Schemas() {
       }
       // Backend didn't have this schema — fall back to the local
       // SCHEMA_DEFINITIONS demo shape so the editor still renders.
-      setEditorSchema(SCHEMA_DEFINITIONS[selectedSchema] ?? null);
+      const fallback = SCHEMA_DEFINITIONS[selectedSchema] ?? null;
+      setEditorSchema(fallback);
+      setFormName(selectedSchema);
+      setFormVersion("1");
+      setFormDescription("");
+      setEditorJson(fallback ? JSON.stringify(fallback, null, 2) : "{}");
     })();
   }, [selectedSchema]);
+
+  // TC_003 (Aishwarya 2026-04-23): when the user clicks "Create
+  // Schema" we must prepare a blank editor with initial JSON so the
+  // SchemaEditor onChange is non-empty and the Create button can
+  // resolve what to POST.
+  useEffect(() => {
+    if (showEditor && !selectedSchema) {
+      const blank = {
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        title: "NewSchema",
+        type: "object",
+        required: [],
+        properties: {},
+      };
+      setEditorJson(JSON.stringify(blank, null, 2));
+      setFormName("");
+      setFormVersion("1");
+      setFormDescription("");
+      setFormError(null);
+      setFormNotice(null);
+    }
+  }, [showEditor, selectedSchema]);
+
+  async function handleSaveSchema() {
+    setFormError(null);
+    setFormNotice(null);
+
+    const trimmedName = formName.trim();
+    if (!trimmedName) {
+      setFormError("Schema name is required.");
+      return;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(editorJson || "{}");
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Invalid JSON";
+      setFormError(`Invalid JSON: ${msg}`);
+      return;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      setFormError("Schema JSON must be an object.");
+      return;
+    }
+
+    const payload = {
+      name: trimmedName,
+      version: (formVersion || "1").trim() || "1",
+      description: formDescription.trim() || null,
+      json_schema: parsed,
+      is_default: false,
+    };
+
+    setSaving(true);
+    try {
+      if (selectedSchema) {
+        // Editing an existing schema → PUT /schemas/{name}
+        const { data } = await api.put(
+          `/schemas/${encodeURIComponent(selectedSchema)}`,
+          payload,
+        );
+        setFormNotice(
+          data?.created
+            ? "New version created."
+            : "Schema updated.",
+        );
+      } else {
+        // Creating a new schema → POST /schemas
+        await api.post("/schemas", payload);
+        setFormNotice("Schema created.");
+      }
+      await fetchSchemas();
+      setShowEditor(false);
+      setSelectedSchema(null);
+    } catch (e: unknown) {
+      setFormError(extractApiError(e, "Failed to save schema."));
+    } finally {
+      setSaving(false);
+    }
+  }
 
   async function fetchSchemas() {
     setLoading(true);
@@ -333,11 +440,96 @@ export default function Schemas() {
           <CardHeader>
             <div className="flex justify-between items-center">
               <CardTitle>{selectedSchema ? `Edit: ${selectedSchema}` : "New Schema"}</CardTitle>
-              <Button variant="outline" size="sm" onClick={() => { setShowEditor(false); setSelectedSchema(null); }}>Close</Button>
+              <Button variant="outline" size="sm" onClick={() => { setShowEditor(false); setSelectedSchema(null); setFormError(null); setFormNotice(null); }}>Close</Button>
             </div>
           </CardHeader>
-          <CardContent>
-            <SchemaEditor schema={selectedSchema ? (editorSchema ?? SCHEMA_DEFINITIONS[selectedSchema]) : { $schema: "https://json-schema.org/draft/2020-12/schema", title: "NewSchema", type: "object", required: [], properties: {} }} />
+          <CardContent className="space-y-3">
+            {/* TC_003/TC_004 (Aishwarya 2026-04-23): name + version +
+                description form fields and an explicit Save/Create
+                button. Without these, the editor rendered but the
+                user had no way to persist their changes. */}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+              <div>
+                <label className="text-xs font-medium text-muted-foreground" htmlFor="schema-name">
+                  Schema name
+                </label>
+                <input
+                  id="schema-name"
+                  type="text"
+                  className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                  value={formName}
+                  onChange={(e) => setFormName(e.target.value)}
+                  placeholder="e.g. InvoiceV2"
+                  disabled={!!selectedSchema}
+                  aria-label="Schema name"
+                />
+              </div>
+              <div>
+                <label className="text-xs font-medium text-muted-foreground" htmlFor="schema-version">
+                  Version
+                </label>
+                <input
+                  id="schema-version"
+                  type="text"
+                  className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                  value={formVersion}
+                  onChange={(e) => setFormVersion(e.target.value)}
+                  placeholder="1"
+                  aria-label="Schema version"
+                />
+              </div>
+              <div>
+                <label className="text-xs font-medium text-muted-foreground" htmlFor="schema-description">
+                  Description (optional)
+                </label>
+                <input
+                  id="schema-description"
+                  type="text"
+                  className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                  value={formDescription}
+                  onChange={(e) => setFormDescription(e.target.value)}
+                  placeholder="Short summary"
+                  aria-label="Schema description"
+                />
+              </div>
+            </div>
+
+            <SchemaEditor
+              schema={selectedSchema ? (editorSchema ?? SCHEMA_DEFINITIONS[selectedSchema]) : { $schema: "https://json-schema.org/draft/2020-12/schema", title: "NewSchema", type: "object", required: [], properties: {} }}
+              onChange={(v) => setEditorJson(v)}
+            />
+
+            {formError && (
+              <p className="text-sm text-red-600" role="alert" data-testid="schema-form-error">
+                {formError}
+              </p>
+            )}
+            {formNotice && (
+              <p className="text-sm text-emerald-700" role="status" data-testid="schema-form-notice">
+                {formNotice}
+              </p>
+            )}
+
+            <div className="flex gap-2">
+              <Button
+                onClick={handleSaveSchema}
+                disabled={saving}
+                data-testid="schema-save-button"
+              >
+                {saving
+                  ? "Saving…"
+                  : selectedSchema
+                  ? "Save"
+                  : "Create"}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => { setShowEditor(false); setSelectedSchema(null); setFormError(null); setFormNotice(null); }}
+                disabled={saving}
+              >
+                Cancel
+              </Button>
+            </div>
           </CardContent>
         </Card>
       )}


### PR DESCRIPTION
## Summary

Two rolled-up work items:

1. **QA sweep for the 2026-04-23 bug lists** (Aishwarya + Uday/Ramesh). Every bug has an explicit verdict from the fail-closed matrix in `docs/bug_triage_skill.md`. Verdicts matrix attached as `AgenticOrg_BugFix_Summary_23April2026.xlsx` in Downloads.
2. **Codex's prod re-verification sign-off blockers for the K-round fixes** — wire the K-E strict-mode env var into Helm, exempt the /billing/health and /knowledge/health probes from AuthMiddleware, expose the deployed commit SHA on /health.

## Aishwarya 23-Apr verdicts

| Bug | Verdict | Fix |
| --- | --- | --- |
| TC_001 HTTP 500 on create schedule (Reopen) | **Partially closed** | Validators + UI blocker + catch-all all verified via local 5-case Pydantic repro. No residual 500 path identified. If tester still sees 500 post-deploy, needs exact payload. |
| TC_002 KB search "Something went wrong" | **Fixed** | `handleSearch` now uses `extractApiError`; new `searchError` state surfaces real backend detail; zero-results gets its own no-matches message. |
| TC_003 Create button missing on Schema | **Fixed** | Schemas page now has name/version/description inputs + Save/Create button wired to POST /schemas. |
| TC_004 Save missing on Edit Schema | **Fixed** | Same mechanism, using PUT /schemas/{name}; Name disabled during edit. |
| TC_005 Buttons overlap on 100% zoom | **Fixed** | Replaced absolute-positioned bar with flex column; responsive grid. |
| TC_006 GSTN test fails despite Verified vault | **Fixed** | /connectors/{id}/test bridges to per-company GSTNCredential when ConnectorConfig has no creds. |
| TC_007 Generic "Connector test failed" | **Fixed** | Exception classifier emits specific hints (401 / SSL / DNS / timeout / token-expired); unknown errors surface as ClassName: short-msg. |
| TC_008 Basic auth field mismatch Create vs Edit | **Fixed** | All three surfaces (Create, buildBasicAuthConfig helper, Edit) now use `username` + `password` keys — what the connector runtime actually reads. |

## Uday 23-Apr verdicts

| Bug | Verdict | Fix |
| --- | --- | --- |
| Shadow tab generates 20 in bulk | **Fixed** | UI default 10, ORM default 10, per-sample "Generating N/M" status. |
| Shadow dynamic sample count | **Fixed** | Display split into "Samples generated" and "Promotion target". |
| Connector delete + re-create 409s | **Fixed** | POST /connectors reactivates soft-deleted twin in place; GET filters status=deleted. |

## Ramesh 23-Apr verdicts

| Bug | Verdict | Notes |
| --- | --- | --- |
| RA-1 Shadow accuracy 40% | **Enhancement** | Roadmap: prompt library + tool authorization + evaluation. |
| RA-2 connector_ids missing | **Already fixed (stale)** | PR #272 live; AgentCreate.tsx:127 has connectorIds state. |
| RA-3 Zoho Books not implemented | **Already fixed (stale)** | `connectors/finance/zoho_books.py` exists. |
| RA-5 Gmail demo creds | **Not reproducible** | Grep confirms no hardcoded demo creds. |
| RA-6 PII deps missing | **Already fixed (stale)** | presidio in pyproject; redactor.py guards import. |
| RA-7 GSTN sandbox mode | **Enhancement** | Roadmap. |
| RA-8 Income Tax DSC incomplete | **Enhancement** | Roadmap. |

## Codex K-round sign-off wiring

| Fix | File |
| --- | --- |
| `AGENTICORG_AUTH_STATE_STRICT=1` in prod Helm | `helm/values-production.yaml`, `helm/values.yaml`, `.env.example` |
| Health probes exempted from AuthMiddleware | `auth/middleware.py` (added `/api/v1/billing/health`, `/api/v1/knowledge/health`) |
| `/health` exposes `"commit"` from env | `api/v1/health.py` (`_deployed_commit()` reads `AGENTICORG_GIT_SHA` / `GIT_SHA` / `GIT_COMMIT` / `K_REVISION`) |

## Test plan

- [x] `tests/regression/test_qa_23apr_sweep.py` — 8 AST/source-inspection pins for each code-fixed verdict.
- [x] `tests/regression/test_codex_round4_blockers.py` — extended to 12 tests; 3 new pins for the sign-off wiring.
- [x] Full preflight gate green (branch safety, ruff, bandit, alembic, verify=False, 3081-test regression+unit, tsc, vite build, consistency sweep, module coverage, critical-path tags).
- [x] TypeScript strict build passes on all touched UI files.

## /audit /critique /polish summary (per feedback_frontend_design_impeccable)

UI touches are narrow: Schemas form inputs, KnowledgeBase error state, Connectors grid refactor, AgentDetail shadow progress split, ConnectorDetail basic-auth username input. All preserve existing design tokens (shadcn card / Button variants). No new fonts, colors, or icons introduced. New elements follow existing layout rhythm (border, p-3, gap-2).

## Residual risks

- TC_001 still producing 500 in rare production flows cannot be root-caused without the tester's exact payload + response detail. Tracked.
- RA-1/7/8 enhancements not shipped in this PR.
- K-C/D/H (workflow durability, auth cookie migration, startup-DDL removal) remain roadmap items per docs/roadmap/*.md — not in this PR's scope.

## Reviewers

@codex — please re-verify the Aishwarya TCs against the current deploy + confirm the K-E strict-mode wiring + commit-SHA surface unblock the previous sign-off hold.