### PR TITLE
infra(cloud-run): add deployment artifacts for GKE → Cloud Run migration

### DIFF
--- a/Dockerfile.ui.cloudrun
+++ b/Dockerfile.ui.cloudrun
@@ -1,0 +1,19 @@
+FROM node:25-slim AS builder
+WORKDIR /app
+COPY ui/package.json ui/package-lock.json* ./
+RUN npm install --legacy-peer-deps
+ARG CACHE_BUST=1
+COPY ui/ .
+COPY core/agents/ ../core/agents/
+COPY connectors/ ../connectors/
+ARG VITE_GA4_ID=""
+ENV VITE_GA4_ID=$VITE_GA4_ID
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY ui/nginx.cloudrun.conf.template /etc/nginx/templates/default.conf.template
+ENV NGINX_ENVSUBST_FILTER='^(API_BACKEND_HOST|PORT)$'
+ENV PORT=8080
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=3s CMD wget -q --spider http://localhost:${PORT}/health || exit 1

--- a/cloudbuild.ui.cloudrun.yaml
+++ b/cloudbuild.ui.cloudrun.yaml
@@ -1,0 +1,14 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - -f
+      - Dockerfile.ui.cloudrun
+      - -t
+      - asia-south1-docker.pkg.dev/perfect-period-305406/agenticorg/agenticorg-ui-cloudrun:v1
+      - .
+images:
+  - asia-south1-docker.pkg.dev/perfect-period-305406/agenticorg/agenticorg-ui-cloudrun:v1
+options:
+  machineType: E2_HIGHCPU_8
+timeout: 1500s

--- a/scripts/gcp_billing_mtd.py
+++ b/scripts/gcp_billing_mtd.py
@@ -20,8 +20,9 @@ DATASET = "billing_export"
 
 
 def run_query(sql: str) -> list[dict]:
-    token = subprocess.check_output(
-        ["gcloud", "auth", "print-access-token"], text=True
+    token = subprocess.check_output(  # noqa: S603
+        ["gcloud", "auth", "print-access-token"],  # noqa: S607
+        text=True,
     ).strip()
     import urllib.request
 
@@ -34,7 +35,7 @@ def run_query(sql: str) -> list[dict]:
         },
         method="POST",
     )
-    with urllib.request.urlopen(req) as resp:
+    with urllib.request.urlopen(req) as resp:  # noqa: S310
         body = json.loads(resp.read())
     if not body.get("jobComplete"):
         sys.exit("Query did not complete synchronously; rerun.")
@@ -46,8 +47,9 @@ def run_query(sql: str) -> list[dict]:
 
 
 def find_billing_table() -> str:
-    token = subprocess.check_output(
-        ["gcloud", "auth", "print-access-token"], text=True
+    token = subprocess.check_output(  # noqa: S603
+        ["gcloud", "auth", "print-access-token"],  # noqa: S607
+        text=True,
     ).strip()
     import urllib.request
 
@@ -55,7 +57,7 @@ def find_billing_table() -> str:
         f"https://bigquery.googleapis.com/bigquery/v2/projects/{PROJECT}/datasets/{DATASET}/tables",
         headers={"Authorization": f"Bearer {token}"},
     )
-    with urllib.request.urlopen(req) as resp:
+    with urllib.request.urlopen(req) as resp:  # noqa: S310
         body = json.loads(resp.read())
     tables = [t["tableReference"]["tableId"] for t in body.get("tables", [])]
     standard = [t for t in tables if t.startswith("gcp_billing_export_v1_")]
@@ -82,6 +84,8 @@ def main() -> None:
     table = find_billing_table()
     fq = f"`{PROJECT}.{DATASET}.{table}`"
 
+    # year/month are int from argparse/date.today; table name is a fixed-prefix match
+    # from the BigQuery API listing (find_billing_table). No user-controlled string interpolation.
     total_sql = f"""
     SELECT
       ROUND(SUM(cost), 2) AS gross_cost,
@@ -91,7 +95,7 @@ def main() -> None:
     WHERE EXTRACT(YEAR FROM usage_start_time) = {year}
       AND EXTRACT(MONTH FROM usage_start_time) = {month}
     GROUP BY currency
-    """
+    """  # noqa: S608
     by_service_sql = f"""
     SELECT
       service.description AS service,
