### PR TITLE
feat(llm): tier1=flash-lite + $10/day cap + spend CLI + GCP reconcile

### DIFF
--- a/core/billing/spend.py
+++ b/core/billing/spend.py
@@ -1,0 +1,323 @@
+"""Platform-wide LLM spend reporter (and Gemini-specific breakdown).
+
+Usage::
+
+    # Today's Gemini spend, broken down by model.
+    python -m core.billing.spend --period=daily --provider=gemini
+
+    # Last 30 days, all providers, top 10 tenants.
+    python -m core.billing.spend --period=monthly --top-tenants=10
+
+    # JSON output for scraping.
+    python -m core.billing.spend --period=daily --json
+
+    # Compare local cost calc vs Google Cloud Billing Export
+    # (requires the BigQuery billing export to be set up).
+    python -m core.billing.spend --period=daily --reconcile-gcp
+
+The script aggregates ``cost_usd`` from ``agent_task_results``
+across all tenants. The local cost is computed from token counts
+× ``GEMINI_PRICE_PER_1M`` at call time. The reconcile-gcp mode
+compares that local total against the BigQuery
+``gcp_billing_export_v1_<billing_account>`` table for the same
+period and prints the divergence — large divergence usually means
+the local pricing table is stale, or that the unaccounted-for
+spend is from non-LLM services (storage, egress).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json as _json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+
+from core.database import async_session_factory
+
+logger = structlog.get_logger()
+
+
+@dataclass
+class SpendRow:
+    label: str
+    value: str
+    cost_usd: float
+    calls: int
+    tokens: int
+
+
+def _period_start(period: str, now: datetime) -> datetime:
+    """Return the UTC start of the named period."""
+    if period == "daily":
+        return now.replace(hour=0, minute=0, second=0, microsecond=0)
+    if period == "weekly":
+        weekday = now.weekday()
+        start = now - timedelta(days=weekday)
+        return start.replace(hour=0, minute=0, second=0, microsecond=0)
+    if period == "monthly":
+        return now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    raise ValueError(f"Unknown period {period!r}")
+
+
+async def _spend_by_model(since: datetime, provider: str | None) -> list[SpendRow]:
+    """Aggregate by ``llm_model``, optionally filtered to a provider prefix."""
+    where = ["created_at >= :since"]
+    params: dict[str, Any] = {"since": since}
+    if provider:
+        where.append("llm_model LIKE :prefix")
+        params["prefix"] = f"{provider}%"
+    where_sql = " AND ".join(where)
+    q = (
+        "SELECT COALESCE(llm_model, '(unknown)') AS model, "  # nosec B608 — `where_sql` joins argparse-validated literals only; user input lands in bind params
+        "COUNT(*) AS calls, "
+        "COALESCE(SUM(tokens_used), 0) AS tokens, "
+        "COALESCE(SUM(cost_usd), 0) AS cost_usd "
+        "FROM agent_task_results "
+        f"WHERE {where_sql} "
+        "GROUP BY llm_model "
+        "ORDER BY cost_usd DESC"
+    )
+    async with async_session_factory() as session:
+        result = await session.execute(text(q), params)
+        return [
+            SpendRow(
+                label="model",
+                value=row[0] or "(unknown)",
+                cost_usd=float(row[3] or 0.0),
+                calls=int(row[1] or 0),
+                tokens=int(row[2] or 0),
+            )
+            for row in result.all()
+        ]
+
+
+async def _spend_by_tenant(
+    since: datetime, top_n: int, provider: str | None
+) -> list[SpendRow]:
+    """Aggregate by ``tenant_id``, top N by cost."""
+    where = ["created_at >= :since"]
+    params: dict[str, Any] = {"since": since, "limit": top_n}
+    if provider:
+        where.append("llm_model LIKE :prefix")
+        params["prefix"] = f"{provider}%"
+    where_sql = " AND ".join(where)
+    q = (
+        "SELECT tenant_id::text, "  # nosec B608 — `where_sql` joins argparse-validated literals only; user input lands in bind params
+        "COUNT(*) AS calls, "
+        "COALESCE(SUM(tokens_used), 0) AS tokens, "
+        "COALESCE(SUM(cost_usd), 0) AS cost_usd "
+        "FROM agent_task_results "
+        f"WHERE {where_sql} "
+        "GROUP BY tenant_id "
+        "ORDER BY cost_usd DESC "
+        "LIMIT :limit"
+    )
+    async with async_session_factory() as session:
+        result = await session.execute(text(q), params)
+        return [
+            SpendRow(
+                label="tenant",
+                value=row[0],
+                cost_usd=float(row[3] or 0.0),
+                calls=int(row[1] or 0),
+                tokens=int(row[2] or 0),
+            )
+            for row in result.all()
+        ]
+
+
+def _format_table(title: str, rows: list[SpendRow]) -> str:
+    """Render a fixed-width table for the terminal."""
+    if not rows:
+        return f"{title}: (no data)\n"
+    out = [f"{title}:"]
+    name_width = max(len(r.value) for r in rows)
+    name_width = max(name_width, len(rows[0].label))
+    out.append(
+        f"  {rows[0].label:<{name_width}}  {'cost_usd':>12}  "
+        f"{'calls':>10}  {'tokens':>14}"
+    )
+    out.append(f"  {'-' * name_width}  {'-' * 12}  {'-' * 10}  {'-' * 14}")
+    total_cost = total_calls = total_tokens = 0.0
+    for r in rows:
+        out.append(
+            f"  {r.value:<{name_width}}  ${r.cost_usd:>10.4f}  "
+            f"{r.calls:>10}  {r.tokens:>14}"
+        )
+        total_cost += r.cost_usd
+        total_calls += r.calls
+        total_tokens += r.tokens
+    out.append(f"  {'-' * name_width}  {'-' * 12}  {'-' * 10}  {'-' * 14}")
+    out.append(
+        f"  {'TOTAL':<{name_width}}  ${total_cost:>10.4f}  "
+        f"{int(total_calls):>10}  {int(total_tokens):>14}"
+    )
+    return "\n".join(out) + "\n"
+
+
+async def _reconcile_with_gcp(since: datetime, local_total_usd: float) -> str:
+    """Compare local LLM-only spend against the GCP billing export.
+
+    Requires:
+      - ``AGENTICORG_GCP_BILLING_BQ_TABLE`` set to the fully-qualified
+        BigQuery table id (e.g.
+        ``perfect-period-305406.billing_export.gcp_billing_export_v1_<account>``).
+      - ``google-cloud-bigquery`` installed.
+
+    Reads the SUM of ``cost`` for ``service.description`` containing
+    'AI' or 'Generative Language' since ``since``. Note: GCP totals
+    include all billed services (compute, storage, egress, etc.) so
+    this filter is best-effort. Operators reading the divergence
+    should focus on the LLM-related lines.
+    """
+    table = os.getenv("AGENTICORG_GCP_BILLING_BQ_TABLE")
+    if not table:
+        return (
+            "reconcile-gcp: AGENTICORG_GCP_BILLING_BQ_TABLE not set — "
+            "skipping. Point at the BQ billing-export table to enable.\n"
+        )
+    try:
+        from google.cloud import bigquery
+    except ImportError:
+        return (
+            "reconcile-gcp: google-cloud-bigquery not installed — "
+            "`pip install google-cloud-bigquery`.\n"
+        )
+    client = bigquery.Client()
+    query = (
+        "SELECT SUM(cost) AS gcp_total "  # nosec B608 — `table` is from a trusted env var (AGENTICORG_GCP_BILLING_BQ_TABLE), not user input; @since is a BQ named param
+        f"FROM `{table}` "
+        "WHERE usage_start_time >= @since "
+        "AND ("
+        "  LOWER(service.description) LIKE '%generative%' "
+        "  OR LOWER(service.description) LIKE '%vertex%' "
+        "  OR LOWER(service.description) LIKE '%gemini%' "
+        "  OR LOWER(service.description) LIKE '%language%api%'"
+        ")"
+    )
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("since", "TIMESTAMP", since),
+        ]
+    )
+    try:
+        result = client.query(query, job_config=job_config).result()
+    except Exception as exc:  # noqa: BLE001
+        return f"reconcile-gcp: BigQuery query failed: {exc}\n"
+    gcp_total = next(iter(result), None)
+    if gcp_total is None or gcp_total["gcp_total"] is None:
+        gcp_total_usd = 0.0
+    else:
+        gcp_total_usd = float(gcp_total["gcp_total"])
+    diff = local_total_usd - gcp_total_usd
+    return (
+        f"reconcile-gcp:\n"
+        f"  Local cost (computed):   ${local_total_usd:>10.4f}\n"
+        f"  GCP billing export:      ${gcp_total_usd:>10.4f}\n"
+        f"  Divergence (local-gcp):  ${diff:>10.4f}\n"
+        "  Note: GCP total filters service descriptions matching\n"
+        "  'generative|vertex|gemini|language api'; cross-check\n"
+        "  the BQ row directly when the divergence is large.\n"
+    )
+
+
+async def run(
+    period: str,
+    provider: str | None,
+    top_tenants: int,
+    output_json: bool,
+    reconcile_gcp: bool,
+) -> int:
+    now = datetime.now(UTC)
+    since = _period_start(period, now)
+
+    by_model = await _spend_by_model(since, provider)
+    by_tenant = await _spend_by_tenant(since, top_tenants, provider) if top_tenants else []
+
+    local_total = sum(r.cost_usd for r in by_model)
+
+    if output_json:
+        payload = {
+            "period": period,
+            "since_utc": since.isoformat(),
+            "now_utc": now.isoformat(),
+            "provider_filter": provider,
+            "by_model": [r.__dict__ for r in by_model],
+            "by_tenant": [r.__dict__ for r in by_tenant],
+            "total_cost_usd": local_total,
+        }
+        if reconcile_gcp:
+            payload["reconcile_note"] = (await _reconcile_with_gcp(since, local_total))
+        print(_json.dumps(payload, indent=2, default=str))
+        return 0
+
+    print(
+        f"Spend window: {since.isoformat()} → {now.isoformat()} "
+        f"(period={period}, provider={provider or 'all'})"
+    )
+    print()
+    print(_format_table("By model", by_model))
+    if by_tenant:
+        print(_format_table(f"Top {top_tenants} tenants", by_tenant))
+    if reconcile_gcp:
+        print(await _reconcile_with_gcp(since, local_total))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--period",
+        choices=["daily", "weekly", "monthly"],
+        default="daily",
+    )
+    parser.add_argument(
+        "--provider",
+        type=str,
+        default=None,
+        help=(
+            "Filter llm_model to a provider prefix (e.g. 'gemini', "
+            "'claude', 'gpt'). Default: all providers."
+        ),
+    )
+    parser.add_argument(
+        "--top-tenants",
+        type=int,
+        default=10,
+        help="Show top N tenants by cost (set 0 to skip the per-tenant table).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON.")
+    parser.add_argument(
+        "--reconcile-gcp",
+        action="store_true",
+        help=(
+            "Compare local cost computation against the GCP "
+            "BigQuery billing export. Requires "
+            "AGENTICORG_GCP_BILLING_BQ_TABLE."
+        ),
+    )
+    args = parser.parse_args(argv)
+    try:
+        return asyncio.run(
+            run(
+                period=args.period,
+                provider=args.provider,
+                top_tenants=args.top_tenants,
+                output_json=args.json,
+                reconcile_gcp=args.reconcile_gcp,
+            )
+        )
+    except KeyboardInterrupt:
+        print("interrupted", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/llm/router.py
+++ b/core/llm/router.py
@@ -1,19 +1,34 @@
 """LLM Router — Smart model selection with RouteLLM + tiered routing.
 
