### PR TITLE
feat(crypto): keyring with multi-key decrypt + key-version stamping (Foundation #4 iteration 1)

### DIFF
--- a/core/crypto/credential_vault.py
+++ b/core/crypto/credential_vault.py
@@ -163,7 +163,7 @@ def decrypt_credential(ciphertext: str) -> str:
         )
 
     # Un-stamped (legacy) ciphertext — try every key
-    for kid, kbytes in keyring:
+    for _kid, kbytes in keyring:
         try:
             return Fernet(kbytes).decrypt(ciphertext.encode()).decode()
         except InvalidToken:

--- a/core/crypto/credential_vault.py
+++ b/core/crypto/credential_vault.py
@@ -1,9 +1,32 @@
-"""Credential vault — Fernet symmetric encryption for stored secrets.
+"""Credential vault — Fernet symmetric encryption with keyring support.
 
 Used for things like GSTN portal passwords, OAuth refresh tokens, and
 other per-tenant credentials where we don't need the full envelope-
-encryption flow. The key is derived from ``AGENTICORG_VAULT_KEY`` (or
-the main ``AGENTICORG_SECRET_KEY`` in dev).
+encryption flow.
+
+Foundation #4 — keyring (replaces single-key fallback)
+
+Key derivation reads ``AGENTICORG_VAULT_KEYRING`` first. The keyring
+is an ordered list of ``id:source`` entries, separated by commas:
+
+    AGENTICORG_VAULT_KEYRING=v3:<raw3>,v2:<raw2>,v1:<raw1>
+
+The FIRST entry is the active encryption key. Every entry is allowed
+for decryption. New ciphertext is stamped with the producing key id
+(``agko_v{id}$<base64>``) so a future rotation can find the right key
+without trial-and-error.
+
+Backwards compatibility:
+- If ``AGENTICORG_VAULT_KEYRING`` is unset, the keyring is a single
+  ``"legacy"`` entry derived from ``AGENTICORG_VAULT_KEY`` (or
+  ``AGENTICORG_SECRET_KEY`` in dev) — exactly the pre-Foundation-#4
+  behaviour. Old un-prefixed ciphertext continues to decrypt because
+  the legacy keyring contains the same key.
+- A new keyring entry can be added (rotation) without removing the old
+  one. Both keys decrypt; new encrypts use the active (first) key.
+- A migration that re-encrypts every row under the active key is the
+  pre-condition for retiring an old key (Foundation #4 verify-all
+  CLI, follow-up iteration).
 
 For large blobs and customer BYOK see ``core.crypto.envelope``.
 """
@@ -13,40 +36,150 @@ from __future__ import annotations
 import base64
 import hashlib
 import os
+import re
 
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
+
+# Stamp prefix on all NEW ciphertext: agko_v{id}$<base64-fernet-token>
+_PREFIX_RE = re.compile(r"^agko_v([^$]+)\$(.*)$", re.DOTALL)
 
 
-def _get_vault_key() -> bytes:
-    """Derive a Fernet-compatible key from the vault secret.
+def _derive_fernet_key(raw: str) -> bytes:
+    """Derive a Fernet-compatible 32-byte base64-encoded key from raw input.
 
-    Fernet requires a 32-byte base64-encoded key. We derive it from
-    the raw secret using SHA-256 to ensure correct length.
+    Same SHA-256-then-urlsafe-base64 derivation as before. Lifted out
+    so the keyring loader can reuse it per entry.
     """
-    raw = os.environ.get(
-        "AGENTICORG_VAULT_KEY",
-        os.environ.get("AGENTICORG_SECRET_KEY", "dev-only-vault-key"),
-    )
     digest = hashlib.sha256(raw.encode()).digest()
     return base64.urlsafe_b64encode(digest)
 
 
