### PR TITLE
feat(test): Foundation #7 PR-B — fake mail hermetic seam

### DIFF
--- a/core/email.py
+++ b/core/email.py
@@ -53,17 +53,31 @@ def send_email(to: str, subject: str, html: str) -> None:
     Uses AGENTICORG_SMTP_LOGIN for SMTP authentication (Gmail account)
     and AGENTICORG_DEMO_SENDER for the display From address.
     """
+    # Validate email domain BEFORE the fake-mail seam so tests
+    # asserting "invalid domain → no send" stay accurate even when
+    # the fake is active. Foundation #8 forbids the false-green
+    # pattern where a fake masks a production validation contract.
+    is_valid, reason = validate_email_domain(to)
+    if not is_valid:
+        logger.warning("Skipping email to %s: %s", to, reason)
+        return
+
+    # Foundation #7 PR-B: hermetic-CI seam. When the env flag is
+    # set, capture the email in-process instead of opening a real
+    # SMTP connection. See docs/hermetic_test_doubles.md.
+    from core.test_doubles import fake_mail  # noqa: PLC0415 — lazy keeps prod cold-path lean
+
+    if fake_mail.is_active():
+        display_sender = os.getenv("AGENTICORG_DEMO_SENDER", "sanjeev@agenticorg.ai")
+        fake_mail.capture(to=to, subject=subject, html=html, sender=display_sender)
+        logger.info("[fake_mail] captured email to=%s subject=%r", to, subject)
+        return
+
     password = os.getenv("AGENTICORG_GMAIL_APP_PASSWORD", "")
     smtp_login = os.getenv("AGENTICORG_SMTP_LOGIN", os.getenv("AGENTICORG_DEMO_SENDER", ""))
     display_sender = os.getenv("AGENTICORG_DEMO_SENDER", "sanjeev@agenticorg.ai")
     if not password or not smtp_login:
         logger.warning("AGENTICORG_GMAIL_APP_PASSWORD or SMTP_LOGIN not set — skipping email")
-        return
-
-    # Validate email domain before sending
-    is_valid, reason = validate_email_domain(to)
-    if not is_valid:
-        logger.warning("Skipping email to %s: %s", to, reason)
         return
     msg = MIMEText(html, "html")
     msg["Subject"] = subject

--- a/core/test_doubles/fake_mail.py
+++ b/core/test_doubles/fake_mail.py
@@ -1,0 +1,90 @@
+"""Hermetic fake mail (Foundation #7 PR-B).
+
+Replaces the SMTP send in ``core.email.send_email`` with an
+in-process capture so tests can assert that an email *would have*
+been sent — what the To/Subject/HTML were — without standing up
+MailHog or hitting Gmail SMTP.
+
+Activation: ``AGENTICORG_TEST_FAKE_MAIL=1``. The conftest sets
+this by default for every test run.
+
+Inspection::
+
+    from core.test_doubles import fake_mail
+
+    fake_mail.outbox()              # list of CapturedEmail
+    fake_mail.last()                # most-recent CapturedEmail
+    fake_mail.count_to("a@b.com")  # how many sent to that address
+    fake_mail.reset()               # clear between tests
+
+The autouse fixture in tests/conftest.py calls ``reset()`` before
+each test so captures don't leak across cases.
+
+Domain-validation behavior is preserved — the fake still calls
+``validate_email_domain`` first (when the production caller does)
+so tests asserting "invalid domain → no send" remain accurate.
+That preservation lives at the call-site in ``core/email.py``;
+this module is just the capture sink.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CapturedEmail:
+    """One captured email. Mirrors the inputs to send_email()."""
+
+    to: str
+    subject: str
+    html: str
+    sender: str = ""
+    timestamp: float = field(default_factory=time.time)
+
+
+_OUTBOX: list[CapturedEmail] = []
+
+
+def is_active() -> bool:
+    """True iff ``AGENTICORG_TEST_FAKE_MAIL`` is truthy."""
+    return os.getenv("AGENTICORG_TEST_FAKE_MAIL", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def capture(*, to: str, subject: str, html: str, sender: str = "") -> CapturedEmail:
+    """Record one captured email and return the record."""
+    rec = CapturedEmail(to=to, subject=subject, html=html, sender=sender)
+    _OUTBOX.append(rec)
+    return rec
+
+
+def outbox() -> list[CapturedEmail]:
+    """Return a copy of the captured emails, oldest first."""
+    return list(_OUTBOX)
+
+
+def last() -> CapturedEmail | None:
+    """Return the most-recent captured email, or None if empty."""
+    return _OUTBOX[-1] if _OUTBOX else None
+
+
+def count() -> int:
+    """Total emails captured since the last reset."""
+    return len(_OUTBOX)
+
+
+def count_to(addr: str) -> int:
+    """Count of captured emails whose ``to`` matches ``addr``."""
+    return sum(1 for e in _OUTBOX if e.to == addr)
+
+
+def reset() -> None:
+    """Clear the captured outbox. Call from a test fixture to keep
+    captures isolated between cases."""
+    _OUTBOX.clear()

--- a/docs/hermetic_test_doubles.md
+++ b/docs/hermetic_test_doubles.md
@@ -68,12 +68,50 @@ These tests should be rare and should be marked
 `@pytest.mark.skipif(not os.getenv("AGENTICORG_GEMINI_API_KEY"))`
 so they skip cleanly when the key is absent.
 
+### Fake mail — `core/test_doubles/fake_mail.py`
+
+| | |
+|---|---|
+| Replaces | SMTP send in `core.email.send_email` |
+| Activation | `AGENTICORG_TEST_FAKE_MAIL=1` |
+| Default in tests | Yes — `tests/conftest.py` sets the flag at import time |
+| Capture | In-process `_OUTBOX` — every send becomes a `CapturedEmail` |
+| Inspection | `fake_mail.outbox()`, `last()`, `count()`, `count_to(addr)` |
+| Cleanup between tests | `fake_mail.reset()` runs in the autouse conftest fixture |
+
+#### Domain validation runs FIRST
+
+`send_email` validates the recipient domain BEFORE checking the
+fake-mail flag. Tests that assert "invalid domain → no send"
+(e.g. SECURITY tests for SSRF / open-relay protection) keep
+working under the fake. Foundation #8's claude-mistakes test
+forbids the false-green pattern where a fake masks a production
+validation contract.
+
+#### Adding a test that asserts an email was sent
+
+```python
+from core.test_doubles import fake_mail
+from core.email import send_welcome_email
+
+
+def test_welcome_email_sent_to_new_user():
+    send_welcome_email(to="alice@example.com", org_name="Acme", name="Alice")
+    rec = fake_mail.last()
+    assert rec is not None
+    assert rec.to == "alice@example.com"
+    assert "Welcome" in rec.subject
+```
+
+The autouse fixture resets the outbox between tests so captures
+don't leak.
+
 ## Planned doubles (Foundation #7 follow-up PRs)
 
 | Service | Double | Status |
 |---------|--------|--------|
-| LLM | Fake LLM | **Shipped (PR-A)** |
-| Mail | MailHog | PR-B |
+| LLM | Fake LLM | **Shipped (PR-A #357)** |
+| Mail | Fake mail | **Shipped (PR-B)** |
 | Object storage | LocalStack S3 / fake-gcs | PR-C |
 | Connector APIs | Stub server (httpx mock app) | PR-D |
 | Celery worker | service container in CI | PR-E |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,18 +20,24 @@ os.environ.setdefault("TMPDIR", str(_TEST_TMPDIR))
 # because no GEMINI_API_KEY in CI" pattern that's been the largest
 # silent coverage gap. See docs/hermetic_test_doubles.md.
 os.environ.setdefault("AGENTICORG_TEST_FAKE_LLM", "1")
+os.environ.setdefault("AGENTICORG_TEST_FAKE_MAIL", "1")
 
 
 @pytest.fixture(autouse=True)
-def _reset_fake_llm_between_tests():
-    """Clear the fake LLM's registered responses + call log before
-    each test so prompts registered in test A can't bleed into B."""
+def _reset_fake_doubles_between_tests():
+    """Clear hermetic doubles' state before each test so captures
+    + registrations don't bleed across cases."""
     try:
         from core.test_doubles import fake_llm
 
         fake_llm.reset()
     except ImportError:
-        # Module isn't available in checkouts before Foundation #7.
+        pass
+    try:
+        from core.test_doubles import fake_mail
+
+        fake_mail.reset()
+    except ImportError:
         pass
     yield
 

--- a/tests/regression/test_fake_mail_seam.py
+++ b/tests/regression/test_fake_mail_seam.py
@@ -1,0 +1,134 @@
+"""Foundation #7 PR-B — fake mail hermetic seam regressions.
+
+Pinned behaviors:
+
+- ``is_active()`` reflects the env var.
+- A real ``send_email`` call captures into the in-process outbox
+  when the flag is set; no SMTP connection attempted.
+- Domain validation runs BEFORE the fake-mail check so a test
+  asserting "invalid domain → no send" still works under the
+  fake (Foundation #8 false-green prevention).
+- ``capture()``, ``count_to()``, ``last()``, ``reset()`` work as
+  documented.
+- The conftest sets the flag by default and the autouse fixture
+  resets the outbox between tests.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from core.test_doubles import fake_mail
+
+
+def test_is_active_reflects_env_var(monkeypatch) -> None:
+    monkeypatch.delenv("AGENTICORG_TEST_FAKE_MAIL", raising=False)
+    assert fake_mail.is_active() is False
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_MAIL", "1")
+    assert fake_mail.is_active() is True
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_MAIL", "true")
+    assert fake_mail.is_active() is True
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_MAIL", "no")
+    assert fake_mail.is_active() is False
+
+
+def test_capture_records_email() -> None:
+    rec = fake_mail.capture(
+        to="alice@example.com",
+        subject="Hi",
+        html="<p>hello</p>",
+        sender="bot@agenticorg.ai",
+    )
+    assert rec.to == "alice@example.com"
+    assert rec.subject == "Hi"
+    assert "hello" in rec.html
+    assert fake_mail.count() == 1
+    assert fake_mail.last() is rec
+
+
+def test_count_to_filters_by_address() -> None:
+    fake_mail.capture(to="a@x.com", subject="1", html="x")
+    fake_mail.capture(to="b@x.com", subject="2", html="x")
+    fake_mail.capture(to="a@x.com", subject="3", html="x")
+    assert fake_mail.count_to("a@x.com") == 2
+    assert fake_mail.count_to("b@x.com") == 1
+    assert fake_mail.count_to("nobody@x.com") == 0
+
+
+def test_reset_clears_outbox() -> None:
+    fake_mail.capture(to="x@y.com", subject="x", html="x")
+    assert fake_mail.count() == 1
+    fake_mail.reset()
+    assert fake_mail.count() == 0
+    assert fake_mail.last() is None
+
+
+def test_send_email_captures_under_fake(monkeypatch) -> None:
+    """End-to-end: production send_email path captures the message
+    in the fake outbox when the flag is on, never touching SMTP."""
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_MAIL", "1")
+    # Ensure the SMTP path would have refused too — proves the
+    # capture isn't an accident of missing creds.
+    monkeypatch.delenv("AGENTICORG_GMAIL_APP_PASSWORD", raising=False)
+
+    # Real-domain target so domain validation passes (gmail.com
+    # has MX records).
+    from core.email import send_email
+
+    send_email(
+        to="qa@gmail.com",
+        subject="Welcome",
+        html="<p>welcome</p>",
+    )
+    assert fake_mail.count() == 1
+    rec = fake_mail.last()
+    assert rec is not None
+    assert rec.to == "qa@gmail.com"
+    assert rec.subject == "Welcome"
+
+
+def test_send_email_skips_invalid_domain_under_fake(monkeypatch) -> None:
+    """Domain validation must still gate the fake — an invalid
+    domain produces NO captured email. This pins the false-green
+    prevention pattern from Foundation #8."""
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_MAIL", "1")
+
+    from core.email import send_email
+
+    send_email(
+        to="x@nonexistent-domain-with-no-mx-record-12345.invalid",
+        subject="should not capture",
+        html="x",
+    )
+    assert fake_mail.count() == 0
+
+
+def test_conftest_default_makes_fake_mail_active() -> None:
+    """Pin the conftest sets the env var so every test gets the
+    fake by default."""
+    assert os.environ.get("AGENTICORG_TEST_FAKE_MAIL") == "1"
+    assert fake_mail.is_active() is True
+
+
+def test_autouse_fixture_resets_between_tests_part_1() -> None:
+    """First half of the bleed-check pair — capture an email."""
+    fake_mail.capture(to="bleed@x.com", subject="bleed", html="x")
+    assert fake_mail.count() == 1
+
+
+def test_autouse_fixture_resets_between_tests_part_2() -> None:
+    """Second half of the bleed-check pair — outbox must be empty
+    even though part_1 captured one. If this fails, the autouse
+    fixture in tests/conftest.py is broken or not registered."""
+    assert fake_mail.count() == 0
+
+
+@pytest.mark.parametrize("addr", ["alice@gmail.com", "bob@gmail.com", "carol@gmail.com"])
+def test_each_param_starts_with_empty_outbox(addr) -> None:
+    """Parametrized sanity check — every parameter case sees a
+    clean outbox at the start."""
+    assert fake_mail.count() == 0
+    fake_mail.capture(to=addr, subject="x", html="x")
+    assert fake_mail.count() == 1

--- a/tests/unit/test_auth_and_core.py
+++ b/tests/unit/test_auth_and_core.py
@@ -963,9 +963,18 @@ class TestSendEmail:
 
     def test_sends_when_valid(self):
         from core.email import send_email
+        # This test verifies the real-SMTP wiring (login + send_message
+        # are called). It MUST opt out of the Foundation #7 PR-B
+        # fake-mail seam — otherwise send_email captures into the
+        # fake outbox and never reaches SMTP, so the mock assertions
+        # below see zero calls. See docs/hermetic_test_doubles.md.
         with patch.dict(
             "os.environ",
-            {"AGENTICORG_GMAIL_APP_PASSWORD": "pw", "AGENTICORG_SMTP_LOGIN": "sender@y.com"},
+            {
+                "AGENTICORG_GMAIL_APP_PASSWORD": "pw",
+                "AGENTICORG_SMTP_LOGIN": "sender@y.com",
+                "AGENTICORG_TEST_FAKE_MAIL": "",
+            },
             clear=False,
         ):
             with patch("core.email.validate_email_domain", return_value=(True, "OK")):


### PR DESCRIPTION
## Summary

Foundation #7 PR-B — same shape as PR-A (#357 fake LLM): one env-var seam at the boundary, in-process capture sink, autouse reset fixture, regression suite pinning the contract.

## What lands

- **\`core/test_doubles/fake_mail.py\`** — \`is_active()\`, \`capture()\`, \`outbox()\`, \`last()\`, \`count()\`, \`count_to(addr)\`, \`reset()\`.
- **\`core/email.py\`** — \`send_email\` captures to \`fake_mail\` when \`AGENTICORG_TEST_FAKE_MAIL=1\` instead of opening SMTP_SSL. **Domain validation runs FIRST** so tests asserting "invalid domain → no send" stay accurate (the false-green prevention pattern Foundation #8 forbids).
- **\`tests/conftest.py\`** — sets \`AGENTICORG_TEST_FAKE_MAIL=1\` at import time. Autouse fixture (renamed \`_reset_fake_doubles_between_tests\`) now resets BOTH fake_llm + fake_mail.
- **\`tests/regression/test_fake_mail_seam.py\`** — 12 tests including: env-var reflection, capture, count_to, reset, end-to-end \`send_email\` under fake, domain-validation-first contract, conftest default pin, autouse-bleed verification (paired tests + parametrized).
- **\`docs/hermetic_test_doubles.md\`** — updated with fake-mail contract section.

## Verification

- \`pytest tests/regression/test_fake_mail_seam.py tests/regression/test_fake_llm_seam.py\` → **24 passed**
- ruff + bandit clean

## Roadmap (Foundation #7)

| PR | Double | Status |
|----|--------|--------|
| PR-A | Fake LLM | Merged (#357) |
| **PR-B** | **Fake mail** | **This PR** |
| PR-C | LocalStack / fake-gcs | Next |
| PR-D | Connector stub server | After |
| PR-E | Celery worker service | After |

@codex please review

## Test plan

- [x] 24 hermetic-double seam tests green locally
- [ ] CI green
- [ ] Existing tests that mock SMTP can be simplified in a follow-up cleanup PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)