### PR TITLE
feat(rag): TEI dispatch path — dedicated embeddings service (Option B)

### DIFF
--- a/core/embeddings.py
+++ b/core/embeddings.py
@@ -209,12 +209,23 @@ def _get_bge_m3_model() -> Any:
 def embed_bge_m3(texts: list[str], batch_size: int = 32) -> list[list[float]]:
     """Embed ``texts`` with bge-m3 (1024-dim, multilingual, 8192 ctx).
 
+    Routing:
+      - When ``AGENTICORG_TEI_URL`` is set, POST to that TEI service
+        (HuggingFace text-embeddings-inference) — recommended for the
+        request path so the api container does NOT need to hold the
+        2.3 GB weights in memory.
+      - Otherwise load FlagEmbedding in-process — used by the backfill
+        Cloud Run job (which can afford the 16 GiB peak memory) and
+        by local development.
+
     Returns dense vectors only — bge-m3 also produces sparse and
     multi-vector outputs but the request path uses pgvector dense
     cosine search, so the other modes are not exposed here.
     """
     if not texts:
         return []
+    if os.getenv("AGENTICORG_TEI_URL"):
+        return _embed_via_tei(texts)
     model = _get_bge_m3_model()
     out = model.encode(
         texts,
@@ -226,6 +237,44 @@ def embed_bge_m3(texts: list[str], batch_size: int = 32) -> list[list[float]]:
     )
     dense = out["dense_vecs"]
     return [list(map(float, v)) for v in dense]
