### PR TITLE
infra: TEI bge-m3-baked image (Option D — min=0, ~/usr/bin/bash-5/mo)

### DIFF
--- a/Dockerfile.tei.baked
+++ b/Dockerfile.tei.baked
@@ -1,0 +1,37 @@
+# Pre-bake BAAI/bge-m3 ONNX weights into the TEI image so cold starts
+# skip the ~150s HuggingFace Hub download. Combined with min-instances=0
+# this drops the embeddings service ongoing cost from ~$55/mo (always-on
+# at 16 GiB) to ~$0-5/mo (idle is $0; only pay during /embed bursts).
+#
+# Cold start cost trade: still ~30-60s for ONNX load + warmup before
+# the first request after idle. Acceptable for /knowledge/search which
+# isn't a hot path.
+#
+# Layout: huggingface-cli download --local-dir lays out files under
+# /model/{onnx,1_Pooling,...}. TEI accepts --model-id /model directly,
+# bypassing the HF cache lookup entirely.
+
+FROM python:3.12-slim AS downloader
+# huggingface_hub 1.12+ deprecated `huggingface-cli` in favour of `hf`.
+RUN pip install --no-cache-dir 'huggingface_hub[cli]>=1.12.0'
+# Only the ONNX backend files — skip pytorch_model.bin (~2.3 GB) and
+# the colbert/sparse heads we don't use. This keeps the image lean.
+RUN hf download BAAI/bge-m3 \
+    --local-dir /model \
+    onnx/model.onnx \
+    onnx/model.onnx_data \
+    config.json \
+    config_sentence_transformers.json \
+    sentence_bert_config.json \
+    tokenizer.json \
+    tokenizer_config.json \
+    special_tokens_map.json \
+    1_Pooling/config.json
+
+FROM asia-south1-docker.pkg.dev/perfect-period-305406/agenticorg/text-embeddings-inference:cpu-latest
+COPY --from=downloader /model /model
+# Cloud Run service args still pass --model-id, but we override the
+# default here so a typo in the service args still finds the baked
+# weights. Cloud Run --args replaces this CMD entirely though, so
+# keep the args list in `gcloud run deploy` in sync.
+CMD ["--model-id=/model", "--port=80", "--hostname=0.0.0.0"]

--- a/cloudbuild-api.yaml
+++ b/cloudbuild-api.yaml
@@ -1,0 +1,18 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - -f
+      - Dockerfile
+      - -t
+      - $_IMAGE
+      - .
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - $_IMAGE
+substitutions:
+  _IMAGE: asia-south1-docker.pkg.dev/perfect-period-305406/agenticorg/agenticorg:rebuild
+options:
+  machineType: E2_HIGHCPU_8
+timeout: 1500s

--- a/cloudbuild-tei-baked.yaml
+++ b/cloudbuild-tei-baked.yaml
@@ -1,0 +1,18 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - -f
+      - Dockerfile.tei.baked
+      - -t
+      - $_IMAGE
+      - .
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - $_IMAGE
+substitutions:
+  _IMAGE: asia-south1-docker.pkg.dev/perfect-period-305406/agenticorg/text-embeddings-inference:bge-m3-baked
+options:
+  machineType: E2_HIGHCPU_8
+timeout: 1500s

--- a/cloudbuild-tei-mirror.yaml
+++ b/cloudbuild-tei-mirror.yaml
@@ -1,0 +1,14 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        docker pull ghcr.io/huggingface/text-embeddings-inference:cpu-1.7 && \
+        docker tag ghcr.io/huggingface/text-embeddings-inference:cpu-1.7 $_IMAGE && \
+        docker push $_IMAGE
+substitutions:
+  _IMAGE: asia-south1-docker.pkg.dev/perfect-period-305406/agenticorg/text-embeddings-inference:cpu-1.7
+options:
+  machineType: E2_HIGHCPU_8
+timeout: 600s


### PR DESCRIPTION
## Summary

Option D rollout (replaces the always-on Option B at ~\$55/mo). Pre-bakes \`BAAI/bge-m3\` ONNX weights into the TEI image so the embeddings service can run \`min-instances=0\` without paying the ~150s HF Hub download on every cold start.

## Cost shape

| Component | Idle | Active | Monthly est |
|-----------|------|--------|-------------|
| agenticorg-embeddings (16 GiB, **min=0**) | **\$0** | per-burst | **\$0-5** |
| (was: min=1) | \$52 | n/a | \$55 |

Net monthly delta: **-\$50** for the embeddings tier.

## Files

- \`Dockerfile.tei.baked\` — multi-stage: \`hf download\` into /model, then COPY into TEI image
- \`cloudbuild-tei-baked.yaml\` — build config
- \`cloudbuild-tei-mirror.yaml\` — kept around for the upstream ghcr→GAR mirror
- \`cloudbuild-api.yaml\` — api Cloud Build wrapper

## Live state

- \`agenticorg-embeddings\` rev \`00007-hlz\` running \`tei:bge-m3-baked\`, min=0
- Smoke \`/embed\` returned HTTP 200, 1024-dim vector
- \`/knowledge/search\` end-to-end works via the api → TEI dispatch chain

## Path-mangling gotcha (memory: bge_m3_architecture.md)

\`gcloud run deploy --args=--model-id=/model\` MUST be invoked from PowerShell on Windows. Git Bash's MSYS layer translates \`/model\` into \`C:/Program Files/Git/model\` and TEI tries to fetch it as an HF Hub repo (404 → container fails to start).

## Test plan
- [x] Cloud Build succeeded (\`fc707378-341e-4403-a1aa-4e81bd1b23dd\`)
- [x] Cloud Run revision \`00007-hlz\` deploys cleanly
- [x] \`/embed\` smoke returns 1024-dim vector
- [x] Preflight green (no code changes — config files only, but full preflight ran)

@codex please review.