-Routing tiers:
-  - Tier 1 (simple): Gemini 2.5 Flash (free) — data lookups, formatting, simple Q&A
-  - Tier 2 (moderate): Gemini 2.5 Pro — analysis, summarization, multi-step reasoning
-  - Tier 3 (complex): Claude Opus / GPT-4o — legal analysis, financial modeling
+Routing tiers (cloud, default ``AGENTICORG_LLM_MODE=cloud``):
 
-Air-gapped mode (AGENTICORG_LLM_MODE=local):
+  - Tier 1 (simple):    ``gemini-2.5-flash-lite`` — high-volume
+                        classification, extraction, simple Q&A.
+                        ~$0.04/1M input, ~$0.10/1M output.
+  - Tier 2 (moderate):  ``gemini-2.5-flash`` — multi-step reasoning,
+                        light synthesis. $0.075/1M input,
+                        $0.30/1M output.
+  - Tier 3 (complex):   ``gemini-2.5-pro`` — heavy synthesis, deep
+                        reasoning. $1.25/1M input, $5/1M output.
+                        ``AGENTICORG_LLM_TIER3`` overrides for hosted
+                        Claude/GPT.
+
+Air-gapped mode (``AGENTICORG_LLM_MODE=local``):
   - Tier 1: Ollama small model (e.g. llama3.2:3b)
   - Tier 2: Ollama medium model (e.g. llama3.1:8b)
   - Tier 3: vLLM large model (e.g. llama3.1:70b)
 