+def _load_keyring() -> list[tuple[str, bytes]]:
+    """Return ordered ``[(key_id, fernet_key_bytes), …]``.
+
+    First entry = active encryption key. All entries allowed for
+    decryption.
+
+    Reading order:
+      1. ``AGENTICORG_VAULT_KEYRING=id1:raw1,id2:raw2,…`` (multi-key)
+      2. fallback to single-key keyring derived from
+         ``AGENTICORG_VAULT_KEY`` or ``AGENTICORG_SECRET_KEY`` with id
+         ``"legacy"``.
+    """
+    spec = os.environ.get("AGENTICORG_VAULT_KEYRING", "").strip()
+    if spec:
+        out: list[tuple[str, bytes]] = []
+        for entry in spec.split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            if ":" not in entry:
+                raise ValueError(
+                    "AGENTICORG_VAULT_KEYRING entry missing 'id:' prefix: "
+                    f"{entry!r}. Expected format: id1:raw1,id2:raw2,…"
+                )
+            kid, raw = entry.split(":", 1)
+            kid = kid.strip()
+            if not kid:
+                raise ValueError(
+                    f"AGENTICORG_VAULT_KEYRING entry has empty id: {entry!r}"
+                )
+            out.append((kid, _derive_fernet_key(raw)))
+        if out:
+            return out
+
+    # Legacy fallback — exactly the pre-keyring single-key behaviour.
+    raw = os.environ.get(
+        "AGENTICORG_VAULT_KEY",
+        os.environ.get("AGENTICORG_SECRET_KEY", "dev-only-vault-key"),
+    )
+    return [("legacy", _derive_fernet_key(raw))]
+
+
+def _get_vault_key() -> bytes:
+    """Return the ACTIVE Fernet key (first entry in the keyring).
+
+    Kept as a module-level helper for backward compatibility — anything
+    that imported this name continues to work, but ``encrypt_credential``
+    and ``decrypt_credential`` now use the full keyring directly.
+    """
+    return _load_keyring()[0][1]
+
+
 def encrypt_credential(plaintext: str) -> str:
-    """Encrypt a credential string. Returns base64-encoded ciphertext."""
-    f = Fernet(_get_vault_key())
-    return f.encrypt(plaintext.encode()).decode()
+    """Encrypt with the active key. Output: ``agko_v{id}$<base64-fernet>``.
+
+    The key id stamped in the prefix is the id of the FIRST entry in
+    the keyring at encrypt time. A subsequent rotation that demotes
+    that entry but keeps it in the keyring still allows decryption.
+    """
+    keyring = _load_keyring()
+    kid, kbytes = keyring[0]
+    f = Fernet(kbytes)
+    token = f.encrypt(plaintext.encode()).decode()
+    return f"agko_v{kid}${token}"
 
 
 def decrypt_credential(ciphertext: str) -> str:
-    """Decrypt a credential string. Returns plaintext."""
-    f = Fernet(_get_vault_key())
-    return f.decrypt(ciphertext.encode()).decode()
+    """Decrypt under any allowed key in the keyring.
+
+    Strategy:
+    1. If the ciphertext is stamped (``agko_v{id}$…``), look up the
+       matching key in the keyring and try it first. If that fails
+       (key in keyring but Fernet rejects), or if no key matches the
+       stamp, fall through to step 2.
+    2. Try every key in the keyring against the (possibly un-stamped)
+       payload. This covers (a) legacy ciphertext written before
+       Foundation #4 landed, (b) ciphertext whose stamp id was retired
+       (re-encrypt in progress), and (c) recovery cases where the
+       stamp was corrupted.
+    3. If nothing decrypts, raise InvalidToken with a precise message.
+    """
+    keyring = _load_keyring()
+
+    m = _PREFIX_RE.match(ciphertext)
+    if m:
+        kid_target = m.group(1)
+        token = m.group(2)
+        # Try the matching key first
+        for kid, kbytes in keyring:
+            if kid == kid_target:
+                try:
+                    return Fernet(kbytes).decrypt(token.encode()).decode()
+                except InvalidToken:
+                    break  # fall through to brute-force the others
+        # Try every other key (matching key not in keyring or rejected)
+        for kid, kbytes in keyring:
+            if kid == kid_target:
+                continue
+            try:
+                return Fernet(kbytes).decrypt(token.encode()).decode()
+            except InvalidToken:
+                continue
+        raise InvalidToken(
+            f"No keyring entry decrypted ciphertext stamped 'v{kid_target}'. "
+            f"Keyring has {len(keyring)} entr{'y' if len(keyring) == 1 else 'ies'}: "
+            f"{[k for k, _ in keyring]}"
+        )
+
+    # Un-stamped (legacy) ciphertext — try every key
+    for kid, kbytes in keyring:
+        try:
+            return Fernet(kbytes).decrypt(ciphertext.encode()).decode()
+        except InvalidToken:
+            continue
+    raise InvalidToken(
+        "No keyring entry decrypted legacy unprefixed ciphertext. "
+        f"Keyring tried: {[k for k, _ in keyring]}"
+    )
 
 
 def verify_credential(ciphertext: str) -> bool:
-    """Check if a ciphertext can be decrypted (key is valid)."""
+    """Check if a ciphertext can be decrypted (any key in the keyring is valid)."""
     try:
         decrypt_credential(ciphertext)
         return True
+    except InvalidToken:
+        return False
     except Exception:
         return False

--- a/tests/regression/test_crypto_keyring.py
+++ b/tests/regression/test_crypto_keyring.py
@@ -45,6 +45,22 @@ def _set_secret_key(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
     monkeypatch.setenv("AGENTICORG_SECRET_KEY", value)
     # Reset the connector vault module's cached key derivation if any.
     monkeypatch.delenv("AGENTICORG_VAULT_KEY", raising=False)
+    # Important: a stray AGENTICORG_VAULT_KEYRING from a previous test
+    # would override the single-key fallback path under exercise here.
+    monkeypatch.delenv("AGENTICORG_VAULT_KEYRING", raising=False)
+
+
+def _set_keyring(monkeypatch: pytest.MonkeyPatch, *entries: tuple[str, str]) -> None:
+    """Set AGENTICORG_VAULT_KEYRING from ``(id, raw)`` tuples.
+
+    First entry = active encryption key. All entries allowed for
+    decryption. Other vault env vars cleared so the keyring path is
+    the only one in play.
+    """
+    spec = ",".join(f"{kid}:{raw}" for kid, raw in entries)
+    monkeypatch.setenv("AGENTICORG_VAULT_KEYRING", spec)
+    monkeypatch.delenv("AGENTICORG_VAULT_KEY", raising=False)
+    monkeypatch.delenv("AGENTICORG_SECRET_KEY", raising=False)
 
 
 # ---------------------------------------------------------------------------
@@ -61,31 +77,44 @@ def _set_secret_key(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
 # to a real pass.
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Foundation #4 not yet implemented. _get_vault_key() returns a "
-        "single derived key — there is no allowed_decrypt_keys list. "
-        "Encrypting with key A and swapping env to key B orphans the "
-        "ciphertext. The keyring PR will land allowed_decrypt_keys + "
-        "key-version stamping; this xfail flips to PASS at that point."
-    ),
-)
 def test_case1_decrypt_old_fernet_after_adding_new_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Foundation #4 contract: a rotation that mounts the new key as
