### PR TITLE
feat(crypto): rewrap cache invalidation hook (Foundation #4 iter 4)

### DIFF
--- a/core/crypto/rewrap.py
+++ b/core/crypto/rewrap.py
@@ -62,7 +62,7 @@ from core.crypto.credential_vault import (
     decrypt_credential,
     encrypt_credential,
 )
-from core.crypto.verify_all import _SCANNERS
+from core.crypto.verify_all import _CACHE_INVALIDATORS, _SCANNERS
 from core.database import async_session_factory
 
 logger = structlog.get_logger()
@@ -100,6 +100,43 @@ def _split_column_label(label: str) -> tuple[str, str]:
         raise ValueError(f"rewrap: column label missing '.': {label!r}")
     table, column = label.split(".", 1)
     return table, column
+
+
+def _fire_cache_invalidators(label: str) -> None:
+    """Run every cache-invalidator registered for ``label``.
+
+    Each invalidator is a ``"module.path:callable"`` string. We import
+    on demand so verify_all/rewrap stay importable in environments
+    where the consuming module isn't loaded (CLI before app startup).
+    Errors are logged but never block the rewrap — the worst case is
+    callers get cached plaintext for up to one TTL window after
+    rewrap completes, which is the same as the pre-iter-4 baseline.
+    """
+    for dotted in _CACHE_INVALIDATORS.get(label, []):
+        try:
+            mod_path, attr = dotted.split(":", 1)
+            mod = __import__(mod_path, fromlist=[attr])
+            callable_obj = getattr(mod, attr, None)
+            if callable(callable_obj):
+                callable_obj()
+                logger.info(
+                    "rewrap_cache_invalidated",
+                    column=label,
+                    invalidator=dotted,
+                )
+            else:
+                logger.warning(
+                    "rewrap_cache_invalidator_not_callable",
+                    column=label,
+                    invalidator=dotted,
+                )
+        except Exception as exc:
+            logger.warning(
+                "rewrap_cache_invalidator_failed",
+                column=label,
+                invalidator=dotted,
+                error=str(exc),
+            )
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -285,6 +322,7 @@ async def run(
 
     written = 0
     started = time.monotonic()
+    touched_columns: set[str] = set()
     for label, _dotted in columns:
         while True:
             async with async_session_factory() as session:
@@ -297,6 +335,7 @@ async def run(
                 )
                 if not rows:
                     break
+                touched_columns.add(label)
                 for row_id, raw in rows:
                     ct = _extract_ciphertext(label, raw)
                     if ct is None:
@@ -340,6 +379,11 @@ async def run(
                 f"(rate={rate:.1f} rows/s)",
                 file=sys.stderr,
             )
+    # Foundation #4 iter 4: flush downstream credential caches for any
+    # column we actually wrote to. Eager flush; cache re-warms on next
+    # access. Failures don't propagate — see _fire_cache_invalidators.
+    for label in sorted(touched_columns):
+        _fire_cache_invalidators(label)
     return 0
 
 

--- a/core/crypto/verify_all.py
+++ b/core/crypto/verify_all.py
@@ -145,7 +145,33 @@ _SCANNERS: list[tuple[str, str]] = [
      "core.models.connector_config:ConnectorConfig:credentials_encrypted"),
     ("gstn_credentials.password_encrypted",
      "core.models.gstn_credential:GSTNCredential:password_encrypted"),
+    # Foundation #4 iter 4 — tenant_ai_credentials must rewrap too.
+    # The cache invalidator below ensures decrypted plaintext held in
+    # ``core.ai_providers.resolver._CACHE`` is dropped after a row is
+    # restamped so callers don't get stale plaintext from the
+    # 120s-TTL cache.
+    ("tenant_ai_credentials.credentials_encrypted",
+     "core.models.tenant_ai_credential:TenantAICredential:credentials_encrypted"),
 ]
+
+
+# Foundation #4 iter 4 — cache invalidation on rotated_at.
+#
+# Some encrypted columns feed in-process caches that hold the
+# decrypted plaintext. After ``rewrap`` UPDATEs a row in such a
+# column, the cache must be told to drop any entry that may now be
+# pointing at a stale plaintext (cf. the SECRET_KEY incident — same
+# class of failure: rotated under us, downstream lookup served pre-
+# rotation data). Each invalidator is a dotted ``module:callable``
+# that takes no args and flushes its whole cache. Whole-cache flush
+# (rather than per-row) is intentional: rewrap runs in operator-
+# initiated bursts, and the caches re-warm on next access in O(1
+# round-trip).
+_CACHE_INVALIDATORS: dict[str, list[str]] = {
+    "tenant_ai_credentials.credentials_encrypted": [
+        "core.ai_providers.resolver:invalidate_cache",
+    ],
+}
 
 
 async def _fetch_column(session, dotted: str) -> Iterable:

--- a/tests/regression/test_crypto_rewrap.py
+++ b/tests/regression/test_crypto_rewrap.py
@@ -330,6 +330,165 @@ def test_run_decrypt_failure_exits_one(monkeypatch: pytest.MonkeyPatch) -> None:
 # ──────────────────────────────────────────────────────────────────────
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Foundation #4 iter 4 — cache invalidation hook
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_cache_invalidator_registry_includes_tenant_ai_credentials() -> None:
+    """Pin the registration: rewrap MUST flush the resolver cache after
+    touching tenant_ai_credentials. Without this entry callers get
+    pre-rotation plaintext from the 120s-TTL cache.
+    """
+    from core.crypto.verify_all import _CACHE_INVALIDATORS
+
+    invalidators = _CACHE_INVALIDATORS.get(
+        "tenant_ai_credentials.credentials_encrypted"
+    )
+    assert invalidators is not None, (
+        "tenant_ai_credentials.credentials_encrypted must be registered "
+        "in _CACHE_INVALIDATORS so rewrap flushes the resolver cache"
+    )
+    assert "core.ai_providers.resolver:invalidate_cache" in invalidators
+
+
+def test_tenant_ai_credentials_is_in_scanners() -> None:
+    """If the column isn't in _SCANNERS, rewrap won't even visit it —
+    iter 4 silently regresses."""
+    from core.crypto.verify_all import _SCANNERS
+
+    labels = {label for label, _dotted in _SCANNERS}
+    assert "tenant_ai_credentials.credentials_encrypted" in labels
+
+
+def test_fire_cache_invalidators_calls_registered_callable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every registered dotted callable runs once."""
+    calls: list[str] = []
+
+    def fake_invalidate(*_args, **_kwargs):
+        calls.append("called")
+
+    # Inject a fake callable into a fake module path the helper can resolve.
+    fake_mod = type(sys)("fake_mod_for_iter4")
+    fake_mod.flush = fake_invalidate
+    monkeypatch.setitem(sys.modules, "fake_mod_for_iter4", fake_mod)
+    monkeypatch.setitem(
+        rw._CACHE_INVALIDATORS,
+        "test.column",
+        ["fake_mod_for_iter4:flush"],
+    )
+
+    rw._fire_cache_invalidators("test.column")
+    assert calls == ["called"]
+
+
+def test_fire_cache_invalidators_swallows_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing invalidator must not block rewrap completion."""
+    fake_mod = type(sys)("fake_mod_for_iter4_boom")
+    fake_mod.flush = lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    monkeypatch.setitem(sys.modules, "fake_mod_for_iter4_boom", fake_mod)
+    monkeypatch.setitem(
+        rw._CACHE_INVALIDATORS,
+        "test.column.boom",
+        ["fake_mod_for_iter4_boom:flush"],
+    )
+    # Must not raise.
+    rw._fire_cache_invalidators("test.column.boom")
+
+
+def test_run_invalidates_cache_after_rewrap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: when rewrap touches a registered column, the
+    invalidator fires once after the loop completes."""
+    monkeypatch.setenv("AGENTICORG_VAULT_KEYRING", "v2:active,v1:older")
+
+    invalidator_calls: list[str] = []
+
+    def fake_invalidate(*_args, **_kwargs):
+        invalidator_calls.append("flushed")
+
+    fake_mod = type(sys)("fake_mod_for_iter4_run")
+    fake_mod.flush = fake_invalidate
+    monkeypatch.setitem(sys.modules, "fake_mod_for_iter4_run", fake_mod)
+
+    monkeypatch.setattr(
+        rw, "_SCANNERS",
+        [("connector_configs.credentials_encrypted", "ignored")],
+    )
+    # Override the registry so this test doesn't depend on the live
+    # tenant_ai_credentials wiring (that's covered separately).
+    monkeypatch.setattr(
+        rw, "_CACHE_INVALIDATORS",
+        {"connector_configs.credentials_encrypted":
+         ["fake_mod_for_iter4_run:flush"]},
+    )
+
+    old_ct = _stamp_with("v1", "x")
+    full_set = [("a", {"_encrypted": old_ct})]
+    rows_per_call = [full_set, full_set, []]
+    session = _mock_session_for(rows_per_call=rows_per_call)
+    monkeypatch.setattr(rw, "async_session_factory", lambda: _session_cm(session))
+
+    rc = asyncio.run(
+        rw.run(
+            only_column=None, only_kid=None, batch_size=10, dry_run=False
+        )
+    )
+    assert rc == 0
+    # Invalidator fired exactly once after the loop, not per-row.
+    assert invalidator_calls == ["flushed"]
+
+
+def test_run_does_not_invalidate_when_nothing_touched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If every row is already on the active key, no invalidator fires.
+
+    Pointless cache flushes during a "nothing to do" rewrap waste the
+    next caller's first request on a re-fetch.
+    """
+    monkeypatch.setenv("AGENTICORG_VAULT_KEYRING", "v2:active,v1:older")
+
+    invalidator_calls: list[str] = []
+
+    def fake_invalidate(*_args, **_kwargs):
+        invalidator_calls.append("flushed")
+
+    fake_mod = type(sys)("fake_mod_for_iter4_clean")
+    fake_mod.flush = fake_invalidate
+    monkeypatch.setitem(sys.modules, "fake_mod_for_iter4_clean", fake_mod)
+
+    monkeypatch.setattr(
+        rw, "_SCANNERS",
+        [("connector_configs.credentials_encrypted", "ignored")],
+    )
+    monkeypatch.setattr(
+        rw, "_CACHE_INVALIDATORS",
+        {"connector_configs.credentials_encrypted":
+         ["fake_mod_for_iter4_clean:flush"]},
+    )
+
+    # Only active-key ciphertext present → 0 rows pending.
+    active_ct = encrypt_credential("on-active")
+    full_set = [("a", {"_encrypted": active_ct})]
+    rows_per_call = [full_set]
+    session = _mock_session_for(rows_per_call=rows_per_call)
+    monkeypatch.setattr(rw, "async_session_factory", lambda: _session_cm(session))
+
+    rc = asyncio.run(
+        rw.run(
+            only_column=None, only_kid=None, batch_size=10, dry_run=False
+        )
+    )
+    assert rc == 0
+    assert invalidator_calls == []
+
+
 def test_cli_help_documents_flags() -> None:
     captured = io.StringIO()
     sys.stdout = captured


### PR DESCRIPTION
## Summary

Closes the keyring rotate→rewrap→verify→retire lifecycle from \`feedback_key_rotation_discipline.md\`. After \`rewrap\` (PR #328 / iter 3) UPDATEs a row in a column that feeds an in-process plaintext cache, the cache is now told to flush so callers don't get pre-rotation plaintext from the 120s-TTL cache.

## What changes

1. **\`verify_all._SCANNERS\` picks up \`tenant_ai_credentials.credentials_encrypted\`.** Previously the rewrap CLI couldn't see this column, so AI BYO credentials would never be re-stamped after a key rotation.

2. **New \`_CACHE_INVALIDATORS\` registry** maps column label → list of dotted \`module:callable\` entries to invoke after rewrap touches that column. \`tenant_ai_credentials\` is registered with \`core.ai_providers.resolver:invalidate_cache\`.

3. **\`rewrap.run()\` tracks touched columns** and fires the registered invalidators after the main loop. Eager whole-cache flush (not per-row) — caches re-warm on next access in O(1) round trip. Failures in invalidators are logged but never block rewrap completion.

## Test plan
- [x] 6 new regression tests (registry shape, invalidator helper happy + error swallow, run-level invalidate-after-rewrap, no-op when nothing-touched). 18 total in \`tests/regression/test_crypto_rewrap.py\`.
- [x] Preflight green (ruff + bandit + alembic + pytest + ui tsc + ui build + module-coverage + critical-path tags)

## Final state of the iter 1-4 lifecycle

After this PR an operator can do:

\`\`\`
1. Add new keyring entry, redeploy
2. python -m core.crypto.rewrap
3. python -m core.crypto.verify_all --check=<old_id>  → 0 references
4. Drop the old keyring entry, redeploy
5. Cache automatically picks up new ciphertext on next call
\`\`\`

@codex please review.