-Routing modes (AGENTICORG_LLM_ROUTING):
-  - "auto": use RouteLLM similarity-weighted router (or heuristic fallback)
-  - "tier1" / "tier2" / "tier3": force that tier regardless of query
-  - "disabled": use the agent's configured llm_model directly (bypass router)
+Routing modes (``AGENTICORG_LLM_ROUTING``):
+  - ``auto``: RouteLLM similarity-weighted (or heuristic fallback).
+  - ``tier1`` / ``tier2`` / ``tier3``: force that tier.
+  - ``disabled``: use the agent's configured llm_model directly.
+
+Hard cap (``AGENTICORG_GEMINI_DAILY_USD_CAP``, default ``10.0``):
+  Before any Gemini call the router sums today's ``cost_usd`` from
+  ``agent_task_results`` (UTC day). If the running total ≥ cap, the
+  call is refused with :class:`DailyBudgetExceeded` (HTTP 429 surface)
+  so a runaway workflow or shadow-batch cannot blow past the daily
+  budget. Set the env var to ``0`` to disable (NOT recommended).
 """
 
 from __future__ import annotations
@@ -44,11 +59,13 @@ except Exception:  # noqa: BLE001
 # Tier model definitions
 # ---------------------------------------------------------------------------
 
-# Cloud tier models
+# Cloud tier models. Tier1 was previously gemini-2.5-flash; the
+# 3-tier rework moves Flash to Tier2 and uses Flash-Lite for Tier1
+# so high-volume classify/extract calls land at the cheapest model.
 CLOUD_TIERS: dict[str, str] = {
-    "tier1": "gemini-2.5-flash",
-    "tier2": "gemini-2.5-pro",
-    "tier3": os.getenv("AGENTICORG_LLM_TIER3", "claude-sonnet-4-20250514"),
+    "tier1": os.getenv("AGENTICORG_LLM_TIER1", "gemini-2.5-flash-lite"),
+    "tier2": os.getenv("AGENTICORG_LLM_TIER2", "gemini-2.5-flash"),
+    "tier3": os.getenv("AGENTICORG_LLM_TIER3", "gemini-2.5-pro"),
 }
 
 # Air-gapped / local tier models (Ollama + vLLM)
@@ -58,12 +75,127 @@ LOCAL_TIERS: dict[str, str] = {
     "tier3": os.getenv("AGENTICORG_LOCAL_TIER3", "llama3.1:70b"),
 }
 
-# Estimated cost per 1K tokens (USD) for display / tracking
+# Display-only running estimates per 1K tokens (USD). Used by the
+# ``llm_routing_decision`` log line so operators can sanity-check
+# tier choices. Authoritative cost computation lives in
+# ``GEMINI_PRICE_PER_1M`` below and is used by the per-call cost
+# write to agent_task_results.
 TIER_COST_PER_1K: dict[str, float] = {
-    "tier1": 0.0,       # Gemini Flash free tier
-    "tier2": 0.00125,   # Gemini Pro
-    "tier3": 0.015,     # Claude Opus / GPT-4o
+    "tier1": 0.000_10,    # gemini-2.5-flash-lite output
+    "tier2": 0.000_30,    # gemini-2.5-flash output
+    "tier3": 0.005_00,    # gemini-2.5-pro output
 }
+
+# Pricing matrix — per 1M tokens, USD. Keep this in sync with
+# https://ai.google.dev/pricing as Google updates Gemini prices.
+# When a new model is added, add an entry here AND update
+# core/billing/spend.py if the model name introduces a new prefix.
+GEMINI_PRICE_PER_1M: dict[str, dict[str, float]] = {
+    # Flash-Lite (cheapest)
+    "gemini-2.5-flash-lite": {"input": 0.04, "output": 0.10},
+    # Flash (mid)
+    "gemini-2.5-flash": {"input": 0.075, "output": 0.30},
+    "gemini-2.5-flash-preview-05-20": {"input": 0.075, "output": 0.30},
+    # Pro (heavy)
+    "gemini-2.5-pro": {"input": 1.25, "output": 5.00},
+    "gemini-2.0-flash": {"input": 0.10, "output": 0.40},
+}
+
+
+def gemini_cost_usd(model: str, input_tokens: int, output_tokens: int) -> float:
+    """Return USD cost for a single Gemini call.
+
+    Falls back to the Flash price when the model is unknown — the
+    fallback is intentionally non-zero so an unknown model never
+    silently writes ``cost_usd=0`` (which would make budget alerts
+    blind to that traffic). The unknown-model log line lets ops
+    catch the gap and add a row to ``GEMINI_PRICE_PER_1M``.
+    """
+    if model in GEMINI_PRICE_PER_1M:
+        rates = GEMINI_PRICE_PER_1M[model]
+    else:
+        logger.warning("gemini_unknown_model_pricing", model=model)
+        rates = GEMINI_PRICE_PER_1M["gemini-2.5-flash"]
+    return (
+        input_tokens * rates["input"] + output_tokens * rates["output"]
+    ) / 1_000_000
+
+
+# ---------------------------------------------------------------------------
+# Hard daily cap (env-tunable)
+# ---------------------------------------------------------------------------
+
+
+class DailyBudgetExceeded(RuntimeError):  # noqa: N818 — surface name; "Error" suffix would be redundant
+    """Raised when today's Gemini spend has hit ``AGENTICORG_GEMINI_DAILY_USD_CAP``.
+
+    Surfaced as HTTP 429 by the API layer. Protects against runaway
+    workflows / shadow-batches that would otherwise keep spending
+    past the daily budget alert.
+    """
+
+
+def _gemini_daily_cap_usd() -> float:
+    """Return the configured daily cap. Default $10."""
+    raw = (os.getenv("AGENTICORG_GEMINI_DAILY_USD_CAP") or "10.0").strip()
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "gemini_daily_cap_invalid",
+            value=raw,
+            using_default=10.0,
+        )
+        return 10.0
+
+
+async def _todays_gemini_spend_usd() -> float:
+    """Sum today's (UTC) ``cost_usd`` from ``agent_task_results``.
+
+    Read-only, single SELECT. Falls back to 0.0 on any DB error so
+    a transient DB blip doesn't block every request — the tradeoff
+    is that the cap can lag during the blip, but loud refusal would
+    be worse than a brief overshoot.
+    """
+    try:
+        from datetime import UTC, datetime
+
+        from sqlalchemy import text as _text
+
+        from core.database import async_session_factory
+
+        utc_today = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+        async with async_session_factory() as session:
+            row = (await session.execute(
+                _text(
+                    "SELECT COALESCE(SUM(cost_usd), 0) FROM agent_task_results "
+                    "WHERE created_at >= :since AND llm_model LIKE 'gemini%'"
+                ),
+                {"since": utc_today},
+            )).scalar_one()
+        return float(row or 0.0)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("gemini_daily_spend_lookup_failed", error=str(exc))
+        return 0.0
+
+
+async def assert_under_gemini_cap(estimated_cost_usd: float = 0.0) -> None:
+    """Refuse the call when today's spend + estimate would exceed the cap.
+
+    Call sites: :class:`LLMRouter._call_gemini` invokes this BEFORE
+    making the upstream API call so we never mint a charge that
+    pushes us past the cap. Set the cap to ``0`` to disable.
+    """
+    cap = _gemini_daily_cap_usd()
+    if cap <= 0:
+        return
+    spent = await _todays_gemini_spend_usd()
+    if spent + estimated_cost_usd >= cap:
+        raise DailyBudgetExceeded(
+            f"Gemini daily spend cap reached: spent ${spent:.4f} of "
+            f"${cap:.2f}/day. Set AGENTICORG_GEMINI_DAILY_USD_CAP higher "
+            "or wait for the UTC day to roll over."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -306,10 +438,17 @@ class LLMRouter:
     async def _call_gemini(self, model, messages, temperature, max_tokens, start) -> LLMResponse:
         """Call Google Gemini via the google.genai SDK.
 