+    active and keeps the old key in the keyring must decrypt ciphertext
+    encrypted under the old key.
+
+    The 2026-04-25 incident violated this — rotating
+    AGENTICORG_SECRET_KEY orphaned every existing connector credential.
+    The fix is the keyring: encrypts use the active (first) key,
+    decrypts try every allowed key. Old ciphertext continues to read
+    until a re-encrypt sweep migrates it.
+    """
     from core.crypto.credential_vault import decrypt_credential, encrypt_credential
 
-    _set_secret_key(monkeypatch, "key-A-original" + "0" * 50)
+    # T0 — only key A in the keyring; encrypt
+    _set_keyring(monkeypatch, ("v1", "key-A-original" + "0" * 50))
     ciphertext = encrypt_credential("connector-secret-from-key-A")
+    assert ciphertext.startswith("agko_vv1$"), (
+        f"new ciphertext must be stamped 'agko_vv1$': got {ciphertext[:40]!r}"
+    )
 
-    # Rotate to key B (old key NOT mounted alongside — exactly today's bug)
-    _set_secret_key(monkeypatch, "key-B-rotated" + "0" * 50)
+    # T1 — rotation: v2 is now the active encryption key, v1 is kept
+    # in the keyring as an allowed decryption key.
+    _set_keyring(
+        monkeypatch,
+        ("v2", "key-B-rotated" + "0" * 50),
+        ("v1", "key-A-original" + "0" * 50),
+    )
 
-    # Today this raises InvalidToken. With keyring, decrypt should try
-    # both keys (A is in allowed_decrypt_keys) and succeed.
+    # The old ciphertext (stamped 'v1') must still decrypt under v1.
     plaintext = decrypt_credential(ciphertext)
     assert plaintext == "connector-secret-from-key-A"
+
+    # And new encrypts at T1 use the v2 active key.
+    new_ciphertext = encrypt_credential("connector-secret-from-key-B")
+    assert new_ciphertext.startswith("agko_vv2$")
+    assert decrypt_credential(new_ciphertext) == "connector-secret-from-key-B"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Architectural fix for the 2026-04-25 SECRET_KEY rotation incident.

## What this PR ships

`encrypt_credential` and `decrypt_credential` now operate on a keyring, not a single derived key.

```
AGENTICORG_VAULT_KEYRING=v3:rawkey3,v2:rawkey2,v1:rawkey1
```

- First entry = active encryption key
- Every entry allowed for decryption
- New ciphertext stamped `agko_v{id}$<base64-fernet>` for fast key-lookup on decrypt
- Decryption parses the stamp, tries the matching key first; falls back to trying every key on stamp mismatch (covers retired-but-readable rotations + corrupted stamps)

## Backwards compatibility

- If `AGENTICORG_VAULT_KEYRING` is unset, the keyring is a single `legacy` entry derived from `AGENTICORG_VAULT_KEY` / `AGENTICORG_SECRET_KEY` — exactly the pre-keyring behaviour.
- Existing un-prefixed production ciphertext continues to decrypt under the legacy single-key path.
- A new keyring entry can be added (rotation) without removing the old one. Both keys decrypt; new encrypts use the active (first) key.

## Foundation #3 contracts now satisfied

| Case | Was | Now |
|---|---|---|
| 1 — decrypt-old-after-new-key | strict-xfail | ✅ PASS |
| 6 — partial credential update preserves untouched fields | PASS | PASS |
| Incident pin (single-key path) | PASS | PASS — pinned as 'don't simplify back to single-key' |

## Still xfail (next iterations)

- case 2 — envelope KEK rotation (needs `envelope.py` keyring support)
- case 3 — refuse delete of referenced key (needs `verify-all` CLI)
- case 4/5 — rewrap idempotent + dry-run/canary/rollback/audit (needs rewrap job)
- case 7 — every encrypted column decrypts after rotation (needs envelope path too)
- case 8 — cache invalidation on `rotated_at` change
- case 9 — backup-restore drill (operational)

## Operational meaning

If today's SECRET_KEY rotation incident happened with this code in place, the recovery becomes:
```
AGENTICORG_VAULT_KEYRING="v2:<new-raw>,v1:<old-raw>"
```
Both keys mounted, no orphan. All existing ciphertext continues to decrypt under v1; new encrypts use v2. Rewrap (next iteration) eventually retires v1.

@codex — please flag if the agko_v{id}$ prefix format is going to clash with anything else that might write to these columns (e.g. an external integration that bypasses encrypt_credential).