### PR TITLE
test(ci): fix preflight blockers — Excel renderer Windows tempdir flake + s009 .uv-cache scan

### DIFF
--- a/tests/regression/test_s009_byo_tokens.py
+++ b/tests/regression/test_s009_byo_tokens.py
@@ -283,11 +283,15 @@ def test_no_direct_provider_env_reads_outside_resolver() -> None:
         # fallback path. This IS the canonical env reader.
         "core/ai_providers/resolver.py",
     }
-    # Skip directories that don't belong to us.
+    # Skip directories that don't belong to us. (.uv-cache/ added
+    # 2026-04-26: `uv` extracts wheel sources into the cache dir at
+    # install time on Windows; rglob('*.py') sees them as repo files
+    # otherwise and false-positives on third-party reads.)
     skip_prefixes = (
         "tests/",
         ".venv/",
         ".tmp_lc/",
+        ".uv-cache/",
         "ui/",
         "node_modules/",
         ".git/",

--- a/tests/unit/test_edge_cases.py
+++ b/tests/unit/test_edge_cases.py
@@ -359,7 +359,15 @@ class TestPDFRendererEdgeCases:
 class TestExcelRendererEdgeCases:
     """Edge cases for render_excel."""
 
-    def test_render_excel_empty_content_data(self):
+    # 2026-04-26: replaced `tempfile.TemporaryDirectory()` with the
+    # pytest `tmp_path` fixture. On Windows, TemporaryDirectory's
+    # cleanup races with OS file-handle release inside openpyxl —
+    # `_rmtree_unsafe` would fail on `os.rmdir(path)` ~5-10% of the
+    # time. pytest's tmp_path uses a deferred cleanup queue that
+    # tolerates that lag. This is the same cause the user flagged
+    # blocking the Foundation #2/#3 PR preflight — see
+    # `feedback_no_manual_qa_closure_plan.md` rule on no-flake CI.
+    def test_render_excel_empty_content_data(self, tmp_path):
         """Excel render with empty data should create a valid .xlsx."""
         from core.reports.generator import ReportOutput
         from core.reports.renderer import render_excel
@@ -369,15 +377,14 @@ class TestExcelRendererEdgeCases:
             content_data={},
             report_type="cfo_daily",
         )
-        with tempfile.TemporaryDirectory() as tmpdir:
-            path = os.path.join(tmpdir, "empty_test.xlsx")
-            result = render_excel(report, path)
-            assert os.path.exists(result)
-            assert os.path.getsize(result) > 0
-            with open(result, "rb") as f:
-                assert f.read(2) == b"PK"  # XLSX is a ZIP
+        path = str(tmp_path / "empty_test.xlsx")
+        result = render_excel(report, path)
+        assert os.path.exists(result)
+        assert os.path.getsize(result) > 0
+        with open(result, "rb") as f:
+            assert f.read(2) == b"PK"  # XLSX is a ZIP
 
-    def test_render_excel_unknown_report_type(self):
+    def test_render_excel_unknown_report_type(self, tmp_path):
         """Excel renderer should handle unknown report types gracefully."""
         from core.reports.generator import ReportOutput
         from core.reports.renderer import render_excel
@@ -387,10 +394,9 @@ class TestExcelRendererEdgeCases:
             content_data={"custom_key": "custom_val"},
             report_type="custom_unknown",
         )
-        with tempfile.TemporaryDirectory() as tmpdir:
-            path = os.path.join(tmpdir, "custom.xlsx")
-            result = render_excel(report, path)
-            assert os.path.exists(result)
+        path = str(tmp_path / "custom.xlsx")
+        result = render_excel(report, path)
+        assert os.path.exists(result)
 
 
 class TestDeliveryEdgeCases:


### PR DESCRIPTION
Two CI-stability fixes that unblock Foundation #2 + #3 PR pushes.

(1) **test_render_excel_empty_content_data + test_render_excel_unknown_report_type** — switched from `tempfile.TemporaryDirectory()` to pytest's `tmp_path` fixture. On Windows, the context-manager cleanup races with OS file-handle release inside openpyxl, failing `os.rmdir` ~5–10% of runs. pytest's tmp_path uses deferred cleanup. Verified 8/8 consecutive runs pass.

(2) **test_no_direct_provider_env_reads_outside_resolver** — added `.uv-cache/` to skip_prefixes. `uv` extracts wheel sources into that cache on Windows install; the `rglob('*.py')` scan was treating third-party langsmith client.py as a repo file and false-positiving on its os.getenv reads.

User directive 2026-04-26 (`feedback_no_manual_qa_closure_plan.md`): no green CI accepted with unexplained skips/flakes. This PR is the explanation + the fix.