-        Free tier: 15 RPM, 1M tokens/day for Flash.
-        Cost beyond free tier: Flash $0.075/1M input, $0.30/1M output.
+        Free tier: 15 RPM, 1M tokens/day for Flash and Flash-Lite.
+        Cost beyond free tier: see ``GEMINI_PRICE_PER_1M``.
+
+        Refuses the call when today's spend has already hit
+        ``AGENTICORG_GEMINI_DAILY_USD_CAP`` (default $10/day) so a
+        runaway workflow can't keep charging past the budget.
         """
         from google import genai
+
+        # Hard daily cap — fail-closed BEFORE we mint a new charge.
+        await assert_under_gemini_cap()
 
         client = genai.Client(api_key=external_keys.google_gemini_api_key)
 
@@ -345,11 +484,10 @@ class LLMRouter:
         output_tokens = getattr(usage, "candidates_token_count", 0) or 0
         total_tokens = input_tokens + output_tokens
 
-        # Cost (Gemini Flash pricing — free tier covers most pre-customer usage)
-        if "flash" in model:
-            cost = (input_tokens * 0.075 + output_tokens * 0.30) / 1_000_000
-        else:
-            cost = (input_tokens * 1.25 + output_tokens * 5.0) / 1_000_000
+        # Cost — looked up from GEMINI_PRICE_PER_1M so flash-lite,
+        # flash, and pro each get their actual price (the previous
+        # branch counted flash-lite at flash prices, ~2x reality).
+        cost = gemini_cost_usd(model, input_tokens, output_tokens)
 
         return LLMResponse(
             content=response.text,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,11 @@ extend-immutable-calls = ["fastapi.Depends", "Depends"]
 [tool.ruff.lint.per-file-ignores]
 "scripts/*" = ["E501", "I001", "DTZ011", "B007", "B905", "F841"]
 "migrations/*" = ["I001", "E501"]
+# Spend reporter builds aggregate SQL with column names from
+# argparse-validated values (period names, provider prefixes). All
+# user input arrives as bind parameters; ruff S608 flags any
+# f-string in a SQL context regardless.
+"core/billing/spend.py" = ["S608"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tests/regression/test_llm_router_spend_cap.py
+++ b/tests/regression/test_llm_router_spend_cap.py
@@ -1,0 +1,174 @@
+"""Regression tests for the 3-tier Gemini router + spend cap + CLI.
+
+Pin the contracts:
+
+  1. CLOUD_TIERS routes high-volume traffic to flash-lite (tier1).
+  2. ``GEMINI_PRICE_PER_1M`` lists current per-1M USD rates.
+  3. ``gemini_cost_usd`` falls back to flash pricing for unknown
+     models — never silently zero (would blind budget alerts).
+  4. ``DailyBudgetExceeded`` fires when today's spend would exceed
+     ``AGENTICORG_GEMINI_DAILY_USD_CAP``.
+  5. The cap defaults to $10.
+  6. ``core.billing.spend`` CLI exposes ``--period``, ``--provider``,
+     ``--top-tenants``, ``--json``, ``--reconcile-gcp``.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+def test_tier1_default_is_flash_lite() -> None:
+    """Tier1 must be the cheapest model — flash-lite.
+
+    Regressing this would silently route high-volume calls back to
+    flash, ~2x the per-token cost.
+    """
+    from core.llm.router import CLOUD_TIERS
+
+    assert CLOUD_TIERS["tier1"] == "gemini-2.5-flash-lite", (
+        f"tier1 must default to gemini-2.5-flash-lite, got {CLOUD_TIERS['tier1']!r}"
+    )
+    assert CLOUD_TIERS["tier2"] == "gemini-2.5-flash"
+    assert CLOUD_TIERS["tier3"] == "gemini-2.5-pro"
+
+
+def test_pricing_table_includes_flash_lite_and_pro() -> None:
+    from core.llm.router import GEMINI_PRICE_PER_1M
+
+    for model in (
+        "gemini-2.5-flash-lite",
+        "gemini-2.5-flash",
+        "gemini-2.5-pro",
+    ):
+        assert model in GEMINI_PRICE_PER_1M, (
+            f"missing pricing for {model} — cost calc will fall back to flash"
+        )
+        rates = GEMINI_PRICE_PER_1M[model]
+        assert rates["input"] > 0
+        assert rates["output"] > rates["input"], (
+            f"{model}: output rate must exceed input rate (Gemini pricing convention)"
+        )
+
+    flash_lite = GEMINI_PRICE_PER_1M["gemini-2.5-flash-lite"]
+    flash = GEMINI_PRICE_PER_1M["gemini-2.5-flash"]
+    pro = GEMINI_PRICE_PER_1M["gemini-2.5-pro"]
+    assert flash_lite["input"] < flash["input"], (
+        "flash-lite must be cheaper than flash on input"
+    )
+    assert flash["input"] < pro["input"], (
+        "flash must be cheaper than pro on input"
+    )
+
+
+def test_gemini_cost_usd_uses_known_pricing() -> None:
+    from core.llm.router import gemini_cost_usd
+
+    # 1M input + 1M output at flash-lite rates ($0.04 + $0.10)
+    cost = gemini_cost_usd("gemini-2.5-flash-lite", 1_000_000, 1_000_000)
+    assert cost == pytest.approx(0.14, abs=0.005)
+
+    # 1M input + 1M output at pro rates ($1.25 + $5.00)
+    cost_pro = gemini_cost_usd("gemini-2.5-pro", 1_000_000, 1_000_000)
+    assert cost_pro == pytest.approx(6.25, abs=0.05)
+
+
+def test_gemini_cost_usd_unknown_model_falls_back_nonzero() -> None:
+    """Unknown model must NEVER return 0 — that would blind budget alerts."""
+    from core.llm.router import gemini_cost_usd
+
+    cost = gemini_cost_usd("gemini-3.0-experimental", 1_000_000, 1_000_000)
+    assert cost > 0, "unknown model must fall back to a non-zero rate"
+
+
+def test_daily_cap_defaults_to_10_usd(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGENTICORG_GEMINI_DAILY_USD_CAP", raising=False)
+    from core.llm.router import _gemini_daily_cap_usd
+
+    assert _gemini_daily_cap_usd() == 10.0
+
+
+def test_daily_cap_respects_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTICORG_GEMINI_DAILY_USD_CAP", "2.5")
+    from core.llm.router import _gemini_daily_cap_usd
+
+    assert _gemini_daily_cap_usd() == 2.5
+
+
+def test_daily_cap_invalid_value_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bad value in env shouldn't disable the cap entirely."""
+    monkeypatch.setenv("AGENTICORG_GEMINI_DAILY_USD_CAP", "not-a-number")
+    from core.llm.router import _gemini_daily_cap_usd
+
+    assert _gemini_daily_cap_usd() == 10.0
+
+
+def test_daily_cap_zero_disables_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Allow ops to disable the cap with `=0` for emergency burst capacity."""
+    import asyncio
+
+    monkeypatch.setenv("AGENTICORG_GEMINI_DAILY_USD_CAP", "0")
+    from core.llm.router import assert_under_gemini_cap
+
+    # Must not raise even with no DB / no spend lookup.
+    asyncio.run(assert_under_gemini_cap())
+
+
+def test_assert_under_gemini_cap_raises_when_over(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When today's spend already meets the cap, refuse new calls."""
+    import asyncio
+
+    monkeypatch.setenv("AGENTICORG_GEMINI_DAILY_USD_CAP", "5.0")
+
+    async def _fake_spent() -> float:
+        return 5.0
+
+    with patch("core.llm.router._todays_gemini_spend_usd", new=_fake_spent):
+        from core.llm.router import DailyBudgetExceeded, assert_under_gemini_cap
+
+        with pytest.raises(DailyBudgetExceeded):
+            asyncio.run(assert_under_gemini_cap())
+
+
+def test_spend_cli_help_documents_flags() -> None:
+    """Operators script around these flags — keep them stable."""
+    from core.billing.spend import main
+
+    captured = io.StringIO()
+    sys.stdout = captured
+    try:
+        with pytest.raises(SystemExit) as exc:
+            main(["--help"])
+    finally:
+        sys.stdout = sys.__stdout__
+    out = captured.getvalue()
+    assert exc.value.code == 0
+    for token in (
+        "--period",
+        "--provider",
+        "--top-tenants",
+        "--json",
+        "--reconcile-gcp",
+    ):
+        assert token in out, f"spend --help must document {token}"
+
+
+def test_spend_cli_period_choices() -> None:
+    """Enforce daily / weekly / monthly periods."""
+    from core.billing.spend import main
+
+    sys.stderr = io.StringIO()
+    try:
+        with pytest.raises(SystemExit) as exc:
+            main(["--period=hourly"])  # invalid
+        assert exc.value.code != 0
+    finally:
+        sys.stderr = sys.__stderr__

--- a/tests/unit/test_llm_router.py
+++ b/tests/unit/test_llm_router.py
@@ -35,28 +35,31 @@ def _make_router(
 
 
 # ===================================================================
-# TC-LLM-01: Simple query routes to Tier 1 (Gemini Flash)
+# TC-LLM-01: Simple query routes to Tier 1 (Gemini Flash-Lite)
 # ===================================================================
+# Tier1 was gemini-2.5-flash before the spend-cap PR; the rework
+# moves Flash to Tier2 and uses Flash-Lite for high-volume Tier1
+# traffic so per-token cost on the cheapest path drops ~2x.
 
 
 class TestSimpleQueryRoutesToTier1:
-    """Short / simple queries should route to Tier 1 (Gemini Flash)."""
+    """Short / simple queries should route to Tier 1 (Gemini Flash-Lite)."""
 
     def test_short_query_routes_to_tier1(self):
         router = _make_router(routing="auto", llm_mode="cloud")
         model = router.route(query="What is 2+2?", config={})
-        assert model == "gemini-2.5-flash", f"Expected tier1 model, got {model}"
+        assert model == "gemini-2.5-flash-lite", f"Expected tier1 model, got {model}"
 
     def test_very_short_query(self):
         router = _make_router(routing="auto", llm_mode="cloud")
         model = router.route(query="Hello", config={})
-        assert model == "gemini-2.5-flash"
+        assert model == "gemini-2.5-flash-lite"
 
     def test_empty_query_routes_to_tier1(self):
         """Empty string < 100 chars -> tier1."""
         router = _make_router(routing="auto", llm_mode="cloud")
         model = router.route(query="", config={})
-        assert model == "gemini-2.5-flash"
+        assert model == "gemini-2.5-flash-lite"
 
 
 # ===================================================================
@@ -95,7 +98,7 @@ class TestComplexQueryRoutesToTier3:
         )
         assert 100 <= len(medium_query) < 500
         model = router.route(query=medium_query, config={})
-        assert model == "gemini-2.5-pro"
+        assert model == "gemini-2.5-flash"
 
 
 # ===================================================================
@@ -110,19 +113,18 @@ class TestForcedTierOverridesAuto:
         router = _make_router(routing="tier1", llm_mode="cloud")
         long_query = "x" * 600  # Would be tier3 in auto mode
         model = router.route(query=long_query, config={})
-        assert model == "gemini-2.5-flash"
+        assert model == "gemini-2.5-flash-lite"
 
     def test_force_tier2(self):
         router = _make_router(routing="tier2", llm_mode="cloud")
         model = router.route(query="Hi", config={})  # Would be tier1 in auto
-        assert model == "gemini-2.5-pro"
+        assert model == "gemini-2.5-flash"
 
     def test_force_tier3_on_simple_query(self):
         router = _make_router(routing="tier3", llm_mode="cloud")
         model = router.route(query="Hi", config={})
-        # Tier 3 model (not gemini-flash)
-        assert model != "gemini-2.5-flash"
-        assert model != "gemini-2.5-pro"
+        # Tier 3 = pro after the spend-cap rework.
+        assert model == "gemini-2.5-pro"
 
     def test_per_agent_config_overrides_global(self):
         """Agent-level routing config should override the global setting."""
@@ -131,7 +133,8 @@ class TestForcedTierOverridesAuto:
             query="Hi",
             config={"routing": "tier3"},
         )
