### PR TITLE
fix(qa): TC_001 layer-2 — self-heal report_schedules in init_db

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -743,6 +743,58 @@ async def init_db() -> None:
             );
         """))
 
+        # 9d. v4.4.0 safety net — report_schedules.
+        # The v4.4.0 alembic migration created this table, but envs that
+        # were stamped past v4.4.0 without ever running it (e.g. prod
+        # 2026-04-22 cutover) ended up missing the table. The 2026-04-22
+        # company_id migration explicitly guards on table existence and
+        # logs that this safety-net path is the canonical creator. The
+        # 27-Apr TC_001 reopen (Aishwarya, "report schedule create 500")
+        # surfaced because instrumentation revealed
+        # `relation "report_schedules" does not exist`. Idempotent on
+        # repeat startups.
+        await conn.execute(text("""
+            CREATE TABLE IF NOT EXISTS report_schedules (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                tenant_id UUID NOT NULL REFERENCES tenants(id),
+                company_id UUID NULL,
+                name VARCHAR(200) NOT NULL,
+                report_type VARCHAR(50) NOT NULL,
+                cron_expression VARCHAR(100) NOT NULL,
+                recipients JSONB NOT NULL DEFAULT '[]'::jsonb,
+                delivery_channel VARCHAR(20) NOT NULL DEFAULT 'email',
+                format VARCHAR(10) NOT NULL DEFAULT 'pdf',
+                enabled BOOLEAN NOT NULL DEFAULT TRUE,
+                last_run_at TIMESTAMPTZ,
+                next_run_at TIMESTAMPTZ,
+                config JSONB NOT NULL DEFAULT '{}'::jsonb,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at TIMESTAMPTZ
+            );
+        """))
+        # If the table already existed from an older env without the
+        # v488 company_id migration, ensure the column is present.
+        await conn.execute(text("""
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'report_schedules'
+                      AND column_name = 'company_id'
+                ) THEN
+                    ALTER TABLE report_schedules ADD COLUMN company_id UUID NULL;
+                END IF;
+            END $$;
+        """))
+        await conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS ix_report_schedules_tenant "
+            "ON report_schedules(tenant_id);"
+        ))
+        await conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS ix_report_schedules_tenant_company "
+            "ON report_schedules(tenant_id, company_id);"
+        ))
+
         # 9c. RLS for ALL v4.7 tenant-scoped tables
         # (Missing from the original v4.7.0 ship — found in gap analysis #6)
         _v47_rls_tables = [
@@ -751,6 +803,7 @@ async def init_db() -> None:
             "invoices",
             "tenant_branding",
             "workflow_variants",
+            "report_schedules",
         ]
         for _rls_tbl in _v47_rls_tables:
             await conn.execute(text(f"ALTER TABLE {_rls_tbl} ENABLE ROW LEVEL SECURITY;"))  # noqa: S608

--- a/migrations/versions/v4_9_6_report_schedules_recreate.py
+++ b/migrations/versions/v4_9_6_report_schedules_recreate.py
@@ -1,0 +1,104 @@
+"""Idempotently re-create report_schedules on envs that missed v4.4.0.
+
+Revision ID: v496_report_sched_recreate
+Revises: v495_bge_m3_column
+Create Date: 2026-04-28
+
+The 27-Apr TC_001 reopen (Aishwarya, "report schedule create returns
+500") surfaced a hidden gap: the v4.4.0 alembic migration was the
+canonical creator of ``report_schedules``, but envs that were stamped
+past v4.4.0 without ever running it (prod 2026-04-22 cutover) ended up
+with the table missing. The v4.8.8 company_id migration documented the
+gap in its preamble — "the table is created by the ORM at startup
+(Base.metadata.create_all)" — but ``init_db`` never actually called
+``metadata.create_all`` for this model.
+
+The companion fix in ``core/database.py`` (commit c57126f) added
+report_schedules to the init_db CREATE-TABLE-IF-NOT-EXISTS safety net.
+This migration mirrors that DDL on the alembic side so:
+
+1. Fresh envs that bootstrap purely via ``alembic upgrade head`` get
+   the table without depending on init_db.
+2. The CI gate ``scripts/check_migration_required.py`` is satisfied
+   for the init_db change.
+3. Envs missing the table from the v4.4.0 gap pick it up on next
+   ``alembic upgrade head`` even if they don't restart the api pod.
+
+Idempotent — every step guarded with IF NOT EXISTS / EXISTS checks.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# Alembic identifiers — kept <=32 chars (alembic_version.version_num size).
+revision = "v496_report_sched_recreate"
+down_revision = "v495_bge_m3_column"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS report_schedules (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id UUID NOT NULL REFERENCES tenants(id),
+            company_id UUID NULL,
+            name VARCHAR(200) NOT NULL,
+            report_type VARCHAR(50) NOT NULL,
+            cron_expression VARCHAR(100) NOT NULL,
+            recipients JSONB NOT NULL DEFAULT '[]'::jsonb,
+            delivery_channel VARCHAR(20) NOT NULL DEFAULT 'email',
+            format VARCHAR(10) NOT NULL DEFAULT 'pdf',
+            enabled BOOLEAN NOT NULL DEFAULT TRUE,
+            last_run_at TIMESTAMPTZ,
+            next_run_at TIMESTAMPTZ,
+            config JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ
+        );
+    """)
+
+    # Pick up the v488 company_id column on envs that ran the v488
+    # migration as a no-op (table didn't exist yet).
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'report_schedules'
+                  AND column_name = 'company_id'
+            ) THEN
+                ALTER TABLE report_schedules ADD COLUMN company_id UUID NULL;
+            END IF;
+        END $$;
+    """)
+
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_report_schedules_tenant
+            ON report_schedules(tenant_id);
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_report_schedules_tenant_company
+            ON report_schedules(tenant_id, company_id);
+    """)
+
+    # RLS policy — must match init_db's enforcement so cross-tenant
+    # reads are blocked the moment the table exists.
+    op.execute("ALTER TABLE report_schedules ENABLE ROW LEVEL SECURITY;")
+    op.execute("ALTER TABLE report_schedules FORCE ROW LEVEL SECURITY;")
+    op.execute(
+        "DROP POLICY IF EXISTS report_schedules_tenant_isolation "
+        "ON report_schedules;"
+    )
+    op.execute("""
+        CREATE POLICY report_schedules_tenant_isolation ON report_schedules
+        USING (tenant_id::text = current_setting('agenticorg.tenant_id', true));
+    """)
+
+
+def downgrade() -> None:
+    # Intentionally a no-op: this migration only re-creates a table
+    # whose canonical owner is v4.4.0. Dropping here would orphan the
+    # v488 column and policy that other migrations expect.
+    pass

--- a/tests/regression/test_qa_27apr_sweep.py
+++ b/tests/regression/test_qa_27apr_sweep.py
@@ -55,6 +55,24 @@ def test_tc_001_report_schedule_surfaces_exception_class() -> None:
     assert "Could not load report schedules ({exc_class}:" in src
 
 
+def test_tc_001_report_schedules_table_self_heal_in_init_db() -> None:
+    """init_db must create report_schedules + index + RLS.
+
+    Pinned because the 27-Apr re-reopen of TC_001 had a hidden second
+    layer: instrumentation surfaced the exception class but the
+    underlying error was ``UndefinedTableError: relation
+    "report_schedules" does not exist``. The v4.4.0 alembic migration
+    was the canonical creator, but envs stamped past that revision
+    (e.g. prod 2026-04-22 cutover) ended up with no table. Without
+    this safety net, every fresh prod env regresses TC_001.
+    """
+    src = (REPO / "core" / "database.py").read_text(encoding="utf-8")
+    assert "CREATE TABLE IF NOT EXISTS report_schedules" in src
+    assert "ix_report_schedules_tenant_company" in src
+    # Must be in the RLS list so cross-tenant reads are blocked.
+    assert '"report_schedules",' in src
+
+
 # ──────────────────────────────────────────────────────────────────
 # TC_004 — Stop button uses AbortController
 # ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Root cause discovered**: TC_001 (Aishwarya, "report schedule create returns 500") re-reopened on 27-Apr because the prior 22-Apr fix only wrapped in try/except + returned a generic message. The 27-Apr instrumentation in commit 9ab1497 surfaced the underlying exception class in the response detail and revealed: \`UndefinedTableError: relation "report_schedules" does not exist\`.
- **Why it shipped this way**: v4.4.0 alembic migration is the canonical creator. Envs that were stamped past v4.4.0 without ever running it (prod 2026-04-22 cutover) end up with the table missing. The v488 company_id migration explicitly documented this gap ("table is created by the ORM at startup (Base.metadata.create_all)") but \`init_db\` never actually called \`metadata.create_all\` for this model.
- **Fix**: add a \`CREATE TABLE IF NOT EXISTS report_schedules\` block to the existing \`init_db\` DDL safety net (same pattern as companies, ca_subscriptions, invoices, approval_policies, tenant_branding, workflow_variants). Include the v488 company_id column hotfix + composite index + RLS policy.
- **Pinned**: new test in \`tests/regression/test_qa_27apr_sweep.py\` so a future refactor can't silently drop the safety net.

## Verification

- \`pytest tests/regression/test_qa_27apr_sweep.py -q --no-cov\` → 7 passed
- Will re-test TC_001 against prod after deploy lands

@codex please review

## Test plan

- [x] Local regression suite green (7/7)
- [ ] CI green
- [ ] cloudbuild-api deploys new revision
- [ ] \`init_db\` runs at startup → table created
- [ ] TC_001 curl returns 201 / 422 (not 500 with UndefinedTable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)