### PR TITLE
feat(rag): BGE-M3 column + backfill + flag-gated RAG path (PR-A of 2)

### DIFF
--- a/api/v1/knowledge.py
+++ b/api/v1/knowledge.py
@@ -319,11 +319,16 @@ async def _db_chunk_count(tenant_id: str) -> int:
     total = 0
     try:
         async with get_tenant_session(tid) as session:
-            # Legacy KB content with computed embeddings.
+            # Legacy KB content with computed embeddings — column
+            # follows the RAG_USE_BGE_M3 flag so the count stays
+            # consistent with what /search actually queries.
+            from core.embeddings import rag_embedding_column
+
+            ecol = rag_embedding_column()
             legacy_row = (await session.execute(
                 _sqtext(
-                    "SELECT COUNT(*) FROM knowledge_documents "
-                    "WHERE tenant_id = :tid AND embedding IS NOT NULL"
+                    "SELECT COUNT(*) FROM knowledge_documents "  # nosec B608 — `ecol` is a module-level constant name, not user input
+                    f"WHERE tenant_id = :tid AND {ecol} IS NOT NULL"
                 ),
                 {"tid": str(tid)},
             )).fetchone()
@@ -847,20 +852,22 @@ async def _native_semantic_search(
 
     tid = _UUID(tenant_id)
 
-    # Try the vector path first.
+    # Try the vector path first. Column + model swap honour the
+    # RAG_USE_BGE_M3 flag — both sides flip atomically.
     try:
-        from core.embeddings import embed_one
+        from core.embeddings import embed_one, rag_embedding_column
 
         qvec = embed_one(query)
         vector_literal = "[" + ",".join(f"{x:.6f}" for x in qvec) + "]"
+        col = rag_embedding_column()
         async with get_tenant_session(tid) as session:
             rows = (await session.execute(
                 _sqtext(
-                    "SELECT title, content, "
-                    "1 - (embedding <=> CAST(:q AS vector)) AS score "
+                    "SELECT title, content, "  # nosec B608 — `col` is a module-level constant name, not user input
+                    f"1 - ({col} <=> CAST(:q AS vector)) AS score "
                     "FROM knowledge_documents "
-                    "WHERE tenant_id = :tid AND embedding IS NOT NULL "
-                    "ORDER BY embedding <=> CAST(:q AS vector) "
+                    f"WHERE tenant_id = :tid AND {col} IS NOT NULL "
+                    f"ORDER BY {col} <=> CAST(:q AS vector) "
                     "LIMIT :k"
                 ),
                 {"q": vector_literal, "tid": str(tid), "k": top_k},

--- a/core/embeddings.py
+++ b/core/embeddings.py
@@ -1,36 +1,54 @@
-"""Self-hosted embedding service backed by fastembed (ONNX).
+"""Self-hosted embedding service.
 
-Default model: `BAAI/bge-small-en-v1.5` (384 dim, MIT, ~66 MB ONNX).
+Default request-path model (PR-A): ``BAAI/bge-small-en-v1.5`` (384 dim,
+MIT, ~66 MB ONNX), loaded via fastembed. PR-B will flip the request
+path to ``BAAI/bge-m3`` once the backfill verifies no orphan rows.
 
-Operators can flip to a different model via `AGENTICORG_EMBEDDING_MODEL`.
-Known supported choices:
+A second loader path —
+:func:`embed_bge_m3` — uses BAAI's official **FlagEmbedding** package
+because fastembed does not ship bge-m3 in any released version.
+FlagEmbedding loads the full PyTorch weights (~2.3 GB) lazily on
+first call. Only the backfill job (PR-A) and PR-B's flipped request
+path import it; request-path callers in PR-A still get the small
+ONNX model.
 
-    BAAI/bge-small-en-v1.5    384-dim, English+ (default, smallest)
-    BAAI/bge-base-en-v1.5     768-dim, English+
-    BAAI/bge-m3               1024-dim, multilingual (100+ languages, 2.3 GB)
+Operators can flip the platform default via
+``AGENTICORG_EMBEDDING_MODEL``. Known supported choices:
 
-Flipping the model means the pgvector column dimensionality and the
-IVFFlat index must match. Rotating is a three-step operation:
+    BAAI/bge-small-en-v1.5    384-dim, English+ (default, smallest, fastembed)
+    BAAI/bge-base-en-v1.5     768-dim, English+ (fastembed)
+    BAAI/bge-large-en-v1.5    1024-dim, English+ (fastembed)
+    BAAI/bge-m3               1024-dim, multilingual (~100), 8192 ctx
+                              (FlagEmbedding only — see embed_bge_m3)
 
-    1. `ALTER TABLE knowledge_documents ADD COLUMN embedding_new vector(N)`
-       where N = dim of new model.
-    2. Re-run seed / re-embed every document, writing `embedding_new`.
-    3. `DROP COLUMN embedding; ALTER COLUMN embedding_new RENAME TO embedding`
-       and recreate the IVFFlat index.
+Flipping the default is **not safe** while existing rows are stored in
+a column whose dimension does not match the new model. The cutover
+sequence is:
 
-Until that's wired the default bge-small is the only model that's
-guaranteed to round-trip against the current `vector(384)` column.
+    1. Migration adds ``embedding_bge_m3 vector(1024)`` (PR-A,
+       v495_bge_m3_column).
+    2. Backfill job ``python -m core.embeddings_backfill`` re-embeds
+       every row with bge-m3 into ``embedding_bge_m3``. Idempotent —
+       only writes where the target is NULL.
+    3. PR-B drops ``embedding``, renames ``embedding_bge_m3`` to
+       ``embedding``, recreates the IVFFlat index, and bumps
+       ``DEFAULT_EMBEDDING_MODEL`` to ``BAAI/bge-m3``.
 
-The model is loaded lazily on first call and cached for the process
-lifetime. Set `FASTEMBED_CACHE_DIR` to pin weights to a known directory
-(useful in CI to skip the download on subsequent runs).
+Until PR-B lands the default stays bge-small to guarantee round-trip
+against ``vector(384)``.
+
+Both loaders are cached for the process lifetime. Set
+``FASTEMBED_CACHE_DIR`` (fastembed) or ``HF_HOME``
+(FlagEmbedding/Hugging Face) to pin weights to a known directory —
+useful in CI and on Cloud Run revisions to skip the download on
+subsequent boots.
 """
 
 from __future__ import annotations
 
 import os
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
@@ -40,9 +58,38 @@ if TYPE_CHECKING:
 logger = structlog.get_logger()
 
 DEFAULT_EMBEDDING_MODEL = "BAAI/bge-small-en-v1.5"
+BGE_M3_MODEL = "BAAI/bge-m3"
+
+
+def rag_use_bge_m3() -> bool:
+    """Return True when the request path should embed + query with bge-m3.
+
+    Read at every call (not module-load) so operators can flip the
+    flag in Cloud Run without a redeploy. Treated as a feature flag,
+    not a setting — the value MUST stay False until the BGE-M3
+    backfill (``python -m core.embeddings_backfill --verify``) reports
+    zero orphan rows. Otherwise queries embed with bge-m3 (1024 dim)
+    but read the legacy ``embedding`` column (384 dim) and every
+    /knowledge/search call 500s with a vector dimension mismatch.
+
+    Truthy values: ``1``, ``true``, ``yes``, ``on`` (case-insensitive).
+    """
+    raw = (os.getenv("AGENTICORG_RAG_USE_BGE_M3") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+# Column names used by RAG ingest + search. Centralised here so the
+# flag-flip rolls both paths atomically.
+RAG_EMBEDDING_COLUMN_LEGACY = "embedding"
+RAG_EMBEDDING_COLUMN_BGE_M3 = "embedding_bge_m3"
+
+
+def rag_embedding_column() -> str:
+    """Return the pgvector column name the request path should read/write."""
+    return RAG_EMBEDDING_COLUMN_BGE_M3 if rag_use_bge_m3() else RAG_EMBEDDING_COLUMN_LEGACY
 
 # Dimensionality per known model. Add new entries here when validating
-# a new fastembed-supported model.
+# a new model against pgvector.
 _MODEL_DIMS: dict[str, int] = {
     "BAAI/bge-small-en-v1.5": 384,
     "BAAI/bge-base-en-v1.5": 768,
@@ -58,12 +105,26 @@ def _configured_model_name() -> str:
 EMBEDDING_MODEL_NAME = _configured_model_name()
 EMBEDDING_DIM = _MODEL_DIMS.get(EMBEDDING_MODEL_NAME, 384)
 
+
+def model_dim(model_name: str) -> int:
+    """Return the embedding dimension for ``model_name``.
+
+    Unknown models default to 384 — the same fallback ``EMBEDDING_DIM``
+    uses — but the caller almost always wants to fail loudly when the
+    backfill points at an unrecognised model. Callers that need that
+    contract should look up ``_MODEL_DIMS`` directly.
+    """
+    return _MODEL_DIMS.get(model_name, 384)
+
+
+# ─── fastembed (default request-path) ───────────────────────────────
+
 _model_lock = threading.Lock()
 _model: TextEmbedding | None = None
 
 
 def _get_model() -> TextEmbedding:
-    """Return a singleton TextEmbedding, loading on first call."""
+    """Return a singleton TextEmbedding for the configured default."""
     global _model
     if _model is not None:
         return _model
@@ -78,15 +139,23 @@ def _get_model() -> TextEmbedding:
             model=EMBEDDING_MODEL_NAME,
             dim=EMBEDDING_DIM,
             cache_dir=cache_dir,
+            loader="fastembed",
         )
         _model = TextEmbedding(model_name=EMBEDDING_MODEL_NAME, cache_dir=cache_dir)
         return _model
 
 
 def embed(texts: list[str]) -> list[list[float]]:
-    """Embed a batch of strings, returning one vector per input."""
+    """Embed a batch of strings, returning one vector per input.
+
+    Routes to bge-m3 when ``AGENTICORG_RAG_USE_BGE_M3`` is set,
+    otherwise to the configured fastembed default. Both paths are
+    cached for the process lifetime by their respective loaders.
+    """
     if not texts:
         return []
+    if rag_use_bge_m3():
+        return embed_bge_m3(texts)
     model = _get_model()
     vectors = [v.tolist() for v in model.embed(texts)]
     return vectors
@@ -95,3 +164,86 @@ def embed(texts: list[str]) -> list[list[float]]:
 def embed_one(text: str) -> list[float]:
     """Convenience wrapper for single-string embedding."""
     return embed([text])[0]
+
+
+# ─── FlagEmbedding (bge-m3) ─────────────────────────────────────────
+
+_bge_m3_lock = threading.Lock()
+_bge_m3_model: Any | None = None
+
+
+def _get_bge_m3_model() -> Any:
+    """Return the singleton BGEM3FlagModel.
+
+    First call downloads ~2.3 GB of weights from Hugging Face and
+    loads them into memory (fp16 ≈ 1.2 GB resident). Pin
+    ``HF_HOME`` so subsequent process boots reuse the cached weights
+    instead of re-downloading on every Cloud Run cold start.
+    """
+    global _bge_m3_model
+    if _bge_m3_model is not None:
+        return _bge_m3_model
+    with _bge_m3_lock:
+        if _bge_m3_model is not None:
+            return _bge_m3_model
+        try:
+            from FlagEmbedding import BGEM3FlagModel
+        except ImportError as exc:
+            raise RuntimeError(
+                "FlagEmbedding is required to load BAAI/bge-m3. "
+                "Install with `pip install FlagEmbedding>=1.2.0`."
+            ) from exc
+
+        cache_dir = os.getenv("HF_HOME") or None
+        logger.info(
+            "embedding_model_loading",
+            model=BGE_M3_MODEL,
+            dim=_MODEL_DIMS[BGE_M3_MODEL],
+            cache_dir=cache_dir,
+            loader="FlagEmbedding",
+        )
+        _bge_m3_model = BGEM3FlagModel(BGE_M3_MODEL, use_fp16=True, cache_dir=cache_dir)
+        return _bge_m3_model
+
+
+def embed_bge_m3(texts: list[str], batch_size: int = 32) -> list[list[float]]:
+    """Embed ``texts`` with bge-m3 (1024-dim, multilingual, 8192 ctx).
+
+    Returns dense vectors only — bge-m3 also produces sparse and
+    multi-vector outputs but the request path uses pgvector dense
+    cosine search, so the other modes are not exposed here.
+    """
+    if not texts:
+        return []
+    model = _get_bge_m3_model()
+    out = model.encode(
+        texts,
+        batch_size=batch_size,
+        max_length=8192,
+        return_dense=True,
+        return_sparse=False,
+        return_colbert_vecs=False,
+    )
+    dense = out["dense_vecs"]
+    return [list(map(float, v)) for v in dense]
+
+
+# Compatibility shim for the backfill — keeps the call site model-name
+# agnostic so a future swap (e.g. to e5-large via fastembed) doesn't
+# require re-routing through a different function name.
+def embed_with(model_name: str, texts: list[str]) -> list[list[float]]:
+    """Embed ``texts`` with the model identified by ``model_name``.
+
+    Routes to ``embed_bge_m3`` for bge-m3 (FlagEmbedding) and to the
+    fastembed default loader for everything else.
+    """
+    if model_name == BGE_M3_MODEL:
+        return embed_bge_m3(texts)
+    if model_name != EMBEDDING_MODEL_NAME:
+        raise NotImplementedError(
+            f"embed_with: model {model_name!r} is not loadable from this "
+            f"process. Default request-path model is {EMBEDDING_MODEL_NAME!r}; "
+            f"only {BGE_M3_MODEL!r} has a second loader. Add a loader path "
+            "before calling embed_with with another model name."
+        )
+    return embed(texts)

--- a/core/embeddings_backfill.py
+++ b/core/embeddings_backfill.py
@@ -1,0 +1,281 @@
+"""Backfill ``knowledge_documents.embedding_bge_m3`` from row content.
+
+PR-A of the BGE-M3 embedding upgrade. Reads every row whose target
+column is ``NULL``, re-embeds the source text with ``BAAI/bge-m3``,
+and writes a 1024-dim vector to ``embedding_bge_m3``. Idempotent —
+re-running picks up only the rows still ``NULL``.
+
+The cutover (PR-B, ``v496_bge_m3_cutover``) refuses to drop the old
+``embedding`` column unless this script reports zero rows where
+``embedding IS NOT NULL AND embedding_bge_m3 IS NULL`` — that gate
+prevents the SECRET_KEY-style "rotated and orphaned" incident
+captured in ``feedback_key_rotation_discipline.md`` from recurring
+for embeddings.
+
+Usage::
+
+    # Dry-run — print how many rows would be touched, no writes.
+    python -m core.embeddings_backfill --dry-run
+
+    # Real run, default batch size 64, all tenants.
+    python -m core.embeddings_backfill
+
+    # Limit to one tenant + smaller batch (useful in low-RAM envs).
+    python -m core.embeddings_backfill --tenant=<uuid> --batch-size=16
+
+    # Verify completeness (exit 0 if backfill complete, 1 otherwise).
+    python -m core.embeddings_backfill --verify
+
+The CLI exits non-zero on any embedding/db error so a CI / cron run
+fails loudly instead of partially completing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import time
+import uuid
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+
+from core.database import async_session_factory
+from core.embeddings import embed_with, model_dim
+
+logger = structlog.get_logger()
+
+TARGET_MODEL = "BAAI/bge-m3"
+TARGET_COLUMN = "embedding_bge_m3"
+SOURCE_TEXT_COLUMN = "content"  # knowledge_documents.content holds the original text
+
+
+def _validate_target_dim() -> None:
+    """Fail loudly if the target model's dim doesn't match the column.
+
+    The migration created ``vector(1024)``. If a future model swap
+    bumps bge-m3 to a different dim, the INSERT will silently
+    truncate or 500 — neither is acceptable. Pin the contract here.
+    """
+    if (dim := model_dim(TARGET_MODEL)) != 1024:
+        raise SystemExit(
+            f"backfill aborted: TARGET_MODEL={TARGET_MODEL} "
+            f"reports dim={dim}, but the column is vector(1024). "
+            "Either fix _MODEL_DIMS or change TARGET_COLUMN."
+        )
+
+
+async def _column_exists(session: Any, column: str) -> bool:
+    """Check that the target column exists before any work happens.
+
+    Without this guard the script would hit a 500 on the first batch
+    and operators wouldn't know whether the migration was missed or
+    the rows were just empty.
+    """
+    result = await session.execute(
+        text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = 'knowledge_documents' AND column_name = :col"
+        ),
+        {"col": column},
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def _count_pending(session: Any, tenant_id: uuid.UUID | None) -> int:
+    """Count rows where the target column is still NULL (and source text exists).
+
+    The column names interpolated into the SQL are module-level
+    constants; ruff S608 is suppressed for this file in pyproject.toml.
+    """
+    q = (
+        f"SELECT COUNT(*) FROM knowledge_documents "  # nosec B608 — TARGET_COLUMN/SOURCE_TEXT_COLUMN are module-level constants, not user input
+        f"WHERE {TARGET_COLUMN} IS NULL AND {SOURCE_TEXT_COLUMN} IS NOT NULL "
+        f"AND length({SOURCE_TEXT_COLUMN}) > 0"
+    )
+    params: dict[str, Any] = {}
+    if tenant_id is not None:
+        q += " AND tenant_id = :tid"
+        params["tid"] = str(tenant_id)
+    result = await session.execute(text(q), params)
+    return int(result.scalar_one() or 0)
+
+
+async def _count_orphan_risk(session: Any, tenant_id: uuid.UUID | None) -> int:
+    """Count rows where the OLD column is set but the NEW column is not.
+
+    These are the rows the cutover would orphan if it ran today.
+    """
+    q = (
+        f"SELECT COUNT(*) FROM knowledge_documents "  # nosec B608 — TARGET_COLUMN is a module-level constant, not user input
+        f"WHERE embedding IS NOT NULL AND {TARGET_COLUMN} IS NULL"
+    )
+    params: dict[str, Any] = {}
+    if tenant_id is not None:
+        q += " AND tenant_id = :tid"
+        params["tid"] = str(tenant_id)
+    result = await session.execute(text(q), params)
+    return int(result.scalar_one() or 0)
+
+
+async def _fetch_batch(
+    session: Any, tenant_id: uuid.UUID | None, batch_size: int
+) -> list[tuple[uuid.UUID, str]]:
+    """Fetch the next batch of (id, content) pairs needing backfill.
+
+    Order by id so progress is monotonic across runs and we never
+    accidentally re-process the same row twice in a single CLI run.
+    """
+    q = (
+        f"SELECT id, {SOURCE_TEXT_COLUMN} FROM knowledge_documents "  # nosec B608 — TARGET_COLUMN/SOURCE_TEXT_COLUMN are module-level constants, not user input
+        f"WHERE {TARGET_COLUMN} IS NULL AND {SOURCE_TEXT_COLUMN} IS NOT NULL "
+        f"AND length({SOURCE_TEXT_COLUMN}) > 0"
+    )
+    params: dict[str, Any] = {"limit": batch_size}
+    if tenant_id is not None:
+        q += " AND tenant_id = :tid"
+        params["tid"] = str(tenant_id)
+    q += " ORDER BY id LIMIT :limit"
+    result = await session.execute(text(q), params)
+    return [(row[0], row[1]) for row in result.all()]
+
+
+async def _write_batch(
+    session: Any, ids: list[uuid.UUID], vectors: list[list[float]]
+) -> None:
+    """Persist a batch of vectors. pgvector accepts the literal text form."""
+    if len(ids) != len(vectors):
+        raise RuntimeError(
+            f"_write_batch length mismatch: {len(ids)} ids vs {len(vectors)} vectors"
+        )
+    for row_id, vec in zip(ids, vectors, strict=True):
+        # pgvector accepts a string literal "[v1,v2,...]" — encoded via
+        # cast(:vec AS vector) so we don't risk arg-binding quirks.
+        await session.execute(
+            text(
+                f"UPDATE knowledge_documents SET {TARGET_COLUMN} = "  # nosec B608 — TARGET_COLUMN is a module-level constant, not user input
+                "CAST(:vec AS vector) WHERE id = :id"
+            ),
+            {"vec": "[" + ",".join(repr(float(x)) for x in vec) + "]", "id": str(row_id)},
+        )
+    await session.commit()
+
+
+async def _verify(tenant_id: uuid.UUID | None) -> int:
+    """Return non-zero if the cutover would orphan rows.
+
+    Used by the PR-B Alembic migration's pre-flight gate and by
+    operators answering "is the backfill done?".
+    """
+    async with async_session_factory() as session:
+        if not await _column_exists(session, TARGET_COLUMN):
+            print(
+                f"verify: column {TARGET_COLUMN} does not exist — "
+                "PR-A migration v495_bge_m3_column has not been applied",
+                file=sys.stderr,
+            )
+            return 2
+        orphan_risk = await _count_orphan_risk(session, tenant_id)
+        if orphan_risk == 0:
+            print("verify: 0 rows would be orphaned by cutover (OK)")
+            return 0
+        print(
+            f"verify: {orphan_risk} rows have embedding set but "
+            f"{TARGET_COLUMN} is still NULL — backfill is not complete",
+            file=sys.stderr,
+        )
+        return 1
+
+
+async def run(
+    tenant_id: uuid.UUID | None,
+    batch_size: int,
+    dry_run: bool,
+) -> int:
+    """Main backfill loop. Returns process exit code."""
+    _validate_target_dim()
+    async with async_session_factory() as session:
+        if not await _column_exists(session, TARGET_COLUMN):
+            print(
+                f"abort: column {TARGET_COLUMN} does not exist — "
+                "apply migration v495_bge_m3_column first",
+                file=sys.stderr,
+            )
+            return 2
+        pending = await _count_pending(session, tenant_id)
+    print(f"pending rows: {pending} (model={TARGET_MODEL}, batch={batch_size})")
+    if dry_run:
+        print("dry-run: no writes performed")
+        return 0
+    if pending == 0:
+        return 0
+
+    written = 0
+    started = time.monotonic()
+    while True:
+        async with async_session_factory() as session:
+            batch = await _fetch_batch(session, tenant_id, batch_size)
+            if not batch:
+                break
+            ids = [row[0] for row in batch]
+            texts = [row[1] for row in batch]
+            try:
+                vectors = embed_with(TARGET_MODEL, texts)
+            except Exception as exc:
+                logger.exception("backfill_embed_failed", error=str(exc))
+                # Surfacing the first failure is more useful than
+                # silently skipping — operators can fix the bad row
+                # (or pin its tenant) and re-run.
+                return 1
+            await _write_batch(session, ids, vectors)
+            written += len(ids)
+            elapsed = time.monotonic() - started
+            rate = written / elapsed if elapsed > 0 else 0.0
+            print(
+                f"  batch wrote {len(ids)} rows  "
+                f"(total={written}/{pending}, "
+                f"rate={rate:.1f} rows/s)"
+            )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tenant",
+        type=str,
+        default=None,
+        help="Limit backfill to a single tenant_id (UUID).",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=64,
+        help="Rows per embedding+UPDATE batch (default: 64).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print pending count without writing anything.",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help=(
+            "Exit 0 if no rows would be orphaned by the PR-B cutover, "
+            "1 otherwise."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    tenant = uuid.UUID(args.tenant) if args.tenant else None
+
+    if args.verify:
+        return asyncio.run(_verify(tenant))
+    return asyncio.run(run(tenant, args.batch_size, args.dry_run))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/rag/ingest.py
+++ b/core/rag/ingest.py
@@ -294,14 +294,19 @@ async def ingest_document(
             dedup_key = _content_hash(chunk_text)[:12]
             canonical_source = f"{chunk_source}#chunk{idx + 1}-{dedup_key}"
 
+            # Column name + model swap honour the RAG_USE_BGE_M3 flag
+            # so the request path stays atomic with the search side.
+            from core.embeddings import rag_embedding_column
+
+            target_column = rag_embedding_column()
             await session.execute(
                 sqltext(
-                    "INSERT INTO knowledge_documents "
+                    "INSERT INTO knowledge_documents "  # nosec B608 — `target_column` is a module-level constant name, not user input
                     "  (id, tenant_id, title, content, category, source, "
                     "   file_type, mime_type, embedding_model, "
                     "   embedding_dimensions, token_count, "
                     "   source_object_id, source_object_type, "
-                    "   status, embedding, created_at) "
+                    f"   status, {target_column}, created_at) "
                     "VALUES "
                     "  (gen_random_uuid(), :tid, :title, :content, "
                     "   :category, :source, 'rag', :mime_type, "

--- a/core/seed_knowledge.py
+++ b/core/seed_knowledge.py
@@ -252,6 +252,13 @@ async def seed_knowledge_base(tenant_id_str: str) -> dict:
             "ALTER TABLE knowledge_documents "
             "ADD COLUMN IF NOT EXISTS embedding vector(384)"
         ))
+        # PR-A: also add the bge-m3 destination column when the seed
+        # path runs ahead of the alembic migration (test fixtures /
+        # local first-boot). Idempotent ADD COLUMN IF NOT EXISTS.
+        await conn.execute(text(
+            "ALTER TABLE knowledge_documents "
+            "ADD COLUMN IF NOT EXISTS embedding_bge_m3 vector(1024)"
+        ))
 
     # Compute embeddings for the curated corpus once, up front.
     # title + short lead of the content gives a semantically strong vector
@@ -289,11 +296,16 @@ async def seed_knowledge_base(tenant_id_str: str) -> dict:
                 else None
             )
 
+            # Column follows the RAG_USE_BGE_M3 flag so seed-time
+            # writes land in the same place /search reads from.
+            from core.embeddings import rag_embedding_column
+
+            ecol = rag_embedding_column()
             await session.execute(
                 text(
-                    "INSERT INTO knowledge_documents "
+                    "INSERT INTO knowledge_documents "  # nosec B608 — `ecol` is a module-level constant name, not user input
                     "(id, tenant_id, title, content, category, source, "
-                    "file_type, status, token_count, embedding, created_at) "
+                    f"file_type, status, token_count, {ecol}, created_at) "
                     "VALUES (:id, :tid, :title, :content, :cat, :src, "
                     "'text', 'ready', :tokens, CAST(:emb AS vector), now())"
                 ),

--- a/coverage_report.json
+++ b/coverage_report.json
@@ -1,0 +1,101 @@
+{
+  "generated_at": "2026-04-26T14:29:28.532481+00:00",
+  "global_percent": 55.0,
+  "global_floor": 55.0,
+  "global_target": 80.0,
+  "critical_path_target": 90.0,
+  "status": "ok",
+  "modules": [
+    {
+      "glob": "auth/*",
+      "percent": 70.0,
+      "floor": 70.0,
+      "target": 90.0,
+      "status": "ok"
+    },
+    {
+      "glob": "api/v1/auth.py",
+      "percent": 50.0,
+      "floor": 50.0,
+      "target": 90.0,
+      "status": "ok"
+    },
+    {
+      "glob": "core/crypto/*",
+      "percent": 70.0,
+      "floor": 0.0,
+      "target": 90.0,
+      "status": "ok"
+    },
+    {
+      "glob": "core/database.py",
+      "percent": 32.0,
+      "floor": 30.0,
+      "target": 90.0,
+      "status": "ok"
+    },
+    {
+      "glob": "api/deps.py",
+      "percent": 94.0,
+      "floor": 0.0,
+      "target": 90.0,
+      "status": "ok"
+    },
+    {
+      "glob": "core/billing/*",
+      "percent": 57.0,
+      "floor": 0.0,
+      "target": 90.0,
+      "status": "ok"
+    },
+    {
+      "glob": "api/v1/billing.py",
+      "percent": 40.0,
+      "floor": 0.0,
+      "target": 90.0,
+      "status": "ok"
+    },
+    {
+      "glob": "workflows/*",
+      "percent": 79.0,
+      "floor": 0.0,
+      "target": 90.0,
+      "status": "ok"
+    },
+    {
+      "glob": "core/tasks/workflow_tasks.py",
+      "percent": 15.0,
+      "floor": 0.0,
+      "target": 90.0,
+      "status": "ok"
+    },
+    {
+      "glob": "connectors/framework/*",
+      "percent": null,
+      "floor": 0.0,
+      "target": 90.0,
+      "status": "skip"
+    },
+    {
+      "glob": "api/v1/connectors.py",
+      "percent": 36.0,
+      "floor": 0.0,
+      "target": 90.0,
+      "status": "ok"
+    },
+    {
+      "glob": "api/v1/governance.py",
+      "percent": 40.0,
+      "floor": 35.0,
+      "target": 70.0,
+      "status": "ok"
+    },
+    {
+      "glob": "api/v1/mcp.py",
+      "percent": 49.0,
+      "floor": 45.0,
+      "target": 70.0,
+      "status": "ok"
+    }
+  ]
+}

--- a/migrations/versions/v4_9_5_bge_m3_column.py
+++ b/migrations/versions/v4_9_5_bge_m3_column.py
@@ -1,0 +1,62 @@
+"""Add ``embedding_bge_m3 vector(1024)`` column + IVFFlat index.
+
+Revision ID: v495_bge_m3_column
+Revises: v494_multimodal_rag
+Create Date: 2026-04-26
+
+PR-A of 2 for the BGE-M3 embedding upgrade. Adds the new column +
+index alongside the existing ``embedding vector(384)`` column. PR-A
+does NOT touch the existing column or flip the default model — it
+only makes the destination column available so the backfill job can
+populate it without taking a schema-rename outage.
+
+The cutover (drop ``embedding``, rename ``embedding_bge_m3`` to
+``embedding``, flip ``DEFAULT_EMBEDDING_MODEL``) is in PR-B and is
+gated on the backfill job reporting zero rows where
+``embedding IS NOT NULL AND embedding_bge_m3 IS NULL``.
+
+Idempotent — guarded on information_schema.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v495_bge_m3_column"
+down_revision = "v494_multimodal_rag"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_name = 'knowledge_documents'
+            ) THEN
+                ALTER TABLE knowledge_documents
+                    ADD COLUMN IF NOT EXISTS embedding_bge_m3 vector(1024);
+                -- IVFFlat with lists=100 mirrors the existing index. The
+                -- backfill job will populate the column before any
+                -- production query targets it.
+                CREATE INDEX IF NOT EXISTS ix_knowledge_documents_embedding_bge_m3
+                    ON knowledge_documents
+                    USING ivfflat (embedding_bge_m3 vector_cosine_ops)
+                    WITH (lists = 100);
+            END IF;
+        END
+        $$;
+    """)
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP INDEX IF EXISTS ix_knowledge_documents_embedding_bge_m3"
+    )
+    op.execute(
+        "ALTER TABLE knowledge_documents "
+        "DROP COLUMN IF EXISTS embedding_bge_m3"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,12 @@ dependencies = [
     "reportlab>=4.4.10",
     "google-cloud-kms>=3.12.0",
     "fastembed>=0.7.0",
+    # FlagEmbedding is BAAI's official loader for bge-m3 (8192 ctx,
+    # 1024 dim, multilingual). fastembed does not ship bge-m3.
+    # Loaded lazily — only the backfill job (PR-A) and PR-B's flipped
+    # request path import it. The default request-path embedder stays
+    # on fastembed/bge-small until PR-B cutover.
+    "FlagEmbedding>=1.2.0",
 ]
 
 [project.optional-dependencies]
@@ -141,6 +147,16 @@ extend-immutable-calls = ["fastapi.Depends", "Depends"]
 # user input arrives as bind parameters; ruff S608 flags any
 # f-string in a SQL context regardless.
 "core/billing/spend.py" = ["S608"]
+# RAG layer interpolates ``rag_embedding_column()`` (a module-level
+# constant getter) into SQL to flip between the legacy ``embedding``
+# column and the new ``embedding_bge_m3`` column without a deploy.
+# All values reaching the SQL string are constants under our control;
+# bind parameters carry the actual user input. Ruff/bandit S608 flags
+# any f-string in a SQL context, hence the per-file ignore.
+"core/embeddings_backfill.py" = ["S608"]
+"core/rag/ingest.py" = ["S608"]
+"core/seed_knowledge.py" = ["S608"]
+"api/v1/knowledge.py" = ["S608"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tests/regression/test_bge_m3_pr_a.py
+++ b/tests/regression/test_bge_m3_pr_a.py
@@ -1,0 +1,397 @@
+"""Regression tests for the BGE-M3 embedding upgrade PR-A.
+
+PR-A adds the ``embedding_bge_m3`` column + IVFFlat index alongside
+the existing ``embedding`` column. It does NOT flip the platform
+default. PR-B (cutover) is gated on the backfill script reporting
+zero orphan-risk rows.
+
+These tests pin contracts that, if regressed, would silently break
+the rollout:
+
+  1. The ``embedding_bge_m3`` column is exposed by the migration.
+  2. The default model is still ``bge-small-en-v1.5`` — PR-A must
+     not change ``DEFAULT_EMBEDDING_MODEL``.
+  3. ``embed_with("BAAI/bge-m3", ...)`` returns 1024-dim vectors.
+  4. The backfill CLI's ``--verify`` mode exits non-zero when rows
+     are still pending and zero when they aren't.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Migration + default-model pins (do not require fastembed at import time)
+# ---------------------------------------------------------------------------
+
+
+def test_pr_a_migration_file_exists() -> None:
+    """PR-A is delivered by v495_bge_m3_column."""
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    migration = repo / "migrations" / "versions" / "v4_9_5_bge_m3_column.py"
+    src = migration.read_text(encoding="utf-8")
+    assert 'revision = "v495_bge_m3_column"' in src
+    assert "embedding_bge_m3 vector(1024)" in src
+    assert "ix_knowledge_documents_embedding_bge_m3" in src
+    # Must be guarded so it's safe on environments where
+    # knowledge_documents was never created.
+    assert "information_schema.tables" in src
+
+
+def test_pr_a_does_not_flip_default_model() -> None:
+    """The platform default MUST stay bge-small until PR-B cutover.
+
+    PR-B is the one that drops the old column and renames the new
+    one. If PR-A flips ``DEFAULT_EMBEDDING_MODEL``, the request path
+    starts emitting 1024-dim vectors that won't fit ``vector(384)``
+    and every ``/knowledge/search`` call 500s.
+    """
+    embeddings = importlib.import_module("core.embeddings")
+    assert embeddings.DEFAULT_EMBEDDING_MODEL == "BAAI/bge-small-en-v1.5"
+    # Sanity — the bge-m3 dim entry is present so the backfill knows
+    # the column dimensionality without having to load fastembed.
+    assert embeddings._MODEL_DIMS["BAAI/bge-m3"] == 1024
+
+
+def test_model_dim_helper_returns_1024_for_bge_m3() -> None:
+    embeddings = importlib.import_module("core.embeddings")
+    assert embeddings.model_dim("BAAI/bge-m3") == 1024
+    assert embeddings.model_dim("BAAI/bge-small-en-v1.5") == 384
+
+
+# ---------------------------------------------------------------------------
+# Embedding round-trip (skipped when fastembed isn't installed in the env)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_embed_with_bge_m3_returns_1024_dim_vectors() -> None:
+    """End-to-end smoke test for bge-m3 via FlagEmbedding.
+
+    Skipped when FlagEmbedding isn't in the env — the package pulls
+    ~2.3 GB of weights and PyTorch on first call, which we don't want
+    to install just to satisfy a unit-test runner. The Cloud Run
+    backfill image MUST install it.
+    """
+    flag = pytest.importorskip(
+        "FlagEmbedding", reason="FlagEmbedding not installed in this env"
+    )
+    del flag
+    from core.embeddings import embed_bge_m3
+
+    vectors = embed_bge_m3(["hello world", "second sample"])
+    assert len(vectors) == 2
+    assert all(len(v) == 1024 for v in vectors)
+    assert all(isinstance(x, float) for x in vectors[0])
+
+
+# ---------------------------------------------------------------------------
+# Backfill CLI surface tests (no DB required)
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_cli_help_documents_dry_run_and_verify() -> None:
+    """The CLI flags must stay stable — operators script around them."""
+    import io
+    import sys
+
+    from core.embeddings_backfill import main
+
+    captured = io.StringIO()
+    sys.stdout = captured
+    try:
+        with pytest.raises(SystemExit) as exc:
+            main(["--help"])
+    finally:
+        sys.stdout = sys.__stdout__
+    out = captured.getvalue()
+    assert exc.value.code == 0
+    for token in ("--tenant", "--batch-size", "--dry-run", "--verify"):
+        assert token in out, f"backfill --help must document {token}"
+
+
+def test_backfill_target_model_dim_matches_column() -> None:
+    """The dimension contract that prevents a silent vector-size mismatch."""
+    from core.embeddings_backfill import (
+        TARGET_COLUMN,
+        TARGET_MODEL,
+        _validate_target_dim,
+    )
+
+    assert TARGET_COLUMN == "embedding_bge_m3"
+    assert TARGET_MODEL == "BAAI/bge-m3"
+    # Should not raise.
+    _validate_target_dim()
+
+
+# ---------------------------------------------------------------------------
+# Feature-flag wiring (RAG_USE_BGE_M3) — the gate that PR-A introduces so the
+# RAG ingest + search paths flip atomically. Must default OFF.
+# ---------------------------------------------------------------------------
+
+
+def test_rag_use_bge_m3_defaults_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default is OFF — flipping requires explicit env opt-in.
+
+    If this regresses to ON-by-default, every fresh deploy starts
+    embedding queries with bge-m3 against a `vector(384)` column on
+    environments where the backfill hasn't run yet.
+    """
+    monkeypatch.delenv("AGENTICORG_RAG_USE_BGE_M3", raising=False)
+    from core.embeddings import rag_embedding_column, rag_use_bge_m3
+
+    assert rag_use_bge_m3() is False
+    assert rag_embedding_column() == "embedding"
+
+
+@pytest.mark.parametrize("v", ["1", "true", "TRUE", "yes", "on", "True"])
+def test_rag_use_bge_m3_truthy_values(
+    monkeypatch: pytest.MonkeyPatch, v: str
+) -> None:
+    monkeypatch.setenv("AGENTICORG_RAG_USE_BGE_M3", v)
+    from core.embeddings import rag_embedding_column, rag_use_bge_m3
+
+    assert rag_use_bge_m3() is True
+    assert rag_embedding_column() == "embedding_bge_m3"
+
+
+@pytest.mark.parametrize("v", ["", "0", "false", "no", "off", "anything else"])
+def test_rag_use_bge_m3_falsy_values(
+    monkeypatch: pytest.MonkeyPatch, v: str
+) -> None:
+    monkeypatch.setenv("AGENTICORG_RAG_USE_BGE_M3", v)
+    from core.embeddings import rag_embedding_column, rag_use_bge_m3
+
+    assert rag_use_bge_m3() is False
+    assert rag_embedding_column() == "embedding"
+
+
+def test_rag_search_query_uses_flag_column() -> None:
+    """``api/v1/knowledge.py`` search must read the column the flag picks.
+
+    Source-pin: the SELECT must reference ``rag_embedding_column()``,
+    not the hard-coded ``embedding`` literal that pre-dated the flag.
+    Otherwise flipping the flag rotates the write path without
+    rotating reads — every search 500s with a dim mismatch.
+    """
+    from pathlib import Path
+
+    src = (
+        Path(__file__).resolve().parents[2] / "api" / "v1" / "knowledge.py"
+    ).read_text(encoding="utf-8")
+    assert "rag_embedding_column" in src, (
+        "search path must import + use rag_embedding_column() so the "
+        "column flip is atomic with embed_one()"
+    )
+
+
+def test_rag_ingest_insert_uses_flag_column() -> None:
+    """``core/rag/ingest.py`` INSERT must target the flag-selected column."""
+    from pathlib import Path
+
+    src = (
+        Path(__file__).resolve().parents[2] / "core" / "rag" / "ingest.py"
+    ).read_text(encoding="utf-8")
+    assert "rag_embedding_column" in src, (
+        "ingest path must use rag_embedding_column() so writes land in "
+        "the column /search reads from"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mock-DB exercise of the backfill flow — bumps coverage on the script's
+# DB-touching helpers without needing a real Postgres.
+# ---------------------------------------------------------------------------
+
+
+import asyncio  # noqa: E402
+from contextlib import asynccontextmanager  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+
+def _make_mock_session(scalar_values: list, fetch_rows: list | None = None):
+    """Return an AsyncMock session yielding controlled SELECT/UPDATE results."""
+    session = AsyncMock()
+    session.commit = AsyncMock()
+
+    call_idx = {"n": 0}
+
+    async def execute(_stmt, _params=None):
+        result = MagicMock()
+        # Distribute scalar/all results round-robin in call order so a
+        # single test can stage multiple SELECT counts.
+        if call_idx["n"] < len(scalar_values):
+            result.scalar_one_or_none.return_value = scalar_values[call_idx["n"]]
+            result.scalar_one.return_value = scalar_values[call_idx["n"]]
+        else:
+            result.scalar_one_or_none.return_value = None
+            result.scalar_one.return_value = 0
+        if fetch_rows is not None and call_idx["n"] < len(fetch_rows):
+            result.all.return_value = fetch_rows[call_idx["n"]]
+        else:
+            result.all.return_value = []
+        call_idx["n"] += 1
+        return result
+
+    session.execute = execute
+    return session
+
+
+@asynccontextmanager
+async def _session_cm(session):
+    yield session
+
+
+def test_backfill_verify_returns_2_when_column_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--verify`` exits 2 when the destination column doesn't exist."""
+    from core import embeddings_backfill as eb
+
+    session = _make_mock_session(scalar_values=[None])  # column lookup -> None
+    monkeypatch.setattr(eb, "async_session_factory", lambda: _session_cm(session))
+    rc = asyncio.run(eb._verify(None))
+    assert rc == 2
+
+
+def test_backfill_verify_returns_0_when_no_orphans(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--verify`` exits 0 when zero rows would be orphaned."""
+    from core import embeddings_backfill as eb
+
+    # First execute: column exists (returns 1). Second: orphan count = 0.
+    session = _make_mock_session(scalar_values=[1, 0])
+    monkeypatch.setattr(eb, "async_session_factory", lambda: _session_cm(session))
+    rc = asyncio.run(eb._verify(None))
+    assert rc == 0
+
+
+def test_backfill_verify_returns_1_when_orphans_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--verify`` exits 1 when rows would still be orphaned by cutover."""
+    from core import embeddings_backfill as eb
+
+    # column exists (1), 17 rows with old col but no new col
+    session = _make_mock_session(scalar_values=[1, 17])
+    monkeypatch.setattr(eb, "async_session_factory", lambda: _session_cm(session))
+    rc = asyncio.run(eb._verify(None))
+    assert rc == 1
+
+
+def test_backfill_run_dry_run_does_not_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--dry-run`` reports the count and returns 0 without calling embed_with."""
+    from core import embeddings_backfill as eb
+
+    # column exists (1), 5 pending
+    session = _make_mock_session(scalar_values=[1, 5])
+    monkeypatch.setattr(eb, "async_session_factory", lambda: _session_cm(session))
+    with patch.object(eb, "embed_with") as embed_mock:
+        rc = asyncio.run(eb.run(tenant_id=None, batch_size=10, dry_run=True))
+    assert rc == 0
+    embed_mock.assert_not_called()
+
+
+def test_backfill_run_aborts_when_column_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``run`` exits 2 when the destination column doesn't exist."""
+    from core import embeddings_backfill as eb
+
+    session = _make_mock_session(scalar_values=[None])
+    monkeypatch.setattr(eb, "async_session_factory", lambda: _session_cm(session))
+    rc = asyncio.run(eb.run(tenant_id=None, batch_size=10, dry_run=False))
+    assert rc == 2
+
+
+def test_backfill_run_writes_then_terminates_on_empty_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One batch then empty -> writes 2 rows and returns 0."""
+    from core import embeddings_backfill as eb
+
+    # Sequence:
+    #  1) _column_exists -> 1
+    #  2) _count_pending -> 2
+    #  3) (loop iter 1) _fetch_batch -> 2 rows
+    #  4) UPDATE x2 + commit (results not consumed)
+    #  5) (loop iter 2) _fetch_batch -> empty
+    fetch_rows = [None, None, [("id-1", "hello"), ("id-2", "world")], None, None, []]
+    session = _make_mock_session(scalar_values=[1, 2], fetch_rows=fetch_rows)
+    monkeypatch.setattr(eb, "async_session_factory", lambda: _session_cm(session))
+
+    def fake_embed(model, texts):
+        # Return 1024-dim zero vectors so the float formatting works.
+        return [[0.0] * 1024 for _ in texts]
+
+    monkeypatch.setattr(eb, "embed_with", fake_embed)
+
+    rc = asyncio.run(eb.run(tenant_id=None, batch_size=2, dry_run=False))
+    assert rc == 0
+
+
+def test_backfill_run_returns_1_on_embed_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Embedding failure surfaces non-zero exit code, not silent skip."""
+    from core import embeddings_backfill as eb
+
+    fetch_rows = [None, None, [("id-1", "hello")]]
+    session = _make_mock_session(scalar_values=[1, 1], fetch_rows=fetch_rows)
+    monkeypatch.setattr(eb, "async_session_factory", lambda: _session_cm(session))
+
+    def boom(_m, _t):
+        raise RuntimeError("model not loaded")
+
+    monkeypatch.setattr(eb, "embed_with", boom)
+
+    rc = asyncio.run(eb.run(tenant_id=None, batch_size=1, dry_run=False))
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Embedding helpers (no network, no fastembed) — exercise the dispatch paths.
+# ---------------------------------------------------------------------------
+
+
+def test_embed_with_unknown_model_raises_not_implemented() -> None:
+    """``embed_with`` rejects unsupported model names loudly."""
+    from core.embeddings import embed_with
+
+    with pytest.raises(NotImplementedError):
+        embed_with("totally-fake-model", ["one"])
+
+
+def test_embed_with_empty_texts_returns_empty() -> None:
+    """Both paths short-circuit on empty input — no model load."""
+    from core.embeddings import embed_with
+
+    assert embed_with("BAAI/bge-m3", []) == []
+
+
+def test_embed_one_routes_through_embed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`embed_one` is a thin wrapper around `embed`."""
+    from core import embeddings as emb
+
+    monkeypatch.setattr(emb, "embed", lambda texts: [[0.5] * 4 for _ in texts])
+    assert emb.embed_one("hi") == [0.5, 0.5, 0.5, 0.5]
+
+
+def test_embed_routes_to_bge_m3_when_flag_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flag flip routes the default embed() through bge-m3."""
+    from core import embeddings as emb
+
+    monkeypatch.setenv("AGENTICORG_RAG_USE_BGE_M3", "1")
+    monkeypatch.setattr(emb, "embed_bge_m3", lambda texts: [[1.0] * 1024 for _ in texts])
+    out = emb.embed(["q"])
+    assert len(out) == 1
+    assert len(out[0]) == 1024


### PR DESCRIPTION
## Summary

PR-A of the embedding upgrade. Adds the destination column + IVFFlat index alongside the existing one and ships an idempotent backfill that re-embeds every row with **bge-m3** (1024 dim, multilingual, 8192 ctx) into the new column.

A feature flag \`AGENTICORG_RAG_USE_BGE_M3\` (default OFF) controls whether the request path uses bge-m3 or stays on bge-small. Until the backfill verify reports zero orphan rows, the flag MUST stay OFF — flipping it without the data lands every \`/knowledge/search\` call on a dimension mismatch.

## Why bge-m3 vs alternatives

| Model | License | Dim | Context | Languages | Verdict |
|-------|---------|-----|---------|-----------|---------|
| **BAAI/bge-m3** ✓ | MIT | 1024 | **8192** | 100+ | meets all requirements |
| jinaai/jina-embeddings-v3 | CC BY-NC 4.0 ⚠️ | 1024 | 1024 | 100+ | non-commercial license blocks production |
| intfloat/multilingual-e5-large | MIT | 1024 | 512 | 100+ | ctx too short for CA firm docs |
| Alibaba-NLP/gte-multilingual-base | Apache 2.0 | 768 ❌ | 8192 | 70+ | wrong dim |

## Why FlagEmbedding (BAAI's official loader)

- fastembed does not ship bge-m3 in any released version (verified 0.7.3 / 0.7.4 / 0.8.0).
- TEI / Ollama would mean a new Cloud Run service or sidecar; user picked Option A (in-process, simpler ops).
- FlagEmbedding loads ~2.3 GB lazily on first call and is only imported when the bge-m3 path is exercised.

## Cutover gate

PR-B refuses to drop the old \`embedding\` column unless:
\`\`\`
python -m core.embeddings_backfill --verify  # exit 0 = no rows would be orphaned
\`\`\`

This is the same fail-closed discipline as \`feedback_key_rotation_discipline.md\` applied to embeddings — rotating an embedding model MUST NOT orphan existing vectors.

## Files

- \`migrations/versions/v4_9_5_bge_m3_column.py\` — adds \`embedding_bge_m3 vector(1024)\` + IVFFlat index, idempotent
- \`core/embeddings.py\` — adds FlagEmbedding loader path, RAG_USE_BGE_M3 flag helpers
- \`core/embeddings_backfill.py\` — idempotent batched CLI (\`--dry-run\` / \`--tenant\` / \`--batch-size\` / \`--verify\`)
- \`core/rag/ingest.py\` — INSERT routes via \`rag_embedding_column()\`
- \`api/v1/knowledge.py\` — search SELECT routes via \`rag_embedding_column()\`
- \`core/seed_knowledge.py\` — seed routes via \`rag_embedding_column()\`
- \`tests/regression/test_bge_m3_pr_a.py\` — 20 contract tests + 1 fastembed-skipped smoke test
- \`pyproject.toml\` — adds \`FlagEmbedding>=1.2.0\`, S608 ignores for the SQL-templating files

## Rollout plan

1. Merge PR-A (this PR) → deploy → migration v495 runs at startup
2. Run \`python -m core.embeddings_backfill\` from a backfill container (Cloud Run job)
3. Run \`python -m core.embeddings_backfill --verify\` until it exits 0
4. Set \`AGENTICORG_RAG_USE_BGE_M3=true\` on agenticorg-api, redeploy
5. Smoke /knowledge/search returns results from the new column
6. PR-B drops legacy column + flips default

## Test plan
- [x] 20 regression tests + 1 fastembed-skipped smoke pass locally
- [x] Preflight green (ruff + bandit + alembic + pytest + ui tsc + ui build + module coverage + critical-path tags)

@codex please review.