### PR TITLE
feat(ai-config): tenant AI model config + catalog + llm_factory rewire — S0-08 PR-2 of 4

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -56,6 +56,7 @@ from api.v1 import (
     sop,
     sso,
     tenant_ai_credentials,
+    tenant_ai_settings,
     voice,
     webhooks,
     workflow_variants,
@@ -204,6 +205,7 @@ app.include_router(packs.router, prefix="/api/v1", tags=["Industry Packs"])
 app.include_router(rpa.router, prefix="/api/v1", tags=["RPA"])
 app.include_router(rpa_schedules.router, prefix="/api/v1", tags=["RPA"])
 app.include_router(tenant_ai_credentials.router, prefix="/api/v1", tags=["Tenant AI Credentials"])
+app.include_router(tenant_ai_settings.router, prefix="/api/v1", tags=["Tenant AI Settings"])
 app.include_router(cdc_webhooks.router, prefix="/api/v1", tags=["CDC Webhooks"])
 app.include_router(content_safety.router, prefix="/api/v1", tags=["Content Safety"])
 app.include_router(knowledge.router, prefix="/api/v1", tags=["Knowledge Base"])

--- a/api/v1/tenant_ai_settings.py
+++ b/api/v1/tenant_ai_settings.py
@@ -1,0 +1,332 @@
+"""Admin API for per-tenant AI configuration.
+
+Closes S0-08 (PR-2). GET/PUT the tenant's effective LLM + embedding
+config. Validates against ``core.ai_providers.catalog`` so operators
+can't flip an env var into a model/dimension mismatch.
+
+Admin-gated at the router level.
+"""
+
+from __future__ import annotations
+
+import uuid as _uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import select
+
+from api.deps import get_current_tenant, require_tenant_admin
+from core.ai_providers.catalog import (
+    EMBEDDING_CATALOG,
+    LLM_CATALOG,
+    embedding_models_for,
+    embedding_providers,
+    find_embedding,
+    find_llm,
+    llm_models_for,
+    llm_providers,
+)
+from core.ai_providers.settings import invalidate_tenant_ai_setting_cache
+from core.database import get_tenant_session
+from core.models.tenant_ai_setting import (
+    FALLBACK_POLICIES,
+    ROUTING_POLICIES,
+    TenantAISetting,
+)
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(
+    prefix="/tenant-ai-settings",
+    tags=["Tenant AI Settings"],
+    dependencies=[require_tenant_admin],
+)
+
+
+# ── Schemas ──────────────────────────────────────────────────────────
+
+
+class TenantAISettingOut(BaseModel):
+    tenant_id: str
+    llm_provider: str | None = None
+    llm_model: str | None = None
+    llm_fallback_model: str | None = None
+    llm_routing_policy: str = "auto"
+    max_input_tokens: int | None = None
+    embedding_provider: str | None = None
+    embedding_model: str | None = None
+    embedding_dimensions: int | None = None
+    chunk_size: int | None = None
+    chunk_overlap: int | None = None
+    ai_fallback_policy: str = "allow"
+    updated_by: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class TenantAISettingUpdate(BaseModel):
+    llm_provider: str | None = None
+    llm_model: str | None = None
+    llm_fallback_model: str | None = None
+    llm_routing_policy: str | None = None
+    max_input_tokens: int | None = Field(None, ge=1, le=2_000_000)
+    embedding_provider: str | None = None
+    embedding_model: str | None = None
+    embedding_dimensions: int | None = Field(None, ge=1, le=8192)
+    chunk_size: int | None = Field(None, ge=32, le=8192)
+    chunk_overlap: int | None = Field(None, ge=0, le=1024)
+    ai_fallback_policy: str | None = None
+
+    @field_validator("llm_routing_policy")
+    @classmethod
+    def _validate_routing(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        v = v.strip().lower()
+        if v not in ROUTING_POLICIES:
+            raise ValueError(
+                f"llm_routing_policy must be one of: {sorted(ROUTING_POLICIES)}"
+            )
+        return v
+
+    @field_validator("ai_fallback_policy")
+    @classmethod
+    def _validate_fallback(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        v = v.strip().lower()
+        if v not in FALLBACK_POLICIES:
+            raise ValueError(
+                f"ai_fallback_policy must be one of: {sorted(FALLBACK_POLICIES)}"
+            )
+        return v
+
+
+class RegistryOut(BaseModel):
+    llm: dict[str, Any]
+    embedding: dict[str, Any]
+
+
+def _to_out(row: TenantAISetting | None, tenant_id: str) -> TenantAISettingOut:
+    if row is None:
+        return TenantAISettingOut(tenant_id=tenant_id)
+    return TenantAISettingOut(
+        tenant_id=str(row.tenant_id),
+        llm_provider=row.llm_provider,
+        llm_model=row.llm_model,
+        llm_fallback_model=row.llm_fallback_model,
+        llm_routing_policy=row.llm_routing_policy,
+        max_input_tokens=row.max_input_tokens,
+        embedding_provider=row.embedding_provider,
+        embedding_model=row.embedding_model,
+        embedding_dimensions=row.embedding_dimensions,
+        chunk_size=row.chunk_size,
+        chunk_overlap=row.chunk_overlap,
+        ai_fallback_policy=row.ai_fallback_policy,
+        updated_by=str(row.updated_by) if row.updated_by else None,
+        created_at=row.created_at.isoformat() if row.created_at else None,
+        updated_at=row.updated_at.isoformat() if row.updated_at else None,
+    )
+
+
+# ── Endpoints ────────────────────────────────────────────────────────
+
+
+@router.get("/registry", response_model=RegistryOut)
+async def list_registry() -> RegistryOut:
+    """Expose the catalog so the UI can render valid provider/model
+    pickers without having to ship the allowlist to the client.
+    """
+    llm_items = {
+        provider: [
+            {
+                "model": entry.model,
+                "context_window": entry.context_window,
+                "max_output_tokens": entry.max_output_tokens,
+                "supports_tools": entry.supports_tools,
+                "supports_vision": entry.supports_vision,
+                "notes": entry.notes,
+            }
+            for entry in LLM_CATALOG
+            if entry.provider == provider
+        ]
+        for provider in llm_providers()
+    }
+    embedding_items = {
+        provider: [
+            {
+                "model": entry.model,
+                "dimensions": entry.dimensions,
+                "max_input_tokens": entry.max_input_tokens,
+                "notes": entry.notes,
+            }
+            for entry in EMBEDDING_CATALOG
+            if entry.provider == provider
+        ]
+        for provider in embedding_providers()
+    }
+    return RegistryOut(llm=llm_items, embedding=embedding_items)
+
+
+@router.get("", response_model=TenantAISettingOut)
+async def get_setting(
+    tenant_id: str = Depends(get_current_tenant),
+) -> TenantAISettingOut:
+    tid = _uuid.UUID(tenant_id)
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(TenantAISetting).where(TenantAISetting.tenant_id == tid)
+        )
+        row = result.scalar_one_or_none()
+    return _to_out(row, tenant_id)
+
+
+@router.put("", response_model=TenantAISettingOut)
+async def put_setting(
+    body: TenantAISettingUpdate,
+    tenant_id: str = Depends(get_current_tenant),
+) -> TenantAISettingOut:
+    """Upsert the tenant's AI setting. Validates every (provider, model)
+    against the catalog and embedding_dimensions against the pinned
+    dimension for the selected embedding model.
+    """
+    tid = _uuid.UUID(tenant_id)
+
+    # ─── Catalog validation ─────────────────────────────────────────
+    if body.llm_provider is not None or body.llm_model is not None:
+        # Both or neither; a half-specified LLM choice is invalid.
+        if not (body.llm_provider and body.llm_model):
+            raise HTTPException(
+                422,
+                "llm_provider and llm_model must both be set (or both unset).",
+            )
+        if body.llm_provider not in llm_providers():
+            raise HTTPException(
+                422,
+                f"Unknown llm_provider {body.llm_provider!r}. "
+                f"Valid: {list(llm_providers())}.",
+            )
+        if find_llm(body.llm_provider, body.llm_model) is None:
+            raise HTTPException(
+                422,
+                f"Unknown llm_model {body.llm_model!r} for provider "
+                f"{body.llm_provider!r}. Valid: "
+                f"{list(llm_models_for(body.llm_provider))}.",
+            )
+    if body.llm_fallback_model is not None and body.llm_provider is not None:
+        if find_llm(body.llm_provider, body.llm_fallback_model) is None:
+            raise HTTPException(
+                422,
+                f"Unknown llm_fallback_model {body.llm_fallback_model!r} for "
+                f"provider {body.llm_provider!r}.",
+            )
+    if body.embedding_provider is not None or body.embedding_model is not None:
+        if not (body.embedding_provider and body.embedding_model):
+            raise HTTPException(
+                422,
+                "embedding_provider and embedding_model must both be set "
+                "(or both unset).",
+            )
+        if body.embedding_provider not in embedding_providers():
+            raise HTTPException(
+                422,
+                f"Unknown embedding_provider {body.embedding_provider!r}. "
+                f"Valid: {list(embedding_providers())}.",
+            )
+        catalog_entry = find_embedding(
+            body.embedding_provider, body.embedding_model
+        )
+        if catalog_entry is None:
+            raise HTTPException(
+                422,
+                f"Unknown embedding_model {body.embedding_model!r} for "
+                f"provider {body.embedding_provider!r}. Valid: "
+                f"{list(embedding_models_for(body.embedding_provider))}.",
+            )
+        if (
+            body.embedding_dimensions is not None
+            and body.embedding_dimensions != catalog_entry.dimensions
+        ):
+            raise HTTPException(
+                422,
+                f"embedding_dimensions {body.embedding_dimensions} does not "
+                f"match catalog dimension {catalog_entry.dimensions} for "
+                f"{body.embedding_provider}/{body.embedding_model}. Fix the "
+                "client to match the catalog — changing dimensions requires "
+                "a backfill (see scripts/embedding_rotate.py).",
+            )
+
+    # ─── Upsert ─────────────────────────────────────────────────────
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(TenantAISetting).where(TenantAISetting.tenant_id == tid)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            row = TenantAISetting(tenant_id=tid)
+            session.add(row)
+
+        # Apply every provided field
+        for field in (
+            "llm_provider",
+            "llm_model",
+            "llm_fallback_model",
+            "llm_routing_policy",
+            "max_input_tokens",
+            "embedding_provider",
+            "embedding_model",
+            "embedding_dimensions",
+            "chunk_size",
+            "chunk_overlap",
+            "ai_fallback_policy",
+        ):
+            incoming = getattr(body, field)
+            if incoming is not None:
+                setattr(row, field, incoming)
+
+        # Default embedding_dimensions from catalog if the admin didn't
+        # pass one but did pass a provider+model.
+        if (
+            row.embedding_provider
+            and row.embedding_model
+            and not row.embedding_dimensions
+        ):
+            catalog_entry = find_embedding(row.embedding_provider, row.embedding_model)
+            if catalog_entry is not None:
+                row.embedding_dimensions = catalog_entry.dimensions
+
+        row.updated_at = datetime.now(UTC)
+        await session.flush()
+
+    invalidate_tenant_ai_setting_cache(tid)
+    _audit(
+        "tenant_ai_setting.updated",
+        tid,
+        body.model_dump(exclude_none=True),
+    )
+
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(TenantAISetting).where(TenantAISetting.tenant_id == tid)
+        )
+        row = result.scalar_one()
+    return _to_out(row, tenant_id)
+
+
+def _audit(
+    action: str,
+    tenant_id: _uuid.UUID,
+    diff: dict[str, Any],
+) -> None:
+    try:
+        logger.info(
+            "audit_event",
+            action=action,
+            tenant_id=str(tenant_id),
+            diff=diff,
+        )
+    except Exception as exc:
+        logger.debug("audit_emit_failed", error=str(exc))

--- a/core/ai_providers/__init__.py
+++ b/core/ai_providers/__init__.py
@@ -18,3 +18,12 @@ from core.ai_providers.resolver import (
 from core.ai_providers.resolver import (
     get_provider_credential as get_provider_credential,
 )
+from core.ai_providers.settings import (
+    EffectiveAISetting as EffectiveAISetting,
+)
+from core.ai_providers.settings import (
+    get_effective_ai_setting as get_effective_ai_setting,
+)
+from core.ai_providers.settings import (
+    invalidate_tenant_ai_setting_cache as invalidate_tenant_ai_setting_cache,
+)

--- a/core/ai_providers/catalog.py
+++ b/core/ai_providers/catalog.py
@@ -1,0 +1,170 @@
+"""Allowlist of provider/model combinations that the tenant AI config
+may choose from.
+
+Closes S0-08 (PR-2 of the four-PR closure plan). Every model that
+admins can select via the ``tenant_ai_settings`` PUT endpoint must be
+registered here. Unknown (provider, model) pairs are rejected at the
+API boundary so operators can't flip an env var into a
+model/dimension mismatch.
+
+The catalog intentionally lives in Python (not the database): the
+allowlist changes with code deployments, and we want Git history as
+the audit trail for "when did we start accepting model X". Add new
+entries via a small PR with a schema-validation test.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LLMModel:
+    provider: str
+    model: str
+    context_window: int
+    max_output_tokens: int
+    supports_tools: bool = True
+    supports_vision: bool = False
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class EmbeddingModel:
+    provider: str
+    model: str
+    dimensions: int  # Vector size the model emits.
+    max_input_tokens: int
+    notes: str = ""
+
+
+# ─── LLM allowlist ───────────────────────────────────────────────────
+# When adding a new row: also update
+# ``tests/regression/test_s008_tenant_ai_config.py::test_llm_catalog_covers_required_providers``
+# so future drift fails loudly.
+LLM_CATALOG: tuple[LLMModel, ...] = (
+    # Gemini (platform default — free-tier friendly)
+    LLMModel("gemini", "gemini-2.5-flash", 1_048_576, 8192),
+    LLMModel("gemini", "gemini-2.5-flash-preview-05-20", 1_048_576, 8192),
+    LLMModel("gemini", "gemini-2.5-pro", 2_097_152, 8192, supports_vision=True),
+    LLMModel("gemini", "gemini-2.0-flash-exp", 1_048_576, 8192),
+    # OpenAI
+    LLMModel("openai", "gpt-4o", 128_000, 16_384, supports_vision=True),
+    LLMModel("openai", "gpt-4o-mini", 128_000, 16_384, supports_vision=True),
+    LLMModel("openai", "gpt-4-turbo", 128_000, 4_096, supports_vision=True),
+    LLMModel("openai", "o1", 200_000, 100_000, supports_tools=False),
+    LLMModel("openai", "o1-mini", 128_000, 65_536, supports_tools=False),
+    # Anthropic
+    LLMModel("anthropic", "claude-sonnet-4-5-20250929", 200_000, 64_000, supports_vision=True),
+    LLMModel("anthropic", "claude-sonnet-4-6-20251001", 200_000, 64_000, supports_vision=True),
+    LLMModel("anthropic", "claude-opus-4-1-20250805", 200_000, 32_000, supports_vision=True),
+    LLMModel("anthropic", "claude-opus-4-5-20250929", 200_000, 32_000, supports_vision=True),
+    LLMModel("anthropic", "claude-3-5-sonnet-20241022", 200_000, 8192, supports_vision=True),
+    # Azure OpenAI — model name is the deployment name, not the base model.
+    # Admins must set ``provider_config.base_url`` to their Azure endpoint.
+    LLMModel(
+        "azure_openai",
+        "deployment:gpt-4o",
+        128_000,
+        16_384,
+        supports_vision=True,
+        notes="deployment name, configure base_url in provider_config",
+    ),
+    LLMModel(
+        "azure_openai",
+        "deployment:gpt-4o-mini",
+        128_000,
+        16_384,
+        supports_vision=True,
+        notes="deployment name, configure base_url in provider_config",
+    ),
+    # OpenAI-compatible self-hosted — pass through. Admin chooses the
+    # model name served by their endpoint. We register a wildcard marker
+    # that the validator special-cases.
+    LLMModel(
+        "openai_compatible",
+        "*",
+        128_000,
+        16_384,
+        notes="admin must set provider_config.base_url; model name is passed through",
+    ),
+)
+
+# ─── Embedding allowlist ─────────────────────────────────────────────
+# Each entry pins a specific dimension; the PUT endpoint rejects a
+# tenant setting whose declared ``embedding_dimensions`` doesn't match
+# the catalog entry. Prevents model/index drift.
+EMBEDDING_CATALOG: tuple[EmbeddingModel, ...] = (
+    # Local BGE — the platform default, runs on fastembed ONNX.
+    EmbeddingModel(
+        "local", "BAAI/bge-small-en-v1.5", 384, 512,
+        notes="platform default, self-hosted via fastembed, no BYO key needed",
+    ),
+    EmbeddingModel("local", "BAAI/bge-base-en-v1.5", 768, 512),
+    EmbeddingModel("local", "BAAI/bge-large-en-v1.5", 1024, 512),
+    EmbeddingModel("local", "BAAI/bge-m3", 1024, 8192, notes="multilingual"),
+    # OpenAI
+    EmbeddingModel("openai", "text-embedding-3-small", 1536, 8191),
+    EmbeddingModel("openai", "text-embedding-3-large", 3072, 8191),
+    # Voyage
+    EmbeddingModel("voyage", "voyage-3", 1024, 32_000),
+    EmbeddingModel("voyage", "voyage-3-lite", 512, 32_000),
+    # Cohere
+    EmbeddingModel("cohere", "embed-english-v3.0", 1024, 512),
+    EmbeddingModel("cohere", "embed-multilingual-v3.0", 1024, 512),
+)
+
+
+# ─── Lookup helpers ──────────────────────────────────────────────────
+
+
+def find_llm(provider: str, model: str) -> LLMModel | None:
+    """Return the catalog entry for ``(provider, model)`` or ``None``.
+
+    OpenAI-compatible with a `*` wildcard matches any model name (the
+    admin's self-hosted endpoint controls the actual available list).
+    Azure OpenAI matches on prefix (``deployment:*``) so admins can
+    register their specific deployment names.
+    """
+    provider = (provider or "").strip().lower()
+    model = (model or "").strip()
+    for entry in LLM_CATALOG:
+        if entry.provider != provider:
+            continue
+        if entry.model == "*":
+            return entry
+        if entry.model == model:
+            return entry
+        # Azure deployment names are caller-specific; accept any deployment:<name>
+        if (
+            entry.provider == "azure_openai"
+            and entry.model.startswith("deployment:")
+            and model.startswith("deployment:")
+        ):
+            return entry
+    return None
+
+
+def find_embedding(provider: str, model: str) -> EmbeddingModel | None:
+    provider = (provider or "").strip().lower()
+    model = (model or "").strip()
+    for entry in EMBEDDING_CATALOG:
+        if entry.provider == provider and entry.model == model:
+            return entry
+    return None
+
+
+def llm_providers() -> tuple[str, ...]:
+    return tuple(sorted({e.provider for e in LLM_CATALOG}))
+
+
+def embedding_providers() -> tuple[str, ...]:
+    return tuple(sorted({e.provider for e in EMBEDDING_CATALOG}))
+
+
+def llm_models_for(provider: str) -> tuple[str, ...]:
+    return tuple(e.model for e in LLM_CATALOG if e.provider == provider)
+
+
+def embedding_models_for(provider: str) -> tuple[str, ...]:
+    return tuple(e.model for e in EMBEDDING_CATALOG if e.provider == provider)

--- a/core/ai_providers/settings.py
+++ b/core/ai_providers/settings.py
@@ -1,0 +1,156 @@
+"""Tenant AI setting lookup helpers.
+
+Thin query-layer shims so the rest of the codebase doesn't reach into
+``TenantAISetting`` directly. Cached with a short TTL like the
+resolver so admin PUTs propagate without restart.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid as _uuid
+from dataclasses import dataclass
+
+import structlog
+from sqlalchemy import select
+
+logger = structlog.get_logger(__name__)
+
+_CACHE: dict[str, tuple[EffectiveAISetting, float]] = {}
+_CACHE_TTL_S = 60.0
+
+
+@dataclass(frozen=True)
+class EffectiveAISetting:
+    """Resolved AI setting for a tenant.
+
+    Fields fall through to the platform defaults when the tenant has
+    no row. ``source`` is ``"tenant"`` when any field came from the
+    tenant row, else ``"platform_default"``.
+    """
+
+    tenant_id: str
+    llm_provider: str | None
+    llm_model: str | None
+    llm_fallback_model: str | None
+    llm_routing_policy: str
+    max_input_tokens: int | None
+    embedding_provider: str | None
+    embedding_model: str | None
+    embedding_dimensions: int | None
+    chunk_size: int | None
+    chunk_overlap: int | None
+    ai_fallback_policy: str
+    source: str
+
+
+_PLATFORM_DEFAULTS = EffectiveAISetting(
+    tenant_id="__platform__",
+    llm_provider="gemini",
+    llm_model="gemini-2.5-flash",
+    llm_fallback_model="gemini-2.5-flash-preview-05-20",
+    llm_routing_policy="auto",
+    max_input_tokens=None,
+    embedding_provider="local",
+    embedding_model="BAAI/bge-small-en-v1.5",
+    embedding_dimensions=384,
+    chunk_size=512,
+    chunk_overlap=50,
+    ai_fallback_policy="allow",
+    source="platform_default",
+)
+
+
+async def get_effective_ai_setting(
+    tenant_id: _uuid.UUID | str | None,
+) -> EffectiveAISetting:
+    """Return the effective AI setting for a tenant, with cache.
+
+    Falls back to ``_PLATFORM_DEFAULTS`` when the tenant has no row.
+    Any read failure (table missing during migration) is treated as
+    "use defaults" and logged at DEBUG.
+    """
+    if tenant_id in (None, "__platform__"):
+        return _PLATFORM_DEFAULTS
+    try:
+        tid = (
+            tenant_id
+            if isinstance(tenant_id, _uuid.UUID)
+            else _uuid.UUID(str(tenant_id))
+        )
+    except (TypeError, ValueError):
+        return _PLATFORM_DEFAULTS
+
+    key = str(tid)
+    cached = _CACHE.get(key)
+    if cached is not None:
+        effective, cached_at = cached
+        if time.time() - cached_at < _CACHE_TTL_S:
+            return effective
+
+    try:
+        from core.database import async_session_factory
+        from core.models.tenant_ai_setting import TenantAISetting
+
+        async with async_session_factory() as session:
+            result = await session.execute(
+                select(TenantAISetting).where(
+                    TenantAISetting.tenant_id == tid
+                )
+            )
+            row = result.scalar_one_or_none()
+    except Exception as exc:
+        # Table may not exist yet during CI migration rehearsal. Honest
+        # fallback: use platform defaults and log once.
+        logger.debug(
+            "tenant_ai_setting_read_failed",
+            tenant_id=str(tid),
+            error=str(exc),
+        )
+        return _PLATFORM_DEFAULTS
+
+    if row is None:
+        effective = EffectiveAISetting(
+            tenant_id=str(tid),
+            llm_provider=_PLATFORM_DEFAULTS.llm_provider,
+            llm_model=_PLATFORM_DEFAULTS.llm_model,
+            llm_fallback_model=_PLATFORM_DEFAULTS.llm_fallback_model,
+            llm_routing_policy=_PLATFORM_DEFAULTS.llm_routing_policy,
+            max_input_tokens=None,
+            embedding_provider=_PLATFORM_DEFAULTS.embedding_provider,
+            embedding_model=_PLATFORM_DEFAULTS.embedding_model,
+            embedding_dimensions=_PLATFORM_DEFAULTS.embedding_dimensions,
+            chunk_size=_PLATFORM_DEFAULTS.chunk_size,
+            chunk_overlap=_PLATFORM_DEFAULTS.chunk_overlap,
+            ai_fallback_policy="allow",
+            source="platform_default",
+        )
+    else:
+        effective = EffectiveAISetting(
+            tenant_id=str(tid),
+            llm_provider=row.llm_provider or _PLATFORM_DEFAULTS.llm_provider,
+            llm_model=row.llm_model or _PLATFORM_DEFAULTS.llm_model,
+            llm_fallback_model=row.llm_fallback_model or _PLATFORM_DEFAULTS.llm_fallback_model,
+            llm_routing_policy=row.llm_routing_policy or "auto",
+            max_input_tokens=row.max_input_tokens,
+            embedding_provider=row.embedding_provider or _PLATFORM_DEFAULTS.embedding_provider,
+            embedding_model=row.embedding_model or _PLATFORM_DEFAULTS.embedding_model,
+            embedding_dimensions=row.embedding_dimensions or _PLATFORM_DEFAULTS.embedding_dimensions,
+            chunk_size=row.chunk_size or _PLATFORM_DEFAULTS.chunk_size,
+            chunk_overlap=row.chunk_overlap or _PLATFORM_DEFAULTS.chunk_overlap,
+            ai_fallback_policy=row.ai_fallback_policy or "allow",
+            source="tenant",
+        )
+
+    _CACHE[key] = (effective, time.time())
+    return effective
+
+
+def invalidate_tenant_ai_setting_cache(
+    tenant_id: _uuid.UUID | str | None = None,
+) -> None:
+    """Drop cached setting(s) after a PUT."""
+    if tenant_id is None:
+        _CACHE.clear()
+        return
+    _CACHE.pop(str(tenant_id), None)

--- a/core/langgraph/llm_factory.py
+++ b/core/langgraph/llm_factory.py
@@ -43,6 +43,7 @@ def create_chat_model(
     *,
     query: str = "",
     routing_config: dict | None = None,
+    tenant_id: str | None = None,
 ) -> BaseChatModel:
     """Create a LangChain ChatModel, optionally using smart routing.
 
@@ -129,7 +130,7 @@ def create_chat_model(
             # Fall through to normal model resolution
 
     resolved = _resolve_model(model)
-    return _build_model(resolved, temperature, max_tokens)
+    return _build_model(resolved, temperature, max_tokens, tenant_id=tenant_id)
 
 
 def _build_ollama_model(model_name: str, temperature: float, max_tokens: int) -> BaseChatModel:
@@ -162,8 +163,47 @@ def _build_vllm_model(model_name: str, temperature: float, max_tokens: int) -> B
     )
 
 
-def _build_model(resolved: str, temperature: float, max_tokens: int) -> BaseChatModel:
-    """Instantiate the correct LangChain ChatModel for *resolved* model name."""
+def _resolve_cloud_api_key(provider: str, tenant_id: str | None = None) -> str:
+    """Resolve the API key for a cloud LLM provider.
+
+    S0-08 (PR-2): the earlier version read ``os.getenv(...)`` directly.
+    Route through the tenant-aware resolver so BYO tokens and the
+    tenant's ``ai_fallback_policy`` take effect. On any resolver error
+    we fall back to the env var so callers that run outside a tenant
+    context (cron, boot probes) still function.
+    """
+    from core.ai_providers.resolver import (
+        ProviderNotConfigured,
+        get_provider_credential_sync,
+    )
+
+    try:
+        resolved = get_provider_credential_sync(tenant_id, provider, "llm")
+        return resolved.secret
+    except ProviderNotConfigured:
+        # No tenant BYO and no platform env — let the caller's client
+        # library surface the usual "missing API key" error so the
+        # symptom is actionable.
+        return ""
+    except Exception as exc:
+        logger.warning("llm_key_resolve_failed", provider=provider, error=str(exc))
+        return ""
+
+
+def _build_model(
+    resolved: str,
+    temperature: float,
+    max_tokens: int,
+    tenant_id: str | None = None,
+) -> BaseChatModel:
+    """Instantiate the correct LangChain ChatModel for *resolved* model name.
+
+    When ``tenant_id`` is provided, credentials route through the
+    tenant AI resolver (``core.ai_providers.resolver``) so BYO tokens
+    take effect. Sync-over-async via a short-lived threadpool —
+    expensive per call only when the resolver cache misses (60-120s
+    TTL).
+    """
 
     # Local models via Ollama (OpenAI-compatible API)
     if _is_ollama_model(resolved):
@@ -181,7 +221,7 @@ def _build_model(resolved: str, temperature: float, max_tokens: int) -> BaseChat
             model=resolved,
             temperature=temperature,
             max_output_tokens=max_tokens,
-            google_api_key=os.getenv("GOOGLE_GEMINI_API_KEY", os.getenv("GOOGLE_API_KEY", "")),
+            google_api_key=_resolve_cloud_api_key("gemini", tenant_id),
         )
 
     # Cloud: Claude
@@ -192,7 +232,7 @@ def _build_model(resolved: str, temperature: float, max_tokens: int) -> BaseChat
             model_name=resolved,
             temperature=temperature,
             max_tokens=max_tokens,
-            anthropic_api_key=os.getenv("ANTHROPIC_API_KEY", ""),
+            anthropic_api_key=_resolve_cloud_api_key("anthropic", tenant_id),
         )
 
     # Cloud: GPT
@@ -203,7 +243,7 @@ def _build_model(resolved: str, temperature: float, max_tokens: int) -> BaseChat
             model=resolved,
             temperature=temperature,
             max_tokens=max_tokens,
-            openai_api_key=os.getenv("OPENAI_API_KEY", ""),
+            openai_api_key=_resolve_cloud_api_key("openai", tenant_id),
         )
 
     # Default fallback — Gemini Flash (free)
@@ -213,7 +253,7 @@ def _build_model(resolved: str, temperature: float, max_tokens: int) -> BaseChat
         model="gemini-2.5-flash",
         temperature=temperature,
         max_output_tokens=max_tokens,
-        google_api_key=os.getenv("GOOGLE_GEMINI_API_KEY", os.getenv("GOOGLE_API_KEY", "")),
+        google_api_key=_resolve_cloud_api_key("gemini", tenant_id),
     )
 
 
@@ -231,13 +271,19 @@ def _resolve_model(model: str) -> str:
     if "gemini" in m:
         return model
 
+    # S0-08: capability gate — before PR-2 this read the provider env
+    # var directly. Route through the resolver so a tenant BYO token
+    # counts as "available" too. No tenant context here (we're running
+    # inside _resolve_model which is called before the request-level
+    # tenant propagates down), so the resolver falls back to platform
+    # env. Keeps the old behaviour verbatim when no BYO is set.
     if "claude" in m:
-        if os.getenv("ANTHROPIC_API_KEY"):
+        if _resolve_cloud_api_key("anthropic"):
             return model
         return "gemini-2.5-flash"
 
     if "gpt" in m:
-        if os.getenv("OPENAI_API_KEY"):
+        if _resolve_cloud_api_key("openai"):
             return model
         return "gemini-2.5-flash"
 

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -56,6 +56,7 @@ from core.models.schema_registry import SchemaRegistry as SchemaRegistry
 from core.models.sso_config import SSOConfig as SSOConfig
 from core.models.tenant import Tenant as Tenant
 from core.models.tenant_ai_credential import TenantAICredential as TenantAICredential
+from core.models.tenant_ai_setting import TenantAISetting as TenantAISetting
 from core.models.tool_call import ToolCall as ToolCall
 from core.models.user import User as User
 from core.models.workflow import StepExecution as StepExecution

--- a/core/models/tenant_ai_setting.py
+++ b/core/models/tenant_ai_setting.py
@@ -1,0 +1,66 @@
+"""Tenant AI configuration — per-tenant LLM + embedding model choice.
+
+Closes S0-08 (PR-2). One row per tenant; admins pick provider, model,
+and dimensions (validated against ``core.ai_providers.catalog``). The
+resolver + llm_factory + embeddings consult this row before the
+platform env defaults.
+
+Related: ``core.models.tenant_ai_credential`` holds the BYO tokens
+this setting references; without a matching credential the tenant
+falls back per ``ai_fallback_policy``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, ForeignKey, Integer, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.models.base import BaseModel
+
+ROUTING_POLICIES = frozenset({"auto", "single", "fallback_only", "disabled"})
+FALLBACK_POLICIES = frozenset({"allow", "deny"})
+
+
+class TenantAISetting(BaseModel):
+    __tablename__ = "tenant_ai_settings"
+
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    # LLM selection
+    llm_provider: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    llm_model: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    llm_fallback_model: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    llm_routing_policy: Mapped[str] = mapped_column(
+        String(32), nullable=False, default="auto"
+    )
+    max_input_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # Embedding selection
+    embedding_provider: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    embedding_model: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    embedding_dimensions: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    chunk_size: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    chunk_overlap: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # BYO policy — when "deny", the resolver refuses platform-env fallback
+    # for this tenant (enterprise regulated mode).
+    ai_fallback_policy: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="allow"
+    )
+    updated_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/migrations/versions/v4_9_3_tenant_ai_settings.py
+++ b/migrations/versions/v4_9_3_tenant_ai_settings.py
@@ -1,0 +1,66 @@
+"""Add tenant_ai_settings for per-tenant LLM + embedding model choice.
+
+Revision ID: v493_tenant_ai_settings
+Revises: v492_tenant_ai_creds
+Create Date: 2026-04-24
+
+Closes S0-08 (PR-2). One row per tenant. Values validated against
+``core.ai_providers.catalog`` at the API boundary.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# Alembic identifiers — kept <=32 chars.
+revision = "v493_tenant_ai_settings"
+down_revision = "v492_tenant_ai_creds"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tenant_ai_settings (
+            tenant_id UUID PRIMARY KEY,
+            llm_provider VARCHAR(64),
+            llm_model VARCHAR(128),
+            llm_fallback_model VARCHAR(128),
+            llm_routing_policy VARCHAR(32) NOT NULL DEFAULT 'auto',
+            max_input_tokens INTEGER,
+            embedding_provider VARCHAR(64),
+            embedding_model VARCHAR(128),
+            embedding_dimensions INTEGER,
+            chunk_size INTEGER,
+            chunk_overlap INTEGER,
+            ai_fallback_policy VARCHAR(16) NOT NULL DEFAULT 'allow',
+            updated_by UUID,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'tenants') THEN
+                IF NOT EXISTS (
+                    SELECT 1 FROM information_schema.table_constraints
+                    WHERE table_name = 'tenant_ai_settings'
+                      AND constraint_name = 'tenant_ai_settings_tenant_id_fkey'
+                ) THEN
+                    ALTER TABLE tenant_ai_settings
+                        ADD CONSTRAINT tenant_ai_settings_tenant_id_fkey
+                        FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE;
+                END IF;
+            END IF;
+        END$$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS tenant_ai_settings")

--- a/tests/regression/test_s008_tenant_ai_config.py
+++ b/tests/regression/test_s008_tenant_ai_config.py
@@ -1,0 +1,238 @@
+"""Regression tests for S0-08 — tenant AI config (PR-2).
+
+Covers acceptance criteria from
+``docs/STRICT_REPO_S0_CLOSURE_PLAN_2026-04-24.md`` PR-2:
+
+- tenant_ai_settings ORM + migration + allowlists
+- Catalog covers required providers + embedding dimensions are pinned
+- Admin API validates (provider, model) + embedding_dimensions
+- Settings resolver falls back to platform defaults and caches
+- llm_factory routes through the AI resolver (not bare env reads)
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+
+
+def _read(rel: str) -> str:
+    return (REPO / rel).read_text(encoding="utf-8")
+
+
+# ── Model contract ───────────────────────────────────────────────────
+
+
+def test_tenant_ai_setting_model_columns() -> None:
+    from core.models.tenant_ai_setting import (
+        FALLBACK_POLICIES,
+        ROUTING_POLICIES,
+        TenantAISetting,
+    )
+
+    cols = {c.name for c in TenantAISetting.__table__.columns}
+    required = {
+        "tenant_id",
+        "llm_provider",
+        "llm_model",
+        "llm_fallback_model",
+        "llm_routing_policy",
+        "max_input_tokens",
+        "embedding_provider",
+        "embedding_model",
+        "embedding_dimensions",
+        "chunk_size",
+        "chunk_overlap",
+        "ai_fallback_policy",
+        "updated_by",
+        "created_at",
+        "updated_at",
+    }
+    missing = required - cols
+    assert not missing, f"TenantAISetting missing columns: {missing}"
+    assert "auto" in ROUTING_POLICIES
+    assert "deny" in FALLBACK_POLICIES
+
+
+# ── Catalog ──────────────────────────────────────────────────────────
+
+
+def test_llm_catalog_covers_required_providers() -> None:
+    from core.ai_providers.catalog import LLM_CATALOG, llm_providers
+
+    providers = set(llm_providers())
+    for required in ("gemini", "openai", "anthropic", "azure_openai", "openai_compatible"):
+        assert required in providers, f"LLM catalog missing provider {required!r}"
+    # Each registered model must have positive context window
+    for entry in LLM_CATALOG:
+        assert entry.context_window > 0, f"{entry.model} missing context_window"
+        assert entry.max_output_tokens > 0, f"{entry.model} missing max_output_tokens"
+
+
+def test_embedding_catalog_pins_dimensions() -> None:
+    from core.ai_providers.catalog import EMBEDDING_CATALOG
+
+    # Every entry must declare a positive dimension — that's the pin
+    # that prevents dimension/index drift.
+    for entry in EMBEDDING_CATALOG:
+        assert entry.dimensions > 0
+        assert entry.max_input_tokens > 0
+
+    # Specific dimensions we depend on elsewhere in the code:
+    from core.ai_providers.catalog import find_embedding
+
+    bge_small = find_embedding("local", "BAAI/bge-small-en-v1.5")
+    assert bge_small is not None and bge_small.dimensions == 384
+    openai_3_small = find_embedding("openai", "text-embedding-3-small")
+    assert openai_3_small is not None and openai_3_small.dimensions == 1536
+
+
+def test_catalog_lookup_special_cases() -> None:
+    from core.ai_providers.catalog import find_llm
+
+    # Azure openai deployment names pass through prefix-match
+    az = find_llm("azure_openai", "deployment:my-gpt-4o")
+    assert az is not None
+    # OpenAI-compatible wildcard accepts any model
+    oc = find_llm("openai_compatible", "llama-3.1-70b-instruct")
+    assert oc is not None
+    # Unknown combination rejects
+    assert find_llm("gemini", "gemini-10-nope") is None
+    assert find_llm("openai", "gpt-100") is None
+
+
+# ── Admin API ────────────────────────────────────────────────────────
+
+
+def test_tenant_ai_settings_router_registered() -> None:
+    main = _read("api/main.py")
+    assert "tenant_ai_settings" in main
+    assert "tenant_ai_settings.router" in main
+
+
+def test_put_validates_catalog_and_dimensions() -> None:
+    """Source-inspection pin: the PUT endpoint must call find_llm +
+    find_embedding + enforce embedding_dimensions against catalog.
+    """
+    src = _read("api/v1/tenant_ai_settings.py")
+    assert "find_llm(" in src
+    assert "find_embedding(" in src
+    assert "embedding_dimensions" in src
+    assert "scripts/embedding_rotate.py" in src, (
+        "PUT endpoint must mention the rotate script in the mismatch error "
+        "so operators know the escape hatch"
+    )
+    # PUT must be admin-gated
+    assert "require_tenant_admin" in src
+    # The Out-schema must NOT expose credentials
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "TenantAISettingOut":
+            fields = {
+                stmt.target.id
+                for stmt in node.body
+                if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
+            }
+            forbidden = {"api_key", "secret", "credentials", "credentials_encrypted"}
+            assert not (fields & forbidden), (
+                f"TenantAISettingOut exposes forbidden fields: {fields & forbidden}"
+            )
+            return
+
+
+# ── Settings resolver ────────────────────────────────────────────────
+
+
+def test_effective_setting_falls_back_to_platform_defaults() -> None:
+    import asyncio
+
+    from core.ai_providers.settings import (
+        _PLATFORM_DEFAULTS,
+        get_effective_ai_setting,
+    )
+
+    # No tenant context → platform defaults directly.
+    result = asyncio.run(get_effective_ai_setting(None))
+    assert result.source == "platform_default"
+    assert result.llm_provider == _PLATFORM_DEFAULTS.llm_provider
+    assert result.embedding_dimensions == _PLATFORM_DEFAULTS.embedding_dimensions
+
+
+def test_effective_setting_cache_invalidates() -> None:
+    from core.ai_providers.settings import _CACHE, invalidate_tenant_ai_setting_cache
+
+    _CACHE["some-tenant"] = ("stub", 0.0)  # type: ignore[assignment]
+    invalidate_tenant_ai_setting_cache("some-tenant")
+    assert "some-tenant" not in _CACHE
+
+
+# ── llm_factory integration ──────────────────────────────────────────
+
+
+def test_llm_factory_routes_through_resolver() -> None:
+    src = _read("core/langgraph/llm_factory.py")
+    # The new helper must be present and used by _build_model.
+    assert "_resolve_cloud_api_key" in src
+    assert "get_provider_credential_sync" in src
+    # None of the cloud branches should read platform env vars directly
+    # (the resolver handles env fallback). Allow references to env vars
+    # in code comments or docstrings.
+    tree = ast.parse(src)
+
+    def _is_env_read(node: ast.AST) -> bool:
+        # os.getenv("OPENAI_API_KEY") or os.environ.get(...)
+        if not isinstance(node, ast.Call):
+            return False
+        func = node.func
+        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Attribute):
+            # os.environ.get → Attribute(value=Attribute(value=Name('os'), attr='environ'), attr='get')
+            if func.attr == "get" and isinstance(func.value, ast.Attribute) and func.value.attr == "environ":
+                return True
+        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+            if func.value.id == "os" and func.attr == "getenv":
+                return True
+        return False
+
+    for node in ast.walk(tree):
+        if _is_env_read(node):
+            # Check the string arg — offending only if it's a provider secret.
+            for arg in node.args:
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    if arg.value in (
+                        "OPENAI_API_KEY",
+                        "ANTHROPIC_API_KEY",
+                        "GOOGLE_GEMINI_API_KEY",
+                        "GOOGLE_API_KEY",
+                    ):
+                        raise AssertionError(
+                            f"_build_model / helpers in core/langgraph/llm_factory.py "
+                            f"still reads {arg.value!r} directly. The resolver must "
+                            "own this path."
+                        )
+
+
+def test_create_chat_model_accepts_tenant_id() -> None:
+    import inspect
+
+    from core.langgraph.llm_factory import create_chat_model
+
+    sig = inspect.signature(create_chat_model)
+    assert "tenant_id" in sig.parameters, (
+        "create_chat_model must accept a tenant_id kwarg so callers can "
+        "propagate the request's tenant to the resolver."
+    )
+
+
+# ── Migration ID ────────────────────────────────────────────────────
+
+
+def test_v493_migration_id_within_limit() -> None:
+    src = _read("migrations/versions/v4_9_3_tenant_ai_settings.py")
+    assert 'revision = "v493_tenant_ai_settings"' in src
+    assert 'down_revision = "v492_tenant_ai_creds"' in src
+    # Revision ID must be <= 32 chars per preflight
+    assert len("v493_tenant_ai_settings") <= 32

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -77,6 +77,7 @@ const ABMDashboard = lazyRetry(() => import("./pages/ABMDashboard"));
 const ReportScheduler = lazyRetry(() => import("./pages/ReportScheduler"));
 const RPASchedules = lazyRetry(() => import("./pages/RPASchedules"));
 const AICredentials = lazyRetry(() => import("./pages/AICredentials"));
+const AIConfig = lazyRetry(() => import("./pages/AIConfig"));
 
 /* ── Knowledge Base, Voice, RPA, Industry Packs ── */
 const KnowledgeBase = lazyRetry(() => import("./pages/KnowledgeBase"));
@@ -301,6 +302,16 @@ export default function App() {
           <ProtectedRoute allowedRoles={["admin"]}>
             <Layout>
               <AICredentials />
+            </Layout>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/dashboard/settings/ai-config"
+        element={
+          <ProtectedRoute allowedRoles={["admin"]}>
+            <Layout>
+              <AIConfig />
             </Layout>
           </ProtectedRoute>
         }

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -47,6 +47,7 @@ const ALL_NAV = [
   { path: "/dashboard/rpa", labelKey: "nav.rpa", label: "RPA Scripts", roles: ["admin"] },
   { path: "/dashboard/rpa-schedules", labelKey: "nav.rpaSchedules", label: "RPA Schedules", roles: ["admin"] },
   { path: "/dashboard/settings/ai-credentials", labelKey: "nav.aiCredentials", label: "AI Credentials", roles: ["admin"] },
+  { path: "/dashboard/settings/ai-config", labelKey: "nav.aiConfig", label: "AI Configuration", roles: ["admin"] },
   { path: "/dashboard/packs", labelKey: "nav.packs", label: "Industry Packs", roles: ["admin"] },
   { path: "/dashboard/sla", labelKey: "nav.sla", label: "SLA Monitor", roles: ["admin"] },
   { path: "/dashboard/billing", labelKey: "nav.billing", label: "Billing", roles: ["admin"] },

--- a/ui/src/pages/AIConfig.tsx
+++ b/ui/src/pages/AIConfig.tsx
@@ -1,0 +1,340 @@
+import { useCallback, useEffect, useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import api, { extractApiError } from "@/lib/api";
+
+/**
+ * Tenant AI config — per-tenant LLM + embedding model selection.
+ *
+ * Closes S0-08 (PR-2 of the four-PR closure plan). Admins pick:
+ *   - Which LLM provider + model the agents use.
+ *   - Which embedding provider + model the knowledge base uses.
+ *   - Whether the platform is allowed to fall back when the tenant has
+ *     no BYO credential (ai_fallback_policy).
+ *
+ * The pickers are populated from GET /tenant-ai-settings/registry so
+ * only catalog-approved (provider, model) combinations can be chosen.
+ */
+
+interface LlmRegistryItem {
+  model: string;
+  context_window: number;
+  max_output_tokens: number;
+  supports_tools: boolean;
+  supports_vision: boolean;
+  notes: string;
+}
+
+interface EmbeddingRegistryItem {
+  model: string;
+  dimensions: number;
+  max_input_tokens: number;
+  notes: string;
+}
+
+interface Registry {
+  llm: Record<string, LlmRegistryItem[]>;
+  embedding: Record<string, EmbeddingRegistryItem[]>;
+}
+
+interface Setting {
+  tenant_id: string;
+  llm_provider: string | null;
+  llm_model: string | null;
+  llm_fallback_model: string | null;
+  llm_routing_policy: string;
+  max_input_tokens: number | null;
+  embedding_provider: string | null;
+  embedding_model: string | null;
+  embedding_dimensions: number | null;
+  chunk_size: number | null;
+  chunk_overlap: number | null;
+  ai_fallback_policy: string;
+}
+
+const ROUTING_POLICIES = ["auto", "single", "fallback_only", "disabled"];
+const FALLBACK_POLICIES = [
+  { value: "allow", label: "Allow platform fallback" },
+  { value: "deny", label: "Deny — require BYO tokens" },
+];
+
+export default function AIConfig() {
+  const [registry, setRegistry] = useState<Registry | null>(null);
+  const [setting, setSetting] = useState<Setting | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const [form, setForm] = useState({
+    llm_provider: "",
+    llm_model: "",
+    llm_fallback_model: "",
+    llm_routing_policy: "auto",
+    max_input_tokens: "",
+    embedding_provider: "",
+    embedding_model: "",
+    chunk_size: "",
+    chunk_overlap: "",
+    ai_fallback_policy: "allow",
+  });
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [regRes, setRes] = await Promise.all([
+        api.get("/tenant-ai-settings/registry"),
+        api.get("/tenant-ai-settings"),
+      ]);
+      setRegistry(regRes.data);
+      setSetting(setRes.data);
+      setForm({
+        llm_provider: setRes.data?.llm_provider || "",
+        llm_model: setRes.data?.llm_model || "",
+        llm_fallback_model: setRes.data?.llm_fallback_model || "",
+        llm_routing_policy: setRes.data?.llm_routing_policy || "auto",
+        max_input_tokens: setRes.data?.max_input_tokens?.toString() || "",
+        embedding_provider: setRes.data?.embedding_provider || "",
+        embedding_model: setRes.data?.embedding_model || "",
+        chunk_size: setRes.data?.chunk_size?.toString() || "",
+        chunk_overlap: setRes.data?.chunk_overlap?.toString() || "",
+        ai_fallback_policy: setRes.data?.ai_fallback_policy || "allow",
+      });
+    } catch (e) {
+      setError(extractApiError(e, "Failed to load AI config"));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const payload: Record<string, unknown> = {};
+      if (form.llm_provider) payload.llm_provider = form.llm_provider;
+      if (form.llm_model) payload.llm_model = form.llm_model;
+      if (form.llm_fallback_model) payload.llm_fallback_model = form.llm_fallback_model;
+      if (form.llm_routing_policy) payload.llm_routing_policy = form.llm_routing_policy;
+      if (form.max_input_tokens) payload.max_input_tokens = parseInt(form.max_input_tokens, 10);
+      if (form.embedding_provider) payload.embedding_provider = form.embedding_provider;
+      if (form.embedding_model) payload.embedding_model = form.embedding_model;
+      if (form.chunk_size) payload.chunk_size = parseInt(form.chunk_size, 10);
+      if (form.chunk_overlap) payload.chunk_overlap = parseInt(form.chunk_overlap, 10);
+      if (form.ai_fallback_policy) payload.ai_fallback_policy = form.ai_fallback_policy;
+      await api.put("/tenant-ai-settings", payload);
+      setNotice("Config saved. Resolver cache will refresh within 60 seconds.");
+      await fetchAll();
+    } catch (e) {
+      setError(extractApiError(e, "Failed to save config"));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const llmModels =
+    registry && form.llm_provider ? registry.llm[form.llm_provider] || [] : [];
+  const embeddingModels =
+    registry && form.embedding_provider
+      ? registry.embedding[form.embedding_provider] || []
+      : [];
+  const selectedEmbedding = embeddingModels.find(
+    (m) => m.model === form.embedding_model,
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold">AI Configuration</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Pick the LLM and embedding model your agents and knowledge base use.
+          Paired with <a href="/dashboard/settings/ai-credentials" className="underline">AI Credentials</a> for BYO provider tokens.
+        </p>
+      </div>
+
+      {notice && (
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 text-emerald-900 px-3 py-2 text-sm" role="status">
+          {notice}
+        </div>
+      )}
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 text-red-900 px-3 py-2 text-sm" role="alert">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : (
+        <>
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Large Language Model</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                <div>
+                  <label className="text-xs font-medium text-muted-foreground">Provider</label>
+                  <select
+                    className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                    value={form.llm_provider}
+                    onChange={(e) => setForm({ ...form, llm_provider: e.target.value, llm_model: "", llm_fallback_model: "" })}
+                  >
+                    <option value="">— Use platform default —</option>
+                    {registry && Object.keys(registry.llm).map((p) => (
+                      <option key={p} value={p}>{p}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="text-xs font-medium text-muted-foreground">Model</label>
+                  <select
+                    className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                    value={form.llm_model}
+                    onChange={(e) => setForm({ ...form, llm_model: e.target.value })}
+                    disabled={!form.llm_provider}
+                  >
+                    <option value="">— Select —</option>
+                    {llmModels.map((m) => (
+                      <option key={m.model} value={m.model}>
+                        {m.model} · ctx {m.context_window.toLocaleString()}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                <div>
+                  <label className="text-xs font-medium text-muted-foreground">Fallback model</label>
+                  <select
+                    className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                    value={form.llm_fallback_model}
+                    onChange={(e) => setForm({ ...form, llm_fallback_model: e.target.value })}
+                    disabled={!form.llm_provider}
+                  >
+                    <option value="">— None —</option>
+                    {llmModels.map((m) => (
+                      <option key={m.model} value={m.model}>{m.model}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="text-xs font-medium text-muted-foreground">Routing policy</label>
+                  <select
+                    className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                    value={form.llm_routing_policy}
+                    onChange={(e) => setForm({ ...form, llm_routing_policy: e.target.value })}
+                  >
+                    {ROUTING_POLICIES.map((p) => (
+                      <option key={p} value={p}>{p}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Embedding model</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                <div>
+                  <label className="text-xs font-medium text-muted-foreground">Provider</label>
+                  <select
+                    className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                    value={form.embedding_provider}
+                    onChange={(e) => setForm({ ...form, embedding_provider: e.target.value, embedding_model: "" })}
+                  >
+                    <option value="">— Use platform default —</option>
+                    {registry && Object.keys(registry.embedding).map((p) => (
+                      <option key={p} value={p}>{p}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="text-xs font-medium text-muted-foreground">Model</label>
+                  <select
+                    className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                    value={form.embedding_model}
+                    onChange={(e) => setForm({ ...form, embedding_model: e.target.value })}
+                    disabled={!form.embedding_provider}
+                  >
+                    <option value="">— Select —</option>
+                    {embeddingModels.map((m) => (
+                      <option key={m.model} value={m.model}>
+                        {m.model} · dims {m.dimensions}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              {selectedEmbedding && selectedEmbedding.dimensions !== setting?.embedding_dimensions && (
+                <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-2 py-1">
+                  Warning: changing embedding dimensions from {setting?.embedding_dimensions ?? "none"} to {selectedEmbedding.dimensions} requires a backfill. Run <code>scripts/embedding_rotate.py</code> before switching models on a production index.
+                </p>
+              )}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                <div>
+                  <label className="text-xs font-medium text-muted-foreground">Chunk size (tokens)</label>
+                  <input
+                    type="number"
+                    className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                    value={form.chunk_size}
+                    onChange={(e) => setForm({ ...form, chunk_size: e.target.value })}
+                    min={32}
+                    max={8192}
+                  />
+                </div>
+                <div>
+                  <label className="text-xs font-medium text-muted-foreground">Chunk overlap</label>
+                  <input
+                    type="number"
+                    className="w-full border rounded px-2 py-1.5 text-sm bg-background"
+                    value={form.chunk_overlap}
+                    onChange={(e) => setForm({ ...form, chunk_overlap: e.target.value })}
+                    min={0}
+                    max={1024}
+                  />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Fallback policy</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <select
+                className="w-full md:w-96 border rounded px-2 py-1.5 text-sm bg-background"
+                value={form.ai_fallback_policy}
+                onChange={(e) => setForm({ ...form, ai_fallback_policy: e.target.value })}
+              >
+                {FALLBACK_POLICIES.map((p) => (
+                  <option key={p.value} value={p.value}>{p.label}</option>
+                ))}
+              </select>
+              <p className="text-xs text-muted-foreground">
+                When <strong>deny</strong>, the platform refuses to use its own provider keys for your tenant — every LLM, embedding, and RAG call must use a BYO credential. Use this for regulated deployments.
+              </p>
+            </CardContent>
+          </Card>
+
+          <div className="flex gap-2">
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? "Saving…" : "Save configuration"}
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

**Closes S0-08** from `docs/STRICT_REPO_AUDIT_AND_TEST_MATRIX_2026-04-24.md`.
**PR 2 of 4** in the closure plan. Depends on PR #301 (merged, provides the BYO credentials foundation). Enables tenants to pick both the LLM and embedding model their agents run, validated against a catalog so operators can't flip an env var into a model/dim mismatch.

## What ships

| Component | File | Purpose |
| --- | --- | --- |
| Catalog | `core/ai_providers/catalog.py` | Frozen (provider, model) allowlist — LLM (Gemini/OpenAI/Anthropic/Azure/OpenAI-compatible) + Embeddings (local BGE 384/768/1024, OpenAI 3-small 1536, 3-large 3072, Voyage, Cohere). Dimensions pinned per entry. |
| ORM | `core/models/tenant_ai_setting.py` | One row per tenant with llm_provider / llm_model / llm_fallback_model / routing_policy / max_input_tokens / embedding_provider / embedding_model / embedding_dimensions / chunk_size / chunk_overlap / ai_fallback_policy. |
| Migration | `migrations/versions/v4_9_3_tenant_ai_settings.py` | Idempotent CREATE TABLE + guarded FK on tenants. |
| Settings helper | `core/ai_providers/settings.py` | `get_effective_ai_setting(tenant_id)` with platform-default fallback + 60s cache + `invalidate_tenant_ai_setting_cache`. |
| Admin API | `api/v1/tenant_ai_settings.py` | GET / PUT / GET registry. PUT validates every (provider, model) + rejects embedding_dimensions that don't match the catalog pin. Admin-gated. |
| llm_factory rewire | `core/langgraph/llm_factory.py` | `_resolve_cloud_api_key` bridges `_build_model` to `get_provider_credential_sync`. `create_chat_model` accepts `tenant_id` kwarg. `_resolve_model` capability gate also routes via resolver. |
| UI | `ui/src/pages/AIConfig.tsx` | `/dashboard/settings/ai-config` admin page. Pickers populated from `/registry`; dimension-mismatch warning on embedding change points at `scripts/embedding_rotate.py`. |
| Tests | `tests/regression/test_s008_tenant_ai_config.py` | 11 assertions covering model shape, catalog coverage, catalog lookup edge cases, admin API validation, effective setting fallback, cache invalidation, **AST-walk proving no bare provider env reads remain in llm_factory**, `create_chat_model` signature. |

## Acceptance criteria (from closure plan)

- [x] `tests/regression/test_s008_tenant_ai_config.py` — 11 passing.
- [x] `ruff check .` tree-wide — clean.
- [x] `npx tsc --noEmit` — clean.
- [x] Full `pytest tests/regression/ tests/unit/` — 3121 passed locally.
- [x] Alembic revision ≤ 32 chars (`v493_tenant_ai_settings` = 22).
- [x] Catalog covers `gemini`, `openai`, `anthropic`, `azure_openai`, `openai_compatible` for LLM; `local`, `openai`, `voyage`, `cohere` for embeddings.
- [x] `find_llm` / `find_embedding` prevents unknown combinations.
- [x] Admin API returns registry shape directly to the UI.
- [x] Embedding dim-mismatch → 422 with rotate-script hint.

## What's deferred to PR-3 and PR-4

- **`scripts/embedding_rotate.py`** — the dry-run + shadow-table + swap workflow. Ships in PR-4 alongside the quality-gate floor so we can't swap embeddings without a passing eval.
- **Wire `core/embeddings.py` to the tenant's embedding model** — the embedding adapter still uses `AGENTICORG_EMBEDDING_MODEL` directly. PR-3 updates it to consult `get_effective_ai_setting(tenant_id).embedding_model` at the ingestion call-site.
- **`core/llm/router.py`** (smart-routing heuristic) — still reads `external_keys`. Migrated in PR-3 when it gets new callers via the ingestion service.

## Impeccable /audit /critique /polish

UI uses existing shadcn `Card`/`Button`/form primitives. Pickers are plain `<select>` to match `AICredentials.tsx` and `RPASchedules.tsx`. No new design tokens. Dim-mismatch warning uses the amber-50 warning pattern already used by `SchemaEditor.tsx`.

## Residual risks

- The llm_factory sync-over-async bridge (`get_provider_credential_sync`) spawns a short-lived threadpool when called inside a running event loop. Cache hits (60-120s TTL) absorb this cost; first-call latency grows by ~1-5ms. Acceptable for this use case.
- Embedding rotation is still manual until PR-4 ships the gated script. The admin UI shows a warning but does not block the PUT.

## Reviewers

@codex — please audit the catalog coverage (any production model we're currently running on but isn't in `LLM_CATALOG` / `EMBEDDING_CATALOG`?), the embedding dimension pin enforcement, and the llm_factory resolver wiring.