@@ -103,7 +107,7 @@ def main() -> None:
     HAVING net_cost > 0
     ORDER BY net_cost DESC
     LIMIT 15
-    """
+    """  # noqa: S608
 
     print(f"=== {year}-{month:02d} (project: {PROJECT}) ===\n")
     totals = run_query(total_sql)

--- a/scripts/gcp_billing_mtd.py
+++ b/scripts/gcp_billing_mtd.py
@@ -1,0 +1,124 @@
+"""Query month-to-date GCP spend from the BigQuery billing export.
+
+Usage:
+    python scripts/gcp_billing_mtd.py                # MTD total + by-service
+    python scripts/gcp_billing_mtd.py --month 2026-03 # specific month
+
+Requires: gcloud auth application-default login (or ADC), BigQuery billing
+export configured to perfect-period-305406.billing_export.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import date
+
+PROJECT = "perfect-period-305406"
+DATASET = "billing_export"
+
+
+def run_query(sql: str) -> list[dict]:
+    token = subprocess.check_output(
+        ["gcloud", "auth", "print-access-token"], text=True
+    ).strip()
+    import urllib.request
+
+    req = urllib.request.Request(
+        f"https://bigquery.googleapis.com/bigquery/v2/projects/{PROJECT}/queries",
+        data=json.dumps({"query": sql, "useLegacySql": False}).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        body = json.loads(resp.read())
+    if not body.get("jobComplete"):
+        sys.exit("Query did not complete synchronously; rerun.")
+    fields = [f["name"] for f in body["schema"]["fields"]]
+    rows = []
+    for r in body.get("rows", []):
+        rows.append({fields[i]: c["v"] for i, c in enumerate(r["f"])})
+    return rows
+
+
+def find_billing_table() -> str:
+    token = subprocess.check_output(
+        ["gcloud", "auth", "print-access-token"], text=True
+    ).strip()
+    import urllib.request
+
+    req = urllib.request.Request(
+        f"https://bigquery.googleapis.com/bigquery/v2/projects/{PROJECT}/datasets/{DATASET}/tables",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(req) as resp:
+        body = json.loads(resp.read())
+    tables = [t["tableReference"]["tableId"] for t in body.get("tables", [])]
+    standard = [t for t in tables if t.startswith("gcp_billing_export_v1_")]
+    if not standard:
+        sys.exit(
+            f"No billing export table found in {PROJECT}.{DATASET}. "
+            "Enable the export in Console (Billing → Billing export → BigQuery export) "
+            "and wait up to 24h for the first data."
+        )
+    return standard[0]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--month", help="YYYY-MM (default: current month)")
+    args = parser.parse_args()
+
+    if args.month:
+        year, month = map(int, args.month.split("-"))
+    else:
+        today = date.today()
+        year, month = today.year, today.month
+
+    table = find_billing_table()
+    fq = f"`{PROJECT}.{DATASET}.{table}`"
+
+    total_sql = f"""
+    SELECT
+      ROUND(SUM(cost), 2) AS gross_cost,
+      ROUND(SUM(cost) + SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)), 2) AS net_cost,
+      currency
+    FROM {fq}
+    WHERE EXTRACT(YEAR FROM usage_start_time) = {year}
+      AND EXTRACT(MONTH FROM usage_start_time) = {month}
+    GROUP BY currency
+    """
+    by_service_sql = f"""
+    SELECT
+      service.description AS service,
+      ROUND(SUM(cost) + SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)), 2) AS net_cost
+    FROM {fq}
+    WHERE EXTRACT(YEAR FROM usage_start_time) = {year}
+      AND EXTRACT(MONTH FROM usage_start_time) = {month}
+    GROUP BY service
+    HAVING net_cost > 0
+    ORDER BY net_cost DESC
+    LIMIT 15
+    """
+
+    print(f"=== {year}-{month:02d} (project: {PROJECT}) ===\n")
+    totals = run_query(total_sql)
+    if not totals:
+        print("No usage rows yet for this month.")
+        return
+    for t in totals:
+        print(
+            f"Gross: {t['gross_cost']} {t['currency']}    "
+            f"Net (after credits): {t['net_cost']} {t['currency']}"
+        )
+    print("\nTop services:")
+    for r in run_query(by_service_sql):
+        print(f"  {r['net_cost']:>12}  {r['service']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ui/nginx.cloudrun.conf.template
+++ b/ui/nginx.cloudrun.conf.template
@@ -1,0 +1,155 @@
+server_tokens off;
+
+gzip on;
+gzip_vary on;
+gzip_proxied any;
+gzip_comp_level 6;
+gzip_min_length 256;
+gzip_types
+    text/plain
+    text/css
+    text/javascript
+    application/javascript
+    application/json
+    application/xml
+    image/svg+xml;
+
+resolver 169.254.169.254 8.8.8.8 valid=60s ipv6=off;
+
+server {
+    listen ${PORT};
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    rewrite ^(.+)/$ $1 permanent;
+
+    error_page 502 503 504 /index.html;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://apis.google.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://accounts.google.com; img-src 'self' data: blob: https://*.googleusercontent.com https://www.google-analytics.com; font-src 'self' data:; connect-src 'self' wss: ws: https://accounts.google.com https://oauth2.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none';" always;
+
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri /index.html;
+    }
+
+    location ~* ^/(?!api/|ws/).*\.(svg|ico|json|txt|xml)$ {
+        expires 1d;
+        add_header Cache-Control "public";
+        try_files $uri =404;
+    }
+
+    location ^~ /api/ {
+        set $api_backend "${API_BACKEND_HOST}";
+        proxy_pass https://$api_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $api_backend;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+        proxy_ssl_server_name on;
+        proxy_ssl_name $api_backend;
+
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+
+        proxy_buffering on;
+        proxy_buffer_size 16k;
+        proxy_buffers 8 16k;
+
+        client_max_body_size 10m;
+    }
+
+    location /ws/ {
+        set $api_backend "${API_BACKEND_HOST}";
+        proxy_pass https://$api_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $api_backend;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_ssl_server_name on;
+        proxy_ssl_name $api_backend;
+
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 86400s;
+        proxy_read_timeout 86400s;
+    }
+
+    location = /health {
+        access_log off;
+        return 200 "ok";
+        add_header Content-Type text/plain;
+    }
+
+    location = /llms.txt {
+        add_header Content-Type text/plain;
+        try_files /llms.txt =404;
+    }
+    location = /llms-full.txt {
+        add_header Content-Type text/plain;
+        try_files /llms-full.txt =404;
+    }
+
+    sub_filter_once on;
+    sub_filter_types text/html;
+
+    location = /pricing {
+        sub_filter '<title>AgenticOrg' '<title>Pricing — AgenticOrg';
+        sub_filter 'content="AI agents that reason AND act' 'content="AgenticOrg pricing: Free, Pro ($499/mo), Enterprise. 50+ AI agents';
+        try_files /index.html =404;
+    }
+
+    location = /playground {
+        sub_filter '<title>AgenticOrg' '<title>Agent Playground — Try AgenticOrg Live | AgenticOrg';
+        sub_filter 'content="AI agents that reason AND act' 'content="Try 8 AI agents live — process invoices, screen resumes, classify tickets. No signup required. 50+ AI agents';
+        try_files /index.html =404;
+    }
+
+    location = /evals {
+        sub_filter '<title>AgenticOrg' '<title>Evaluation Matrix — 22 AI Agents Scored | AgenticOrg';
+        sub_filter 'content="AI agents that reason AND act' 'content="Published evaluation scorecard: 50+ AI agents scored across quality, safety, performance, reliability, security, cost. 50+ AI agents';
+        try_files /index.html =404;
+    }
+
+    location = /signup {
+        sub_filter '<title>AgenticOrg' '<title>Create Account — AgenticOrg';
+        sub_filter 'content="AI agents that reason AND act' 'content="Create your organization on AgenticOrg. 50+ AI agents';
+        try_files /index.html =404;
+    }
+
+    location = /login {
+        sub_filter '<title>AgenticOrg' '<title>Sign In — AgenticOrg';
+        try_files /index.html =404;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+    }
+
+    location = /404 {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header X-Robots-Tag "noindex, nofollow" always;
+        return 404;
+    }
+
+    location / {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary

Adds the build + runtime config needed to run AgenticOrg on **Cloud Run** (Singapore, `asia-southeast1`), replacing the GKE Autopilot deployment. The actual cutover already happened end-to-end — this PR just lands the source artifacts that produced the live system.

- **`Dockerfile.ui.cloudrun`** — nginx-alpine image that templates the API upstream from runtime env (`API_BACKEND_HOST`, `PORT`) using the standard nginx-alpine envsubst feature
- **`ui/nginx.cloudrun.conf.template`** — HTTPS `proxy_pass` with proper SNI + `Host` header rewrite + runtime DNS resolver (Cloud Run rotates IPs per request); preserves all SEO sub_filters, security headers, CSP, and WebSocket support from the existing `nginx.conf`
- **`cloudbuild.ui.cloudrun.yaml`** — Cloud Build config that produces the new image and pushes to Artifact Registry
- **`scripts/gcp_billing_mtd.py`** — utility to query month-to-date GCP spend from the BigQuery billing export

The existing `Dockerfile.ui` and `ui/nginx.conf` are **left untouched** — they remain valid for the GKE deployment until Stage 4 (cluster teardown).

## Migration context (already executed before this PR)

| Stage | What | Status |
|---|---|---|
| 1 | Build Cloud Run services in parallel to GKE (api + ui + redis sidecar + Secret Manager + Cloud SQL connector) | ✅ Live |
| 2A | Migrate `agenticorg.ai` zone to Cloud DNS (Namecheap NS swap) | ✅ Done |
| 2B | Cloud Run domain mappings + DNS cutover + TLS provisioning | ✅ All 3 hosts on HTTPS |
| 3 | Cron jobs → Cloud Scheduler + Cloud Run Jobs (currently paused per user request — domain reputation) | ✅ Migrated, paused |
| 4 | GKE cluster + LB teardown (~$120/mo savings) | ⏳ Pending 24-48h soak |

## Verification

- All 11 preflight gates green: ruff, bandit, alembic, verify=False scan, pytest (regression+unit, 2426 pass), ui tsc, ui build, consistency sweep, module coverage floor, critical-path tags
- All 3 production hosts return HTTP 200 with valid Google Trust Services certs:
  - `https://app.agenticorg.ai` ✓
  - `https://www.agenticorg.ai` ✓
  - `https://agenticorg.ai` ✓
- API proxy through nginx works end-to-end (UI → api Cloud Run → Cloud SQL + Redis sidecar)

## Test plan

- [x] Cloud Run API `/api/v1/health` returns `{db: healthy, redis: healthy}` ✓
- [x] UI nginx serves SPA + proxies `/api/*` correctly ✓
- [x] All 3 hosts have valid Let's Encrypt-equivalent (Google Trust Services WR3) certs ✓
- [x] SEO `sub_filter` routes work (e.g. `/pricing`) ✓
- [x] `/llms.txt` served correctly ✓
- [x] Cron jobs migrated to Cloud Scheduler + Cloud Run Jobs ✓ (currently paused)
- [ ] Stage 4 GKE teardown — separate, after 24-48h soak

## Reviewer

@codex — please review the nginx config (HTTPS upstream, SNI, DNS resolver) and the templating filter (`NGINX_ENVSUBST_FILTER='^(API_BACKEND_HOST|PORT)$'` to avoid clobbering nginx's own `\$host`/`\$remote_addr` variables).

## Follow-ups (not in this PR)

- Rotate exposed secrets (Gmail app pass, Composio key, Plural secrets, VAPID, Slack, Grantex, Gemini, DB password) — these surfaced in pod env-var dumps during migration
- Cloud SQL is open to `0.0.0.0/0` with SSL not required — pre-existing, unblocked by Cloud SQL connector usage but still wide open at network level
- Helm chart in `helm/` becomes obsolete after Stage 4 teardown
- Add `pytest-asyncio` etc. to a documented dev-bootstrap script (the local venv was missing them; without the plugin 758 async tests silently fail)