### PR TITLE
feat(rpa): generic RPA framework + RBI.org.in scraper + scheduling + 4.8/5 quality gate

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -50,6 +50,7 @@ from api.v1 import (
     push,
     report_schedules,
     rpa,
+    rpa_schedules,
     sales,
     schemas,
     sop,
@@ -200,6 +201,7 @@ app.include_router(billing.router, prefix="/api/v1", tags=["Billing"])
 app.include_router(composio.router, prefix="/api/v1", tags=["Composio Marketplace"])
 app.include_router(packs.router, prefix="/api/v1", tags=["Industry Packs"])
 app.include_router(rpa.router, prefix="/api/v1", tags=["RPA"])
+app.include_router(rpa_schedules.router, prefix="/api/v1", tags=["RPA"])
 app.include_router(cdc_webhooks.router, prefix="/api/v1", tags=["CDC Webhooks"])
 app.include_router(content_safety.router, prefix="/api/v1", tags=["Content Safety"])
 app.include_router(knowledge.router, prefix="/api/v1", tags=["Knowledge Base"])

--- a/api/v1/rpa.py
+++ b/api/v1/rpa.py
@@ -157,27 +157,33 @@ async def list_scripts(
 ) -> list[RPAScriptOut]:
     """List available RPA scripts (built-in + custom).
 
-    Built-in scripts are discovered from the ``rpa/scripts/`` directory.
-    Custom (tenant-specific) scripts will come from the DB in a future
-    release.
+    Delegates to ``rpa.scripts._registry.discover_scripts`` so adding
+    a new RPA is as simple as dropping a ``*.py`` file with SCRIPT_META
+    + ``async def run(...)`` — no edits needed here or elsewhere. The
+    hardcoded ``_BUILTIN_SCRIPTS`` dict above is kept as a
+    back-compat augmentation: anything it declares that the registry
+    also declares prefers the registry metadata.
     """
+    del tenant_id  # unused — listing is tenant-agnostic catalog
+    from rpa.scripts._registry import discover_scripts
+
+    registry = discover_scripts()
     scripts: list[RPAScriptOut] = []
-
-    # Built-in scripts
-    for key, meta in _BUILTIN_SCRIPTS.items():
-        script_file = _SCRIPTS_DIR / f"{key}.py"
-        if script_file.exists():
-            scripts.append(RPAScriptOut(
+    for key, meta in sorted(registry.items()):
+        # Merge hardcoded metadata for back-compat where it exists.
+        merged = {**_BUILTIN_SCRIPTS.get(key, {}), **meta}
+        scripts.append(
+            RPAScriptOut(
                 id=f"builtin-{key}",
-                name=meta["name"],
-                description=meta["description"],
-                category=meta.get("category", "general"),
+                name=merged.get("name") or key,
+                description=merged.get("description") or "",
+                category=merged.get("category", "general"),
                 script_key=key,
-                params_schema=meta.get("params_schema", {}),
-                estimated_duration_s=meta.get("estimated_duration_s", 60),
+                params_schema=merged.get("params_schema", {}),
+                estimated_duration_s=merged.get("estimated_duration_s", 60),
                 is_builtin=True,
-            ))
-
+            )
+        )
     return scripts
 
 
@@ -215,13 +221,21 @@ async def run_script(
     pointed at arbitrary URLs and are therefore a server-side
     automation/SSRF surface.
     """
-    # Resolve script key
+    # Resolve script key against the generic registry first; fall
+    # back to the legacy hardcoded _BUILTIN_SCRIPTS map for scripts
+    # that haven't yet been normalised to SCRIPT_META.
+    from rpa.scripts._registry import discover_scripts
+
     script_key = script_id.replace("builtin-", "") if script_id.startswith("builtin-") else script_id
 
-    if script_key not in _BUILTIN_SCRIPTS:
+    registry = discover_scripts()
+    if script_key not in registry and script_key not in _BUILTIN_SCRIPTS:
         raise HTTPException(404, f"RPA script '{script_key}' not found")
 
-    if script_key in _ADMIN_ONLY_SCRIPTS:
+    meta = {**_BUILTIN_SCRIPTS.get(script_key, {}), **registry.get(script_key, {})}
+
+    # Admin gate: honour both the legacy set and the per-script flag.
+    if script_key in _ADMIN_ONLY_SCRIPTS or meta.get("admin_only"):
         scopes = getattr(request.state, "scopes", []) or []
         claims = getattr(request.state, "claims", {}) or {}
         is_admin = (
@@ -236,8 +250,6 @@ async def run_script(
                 "it can be pointed at arbitrary URLs and is gated to "
                 "privileged operators.",
             )
-
-    meta = _BUILTIN_SCRIPTS[script_key]
     execution_id = str(uuid.uuid4())
     started_at = datetime.now(UTC)
 

--- a/api/v1/rpa_schedules.py
+++ b/api/v1/rpa_schedules.py
@@ -1,0 +1,465 @@
+"""RPA Schedule API — CRUD + run-now + list available scripts.
+
+Exposes tenant-scheduled RPA runs on top of the generic registry in
+``rpa/scripts/_registry.py``. Mirrors the shape of /report-schedules
+(validators, tenant isolation, cron discipline) so operators can use
+it the same way.
+
+Contract:
+- Only tenant admins can create / update / delete schedules because
+  some RPA scripts are ``admin_only`` (SSRF-capable) and admin-gating
+  at the router level is the simpler control.
+- ``cron_expression`` supports presets (daily/weekly/monthly/...) and
+  full 5-field crons, mirroring the report-schedules validator.
+- ``next_run_at`` is computed at write time using croniter when
+  available, falling back to a coarse "now + 1 day" so the UI has a
+  value to display.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid as _uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import select
+
+from api.deps import get_current_tenant, require_tenant_admin
+from core.database import get_tenant_session
+from core.models.rpa_schedule import RPASchedule
+
+logger = structlog.get_logger()
+
+# Admin gate at the router level — all endpoints below require admin.
+# The generic RPA executor has an ``admin_only`` flag per-script too,
+# but schedule creation is a privileged configuration op regardless.
+router = APIRouter(prefix="/rpa-schedules", tags=["RPA"], dependencies=[require_tenant_admin])
+
+_CRON_PRESETS = {
+    "every_5_minutes",
+    "every_15_minutes",
+    "hourly",
+    "daily",
+    "weekly",
+    "monthly",
+}
+_CRON_FIELD_RE = re.compile(r"^[\d*/,\-]+$")
+
+
+def _is_valid_cron(expr: str) -> bool:
+    expr = expr.strip()
+    if expr in _CRON_PRESETS:
+        return True
+    try:
+        from croniter import croniter  # type: ignore[import-untyped]
+
+        return croniter.is_valid(expr)
+    except ImportError:
+        pass
+    parts = expr.split()
+    if len(parts) != 5:
+        return False
+    return all(_CRON_FIELD_RE.match(p) for p in parts)
+
+
+def _compute_next_run(cron_expression: str) -> datetime:
+    now = datetime.now(UTC)
+    presets = {
+        "every_5_minutes": timedelta(minutes=5),
+        "every_15_minutes": timedelta(minutes=15),
+        "hourly": timedelta(hours=1),
+        "daily": timedelta(days=1),
+        "weekly": timedelta(weeks=1),
+        "monthly": timedelta(days=30),
+    }
+    if cron_expression in presets:
+        return now + presets[cron_expression]
+    try:
+        from croniter import croniter  # type: ignore[import-untyped]
+
+        return croniter(cron_expression, now).get_next(datetime)
+    except (ImportError, ValueError, KeyError):
+        return now + timedelta(days=1)
+
+
+# ── Schemas ──────────────────────────────────────────────────────────
+
+
+class RPAScheduleCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    script_key: str = Field(..., min_length=1, max_length=100)
+    cron_expression: str = Field("daily", max_length=100)
+    enabled: bool = True
+    company_id: str | None = None
+    params: dict[str, Any] = Field(default_factory=dict)
+    config: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("cron_expression")
+    @classmethod
+    def _validate_cron(cls, v: str) -> str:
+        v = (v or "").strip()
+        if not _is_valid_cron(v):
+            raise ValueError(
+                "cron_expression must be a preset "
+                f"({', '.join(sorted(_CRON_PRESETS))}) or a valid "
+                "5-field cron expression"
+            )
+        return v
+
+    @field_validator("script_key")
+    @classmethod
+    def _validate_script_key(cls, v: str) -> str:
+        v = v.strip()
+        from rpa.scripts._registry import discover_scripts
+
+        available = set(discover_scripts().keys())
+        if v not in available:
+            raise ValueError(
+                f"unknown RPA script {v!r}. Available: "
+                f"{sorted(available)}"
+            )
+        return v
+
+
+class RPAScheduleUpdate(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=255)
+    cron_expression: str | None = Field(None, max_length=100)
+    enabled: bool | None = None
+    params: dict[str, Any] | None = None
+    config: dict[str, Any] | None = None
+    company_id: str | None = None
+
+    @field_validator("cron_expression")
+    @classmethod
+    def _validate_cron(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        v = v.strip()
+        if not _is_valid_cron(v):
+            raise ValueError(
+                "cron_expression must be a preset or a valid 5-field "
+                "cron expression"
+            )
+        return v
+
+
+class RPAScheduleOut(BaseModel):
+    id: str
+    name: str
+    script_key: str
+    cron_expression: str
+    enabled: bool
+    company_id: str | None = None
+    params: dict[str, Any] = Field(default_factory=dict)
+    config: dict[str, Any] = Field(default_factory=dict)
+    last_run_at: str | None = None
+    next_run_at: str | None = None
+    last_run_status: str | None = None
+    last_run_chunks_published: int | None = None
+    last_run_chunks_rejected: int | None = None
+    last_quality_avg: float | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+def _to_out(row: RPASchedule) -> RPAScheduleOut:
+    return RPAScheduleOut(
+        id=str(row.id),
+        name=row.name,
+        script_key=row.script_key,
+        cron_expression=row.cron_expression,
+        enabled=row.enabled,
+        company_id=str(row.company_id) if row.company_id else None,
+        params=row.params or {},
+        config=row.config or {},
+        last_run_at=row.last_run_at.isoformat() if row.last_run_at else None,
+        next_run_at=row.next_run_at.isoformat() if row.next_run_at else None,
+        last_run_status=row.last_run_status,
+        last_run_chunks_published=row.last_run_chunks_published,
+        last_run_chunks_rejected=row.last_run_chunks_rejected,
+        last_quality_avg=float(row.last_quality_avg) if row.last_quality_avg is not None else None,
+        created_at=row.created_at.isoformat() if row.created_at else None,
+        updated_at=row.updated_at.isoformat() if row.updated_at else None,
+    )
+
+
+# ── Registry probe ───────────────────────────────────────────────────
+
+
+@router.get("/registry")
+async def list_registry_scripts(
+    tenant_id: str = Depends(get_current_tenant),
+) -> dict[str, Any]:
+    """Return every RPA script the platform can schedule.
+
+    Output shape matches the RPAScheduleCreate validator's expectations
+    (same ``script_key`` strings). Lets the UI build a dropdown without
+    having to hardcode a list.
+    """
+    del tenant_id  # admin-gated at the router level; no tenant data here
+    from rpa.scripts._registry import discover_scripts
+
+    items = [
+        {
+            "script_key": key,
+            "name": meta.get("name"),
+            "description": meta.get("description"),
+            "category": meta.get("category"),
+            "params_schema": meta.get("params_schema", {}),
+            "estimated_duration_s": meta.get("estimated_duration_s"),
+            "target_quality": meta.get("target_quality"),
+            "admin_only": meta.get("admin_only", False),
+            "produces_chunks": meta.get("produces_chunks", False),
+        }
+        for key, meta in sorted(discover_scripts().items())
+    ]
+    return {"items": items, "total": len(items)}
+
+
+# ── CRUD ─────────────────────────────────────────────────────────────
+
+
+@router.get("", response_model=list[RPAScheduleOut])
+async def list_schedules(
+    company_id: str | None = None,
+    tenant_id: str = Depends(get_current_tenant),
+) -> list[RPAScheduleOut]:
+    tid = _uuid.UUID(tenant_id)
+    async with get_tenant_session(tid) as session:
+        query = select(RPASchedule).where(RPASchedule.tenant_id == tid)
+        if company_id:
+            try:
+                cid = _uuid.UUID(company_id)
+            except ValueError as exc:
+                raise HTTPException(400, "Invalid company_id format") from exc
+            from sqlalchemy import or_
+
+            query = query.where(
+                or_(
+                    RPASchedule.company_id == cid,
+                    RPASchedule.company_id.is_(None),
+                )
+            )
+        query = query.order_by(RPASchedule.created_at.desc())
+        result = await session.execute(query)
+        rows = result.scalars().all()
+    return [_to_out(r) for r in rows]
+
+
+@router.post("", response_model=RPAScheduleOut, status_code=status.HTTP_201_CREATED)
+async def create_schedule(
+    body: RPAScheduleCreate,
+    tenant_id: str = Depends(get_current_tenant),
+) -> RPAScheduleOut:
+    tid = _uuid.UUID(tenant_id)
+    company_uuid: _uuid.UUID | None = None
+    if body.company_id:
+        try:
+            company_uuid = _uuid.UUID(body.company_id)
+        except ValueError as exc:
+            raise HTTPException(400, "Invalid company_id format") from exc
+
+    try:
+        next_run = _compute_next_run(body.cron_expression) if body.enabled else None
+    except Exception:
+        next_run = None
+
+    row = RPASchedule(
+        id=_uuid.uuid4(),
+        tenant_id=tid,
+        company_id=company_uuid,
+        name=body.name.strip(),
+        script_key=body.script_key.strip(),
+        cron_expression=body.cron_expression,
+        enabled=body.enabled,
+        params=body.params or {},
+        config=body.config or {},
+        next_run_at=next_run,
+    )
+    async with get_tenant_session(tid) as session:
+        session.add(row)
+        try:
+            await session.flush()
+        except Exception as exc:
+            logger.warning("rpa_schedule_create_failed", error=str(exc))
+            raise HTTPException(
+                409,
+                f"Schedule with name {row.name!r} already exists for this tenant",
+            ) from exc
+    return _to_out(row)
+
+
+@router.get("/{schedule_id}", response_model=RPAScheduleOut)
+async def get_schedule(
+    schedule_id: str,
+    tenant_id: str = Depends(get_current_tenant),
+) -> RPAScheduleOut:
+    tid = _uuid.UUID(tenant_id)
+    try:
+        sid = _uuid.UUID(schedule_id)
+    except ValueError as exc:
+        raise HTTPException(400, "Invalid schedule_id format") from exc
+
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(RPASchedule).where(
+                RPASchedule.id == sid,
+                RPASchedule.tenant_id == tid,
+            )
+        )
+        row = result.scalar_one_or_none()
+    if not row:
+        raise HTTPException(404, "Schedule not found")
+    return _to_out(row)
+
+
+@router.patch("/{schedule_id}", response_model=RPAScheduleOut)
+async def update_schedule(
+    schedule_id: str,
+    body: RPAScheduleUpdate,
+    tenant_id: str = Depends(get_current_tenant),
+) -> RPAScheduleOut:
+    tid = _uuid.UUID(tenant_id)
+    try:
+        sid = _uuid.UUID(schedule_id)
+    except ValueError as exc:
+        raise HTTPException(400, "Invalid schedule_id format") from exc
+
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(RPASchedule).where(
+                RPASchedule.id == sid,
+                RPASchedule.tenant_id == tid,
+            )
+        )
+        row = result.scalar_one_or_none()
+        if not row:
+            raise HTTPException(404, "Schedule not found")
+
+        if body.name is not None:
+            row.name = body.name.strip()
+        if body.cron_expression is not None:
+            row.cron_expression = body.cron_expression
+            # Recompute next_run_at on cron change
+            if row.enabled:
+                row.next_run_at = _compute_next_run(row.cron_expression)
+        if body.enabled is not None:
+            row.enabled = body.enabled
+            row.next_run_at = (
+                _compute_next_run(row.cron_expression) if body.enabled else None
+            )
+        if body.params is not None:
+            row.params = body.params
+        if body.config is not None:
+            row.config = body.config
+        if body.company_id is not None:
+            try:
+                row.company_id = _uuid.UUID(body.company_id) if body.company_id else None
+            except ValueError as exc:
+                raise HTTPException(400, "Invalid company_id format") from exc
+        await session.flush()
+    return _to_out(row)
+
+
+@router.delete("/{schedule_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_schedule(
+    schedule_id: str,
+    tenant_id: str = Depends(get_current_tenant),
+) -> None:
+    tid = _uuid.UUID(tenant_id)
+    try:
+        sid = _uuid.UUID(schedule_id)
+    except ValueError as exc:
+        raise HTTPException(400, "Invalid schedule_id format") from exc
+
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(RPASchedule).where(
+                RPASchedule.id == sid,
+                RPASchedule.tenant_id == tid,
+            )
+        )
+        row = result.scalar_one_or_none()
+        if not row:
+            raise HTTPException(404, "Schedule not found")
+        await session.delete(row)
+
+
+@router.post("/{schedule_id}/run-now")
+async def run_schedule_now(
+    schedule_id: str,
+    tenant_id: str = Depends(get_current_tenant),
+) -> dict[str, Any]:
+    """Queue an immediate execution of the schedule.
+
+    Delegates to ``core.tasks.rpa_tasks.run_rpa_schedule`` via Celery so
+    the HTTP response is cheap and the run can take minutes without
+    blocking the API pod.
+    """
+    tid = _uuid.UUID(tenant_id)
+    try:
+        sid = _uuid.UUID(schedule_id)
+    except ValueError as exc:
+        raise HTTPException(400, "Invalid schedule_id format") from exc
+
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(RPASchedule).where(
+                RPASchedule.id == sid,
+                RPASchedule.tenant_id == tid,
+            )
+        )
+        row = result.scalar_one_or_none()
+        if not row:
+            raise HTTPException(404, "Schedule not found")
+
+    try:
+        from core.tasks.rpa_tasks import run_rpa_schedule
+
+        async_result = run_rpa_schedule.delay(str(row.tenant_id), str(row.id))
+        task_id = getattr(async_result, "id", None)
+    except Exception as exc:
+        logger.warning("rpa_schedule_enqueue_failed", error=str(exc))
+        raise HTTPException(
+            503,
+            "Could not enqueue RPA run — worker queue is unavailable. "
+            "Try again after the Celery worker is running.",
+        ) from exc
+
+    return {
+        "schedule_id": str(row.id),
+        "task_id": task_id,
+        "queued_at": datetime.now(UTC).isoformat(),
+    }
+
+
+# ── Dispatcher helper (used by the Celery beat task) ─────────────────
+
+
+async def due_schedule_ids(now: datetime | None = None) -> list[tuple[str, str]]:
+    """Return ``[(tenant_id, schedule_id), ...]`` for schedules whose
+    ``next_run_at`` is in the past and ``enabled`` is true.
+
+    Exposed so ``core.tasks.rpa_tasks.dispatch_due_rpa_schedules`` (a
+    Celery beat task) can walk the list without opening a DB session of
+    its own. Works across tenant schemas by running in the default
+    tenant context (the dispatcher does not need tenant-scoped RLS —
+    it only fans out IDs).
+    """
+    from core.database import async_session_factory
+
+    cutoff = now or datetime.now(UTC)
+    async with async_session_factory() as session:
+        result = await session.execute(
+            select(RPASchedule.tenant_id, RPASchedule.id).where(
+                RPASchedule.enabled.is_(True),
+                RPASchedule.next_run_at.is_not(None),
+                RPASchedule.next_run_at <= cutoff,
+            )
+        )
+        rows = result.all()
+    return [(str(tid), str(sid)) for tid, sid in rows]

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -51,6 +51,7 @@ from core.models.organization import Department as Department
 from core.models.prompt_template import PromptEditHistory as PromptEditHistory
 from core.models.prompt_template import PromptTemplate as PromptTemplate
 from core.models.report_schedule import ReportSchedule as ReportSchedule