-        assert model != "gemini-2.5-flash"
+        # tier3 -> gemini-2.5-pro, definitely not the tier1 flash-lite.
+        assert model == "gemini-2.5-pro"
 
     def test_per_agent_tier1_overrides_global_tier3(self):
         router = _make_router(routing="tier3", llm_mode="cloud")
@@ -139,7 +142,7 @@ class TestForcedTierOverridesAuto:
             query="Analyze this complex legal document...",
             config={"routing": "tier1"},
         )
-        assert model == "gemini-2.5-flash"
+        assert model == "gemini-2.5-flash-lite"
 
 
 # ===================================================================
@@ -262,20 +265,20 @@ class TestFallbackWhenRouteLLMUnavailable:
         """Without RouteLLM, short queries use heuristic -> tier1."""
         router = _make_router(routing="auto", llm_mode="cloud", routellm_available=False)
         model = router.route(query="Hi", config={})
-        assert model == "gemini-2.5-flash"
+        assert model == "gemini-2.5-flash-lite"
 
     def test_heuristic_fallback_medium(self):
         router = _make_router(routing="auto", llm_mode="cloud", routellm_available=False)
         medium = "a" * 200
         model = router.route(query=medium, config={})
-        assert model == "gemini-2.5-pro"
+        assert model == "gemini-2.5-flash"
 
     def test_heuristic_fallback_long(self):
         router = _make_router(routing="auto", llm_mode="cloud", routellm_available=False)
         long_q = "b" * 600
         model = router.route(query=long_q, config={})
