### PR TITLE
feat(test): Foundation #7 PR-A — fake LLM hermetic seam

### DIFF
--- a/core/llm/router.py
+++ b/core/llm/router.py
@@ -426,6 +426,14 @@ class LLMRouter:
     ) -> LLMResponse:
         start = time.monotonic()
 
+        # Validate the model name FIRST so the fake LLM preserves
+        # the same contract as the real providers. Without this,
+        # a test asserting "unsupported model raises ValueError"
+        # would silently pass under the fake — exactly the false-
+        # green pattern Foundation #8 forbids.
+        if not any(prefix in model for prefix in ("gemini", "claude", "gpt")):
+            raise ValueError(f"Unsupported model: {model}")
+
         # Foundation #7 PR-A: hermetic-CI seam. When the env flag is
         # set, short-circuit ALL providers to the deterministic fake
         # so PR CI never makes a real LLM call. The fake is keyed by
@@ -446,10 +454,8 @@ class LLMRouter:
             return await self._call_gemini(model, messages, temperature, max_tokens, start)
         elif "claude" in model:
             return await self._call_claude(model, messages, temperature, max_tokens, start)
-        elif "gpt" in model:
+        else:  # gpt
             return await self._call_openai(model, messages, temperature, max_tokens, start)
-        else:
-            raise ValueError(f"Unsupported model: {model}")
 
     async def _call_gemini(self, model, messages, temperature, max_tokens, start) -> LLMResponse:
         """Call Google Gemini via the google.genai SDK.

--- a/core/llm/router.py
+++ b/core/llm/router.py
@@ -426,6 +426,22 @@ class LLMRouter:
     ) -> LLMResponse:
         start = time.monotonic()
 
+        # Foundation #7 PR-A: hermetic-CI seam. When the env flag is
+        # set, short-circuit ALL providers to the deterministic fake
+        # so PR CI never makes a real LLM call. The fake is keyed by
+        # prompt fingerprint so cost-cap and routing tests stay
+        # reproducible. See docs/hermetic_test_doubles.md.
+        from core.test_doubles import fake_llm  # noqa: PLC0415 — local import keeps prod cold-path lean
+
+        if fake_llm.is_active():
+            payload = fake_llm.fake_complete(
+                model=model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+            return LLMResponse(**payload)
+
         if "gemini" in model:
             return await self._call_gemini(model, messages, temperature, max_tokens, start)
         elif "claude" in model:

--- a/core/test_doubles/__init__.py
+++ b/core/test_doubles/__init__.py
@@ -1,0 +1,17 @@
+"""Hermetic test doubles (Foundation #7).
+
+These modules provide deterministic, dependency-free replacements
+for external services so PR CI can exercise real code paths
+without prod secrets, real network calls, or unpredictable LLM
+output.
+
+Each double is wired into the production code through a single
+env-var seam — a flag the production code reads at the boundary
+to decide between real client and fake. The seams are documented
+in ``docs/hermetic_test_doubles.md``.
+
+Currently exposed:
+
+- ``fake_llm`` — deterministic LLM responses keyed by prompt
+  fingerprint. Activated via ``AGENTICORG_TEST_FAKE_LLM=1``.
+"""

--- a/core/test_doubles/fake_llm.py
+++ b/core/test_doubles/fake_llm.py
@@ -1,0 +1,206 @@
+"""Deterministic fake LLM for hermetic CI (Foundation #7 PR-A).
+
+Purpose
+-------
+
+Real LLM calls in CI are expensive, slow, and non-deterministic.
+Tests that need an LLM either:
+
+1. Skip when no API key is present — invisible coverage gap.
+2. Use ad-hoc ``MagicMock`` patches — duplicated in 10+ files
+   with subtly different return shapes.
+3. Hit the real API and rely on a CI secret — the explicit
+   pattern the closure plan forbids.
+
+This module gives every test (and prod code under
+``AGENTICORG_TEST_FAKE_LLM=1``) a single, deterministic LLM
+substitute. Same prompt fingerprint always yields the same
+response. Tests can register custom responses for prompts they
+care about and rely on the default for everything else.
+
+Activation
+----------
+
+Set ``AGENTICORG_TEST_FAKE_LLM=1`` in the environment. The
+production ``LLMRouter._call_model`` checks this flag before
+dispatching to the real provider and short-circuits to
+``fake_complete()`` if set.
+
+Determinism
+-----------
+
+The fingerprint is ``sha256(model + json(messages))`` — same
+input always returns the same output. Tokens-used and cost are
+also deterministic functions of the input length so cost-cap
+tests are reproducible.
+
+Custom responses
+----------------
+
+::
+
+    from core.test_doubles import fake_llm
+
+    fake_llm.register_response(
+        prompt_contains="extract entities",
+        content='{"entities": ["Alice", "Bob"]}',
+    )
+
+The registered response wins over the default for any messages
+whose joined content matches ``prompt_contains`` (case-insensitive
+substring).
+
+Tests can ``fake_llm.reset()`` between cases to clear registered
+responses + the call log.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class FakeCall:
+    """One recorded call to the fake LLM."""
+
+    model: str
+    messages: list[dict[str, str]]
+    temperature: float
+    max_tokens: int
+    response_content: str
+    fingerprint: str
+    timestamp: float = field(default_factory=time.time)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Module-level state — intentional. The seam is global on purpose:
+# every code path that calls the real LLM gets the fake when the
+# flag is set, without needing to thread an extra dependency
+# through every layer.
+# ─────────────────────────────────────────────────────────────────
+
+_REGISTERED: list[tuple[str, str]] = []
+_CALL_LOG: list[FakeCall] = []
+
+
+def is_active() -> bool:
+    """True iff ``AGENTICORG_TEST_FAKE_LLM`` is set to a truthy value."""
+    return os.getenv("AGENTICORG_TEST_FAKE_LLM", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def register_response(*, prompt_contains: str, content: str) -> None:
+    """Register a custom response for any prompt whose joined
+    content contains ``prompt_contains`` (case-insensitive).
+
+    Last-registered wins on conflicts. Use ``reset()`` between
+    tests to avoid bleed-over.
+    """
+    if not prompt_contains.strip():
+        raise ValueError("prompt_contains must be non-empty")
+    _REGISTERED.append((prompt_contains.lower(), content))
+
+
+def reset() -> None:
+    """Clear all registered responses + the call log. Call from
+    pytest fixtures to keep tests isolated."""
+    _REGISTERED.clear()
+    _CALL_LOG.clear()
+
+
+def call_log() -> list[FakeCall]:
+    """Return a copy of the recorded calls, oldest first."""
+    return list(_CALL_LOG)
+
+
+def call_count() -> int:
+    """Number of fake calls since the last ``reset()``."""
+    return len(_CALL_LOG)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Fingerprinting + default response
+# ─────────────────────────────────────────────────────────────────
+
+
+def _fingerprint(model: str, messages: list[dict[str, str]]) -> str:
+    payload = json.dumps([model, messages], sort_keys=True, default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _joined_content(messages: list[dict[str, str]]) -> str:
+    return " ".join(m.get("content", "") for m in messages).lower()
+
+
+def _default_response(model: str, joined: str) -> str:
+    """Generate a marker response that's recognizable in logs but
+    looks plausibly LLM-shaped to downstream JSON parsers."""
+    if "json" in joined or '"' in joined:
+        return '{"fake": true, "model": "' + model + '"}'
+    return f"[FAKE_LLM:{model}] deterministic response"
+
+
+# ─────────────────────────────────────────────────────────────────
+# The seam — called by LLMRouter._call_model when is_active()
+# ─────────────────────────────────────────────────────────────────
+
+
+def fake_complete(
+    *,
+    model: str,
+    messages: list[dict[str, str]],
+    temperature: float,
+    max_tokens: int,
+) -> dict[str, Any]:
+    """Return a deterministic response shaped like the production
+    ``LLMResponse`` constructor expects. The router builds the
+    real dataclass from this dict.
+
+    Token + cost numbers are deterministic functions of the input
+    so cost-cap tests are reproducible without depending on real
+    pricing tables.
+    """
+    joined = _joined_content(messages)
+    content = _default_response(model, joined)
+    for marker, override in _REGISTERED:
+        if marker in joined:
+            content = override
+            break
+
+    fingerprint = _fingerprint(model, messages)
+    in_tokens = max(1, sum(len(m.get("content", "")) for m in messages) // 4)
+    out_tokens = max(1, len(content) // 4)
+
+    _CALL_LOG.append(
+        FakeCall(
+            model=model,
+            messages=list(messages),
+            temperature=temperature,
+            max_tokens=max_tokens,
+            response_content=content,
+            fingerprint=fingerprint,
+        )
+    )
+
+    return {
+        "content": content,
+        "model": model,
+        "tokens_used": in_tokens + out_tokens,
+        # $0 cost — fake calls must never trip the cap.
+        "cost_usd": 0.0,
+        "latency_ms": 0,
+        "raw": {
+            "fake": True,
+            "fingerprint": fingerprint,
+            "input_tokens": in_tokens,
+            "output_tokens": out_tokens,
+        },
+    }

--- a/docs/hermetic_test_doubles.md
+++ b/docs/hermetic_test_doubles.md
@@ -1,0 +1,83 @@
+# Hermetic test doubles (Foundation #7)
+
+PR CI must run without prod secrets, real LLM credits, or real
+external services. This doc tracks each environmental dependency,
+its in-process double, and the env-var seam that selects between
+them.
+
+The doubles live under `core/test_doubles/` and are imported
+lazily inside the production seam so they don't add to cold-path
+imports outside test runs.
+
+## Active doubles
+
+### Fake LLM — `core/test_doubles/fake_llm.py`
+
+| | |
+|---|---|
+| Replaces | Gemini / Claude / OpenAI clients in `core.llm.router.LLMRouter._call_model` |
+| Activation | `AGENTICORG_TEST_FAKE_LLM=1` |
+| Default in tests | Yes — `tests/conftest.py` sets the flag at import time |
+| Determinism | Same `(model, messages)` always returns the same response (sha256 of inputs) |
+| Cost | Always `$0` so it can never trip `AGENTICORG_GEMINI_DAILY_USD_CAP` |
+| Custom responses | `fake_llm.register_response(prompt_contains="...", content="...")` |
+| Inspection | `fake_llm.call_log()` and `fake_llm.call_count()` |
+| Cleanup between tests | `fake_llm.reset()` runs in an autouse conftest fixture |
+
+#### Why a single global flag, not dependency injection?
+
+Every code path that ends up calling the LLM (workflows,
+explainers, agent generators, content safety, summarisers, ...)
+would otherwise need `llm_router=` threaded through every
+constructor. The flag gives us one seam at the boundary that
+catches every caller, without growing the surface area of every
+intermediate service.
+
+#### Adding a new test that needs a specific LLM response
+
+```python
+from core.test_doubles import fake_llm
+
+
+def test_my_workflow_with_specific_llm_output():
+    fake_llm.register_response(
+        prompt_contains="extract entities",
+        content='{"entities": ["Alice", "Bob"]}',
+    )
+    result = my_workflow.run(...)
+    assert result["entities"] == ["Alice", "Bob"]
+    # Optional: assert which prompts the workflow sent.
+    assert any(
+        "extract entities" in c.messages[0]["content"].lower()
+        for c in fake_llm.call_log()
+    )
+```
+
+The autouse fixture in `tests/conftest.py` calls `fake_llm.reset()`
+before every test, so registrations + the call log start fresh.
+
+#### Opting back into the real client for one test
+
+```python
+def test_real_gemini_call(monkeypatch):
+    monkeypatch.delenv("AGENTICORG_TEST_FAKE_LLM", raising=False)
+    # ... requires AGENTICORG_GEMINI_API_KEY in the environment ...
+```
+
+These tests should be rare and should be marked
+`@pytest.mark.skipif(not os.getenv("AGENTICORG_GEMINI_API_KEY"))`
+so they skip cleanly when the key is absent.
+
+## Planned doubles (Foundation #7 follow-up PRs)
+
+| Service | Double | Status |
+|---------|--------|--------|
+| LLM | Fake LLM | **Shipped (PR-A)** |
+| Mail | MailHog | PR-B |
+| Object storage | LocalStack S3 / fake-gcs | PR-C |
+| Connector APIs | Stub server (httpx mock app) | PR-D |
+| Celery worker | service container in CI | PR-E |
+
+Each follow-up follows the same shape: env-var seam at the
+boundary, in-process double, autouse fixture, regression test
+pinning the seam, doc entry above.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,27 @@ os.environ.setdefault("TMP", str(_TEST_TMPDIR))
 os.environ.setdefault("TEMP", str(_TEST_TMPDIR))
 os.environ.setdefault("TMPDIR", str(_TEST_TMPDIR))
 
+# Foundation #7 PR-A: hermetic CI default. Every test run gets the
+# fake LLM unless a specific test opts back in to the real client by
+# clearing the flag in a fixture. This eliminates the "skipped
+# because no GEMINI_API_KEY in CI" pattern that's been the largest
+# silent coverage gap. See docs/hermetic_test_doubles.md.
+os.environ.setdefault("AGENTICORG_TEST_FAKE_LLM", "1")
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_llm_between_tests():
+    """Clear the fake LLM's registered responses + call log before
+    each test so prompts registered in test A can't bleed into B."""
+    try:
+        from core.test_doubles import fake_llm
+
+        fake_llm.reset()
+    except ImportError:
+        # Module isn't available in checkouts before Foundation #7.
+        pass
+    yield
+
 
 @pytest.fixture
 def tenant_id():

--- a/tests/regression/test_fake_llm_seam.py
+++ b/tests/regression/test_fake_llm_seam.py
@@ -1,0 +1,195 @@
+"""Foundation #7 PR-A — fake LLM hermetic seam regressions.
+
+Pinned behaviors:
+
+- ``is_active()`` reflects the env var.
+- ``fake_complete`` returns a deterministic response for the same
+  ``(model, messages)`` input.
+- Custom registered responses win over the default.
+- ``reset()`` clears registered responses + the call log.
+- ``LLMRouter._call_model`` short-circuits to the fake when the
+  flag is set — we verify by patching the real provider methods to
+  raise and confirming a fake call still succeeds.
+- The fake's ``cost_usd`` is always 0 so it can't trip the cap.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from core.test_doubles import fake_llm
+
+
+def test_is_active_reflects_env_var(monkeypatch) -> None:
+    monkeypatch.delenv("AGENTICORG_TEST_FAKE_LLM", raising=False)
+    assert fake_llm.is_active() is False
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_LLM", "1")
+    assert fake_llm.is_active() is True
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_LLM", "true")
+    assert fake_llm.is_active() is True
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_LLM", "no")
+    assert fake_llm.is_active() is False
+
+
+def test_fake_complete_is_deterministic_for_same_input() -> None:
+    msg = [{"role": "user", "content": "summarise this paragraph"}]
+    a = fake_llm.fake_complete(
+        model="gemini-2.5-flash", messages=msg, temperature=0.2, max_tokens=500
+    )
+    b = fake_llm.fake_complete(
+        model="gemini-2.5-flash", messages=msg, temperature=0.2, max_tokens=500
+    )
+    assert a["content"] == b["content"]
+    assert a["raw"]["fingerprint"] == b["raw"]["fingerprint"]
+
+
+def test_fake_complete_differs_for_different_input() -> None:
+    a = fake_llm.fake_complete(
+        model="gemini-2.5-flash",
+        messages=[{"role": "user", "content": "alpha"}],
+        temperature=0.0,
+        max_tokens=100,
+    )
+    b = fake_llm.fake_complete(
+        model="gemini-2.5-flash",
+        messages=[{"role": "user", "content": "beta"}],
+        temperature=0.0,
+        max_tokens=100,
+    )
+    assert a["raw"]["fingerprint"] != b["raw"]["fingerprint"]
+
+
+def test_register_response_overrides_default() -> None:
+    fake_llm.register_response(
+        prompt_contains="extract entities",
+        content='{"entities": ["Alice"]}',
+    )
+    out = fake_llm.fake_complete(
+        model="gemini-2.5-flash",
+        messages=[
+            {"role": "user", "content": "Please extract entities from this text"}
+        ],
+        temperature=0.0,
+        max_tokens=200,
+    )
+    assert out["content"] == '{"entities": ["Alice"]}'
+
+
+def test_register_empty_marker_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        fake_llm.register_response(prompt_contains="   ", content="x")
+
+
+def test_call_log_records_each_call_in_order() -> None:
+    assert fake_llm.call_count() == 0
+    fake_llm.fake_complete(
+        model="gemini-2.5-flash",
+        messages=[{"role": "user", "content": "first"}],
+        temperature=0.0,
+        max_tokens=100,
+    )
+    fake_llm.fake_complete(
+        model="gemini-2.5-flash",
+        messages=[{"role": "user", "content": "second"}],
+        temperature=0.0,
+        max_tokens=100,
+    )
+    log = fake_llm.call_log()
+    assert len(log) == 2
+    assert log[0].messages[0]["content"] == "first"
+    assert log[1].messages[0]["content"] == "second"
+
+
+def test_reset_clears_state() -> None:
+    fake_llm.register_response(prompt_contains="leak", content="leaked")
+    fake_llm.fake_complete(
+        model="gemini-2.5-flash",
+        messages=[{"role": "user", "content": "leak"}],
+        temperature=0.0,
+        max_tokens=100,
+    )
+    assert fake_llm.call_count() == 1
+    fake_llm.reset()
+    assert fake_llm.call_count() == 0
+    # Registered response is also gone — re-fingerprint without
+    # the override should now return the default marker.
+    out = fake_llm.fake_complete(
+        model="gemini-2.5-flash",
+        messages=[{"role": "user", "content": "leak"}],
+        temperature=0.0,
+        max_tokens=100,
+    )
+    assert out["content"] != "leaked"
+    assert "[FAKE_LLM" in out["content"]
+
+
+def test_fake_cost_is_always_zero() -> None:
+    """The fake must never trip the daily cost cap."""
+    out = fake_llm.fake_complete(
+        model="gemini-2.5-pro",
+        messages=[{"role": "user", "content": "x" * 10000}],
+        temperature=0.0,
+        max_tokens=4096,
+    )
+    assert out["cost_usd"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_router_short_circuits_to_fake_when_flag_set(monkeypatch) -> None:
+    """End-to-end: with the flag on, LLMRouter._call_model never
+    reaches _call_gemini/claude/openai. We patch all three to raise
+    and assert the call still returns a FAKE_LLM response."""
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_LLM", "1")
+
+    from core.llm.router import LLMResponse, LLMRouter
+
+    async def _explode(*args, **kwargs):
+        raise AssertionError("real provider must not be called when fake is active")
+
+    router = LLMRouter()
+    monkeypatch.setattr(router, "_call_gemini", _explode)
+    monkeypatch.setattr(router, "_call_claude", _explode)
+    monkeypatch.setattr(router, "_call_openai", _explode)
+
+    resp = await router.complete(
+        messages=[{"role": "user", "content": "hello"}],
+        model_override="gemini-2.5-flash",
+    )
+    assert isinstance(resp, LLMResponse)
+    assert "[FAKE_LLM" in resp.content or '"fake"' in resp.content
+    assert resp.cost_usd == 0.0
+
+
+@pytest.mark.asyncio
+async def test_router_uses_real_provider_when_flag_off(monkeypatch) -> None:
+    """Inverse pin: with the flag OFF, the seam must NOT short-
+    circuit. We assert the real provider gets called by replacing
+    it with a sentinel."""
+    monkeypatch.delenv("AGENTICORG_TEST_FAKE_LLM", raising=False)
+
+    from core.llm.router import LLMResponse, LLMRouter
+
+    sentinel_called = {"yes": False}
+
+    async def _sentinel(*args, **kwargs):
+        sentinel_called["yes"] = True
+        return LLMResponse(content="REAL", model="gemini-2.5-flash")
+
+    router = LLMRouter()
+    monkeypatch.setattr(router, "_call_gemini", _sentinel)
+
+    resp = await router.complete(
+        messages=[{"role": "user", "content": "hello"}],
+        model_override="gemini-2.5-flash",
+    )
+    assert sentinel_called["yes"] is True
+    assert resp.content == "REAL"
+
+
+def test_conftest_default_makes_fake_active() -> None:
+    """The conftest sets the env var so every test gets the fake by
+    default. Pin that the variable is set during a test run."""
+    assert os.environ.get("AGENTICORG_TEST_FAKE_LLM") == "1"
+    assert fake_llm.is_active() is True

--- a/tests/regression/test_fake_llm_seam.py
+++ b/tests/regression/test_fake_llm_seam.py
@@ -193,3 +193,26 @@ def test_conftest_default_makes_fake_active() -> None:
     default. Pin that the variable is set during a test run."""
     assert os.environ.get("AGENTICORG_TEST_FAKE_LLM") == "1"
     assert fake_llm.is_active() is True
+
+
+@pytest.mark.asyncio
+async def test_unsupported_model_still_raises_under_fake() -> None:
+    """The fake must NOT mask the production validation contract.
+    An unsupported model name should raise ValueError even when
+    the fake is active — otherwise tests asserting the rejection
+    silently pass (a false-green that Foundation #8 forbids).
+
+    Tests _call_model directly (rather than complete()) because
+    complete() has a fallback chain that masks the primary error.
+    The fix is to validate BEFORE the fake-active check.
+    """
+    from core.llm.router import LLMRouter
+
+    router = LLMRouter()
+    with pytest.raises(ValueError, match="Unsupported model"):
+        await router._call_model(
+            model="some-unknown-model-xyz",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.0,
+            max_tokens=100,
+        )


### PR DESCRIPTION
## Summary

The closure plan (#7) demands PR CI run without prod secrets, real LLM credits, or unpredictable provider output. Today: 10+ test files have ad-hoc \`MagicMock\` patches with subtly different return shapes, and any test that needs an LLM but isn't patched ends up either skipped (the silent coverage gap) or reaching the real API via a CI secret.

This PR ships the first hermetic double — a single, deterministic LLM substitute with one env-var seam at the boundary.

## What lands

- **\`core/test_doubles/fake_llm.py\`** — \`is_active()\`, \`fake_complete()\` (sha256-deterministic), \`register_response()\`, \`call_log()\`, \`reset()\`. Cost is always \$0 so the daily-cap gate can't trip.
- **\`core/llm/router.py\`** — \`LLMRouter._call_model\` checks the flag FIRST and short-circuits before any real provider dispatch. Lazy import keeps prod cold-path lean.
- **\`tests/conftest.py\`** — sets \`AGENTICORG_TEST_FAKE_LLM=1\` at import time. Autouse fixture calls \`fake_llm.reset()\` between tests.
- **11 regression tests** in \`tests/regression/test_fake_llm_seam.py\` — env reflection, determinism, override, reset, cost-zero, both directions of the seam, conftest default pin.
- **\`docs/hermetic_test_doubles.md\`** — contract doc + roadmap.

## Verification

- \`pytest tests/regression/test_fake_llm_seam.py + companion files\` → **68 passed**
- ruff + bandit clean on all new files

## Roadmap (Foundation #7 follow-ups)

| PR | Double | Status |
|----|--------|--------|
| **PR-A** | Fake LLM | **This PR** |
| PR-B | MailHog | Next |
| PR-C | LocalStack / fake-gcs | After |
| PR-D | Connector stub server | After |
| PR-E | Celery worker service | After |

Each follow-up uses the same shape: env-var seam, in-process double, autouse fixture, regression test pinning the seam, doc entry.

@codex please review

## Test plan

- [x] 11 fake-llm seam tests + 57 companion regressions all green locally
- [ ] CI green
- [ ] After merge, audit existing \`MagicMock(LLMRouter)\` patches in tests/ — many can be deleted in a follow-up cleanup PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)