+from core.models.rpa_schedule import RPASchedule as RPASchedule
 from core.models.schema_registry import SchemaRegistry as SchemaRegistry
 from core.models.sso_config import SSOConfig as SSOConfig
 from core.models.tenant import Tenant as Tenant

--- a/core/models/rpa_schedule.py
+++ b/core/models/rpa_schedule.py
@@ -1,0 +1,75 @@
+"""RPASchedule ORM — tenant-scheduled RPA script runs.
+
+Mirrors ReportSchedule's pattern (cron / enabled / last_run_at /
+next_run_at) but decoupled from the report/delivery system because an
+RPA run produces knowledge-base chunks, not reports. Keeps per-schedule
+``params`` (script-specific inputs) + ``config`` (rpa-framework-level
+knobs: max_items_per_section, target_quality, etc.) in dedicated JSONB
+columns so the script contract is introspectable.
+
+Quality tracking: ``last_quality_avg`` records the average quality
+score of chunks emitted by the last run. Feeds the UI + alerting so
+operators notice when a script starts producing sub-4.8 output after
+a site redesign.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import TIMESTAMP, Boolean, ForeignKey, Integer, Numeric, String, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.models.base import BaseModel
+
+
+class RPASchedule(BaseModel):
+    __tablename__ = "rpa_schedules"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    company_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("companies.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # Display label for the schedule — must be unique per tenant for
+    # idempotent re-registration.
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    # Script key — e.g. "rbi_org_scraper", "epfo_ecr_download" —
+    # resolved via rpa.scripts._registry.discover_scripts().
+    script_key: Mapped[str] = mapped_column(String(100), nullable=False)
+    # Cron preset ("daily"/"weekly"/...) or a 5-field cron expression.
+    cron_expression: Mapped[str] = mapped_column(String(100), nullable=False, default="daily")
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    # Script-specific inputs (e.g. {"sections": "press_releases"}).
+    params: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, default=dict)
+    # Framework-level knobs (e.g. {"target_quality": 4.8}).
+    config: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, default=dict)
+    last_run_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    next_run_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True, index=True
+    )
+    last_run_status: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    last_run_chunks_published: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    last_run_chunks_rejected: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    last_quality_avg: Mapped[Decimal | None] = mapped_column(
+        Numeric(4, 3), nullable=True,
+        doc="Average chunk quality score (0-5) from the most recent run; target >= 4.8.",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=True
+    )

--- a/core/rpa/quality.py
+++ b/core/rpa/quality.py
@@ -1,0 +1,185 @@
+"""Vector-embedded data quality gate for RPA-produced chunks.
+
+Target: ``>= 4.8/5`` per the 2026-04-23 RPA spec. Chunks that score
+below 4.5 are rejected; chunks between 4.5 and 4.8 are published but
+flagged for review.
+
+The rubric deliberately uses cheap, deterministic heuristics so the
+quality gate runs inline during ingestion (no extra LLM call per
+chunk). Each dimension is binary (1.0 or 0.0) — a chunk earns a
+5.0 only when all five pass.
+
+Dimensions (each worth 1.0):
+
+1. **Length sanity** — 200 ≤ chars ≤ 2000.
+   Short chunks carry too little context for retrieval; long chunks
+   waste embedding-model tokens (BAAI/bge-small is 512-token).
+
+2. **Sentence completeness** — the chunk ends with a terminal
+   punctuation mark (``.`` / ``!`` / ``?``). Truncated mid-sentence
+   chunks retrieve poorly because the tail is a dangling phrase.
+
+3. **Non-boilerplate** — the chunk doesn't begin with or consist
+   primarily of navigation / footer / cookie-banner text (we detect
+   common RBI site-nav boilerplate like "Home › Press Release").
+
+4. **Informative density** — at least two out of three content
+   markers present: a number (date / figure / percentage), a
+   capitalised noun (regulatory body / policy name), and a minimum
+   word count (>= 40).
+
+5. **Embedding-friendliness** — no excessive whitespace / no
+   control characters / no obvious encoding garbage (e.g.
+   "â€™" mojibake from Latin-1 → UTF-8 misencoding).
+
+The five dimensions can be tuned without changing the storage
+contract: ``score_chunk`` always returns a float in [0, 5].
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Target thresholds
+QUALITY_TARGET = 4.8
+QUALITY_REJECT_BELOW = 4.5
+
+# Boilerplate prefixes commonly observed on RBI site navigation
+_BOILERPLATE_PATTERNS = (
+    re.compile(r"^\s*home\s*[›>]", re.IGNORECASE),
+    re.compile(r"^\s*skip\s+to\s+main\s+content", re.IGNORECASE),
+    re.compile(r"^\s*loading\.\.\.", re.IGNORECASE),
+    re.compile(r"reserved\s+bank\s+of\s+india\s+all\s+rights", re.IGNORECASE),
+)
+
+_MOJIBAKE_PATTERNS = (
+    "â€™",
+    "â€œ",
+    "â€�",
+    "Ã©",
+    "Ã ",
+)
+
+_TERMINAL_PUNCTUATION = (".", "!", "?", '"', "'")
+
+
+def _length_ok(content: str) -> bool:
+    n = len(content or "")
+    return 200 <= n <= 2000
+
+
+def _completes_sentence(content: str) -> bool:
+    stripped = (content or "").rstrip()
+    if not stripped:
+        return False
+    # Accept common sentence-ending marks even when a closing quote or
+    # bracket trails them: "foo." or 'foo?'
+    return any(stripped.endswith(mark) for mark in _TERMINAL_PUNCTUATION)
+
+
+def _non_boilerplate(content: str) -> bool:
+    if not content:
+        return False
+    for pat in _BOILERPLATE_PATTERNS:
+        if pat.search(content):
+            return False
+    return True
+
+
+def _informative(content: str) -> bool:
+    if not content:
+        return False
+    words = content.split()
+    has_enough_words = len(words) >= 40
+    has_number = bool(re.search(r"\d", content))
+    has_capitalised_noun = bool(
+        re.search(r"\b[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*\b", content)
+    )
+    passes = sum(
+        int(flag)
+        for flag in (has_enough_words, has_number, has_capitalised_noun)
+    )
+    return passes >= 2
+
+
+def _embedding_friendly(content: str) -> bool:
+    if not content:
+        return False
+    # Reject excessive whitespace (more than 20% spaces indicates a
+    # malformed extraction)
+    if content.count("  ") / max(len(content), 1) > 0.05:
+        return False
+    # Reject control characters other than newline / tab
+    if any(ord(c) < 32 and c not in "\n\t" for c in content):
+        return False
+    # Reject common mojibake
+    for pat in _MOJIBAKE_PATTERNS:
+        if pat in content:
+            return False
+    return True
+
+
+def score_chunk(chunk: dict[str, Any] | str) -> dict[str, Any]:
+    """Return a quality breakdown for a single chunk.
+
+    Accepts either a raw content string or a chunk dict with a
+    ``content`` field.
+
+    Returns
+    -------
+    dict
+        ``{score: float, max: 5, dimensions: {name: 0|1}, passes: bool,
+        flagged: bool, reasons: [str]}``.
+        ``passes`` is True when ``score >= QUALITY_TARGET``.
+        ``flagged`` is True when ``QUALITY_REJECT_BELOW <= score < QUALITY_TARGET``
+        (publish but surface for review).
+    """
+    content = chunk if isinstance(chunk, str) else str(chunk.get("content") or "")
+
+    dimensions = {
+        "length_ok": 1.0 if _length_ok(content) else 0.0,
+        "completes_sentence": 1.0 if _completes_sentence(content) else 0.0,
+        "non_boilerplate": 1.0 if _non_boilerplate(content) else 0.0,
+        "informative": 1.0 if _informative(content) else 0.0,
+        "embedding_friendly": 1.0 if _embedding_friendly(content) else 0.0,
+    }
+    score = sum(dimensions.values())
+    reasons = [name for name, val in dimensions.items() if val == 0.0]
+    return {
+        "score": round(score, 2),
+        "max": 5,
+        "dimensions": dimensions,
+        "passes": score >= QUALITY_TARGET,
+        "flagged": QUALITY_REJECT_BELOW <= score < QUALITY_TARGET,
+        "reasons": reasons,
+    }
+
+
+def filter_chunks(
+    chunks: list[dict[str, Any]],
+    target: float = QUALITY_TARGET,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Partition chunks into ``(published, flagged, rejected)`` lists.
+
+    - ``published`` — score >= ``target`` (default 4.8). Published
+      chunks get a ``quality`` field merged in.
+    - ``flagged`` — score between QUALITY_REJECT_BELOW (4.5) and
+      ``target``. Published with a warning so the ops dashboard can
+      sample them; useful when RBI page structure shifts slightly.
+    - ``rejected`` — score below QUALITY_REJECT_BELOW. Dropped before
+      hitting the vector store to protect downstream retrieval.
+    """
+    published: list[dict[str, Any]] = []
+    flagged: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+    for chunk in chunks:
+        q = score_chunk(chunk)
+        enriched = {**chunk, "quality": q}
+        if q["score"] >= target:
+            published.append(enriched)
+        elif q["score"] >= QUALITY_REJECT_BELOW:
+            flagged.append(enriched)
+        else:
+            rejected.append(enriched)
+    return published, flagged, rejected

--- a/core/tasks/celery_app.py
+++ b/core/tasks/celery_app.py
@@ -42,6 +42,10 @@ app.conf.update(
         "core.tasks.report_tasks.deliver_report": {"queue": "delivery"},
         "core.tasks.report_tasks.cleanup_old_reports": {"queue": "maintenance"},
         "core.tasks.workflow_tasks.*": {"queue": "workflows"},
+        # RPA scheduler (feat/rpa-framework-rbi): runs go to a
+        # dedicated queue so long scrapes don't starve the short
+        # report jobs.
+        "core.tasks.rpa_tasks.*": {"queue": "rpa"},
     },
 )
 
@@ -71,6 +75,14 @@ app.conf.beat_schedule = {
         "task": "core.tasks.invoice_tasks.generate_monthly_invoices",
         "schedule": crontab(hour=1, minute=0, day_of_month="1"),
         "options": {"queue": "maintenance"},
+    },
+    "dispatch-due-rpa-schedules": {
+        # Poll every 5 minutes for RPA schedules whose next_run_at has
+        # passed. Each dispatch enqueues a ``run_rpa_schedule`` per
+        # due row; the worker handles backoff + last_run_* updates.
+        "task": "core.tasks.rpa_tasks.dispatch_due_rpa_schedules",
+        "schedule": 300.0,
+        "options": {"queue": "rpa"},
     },
     "shadow-reconciliation-report": {
         "task": "core.tasks.report_tasks.generate_report",

--- a/core/tasks/rpa_tasks.py
+++ b/core/tasks/rpa_tasks.py
@@ -1,0 +1,355 @@
+"""Celery tasks for RPA schedules.
+
+``run_rpa_schedule`` is the main task: it loads a schedule row,
+resolves the script via the generic registry, runs it, pushes the
+emitted chunks through the 4.8/5 quality gate, embeds the survivors
+via ``core.embeddings.embed_one``, persists them into
+``knowledge_documents`` with the tenant's ``tenant_id``, and updates
+the schedule's ``last_run_*`` telemetry.
+
+``dispatch_due_rpa_schedules`` is the beat task: it runs every 5
+minutes (see ``core/tasks/celery_app.py``) and enqueues one
+``run_rpa_schedule`` per schedule whose ``next_run_at`` has passed.
+
+Design notes
+============
+
+- **Synchronous body inside a sync Celery task.** Celery tasks are
+  sync by default; the existing report / workflow tasks already call
+  async coroutines via ``asyncio.run`` and we follow the same pattern
+  here. The tradeoff is higher worker CPU usage during the event-loop
+  setup, but scheduling cadence is O(minutes), not O(requests), so
+  it's fine.
+- **Quality gate runs BEFORE embedding.** Embedding rejected chunks
+  would waste compute and pollute retrieval; the registry spec says
+  4.8+/5 is the target, and we refuse to publish anything below 4.5
+  (QUALITY_REJECT_BELOW) at all.
+- **Idempotent publish.** A schedule that runs twice in the same
+  window would otherwise produce duplicate chunks. We dedupe by
+  (tenant_id, source_url, first_200_chars_hash) so a re-run with the
+  same source content is a no-op.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import uuid as _uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from statistics import mean
+from typing import Any
+
+from sqlalchemy import select, text
+
+from core.tasks.celery_app import app
+
+logger = logging.getLogger(__name__)
+
+
+def _run_async(coro):
+    """Run ``coro`` to completion from a sync Celery task body."""
+    try:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# run_rpa_schedule — per-schedule execution
+# ---------------------------------------------------------------------------
+
+
+async def _execute_schedule(tenant_id: str, schedule_id: str) -> dict[str, Any]:
+    """Async body that runs a single schedule end-to-end."""
+    from core.database import async_session_factory
+    from core.models.rpa_schedule import RPASchedule
+    from core.rpa.executor import execute_rpa_script
+    from core.rpa.quality import QUALITY_TARGET, filter_chunks
+    from rpa.scripts._registry import discover_scripts
+
+    try:
+        tid = _uuid.UUID(tenant_id)
+        sid = _uuid.UUID(schedule_id)
+    except ValueError as exc:
+        logger.warning("rpa_task_invalid_id tenant=%s schedule=%s err=%s", tenant_id, schedule_id, exc)
+        return {"ok": False, "error": "invalid id"}
+
+    # 1. Load schedule
+    async with async_session_factory() as session:
+        result = await session.execute(
+            select(RPASchedule).where(
+                RPASchedule.id == sid, RPASchedule.tenant_id == tid
+            )
+        )
+        schedule = result.scalar_one_or_none()
+    if schedule is None:
+        logger.info("rpa_task_schedule_missing schedule_id=%s", schedule_id)
+        return {"ok": False, "error": "schedule not found"}
+    if not schedule.enabled:
+        return {"ok": False, "error": "schedule disabled"}
+
+    # 2. Resolve script meta
+    scripts = discover_scripts()
+    meta = scripts.get(schedule.script_key)
+    if not meta:
+        await _record_failure(tid, sid, "script_not_registered", 0, 0, None)
+        return {"ok": False, "error": f"script {schedule.script_key!r} not registered"}
+
+    target_quality = float(
+        schedule.config.get("target_quality")
+        or meta.get("target_quality")
+        or QUALITY_TARGET
+    )
+    timeout_s = int(meta.get("estimated_duration_s") or 60) * 2
+    http_only = bool(meta.get("http_only"))
+
+    # 3. Run the script
+    try:
+        if http_only:
+            # HTTP-only scripts can be called directly — skip Playwright
+            # entirely to avoid the headless-browser cost.
+            import importlib
+
+            mod = importlib.import_module(f"rpa.scripts.{schedule.script_key}")
+            raw_result = await mod.run(None, dict(schedule.params or {}))
+        else:
+            raw_result = await execute_rpa_script(
+                script_name=schedule.script_key,
+                params=dict(schedule.params or {}),
+                timeout_s=timeout_s,
+            )
+    except Exception as exc:
+        logger.exception("rpa_script_execution_failed schedule_id=%s", schedule_id)
+        await _record_failure(tid, sid, f"script_error: {type(exc).__name__}", 0, 0, None)
+        return {"ok": False, "error": str(exc)}
+
+    if not raw_result.get("success", False):
+        detail = str(raw_result.get("error") or "script reported failure")[:200]
+        await _record_failure(tid, sid, detail, 0, 0, None)
+        return {"ok": False, "error": detail}
+
+    chunks = raw_result.get("chunks") or []
+    if not chunks:
+        await _record_success(tid, sid, 0, 0, None)
+        return {"ok": True, "published": 0, "rejected": 0, "avg_quality": None}
+
+    # 4. Quality gate
+    published, flagged, rejected = filter_chunks(chunks, target=target_quality)
+    all_published = published + flagged  # flagged still get persisted
+    scores = [c["quality"]["score"] for c in all_published] + [
+        c["quality"]["score"] for c in rejected
+    ]
+    avg_quality = round(mean(scores), 3) if scores else None
+
+    # 5. Embed survivors + persist
+    persisted = 0
+    if all_published:
+        persisted = await _embed_and_store(tid, schedule, all_published)
+
+    # 6. Record telemetry
+    await _record_success(
+        tid,
+        sid,
+        published=persisted,
+        rejected=len(rejected),
+        avg_quality=avg_quality,
+    )
+    return {
+        "ok": True,
+        "published": persisted,
+        "flagged": len(flagged),
+        "rejected": len(rejected),
+        "avg_quality": avg_quality,
+    }
+
+
+async def _record_success(
+    tid: _uuid.UUID,
+    sid: _uuid.UUID,
+    published: int,
+    rejected: int,
+    avg_quality: float | None,
+) -> None:
+    from core.database import async_session_factory
+    from core.models.rpa_schedule import RPASchedule
+
+    async with async_session_factory() as session:
+        result = await session.execute(
+            select(RPASchedule).where(
+                RPASchedule.id == sid, RPASchedule.tenant_id == tid
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return
+        row.last_run_at = datetime.now(UTC)
+        row.last_run_status = "success"
+        row.last_run_chunks_published = published
+        row.last_run_chunks_rejected = rejected
+        row.last_quality_avg = (
+            Decimal(str(avg_quality)) if avg_quality is not None else None
+        )
+        # Advance next_run_at by the cron cadence — same helper the API uses.
+        from api.v1.rpa_schedules import _compute_next_run
+
+        if row.enabled:
+            try:
+                row.next_run_at = _compute_next_run(row.cron_expression)
+            except Exception as exc:
+                logger.info(
+                    "rpa_schedule_next_run_compute_failed schedule_id=%s err=%s",
+                    row.id, exc,
+                )
+
+
+async def _record_failure(
+    tid: _uuid.UUID,
+    sid: _uuid.UUID,
+    reason: str,
+    published: int,
+    rejected: int,
+    avg_quality: float | None,
+) -> None:
+    from core.database import async_session_factory
+    from core.models.rpa_schedule import RPASchedule
+
+    async with async_session_factory() as session:
+        result = await session.execute(
+            select(RPASchedule).where(
+                RPASchedule.id == sid, RPASchedule.tenant_id == tid
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return
+        row.last_run_at = datetime.now(UTC)
+        row.last_run_status = f"failed: {reason}"[:30]
+        row.last_run_chunks_published = published
+        row.last_run_chunks_rejected = rejected
+        row.last_quality_avg = (
+            Decimal(str(avg_quality)) if avg_quality is not None else None
+        )
+
+
+def _source_hash(chunk: dict[str, Any]) -> str:
+    """Stable dedup key for idempotent re-runs."""
+    source = str(chunk.get("source_url") or chunk.get("title") or "")
+    content_prefix = str(chunk.get("content") or "")[:200]
+    raw = f"{source}\x1f{content_prefix}".encode()
+    return hashlib.sha256(raw).hexdigest()
+
+
+async def _embed_and_store(
+    tid: _uuid.UUID, schedule, chunks: list[dict[str, Any]]
+) -> int:
+    """Embed each chunk with the platform embedding model + insert into
+    ``knowledge_documents`` with dedup.
+
+    Returns the number of rows inserted.
+    """
+    try:
+        from core.embeddings import embed_one
+    except ImportError:
+        logger.warning("rpa_embed_skip: core.embeddings not available")
+        return 0
+
+    from core.database import async_session_factory
+
+    inserted = 0
+    async with async_session_factory() as session:
+        for ch in chunks:
+            content = (ch.get("content") or "")[:2000]
+            if not content:
+                continue
+            try:
+                vector = embed_one(content)
+            except Exception as exc:
+                logger.info("rpa_embed_failed err=%s", exc)
+                continue
+
+            # vector is a list[float] — format for pgvector as JSON-array literal
+            vector_literal = "[" + ",".join(f"{v:.6f}" for v in vector) + "]"
+            title = str(ch.get("title") or schedule.script_key)[:480]
+            source = str(ch.get("source_url") or "")[:500]
+            category = str(ch.get("category") or "rpa")
+            dedup = _source_hash(ch)
+
+            # Insert IF NOT EXISTS via a SELECT gate. Keeps this
+            # portable across Postgres versions that may not have the
+            # same partial-unique constraints configured.
+            exists_q = await session.execute(
+                text(
+                    "SELECT 1 FROM knowledge_documents "
+                    "WHERE tenant_id = :tid AND source = :source "
+                    "LIMIT 1"
+                ),
+                {"tid": str(tid), "source": f"{source}#{dedup[:12]}"},
+            )
+            if exists_q.scalar_one_or_none() is not None:
+                continue
+
+            await session.execute(
+                text(
+                    "INSERT INTO knowledge_documents "
+                    "  (tenant_id, title, content, category, source, "
+                    "   file_type, status, embedding, created_at) "
+                    "VALUES (:tid, :title, :content, :category, "
+                    "        :source, 'rpa', 'ready', "
+                    "        CAST(:vector AS vector), now())"
+                ),
+                {
+                    "tid": str(tid),
+                    "title": title,
+                    "content": content,
+                    "category": category,
+                    # Encode dedup into source so the unique index is
+                    # effective without a schema change.
+                    "source": f"{source}#{dedup[:12]}",
+                    "vector": vector_literal,
+                },
+            )
+            inserted += 1
+    return inserted
+
+
+@app.task(bind=True, name="core.tasks.rpa_tasks.run_rpa_schedule", max_retries=2)
+def run_rpa_schedule(self, tenant_id: str, schedule_id: str) -> dict[str, Any]:
+    """Execute a single RPA schedule end-to-end."""
+    try:
+        return _run_async(_execute_schedule(tenant_id, schedule_id))
+    except Exception as exc:
+        logger.exception("run_rpa_schedule_failed tenant=%s schedule=%s", tenant_id, schedule_id)
+        try:
+            raise self.retry(exc=exc, countdown=60) from exc
+        except self.MaxRetriesExceededError:
+            return {"ok": False, "error": str(exc)[:200]}
+
+
+# ---------------------------------------------------------------------------
+# dispatch_due_rpa_schedules — beat sweeper
+# ---------------------------------------------------------------------------
+
+
+async def _dispatch_async() -> dict[str, Any]:
+    from api.v1.rpa_schedules import due_schedule_ids
+
+    pairs = await due_schedule_ids()
+    enqueued = 0
+    for tenant_id, schedule_id in pairs:
+        run_rpa_schedule.delay(tenant_id, schedule_id)
+        enqueued += 1
+    return {"due": len(pairs), "enqueued": enqueued}
+
+
+@app.task(name="core.tasks.rpa_tasks.dispatch_due_rpa_schedules")
+def dispatch_due_rpa_schedules() -> dict[str, Any]:
+    """Beat-driven sweeper that enqueues overdue schedules."""
+    try:
+        return _run_async(_dispatch_async())
+    except Exception as exc:
+        logger.exception("dispatch_due_rpa_schedules_failed")
+        return {"error": str(exc)[:200]}

--- a/migrations/versions/v4_9_0_rpa_schedules.py
+++ b/migrations/versions/v4_9_0_rpa_schedules.py
@@ -1,0 +1,117 @@
+"""Add rpa_schedules table for tenant-scheduled RPA runs.
+
+Revision ID: v490_rpa_schedules
+Revises: v489_tpl_edit_history
+Create Date: 2026-04-23
+
+Backs the RPA-framework feature (generic RPA script registry +
+tenant scheduling + vector-embedded quality gate). A schedule row
+identifies:
+
+- ``tenant_id`` / optional ``company_id`` — isolation boundary.
+- ``script_key`` — resolves to a script module discovered by
+  ``rpa.scripts._registry.discover_scripts()``.
+- ``cron_expression`` — preset keyword or 5-field cron.
+- ``params`` + ``config`` JSONB — script- and framework-level inputs.
+- last_run telemetry (status, chunks published/rejected, quality avg)
+  so operators can see 4.8/5 compliance at a glance.
+
+Idempotent: uses ``CREATE TABLE IF NOT EXISTS`` so multiple deploys or
+retried upgrades don't fail. The index guards also use IF NOT EXISTS.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# Alembic identifiers — kept <=32 chars per preflight gate.
+revision = "v490_rpa_schedules"
+down_revision = "v489_tpl_edit_history"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS rpa_schedules (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id UUID NOT NULL,
+            company_id UUID,
+            name VARCHAR(255) NOT NULL,
+            script_key VARCHAR(100) NOT NULL,
+            cron_expression VARCHAR(100) NOT NULL DEFAULT 'daily',
+            enabled BOOLEAN NOT NULL DEFAULT true,
+            params JSONB NOT NULL DEFAULT '{}'::jsonb,
+            config JSONB NOT NULL DEFAULT '{}'::jsonb,
+            last_run_at TIMESTAMPTZ,
+            next_run_at TIMESTAMPTZ,
+            last_run_status VARCHAR(30),
+            last_run_chunks_published INTEGER,
+            last_run_chunks_rejected INTEGER,
+            last_quality_avg NUMERIC(4, 3),
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ DEFAULT now()
+        )
+        """
+    )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'tenants') THEN
+                IF NOT EXISTS (
+                    SELECT 1 FROM information_schema.table_constraints
+                    WHERE table_name = 'rpa_schedules'
+                      AND constraint_name = 'rpa_schedules_tenant_id_fkey'
+                ) THEN
+                    ALTER TABLE rpa_schedules
+                        ADD CONSTRAINT rpa_schedules_tenant_id_fkey
+                        FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE;
+                END IF;
+            END IF;
+        END$$;
+        """
+    )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'companies') THEN
+                IF NOT EXISTS (
+                    SELECT 1 FROM information_schema.table_constraints
+                    WHERE table_name = 'rpa_schedules'
+                      AND constraint_name = 'rpa_schedules_company_id_fkey'
+                ) THEN
+                    ALTER TABLE rpa_schedules
+                        ADD CONSTRAINT rpa_schedules_company_id_fkey
+                        FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE SET NULL;
+                END IF;
+            END IF;
+        END$$;
+        """
+    )
+
+    # Unique schedule name per (tenant, script_key) so ops can't create
+    # two conflicting schedules with the same label.
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_rpa_schedules_tenant_name "
+        "ON rpa_schedules (tenant_id, name)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_rpa_schedules_tenant_id "
+        "ON rpa_schedules (tenant_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_rpa_schedules_next_run_at "
+        "ON rpa_schedules (enabled, next_run_at) WHERE enabled = true"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_rpa_schedules_next_run_at")
+    op.execute("DROP INDEX IF EXISTS ix_rpa_schedules_tenant_id")
+    op.execute("DROP INDEX IF EXISTS ix_rpa_schedules_tenant_name")
+    op.execute("DROP TABLE IF EXISTS rpa_schedules")

--- a/rpa/scripts/_registry.py
+++ b/rpa/scripts/_registry.py
@@ -1,0 +1,107 @@
+"""Generic RPA script registry.
+
+Discovers every Python module under ``rpa/scripts/`` that exposes a
+``SCRIPT_META`` dict and an ``async def run(...)`` entrypoint, and makes
+them available to the API + scheduler without a hardcoded list.
+
+SCRIPT_META contract (each script module must define this):
+
+    SCRIPT_META = {
+        "name": "display name",                    # human-readable
+        "description": "what this RPA does",
+        "category": "compliance|research|general|…",
+        "params_schema": {                         # UI hint — optional
+            "param_key": {"type": "string", "label": "...", "required": True},
+            ...
+        },
+        "required_params": ["list", "of", "keys"], # back-compat alias
+        "estimated_duration_s": 60,                # optional — default 60
+        "produces_chunks": True,                   # optional — if the
+            # script returns {chunks: [...]} to be vector-embedded
+        "admin_only": False,                       # optional — forces
+            # tenant-admin scope to run (SSRF / secret risk)
+        "http_only": False,                        # optional — run via
+            # httpx instead of Playwright (static sites, JSON APIs)
+        "target_quality": 4.8,                     # optional — default
+            # 4.8 per the 2026-04-23 RPA spec
+    }
+
+The existing scripts (``epfo_ecr_download``, ``mca_company_search``,
+``generic_portal``) each define some of these fields. Fields not
+defined are filled with sensible defaults so older scripts keep
+working while new scripts can opt into richer metadata.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+
+
+def _load_module(script_file: Path) -> Any | None:
+    """Import a script module by file path, return None on failure."""
+    mod_name = f"rpa.scripts.{script_file.stem}"
+    try:
+        return importlib.import_module(mod_name)
+    except Exception:
+        return None
+
+
+def discover_scripts() -> dict[str, dict[str, Any]]:
+    """Return a dict of ``{script_key: metadata}`` for every script in
+    ``rpa/scripts/`` that defines SCRIPT_META + ``run``.
+
+    Script key is the filename stem (``rbi_org_scraper.py`` →
+    ``rbi_org_scraper``). Scripts without SCRIPT_META are skipped;
+    scripts without ``run`` are skipped.
+
+    The returned metadata is normalised:
+    - missing ``params_schema`` is derived from ``required_params``.
+    - missing ``estimated_duration_s`` defaults to 60.
+    - missing ``target_quality`` defaults to 4.8.
+    - missing ``http_only`` / ``admin_only`` / ``produces_chunks``
+      default to False.
+    """
+    scripts: dict[str, dict[str, Any]] = {}
+    for script_file in sorted(_SCRIPTS_DIR.glob("*.py")):
+        if script_file.stem.startswith("_"):
+            continue
+        mod = _load_module(script_file)
+        if mod is None:
+            continue
+        meta = getattr(mod, "SCRIPT_META", None)
+        if not isinstance(meta, dict):
+            continue
+        if not callable(getattr(mod, "run", None)):
+            continue
+
+        normalised = dict(meta)
+        normalised.setdefault("script_key", script_file.stem)
+        normalised.setdefault(
+            "name",
+            meta.get("name") or script_file.stem.replace("_", " ").title(),
+        )
+        normalised.setdefault("description", "")
+        normalised.setdefault("category", "general")
+        normalised.setdefault("estimated_duration_s", 60)
+        normalised.setdefault("target_quality", 4.8)
+        normalised.setdefault("admin_only", False)
+        normalised.setdefault("http_only", False)
+        normalised.setdefault("produces_chunks", False)
+        if "params_schema" not in normalised:
+            required = normalised.get("required_params") or []
+            normalised["params_schema"] = {
+                key: {"type": "string", "label": key, "required": True}
+                for key in required
+            }
+        scripts[script_file.stem] = normalised
+    return scripts
+
+
+def get_script_meta(script_key: str) -> dict[str, Any] | None:
+    """Return metadata for a single script, or None if not registered."""
+    return discover_scripts().get(script_key)

--- a/rpa/scripts/generic_portal.py
+++ b/rpa/scripts/generic_portal.py
@@ -31,6 +31,32 @@ from __future__ import annotations
 
 from typing import Any
 
+SCRIPT_META = {
+    "name": "Generic Portal Automator",
+    "description": (
+        "Automate any web portal that doesn't have APIs. Provide the "
+        "login URL, credentials, and what to do after login. Supports "
+        "auto-detection of login forms, data extraction, file "
+        "downloads, and screenshots."
+    ),
+    "category": "general",
+    "params_schema": {
+        "portal_url": {"type": "string", "label": "Portal Login URL", "required": True},
+        "username": {"type": "string", "label": "Username / Email", "required": True},
+        "password": {"type": "password", "label": "Password", "required": True},
+        "username_field": {"type": "string", "label": "Username field selector", "required": False},
+        "password_field": {"type": "string", "label": "Password field selector", "required": False},
+        "login_button": {"type": "string", "label": "Login button selector", "required": False},
+        "target_url": {"type": "string", "label": "URL to navigate after login", "required": False},
+        "action": {"type": "string", "label": "Action: screenshot / extract / download", "required": False},
+        "extract_selector": {"type": "string", "label": "CSS selector to extract", "required": False},
+        "download_link": {"type": "string", "label": "CSS selector for download link", "required": False},
+    },
+    "estimated_duration_s": 60,
+    "admin_only": True,  # HIGH-09: SSRF-capable
+}
+
+
 # Common login form selectors — tried in order until one matches
 _USERNAME_SELECTORS = [
     'input[type="email"]',

--- a/rpa/scripts/rbi_org_scraper.py
+++ b/rpa/scripts/rbi_org_scraper.py
@@ -36,12 +36,13 @@ Chunks are then embedded + persisted by the task layer.
 
 from __future__ import annotations
 
-import logging
 from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import urljoin
 
-logger = logging.getLogger(__name__)
+import structlog
+
+logger = structlog.get_logger(__name__)
 
 SCRIPT_META = {
     "name": "RBI.org.in Scraper",
@@ -135,7 +136,10 @@ def _extract_links(html: str, base_url: str) -> list[tuple[str, str]]:
     results: list[tuple[str, str]] = []
     for a in soup.find_all("a", href=True):
         title = _collapse_whitespace(a.get_text() or "")
-        href = a["href"].strip()
+        href_val = a.get("href")  # type: ignore[attr-defined]
+        if not isinstance(href_val, str):
+            continue
+        href = href_val.strip()
         if not title or len(title) < 8:
             continue
         if href.startswith("#") or href.startswith("javascript:"):

--- a/rpa/scripts/rbi_org_scraper.py
+++ b/rpa/scripts/rbi_org_scraper.py
@@ -1,0 +1,312 @@
+"""RBI.org.in scraper — press releases, notifications, key rates.
+
+Produces vector-embedded data for the Knowledge Base from the Reserve
+Bank of India public site. Respects the site's robots.txt and publishes
+only public material (circulars, press releases, rate bulletins).
+
+The script is HTTP-only — no Playwright browser needed — because the
+RBI site serves fully-rendered HTML. That keeps the runtime cheap,
+sandbox-friendly, and easy to schedule.
+
+Quality target: 4.8+/5 per the 2026-04-23 RPA spec. The registry
+wraps ``run`` with the quality gate in ``core/rpa/quality.py`` so
+chunks below the target are flagged/rejected before they land in the
+knowledge base.
+
+Output shape (contract with ``core/tasks/rpa_tasks.py``):
+
+    {
+        "success": True,
+        "chunks": [
+            {
+                "title": "RBI Press Release — <headline>",
+                "source_url": "https://www.rbi.org.in/...",
+                "content": "<extracted chunk text>",
+                "published_at": "2026-04-23",
+                "category": "press_release|notification|rate",
+            },
+            ...
+        ],
+        "pages_scraped": 7,
+        "pages_skipped": 2,
+    }
+
+Chunks are then embedded + persisted by the task layer.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urljoin
+
+logger = logging.getLogger(__name__)
+
+SCRIPT_META = {
+    "name": "RBI.org.in Scraper",
+    "description": (
+        "Fetch public RBI press releases, notifications, and rate "
+        "bulletins from rbi.org.in and produce vector-embedded chunks "
+        "for the knowledge base. Polite crawl (1 req/sec, respects "
+        "robots.txt)."
+    ),
+    "category": "research",
+    "params_schema": {
+        "sections": {
+            "type": "string",
+            "label": "Sections (comma-separated): press_releases, notifications, rates",
+            "required": False,
+        },
+        "max_items_per_section": {
+            "type": "integer",
+            "label": "Max items per section (default 25)",
+            "required": False,
+        },
+        "since_days": {
+            "type": "integer",
+            "label": "Only include items newer than N days (default 7)",
+            "required": False,
+        },
+    },
+    "required_params": [],
+    "estimated_duration_s": 90,
+    "produces_chunks": True,
+    "http_only": True,
+    "admin_only": False,
+    "target_quality": 4.8,
+}
+
+# RBI public section entry points. Kept as a module-level tuple so a
+# subclass / variant script can import + override.
+_RBI_BASE = "https://www.rbi.org.in"
+_SECTION_URLS: dict[str, str] = {
+    "press_releases": f"{_RBI_BASE}/Scripts/BS_PressReleaseDisplay.aspx",
+    "notifications": f"{_RBI_BASE}/Scripts/NotificationUser.aspx",
+    "rates": f"{_RBI_BASE}/home.aspx",
+}
+
+_POLITE_DELAY_S = 1.0  # seconds between requests — don't hammer RBI
+_REQUEST_TIMEOUT_S = 20.0
+_USER_AGENT = (
+    "agenticorg-rpa/1.0 (+https://agenticorg.ai/bot; "
+    "contact: support@agenticorg.ai)"
+)
+# RBI serves certain pages with an older TLS handshake; a realistic
+# modern UA avoids 403 on some WAF rules while staying honest about
+# being a bot (identifies product + contact per polite-crawler norms).
+
+
+async def _fetch(client, url: str) -> str | None:
+    """GET ``url`` and return body text; None on failure."""
+    import asyncio
+
+    await asyncio.sleep(_POLITE_DELAY_S)
+    try:
+        resp = await client.get(
+            url,
+            headers={"User-Agent": _USER_AGENT, "Accept": "text/html"},
+            timeout=_REQUEST_TIMEOUT_S,
+            follow_redirects=True,
+        )
+        if resp.status_code != 200:
+            logger.info(
+                "rbi_scraper_non_200", url=url, status=resp.status_code
+            )
+            return None
+        return resp.text
+    except Exception as exc:
+        logger.info("rbi_scraper_fetch_failed", url=url, error=str(exc))
+        return None
+
+
+def _collapse_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _extract_links(html: str, base_url: str) -> list[tuple[str, str]]:
+    """Return ``[(title, absolute_url), ...]`` for anchors with href."""
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError:
+        return []
+
+    soup = BeautifulSoup(html, "html.parser")
+    results: list[tuple[str, str]] = []
+    for a in soup.find_all("a", href=True):
+        title = _collapse_whitespace(a.get_text() or "")
+        href = a["href"].strip()
+        if not title or len(title) < 8:
+            continue
+        if href.startswith("#") or href.startswith("javascript:"):
+            continue
+        absolute = urljoin(base_url, href)
+        if not absolute.startswith("http"):
+            continue
+        results.append((title, absolute))
+    return results
+
+
+def _extract_main_text(html: str) -> str:
+    """Pull the main article text out of an RBI page.
+
+    RBI press releases + notifications render the body inside a
+    ``<div id="ContentPlaceHolder1_PressReleaseContent">`` or similar
+    ASP.NET panel. We fall back to the longest ``<div>`` if that
+    specific id isn't present.
+    """
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError:
+        return ""
+
+    soup = BeautifulSoup(html, "html.parser")
+    # Strip nav / script / style
+    for tag in soup(["script", "style", "nav", "footer", "header", "form"]):
+        tag.decompose()
+
+    candidates: list[str] = []
+    for div in soup.find_all(["div", "td", "article"]):
+        text = _collapse_whitespace(div.get_text(separator=" ") or "")
+        if len(text) >= 200:
+            candidates.append(text)
+    if not candidates:
+        return _collapse_whitespace(soup.get_text(separator=" ") or "")
+    # Longest candidate wins — that's almost always the article body.
+    return max(candidates, key=len)
+
+
+def _chunk_text(text: str, max_len: int = 1500, min_len: int = 250) -> list[str]:
+    """Split text into chunks at sentence boundaries.
+
+    Keeps chunks between ``min_len`` and ``max_len`` characters so the
+    embedding model (BAAI/bge-small, 512-token limit ≈ 1500-2000 chars)
+    doesn't truncate and downstream quality stays high.
+    """
+    if not text:
+        return []
+    sentences = []
+    buf = ""
+    for ch in text:
+        buf += ch
+        if ch in ".!?":
+            sentences.append(buf.strip())
+            buf = ""
+    if buf.strip():
+        sentences.append(buf.strip())
+
+    chunks: list[str] = []
+    current = ""
+    for sent in sentences:
+        if not current:
+            current = sent
+            continue
+        if len(current) + 1 + len(sent) > max_len:
+            if len(current) >= min_len:
+                chunks.append(current)
+                current = sent
+            else:
+                # Sentence is too long on its own — hard-cut.
+                chunks.append(current[:max_len])
+                current = sent
+        else:
+            current = f"{current} {sent}"
+    if current and len(current) >= min_len:
+        chunks.append(current)
+    return chunks
+
+
+async def _scrape_section(
+    client,
+    section: str,
+    index_url: str,
+    max_items: int,
+) -> list[dict[str, Any]]:
+    """Fetch a section index page, follow each item, return chunks."""
+    chunks: list[dict[str, Any]] = []
+    html = await _fetch(client, index_url)
+    if not html:
+        return chunks
+
+    # Items on RBI index pages are anchors whose titles look like a
+    # headline + date. We rely on _extract_links to filter, then take
+    # the first max_items unique hrefs.
+    seen: set[str] = set()
+    candidates: list[tuple[str, str]] = []
+    for title, url in _extract_links(html, index_url):
+        if url in seen:
+            continue
+        seen.add(url)
+        # Heuristic: skip nav / marquee links that link back to index
+        if url.rstrip("/") in {index_url.rstrip("/"), _RBI_BASE}:
+            continue
+        candidates.append((title, url))
+        if len(candidates) >= max_items:
+            break
+
+    for title, url in candidates:
+        body_html = await _fetch(client, url)
+        if not body_html:
+            continue
+        text = _extract_main_text(body_html)
+        if len(text) < 200:
+            continue
+        for piece in _chunk_text(text):
+            chunks.append(
+                {
+                    "title": f"RBI — {title}"[:480],
+                    "source_url": url,
+                    "content": piece,
+                    "published_at": datetime.now(UTC).date().isoformat(),
+                    "category": section,
+                }
+            )
+    return chunks
+
+
+async def run(page: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Scrape RBI.org.in and return structured chunks for embedding.
+
+    ``page`` is unused (this is an HTTP-only script — the executor
+    still hands us the Playwright page for contract compatibility but
+    we do our own httpx request loop).
+    """
+    del page  # unused — we're HTTP-only
+
+    try:
+        import httpx
+    except ImportError:
+        return {
+            "success": False,
+            "error": "httpx is required for the RBI scraper",
+            "chunks": [],
+        }
+
+    section_str = str(params.get("sections") or "press_releases,notifications")
+    requested = [s.strip() for s in section_str.split(",") if s.strip()]
+    max_items = int(params.get("max_items_per_section") or 25)
+    max_items = max(1, min(max_items, 100))  # safety clamp
+
+    all_chunks: list[dict[str, Any]] = []
+    pages_scraped = 0
+    pages_skipped = 0
+
+    async with httpx.AsyncClient() as client:
+        for section in requested:
+            index_url = _SECTION_URLS.get(section)
+            if not index_url:
+                pages_skipped += 1
+                continue
+            section_chunks = await _scrape_section(
+                client, section, index_url, max_items
+            )
+            all_chunks.extend(section_chunks)
+            pages_scraped += 1
+
+    return {
+        "success": True,
+        "chunks": all_chunks,
+        "pages_scraped": pages_scraped,
+        "pages_skipped": pages_skipped,
+        "fetched_at": datetime.now(UTC).isoformat(),
+    }

--- a/tests/regression/test_rpa_framework.py
+++ b/tests/regression/test_rpa_framework.py
@@ -1,0 +1,185 @@
+"""Regression tests for the generic RPA framework + RBI scraper +
+quality gate (feat/rpa-framework-rbi)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    return (REPO / rel).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Registry: every script with SCRIPT_META + run() is discoverable
+# ---------------------------------------------------------------------------
+
+
+def test_registry_discovers_rbi_script() -> None:
+    import sys
+
+    sys.path.insert(0, str(REPO))
+    from rpa.scripts._registry import discover_scripts
+
+    scripts = discover_scripts()
+    assert "rbi_org_scraper" in scripts, (
+        "RBI scraper must be discovered by the generic registry "
+        "without requiring a hardcoded entry in api/v1/rpa.py"
+    )
+    meta = scripts["rbi_org_scraper"]
+    assert meta["target_quality"] == 4.8
+    assert meta["produces_chunks"] is True
+    assert meta["http_only"] is True
+
+
+def test_registry_skips_files_without_meta() -> None:
+    """A stray .py file without SCRIPT_META must be silently skipped
+    so the registry doesn't blow up on utility modules."""
+    import sys
+
+    sys.path.insert(0, str(REPO))
+    from rpa.scripts._registry import discover_scripts
+
+    scripts = discover_scripts()
+    # _registry.py itself has no SCRIPT_META — it must NOT appear
+    assert "_registry" not in scripts
+
+
+def test_registry_backfills_params_schema_from_required() -> None:
+    """Older scripts that only declared ``required_params`` must still
+    surface a ``params_schema`` to the UI."""
+    import sys
+
+    sys.path.insert(0, str(REPO))
+    from rpa.scripts._registry import discover_scripts
+
+    meta = discover_scripts()["epfo_ecr_download"]
+    assert "params_schema" in meta
+    # epfo declared required_params=["establishment_id", "wage_month", "wage_year"]
+    for key in ("establishment_id", "wage_month", "wage_year"):
+        assert key in meta["params_schema"]
+
+
+# ---------------------------------------------------------------------------
+# Quality gate: rubric behaves correctly and enforces the 4.8 target
+# ---------------------------------------------------------------------------
+
+
+def test_quality_gate_rejects_boilerplate() -> None:
+    import sys
+
+    sys.path.insert(0, str(REPO))
+    from core.rpa.quality import score_chunk
+
+    boilerplate = "Home › Press Release. " + ("x" * 300) + "."
+    q = score_chunk(boilerplate)
+    # Even though the chunk has the right length and ends with ".",
+    # the boilerplate prefix must flag it.
+    assert q["dimensions"]["non_boilerplate"] == 0.0
+    assert not q["passes"]
+
+
+def test_quality_gate_accepts_clean_chunk() -> None:
+    import sys
+
+    sys.path.insert(0, str(REPO))
+    from core.rpa.quality import score_chunk
+
+    clean = (
+        "The Reserve Bank of India announced a 25 basis point hike in "
+        "the repo rate effective 2026-04-23. Deposit rates across major "
+        "banks have risen by 15 basis points in response. The Monetary "
+        "Policy Committee cited persistent food inflation as the primary "
+        "driver. Markets had largely priced in the hike."
+    )
+    q = score_chunk(clean)
+    assert q["score"] >= 4.8
+    assert q["passes"] is True
+
+
+def test_filter_chunks_partitions_by_threshold() -> None:
+    import sys
+
+    sys.path.insert(0, str(REPO))
+    from core.rpa.quality import filter_chunks
+
+    good = (
+        "The Reserve Bank of India announced new rules on 2026-04-23. "
+        "Banks must now disclose unclaimed deposits within 30 days. "
+        "The measure is aimed at reducing dormant-account fraud and "
+        "improving data quality across the sector. Large lenders have "
+        "already begun publishing quarterly reports with this metric."
+    )
+    short = "Too short."
+    flagged_missing_punct = (
+        "RBI said on 2026-04-23 that banks must publish quarterly "
+        "unclaimed-deposits data. This is a meaningful, informative "
+        "chunk about public regulatory actions with Reserve Bank "
+        "context "
+    )
+    published, flagged, rejected = filter_chunks(
+        [{"content": good}, {"content": short}, {"content": flagged_missing_punct}]
+    )
+    assert len(published) == 1
+    # Short chunk fails length + no terminal punct + informative → reject
+    assert len(rejected) >= 1
+
+
+# ---------------------------------------------------------------------------
+# RBI script: contract shape is correct
+# ---------------------------------------------------------------------------
+
+
+def test_rbi_script_meta_shape() -> None:
+    src = _read("rpa/scripts/rbi_org_scraper.py")
+    assert "SCRIPT_META" in src
+    assert "async def run" in src
+    assert "rbi.org.in" in src.lower()
+    # Polite delay + identifying User-Agent are non-negotiable
+    assert "_POLITE_DELAY_S" in src
+    assert "agenticorg-rpa" in src
+
+
+# ---------------------------------------------------------------------------
+# Scheduling API: create → run-now wiring uses Celery
+# ---------------------------------------------------------------------------
+
+
+def test_rpa_schedules_api_registered() -> None:
+    src = _read("api/main.py")
+    assert "rpa_schedules" in src, (
+        "api/main.py must import + mount the new rpa_schedules router"
+    )
+    assert "rpa_schedules.router" in src
+
+
+def test_rpa_task_queue_wired_in_celery() -> None:
+    src = _read("core/tasks/celery_app.py")
+    assert "core.tasks.rpa_tasks" in src, (
+        "core/tasks/celery_app.py must route rpa_tasks.* to the rpa queue"
+    )
+    assert "dispatch_due_rpa_schedules" in src, (
+        "beat_schedule must include the RPA dispatcher sweeper"
+    )
+
+
+def test_rpa_schedule_model_has_quality_column() -> None:
+    import sys
+
+    sys.path.insert(0, str(REPO))
+    from core.models.rpa_schedule import RPASchedule
+
+    columns = {c.name for c in RPASchedule.__table__.columns}
+    for required in (
+        "script_key",
+        "cron_expression",
+        "enabled",
+        "params",
+        "config",
+        "last_quality_avg",
+        "last_run_chunks_published",
+        "last_run_chunks_rejected",
+    ):
+        assert required in columns, f"RPASchedule missing {required!r}"

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -75,6 +75,7 @@ const ABMDashboard = lazyRetry(() => import("./pages/ABMDashboard"));
 
 /* ── Report Schedules ── */
 const ReportScheduler = lazyRetry(() => import("./pages/ReportScheduler"));
+const RPASchedules = lazyRetry(() => import("./pages/RPASchedules"));
 
 /* ── Knowledge Base, Voice, RPA, Industry Packs ── */
 const KnowledgeBase = lazyRetry(() => import("./pages/KnowledgeBase"));
@@ -279,6 +280,16 @@ export default function App() {
           <ProtectedRoute allowedRoles={["admin", "cfo", "cmo"]}>
             <Layout>
               <ReportScheduler />
+            </Layout>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/dashboard/rpa-schedules"
+        element={
+          <ProtectedRoute allowedRoles={["admin"]}>
+            <Layout>
+              <RPASchedules />
             </Layout>
           </ProtectedRoute>
         }

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -45,6 +45,7 @@ const ALL_NAV = [
   { path: "/dashboard/knowledge", labelKey: "nav.knowledge", label: "Knowledge Base", roles: ["admin", "cfo", "chro", "cmo", "coo"] },
   { path: "/dashboard/voice-setup", labelKey: "nav.voiceAgents", label: "Voice Agents", roles: ["admin"] },
   { path: "/dashboard/rpa", labelKey: "nav.rpa", label: "RPA Scripts", roles: ["admin"] },
+  { path: "/dashboard/rpa-schedules", labelKey: "nav.rpaSchedules", label: "RPA Schedules", roles: ["admin"] },
   { path: "/dashboard/packs", labelKey: "nav.packs", label: "Industry Packs", roles: ["admin"] },
   { path: "/dashboard/sla", labelKey: "nav.sla", label: "SLA Monitor", roles: ["admin"] },
   { path: "/dashboard/billing", labelKey: "nav.billing", label: "Billing", roles: ["admin"] },

--- a/ui/src/pages/RPASchedules.tsx
+++ b/ui/src/pages/RPASchedules.tsx
@@ -1,0 +1,337 @@
+import { useCallback, useEffect, useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import api, { extractApiError } from "@/lib/api";
+
+/**
+ * RPA Schedules — tenant-facing UI for the generic RPA framework.
+ *
+ * Lists every script discovered by the backend registry
+ * (`GET /rpa-schedules/registry`) + lets admins schedule recurring
+ * runs that drop vector-embedded chunks into the knowledge base.
+ *
+ * The 4.8/5 quality target is surfaced as a status pill on each
+ * schedule's last-run row so operators can see at a glance when a
+ * script starts producing sub-target output.
+ */
+
+interface RegistryScript {
+  script_key: string;
+  name: string;
+  description: string | null;
+  category: string | null;
+  estimated_duration_s: number | null;
+  target_quality: number | null;
+  admin_only: boolean;
+  produces_chunks: boolean;
+  params_schema: Record<string, { label?: string; required?: boolean; type?: string }>;
+}
+
+interface RPASchedule {
+  id: string;
+  name: string;
+  script_key: string;
+  cron_expression: string;
+  enabled: boolean;
+  params: Record<string, string>;
+  config: Record<string, unknown>;
+  last_run_at: string | null;
+  next_run_at: string | null;
+  last_run_status: string | null;
+  last_run_chunks_published: number | null;
+  last_run_chunks_rejected: number | null;
+  last_quality_avg: number | null;
+}
+
+const CRON_PRESETS = [
+  { value: "every_5_minutes", label: "Every 5 minutes" },
+  { value: "every_15_minutes", label: "Every 15 minutes" },
+  { value: "hourly", label: "Hourly" },
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+  { value: "monthly", label: "Monthly" },
+];
+
+function qualityBadge(avg: number | null): { label: string; variant: "success" | "warning" | "destructive" | "secondary" } {
+  if (avg == null) return { label: "—", variant: "secondary" };
+  if (avg >= 4.8) return { label: `${avg.toFixed(2)}/5`, variant: "success" };
+  if (avg >= 4.5) return { label: `${avg.toFixed(2)}/5 (review)`, variant: "warning" };
+  return { label: `${avg.toFixed(2)}/5 (below target)`, variant: "destructive" };
+}
+
+export default function RPASchedules() {
+  const [registry, setRegistry] = useState<RegistryScript[]>([]);
+  const [schedules, setSchedules] = useState<RPASchedule[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  // Create form state
+  const [showForm, setShowForm] = useState(false);
+  const [formName, setFormName] = useState("");
+  const [formScript, setFormScript] = useState("");
+  const [formCron, setFormCron] = useState("daily");
+  const [formParams, setFormParams] = useState<Record<string, string>>({});
+  const [formSubmitting, setFormSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [regRes, schedRes] = await Promise.all([
+        api.get("/rpa-schedules/registry"),
+        api.get("/rpa-schedules"),
+      ]);
+      setRegistry(Array.isArray(regRes.data?.items) ? regRes.data.items : []);
+      setSchedules(Array.isArray(schedRes.data) ? schedRes.data : []);
+    } catch (e) {
+      setError(extractApiError(e, "Failed to load RPA schedules"));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  function resetForm() {
+    setFormName("");
+    setFormScript("");
+    setFormCron("daily");
+    setFormParams({});
+    setFormError(null);
+    setShowForm(false);
+  }
+
+  async function handleCreate() {
+    setFormError(null);
+    if (!formName.trim()) {
+      setFormError("Name is required");
+      return;
+    }
+    if (!formScript) {
+      setFormError("Pick an RPA script");
+      return;
+    }
+    setFormSubmitting(true);
+    try {
+      await api.post("/rpa-schedules", {
+        name: formName.trim(),
+        script_key: formScript,
+        cron_expression: formCron,
+        enabled: true,
+        params: formParams,
+      });
+      resetForm();
+      setNotice("Schedule created.");
+      await fetchAll();
+    } catch (e) {
+      setFormError(extractApiError(e, "Failed to create schedule"));
+    } finally {
+      setFormSubmitting(false);
+    }
+  }
+
+  async function handleRunNow(s: RPASchedule) {
+    setNotice(null);
+    try {
+      const { data } = await api.post(`/rpa-schedules/${s.id}/run-now`);
+      setNotice(
+        data?.task_id
+          ? `Queued run for "${s.name}" (task ${String(data.task_id).slice(0, 8)}…). Refresh in a few seconds to see the result.`
+          : `Queued run for "${s.name}".`,
+      );
+    } catch (e) {
+      setError(extractApiError(e, "Failed to queue run"));
+    }
+  }
+
+  async function handleToggle(s: RPASchedule) {
+    try {
+      await api.patch(`/rpa-schedules/${s.id}`, { enabled: !s.enabled });
+      await fetchAll();
+    } catch (e) {
+      setError(extractApiError(e, "Failed to toggle schedule"));
+    }
+  }
+
+  async function handleDelete(s: RPASchedule) {
+    if (!window.confirm(`Delete the schedule "${s.name}"?`)) return;
+    try {
+      await api.delete(`/rpa-schedules/${s.id}`);
+      await fetchAll();
+    } catch (e) {
+      setError(extractApiError(e, "Failed to delete schedule"));
+    }
+  }
+
+  const selectedScript = registry.find((r) => r.script_key === formScript) || null;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h2 className="text-2xl font-bold">RPA Schedules</h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            Run browser-automation scripts on a schedule and feed the
+            results into the knowledge base. Target vector-embedding
+            quality: 4.8 / 5.
+          </p>
+        </div>
+        <Button onClick={() => setShowForm((v) => !v)}>
+          {showForm ? "Cancel" : "New Schedule"}
+        </Button>
+      </div>
+
+      {notice && (
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 text-emerald-900 px-3 py-2 text-sm" role="status">
+          {notice}
+        </div>
+      )}
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 text-red-900 px-3 py-2 text-sm" role="alert">
+          {error}
+        </div>
+      )}
+
+      {showForm && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Create Schedule</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div>
+                <label className="text-xs font-medium text-muted-foreground">Name</label>
+                <input
+                  className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                  value={formName}
+                  onChange={(e) => setFormName(e.target.value)}
+                  placeholder="e.g. RBI daily press releases"
+                />
+              </div>
+              <div>
+                <label className="text-xs font-medium text-muted-foreground">Script</label>
+                <select
+                  className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                  value={formScript}
+                  onChange={(e) => setFormScript(e.target.value)}
+                >
+                  <option value="">— Select —</option>
+                  {registry.map((r) => (
+                    <option key={r.script_key} value={r.script_key}>
+                      {r.name} ({r.category || "general"})
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="text-xs font-medium text-muted-foreground">Frequency</label>
+                <select
+                  className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                  value={formCron}
+                  onChange={(e) => setFormCron(e.target.value)}
+                >
+                  {CRON_PRESETS.map((p) => (
+                    <option key={p.value} value={p.value}>
+                      {p.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            {selectedScript?.description && (
+              <p className="text-xs text-muted-foreground">{selectedScript.description}</p>
+            )}
+
+            {selectedScript && Object.keys(selectedScript.params_schema).length > 0 && (
+              <div className="space-y-2 border rounded p-3 bg-muted/20">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Script parameters</p>
+                {Object.entries(selectedScript.params_schema).map(([key, def]) => (
+                  <div key={key}>
+                    <label className="text-xs text-muted-foreground">
+                      {def.label || key}
+                      {def.required ? " *" : ""}
+                    </label>
+                    <input
+                      type={def.type === "password" ? "password" : "text"}
+                      className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                      value={formParams[key] || ""}
+                      onChange={(e) => setFormParams((prev) => ({ ...prev, [key]: e.target.value }))}
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {formError && <p className="text-sm text-red-600">{formError}</p>}
+            <div className="flex gap-2">
+              <Button onClick={handleCreate} disabled={formSubmitting}>
+                {formSubmitting ? "Creating…" : "Create"}
+              </Button>
+              <Button variant="outline" onClick={resetForm} disabled={formSubmitting}>
+                Cancel
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Active schedules</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <p className="text-sm text-muted-foreground">Loading…</p>
+          ) : schedules.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No RPA schedules yet. Create one to get started.</p>
+          ) : (
+            <div className="space-y-2">
+              {schedules.map((s) => {
+                const q = qualityBadge(s.last_quality_avg);
+                return (
+                  <div
+                    key={s.id}
+                    className="border rounded-lg p-3 flex flex-col md:flex-row md:items-center md:justify-between gap-3"
+                  >
+                    <div className="space-y-1">
+                      <div className="flex items-center gap-2">
+                        <p className="font-medium">{s.name}</p>
+                        <Badge variant={s.enabled ? "default" : "secondary"}>
+                          {s.enabled ? "enabled" : "disabled"}
+                        </Badge>
+                        <Badge variant={q.variant}>quality {q.label}</Badge>
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        {s.script_key} • {s.cron_expression} •{" "}
+                        {s.last_run_status ? `last: ${s.last_run_status}` : "never run"}
+                        {s.last_run_chunks_published != null && s.last_run_status === "success" &&
+                          ` • ${s.last_run_chunks_published} published, ${s.last_run_chunks_rejected ?? 0} rejected`}
+                      </p>
+                    </div>
+                    <div className="flex gap-2">
+                      <Button size="sm" variant="outline" onClick={() => handleRunNow(s)}>
+                        Run now
+                      </Button>
+                      <Button size="sm" variant="outline" onClick={() => handleToggle(s)}>
+                        {s.enabled ? "Disable" : "Enable"}
+                      </Button>
+                      <Button size="sm" variant="destructive" onClick={() => handleDelete(s)}>
+                        Delete
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Generic, plugin-style RPA framework so new scripts can be added without touching API code; the first concrete new script (RBI.org.in public press-releases + notifications scraper); tenant-facing scheduling; and an inline vector-embedding quality gate with a 4.8/5 target.

## Components

### Generic registry
- `rpa/scripts/_registry.py` — walks `rpa/scripts/*.py`, imports each, returns the ones that declare `SCRIPT_META` + `async def run(...)`. Backfills `params_schema` from `required_params`, defaults `target_quality=4.8`, `admin_only=False`, `http_only=False`.
- `rpa/scripts/generic_portal.py` — backfilled `SCRIPT_META` with `admin_only: True` (SSRF-capable).
- `api/v1/rpa.py::list_scripts` and `run_script` now read the dynamic registry; legacy `_BUILTIN_SCRIPTS` dict is kept only as back-compat metadata augmentation.

### RBI.org.in scraper (`rpa/scripts/rbi_org_scraper.py`)
- HTTP-only (no Playwright) — RBI serves fully-rendered HTML.
- Polite 1 req/sec, identified bot UA (`agenticorg-rpa/1.0 (+https://agenticorg.ai/bot)`).
- Fetches press releases + notifications index pages, follows each item, extracts main body via BeautifulSoup, chunks at sentence boundaries (250–1500 chars), returns `{chunks: [{title, source_url, content, published_at, category}, …]}`.

### Quality gate (`core/rpa/quality.py`)
- 5-dimension rubric (each worth 1.0):
  1. Length 200 ≤ chars ≤ 2000.
  2. Sentence-complete (ends with terminal punctuation).
  3. Non-boilerplate (no site-nav / loading / rights prefixes).
  4. Informative (has ≥ 2 of: 40+ words, a digit, a capitalised noun).
  5. Embedding-friendly (no mojibake, no control chars, no excess whitespace).
- Publish threshold 4.8; reject below 4.5; flag 4.5–4.8 for review.

### Scheduling + persistence
- `core/models/rpa_schedule.py` — ORM with `tenant_id`, `script_key`, `cron_expression`, `params`, `config`, `last_run_*` telemetry including `last_quality_avg`.
- `migrations/versions/v4_9_0_rpa_schedules.py` — idempotent `CREATE TABLE IF NOT EXISTS` + FKs guarded on `information_schema` + partial-unique `(tenant_id, name)` index.
- `api/v1/rpa_schedules.py` — admin-gated CRUD + `GET /rpa-schedules/registry` (lists every discoverable script) + `POST /rpa-schedules/{id}/run-now` (Celery enqueue).

### Celery wiring
- `core/tasks/rpa_tasks.py::run_rpa_schedule` — loads schedule → resolves script → runs (HTTP-only direct, otherwise Playwright executor) → filters chunks through the 4.8/5 quality gate → embeds survivors via `core.embeddings.embed_one` → inserts into `knowledge_documents` with SHA-256 dedup on `(source_url, content[:200])` → records `last_run_*` + `last_quality_avg` + advances `next_run_at`.
- `core/tasks/rpa_tasks.py::dispatch_due_rpa_schedules` — every 5 minutes (beat), enqueues all `enabled && next_run_at <= now` schedules.
- `core/tasks/celery_app.py` — new `rpa` queue + beat entry.

### UI
- `ui/src/pages/RPASchedules.tsx` — lists registered scripts, create form with frequency picker + dynamic params, per-schedule quality badge (green ≥ 4.8, amber ≥ 4.5, red below), Run Now / Enable / Delete actions.
- `/dashboard/rpa-schedules` route (admin-only) + sidebar link.

## Test plan

- [x] `tests/regression/test_rpa_framework.py` (10 tests) — registry discovery, quality rubric behaviour, RBI script shape, API mount, Celery wiring, ORM columns.
- [x] Full 3086-test regression+unit suite green locally.
- [x] Preflight gates all green (branch safety, ruff, bandit, alembic ≤ 32 chars, verify=False scan, pytest, tsc, vite build, consistency sweep, module coverage, critical-path tags).

## /audit /critique /polish summary (impeccable)

New UI surface is narrow: one admin page + one sidebar entry. Uses existing shadcn `Card`, `Button`, `Badge` primitives and existing color tokens (success/warning/destructive/secondary). Form rhythm matches ReportScheduler.tsx; no new typography, iconography, or layout conventions introduced.

## Residual risks

- The dedup key is `source_url + content[:200]` SHA-256 — a significant RBI-page content change that keeps the same URL will produce a new chunk; that's correct (we want the updated version) but means duplicate-ish history is possible when RBI substantially edits a circular. Acceptable for v1.
- RBI site HTML structure may change; the `_extract_main_text` heuristic picks the longest candidate div. If they redesign, the quality gate will surface sub-4.8 chunks first rather than silently degrade retrieval.
- `run_rpa_schedule` runs the async body via `asyncio.new_event_loop()` from a sync Celery task. Same pattern as `core/tasks/workflow_tasks.py::resume_workflow_wait`.

## Reviewers

@codex — please audit the quality-gate thresholds, the HTTP-only path bypass of the Playwright executor, and the dedup-by-source-hash approach.