### PR TITLE
feat(legal): add Support, Privacy, Terms, Refund pages for Stripe activation

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -33,6 +33,10 @@ const ForgotPassword = lazyRetry(() => import("./pages/ForgotPassword"));
 const ResetPassword = lazyRetry(() => import("./pages/ResetPassword"));
 const Evals = lazyRetry(() => import("./pages/Evals"));
 const Pricing = lazyRetry(() => import("./pages/Pricing"));
+const Support = lazyRetry(() => import("./pages/legal/Support"));
+const Privacy = lazyRetry(() => import("./pages/legal/Privacy"));
+const Terms = lazyRetry(() => import("./pages/legal/Terms"));
+const Refund = lazyRetry(() => import("./pages/legal/Refund"));
 const Playground = lazyRetry(() => import("./pages/Playground"));
 const Dashboard = lazyRetry(() => import("./pages/Dashboard"));
 const Agents = lazyRetry(() => import("./pages/Agents"));
@@ -155,6 +159,17 @@ export default function App() {
       <Route path="/evals" element={<Evals />} />
       <Route path="/pricing" element={<Pricing />} />
       <Route path="/playground" element={<Playground />} />
+
+      {/* Legal / policy pages — required for Stripe activation */}
+      <Route path="/support" element={<Support />} />
+      <Route path="/contact" element={<Support />} />
+      <Route path="/privacy" element={<Privacy />} />
+      <Route path="/privacy-policy" element={<Privacy />} />
+      <Route path="/terms" element={<Terms />} />
+      <Route path="/terms-of-service" element={<Terms />} />
+      <Route path="/refund" element={<Refund />} />
+      <Route path="/refund-policy" element={<Refund />} />
+      <Route path="/cancellation" element={<Refund />} />
 
       {/* Blog / Content pages */}
       <Route path="/blog" element={<Blog />} />

--- a/ui/src/pages/legal/Privacy.tsx
+++ b/ui/src/pages/legal/Privacy.tsx
@@ -1,0 +1,158 @@
+import { Helmet } from "react-helmet-async";
+import { Link } from "react-router-dom";
+
+export default function Privacy() {
+  return (
+    <div className="min-h-screen bg-white">
+      <Helmet>
+        <title>Privacy Policy — AgenticOrg</title>
+        <meta
+          name="description"
+          content="How AgenticOrg collects, uses, discloses and secures your data."
+        />
+      </Helmet>
+
+      <header className="border-b border-slate-200">
+        <div className="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between">
+          <Link to="/" className="text-xl font-semibold text-slate-900">
+            AgenticOrg
+          </Link>
+          <Link to="/" className="text-sm text-slate-600 hover:text-slate-900">
+            ← Back to home
+          </Link>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-6 py-12 prose prose-slate">
+        <h1 className="text-4xl font-bold text-slate-900 mb-2">Privacy Policy</h1>
+        <p className="text-sm text-slate-500 mb-10">Last updated: 25 April 2026</p>
+
+        <p className="text-slate-700 leading-relaxed mb-6">
+          This Privacy Policy describes how Mu-Zero Technologies Private Limited
+          (&ldquo;<strong>AgenticOrg</strong>&rdquo;, &ldquo;we&rdquo;, &ldquo;us&rdquo;) collects, uses, discloses and
+          secures information when you use the AgenticOrg platform (the
+          &ldquo;<strong>Service</strong>&rdquo;) accessed at <code>agenticorg.ai</code>.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">1. Information we collect</h2>
+        <ul className="list-disc pl-6 text-slate-700 space-y-2 mb-6">
+          <li>
+            <strong>Account data</strong> — name, work email, organization, role.
+          </li>
+          <li>
+            <strong>Usage data</strong> — agent runs, workflow executions, connector invocations,
+            request/response metadata, IP address, browser/OS for security and product analytics.
+          </li>
+          <li>
+            <strong>Connector content</strong> — when you connect a third-party tool (Gmail, Slack,
+            HubSpot, Tally, etc.) we process the data the agent reads/writes on your behalf.
+            This data is held only as long as needed to fulfil the agent task and is not used
+            for model training.
+          </li>
+          <li>
+            <strong>Payment data</strong> — handled directly by Stripe (USD) or Pine Labs Plural
+            (INR). We never see or store full card numbers, CVVs, or bank credentials.
+          </li>
+          <li>
+            <strong>Support communications</strong> — when you email or call us.
+          </li>
+        </ul>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">2. How we use your information</h2>
+        <ul className="list-disc pl-6 text-slate-700 space-y-2 mb-6">
+          <li>To operate the Service: provision agents, execute workflows, return results.</li>
+          <li>To bill you: invoice generation, subscription management, payment reconciliation.</li>
+          <li>To secure the Service: detect abuse, throttle attacks, audit administrative actions.</li>
+          <li>To improve the Service: aggregated, de-identified usage patterns.</li>
+          <li>To respond to support requests and legal/regulatory obligations.</li>
+        </ul>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">3. Who we share data with</h2>
+        <ul className="list-disc pl-6 text-slate-700 space-y-2 mb-6">
+          <li>
+            <strong>Cloud infrastructure (Google Cloud Platform)</strong> — hosts the Service,
+            stores your data in Singapore (compute) and Singapore (database). Encrypted at rest
+            (AES-256) and in transit (TLS 1.2+).
+          </li>
+          <li>
+            <strong>Payment processors</strong> — Stripe Inc. (USD) and Pine Labs Pvt Ltd
+            (INR/Plural) receive only the fields required to process the transaction.
+          </li>
+          <li>
+            <strong>LLM providers</strong> — Google (Gemini) and Anthropic (Claude) when used.
+            Content sent to providers follows their respective data-handling commitments;
+            we do not allow your data to be used for their model training.
+          </li>
+          <li>
+            <strong>Connector destinations</strong> — only the third-party tools you explicitly
+            authorize, only the data the agent task requires.
+          </li>
+          <li>
+            <strong>Legal authorities</strong> — when required by valid legal process or to
+            protect rights, safety, or property.
+          </li>
+        </ul>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          We do not sell your personal data. We do not share data with advertising networks.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">4. How disclosure happens</h2>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          All sharing is over TLS 1.2+. Database backups, log archives, and document storage
+          are encrypted at rest using Google-managed keys. Access to production systems is
+          role-based, MFA-enforced, and audit-logged. Secrets (API keys, OAuth tokens, database
+          credentials) are stored in Google Secret Manager, never in source code or plaintext logs.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">5. Security practices</h2>
+        <ul className="list-disc pl-6 text-slate-700 space-y-2 mb-6">
+          <li>TLS 1.2+ for all network traffic; HSTS enforced.</li>
+          <li>Database isolated from public network; access via Cloud SQL connector only.</li>
+          <li>Application secrets in Google Secret Manager, rotated on schedule.</li>
+          <li>Tenant isolation enforced at the database row-level (RLS).</li>
+          <li>JWT tokens with short expiry, blacklist on logout, refresh-token rotation.</li>
+          <li>PII masking in logs and traces.</li>
+          <li>Vulnerability scanning (bandit, pip-audit) in CI; dependencies tracked via Dependabot.</li>
+        </ul>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">6. Data retention</h2>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          Account data is retained for the lifetime of your account plus 90 days after closure.
+          Audit logs are retained for 400 days. Transient connector content is retained only as
+          long as needed to complete the agent task. You can request deletion of your data by
+          emailing <a className="text-blue-600 hover:underline" href="mailto:sanjeev@agenticorg.ai">sanjeev@agenticorg.ai</a>.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">7. Your rights</h2>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          Subject to applicable law (including India&rsquo;s Digital Personal Data Protection
+          Act 2023, the EU GDPR where it applies, and California CCPA), you may request access,
+          correction, export, or deletion of your personal data. We will respond within 30 days.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">8. Children</h2>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          The Service is intended for organizational use. We do not knowingly collect data from
+          individuals under 18.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">9. Changes to this policy</h2>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          We will post material changes here with a new &ldquo;Last updated&rdquo; date and, where
+          feasible, notify account admins by email at least 14 days before the change takes effect.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">10. Contact</h2>
+        <p className="text-slate-700 leading-relaxed">
+          Mu-Zero Technologies Private Limited
+          <br />
+          F-1004, Grand Ajnara Heritage, Sector-74, Noida — 201301, Uttar Pradesh, India
+          <br />
+          Email: <a className="text-blue-600 hover:underline" href="mailto:sanjeev@agenticorg.ai">sanjeev@agenticorg.ai</a>
+          <br />
+          Phone: <a className="text-blue-600 hover:underline" href="tel:+917703919243">+91 77039 19243</a>
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/ui/src/pages/legal/Refund.tsx
+++ b/ui/src/pages/legal/Refund.tsx
@@ -1,0 +1,129 @@
+import { Helmet } from "react-helmet-async";
+import { Link } from "react-router-dom";
+
+export default function Refund() {
+  return (
+    <div className="min-h-screen bg-white">
+      <Helmet>
+        <title>Cancellation &amp; Refund Policy — AgenticOrg</title>
+        <meta
+          name="description"
+          content="AgenticOrg cancellation and refund policy under Indian consumer law."
+        />
+      </Helmet>
+
+      <header className="border-b border-slate-200">
+        <div className="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between">
+          <Link to="/" className="text-xl font-semibold text-slate-900">
+            AgenticOrg
+          </Link>
+          <Link to="/" className="text-sm text-slate-600 hover:text-slate-900">
+            ← Back to home
+          </Link>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-6 py-12">
+        <h1 className="text-4xl font-bold text-slate-900 mb-2">Cancellation &amp; Refund Policy</h1>
+        <p className="text-sm text-slate-500 mb-10">Last updated: 25 April 2026</p>
+
+        <p className="text-slate-700 leading-relaxed mb-8">
+          This policy describes how cancellations and refunds work for paid subscriptions to
+          the AgenticOrg platform, operated by Mu-Zero Technologies Private Limited
+          (&ldquo;AgenticOrg&rdquo;). It applies to all paying customers in India and
+          internationally, and abides by the Consumer Protection Act 2019 (India) and the
+          Consumer Protection (E-Commerce) Rules 2020.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">1. How to cancel</h2>
+        <p className="text-slate-700 leading-relaxed mb-3">You can cancel your subscription at any time, using either method:</p>
+        <ul className="list-disc pl-6 text-slate-700 space-y-2 mb-6">
+          <li>From your account dashboard: <strong>Settings → Billing → Cancel subscription</strong>.</li>
+          <li>By email to <a className="text-blue-600 hover:underline" href="mailto:sanjeev@agenticorg.ai">sanjeev@agenticorg.ai</a> from the account&rsquo;s registered admin email, including the workspace name and subscription ID.</li>
+        </ul>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          Cancellation takes effect immediately. Your access continues until the end of the
+          paid billing cycle unless you request immediate termination.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">2. Refund rules</h2>
+        <ul className="list-disc pl-6 text-slate-700 space-y-3 mb-6">
+          <li>
+            <strong>No refunds for past usage.</strong> Amounts charged for usage already
+            consumed in the current billing cycle are not refundable.
+          </li>
+          <li>
+            <strong>Pro-rated refund of unused balance on cancellation.</strong> When you
+            cancel mid-cycle, the unused portion of that cycle is refunded:
+            <br />
+            <em className="text-slate-600">
+              Refund = (cycle subscription fee) × (days remaining in cycle ÷ total days in cycle)
+            </em>
+            <br />
+            We process the refund within <strong>7–10 business days</strong> to the original
+            payment method (Stripe/Card, UPI, NetBanking, EMI, Wallet).
+          </li>
+          <li>
+            <strong>No refund on add-ons or one-time charges.</strong> Implementation services,
+            custom connector development, training, and other one-time fees are non-refundable
+            once the work has been delivered.
+          </li>
+          <li>
+            <strong>Service-failure credits.</strong> If our Service is unavailable for a
+            continuous period exceeding 24 hours due to our fault (excluding scheduled
+            maintenance, force majeure, and third-party outages), you may request a service
+            credit equal to the downtime by emailing support.
+          </li>
+          <li>
+            <strong>Erroneous charges.</strong> If you were charged in error (duplicate
+            charge, wrong plan, billing-system bug), email support within 30 days of the
+            charge. We refund verified errors in full within 7 business days.
+          </li>
+        </ul>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">3. How refunds are processed</h2>
+        <ul className="list-disc pl-6 text-slate-700 space-y-2 mb-6">
+          <li>
+            <strong>Cards (Visa, Mastercard, AmEx, RuPay)</strong>: refund posted within 7–10
+            business days. Bank settlement may take an additional 3–5 days depending on issuer.
+          </li>
+          <li>
+            <strong>UPI / Net Banking</strong>: refund credited to source account within 7
+            business days.
+          </li>
+          <li>
+            <strong>Wallets / EMI</strong>: refund returned to the original wallet/EMI source
+            per provider rules.
+          </li>
+        </ul>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          You will receive an email confirmation when the refund is initiated, with the
+          provider&rsquo;s refund reference ID.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">4. Disputes</h2>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          If you disagree with a refund decision, email{" "}
+          <a className="text-blue-600 hover:underline" href="mailto:sanjeev@agenticorg.ai">
+            sanjeev@agenticorg.ai
+          </a>{" "}
+          with subject &ldquo;Refund Dispute&rdquo;. We will review and respond within 7 business days.
+          Unresolved disputes are subject to the governing law and jurisdiction in our{" "}
+          <Link to="/terms" className="text-blue-600 hover:underline">Terms of Service</Link>{" "}
+          (Gautam Buddha Nagar, Uttar Pradesh, India).
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">5. Contact</h2>
+        <p className="text-slate-700 leading-relaxed">
+          Mu-Zero Technologies Private Limited
+          <br />
+          F-1004, Grand Ajnara Heritage, Sector-74, Noida — 201301, Uttar Pradesh, India
+          <br />
+          Email: <a className="text-blue-600 hover:underline" href="mailto:sanjeev@agenticorg.ai">sanjeev@agenticorg.ai</a>
+          <br />
+          Phone: <a className="text-blue-600 hover:underline" href="tel:+917703919243">+91 77039 19243</a>
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/ui/src/pages/legal/Support.tsx
+++ b/ui/src/pages/legal/Support.tsx
@@ -1,0 +1,97 @@
+import { Helmet } from "react-helmet-async";
+import { Link } from "react-router-dom";
+
+export default function Support() {
+  return (
+    <div className="min-h-screen bg-white">
+      <Helmet>
+        <title>Support &amp; Contact — AgenticOrg</title>
+        <meta
+          name="description"
+          content="Contact AgenticOrg support: registered company address, India phone, email."
+        />
+      </Helmet>
+
+      <header className="border-b border-slate-200">
+        <div className="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between">
+          <Link to="/" className="text-xl font-semibold text-slate-900">
+            AgenticOrg
+          </Link>
+          <Link to="/" className="text-sm text-slate-600 hover:text-slate-900">
+            ← Back to home
+          </Link>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-6 py-12">
+        <h1 className="text-4xl font-bold text-slate-900 mb-2">Support &amp; Contact</h1>
+        <p className="text-slate-600 mb-10">
+          We respond to support requests within one business day (Mon–Fri, 10:00–19:00 IST).
+        </p>
+
+        <section className="mb-10">
+          <h2 className="text-2xl font-semibold text-slate-900 mb-4">Get in touch</h2>
+          <dl className="grid sm:grid-cols-3 gap-y-3 text-slate-700">
+            <dt className="font-medium text-slate-900">Email</dt>
+            <dd className="sm:col-span-2">
+              <a className="text-blue-600 hover:underline" href="mailto:sanjeev@agenticorg.ai">
+                sanjeev@agenticorg.ai
+              </a>
+            </dd>
+            <dt className="font-medium text-slate-900">Phone (India)</dt>
+            <dd className="sm:col-span-2">
+              <a className="text-blue-600 hover:underline" href="tel:+917703919243">
+                +91 77039 19243
+              </a>
+            </dd>
+            <dt className="font-medium text-slate-900">Hours</dt>
+            <dd className="sm:col-span-2">Mon–Fri, 10:00–19:00 IST (excluding Indian public holidays)</dd>
+          </dl>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-2xl font-semibold text-slate-900 mb-4">Registered company address</h2>
+          <address className="not-italic text-slate-700 leading-relaxed">
+            <strong className="text-slate-900">Mu-Zero Technologies Private Limited</strong>
+            <br />
+            F-1004, Grand Ajnara Heritage
+            <br />
+            Sector-74, Noida — 201301
+            <br />
+            Uttar Pradesh, India
+          </address>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-2xl font-semibold text-slate-900 mb-4">Billing &amp; account questions</h2>
+          <p className="text-slate-700 leading-relaxed">
+            For invoices, subscription changes, and refund/cancellation requests please email{" "}
+            <a className="text-blue-600 hover:underline" href="mailto:sanjeev@agenticorg.ai">
+              sanjeev@agenticorg.ai
+            </a>{" "}
+            with your account email and the order/subscription ID. See our{" "}
+            <Link to="/refund" className="text-blue-600 hover:underline">
+              Cancellation &amp; Refund Policy
+            </Link>{" "}
+            for details.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-slate-900 mb-4">Security &amp; privacy concerns</h2>
+          <p className="text-slate-700 leading-relaxed">
+            Report suspected security issues to{" "}
+            <a className="text-blue-600 hover:underline" href="mailto:sanjeev@agenticorg.ai">
+              sanjeev@agenticorg.ai
+            </a>
+            . For data-handling questions, see our{" "}
+            <Link to="/privacy" className="text-blue-600 hover:underline">
+              Privacy Policy
+            </Link>
+            .
+          </p>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/ui/src/pages/legal/Terms.tsx
+++ b/ui/src/pages/legal/Terms.tsx
@@ -1,0 +1,172 @@
+import { Helmet } from "react-helmet-async";
+import { Link } from "react-router-dom";
+
+export default function Terms() {
+  return (
+    <div className="min-h-screen bg-white">
+      <Helmet>
+        <title>Terms of Service — AgenticOrg</title>
+        <meta
+          name="description"
+          content="AgenticOrg Terms of Service: subscriptions, refunds, cancellations, governing law."
+        />
+      </Helmet>
+
+      <header className="border-b border-slate-200">
+        <div className="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between">
+          <Link to="/" className="text-xl font-semibold text-slate-900">
+            AgenticOrg
+          </Link>
+          <Link to="/" className="text-sm text-slate-600 hover:text-slate-900">
+            ← Back to home
+          </Link>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-6 py-12">
+        <h1 className="text-4xl font-bold text-slate-900 mb-2">Terms of Service</h1>
+        <p className="text-sm text-slate-500 mb-10">Last updated: 25 April 2026</p>
+
+        <p className="text-slate-700 leading-relaxed mb-6">
+          These Terms of Service (&ldquo;<strong>Terms</strong>&rdquo;) govern your access to and use of the
+          AgenticOrg platform (the &ldquo;<strong>Service</strong>&rdquo;), operated by Mu-Zero Technologies
+          Private Limited (&ldquo;<strong>AgenticOrg</strong>&rdquo;, &ldquo;we&rdquo;, &ldquo;us&rdquo;). By creating an
+          account or using the Service you agree to these Terms.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">1. The Service</h2>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          AgenticOrg provides a B2B SaaS platform that lets organizations build, deploy, and
+          govern AI agents that perform real work — automating finance, sales, HR, and IT
+          operations through pre-built connectors. The Service is provided on a subscription
+          basis. Free, Pro, and Enterprise tiers are described at{" "}
+          <Link to="/pricing" className="text-blue-600 hover:underline">/pricing</Link>.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">2. Account &amp; eligibility</h2>
+        <ul className="list-disc pl-6 text-slate-700 space-y-2 mb-6">
+          <li>You must be at least 18 years old and authorized to bind your organization.</li>
+          <li>You are responsible for keeping account credentials confidential and for all activity under your account.</li>
+          <li>Notify us immediately at <a className="text-blue-600 hover:underline" href="mailto:sanjeev@agenticorg.ai">sanjeev@agenticorg.ai</a> on any suspected unauthorized access.</li>
+        </ul>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">3. Subscriptions &amp; billing</h2>
+        <ul className="list-disc pl-6 text-slate-700 space-y-2 mb-6">
+          <li>Paid plans are billed in advance for each billing cycle (monthly or annual).</li>
+          <li>USD payments are processed by Stripe; INR payments by Pine Labs Plural.</li>
+          <li>Prices may change on 30 days&rsquo; written notice; the change takes effect on your next renewal.</li>
+          <li>Indian customers are charged inclusive of GST as applicable; tax invoices are emailed at the start of each cycle.</li>
+        </ul>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">4. Cancellation &amp; refund policy</h2>
+        <p className="text-slate-700 leading-relaxed mb-3">
+          You can cancel your subscription at any time from your account dashboard or by emailing
+          <a className="text-blue-600 hover:underline" href="mailto:sanjeev@agenticorg.ai"> sanjeev@agenticorg.ai</a>.
+        </p>
+        <ul className="list-disc pl-6 text-slate-700 space-y-2 mb-6">
+          <li>
+            <strong>No refunds for past usage.</strong> Charges already incurred for the
+            current billing cycle&rsquo;s usage are non-refundable.
+          </li>
+          <li>
+            <strong>Pro-rated refund of unused balance.</strong> When you cancel mid-cycle,
+            we calculate the unused portion of the cycle (days remaining ÷ days in cycle) and
+            refund the corresponding amount within 7–10 business days to the original payment
+            method.
+          </li>
+          <li>
+            <strong>No refund on add-ons or one-time purchases.</strong> One-time charges
+            (e.g., implementation services, custom connectors) are non-refundable once delivered.
+          </li>
+          <li>
+            <strong>Service failure refunds.</strong> If we fail to deliver agreed service for
+            a continuous period exceeding 24 hours due to our fault, you may request a credit
+            equal to that downtime by emailing support.
+          </li>
+        </ul>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          See our standalone <Link to="/refund" className="text-blue-600 hover:underline">
+          Cancellation &amp; Refund Policy</Link> for the full text.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">5. Acceptable use</h2>
+        <p className="text-slate-700 leading-relaxed mb-3">You agree not to:</p>
+        <ul className="list-disc pl-6 text-slate-700 space-y-2 mb-6">
+          <li>Use the Service to violate any law or third-party right.</li>
+          <li>Attempt to reverse-engineer, decompile, or extract source code from the Service.</li>
+          <li>Use the Service to send spam, phishing, malware, or abusive content.</li>
+          <li>Probe, scan, or attempt to compromise the security of the Service.</li>
+          <li>Resell or sublicense the Service without our written permission.</li>
+        </ul>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">6. Your content &amp; data</h2>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          You retain ownership of all data you submit to the Service. You grant us a limited
+          license to process, store, and transmit that data only to provide and improve the
+          Service. We do not allow your data to be used for third-party model training. See
+          our <Link to="/privacy" className="text-blue-600 hover:underline">Privacy Policy</Link>.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">7. Intellectual property</h2>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          The Service, including all software, designs, agent definitions, prompts, and
+          documentation, remains the exclusive property of AgenticOrg. Nothing in these Terms
+          transfers any IP rights to you except the limited license to use the Service.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">8. Service availability</h2>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          We aim for 99.5% monthly uptime on Pro and Enterprise tiers (excluding scheduled
+          maintenance, force majeure, and third-party LLM/connector outages). Free tier is
+          provided as-is with no uptime commitment.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">9. Warranty disclaimer</h2>
+        <p className="text-slate-700 leading-relaxed mb-6 uppercase text-sm">
+          The Service is provided &ldquo;as is&rdquo; and &ldquo;as available&rdquo; without warranty of
+          any kind, express or implied, including merchantability, fitness for a particular
+          purpose, and non-infringement. AI-generated outputs may contain errors; you remain
+          responsible for reviewing and validating outputs before acting on them.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">10. Limitation of liability</h2>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          To the maximum extent permitted by law, AgenticOrg&rsquo;s aggregate liability for any
+          claim arising out of or relating to the Service shall not exceed the amount you paid
+          us in the 12 months preceding the claim. We are not liable for indirect, incidental,
+          special, consequential, or punitive damages.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">11. Termination</h2>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          We may suspend or terminate your account for material breach of these Terms, illegal
+          use, or non-payment, after reasonable notice where feasible. On termination, your
+          access to the Service ends and we will delete your data per our retention schedule.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">12. Governing law &amp; jurisdiction</h2>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          These Terms are governed by the laws of India. Disputes shall be subject to the
+          exclusive jurisdiction of the courts of Gautam Buddha Nagar (Noida), Uttar Pradesh.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">13. Changes</h2>
+        <p className="text-slate-700 leading-relaxed mb-6">
+          We may update these Terms from time to time. Material changes will be posted here and
+          notified to account admins by email at least 14 days before they take effect.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-slate-900 mt-8 mb-3">14. Contact</h2>
+        <p className="text-slate-700 leading-relaxed">
+          Mu-Zero Technologies Private Limited
+          <br />
+          F-1004, Grand Ajnara Heritage, Sector-74, Noida — 201301, Uttar Pradesh, India
+          <br />
+          Email: <a className="text-blue-600 hover:underline" href="mailto:sanjeev@agenticorg.ai">sanjeev@agenticorg.ai</a>
+          <br />
+          Phone: <a className="text-blue-600 hover:underline" href="tel:+917703919243">+91 77039 19243</a>
+        </p>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Stripe (and Pine Labs Plural) activation requires real, customer-facing legal/support pages. The site previously fell back to the SPA homepage for any unknown route — so https://app.agenticorg.ai/privacy returned the landing page, which would fail Stripe's activation review.

Adds 4 lazy-loaded React pages with Mu-Zero Technologies' real registered details:

| Route | Page |
|---|---|
| `/support`, `/contact` | Support contact (registered address, India phone, email, hours) |
| `/privacy`, `/privacy-policy` | Privacy Policy (data handling, payment processors, LLM providers, DPDPA/GDPR/CCPA rights) |
| `/terms`, `/terms-of-service` | Terms of Service (subscription billing, acceptable use, governing law in Gautam Buddha Nagar / Noida UP) |
| `/refund`, `/refund-policy`, `/cancellation` | Cancellation & Refund Policy (no refund for past usage, pro-rated on cancellation, Indian Consumer Protection Act 2019) |

## Verification

- All 11 preflight gates green
- \`npm run build\` clean (3.43s)
- Live URLs return HTTP 200, page chunks (\`Privacy-*.js\`, \`Refund-*.js\`, \`Support-*.js\`, \`Terms-*.js\`) confirmed in dist/

## Live URLs (already deployed via UI image \`:9c4072c\`, revision \`agenticorg-ui-00004-g7v\`)

- https://app.agenticorg.ai/support
- https://app.agenticorg.ai/privacy
- https://app.agenticorg.ai/terms
- https://app.agenticorg.ai/refund

@codex — please review the policy text for legal accuracy. The refund policy specifically states \`no refunds for past usage, pro-rated on cancellation\` per the user's instruction; the Indian Consumer Protection Act references and DPDPA mentions are added as scaffolding and may need a lawyer's eyes before going truly live.