### PR TITLE
fix(qa): Uday CA Firms 26-Apr PM — duplicate Client Secret + test result UI + shadow batch control

### DIFF
--- a/tests/regression/test_qa_uday_26apr_pm.py
+++ b/tests/regression/test_qa_uday_26apr_pm.py
@@ -1,0 +1,147 @@
+"""Regression tests for the Uday CA Firms 2026-04-26 PM bug sweep.
+
+Triage matrix in
+``CA_FIRMS_BugFixSummary_Uday_26Apr2026_PM.xlsx`` (alongside the input).
+Brutal autopsy in
+``~/.claude/.../memory/feedback_26apr_pm_bug_sweep.md``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# BUG 1 — duplicate "Client Secret" field on connector update form
+# ---------------------------------------------------------------------------
+
+
+def test_bug1_no_duplicate_client_secret_for_oauth2() -> None:
+    """When authType is oauth2, the Edit form must render exactly one
+    "Client Secret" input.
+
+    Before this PR: the OAuth2 panel had an explicit Client Secret
+    input, AND the generic ``authTypeLabel(authType)`` helper rendered
+    a SECOND identically-labelled input below (because
+    ``authTypeLabel("oauth2") === "Client Secret"``). Two visually
+    identical fields with different state bindings — the explicit
+    field's value won at save time, but the duplicate was a real UX
+    bug (admins didn't know which was which).
+
+    Pin the contract: the generic helper field must be conditional on
+    ``authType !== "oauth2"``.
+    """
+    src = (REPO / "ui" / "src" / "pages" / "ConnectorDetail.tsx").read_text(
+        encoding="utf-8"
+    )
+
+    # The generic helper field must be guarded
+    assert 'authType !== "oauth2"' in src, (
+        "Generic credential helper field must be skipped when the "
+        "OAuth2-specific Client Secret/Refresh Token block is in play "
+        "— otherwise both inputs render with the same 'Client Secret' "
+        "label."
+    )
+    # The explicit OAuth2 Client Secret input must still exist (the
+    # OAuth2 panel needs it to mint access tokens at runtime).
+    assert "oauth2ClientSecret" in src
+    assert 'placeholder="Enter new client secret' in src
+
+
+# ---------------------------------------------------------------------------
+# BUG 2 — UI shows "Connection test failed" when backend says healthy
+# ---------------------------------------------------------------------------
+
+
+def test_bug2_connection_test_reads_health_status_not_data_success() -> None:
+    """``handleTestConnection`` must dispatch on ``data.health.status``,
+    not on a non-existent ``data.success`` field.
+
+    The ``POST /connectors/{id}/test`` backend response shape is
+    ``{tested: bool, name: str, health: {status: str, http_status?: int,
+    reason?: str}, error?: str}``. Reading ``data.success`` is always
+    ``undefined`` → ``error`` branch → tester sees "Connection test
+    failed" even when the connector returned ``status: "healthy"``.
+    Bug reported by Uday CA Firms 2026-04-26.
+    """
+    src = (REPO / "ui" / "src" / "pages" / "ConnectorDetail.tsx").read_text(
+        encoding="utf-8"
+    )
+
+    # Confirm the handler exists
+    assert "async function handleTestConnection" in src
+
+    # The fix: branch on data.health.status — the real backend shape.
+    assert "data?.health?.status" in src, (
+        "Test-connection result handler must read data?.health?.status "
+        "(the real response shape from POST /connectors/{id}/test)"
+    )
+    # The misleading data.success branch must be gone from this file
+    # (the only place it appeared was the buggy handleTestConnection).
+    assert "data.success" not in src, (
+        "data.success was a fictional field — the previous handler "
+        "always saw it as undefined and showed 'Connection test failed' "
+        "even on healthy responses"
+    )
+
+
+# ---------------------------------------------------------------------------
+# BUG (major) part B — Generate Test Samples must default to 1 + allow Stop
+# ---------------------------------------------------------------------------
+
+
+def test_bug_major_b_shadow_sample_batch_is_user_controlled() -> None:
+    """The Shadow tab's "Generate Test Sample(s)" button must:
+
+    - default the per-click batch to 1 (NOT auto-run 10)
+    - expose an input for batch size (1–10)
+    - render a "Stop" button while a batch is in flight
+    - check a stop signal between samples in the loop
+
+    The previous behaviour was a hardcoded
+    ``Math.min(gap > 0 ? gap : 1, 10)`` calculation that auto-batched
+    up to 10 sequential samples per click. Tester reported it as
+    'no manual control'.
+    """
+    src = (REPO / "ui" / "src" / "pages" / "AgentDetail.tsx").read_text(
+        encoding="utf-8"
+    )
+
+    # batchSize state with default 1
+    assert re.search(
+        r"useState\(1\)[^\n]*\n[\s\S]*?// Stop signal",
+        src,
+    ) or "useState(1)" in src, (
+        "batchSize state must exist and default to 1"
+    )
+    # stopRequestedRef
+    assert "stopRequestedRef" in src, "Stop signal ref must exist"
+    # input for batch size
+    assert re.search(
+        r'aria-label="Samples per click"',
+        src,
+    ), "Batch-size number input must have aria-label='Samples per click'"
+    # Stop button
+    assert re.search(
+        r">\s*Stop\s*</Button>",
+        src,
+    ), "Stop button must render while generating"
+    # Loop must check stopRequestedRef
+    assert "stopRequestedRef.current" in src, (
+        "The generate loop must read the stop signal between samples"
+    )
+
+
+# ---------------------------------------------------------------------------
+# BUG (major) part A — shadow accuracy <40% — STILL Unverified (carryover)
+# ---------------------------------------------------------------------------
+#
+# This contract has not changed since yesterday's sheet (Uday 2026-04-25).
+# Without a specific failing agent_id + 5+ shadow run records (msg_*),
+# root cause cannot be isolated — see the Unverified verdict in the
+# previous summary xlsx and feedback_26apr_bug_sweep.md.
+#
+# Not asserted in code today. Documented here as a sweep marker.

--- a/ui/e2e/qa-uday-26apr-pm.spec.ts
+++ b/ui/e2e/qa-uday-26apr-pm.spec.ts
@@ -1,0 +1,202 @@
+/**
+ * Playwright regression for the Uday CA Firms 2026-04-26 PM bug sweep.
+ *
+ * Backs the source-pin tests in
+ * ``tests/regression/test_qa_uday_26apr_pm.py`` with real DOM assertions
+ * against the deployed app. Source-pin tests catch reverts of the literal
+ * code lines; these e2e tests catch behavioural regressions even when the
+ * source still looks plausible.
+ *
+ * Verdicts in
+ * ``CA_FIRMS_BugFixSummary_Uday_26Apr2026_PM.xlsx``.
+ * Brutal autopsy in ``feedback_26apr_pm_bug_sweep.md``.
+ *
+ * NB: BUG 2 uses ``page.route()`` to control the
+ * ``POST /connectors/{id}/test`` response shape. The bug IS about the UI
+ * handler reading the wrong field on a known backend shape — mocking is
+ * the right tool to assert the dispatch contract independent of which
+ * specific connector happens to be healthy at run time.
+ */
+import { expect, test, type Page } from "@playwright/test";
+
+import { APP, E2E_TOKEN, authenticate, requireAuth } from "./helpers/auth";
+
+interface ConnectorListItem {
+  connector_id: string;
+  name: string;
+  auth_type: string;
+}
+
+async function pickOauth2Connector(page: Page): Promise<ConnectorListItem> {
+  const resp = await page.request.get(`${APP}/api/v1/connectors`, {
+    headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+  });
+  if (!resp.ok()) {
+    throw new Error(
+      `pickOauth2Connector: /api/v1/connectors returned HTTP ${resp.status()} — cannot run BUG 1 / BUG 2 e2e`,
+    );
+  }
+  const data = await resp.json();
+  const items: ConnectorListItem[] = Array.isArray(data) ? data : data?.items ?? [];
+  const oauth2 = items.find((c) => c.auth_type === "oauth2");
+  if (!oauth2) {
+    throw new Error(
+      "pickOauth2Connector: tenant has no oauth2 connector — seed one before running this spec",
+    );
+  }
+  return oauth2;
+}
+
+async function pickAgent(page: Page): Promise<{ id: string; name: string }> {
+  const resp = await page.request.get(`${APP}/api/v1/agents`, {
+    headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+  });
+  if (!resp.ok()) {
+    throw new Error(
+      `pickAgent: /api/v1/agents returned HTTP ${resp.status()} — cannot run BUG (B) e2e`,
+    );
+  }
+  const data = await resp.json();
+  const items = Array.isArray(data) ? data : data?.items ?? [];
+  if (items.length === 0) {
+    throw new Error("pickAgent: tenant has no agents — seed one before running this spec");
+  }
+  return { id: items[0].id, name: items[0].name };
+}
+
+test.describe("Uday CA Firms 2026-04-26 PM @qa @connector @agent", () => {
+  test.beforeEach(async ({ page }) => {
+    requireAuth();
+    await authenticate(page);
+  });
+
+  // -------------------------------------------------------------------------
+  // BUG 1 — connector edit form must render exactly ONE "Client Secret" input
+  //         when authType is oauth2.
+  // -------------------------------------------------------------------------
+
+  test("BUG 1: oauth2 connector edit shows exactly one Client Secret input", async ({ page }) => {
+    const c = await pickOauth2Connector(page);
+    await page.goto(`${APP}/dashboard/connectors/${c.connector_id}`, {
+      waitUntil: "networkidle",
+    });
+
+    // Open the Edit panel — the field-render code only fires in edit mode.
+    const editToggle = page.getByRole("button", { name: /^Edit$/i }).first();
+    await expect(
+      editToggle,
+      "Edit toggle must be reachable from the connector detail page",
+    ).toBeVisible({ timeout: 15_000 });
+    await editToggle.click();
+
+    // Force authType -> oauth2 so the OAuth2 panel is in play.
+    const authTypeSelect = page.locator("select").filter({ hasText: /OAuth2|Auth Type/i }).first();
+    if (await authTypeSelect.isVisible().catch(() => false)) {
+      await authTypeSelect.selectOption({ value: "oauth2" }).catch(() => {});
+    }
+
+    // Count every <label> whose text is exactly "Client Secret". Pre-fix
+    // this was 2 (the explicit OAuth2 panel field + the generic helper
+    // field). Post-fix it must be exactly 1.
+    const labels = page.locator("label").filter({ hasText: /^Client Secret$/ });
+    await expect(labels.first()).toBeVisible({ timeout: 10_000 });
+    const count = await labels.count();
+    expect(
+      count,
+      `Edit form must render exactly one "Client Secret" label for oauth2 (saw ${count}). ` +
+        "Pre-fix the generic authTypeLabel helper rendered a second identically-labelled input.",
+    ).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // BUG 2 — Test Connection must show success when backend returns
+  //         {tested: true, health: {status: "healthy"}} — NOT
+  //         "Connection test failed".
+  // -------------------------------------------------------------------------
+
+  test("BUG 2: Test Connection surfaces healthy response as success, not failure", async ({ page }) => {
+    const c = await pickOauth2Connector(page);
+
+    // Intercept the test endpoint with the canonical healthy shape so we
+    // can assert the UI handler's dispatch logic without depending on
+    // which connectors are currently healthy in production.
+    await page.route(`**/api/v1/connectors/${c.connector_id}/test`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          tested: true,
+          name: c.name,
+          health: { status: "healthy", http_status: 200 },
+        }),
+      });
+    });
+
+    await page.goto(`${APP}/dashboard/connectors/${c.connector_id}`, {
+      waitUntil: "networkidle",
+    });
+
+    const testBtn = page.getByRole("button", { name: /^Test Connection$/ });
+    await expect(testBtn, "Test Connection button must render").toBeVisible({
+      timeout: 15_000,
+    });
+    await testBtn.click();
+
+    // Pre-fix the handler always saw `data.success === undefined` and
+    // therefore always rendered a red "Connection test failed" banner.
+    // Post-fix the green success banner must appear.
+    const success = page.getByText(/Connection test passed/i).first();
+    await expect(success, "Healthy backend response must render the success banner").toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Negative assertion: the error banner phrase from the broken handler
+    // must NOT be visible at the same time.
+    const failure = page.getByText(/Connection test failed/i);
+    expect(await failure.count()).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // BUG (major) part B — Shadow tab must default batch to 1 and expose
+  //                      a Stop control + a "Samples per click" input.
+  // -------------------------------------------------------------------------
+
+  test("BUG (major) part B: shadow Generate button defaults to 1 and exposes batch + Stop controls", async ({ page }) => {
+    const a = await pickAgent(page);
+    await page.goto(`${APP}/dashboard/agents/${a.id}`, { waitUntil: "networkidle" });
+
+    // Try to click the Shadow tab if it exists. Some agent fixtures
+    // do not surface the Shadow tab if they're already in production
+    // stage — in that case skip the test rather than asserting on the
+    // wrong tab.
+    const shadowTab = page.getByRole("tab", { name: /Shadow/i }).first();
+    const shadowClickable = await shadowTab.isVisible().catch(() => false);
+    if (shadowClickable) {
+      await shadowTab.click();
+    }
+
+    const samplesInput = page.getByRole("spinbutton", { name: /Samples per click/i }).first();
+    const visible = await samplesInput.isVisible({ timeout: 8_000 }).catch(() => false);
+    if (!visible) {
+      test.skip(
+        true,
+        `Agent ${a.id} (${a.name}) does not expose the shadow Generate UI — pick a shadow-stage agent for this assertion`,
+      );
+      return;
+    }
+
+    // Default batch must be 1 (pre-fix the loop ran up to 10 per click).
+    await expect(samplesInput).toHaveValue("1");
+
+    // The button label reflects batch=1 ("Generate Test Sample" singular).
+    await expect(
+      page.getByRole("button", { name: /Generate Test Sample$/ }).first(),
+    ).toBeVisible();
+
+    // Bumping the batch updates the label to plural.
+    await samplesInput.fill("3");
+    await expect(
+      page.getByRole("button", { name: /Generate 3 Samples/ }).first(),
+    ).toBeVisible();
+  });
+});

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, lazy, Suspense } from "react";
+import { useState, useEffect, lazy, Suspense, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -1120,6 +1120,14 @@ function ShadowTab({ agent }: { agent: Agent }) {
   const [generating, setGenerating] = useState(false);
   const [retesting, setRetesting] = useState(false);
   const [genResult, setGenResult] = useState<{ type: "success" | "error"; msg: string } | null>(null);
+  // Uday CA Firms 2026-04-26 BUG (major) part B: previously a single
+  // click on "Generate Test Samples" auto-batched up to 10 sequential
+  // runs with no way to stop. Default the batch to 1 (manual control)
+  // and let the user pick a higher count if they want a batch run.
+  const [batchSize, setBatchSize] = useState(1);
+  // Stop signal that's safe to read inside an in-flight async loop
+  // (a bare useState would hand back the closed-over initial value).
+  const stopRequestedRef = useRef(false);
 
   const sampleCount = agent.shadow_sample_count ?? 0;
   // Uday 2026-04-23 Bug 1/2: the default target was 20 samples which
@@ -1145,21 +1153,32 @@ function ShadowTab({ agent }: { agent: Agent }) {
   async function generateSample() {
     setGenerating(true);
     setGenResult(null);
+    stopRequestedRef.current = false;
     try {
-      // Uday 2026-04-23 Bug 1: the earlier loop awaited each call but
-      // without a visible pause between requests the batch felt like a
-      // parallel bulk run — the progress counter jumped several samples
-      // at once so testers couldn't tell each sample had actually
-      // completed before the next one started. Cap the default batch
-      // at 10 (per the 2026-04-23 spec), run each sample strictly
-      // sequentially, and push an intermediate status after each so
-      // the UI shows "Sample 3/10…" progress in real time.
+      // Uday CA Firms 2026-04-26 BUG (major) part B: hardcoded batch of
+      // 10 with no manual control was the old behaviour. Now: user picks
+      // a batch size (default 1 = strictly manual), and a Stop button
+      // can break the loop between samples. Cap remains at 10 so a typo
+      // can't kick off 1000 LLM calls.
+      const requested = Math.max(1, Math.min(batchSize, 10));
       const target = Math.max(1, agent.shadow_min_samples ?? 10);
       const gap = Math.max(0, target - sampleCount);
-      const plannedRuns = Math.min(gap > 0 ? gap : 1, 10);
+      // If the user hasn't met the minimum, cap at the gap so we don't
+      // go past the threshold; otherwise honour the requested count
+      // (re-running a fully sampled agent is allowed but rare).
+      const plannedRuns = gap > 0 ? Math.min(requested, gap) : requested;
       let successes = 0;
       let consecutiveFailures = 0;
       for (let i = 0; i < plannedRuns; i++) {
+        if (stopRequestedRef.current) {
+          setGenResult({
+            type: "success",
+            msg:
+              `Stopped after ${successes} sample${successes === 1 ? "" : "s"} ` +
+              `(of ${plannedRuns} planned). Refresh to see updated count and accuracy.`,
+          });
+          return;
+        }
         setGenResult({
           type: "success",
           msg: `Generating sample ${i + 1}/${plannedRuns}…`,
@@ -1188,6 +1207,7 @@ function ShadowTab({ agent }: { agent: Agent }) {
       setGenResult({ type: "error", msg: err.response?.data?.detail || "Failed to generate sample. The agent may need to be configured first." });
     } finally {
       setGenerating(false);
+      stopRequestedRef.current = false;
     }
   }
 
@@ -1217,14 +1237,41 @@ function ShadowTab({ agent }: { agent: Agent }) {
           <div className="flex justify-between items-center">
             <CardTitle className="text-sm font-semibold">Shadow Sample Progress</CardTitle>
             <div className="flex gap-2">
+              {/* Uday CA Firms 2026-04-26 BUG (major) part B: explicit
+                  batch-size control + Stop button. Default batch=1
+                  (one click = one sample), max 10. */}
+              <input
+                type="number"
+                min={1}
+                max={10}
+                value={batchSize}
+                onChange={(e) => setBatchSize(Math.max(1, Math.min(10, Number(e.target.value) || 1)))}
+                disabled={generating || retesting || meetsCount}
+                className="border rounded px-2 py-1 text-sm w-16"
+                title="Number of samples to run on next click (1-10)"
+                aria-label="Samples per click"
+              />
               <Button
                 variant="outline"
                 size="sm"
                 onClick={generateSample}
                 disabled={generating || retesting || meetsCount}
+                title={`Run ${batchSize} test sample${batchSize === 1 ? "" : "s"}`}
               >
-                {generating ? "Generating..." : "Generate Test Sample"}
+                {generating
+                  ? "Generating..."
+                  : `Generate ${batchSize === 1 ? "Test Sample" : `${batchSize} Samples`}`}
               </Button>
+              {generating && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => { stopRequestedRef.current = true; }}
+                  title="Stop after the current sample finishes"
+                >
+                  Stop
+                </Button>
+              )}
               {sampleCount > 0 && (
                 <Button
                   variant="outline"

--- a/ui/src/pages/ConnectorDetail.tsx
+++ b/ui/src/pages/ConnectorDetail.tsx
@@ -167,7 +167,42 @@ export default function ConnectorDetailPage() {
     setFeedback(null);
     try {
       const { data } = await api.post(`/connectors/${id}/test`);
-      setFeedback({ type: data.success ? "success" : "error", msg: data.message || (data.success ? "Connection test passed" : "Connection test failed") });
+      // Uday CA Firms 2026-04-26 BUG 2: backend returns
+      //   {tested: bool, name: str, health: {status: str, http_status?: int}, error?: str}
+      // The previous handler dispatched on a fictional `success`
+      // field on the response — always undefined → always falsy →
+      // tester saw "Connection test failed" even when the connector
+      // returned status="healthy". Render against the real response
+      // shape: error string (test could not run) → fail;
+      // tested + health.status==="healthy" → success; everything else
+      // (status="unhealthy", "not_configured", "not_connected") shows
+      // the specific reason from the health probe.
+      const tested = Boolean(data?.tested);
+      const status: string = data?.health?.status ?? "";
+      const httpStatus = data?.health?.http_status;
+      if (data?.error) {
+        setFeedback({ type: "error", msg: String(data.error) });
+      } else if (!tested) {
+        setFeedback({ type: "error", msg: "Connection test did not run" });
+      } else if (status === "healthy") {
+        setFeedback({
+          type: "success",
+          msg: httpStatus
+            ? `Connection test passed (HTTP ${httpStatus})`
+            : "Connection test passed",
+        });
+      } else if (status) {
+        const reason: string = data?.health?.reason || data?.health?.error || "";
+        const code = httpStatus ? ` (HTTP ${httpStatus})` : "";
+        setFeedback({
+          type: "error",
+          msg: reason
+            ? `Connection ${status}${code}: ${reason}`
+            : `Connection ${status}${code}`,
+        });
+      } else {
+        setFeedback({ type: "error", msg: "Connection test returned no health status" });
+      }
     } catch (e: unknown) {
       setFeedback({ type: "error", msg: extractApiError(e, "Connection test failed") });
     } finally {
@@ -308,17 +343,31 @@ export default function ConnectorDetailPage() {
                         />
                       </div>
                     )}
-                    <div>
-                      <label className="text-sm font-medium">{authTypeLabel(authType)}</label>
-                      <input
-                        type="password"
-                        value={authToken}
-                        onChange={(e) => setAuthToken(e.target.value)}
-                        placeholder="Enter new credential (leave blank to keep existing)"
-                        className="border rounded px-3 py-2 text-sm w-full mt-1"
-                        autoComplete={authType === "basic" ? "new-password" : "off"}
-                      />
-                    </div>
+                    {/* Uday CA Firms 2026-04-26 BUG 1: when authType is
+                        oauth2 the explicit Client Secret + Refresh
+                        Token fields above already cover the OAuth2
+                        credential surface. The generic helper field
+                        below resolves to authTypeLabel('oauth2') =
+                        "Client Secret", producing TWO identically-
+                        labelled inputs in the form and confusing
+                        admins about which value wins (the explicit
+                        field DID win at save time, but the duplicate
+                        was a real UX bug). Hide the generic field
+                        for oauth2; render it only for the auth types
+                        whose credential sits in a single token. */}
+                    {authType !== "oauth2" && (
+                      <div>
+                        <label className="text-sm font-medium">{authTypeLabel(authType)}</label>
+                        <input
+                          type="password"
+                          value={authToken}
+                          onChange={(e) => setAuthToken(e.target.value)}
+                          placeholder="Enter new credential (leave blank to keep existing)"
+                          className="border rounded px-3 py-2 text-sm w-full mt-1"
+                          autoComplete={authType === "basic" ? "new-password" : "off"}
+                        />
+                      </div>
+                    )}
                     {/* Uday/Ramesh 2026-04-24 (Zoho org_id): connector-
                         specific extras merged into auth_config. Zoho
                         Books needs ``organization_id``; NetSuite


### PR DESCRIPTION
## Summary

Three concrete bugs from `CA_FIRMS_TESTUday26Apr2026.md` (Uday CA Firms 26-Apr-PM sweep). Triage and verdicts in `CA_FIRMS_BugFixSummary_Uday_26Apr2026_PM.xlsx` (alongside the input). Brutal autopsy in `~/.claude/.../memory/feedback_26apr_pm_bug_sweep.md`.

### BUG 1 — duplicate "Client Secret" field on connector edit form (Fixed)

`ConnectorDetail.tsx` rendered TWO inputs labelled "Client Secret" when `authType === "oauth2"`:
- the explicit `oauth2ClientSecret` input in the OAuth2 panel
- a SECOND identically-labelled input from the generic `authTypeLabel(authType)` helper (because `authTypeLabel("oauth2") === "Client Secret"`)

Both bound to different state. Save-time the explicit field won, but admins didn't know which to fill.

**Fix:** guard the generic helper field with `{authType !== "oauth2" && (...)}`.

### BUG 2 — "Connection test failed" UI on healthy backend response (Fixed)

`handleTestConnection` was reading `data.success` to dispatch pass/fail. The actual `POST /connectors/{id}/test` response shape is `{tested, name, health: {status, http_status, reason}, error?}` — there is no `success` key. Always `undefined` → always took the failure branch → tester saw "Connection test failed" even on `status: "healthy"` responses.

**Fix:** branch on `data?.health?.status === "healthy"`, with fallback for `data?.error` and `!tested`. Surfaces `reason` and `http_status` on failure for actionable feedback.

### BUG (major) part B — shadow Generate Test Sample auto-batches 10 (Fixed)

`AgentDetail.tsx` Shadow tab's Generate button computed `Math.min(gap > 0 ? gap : 1, 10)` and looped that many times per click — one click could fire 10 sequential LLM calls with no way to stop or slow down.

**Fix:**
- `batchSize` state, default 1, capped at 10 via a number input (`aria-label="Samples per click"`)
- `stopRequestedRef` set by a Stop button that renders while generating
- loop checks `stopRequestedRef.current` between samples

### BUG (major) part A — shadow accuracy <40% (Unverified, carryover)

Same status as the 25-Apr sheet. Cannot isolate root cause without a specific failing `agent_id` and ≥5 shadow run records (`msg_*` IDs). Documented as a sweep marker in the test file; no code change.

## Test plan

- [x] `tests/regression/test_qa_uday_26apr_pm.py` — 3 source-pin tests, all PASS
- [x] preflight green (ruff + bandit + alembic + pytest + ui tsc + ui build + consistency sweep + module-coverage floor + critical-path tags)
- [x] regression suite runs on every push via the local preflight git hook

## Out of scope

- BUG (major) part A still Unverified — needs tester data
- Foundation #4 iter 3 (rewrap job) and iter 4 (cache invalidation on rotated_at) — tracked separately

@codex please review.