### PR TITLE
revert: fastembed >=0.8.0 — pillow conflict with composio-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dependencies = [
     "authlib>=1.7.0",
     "reportlab>=4.4.10",
     "google-cloud-kms>=3.12.0",
-    "fastembed>=0.8.0",
+    "fastembed>=0.7.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Reverts #267 (fastembed 0.7.0 → 0.8.0).

\`pip install\` fails on Python 3.14 with ResolutionImpossible:

> composio-core 0.7.21 depends on Pillow<11 and >=10.2.0
> fastembed 0.8.0 depends on pillow<13.0 and >=12.0.0; python_version >= "3.14"

(There's already a \`chore(dependabot): ignore fastembed 0.8.x until composio-core widens Pillow\` commit on main — this PR slipped through that ignore rule somehow.)

Cloud Build of the API image fails until this lands. \`main\` is otherwise unbuildable for the backend.

Followup: bump composio-core when it widens Pillow, then unpin fastembed.