### PR TITLE
fix(auth): exempt /billing/health + /knowledge/health on the live GrantexAuthMiddleware

### DIFF
--- a/auth/grantex_middleware.py
+++ b/auth/grantex_middleware.py
@@ -59,6 +59,12 @@ class GrantexAuthMiddleware(BaseHTTPMiddleware):
         "/api/v1/billing/callback",  # Plural redirect callback (browser returning from gateway)
         "/api/v1/billing/callback/stripe",  # Stripe redirect callback
         "/api/v1/billing/plans",  # Public pricing — no tenant data
+        # Codex 2026-04-23 prod re-verification: /billing/health +
+        # /knowledge/health are declared auth-free in their route
+        # files, but GrantexAuthMiddleware still required a token.
+        # Exempt them so ops smoke / uptime probes can call them.
+        "/api/v1/billing/health",
+        "/api/v1/knowledge/health",
         "/api/v1/branding",  # Public tenant branding for the login page
         "/api/v1/status",  # Public status page
         "/api/v1/product-facts",  # Public product counts/version for README, Landing, Pricing

--- a/tests/regression/test_codex_round4_blockers.py
+++ b/tests/regression/test_codex_round4_blockers.py
@@ -263,17 +263,20 @@ def test_k_e_strict_mode_wired_in_prod_manifests() -> None:
 def test_k_e_health_probes_are_public() -> None:
     """Codex 2026-04-23 prod re-verification: /billing/health and
     /knowledge/health were declared auth-free in their route files but
-    the global AuthMiddleware still required a token, so ops could not
-    call them as smoke probes. They must be in EXEMPT_PATHS.
+    the global middleware still required a token. The fix must land
+    on BOTH the legacy ``AuthMiddleware`` and the live
+    ``GrantexAuthMiddleware`` (the one api/main.py registers). The
+    first pass of this regression only checked the legacy class,
+    which is why prod still returned 401 after the first merge.
     """
-    src = _read("auth/middleware.py")
-    assert "/api/v1/billing/health" in src, (
-        "AuthMiddleware.EXEMPT_PATHS must include /api/v1/billing/health "
-        "so deploy smoke checks can reach it unauthenticated"
-    )
-    assert "/api/v1/knowledge/health" in src, (
-        "AuthMiddleware.EXEMPT_PATHS must include /api/v1/knowledge/health"
-    )
+    for rel in ("auth/middleware.py", "auth/grantex_middleware.py"):
+        src = _read(rel)
+        assert "/api/v1/billing/health" in src, (
+            f"{rel} EXEMPT_PATHS must include /api/v1/billing/health"
+        )
+        assert "/api/v1/knowledge/health" in src, (
+            f"{rel} EXEMPT_PATHS must include /api/v1/knowledge/health"
+        )
 
 
 def test_k_e_health_endpoint_exposes_commit_sha() -> None:


### PR DESCRIPTION
## Summary

Prod re-verification of PR #296 showed \`/api/v1/billing/health\` still returns 401. Root cause: \`api/main.py:159\` registers \`GrantexAuthMiddleware\` (from \`auth/grantex_middleware.py\`), not the legacy \`AuthMiddleware\` (from \`auth/middleware.py\`) that my earlier fix exempted.

Both middleware classes have identical \`EXEMPT_PATHS\` structure but only the Grantex one is active in production.

## Fix

- \`auth/grantex_middleware.py\` — add \`/api/v1/billing/health\` + \`/api/v1/knowledge/health\` to \`EXEMPT_PATHS\`.
- \`tests/regression/test_codex_round4_blockers.py::test_k_e_health_probes_are_public\` — now checks BOTH middleware files so we can't miss the parallel class again.

## Test plan

- [x] 12/12 round-4 regression tests pass locally after the expanded assertion.
- [x] Preflight green.

## Residual

Autopsy note in the PR body + commit message so the habit of checking which middleware is actually registered goes into the next session's memory.