+
+
+def _embed_via_tei(texts: list[str]) -> list[list[float]]:
+    """POST ``texts`` to the configured TEI service.
+
+    The TEI service runs as a separate Cloud Run service
+    (``agenticorg-embeddings``) at ``min-instances=1`` so the bge-m3
+    weights live there permanently and the api container stays at
+    2 GiB. Cloud Run's invoker IAM is enforced via an ID token signed
+    by the api's service account audience-bound to the TEI service URL.
+
+    The TEI ``/embed`` endpoint shape:
+        request:  {"inputs": ["t1", "t2"], "normalize": true}
+        response: [[v1...], [v2...]]
+    """
+    import google.auth
+    import google.auth.transport.requests
+    import httpx
+    from google.oauth2 import id_token
+
+    base = os.environ["AGENTICORG_TEI_URL"].rstrip("/")
+    # Mint an audience-bound ID token. Falls back to anonymous if no
+    # GCP creds are available (dev / test environments where TEI is
+    # exposed via --allow-unauthenticated).
+    headers = {"Content-Type": "application/json"}
+    try:
+        auth_req = google.auth.transport.requests.Request()
+        token = id_token.fetch_id_token(auth_req, base)
+        headers["Authorization"] = f"Bearer {token}"
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("tei_id_token_fetch_skipped", error=str(exc))
+
+    payload = {"inputs": texts, "normalize": True, "truncate": True}
+    with httpx.Client(timeout=httpx.Timeout(60.0, connect=10.0)) as client:
+        response = client.post(f"{base}/embed", json=payload, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+    return [list(map(float, v)) for v in data]
 
 
 # Compatibility shim for the backfill — keeps the call site model-name

--- a/tests/regression/test_tei_embeddings_client.py
+++ b/tests/regression/test_tei_embeddings_client.py
@@ -1,0 +1,110 @@
+"""Regression tests for the TEI embeddings dispatch path.
+
+After PR #324 landed and the in-process FlagEmbedding flag flip OOM-
+killed agenticorg-api at 2 GiB (autopsy:
+``bge_m3_rollout_26apr_a_failed.md``), the request path now calls a
+dedicated TEI Cloud Run service when ``AGENTICORG_TEI_URL`` is set.
+The api container stays at 2 GiB; bge-m3 weights live in the
+``agenticorg-embeddings`` service.
+
+Pin the contracts:
+
+  1. ``embed_bge_m3`` routes through TEI when ``AGENTICORG_TEI_URL``
+     is set (no FlagEmbedding import).
+  2. ``embed_bge_m3`` falls back to FlagEmbedding when the env var
+     is unset (used by the backfill Cloud Run job).
+  3. The HTTP payload uses TEI's ``inputs`` + ``normalize`` keys.
+  4. Empty input short-circuits without an HTTP call.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_empty_input_short_circuits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty list returns ``[]`` without touching httpx."""
+    monkeypatch.setenv("AGENTICORG_TEI_URL", "http://example/tei")
+    from core.embeddings import embed_bge_m3
+
+    with patch("httpx.Client") as client:
+        out = embed_bge_m3([])
+    assert out == []
+    client.assert_not_called()
+
+
+def test_routes_via_tei_when_env_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Setting ``AGENTICORG_TEI_URL`` switches to the HTTP path."""
+    monkeypatch.setenv("AGENTICORG_TEI_URL", "http://example/tei")
+    from core import embeddings as emb
+
+    expected = [[0.5] * 1024, [0.25] * 1024]
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = expected
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = MagicMock()
+    mock_client.__enter__.return_value.post.return_value = mock_response
+
+    with (
+        patch("httpx.Client", return_value=mock_client),
+        # Mocking out auth so the test runs without GCP creds.
+        patch("google.oauth2.id_token.fetch_id_token", return_value="fake-id-token"),
+    ):
+        out = emb.embed_bge_m3(["hello", "world"])
+    assert out == expected
+    # Verify the HTTP shape — keys TEI expects.
+    post_call = mock_client.__enter__.return_value.post
+    args, kwargs = post_call.call_args
+    assert args[0].endswith("/embed")
+    assert kwargs["json"]["inputs"] == ["hello", "world"]
+    assert kwargs["json"]["normalize"] is True
+    assert kwargs["headers"]["Authorization"].startswith("Bearer ")
+
+
+def test_falls_back_to_flagembedding_without_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No ``AGENTICORG_TEI_URL`` — must use the in-process loader path."""
+    monkeypatch.delenv("AGENTICORG_TEI_URL", raising=False)
+    from core import embeddings as emb
+
+    fake_model = MagicMock()
+    fake_model.encode.return_value = {"dense_vecs": [[0.1] * 1024]}
+
+    with patch.object(emb, "_get_bge_m3_model", return_value=fake_model):
+        out = emb.embed_bge_m3(["hello"])
+    assert len(out) == 1
+    assert len(out[0]) == 1024
+    fake_model.encode.assert_called_once()
+
+
+def test_anonymous_fallback_when_id_token_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ID-token fetch failure must not crash — TEI may run with
+    --allow-unauthenticated in dev / test envs.
+    """
+    monkeypatch.setenv("AGENTICORG_TEI_URL", "http://example/tei")
+    from core import embeddings as emb
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = [[0.0] * 1024]
+    mock_response.raise_for_status.return_value = None
+    mock_client = MagicMock()
+    mock_client.__enter__.return_value.post.return_value = mock_response
+
+    with (
+        patch("httpx.Client", return_value=mock_client),
+        patch(
+            "google.oauth2.id_token.fetch_id_token",
+            side_effect=RuntimeError("no creds"),
+        ),
+    ):
+        out = emb.embed_bge_m3(["hello"])
+    assert len(out[0]) == 1024
+    headers = mock_client.__enter__.return_value.post.call_args.kwargs["headers"]
+    assert "Authorization" not in headers


### PR DESCRIPTION
## Summary

After PR #324 the in-process FlagEmbedding flag flip OOM-killed agenticorg-api at 2 GiB on the first \`/knowledge/search\` call (autopsy: \`bge_m3_rollout_26apr_a_failed.md\`). bge-m3 needs ~9-10 GiB peak load which doesn't fit Cloud Run's 2 GiB envelope, and bumping api memory to 16 GiB always-on costs ~$90/mo.

This wires a third dispatch in \`embed_bge_m3()\`: when \`AGENTICORG_TEI_URL\` is set, POST to a dedicated text-embeddings-inference Cloud Run service (\`agenticorg-embeddings\`) at min-instances=1. The api stays at 2 GiB; bge-m3 weights live in the embeddings service. Estimated ongoing cost: ~$55/mo (vs $90/mo for in-process at 16 GiB).

The FlagEmbedding fallback stays for the backfill Cloud Run job (which runs at 16 GiB for the burst load) and local dev.

## Architecture

Full topology + the two env-var levers documented in memory \`bge_m3_architecture.md\`. Summary:

| Caller | Loads bge-m3? | Env |
|--------|---------------|-----|
| agenticorg-api (request path) | NO — HTTP only | \`AGENTICORG_TEI_URL=https://agenticorg-embeddings-...run.app\` |
| agenticorg-bge-m3-backfill job | YES — in-process FlagEmbedding | \`AGENTICORG_TEI_URL\` UNSET, 16 GiB memory |

## Auth

\`google.oauth2.id_token.fetch_id_token\` audience-bound to the TEI service URL, signed by the api's service account. TEI is \`--no-allow-unauthenticated\`. Anonymous fallback when fetch_id_token fails so dev/test envs with \`--allow-unauthenticated\` TEI still work.

## Test plan
- [x] 4 new regression tests in \`tests/regression/test_tei_embeddings_client.py\` pass
- [x] Existing 31 PR-A tests still pass
- [x] Preflight green (ruff + bandit + alembic + pytest + ui tsc + ui build + module-coverage + critical-path tags)

## Out of scope
- Setting \`AGENTICORG_TEI_URL\` on the api Cloud Run service — done manually after merge alongside re-flipping \`AGENTICORG_RAG_USE_BGE_M3=true\`.

@codex please review.