### PR TITLE
feat(ai-credentials): tenant BYO AI provider tokens — S0-09 PR-1 of 4

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -55,6 +55,7 @@ from api.v1 import (
     schemas,
     sop,
     sso,
+    tenant_ai_credentials,
     voice,
     webhooks,
     workflow_variants,
@@ -202,6 +203,7 @@ app.include_router(composio.router, prefix="/api/v1", tags=["Composio Marketplac
 app.include_router(packs.router, prefix="/api/v1", tags=["Industry Packs"])
 app.include_router(rpa.router, prefix="/api/v1", tags=["RPA"])
 app.include_router(rpa_schedules.router, prefix="/api/v1", tags=["RPA"])
+app.include_router(tenant_ai_credentials.router, prefix="/api/v1", tags=["Tenant AI Credentials"])
 app.include_router(cdc_webhooks.router, prefix="/api/v1", tags=["CDC Webhooks"])
 app.include_router(content_safety.router, prefix="/api/v1", tags=["Content Safety"])
 app.include_router(knowledge.router, prefix="/api/v1", tags=["Knowledge Base"])

--- a/api/v1/tenant_ai_credentials.py
+++ b/api/v1/tenant_ai_credentials.py
@@ -1,0 +1,428 @@
+"""Admin API for tenant-scoped BYO AI provider credentials.
+
+Closes S0-09 (PR-1). Admin-gated router on top of
+``core.models.tenant_ai_credential.TenantAICredential`` +
+``core.ai_providers.resolver``. Never returns raw tokens — only prefix/
+suffix/status/timestamps/metadata.
+"""
+
+from __future__ import annotations
+
+import uuid as _uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import select
+
+from api.deps import get_current_tenant, require_tenant_admin
+from core.ai_providers.resolver import (
+    ProviderNotConfigured,
+    invalidate_cache,
+    mask_token,
+)
+from core.database import get_tenant_session
+from core.models.tenant_ai_credential import (
+    CREDENTIAL_KIND_ALLOWLIST,
+    PROVIDER_ALLOWLIST,
+    STATUS_ALLOWLIST,
+    TenantAICredential,
+)
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(
+    prefix="/tenant-ai-credentials",
+    tags=["Tenant AI Credentials"],
+    dependencies=[require_tenant_admin],
+)
+
+
+# ── Schemas ──────────────────────────────────────────────────────────
+
+
+class TenantAICredentialCreate(BaseModel):
+    provider: str = Field(..., min_length=1, max_length=64)
+    credential_kind: str = Field(..., min_length=1, max_length=32)
+    api_key: str = Field(..., min_length=1, max_length=4096)
+    label: str | None = Field(None, max_length=255)
+    provider_config: dict[str, Any] | None = None
+
+    @field_validator("provider")
+    @classmethod
+    def _validate_provider(cls, v: str) -> str:
+        v = v.strip().lower()
+        if v not in PROVIDER_ALLOWLIST:
+            raise ValueError(
+                f"provider must be one of: {sorted(PROVIDER_ALLOWLIST)}"
+            )
+        return v
+
+    @field_validator("credential_kind")
+    @classmethod
+    def _validate_kind(cls, v: str) -> str:
+        v = v.strip().lower()
+        if v not in CREDENTIAL_KIND_ALLOWLIST:
+            raise ValueError(
+                f"credential_kind must be one of: {sorted(CREDENTIAL_KIND_ALLOWLIST)}"
+            )
+        return v
+
+    @field_validator("api_key")
+    @classmethod
+    def _validate_api_key(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("api_key is required")
+        if len(v) < 8:
+            raise ValueError("api_key looks too short to be valid")
+        return v
+
+
+class TenantAICredentialUpdate(BaseModel):
+    api_key: str | None = Field(None, min_length=1, max_length=4096)
+    label: str | None = Field(None, max_length=255)
+    provider_config: dict[str, Any] | None = None
+    status: str | None = None
+
+    @field_validator("status")
+    @classmethod
+    def _validate_status(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        v = v.strip().lower()
+        if v not in STATUS_ALLOWLIST:
+            raise ValueError(
+                f"status must be one of: {sorted(STATUS_ALLOWLIST)}"
+            )
+        return v
+
+
+class TenantAICredentialOut(BaseModel):
+    id: str
+    provider: str
+    credential_kind: str
+    status: str
+    label: str | None = None
+    display_prefix: str | None = None
+    display_suffix: str | None = None
+    provider_config: dict[str, Any] | None = None
+    last_health_check_at: str | None = None
+    last_health_check_error: str | None = None
+    last_used_at: str | None = None
+    rotated_at: str | None = None
+    created_at: str
+    updated_at: str
+
+
+def _to_out(row: TenantAICredential) -> TenantAICredentialOut:
+    """Serialize for the API. Never touches credentials_encrypted."""
+    return TenantAICredentialOut(
+        id=str(row.id),
+        provider=row.provider,
+        credential_kind=row.credential_kind,
+        status=row.status,
+        label=row.label,
+        display_prefix=row.display_prefix,
+        display_suffix=row.display_suffix,
+        provider_config=row.provider_config,
+        last_health_check_at=(
+            row.last_health_check_at.isoformat()
+            if row.last_health_check_at else None
+        ),
+        last_health_check_error=row.last_health_check_error,
+        last_used_at=(
+            row.last_used_at.isoformat() if row.last_used_at else None
+        ),
+        rotated_at=(
+            row.rotated_at.isoformat() if row.rotated_at else None
+        ),
+        created_at=row.created_at.isoformat(),
+        updated_at=row.updated_at.isoformat(),
+    )
+
+
+# ── Endpoints ────────────────────────────────────────────────────────
+
+
+@router.get("", response_model=list[TenantAICredentialOut])
+async def list_credentials(
+    tenant_id: str = Depends(get_current_tenant),
+) -> list[TenantAICredentialOut]:
+    tid = _uuid.UUID(tenant_id)
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(TenantAICredential)
+            .where(TenantAICredential.tenant_id == tid)
+            .order_by(TenantAICredential.created_at.desc())
+        )
+        rows = result.scalars().all()
+    return [_to_out(r) for r in rows]
+
+
+@router.post(
+    "",
+    response_model=TenantAICredentialOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_credential(
+    body: TenantAICredentialCreate,
+    tenant_id: str = Depends(get_current_tenant),
+) -> TenantAICredentialOut:
+    from core.crypto.tenant_secrets import encrypt_for_tenant
+
+    tid = _uuid.UUID(tenant_id)
+    prefix, suffix = mask_token(body.api_key)
+    ciphertext = await encrypt_for_tenant(body.api_key, tid)
+
+    row = TenantAICredential(
+        id=_uuid.uuid4(),
+        tenant_id=tid,
+        provider=body.provider,
+        credential_kind=body.credential_kind,
+        credentials_encrypted={"_encrypted": ciphertext},
+        status="unverified",
+        display_prefix=prefix,
+        display_suffix=suffix,
+        label=body.label,
+        provider_config=body.provider_config,
+    )
+    async with get_tenant_session(tid) as session:
+        session.add(row)
+        try:
+            await session.flush()
+        except Exception as exc:
+            logger.warning("tenant_ai_credential_create_failed", error=str(exc))
+            raise HTTPException(
+                409,
+                f"Credential for provider={body.provider!r} "
+                f"kind={body.credential_kind!r} already exists for this tenant. "
+                "Use PATCH to rotate.",
+            ) from exc
+
+    invalidate_cache(tid, body.provider, body.credential_kind)
+    _audit(
+        "tenant_ai_credential.created",
+        tid,
+        row.id,
+        {"provider": body.provider, "credential_kind": body.credential_kind},
+    )
+    return _to_out(row)
+
+
+@router.get("/{credential_id}", response_model=TenantAICredentialOut)
+async def get_credential(
+    credential_id: str,
+    tenant_id: str = Depends(get_current_tenant),
+) -> TenantAICredentialOut:
+    tid = _uuid.UUID(tenant_id)
+    try:
+        cid = _uuid.UUID(credential_id)
+    except ValueError as exc:
+        raise HTTPException(400, "Invalid credential_id") from exc
+
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(TenantAICredential).where(
+                TenantAICredential.id == cid,
+                TenantAICredential.tenant_id == tid,
+            )
+        )
+        row = result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(404, "Credential not found")
+    return _to_out(row)
+
+
+@router.patch("/{credential_id}", response_model=TenantAICredentialOut)
+async def update_credential(
+    credential_id: str,
+    body: TenantAICredentialUpdate,
+    tenant_id: str = Depends(get_current_tenant),
+) -> TenantAICredentialOut:
+    """Rotate the token (``api_key`` set) or update non-secret
+    metadata. Setting ``api_key`` stamps ``rotated_at``.
+    """
+    from core.crypto.tenant_secrets import encrypt_for_tenant
+
+    tid = _uuid.UUID(tenant_id)
+    try:
+        cid = _uuid.UUID(credential_id)
+    except ValueError as exc:
+        raise HTTPException(400, "Invalid credential_id") from exc
+
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(TenantAICredential).where(
+                TenantAICredential.id == cid,
+                TenantAICredential.tenant_id == tid,
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            raise HTTPException(404, "Credential not found")
+
+        rotated = False
+        if body.api_key is not None:
+            ciphertext = await encrypt_for_tenant(body.api_key, tid)
+            row.credentials_encrypted = {"_encrypted": ciphertext}
+            prefix, suffix = mask_token(body.api_key)
+            row.display_prefix = prefix
+            row.display_suffix = suffix
+            row.rotated_at = datetime.now(UTC)
+            row.status = "unverified"
+            rotated = True
+        if body.label is not None:
+            row.label = body.label
+        if body.provider_config is not None:
+            row.provider_config = body.provider_config
+        if body.status is not None:
+            row.status = body.status
+
+        await session.flush()
+
+    invalidate_cache(tid, row.provider, row.credential_kind)
+    _audit(
+        "tenant_ai_credential.rotated" if rotated else "tenant_ai_credential.updated",
+        tid,
+        row.id,
+        {"provider": row.provider, "credential_kind": row.credential_kind},
+    )
+    return _to_out(row)
+
+
+@router.delete(
+    "/{credential_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def delete_credential(
+    credential_id: str,
+    tenant_id: str = Depends(get_current_tenant),
+) -> None:
+    tid = _uuid.UUID(tenant_id)
+    try:
+        cid = _uuid.UUID(credential_id)
+    except ValueError as exc:
+        raise HTTPException(400, "Invalid credential_id") from exc
+
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(TenantAICredential).where(
+                TenantAICredential.id == cid,
+                TenantAICredential.tenant_id == tid,
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            raise HTTPException(404, "Credential not found")
+        provider = row.provider
+        kind = row.credential_kind
+        await session.delete(row)
+
+    invalidate_cache(tid, provider, kind)
+    _audit(
+        "tenant_ai_credential.deleted",
+        tid,
+        cid,
+        {"provider": provider, "credential_kind": kind},
+    )
+
+
+@router.post("/{credential_id}/test")
+async def test_credential(
+    credential_id: str,
+    tenant_id: str = Depends(get_current_tenant),
+) -> dict[str, Any]:
+    """Live-probe the credential against the provider.
+
+    Calls each provider's cheapest identity endpoint so we know the
+    token actually works without running a real completion.
+    """
+    tid = _uuid.UUID(tenant_id)
+    try:
+        cid = _uuid.UUID(credential_id)
+    except ValueError as exc:
+        raise HTTPException(400, "Invalid credential_id") from exc
+
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(TenantAICredential).where(
+                TenantAICredential.id == cid,
+                TenantAICredential.tenant_id == tid,
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            raise HTTPException(404, "Credential not found")
+
+    from core.ai_providers.health import probe_provider
+
+    try:
+        probe_result = await probe_provider(tid, row.provider, row.credential_kind)
+        status_value = "active" if probe_result["ok"] else "failing"
+        err = None if probe_result["ok"] else probe_result.get("error", "")
+    except ProviderNotConfigured as exc:
+        # Shouldn't happen — we just loaded the row — but surface honestly
+        status_value = "failing"
+        err = str(exc)[:500]
+    except Exception as exc:
+        logger.exception("tenant_ai_credential_probe_failed")
+        status_value = "failing"
+        err = f"{type(exc).__name__}: {exc}"[:500]
+
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(TenantAICredential).where(TenantAICredential.id == cid)
+        )
+        db_row = result.scalar_one_or_none()
+        if db_row is not None:
+            db_row.status = status_value
+            db_row.last_health_check_at = datetime.now(UTC)
+            db_row.last_health_check_error = err
+            await session.flush()
+
+    invalidate_cache(tid, row.provider, row.credential_kind)
+    _audit(
+        "tenant_ai_credential.tested",
+        tid,
+        cid,
+        {
+            "provider": row.provider,
+            "credential_kind": row.credential_kind,
+            "result": status_value,
+        },
+    )
+    return {
+        "tested": True,
+        "status": status_value,
+        "error": err,
+        "credential_id": str(cid),
+    }
+
+
+# ── Audit log helper ─────────────────────────────────────────────────
+
+
+def _audit(
+    action: str,
+    tenant_id: _uuid.UUID,
+    target_id: _uuid.UUID,
+    details: dict[str, Any],
+) -> None:
+    """Emit a structured audit event. Never includes the secret.
+
+    The audit log table itself is owned by ``core.models.audit.AuditLog``
+    and written via a best-effort structlog bridge — same pattern used
+    by other admin routes. If the write fails we don't fail the caller.
+    """
+    try:
+        logger.info(
+            "audit_event",
+            action=action,
+            tenant_id=str(tenant_id),
+            target_id=str(target_id),
+            **details,
+        )
+    except Exception as exc:
+        logger.debug("audit_emit_failed", error=str(exc))

--- a/api/v1/voice.py
+++ b/api/v1/voice.py
@@ -331,9 +331,120 @@ async def test_connection(
         )
 
 
-# In-memory per-tenant config store. Replaced with a DB table when the
-# Voice Agent feature graduates from beta.
+# In-memory per-tenant config store.
+#
+# S0-09 (PR-1 2026-04-24): the STT/TTS api_key fields used to be
+# stored here in plaintext — Codex flagged the dict as "partial BYO
+# token". Now the non-secret fields (sip_provider, phone_number,
+# stt_engine, tts_engine, etc.) still live in this process-local dict
+# because they're not secrets and rebooting re-loads them from the UI.
+# The api_key fields are persisted through the encrypted
+# ``tenant_ai_credentials`` vault instead — see _save_voice_keys /
+# _load_voice_key below.
 _VOICE_CONFIG: dict[str, dict] = {}
+
+
+# Mapping between the voice engine choice and the AI-credentials
+# provider slug. Keep in sync with
+# ``core.models.tenant_ai_credential.PROVIDER_ALLOWLIST``.
+_STT_ENGINE_TO_PROVIDER: dict[str, str] = {"deepgram": "stt_deepgram"}
+_TTS_ENGINE_TO_PROVIDER: dict[str, str] = {"google": "tts_azure"}
+# Note: the UI currently exposes "google" TTS but the production
+# path uses Azure Speech under the hood. When a true Google TTS
+# provider is added, register it separately in the allowlist and
+# map it here.
+
+
+async def _save_voice_keys(tenant_uuid, body: VoiceConfig) -> None:
+    """Persist stt_api_key + tts_api_key in tenant_ai_credentials.
+
+    Upserts a row per (provider, kind). Empty keys are left alone
+    (admin can set just one side).
+    """
+    import uuid as _uuid
+
+    from sqlalchemy import select
+
+    from core.ai_providers.resolver import invalidate_cache, mask_token
+    from core.crypto.tenant_secrets import encrypt_for_tenant
+    from core.database import get_tenant_session
+    from core.models.tenant_ai_credential import TenantAICredential
+
+    pairs: list[tuple[str, str, str]] = []  # (provider, kind, raw)
+    if body.stt_api_key and body.stt_api_key.strip():
+        provider = _STT_ENGINE_TO_PROVIDER.get(body.stt_engine)
+        if provider:
+            pairs.append((provider, "stt", body.stt_api_key.strip()))
+    if body.tts_api_key and body.tts_api_key.strip():
+        provider = _TTS_ENGINE_TO_PROVIDER.get(body.tts_engine)
+        if provider:
+            pairs.append((provider, "tts", body.tts_api_key.strip()))
+
+    if not pairs:
+        return
+
+    for provider, kind, raw in pairs:
+        ciphertext = await encrypt_for_tenant(raw, tenant_uuid)
+        prefix, suffix = mask_token(raw)
+        async with get_tenant_session(tenant_uuid) as session:
+            result = await session.execute(
+                select(TenantAICredential).where(
+                    TenantAICredential.tenant_id == tenant_uuid,
+                    TenantAICredential.provider == provider,
+                    TenantAICredential.credential_kind == kind,
+                )
+            )
+            existing = result.scalar_one_or_none()
+            if existing is None:
+                session.add(
+                    TenantAICredential(
+                        id=_uuid.uuid4(),
+                        tenant_id=tenant_uuid,
+                        provider=provider,
+                        credential_kind=kind,
+                        credentials_encrypted={"_encrypted": ciphertext},
+                        status="unverified",
+                        display_prefix=prefix,
+                        display_suffix=suffix,
+                        label=f"voice.{kind}",
+                    )
+                )
+            else:
+                existing.credentials_encrypted = {"_encrypted": ciphertext}
+                existing.display_prefix = prefix
+                existing.display_suffix = suffix
+                existing.status = "unverified"
+                from datetime import UTC, datetime
+
+                existing.rotated_at = datetime.now(UTC)
+        invalidate_cache(tenant_uuid, provider, kind)
+
+
+async def _voice_key_display(tenant_uuid, provider: str, kind: str) -> str | None:
+    """Return a ``prefix…suffix`` masked string for the stored key, or
+    ``None`` if none is configured. Never returns raw material.
+    """
+    from sqlalchemy import select
+
+    from core.database import get_tenant_session
+    from core.models.tenant_ai_credential import TenantAICredential
+
+    async with get_tenant_session(tenant_uuid) as session:
+        result = await session.execute(
+            select(TenantAICredential).where(
+                TenantAICredential.tenant_id == tenant_uuid,
+                TenantAICredential.provider == provider,
+                TenantAICredential.credential_kind == kind,
+            )
+        )
+        row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    prefix = row.display_prefix or ""
+    suffix = row.display_suffix or ""
+    if not prefix and not suffix:
+        return "***"
+    return f"{prefix}...{suffix}"
 
 
 @router.post(
@@ -345,10 +456,31 @@ async def save_voice_config(
     body: VoiceConfig,
     tenant_id: str = Depends(get_current_tenant),
 ):
-    """Save tenant voice config. Admin-only (HIGH-05)."""
+    """Save tenant voice config. Admin-only (HIGH-05).
+
+    The ``stt_api_key`` and ``tts_api_key`` fields are extracted and
+    persisted through the encrypted ``tenant_ai_credentials`` vault
+    (S0-09 closure). The returned body is always masked — the raw
+    token never leaves the server again.
+    """
+    import uuid as _uuid
+
     _validate_voice_config(body)
-    _VOICE_CONFIG[str(tenant_id)] = body.model_dump()
-    # Return masked copy so secrets aren't echoed back in the response.
+
+    try:
+        tenant_uuid = _uuid.UUID(tenant_id)
+    except ValueError as exc:
+        raise HTTPException(400, "Invalid tenant_id") from exc
+
+    # Persist secret material in the encrypted vault
+    await _save_voice_keys(tenant_uuid, body)
+
+    # Store only the non-secret fields in the process-local dict
+    non_secret = body.model_dump()
+    non_secret.pop("stt_api_key", None)
+    non_secret.pop("tts_api_key", None)
+    _VOICE_CONFIG[str(tenant_id)] = non_secret
+
     return VoiceConfig(**_mask_voice_config(body.model_dump()))
 
 
@@ -361,9 +493,35 @@ async def get_voice_config(tenant_id: str = Depends(get_current_tenant)):
     """Return the saved tenant voice config with credentials masked.
 
     HIGH-05 fix — pre-fix any authenticated tenant user could read the
-    full credentials. Now admin-only, and secrets are masked on return.
+    full credentials. Now admin-only, secrets are masked on return,
+    and the secret bodies live in the encrypted vault — this endpoint
+    never touches raw cipher material.
     """
+    import uuid as _uuid
+
     data = _VOICE_CONFIG.get(str(tenant_id))
     if not data:
         return None
-    return VoiceConfig(**_mask_voice_config(data))
+
+    try:
+        tenant_uuid = _uuid.UUID(tenant_id)
+    except ValueError:
+        return VoiceConfig(**_mask_voice_config(data))
+
+    # Overlay masked key displays from the vault so the UI can show
+    # "sk-…abcd" without ever seeing the real body.
+    stt_provider = _STT_ENGINE_TO_PROVIDER.get(data.get("stt_engine", ""))
+    tts_provider = _TTS_ENGINE_TO_PROVIDER.get(data.get("tts_engine", ""))
+    stt_key_display = (
+        await _voice_key_display(tenant_uuid, stt_provider, "stt")
+        if stt_provider else None
+    )
+    tts_key_display = (
+        await _voice_key_display(tenant_uuid, tts_provider, "tts")
+        if tts_provider else None
+    )
+
+    merged = dict(data)
+    merged["stt_api_key"] = stt_key_display
+    merged["tts_api_key"] = tts_key_display
+    return VoiceConfig(**_mask_voice_config(merged))

--- a/core/ai_providers/__init__.py
+++ b/core/ai_providers/__init__.py
@@ -1,0 +1,20 @@
+"""Tenant-aware AI provider resolution.
+
+Exposes a single contract for LLM, embedding, RAG, STT, and TTS callers:
+ask ``resolver.get_provider_credential(...)`` and get back either the
+tenant's BYO token (decrypted on demand) or, if the tenant's
+``ai_fallback_policy`` allows it, the platform env key. Callers NEVER
+read env vars directly past this point.
+
+Part of S0-09 closure (PR-1).
+"""
+
+from core.ai_providers.resolver import (
+    ProviderNotConfigured as ProviderNotConfigured,
+)
+from core.ai_providers.resolver import (
+    ResolvedCredential as ResolvedCredential,
+)
+from core.ai_providers.resolver import (
+    get_provider_credential as get_provider_credential,
+)

--- a/core/ai_providers/health.py
+++ b/core/ai_providers/health.py
@@ -1,0 +1,203 @@
+"""Provider health probes for BYO AI credentials.
+
+Each provider exposes a cheap identity endpoint that proves a token
+works without running a real completion. ``probe_provider`` routes a
+credential to the matching probe and returns ``{ok, error, latency_ms,
+raw_status}`` — never the token body or any response data past status.
+
+Called from ``api/v1/tenant_ai_credentials.py::test_credential``.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid as _uuid
+from typing import Any
+
+import httpx
+import structlog
+
+from core.ai_providers.resolver import ProviderNotConfigured, get_provider_credential
+
+logger = structlog.get_logger(__name__)
+
+_PROBE_TIMEOUT_S = 10.0
+
+
+async def _probe_openai(credential: str, base_url: str | None = None) -> dict[str, Any]:
+    """OpenAI + OpenAI-compatible: GET /v1/models (lists available models)."""
+    url = f"{(base_url or 'https://api.openai.com').rstrip('/')}/v1/models"
+    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_S) as client:
+        start = time.time()
+        resp = await client.get(url, headers={"Authorization": f"Bearer {credential}"})
+        latency_ms = int((time.time() - start) * 1000)
+    if resp.status_code == 200:
+        return {"ok": True, "latency_ms": latency_ms, "raw_status": 200}
+    return {
+        "ok": False,
+        "latency_ms": latency_ms,
+        "raw_status": resp.status_code,
+        "error": _classify_http_error(resp.status_code),
+    }
+
+
+async def _probe_anthropic(credential: str) -> dict[str, Any]:
+    """Anthropic: HEAD /v1/messages fails cheap on bad key (401)."""
+    url = "https://api.anthropic.com/v1/messages"
+    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_S) as client:
+        start = time.time()
+        # POST with an empty body — Anthropic returns 400 for missing
+        # required fields when auth is valid, 401 when auth is bad.
+        resp = await client.post(
+            url,
+            headers={
+                "x-api-key": credential,
+                "anthropic-version": "2023-06-01",
+                "Content-Type": "application/json",
+            },
+            json={},
+        )
+        latency_ms = int((time.time() - start) * 1000)
+    if resp.status_code in (400, 422):
+        # Auth accepted; body validation fired — key is good.
+        return {"ok": True, "latency_ms": latency_ms, "raw_status": resp.status_code}
+    if resp.status_code == 200:
+        return {"ok": True, "latency_ms": latency_ms, "raw_status": 200}
+    return {
+        "ok": False,
+        "latency_ms": latency_ms,
+        "raw_status": resp.status_code,
+        "error": _classify_http_error(resp.status_code),
+    }
+
+
+async def _probe_gemini(credential: str) -> dict[str, Any]:
+    """Gemini: GET /v1beta/models?key=..."""
+    url = "https://generativelanguage.googleapis.com/v1beta/models"
+    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_S) as client:
+        start = time.time()
+        resp = await client.get(url, params={"key": credential})
+        latency_ms = int((time.time() - start) * 1000)
+    if resp.status_code == 200:
+        return {"ok": True, "latency_ms": latency_ms, "raw_status": 200}
+    return {
+        "ok": False,
+        "latency_ms": latency_ms,
+        "raw_status": resp.status_code,
+        "error": _classify_http_error(resp.status_code),
+    }
+
+
+async def _probe_voyage(credential: str) -> dict[str, Any]:
+    """Voyage embedding: a minimal embed call against the cheapest model."""
+    url = "https://api.voyageai.com/v1/embeddings"
+    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_S) as client:
+        start = time.time()
+        resp = await client.post(
+            url,
+            headers={"Authorization": f"Bearer {credential}"},
+            json={"input": ["ping"], "model": "voyage-3-lite"},
+        )
+        latency_ms = int((time.time() - start) * 1000)
+    if resp.status_code == 200:
+        return {"ok": True, "latency_ms": latency_ms, "raw_status": 200}
+    return {
+        "ok": False,
+        "latency_ms": latency_ms,
+        "raw_status": resp.status_code,
+        "error": _classify_http_error(resp.status_code),
+    }
+
+
+async def _probe_cohere(credential: str) -> dict[str, Any]:
+    """Cohere: GET /v1/models."""
+    url = "https://api.cohere.ai/v1/models"
+    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_S) as client:
+        start = time.time()
+        resp = await client.get(url, headers={"Authorization": f"Bearer {credential}"})
+        latency_ms = int((time.time() - start) * 1000)
+    if resp.status_code == 200:
+        return {"ok": True, "latency_ms": latency_ms, "raw_status": 200}
+    return {
+        "ok": False,
+        "latency_ms": latency_ms,
+        "raw_status": resp.status_code,
+        "error": _classify_http_error(resp.status_code),
+    }
+
+
+def _classify_http_error(status_code: int) -> str:
+    """Map HTTP status to a specific, actionable operator message."""
+    if status_code == 401 or status_code == 403:
+        return (
+            f"Provider returned {status_code}: key is invalid, expired, or "
+            "lacks required scopes."
+        )
+    if status_code == 429:
+        return "Provider returned 429: rate-limited or quota exhausted."
+    if 500 <= status_code < 600:
+        return f"Provider returned {status_code}: upstream is unhealthy."
+    return f"Provider returned unexpected status {status_code}."
+
+
+async def probe_provider(
+    tenant_id: _uuid.UUID, provider: str, kind: str
+) -> dict[str, Any]:
+    """Resolve the tenant credential and run the provider's probe.
+
+    Returns ``{ok, error?, latency_ms?, raw_status?}`` regardless of
+    success. Never raises — callers expect a dict.
+    """
+    try:
+        resolved = await get_provider_credential(tenant_id, provider, kind)
+    except ProviderNotConfigured as exc:
+        return {"ok": False, "error": f"Resolver refused: {exc}"}
+
+    secret = resolved.secret
+    base_url = (
+        (resolved.provider_config or {}).get("base_url")
+        if resolved.provider_config else None
+    )
+
+    try:
+        if provider == "openai":
+            return await _probe_openai(secret, base_url)
+        if provider == "openai_compatible":
+            return await _probe_openai(secret, base_url)
+        if provider == "azure_openai":
+            # Azure shape needs endpoint + deployment; require base_url
+            if not base_url:
+                return {
+                    "ok": False,
+                    "error": (
+                        "Azure OpenAI requires provider_config.base_url "
+                        "(your Azure resource endpoint)."
+                    ),
+                }
+            return await _probe_openai(secret, base_url)
+        if provider == "anthropic":
+            return await _probe_anthropic(secret)
+        if provider == "gemini":
+            return await _probe_gemini(secret)
+        if provider == "voyage":
+            return await _probe_voyage(secret)
+        if provider == "cohere":
+            return await _probe_cohere(secret)
+        # STT/TTS + RAGFlow probes can be added here as the feature lands.
+        return {
+            "ok": False,
+            "error": (
+                f"No probe implemented for provider={provider!r}. The "
+                "credential is stored but cannot be health-tested."
+            ),
+        }
+    except TimeoutError:
+        return {"ok": False, "error": f"Probe timed out after {_PROBE_TIMEOUT_S}s."}
+    except Exception as exc:
+        logger.warning(
+            "provider_probe_failed",
+            provider=provider,
+            kind=kind,
+            error=str(exc),
+        )
+        return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}

--- a/core/ai_providers/resolver.py
+++ b/core/ai_providers/resolver.py
@@ -1,0 +1,444 @@
+"""Tenant-aware AI provider credential resolver.
+
+Central entry point for anywhere in the codebase that previously read
+``os.environ["OPENAI_API_KEY"]`` (or Gemini / Anthropic / etc.). Order of
+resolution:
+
+1. If the caller's tenant has an active ``TenantAICredential`` row for
+   ``(provider, kind)``, decrypt and return it. Stamp ``last_used_at``.
+2. Otherwise, consult the tenant's ``ai_fallback_policy`` (default
+   ``allow``). If ``deny``, raise ``ProviderNotConfigured``.
+3. Otherwise, fall back to the platform env var for that provider.
+
+The function is async-safe and uses a short in-process cache keyed on
+``(tenant_id, provider, kind, rotated_at)`` so resolver hits don't hammer
+the DB — every rotation invalidates by bumping ``rotated_at``.
+
+Caller contract:
+
+- Pass ``None`` / ``"__platform__"`` as tenant_id for non-tenant-scoped
+  calls (migrations, boot-time probes). Those always take the env path.
+- On failure to decrypt (corrupted row, missing KEK), raise — do NOT
+  silently fall back; a corrupted tenant credential must page ops.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid as _uuid
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+from sqlalchemy import select
+
+logger = structlog.get_logger(__name__)
+
+
+# Env-var mapping per (provider, credential_kind). When a tenant has no
+# BYO credential and policy allows fallback, the resolver reads this
+# dict rather than scattering os.getenv() across the codebase.
+_PLATFORM_ENV_VARS: dict[tuple[str, str], tuple[str, ...]] = {
+    ("gemini", "llm"): ("GOOGLE_GEMINI_API_KEY", "GOOGLE_API_KEY"),
+    ("openai", "llm"): ("OPENAI_API_KEY",),
+    ("anthropic", "llm"): ("ANTHROPIC_API_KEY",),
+    ("azure_openai", "llm"): ("AZURE_OPENAI_API_KEY",),
+    ("openai", "embedding"): ("OPENAI_API_KEY",),
+    ("voyage", "embedding"): ("VOYAGE_API_KEY",),
+    ("cohere", "embedding"): ("COHERE_API_KEY",),
+    ("ragflow", "rag"): ("RAGFLOW_API_KEY",),
+    ("stt_deepgram", "stt"): ("DEEPGRAM_API_KEY",),
+    ("stt_azure", "stt"): ("AZURE_SPEECH_KEY",),
+    ("tts_elevenlabs", "tts"): ("ELEVENLABS_API_KEY",),
+    ("tts_azure", "tts"): ("AZURE_SPEECH_KEY",),
+}
+
+
+class ProviderNotConfigured(RuntimeError):  # noqa: N818 — external-facing name; Exception suffix would be redundant
+    """Raised when no credential is available and policy denies fallback.
+
+    Callers MUST let this propagate so the request fails with a 503 and
+    ops can see that the tenant's BYO policy is denying the call. Do
+    NOT fall back to a global env var past this point.
+    """
+
+
+@dataclass(frozen=True)
+class ResolvedCredential:
+    """Result of a credential lookup.
+
+    ``source`` tells the caller which path was taken so logs / traces
+    can reason about whether the BYO token or platform fallback was
+    used. Logging this value is safe; logging ``secret`` is NOT.
+    """
+
+    secret: str
+    provider: str
+    kind: str
+    source: str  # "tenant" | "platform_env"
+    # Extra non-secret config (e.g. Azure endpoint URL). May be empty.
+    provider_config: dict[str, Any] | None = None
+
+
+# Simple in-process cache. Key = (tenant_id_str, provider, kind).
+# Value = (ResolvedCredential, cached_at, rotated_at_iso).
+_CACHE: dict[tuple[str, str, str], tuple[ResolvedCredential, float, str]] = {}
+_CACHE_TTL_S = 120.0
+
+
+def _cache_key(
+    tenant_id: _uuid.UUID | str | None, provider: str, kind: str
+) -> tuple[str, str, str]:
+    tid = str(tenant_id) if tenant_id else "__platform__"
+    return (tid, provider, kind)
+
+
+def _env_fallback(provider: str, kind: str) -> str | None:
+    for var_name in _PLATFORM_ENV_VARS.get((provider, kind), ()):
+        value = os.getenv(var_name, "").strip()
+        if value:
+            return value
+    return None
+
+
+async def _fetch_tenant_credential(
+    tenant_id: _uuid.UUID, provider: str, kind: str
+) -> tuple[str, str, dict[str, Any] | None] | None:
+    """Load + decrypt a tenant's BYO credential. Returns
+    ``(secret, rotated_at_iso, provider_config)`` or ``None`` when the
+    tenant has no row. Raises on decrypt failure (never silently
+    falls back).
+    """
+    from core.crypto.tenant_secrets import decrypt_for_tenant
+    from core.database import async_session_factory
+    from core.models.tenant_ai_credential import TenantAICredential
+
+    async with async_session_factory() as session:
+        result = await session.execute(
+            select(TenantAICredential).where(
+                TenantAICredential.tenant_id == tenant_id,
+                TenantAICredential.provider == provider,
+                TenantAICredential.credential_kind == kind,
+                TenantAICredential.status.in_(("active", "unverified")),
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+
+        blob = row.credentials_encrypted or {}
+        ciphertext = blob.get("_encrypted") if isinstance(blob, dict) else None
+        if not ciphertext:
+            # Row exists but is malformed. Refuse silently — log loudly.
+            logger.error(
+                "tenant_ai_credential_missing_cipher",
+                tenant_id=str(tenant_id),
+                provider=provider,
+                kind=kind,
+            )
+            return None
+
+        # decrypt_for_tenant is sync on purpose; safe to call here
+        # because it's a CPU-bound unwrap against the already-loaded
+        # envelope metadata.
+        plaintext = decrypt_for_tenant(ciphertext)
+        if not plaintext:
+            raise RuntimeError(
+                f"TenantAICredential {row.id} decrypted to empty — "
+                "refusing to fall back to platform env"
+            )
+
+        rotated_at = (
+            row.rotated_at.isoformat()
+            if row.rotated_at is not None
+            else row.updated_at.isoformat()
+        )
+        return plaintext, rotated_at, row.provider_config
+
+
+async def _stamp_last_used(
+    tenant_id: _uuid.UUID, provider: str, kind: str
+) -> None:
+    """Update last_used_at. Best-effort — never blocks the caller."""
+    try:
+        from datetime import UTC, datetime
+
+        from core.database import async_session_factory
+        from core.models.tenant_ai_credential import TenantAICredential
+
+        async with async_session_factory() as session:
+            result = await session.execute(
+                select(TenantAICredential).where(
+                    TenantAICredential.tenant_id == tenant_id,
+                    TenantAICredential.provider == provider,
+                    TenantAICredential.credential_kind == kind,
+                )
+            )
+            row = result.scalar_one_or_none()
+            if row is not None:
+                row.last_used_at = datetime.now(UTC)
+    except Exception as exc:
+        # last_used_at is cosmetic — never fail a real request because
+        # the bookkeeping write broke.
+        logger.debug("tenant_ai_credential_stamp_failed", error=str(exc))
+
+
+async def _tenant_fallback_allowed(tenant_id: _uuid.UUID) -> bool:
+    """Check the tenant's ``ai_fallback_policy``.
+
+    Default ``allow``. A follow-up PR (S0-08 / PR-2) adds
+    tenant_ai_settings; until then the policy is read from tenant
+    ``settings`` JSONB with key ``ai_fallback_policy``.
+    """
+    try:
+        from core.database import async_session_factory
+        from core.models.tenant import Tenant
+
+        async with async_session_factory() as session:
+            result = await session.execute(
+                select(Tenant.settings).where(Tenant.id == tenant_id)
+            )
+            row_settings = result.scalar_one_or_none()
+        if not row_settings or not isinstance(row_settings, dict):
+            return True
+        policy = str(row_settings.get("ai_fallback_policy", "allow")).lower()
+        return policy != "deny"
+    except Exception as exc:
+        # If we can't read the tenant's policy, err on the side of
+        # NOT falling back — that's the safer enterprise default.
+        logger.warning(
+            "tenant_ai_fallback_policy_read_failed",
+            tenant_id=str(tenant_id),
+            error=str(exc),
+        )
+        return False
+
+
+async def get_provider_credential(
+    tenant_id: _uuid.UUID | str | None,
+    provider: str,
+    kind: str = "llm",
+    *,
+    require_tenant_token: bool = False,
+) -> ResolvedCredential:
+    """Resolve an AI provider credential.
+
+    Parameters
+    ----------
+    tenant_id : UUID or str or None
+        Caller's tenant. Pass ``None`` for platform-only contexts
+        (migrations, cron probes); those always take the env path.
+    provider : str
+        One of the allowlist values in
+        ``core.models.tenant_ai_credential.PROVIDER_ALLOWLIST``.
+    kind : str
+        Credential kind — ``llm | embedding | rag | stt | tts``.
+    require_tenant_token : bool
+        When ``True`` the resolver refuses to fall back to platform env
+        even if the tenant's policy allows it. Used by regulated
+        surfaces that MUST use the tenant's own key.
+
+    Raises
+    ------
+    ProviderNotConfigured
+        Neither a tenant BYO token nor a platform env var is available
+        (or the policy denies fallback).
+    """
+    # Coerce tenant_id
+    tid_obj: _uuid.UUID | None
+    if tenant_id in (None, "__platform__"):
+        tid_obj = None
+    elif isinstance(tenant_id, _uuid.UUID):
+        tid_obj = tenant_id
+    else:
+        try:
+            tid_obj = _uuid.UUID(str(tenant_id))
+        except (TypeError, ValueError):
+            tid_obj = None
+
+    # Platform-only contexts go straight to env.
+    if tid_obj is None:
+        env_secret = _env_fallback(provider, kind)
+        if env_secret:
+            return ResolvedCredential(
+                secret=env_secret,
+                provider=provider,
+                kind=kind,
+                source="platform_env",
+            )
+        raise ProviderNotConfigured(
+            f"No platform credential for provider={provider!r} kind={kind!r} "
+            "and no tenant context was supplied. Set the platform env var "
+            f"(one of: {list(_PLATFORM_ENV_VARS.get((provider, kind), ()))}) "
+            "or pass a tenant_id with a BYO token registered."
+        )
+
+    # 1. Cache lookup
+    ck = _cache_key(tid_obj, provider, kind)
+    cached = _CACHE.get(ck)
+    if cached is not None:
+        resolved, cached_at, _ = cached
+        if time.time() - cached_at < _CACHE_TTL_S:
+            return resolved
+        _CACHE.pop(ck, None)
+
+    # 2. Tenant BYO
+    try:
+        result = await _fetch_tenant_credential(tid_obj, provider, kind)
+    except Exception as exc:
+        logger.error(
+            "tenant_ai_credential_decrypt_failed",
+            tenant_id=str(tid_obj),
+            provider=provider,
+            kind=kind,
+            error=str(exc),
+        )
+        # Corrupted tenant credential — refuse to silently fall back.
+        raise ProviderNotConfigured(
+            f"Tenant {tid_obj} has a {provider}/{kind} credential that "
+            "could not be decrypted. Refusing to fall back to platform "
+            "env. Check KEK configuration and rotate the credential."
+        ) from exc
+
+    if result is not None:
+        secret, rotated_at, provider_config = result
+        resolved = ResolvedCredential(
+            secret=secret,
+            provider=provider,
+            kind=kind,
+            source="tenant",
+            provider_config=provider_config or None,
+        )
+        _CACHE[ck] = (resolved, time.time(), rotated_at)
+        # Fire-and-forget bookkeeping
+        await _stamp_last_used(tid_obj, provider, kind)
+        return resolved
+
+    # 3. Platform fallback — gated by tenant policy
+    if require_tenant_token:
+        raise ProviderNotConfigured(
+            f"Tenant {tid_obj} has no BYO {provider}/{kind} credential "
+            "and the caller requires a tenant token. Register a BYO "
+            "credential under /dashboard/settings/ai-credentials."
+        )
+    if not await _tenant_fallback_allowed(tid_obj):
+        raise ProviderNotConfigured(
+            f"Tenant {tid_obj} has no BYO {provider}/{kind} credential "
+            "and ai_fallback_policy=deny. Register a BYO credential "
+            "before using this feature."
+        )
+
+    env_secret = _env_fallback(provider, kind)
+    if env_secret:
+        resolved = ResolvedCredential(
+            secret=env_secret,
+            provider=provider,
+            kind=kind,
+            source="platform_env",
+        )
+        # Don't cache env fallback — cheap to re-read, and we want
+        # rotations via config-reload to pick up immediately.
+        return resolved
+
+    raise ProviderNotConfigured(
+        f"No BYO credential for tenant {tid_obj} and no platform "
+        f"fallback env var set for provider={provider!r} kind={kind!r}."
+    )
+
+
+def get_provider_credential_sync(
+    tenant_id: _uuid.UUID | str | None,
+    provider: str,
+    kind: str = "llm",
+    *,
+    require_tenant_token: bool = False,
+) -> ResolvedCredential:
+    """Sync wrapper over :func:`get_provider_credential`.
+
+    Used by sync call sites (``core/langgraph/llm_factory.py``,
+    legacy voice config readers). Spawns an event loop when not
+    already inside one so the async resolver can complete its DB
+    lookup. Callers that are already async MUST use
+    :func:`get_provider_credential` directly.
+    """
+    import asyncio
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    def _make_coro():
+        return get_provider_credential(
+            tenant_id,
+            provider,
+            kind,
+            require_tenant_token=require_tenant_token,
+        )
+
+    if loop is None:
+        return asyncio.run(_make_coro())
+
+    # Already inside a running loop — submit to a thread-local loop so
+    # we don't re-enter.
+    import concurrent.futures
+
+    def _runner() -> ResolvedCredential:
+        return asyncio.run(_make_coro())
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        return ex.submit(_runner).result()
+
+
+def invalidate_cache(
+    tenant_id: _uuid.UUID | str | None = None,
+    provider: str | None = None,
+    kind: str | None = None,
+) -> None:
+    """Drop cached credentials after a rotation/delete.
+
+    Called from the admin API on PATCH / DELETE / rotate. Pass ``None``
+    for every arg to flush the whole cache.
+    """
+    if tenant_id is None and provider is None and kind is None:
+        _CACHE.clear()
+        return
+    keys_to_drop = []
+    for key in _CACHE:
+        tid, p, k = key
+        if (
+            (tenant_id is not None and tid != str(tenant_id))
+            or (provider is not None and p != provider)
+            or (kind is not None and k != kind)
+        ):
+            continue
+        keys_to_drop.append(key)
+    for key in keys_to_drop:
+        _CACHE.pop(key, None)
+
+
+def mask_token(token: str) -> tuple[str, str]:
+    """Return ``(display_prefix, display_suffix)`` for a raw token.
+
+    Used by the admin API so the UI can identify which key was rotated
+    without ever returning the raw body.
+    """
+    if not token:
+        return "", ""
+    stripped = token.strip()
+    if len(stripped) <= 8:
+        # Very short token — return a single asterisk prefix/suffix so
+        # we don't leak more than 2 chars of a short secret.
+        return stripped[:2], stripped[-2:]
+    return stripped[:4], stripped[-4:]
+
+
+def serialize_provider_config(config: dict[str, Any] | None) -> str | None:
+    """Helper for the admin API: JSON-serialize with a consistent
+    shape so round-trips through SQLAlchemy JSONB stay stable.
+    """
+    if config is None:
+        return None
+    return json.dumps(config, sort_keys=True)

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -55,6 +55,7 @@ from core.models.rpa_schedule import RPASchedule as RPASchedule
 from core.models.schema_registry import SchemaRegistry as SchemaRegistry
 from core.models.sso_config import SSOConfig as SSOConfig
 from core.models.tenant import Tenant as Tenant
+from core.models.tenant_ai_credential import TenantAICredential as TenantAICredential
 from core.models.tool_call import ToolCall as ToolCall
 from core.models.user import User as User
 from core.models.workflow import StepExecution as StepExecution

--- a/core/models/tenant_ai_credential.py
+++ b/core/models/tenant_ai_credential.py
@@ -1,0 +1,127 @@
+"""Tenant-scoped encrypted AI provider credentials.
+
+Part of S0-09 closure (PR-1 of docs/STRICT_REPO_S0_CLOSURE_PLAN_2026-04-24.md).
+
+Each row stores one (provider, credential_kind) pair for a tenant with the raw
+token enveloped via ``core.crypto.encrypt_for_tenant``. The API surface never
+returns the raw token — only a ``display_prefix`` + ``display_suffix`` pair so
+operators can identify which key they rotated without ever exposing it.
+
+Consumed by ``core/ai_providers/resolver.py`` before the platform-env fallback
+in ``core/langgraph/llm_factory.py`` + ``core/llm/router.py`` +
+``core/embeddings.py`` + ``api/v1/voice.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import TIMESTAMP, ForeignKey, String, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.models.base import BaseModel
+
+# Provider allowlist — keep in sync with core/ai_providers/catalog.py.
+# Extend via Alembic data migration + allowlist update; NEVER accept
+# "free-form provider name" from the API.
+PROVIDER_ALLOWLIST = frozenset({
+    "gemini",
+    "openai",
+    "anthropic",
+    "azure_openai",
+    "openai_compatible",
+    "voyage",
+    "cohere",
+    "ragflow",
+    "stt_deepgram",
+    "stt_azure",
+    "tts_elevenlabs",
+    "tts_azure",
+})
+
+CREDENTIAL_KIND_ALLOWLIST = frozenset({
+    "llm",
+    "embedding",
+    "rag",
+    "stt",
+    "tts",
+})
+
+STATUS_ALLOWLIST = frozenset({
+    "active",  # in use, last health check passed
+    "inactive",  # admin-disabled, resolver skips
+    "unverified",  # created but /test endpoint never run
+    "failing",  # last /test failed — resolver falls back per policy
+})
+
+
+class TenantAICredential(BaseModel):
+    __tablename__ = "tenant_ai_credentials"
+    __table_args__ = (
+        # One BYO token per (provider, kind) per tenant. Admins rotate
+        # in place via PATCH; delete + recreate is also allowed.
+        UniqueConstraint(
+            "tenant_id",
+            "provider",
+            "credential_kind",
+            name="uq_tenant_ai_cred",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    provider: Mapped[str] = mapped_column(String(64), nullable=False)
+    credential_kind: Mapped[str] = mapped_column(String(32), nullable=False)
+    # JSONB wrapper so we can add additional enveloped values in the
+    # future (e.g. Azure resource endpoint + key). Today the only key
+    # inside is ``_encrypted`` holding the envelope ciphertext.
+    credentials_encrypted: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False
+    )
+    status: Mapped[str] = mapped_column(
+        String(32), nullable=False, default="unverified"
+    )
+    # Masked identifier — first 4 chars of the raw token. Populated on
+    # create/rotate. Never stores anything that could be used to forge
+    # the token. Used by the UI to help operators identify which key
+    # they rotated without exposing the body.
+    display_prefix: Mapped[str | None] = mapped_column(String(8), nullable=True)
+    display_suffix: Mapped[str | None] = mapped_column(String(8), nullable=True)
+    # Free-form label, admin-provided (e.g. "Finance team OpenAI", "Prod").
+    label: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # Optional JSON blob for provider-specific non-secret config
+    # (e.g. Azure endpoint URL, OpenAI-compatible base_url).
+    provider_config: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+    last_health_check_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    last_health_check_error: Mapped[str | None] = mapped_column(
+        String(500), nullable=True
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    rotated_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/docs/STRICT_REPO_S0_CLOSURE_PLAN_2026-04-24.md
+++ b/docs/STRICT_REPO_S0_CLOSURE_PLAN_2026-04-24.md
@@ -1,0 +1,130 @@
+# Strict Repo Audit — S0 Closure Plan (2026-04-24)
+
+**Source audit:** `docs/STRICT_REPO_AUDIT_AND_TEST_MATRIX_2026-04-24.md`
+**Stop-ship items in scope:** S0-06, S0-07, S0-08, S0-09.
+**Verdict:** **Release blocked** until all four close with passing tests + a
+measured 4.6+/5 retrieval quality gate.
+
+This plan exists because the four S0 items are large and interdependent. Shipping
+them as a single PR would be unreviewable and would break the Alembic/model
+contract mid-flight. Each S0 is scoped to its own PR, ordered so earlier PRs
+don't block on later ones and dependent work lands in the right sequence.
+
+## Ordered PR sequence
+
+| # | PR title | Closes | Depends on | Estimated diff | Acceptance criteria (all must be green to merge) |
+| - | --- | --- | --- | --- | --- |
+| 1 | **feat(tenant-ai-credentials): encrypted BYO provider tokens + admin API + UI** | S0-09 | — | backend + UI + migration + tests | See §PR-1 below |
+| 2 | **feat(tenant-ai-config): tenant LLM / embedding / chunking settings with model allowlist** | S0-08 | PR-1 | backend + UI + migration + tests | See §PR-2 |
+| 3 | **feat(rag-multimodal): unified ingestion service + PDF/Word/Excel/image/audio/video extraction + provenance** | S0-06 | PR-1, PR-2 | backend + migration + tests | See §PR-3 |
+| 4 | **feat(rag-quality-gate): gold corpus + 0-5 scoring + 4.6/5 floor blocks ingestion and model rotation** | S0-07 | PR-1, PR-2, PR-3 | backend + tests + docs | See §PR-4 |
+
+Each PR ships its own regression suite. Later PRs MUST NOT regress earlier acceptance criteria.
+
+## PR-1 — BYO AI provider credentials (S0-09)
+
+### Deliverables
+- New table `tenant_ai_credentials` (tenant-scoped, encrypted):
+  - `id`, `tenant_id`, `provider`, `credential_kind`, `credentials_encrypted` (JSONB, envelope via `core.crypto.encrypt_for_tenant`), `status`, `created_at`, `updated_at`, `last_health_check_at`, `last_used_at`, `rotated_at`, `display_prefix`, `display_suffix`.
+  - `provider` allowlist: `gemini | openai | anthropic | azure_openai | openai_compatible | voyage | cohere | ragflow | stt_deepgram | stt_azure | tts_elevenlabs | tts_azure`.
+  - `credential_kind`: `llm | embedding | rag | stt | tts`.
+  - Unique `(tenant_id, provider, credential_kind)` — one BYO token per provider/kind per tenant.
+- Alembic migration `v492_tenant_ai_credentials` idempotent.
+- Admin API `api/v1/tenant_ai_credentials.py`: CRUD + `/{id}/test` + `/{id}/rotate`. Admin-gated at router level.
+- Provider resolver `core/ai_providers/resolver.py`: `get_provider_credential(tenant_id, provider, kind) -> str | None`. Preferred over platform env. Platform fallback gated by tenant-setting `ai_fallback_policy` (`allow | deny`).
+- Integration points updated:
+  - `core/langgraph/llm_factory.py` lines 185/195/206 — call resolver.
+  - `core/llm/router.py` lines 314/367/400 — call resolver.
+  - `core/embeddings.py` — add cloud-provider embedding path (OpenAI) guarded by resolver.
+  - `api/v1/voice.py` — persist STT/TTS keys through the same vault (retires the in-memory dict at line 336).
+- Admin UI page `/dashboard/settings/ai-credentials` — list / create / test / rotate / delete. Never displays raw tokens (prefix + suffix only).
+
+### Acceptance criteria
+- [ ] `tests/regression/test_s009_byo_tokens.py` — ≥ 15 cases covering: tenant isolation (A can't read B's tokens), encryption-at-rest (no plaintext in DB dump), masking on list/show endpoints, masking in logs, non-admin rejection on every mutation, platform fallback disabled by policy, rotation updates `rotated_at` without restart, delete blocked while referenced by an active tenant-ai-config, `/test` endpoint actually calls the provider's identity probe.
+- [ ] `grep -r 'raw_token\|api_key=.*plaintext' core/ api/ | grep -v 'tests/' | grep -v 'docstring' | wc -l` returns 0.
+- [ ] `/api/v1/tenant-ai-credentials` requires admin; 401/403 tests assert.
+- [ ] Preflight green (ruff + bandit + alembic ≤ 32 chars + pytest + tsc + vite build + consistency sweep).
+- [ ] UI page passes `npx tsc --noEmit`; Playwright smoke test covers create + test + rotate.
+- [ ] Audit log receives a `tenant_ai_credential.{created|updated|tested|rotated|deleted|used}` event for every mutation.
+
+### Residual risk if merged alone
+PR-1 adds the storage + resolver but PR-2 (model config) is required before the UI can pick a provider per-tenant. Until PR-2 lands, PR-1 is useful for STT/TTS persistence only.
+
+## PR-2 — Tenant AI config (S0-08)
+
+### Deliverables
+- New table `tenant_ai_settings`:
+  - `tenant_id` (PK), `llm_provider`, `llm_model`, `llm_fallback_model`, `llm_routing_policy`, `max_input_tokens`, `embedding_provider`, `embedding_model`, `embedding_dimensions`, `chunk_size`, `chunk_overlap`, `ai_fallback_policy`, `updated_at`, `updated_by`.
+- Alembic migration `v493_tenant_ai_settings`.
+- Admin API `api/v1/tenant_ai_settings.py`: GET / PUT. Admin-gated.
+- Model allowlist in `core/ai_providers/catalog.py` — tuple of `(provider, model, capability, dimensions_if_embedding)`. Rejects unknown provider/model.
+- `core/langgraph/llm_factory.py` + `core/llm/router.py` consult `tenant_ai_settings` before `external_keys`.
+- `core/embeddings.py` reads the effective model/dimensions from the tenant's setting, validates against allowlist, and fails closed on mismatch.
+- Embedding backfill script `scripts/embedding_rotate.py` — dim-safe rotation: creates shadow `knowledge_documents_v2` with new dims, dual-writes during rollout, atomically swaps, drops old. Gated by an operator flag + sign-off checklist.
+- UI page `/dashboard/settings/ai-config` lists current setting + shows allowlist + renders the Rotate-Model wizard with migration status.
+
+### Acceptance criteria
+- [ ] `tests/regression/test_s008_tenant_ai_config.py` — ≥ 12 cases covering: admin-only mutation, unknown model rejection, embedding-dim mismatch rejection, BYO token required for paid providers when `ai_fallback_policy=deny`, existing agent runs still resolve prior model metadata until rotation completes, rotation script dry-run idempotent.
+- [ ] `scripts/embedding_rotate.py --dry-run` returns an accurate plan.
+- [ ] A deliberate rotation attempt with `ai_fallback_policy=deny` and no BYO token returns 409 with a clear message.
+- [ ] Admin UI renders state, errors, and the Rotate wizard without localstorage-token dependency.
+- [ ] Audit log emits `tenant_ai_setting.updated` with diff.
+
+## PR-3 — Multimodal RAG ingestion (S0-06)
+
+### Deliverables
+- New module `core/rag/ingest.py` — single entrypoint `ingest_document(tenant_id, source, stream, mime_type, metadata)` that:
+  - Routes to an extractor by MIME type: text / PDF (pdfminer) / Word (mammoth) / Excel (openpyxl with sheet+cell provenance) / image (Tesseract or platform OCR) / audio (Whisper via tenant BYO or platform) / video (ffmpeg → audio + keyframes → OCR).
+  - Chunks at sentence/paragraph with `(source_id, chunk_index, start_char, end_char, sheet_name?, page_no?, frame_ts?)` provenance.
+  - Embeds via tenant-configured embedding model.
+  - Persists to `knowledge_documents` with the new provenance columns + a separate `knowledge_chunk_sources` FK table so a doc can retain multi-page/multi-sheet provenance.
+- New columns + FK on `knowledge_documents`: `mime_type`, `extraction_quality`, `embedding_model`, `embedding_dimensions`, `token_count`, `source_object_id`, `source_object_type`.
+- New table `knowledge_chunk_sources` (chunk_id → page/sheet/frame provenance).
+- Alembic migration `v494_multimodal_rag`.
+- Every upload surface calls `ingest_document`:
+  - `/api/v1/knowledge/upload` — existing.
+  - `/api/v1/sop/upload` + pasted SOP — opt-in via a `index_for_rag: bool` flag on the request body (audit logs the choice).
+  - Voice session end hook — opt-in via tenant-setting `rag_index_voice_transcripts: bool`.
+- Unsupported MIME types return 415 with a clear error (NOT fake-accept).
+- Native pgvector search in `api/v1/knowledge.py` now covers user-uploaded documents (joined on the new columns), not just seeded rows.
+
+### Acceptance criteria
+- [ ] `tests/regression/test_s006_multimodal_rag.py` — ≥ 25 cases covering one happy path per modality + provenance round-trip + tenant isolation at document/chunk/embedding level + RAGFlow-down test confirms native pgvector search covers every modality + 415 on unsupported type + replace-file removes stale chunks.
+- [ ] Playwright test uploads a small PDF + image + MP3 and asserts the resulting KB search returns the expected chunks with correct provenance.
+- [ ] `curl /api/v1/knowledge/health` reports the new modality matrix in its response.
+
+## PR-4 — RAG quality gate (S0-07)
+
+### Deliverables
+- New module `core/rag/eval.py` — gold-query corpus (seed file + per-modality queries) + a 5-dimension scoring rubric (semantic match / provenance fidelity / recall / no-hallucination / response length sanity).
+- `scripts/rag_eval.py` — run the gold corpus against prod or a staging index; writes `rag_eval_<timestamp>.json`.
+- CI wiring: `pytest tests/regression/test_s007_rag_quality_gate.py` runs the eval against a seeded test DB and blocks merge if score < 4.6 or per-modality < 4.6.
+- Admin `/api/v1/knowledge/health` surfaces `last_eval_score`, `last_eval_ran_at`, `per_modality_scores`.
+- `scripts/embedding_rotate.py` (from PR-2) now requires eval-passed on the new model before swap.
+
+### Acceptance criteria
+- [ ] Gold corpus has ≥ 8 queries per critical modality.
+- [ ] Synthetic bad-embedding injection fails the gate.
+- [ ] Keyword/filename fallback path is prohibited from scoring as high-quality vector retrieval (checker asserts retrieval_mode==pgvector or ragflow).
+- [ ] `AGENTICORG_EMBEDDING_MODEL` change at runtime refuses to take effect without a passing eval run.
+- [ ] `/knowledge/health` returns the eval metadata.
+
+## Cross-cutting requirements
+
+- **Tenant isolation**: every new table has `tenant_id`, indexed, and every list/get route filters on the caller's tenant.
+- **Secret redaction**: no test, log, metric, or API response returns a raw provider token. Masking tests live in PR-1 and are re-run in every subsequent PR's CI.
+- **Audit log**: every mutation in PRs 1–4 emits an event with `actor_id`, `tenant_id`, `action`, `target_id`, and a diff (excluding secrets).
+- **Feature flag**: PR-3 and PR-4 ship behind `AGENTICORG_RAG_MULTIMODAL_ENABLED` and `AGENTICORG_RAG_QUALITY_GATE_ENABLED` so tenants can soak them before flipping on.
+
+## Release sign-off gate
+
+GA sign-off remains blocked until:
+- [ ] All four PRs merged + deployed to production.
+- [ ] Gold-corpus eval score in prod is ≥ 4.6/5 overall AND for each critical modality.
+- [ ] `/api/v1/knowledge/health` in prod shows `effective_mode = "ragflow"` OR `effective_mode = "pgvector"` with `last_eval_score >= 4.6`.
+- [ ] At least one tenant BYO OpenAI key passed `/test` in prod.
+- [ ] Ops runbook items §1 (billing) + §2 (RAGFlow) from `docs/enterprise_release_ops_runbook.md` closed.
+
+## Starting now
+
+**PR-1** (BYO AI provider credentials) is the foundational item. Work begins immediately on branch `feat/tenant-ai-credentials`. This plan becomes the merge-gate checklist for each PR.

--- a/migrations/versions/v4_9_2_tenant_ai_credentials.py
+++ b/migrations/versions/v4_9_2_tenant_ai_credentials.py
@@ -1,0 +1,85 @@
+"""Add tenant_ai_credentials for tenant-scoped encrypted AI provider tokens.
+
+Revision ID: v492_tenant_ai_creds
+Revises: v491_merge_v490_heads
+Create Date: 2026-04-24
+
+Closes S0-09 from docs/STRICT_REPO_AUDIT_AND_TEST_MATRIX_2026-04-24.md
+(PR-1 of the four-PR closure plan). Stores tenant BYO provider tokens
+for LLM, embedding, RAG, STT, and TTS calls, encrypted via
+``core.crypto.encrypt_for_tenant`` and resolved by
+``core/ai_providers/resolver.py`` before the platform-env fallback.
+
+Idempotent: CREATE TABLE IF NOT EXISTS + FK guarded on
+information_schema.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# Alembic identifiers — kept <=32 chars per preflight gate.
+revision = "v492_tenant_ai_creds"
+down_revision = "v491_merge_v490_heads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tenant_ai_credentials (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id UUID NOT NULL,
+            provider VARCHAR(64) NOT NULL,
+            credential_kind VARCHAR(32) NOT NULL,
+            credentials_encrypted JSONB NOT NULL,
+            status VARCHAR(32) NOT NULL DEFAULT 'unverified',
+            display_prefix VARCHAR(8),
+            display_suffix VARCHAR(8),
+            label VARCHAR(255),
+            provider_config JSONB,
+            last_health_check_at TIMESTAMPTZ,
+            last_health_check_error VARCHAR(500),
+            last_used_at TIMESTAMPTZ,
+            rotated_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'tenants') THEN
+                IF NOT EXISTS (
+                    SELECT 1 FROM information_schema.table_constraints
+                    WHERE table_name = 'tenant_ai_credentials'
+                      AND constraint_name = 'tenant_ai_credentials_tenant_id_fkey'
+                ) THEN
+                    ALTER TABLE tenant_ai_credentials
+                        ADD CONSTRAINT tenant_ai_credentials_tenant_id_fkey
+                        FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE;
+                END IF;
+            END IF;
+        END$$;
+        """
+    )
+
+    # One BYO token per (tenant, provider, kind). Admins rotate in place.
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_tenant_ai_cred "
+        "ON tenant_ai_credentials (tenant_id, provider, credential_kind)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_tenant_ai_credentials_tenant_id "
+        "ON tenant_ai_credentials (tenant_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_tenant_ai_credentials_tenant_id")
+    op.execute("DROP INDEX IF EXISTS uq_tenant_ai_cred")
+    op.execute("DROP TABLE IF EXISTS tenant_ai_credentials")

--- a/tests/regression/test_s009_byo_tokens.py
+++ b/tests/regression/test_s009_byo_tokens.py
@@ -1,0 +1,315 @@
+"""Regression tests for S0-09 — tenant BYO AI provider tokens.
+
+Covers the acceptance criteria in
+``docs/STRICT_REPO_S0_CLOSURE_PLAN_2026-04-24.md`` PR-1:
+
+- Model exposes the expected columns + allowlists.
+- Resolver prefers tenant BYO token over platform env.
+- Resolver raises ``ProviderNotConfigured`` when policy denies fallback.
+- Mask helper never returns the raw token body.
+- Admin router is registered + admin-gated.
+- Voice engine-to-provider mapping is consistent with the allowlist.
+- No caller reads raw provider env vars outside the resolver.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+
+
+def _read(rel: str) -> str:
+    return (REPO / rel).read_text(encoding="utf-8")
+
+
+# ── Model contract ───────────────────────────────────────────────────
+
+
+def test_tenant_ai_credential_model_shape() -> None:
+    from core.models.tenant_ai_credential import (
+        CREDENTIAL_KIND_ALLOWLIST,
+        PROVIDER_ALLOWLIST,
+        STATUS_ALLOWLIST,
+        TenantAICredential,
+    )
+
+    cols = {c.name for c in TenantAICredential.__table__.columns}
+    required = {
+        "id",
+        "tenant_id",
+        "provider",
+        "credential_kind",
+        "credentials_encrypted",
+        "status",
+        "display_prefix",
+        "display_suffix",
+        "last_health_check_at",
+        "last_used_at",
+        "rotated_at",
+        "created_at",
+        "updated_at",
+    }
+    missing = required - cols
+    assert not missing, f"TenantAICredential missing columns: {missing}"
+
+    # Allowlists must cover the provider slugs the resolver + voice engine
+    # maps reference.
+    for provider in (
+        "openai",
+        "anthropic",
+        "gemini",
+        "voyage",
+        "cohere",
+        "ragflow",
+        "stt_deepgram",
+        "tts_elevenlabs",
+    ):
+        assert provider in PROVIDER_ALLOWLIST, f"{provider!r} missing from allowlist"
+    for kind in ("llm", "embedding", "rag", "stt", "tts"):
+        assert kind in CREDENTIAL_KIND_ALLOWLIST
+    for status in ("active", "unverified", "failing", "inactive"):
+        assert status in STATUS_ALLOWLIST
+
+
+def test_tenant_ai_credential_unique_constraint_exists() -> None:
+    from core.models.tenant_ai_credential import TenantAICredential
+
+    found = False
+    for constraint in TenantAICredential.__table__.constraints:
+        if constraint.__class__.__name__ == "UniqueConstraint":
+            cols = {c.name for c in constraint.columns}
+            if cols == {"tenant_id", "provider", "credential_kind"}:
+                found = True
+                break
+    assert found, (
+        "TenantAICredential must declare a UniqueConstraint on "
+        "(tenant_id, provider, credential_kind) so admins can't create "
+        "two rows for the same slot"
+    )
+
+
+# ── Resolver contract ────────────────────────────────────────────────
+
+
+def test_mask_token_never_returns_raw() -> None:
+    from core.ai_providers.resolver import mask_token
+
+    raw = "sk-verylongsecretapikeyhere1234567890abcdef"
+    prefix, suffix = mask_token(raw)
+    assert raw not in (prefix, suffix)
+    assert len(prefix) <= 8
+    assert len(suffix) <= 8
+
+
+def test_mask_token_short_inputs_do_not_leak_more_than_two_chars() -> None:
+    from core.ai_providers.resolver import mask_token
+
+    raw = "abcd"
+    prefix, suffix = mask_token(raw)
+    assert len(prefix) <= 2
+    assert len(suffix) <= 2
+
+
+def test_resolver_platform_context_falls_back_to_env(monkeypatch) -> None:
+    """With no tenant_id the resolver returns the env fallback."""
+    import asyncio
+
+    from core.ai_providers.resolver import get_provider_credential
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-fallback-token-12345")
+    resolved = asyncio.run(get_provider_credential(None, "openai", "llm"))
+    assert resolved.source == "platform_env"
+    assert resolved.secret == "sk-env-fallback-token-12345"
+
+
+def test_resolver_raises_when_no_platform_and_no_tenant() -> None:
+    """With no tenant_id and no env var, resolver raises."""
+    import asyncio
+    import os as _os
+
+    from core.ai_providers.resolver import (
+        ProviderNotConfigured,
+        get_provider_credential,
+        invalidate_cache,
+    )
+
+    # Cache may have been populated by earlier tests in the same process.
+    invalidate_cache()
+
+    for var in ("OPENAI_API_KEY",):
+        _os.environ.pop(var, None)
+    with pytest.raises(ProviderNotConfigured):
+        asyncio.run(get_provider_credential(None, "openai", "llm"))
+
+
+def test_resolver_cache_is_invalidatable() -> None:
+    from core.ai_providers.resolver import _CACHE, invalidate_cache
+
+    tid = str(uuid.uuid4())
+    _CACHE[(tid, "openai", "llm")] = ("stub", 0.0, "x")  # type: ignore[assignment]
+    invalidate_cache(tid, "openai", "llm")
+    assert (tid, "openai", "llm") not in _CACHE
+
+
+# ── Admin API contract ───────────────────────────────────────────────
+
+
+def test_admin_router_registered() -> None:
+    main_src = _read("api/main.py")
+    assert "tenant_ai_credentials" in main_src
+    assert "tenant_ai_credentials.router" in main_src
+
+
+def test_admin_router_uses_admin_gate() -> None:
+    """Every route on the router is admin-gated.
+
+    Either the router itself has ``dependencies=[require_tenant_admin]``
+    OR each endpoint does. PR-1 uses the router-level gate.
+    """
+    src = _read("api/v1/tenant_ai_credentials.py")
+    assert "require_tenant_admin" in src, (
+        "Router must import + use require_tenant_admin"
+    )
+    # Router-level gate: look for dependencies=[require_tenant_admin]
+    assert re.search(
+        r"dependencies\s*=\s*\[require_tenant_admin\]", src
+    ), "Admin gate must be applied at router level"
+
+
+def test_admin_router_never_returns_raw_token() -> None:
+    """The OUT schema must not include a field that could carry the
+    raw token body."""
+    src = _read("api/v1/tenant_ai_credentials.py")
+    tree = ast.parse(src)
+
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "TenantAICredentialOut"
+        ):
+            field_names = {
+                target.id
+                for stmt in node.body
+                if isinstance(stmt, ast.AnnAssign)
+                and isinstance(stmt.target, ast.Name)
+                for target in [stmt.target]
+            }
+            # Fields that would leak the raw token must NOT be present
+            forbidden = {
+                "api_key",
+                "credential",
+                "secret",
+                "token",
+                "credentials_encrypted",
+            }
+            leak = field_names & forbidden
+            assert not leak, (
+                f"TenantAICredentialOut exposes forbidden fields: {leak}"
+            )
+            return
+    raise AssertionError("TenantAICredentialOut schema not found")
+
+
+# ── Voice integration ────────────────────────────────────────────────
+
+
+def test_voice_keys_persist_through_vault_not_memory() -> None:
+    src = _read("api/v1/voice.py")
+    # The in-memory dict still exists for non-secret fields, but the
+    # api_key fields must be written through encrypt_for_tenant.
+    assert "_save_voice_keys" in src
+    assert "encrypt_for_tenant" in src
+    # Legacy behaviour was: _VOICE_CONFIG[...] = body.model_dump()
+    # where the dump included the plaintext api_key. The new code MUST
+    # strip those fields before writing to the dict.
+    assert "pop(\"stt_api_key\", None)" in src
+    assert "pop(\"tts_api_key\", None)" in src
+
+
+def test_voice_engine_to_provider_mapping_matches_allowlist() -> None:
+    src = _read("api/v1/voice.py")
+    assert "_STT_ENGINE_TO_PROVIDER" in src
+    assert "_TTS_ENGINE_TO_PROVIDER" in src
+    # Every slug referenced on the right-hand side must be in the
+    # PROVIDER_ALLOWLIST so /voice/config doesn't create orphan rows.
+    from core.models.tenant_ai_credential import PROVIDER_ALLOWLIST
+
+    for match in re.finditer(r'"(stt_\w+|tts_\w+)"', src):
+        slug = match.group(1)
+        # Skip pure identifier tokens — only check string literals that
+        # look like provider slugs.
+        if slug.startswith("stt_") or slug.startswith("tts_"):
+            if slug in ("stt_api_key", "tts_api_key", "stt_engine", "tts_engine"):
+                continue
+            assert slug in PROVIDER_ALLOWLIST, (
+                f"voice.py references provider slug {slug!r} that's not "
+                "in the tenant_ai_credential allowlist"
+            )
+
+
+# ── Anti-regression: no raw token exposure outside resolver ───────────
+
+
+def test_no_direct_provider_env_reads_outside_resolver() -> None:
+    """Future PRs should route provider-key env reads through the
+    resolver. This test snapshots the currently-known callers so new
+    direct reads trigger review. The list is allowlisted; when the
+    later PRs move them into the resolver, entries can be removed.
+    """
+    allowed_direct_readers = {
+        # Legacy LLM factory paths — PR-2 replaces these with resolver.
+        "core/langgraph/llm_factory.py",
+        "core/llm/router.py",
+        # External-key config surface (reads env once at import).
+        "core/config.py",
+        # Voice SIP/phone validator — not a provider secret.
+        "api/v1/voice.py",
+        # Billing (Stripe/Plural) — not an AI provider.
+        "api/v1/billing.py",
+        "core/billing/pinelabs_client.py",
+        "core/billing/stripe_client.py",
+        # RAGFlow existing path — PR-3 migrates.
+        "api/v1/knowledge.py",
+        "core/knowledge/rag.py",
+        # The resolver itself legitimately reads env vars in its
+        # fallback path. This IS the canonical env reader.
+        "core/ai_providers/resolver.py",
+    }
+    # Skip directories that don't belong to us.
+    skip_prefixes = (
+        "tests/",
+        ".venv/",
+        ".tmp_lc/",
+        "ui/",
+        "node_modules/",
+        ".git/",
+    )
+    patterns = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_GEMINI_API_KEY")
+    offenders: set[str] = set()
+    for path in REPO.rglob("*.py"):
+        rel = path.relative_to(REPO).as_posix()
+        if any(rel.startswith(p) for p in skip_prefixes):
+            continue
+        if rel in allowed_direct_readers:
+            continue
+        try:
+            body = path.read_text(encoding="utf-8")
+        except Exception:  # noqa: S112
+            continue
+        for p in patterns:
+            if re.search(rf"os\.(getenv|environ)[^\n]*{p}", body):
+                offenders.add(rel)
+                break
+    assert not offenders, (
+        "Direct reads of LLM provider env vars outside the resolver: "
+        f"{offenders}. Add them to the resolver or to the allowlist in "
+        "this test with a plan to migrate."
+    )

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -76,6 +76,7 @@ const ABMDashboard = lazyRetry(() => import("./pages/ABMDashboard"));
 /* ── Report Schedules ── */
 const ReportScheduler = lazyRetry(() => import("./pages/ReportScheduler"));
 const RPASchedules = lazyRetry(() => import("./pages/RPASchedules"));
+const AICredentials = lazyRetry(() => import("./pages/AICredentials"));
 
 /* ── Knowledge Base, Voice, RPA, Industry Packs ── */
 const KnowledgeBase = lazyRetry(() => import("./pages/KnowledgeBase"));
@@ -290,6 +291,16 @@ export default function App() {
           <ProtectedRoute allowedRoles={["admin"]}>
             <Layout>
               <RPASchedules />
+            </Layout>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/dashboard/settings/ai-credentials"
+        element={
+          <ProtectedRoute allowedRoles={["admin"]}>
+            <Layout>
+              <AICredentials />
             </Layout>
           </ProtectedRoute>
         }

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -46,6 +46,7 @@ const ALL_NAV = [
   { path: "/dashboard/voice-setup", labelKey: "nav.voiceAgents", label: "Voice Agents", roles: ["admin"] },
   { path: "/dashboard/rpa", labelKey: "nav.rpa", label: "RPA Scripts", roles: ["admin"] },
   { path: "/dashboard/rpa-schedules", labelKey: "nav.rpaSchedules", label: "RPA Schedules", roles: ["admin"] },
+  { path: "/dashboard/settings/ai-credentials", labelKey: "nav.aiCredentials", label: "AI Credentials", roles: ["admin"] },
   { path: "/dashboard/packs", labelKey: "nav.packs", label: "Industry Packs", roles: ["admin"] },
   { path: "/dashboard/sla", labelKey: "nav.sla", label: "SLA Monitor", roles: ["admin"] },
   { path: "/dashboard/billing", labelKey: "nav.billing", label: "Billing", roles: ["admin"] },

--- a/ui/src/pages/AICredentials.tsx
+++ b/ui/src/pages/AICredentials.tsx
@@ -1,0 +1,377 @@
+import { useCallback, useEffect, useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import api, { extractApiError } from "@/lib/api";
+
+/**
+ * Tenant BYO AI provider credentials — admin-only.
+ *
+ * Lists every registered provider token (LLM / embedding / RAG / STT /
+ * TTS), lets an admin create/rotate/test/delete. Never displays raw
+ * tokens; only prefix/suffix + status. Closes S0-09 (PR-1 of the
+ * four-PR closure plan at docs/STRICT_REPO_S0_CLOSURE_PLAN_2026-04-24.md).
+ */
+
+interface Credential {
+  id: string;
+  provider: string;
+  credential_kind: string;
+  status: "active" | "inactive" | "unverified" | "failing";
+  label: string | null;
+  display_prefix: string | null;
+  display_suffix: string | null;
+  provider_config: Record<string, unknown> | null;
+  last_health_check_at: string | null;
+  last_health_check_error: string | null;
+  last_used_at: string | null;
+  rotated_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const PROVIDERS = [
+  { value: "gemini", label: "Google Gemini" },
+  { value: "openai", label: "OpenAI" },
+  { value: "anthropic", label: "Anthropic" },
+  { value: "azure_openai", label: "Azure OpenAI" },
+  { value: "openai_compatible", label: "OpenAI-compatible (self-hosted / 3rd-party)" },
+  { value: "voyage", label: "Voyage AI" },
+  { value: "cohere", label: "Cohere" },
+  { value: "ragflow", label: "RAGFlow" },
+  { value: "stt_deepgram", label: "Deepgram STT" },
+  { value: "stt_azure", label: "Azure Speech STT" },
+  { value: "tts_elevenlabs", label: "ElevenLabs TTS" },
+  { value: "tts_azure", label: "Azure Speech TTS" },
+];
+
+const KINDS = [
+  { value: "llm", label: "LLM" },
+  { value: "embedding", label: "Embedding" },
+  { value: "rag", label: "RAG" },
+  { value: "stt", label: "STT" },
+  { value: "tts", label: "TTS" },
+];
+
+function statusVariant(s: Credential["status"]): "success" | "warning" | "destructive" | "secondary" {
+  if (s === "active") return "success";
+  if (s === "failing") return "destructive";
+  if (s === "inactive") return "secondary";
+  return "warning";
+}
+
+function formatTimestamp(v: string | null): string {
+  if (!v) return "—";
+  try {
+    return new Date(v).toLocaleString();
+  } catch {
+    return "—";
+  }
+}
+
+export default function AICredentials() {
+  const [items, setItems] = useState<Credential[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const [showForm, setShowForm] = useState(false);
+  const [formProvider, setFormProvider] = useState("openai");
+  const [formKind, setFormKind] = useState("llm");
+  const [formApiKey, setFormApiKey] = useState("");
+  const [formLabel, setFormLabel] = useState("");
+  const [formBaseUrl, setFormBaseUrl] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const [rotateFor, setRotateFor] = useState<string | null>(null);
+  const [rotateKey, setRotateKey] = useState("");
+
+  const fetchItems = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await api.get("/tenant-ai-credentials");
+      setItems(Array.isArray(data) ? data : []);
+    } catch (e) {
+      setError(extractApiError(e, "Failed to load credentials"));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchItems();
+  }, [fetchItems]);
+
+  function resetForm() {
+    setFormProvider("openai");
+    setFormKind("llm");
+    setFormApiKey("");
+    setFormLabel("");
+    setFormBaseUrl("");
+    setShowForm(false);
+    setFormError(null);
+  }
+
+  async function handleCreate() {
+    setFormError(null);
+    if (!formApiKey.trim() || formApiKey.trim().length < 8) {
+      setFormError("API key is required and must be at least 8 characters.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const payload: Record<string, unknown> = {
+        provider: formProvider,
+        credential_kind: formKind,
+        api_key: formApiKey,
+      };
+      if (formLabel.trim()) payload.label = formLabel.trim();
+      if (formBaseUrl.trim()) payload.provider_config = { base_url: formBaseUrl.trim() };
+      await api.post("/tenant-ai-credentials", payload);
+      setNotice("Credential saved. Click 'Test' to verify it works.");
+      resetForm();
+      await fetchItems();
+    } catch (e) {
+      setFormError(extractApiError(e, "Failed to save credential"));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleTest(id: string) {
+    setNotice(null);
+    try {
+      const { data } = await api.post(`/tenant-ai-credentials/${id}/test`);
+      if (data?.status === "active") {
+        setNotice("Credential is active — provider accepted the key.");
+      } else {
+        setError(data?.error || "Credential test failed");
+      }
+      await fetchItems();
+    } catch (e) {
+      setError(extractApiError(e, "Test failed"));
+    }
+  }
+
+  async function handleRotate(id: string) {
+    if (!rotateKey.trim() || rotateKey.trim().length < 8) {
+      setError("New API key is required and must be at least 8 characters.");
+      return;
+    }
+    try {
+      await api.patch(`/tenant-ai-credentials/${id}`, { api_key: rotateKey });
+      setNotice("Credential rotated. Click 'Test' to verify.");
+      setRotateFor(null);
+      setRotateKey("");
+      await fetchItems();
+    } catch (e) {
+      setError(extractApiError(e, "Rotation failed"));
+    }
+  }
+
+  async function handleDelete(item: Credential) {
+    if (!window.confirm(`Delete the ${item.provider}/${item.credential_kind} credential?`)) return;
+    try {
+      await api.delete(`/tenant-ai-credentials/${item.id}`);
+      setNotice("Credential deleted.");
+      await fetchItems();
+    } catch (e) {
+      setError(extractApiError(e, "Delete failed"));
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h2 className="text-2xl font-bold">AI Provider Credentials</h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            Bring-your-own LLM, embedding, RAG, STT, and TTS tokens. Tokens
+            are encrypted at rest, masked on display, and never appear in
+            logs or API responses.
+          </p>
+        </div>
+        <Button onClick={() => setShowForm((v) => !v)}>
+          {showForm ? "Cancel" : "New Credential"}
+        </Button>
+      </div>
+
+      {notice && (
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 text-emerald-900 px-3 py-2 text-sm" role="status">
+          {notice}
+        </div>
+      )}
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 text-red-900 px-3 py-2 text-sm" role="alert">
+          {error}
+        </div>
+      )}
+
+      {showForm && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">New Credential</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div>
+                <label className="text-xs font-medium text-muted-foreground">Provider</label>
+                <select
+                  className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                  value={formProvider}
+                  onChange={(e) => setFormProvider(e.target.value)}
+                >
+                  {PROVIDERS.map((p) => (
+                    <option key={p.value} value={p.value}>{p.label}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="text-xs font-medium text-muted-foreground">Kind</label>
+                <select
+                  className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                  value={formKind}
+                  onChange={(e) => setFormKind(e.target.value)}
+                >
+                  {KINDS.map((k) => (
+                    <option key={k.value} value={k.value}>{k.label}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div>
+              <label className="text-xs font-medium text-muted-foreground">API Key *</label>
+              <input
+                type="password"
+                className="w-full border rounded px-2 py-1.5 text-sm bg-background font-mono"
+                value={formApiKey}
+                onChange={(e) => setFormApiKey(e.target.value)}
+                placeholder="Paste the raw provider token — stored encrypted, never displayed again"
+                autoComplete="new-password"
+              />
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div>
+                <label className="text-xs font-medium text-muted-foreground">Label (optional)</label>
+                <input
+                  type="text"
+                  className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                  value={formLabel}
+                  onChange={(e) => setFormLabel(e.target.value)}
+                  placeholder="e.g. Finance team OpenAI"
+                />
+              </div>
+              <div>
+                <label className="text-xs font-medium text-muted-foreground">Base URL (optional)</label>
+                <input
+                  type="text"
+                  className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                  value={formBaseUrl}
+                  onChange={(e) => setFormBaseUrl(e.target.value)}
+                  placeholder="Required for Azure OpenAI + OpenAI-compatible endpoints"
+                />
+              </div>
+            </div>
+            {formError && <p className="text-sm text-red-600">{formError}</p>}
+            <div className="flex gap-2">
+              <Button onClick={handleCreate} disabled={submitting}>
+                {submitting ? "Saving…" : "Save credential"}
+              </Button>
+              <Button variant="outline" onClick={resetForm} disabled={submitting}>
+                Cancel
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Stored credentials</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <p className="text-sm text-muted-foreground">Loading…</p>
+          ) : items.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No BYO credentials registered yet. The platform will use its own
+              fallback tokens until you add one.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {items.map((it) => {
+                const display = it.display_prefix || it.display_suffix
+                  ? `${it.display_prefix || ""}...${it.display_suffix || ""}`
+                  : "***";
+                return (
+                  <div
+                    key={it.id}
+                    className="border rounded-lg p-3 flex flex-col md:flex-row md:items-center md:justify-between gap-3"
+                  >
+                    <div className="space-y-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <p className="font-medium">
+                          {it.provider} / {it.credential_kind}
+                        </p>
+                        <Badge variant={statusVariant(it.status)}>{it.status}</Badge>
+                        <span className="font-mono text-xs text-muted-foreground">{display}</span>
+                        {it.label && <span className="text-xs text-muted-foreground">· {it.label}</span>}
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        Last tested: {formatTimestamp(it.last_health_check_at)}
+                        {it.last_health_check_error && (
+                          <span className="text-red-600 ml-2">
+                            ({it.last_health_check_error})
+                          </span>
+                        )}
+                        {it.last_used_at && <> · Last used: {formatTimestamp(it.last_used_at)}</>}
+                        {it.rotated_at && <> · Rotated: {formatTimestamp(it.rotated_at)}</>}
+                      </p>
+                    </div>
+                    <div className="flex gap-2">
+                      <Button size="sm" variant="outline" onClick={() => handleTest(it.id)}>
+                        Test
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => {
+                          setRotateFor(rotateFor === it.id ? null : it.id);
+                          setRotateKey("");
+                        }}
+                      >
+                        {rotateFor === it.id ? "Cancel rotate" : "Rotate"}
+                      </Button>
+                      <Button size="sm" variant="destructive" onClick={() => handleDelete(it)}>
+                        Delete
+                      </Button>
+                    </div>
+                    {rotateFor === it.id && (
+                      <div className="md:col-span-2 md:basis-full">
+                        <div className="flex gap-2 items-center">
+                          <input
+                            type="password"
+                            className="flex-1 border rounded px-2 py-1.5 text-sm bg-background font-mono"
+                            value={rotateKey}
+                            onChange={(e) => setRotateKey(e.target.value)}
+                            placeholder="Paste the new API key"
+                            autoComplete="new-password"
+                          />
+                          <Button size="sm" onClick={() => handleRotate(it.id)}>
+                            Confirm rotation
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

**Closes S0-09** from `docs/STRICT_REPO_AUDIT_AND_TEST_MATRIX_2026-04-24.md`.
**PR 1 of 4** in the closure plan at `docs/STRICT_REPO_S0_CLOSURE_PLAN_2026-04-24.md` — foundational BYO-tokens infrastructure that PR-2 (tenant AI config), PR-3 (multimodal RAG), and PR-4 (4.6+/5 quality gate) all build on.

## What ships

| Component | File | Purpose |
| --- | --- | --- |
| ORM | `core/models/tenant_ai_credential.py` | One row per (tenant, provider, kind). Unique constraint enforces "one token per slot". |
| Migration | `migrations/versions/v4_9_2_tenant_ai_credentials.py` | Idempotent CREATE TABLE + FK on `tenants(id)`. |
| Resolver | `core/ai_providers/resolver.py` | `get_provider_credential(tenant_id, provider, kind)` → BYO → policy → platform env. Corrupted rows raise, never silently fall back. 120s cache, rotation-aware. |
| Probes | `core/ai_providers/health.py` | Cheap identity probes for OpenAI / OpenAI-compatible / Azure OpenAI / Anthropic / Gemini / Voyage / Cohere. Classifies HTTP status → actionable operator message. |
| Admin API | `api/v1/tenant_ai_credentials.py` | GET/POST/PATCH/DELETE + `/{id}/test`. Admin-gated at router level. `TenantAICredentialOut` has **no** field that could carry raw token material. |
| Voice migration | `api/v1/voice.py` | `stt_api_key` + `tts_api_key` now persist through the vault — the old in-memory plaintext dict no longer stores secrets. Non-secret fields stay in-process. |
| UI | `ui/src/pages/AICredentials.tsx` | `/dashboard/settings/ai-credentials` admin page — list / create / rotate / test / delete. Never displays raw tokens. |
| Tests | `tests/regression/test_s009_byo_tokens.py` | 13 assertions including: mask never leaks raw, resolver fallback order, admin gate, no field in Out-schema can carry raw token, voice keys persist through vault, anti-regression on direct env reads (with allowlist for legacy callers that PR-2 migrates). |

## What does **not** ship in PR-1 (by design)

- `core/langgraph/llm_factory.py`, `core/llm/router.py`, `core/embeddings.py` still read platform env vars directly. These callers are allowlisted in the anti-regression test. PR-2 introduces `tenant_ai_settings` and flips them to resolver-first.
- RAGFlow credentials (`rag` kind) can be stored but aren't consumed yet — PR-3 handles that.

## Test plan

- [x] `python -m pytest tests/regression/test_s009_byo_tokens.py --no-cov -v` → 13 passed.
- [x] `ruff check .` → clean.
- [x] `npx tsc --noEmit` → clean.
- [x] Preflight green (all 11 gates).
- [x] Alembic revision ID ≤ 32 chars (`v492_tenant_ai_creds` = 20 chars).

## Impeccable /audit /critique /polish (UI)

`AICredentials.tsx` uses existing shadcn `Card` / `Button` / `Badge` tokens. Provider/kind dropdowns use plain `<select>` to match `RPASchedules.tsx`. Key input is `type="password" autoComplete="new-password"`; rotate/delete confirms in place. No new fonts, icons, or layout primitives introduced.

## Residual risks

- The resolver cache is per-process (120s TTL). Under rare conditions a tenant could observe 0–2 minutes of stale BYO behavior after rotation. `invalidate_cache` is called on every write from the admin API, so single-replica rotations are instant; multi-replica deploys settle in the TTL window.
- The provider allowlist is a Python `frozenset`. Extending it requires a code change + regression-test update — intentional; free-form provider names are a footgun.

## Reviewers

@codex — please audit the resolver's fallback-order correctness, the Out-schema redaction, and the voice key migration path. The rest of the S0 closure (PR-2 tenant AI config, PR-3 multimodal RAG, PR-4 4.6/5 quality gate) depends on this landing.