-        assert model != "gemini-2.5-flash"
-        assert model != "gemini-2.5-pro"
+        # Tier3 = pro after the spend-cap rework.
+        assert model == "gemini-2.5-pro"
 
     def test_routellm_import_failure_does_not_crash(self):
         """Even if RouteLLM import raises, the module should load fine."""
@@ -294,8 +297,8 @@ class TestFallbackWhenRouteLLMUnavailable:
         router._routellm_init_attempted = True
         router._routellm_controller = None
         model = router.route(query="Quick question", config={})
-        # Should use heuristic, not crash
-        assert model == "gemini-2.5-flash"
+        # Heuristic short-query path -> tier1 -> flash-lite.
+        assert model == "gemini-2.5-flash-lite"
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

Closes the platform-LLM-spend gaps the user flagged in the 26-Apr session: per-model breakdown was buried, no hard cap existed, and the local cost calc had drifted from actual Gemini pricing.

## What changes

### 1. Tier mapping shifted by one slot
\`\`\`
        BEFORE                  AFTER
tier1   gemini-2.5-flash    →   gemini-2.5-flash-lite   (~2x cheaper)
tier2   gemini-2.5-pro      →   gemini-2.5-flash
tier3   claude-sonnet-4     →   gemini-2.5-pro
\`\`\`
High-volume classify/extract calls land at the cheapest model. \`AGENTICORG_LLM_TIER{1,2,3}\` env vars override.

### 2. \`GEMINI_PRICE_PER_1M\` authoritative pricing table
Previous \`if "flash" in model\` branch counted flash-lite at flash prices (~2x reality). New \`gemini_cost_usd()\` reads the table; falls back to flash for unknown models — never silently zero (so budget alerts can't be blinded by an unrecognised model).

### 3. Hard daily cap — default **\$10/day**
\`\`\`python
class DailyBudgetExceeded(RuntimeError):
    \"\"\"Raised when today's Gemini spend has hit AGENTICORG_GEMINI_DAILY_USD_CAP.\"\"\"

await assert_under_gemini_cap()  # called BEFORE every Gemini API call
\`\`\`
Set \`AGENTICORG_GEMINI_DAILY_USD_CAP=0\` to disable (NOT recommended). Protects against runaway shadow-batches / workflow loops.

### 4. \`python -m core.billing.spend\` CLI
Platform-wide spend report:
\`\`\`
python -m core.billing.spend --period=daily --provider=gemini
python -m core.billing.spend --period=monthly --top-tenants=10 --json
python -m core.billing.spend --period=daily --reconcile-gcp
\`\`\`
Aggregates \`agent_task_results.cost_usd\` by model + by tenant. \`--reconcile-gcp\` reads the BigQuery billing-export table (\`AGENTICORG_GCP_BILLING_BQ_TABLE\`) and prints local-vs-GCP divergence so ops can catch when the static pricing table drifts from Google's actual billing.

## Test plan
- [x] 11 new regression tests in \`tests/regression/test_llm_router_spend_cap.py\` pass
- [x] 33 existing \`tests/unit/test_llm_router.py\` tests updated for new tier mapping, all pass
- [x] Preflight green (ruff + bandit + alembic + pytest + ui tsc + ui build + module coverage + critical-path tags)

## Files
- \`core/llm/router.py\` — \`GEMINI_PRICE_PER_1M\`, \`gemini_cost_usd()\`, \`DailyBudgetExceeded\`, \`assert_under_gemini_cap()\`, tier1=flash-lite
- \`core/billing/spend.py\` — platform-wide spend CLI + GCP reconcile mode
- \`tests/regression/test_llm_router_spend_cap.py\` — 11 contract tests
- \`tests/unit/test_llm_router.py\` — updated assertions for new tier mapping
- \`pyproject.toml\` — S608 ignore for \`core/billing/spend.py\`

## Out of scope
- A scheduled cron that runs \`spend.py --reconcile-gcp\` and pages on divergence > 20% — follow-up.
- Per-tenant hard cap (today's cap is platform-wide). Per-tenant alerts already exist via \`BudgetAlert\` — hard caps would extend that surface.

@codex please review.