### PR TITLE
feat(test): Foundation #7 PR-C — fake storage hermetic seam

### DIFF
--- a/core/billing/invoice_generator.py
+++ b/core/billing/invoice_generator.py
@@ -196,19 +196,38 @@ def _render_pdf(
 
 async def _upload_pdf(tenant_id: uuid.UUID, invoice_number: str, data: bytes) -> str:
     """Upload the PDF to GCS and return its URL. Falls back to local /tmp on dev."""
-    try:
-        import os
+    import os
 
+    bucket_name = os.getenv("AGENTICORG_INVOICE_BUCKET", "")
+    key = f"invoices/{tenant_id}/{invoice_number}.pdf"
+
+    # Foundation #7 PR-C: hermetic-CI seam. When the env flag is
+    # set, capture the upload in-process instead of opening a real
+    # GCS client. See docs/hermetic_test_doubles.md.
+    from core.test_doubles import fake_storage  # noqa: PLC0415 — lazy keeps prod cold-path lean
+
+    if fake_storage.is_active():
+        if not bucket_name:
+            logger.debug("fake_storage_invoice_no_bucket")
+            return ""
+        fake_storage.upload(
+            bucket=bucket_name,
+            key=key,
+            data=data,
+            content_type="application/pdf",
+        )
+        return f"gs://{bucket_name}/{key}"
+
+    try:
         from google.cloud import storage
 
-        bucket_name = os.getenv("AGENTICORG_INVOICE_BUCKET", "")
         if not bucket_name:
             raise RuntimeError("AGENTICORG_INVOICE_BUCKET not set")
         client = storage.Client()
         bucket = client.bucket(bucket_name)
-        blob = bucket.blob(f"invoices/{tenant_id}/{invoice_number}.pdf")
+        blob = bucket.blob(key)
         blob.upload_from_string(data, content_type="application/pdf")
-        return f"gs://{bucket_name}/invoices/{tenant_id}/{invoice_number}.pdf"
+        return f"gs://{bucket_name}/{key}"
     except Exception:
         logger.debug("invoice_gcs_upload_skipped")
         return ""

--- a/core/test_doubles/fake_storage.py
+++ b/core/test_doubles/fake_storage.py
@@ -1,0 +1,115 @@
+"""Hermetic fake object storage (Foundation #7 PR-C).
+
+Replaces the GCS upload in
+``core.billing.invoice_generator._upload_pdf`` (and any future
+GCS upload sites) with an in-process bucket so tests can assert
+that an object *would have been* uploaded — what the bucket,
+key, content-type, and bytes were — without needing GCP creds,
+LocalStack, or fake-gcs.
+
+Activation: ``AGENTICORG_TEST_FAKE_STORAGE=1``. The conftest sets
+this by default for every test run.
+
+Inspection::
+
+    from core.test_doubles import fake_storage
+
+    fake_storage.objects()                      # all uploads
+    fake_storage.last()                         # most-recent
+    fake_storage.get(bucket, key)               # one object's bytes
+    fake_storage.list_in(bucket)                # keys in a bucket
+    fake_storage.reset()                        # clear between tests
+
+The autouse fixture in tests/conftest.py calls ``reset()`` before
+each test so uploads don't leak across cases.
+
+Why one global flag, not dependency injection: the GCS upload
+sites are scattered across billing, RAG ingestion, knowledge,
+and whatever ships next. Threading a storage client through every
+constructor would touch dozens of files for one infra concern.
+The flag gives us one seam at the boundary.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass, field
+
+
+@dataclass
+class StoredObject:
+    """One captured object upload."""
+
+    bucket: str
+    key: str
+    data: bytes
+    content_type: str = "application/octet-stream"
+    timestamp: float = field(default_factory=time.time)
+
+    @property
+    def gs_url(self) -> str:
+        return f"gs://{self.bucket}/{self.key}"
+
+
+_OBJECTS: list[StoredObject] = []
+
+
+def is_active() -> bool:
+    """True iff ``AGENTICORG_TEST_FAKE_STORAGE`` is truthy."""
+    return os.getenv("AGENTICORG_TEST_FAKE_STORAGE", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def upload(
+    *,
+    bucket: str,
+    key: str,
+    data: bytes,
+    content_type: str = "application/octet-stream",
+) -> StoredObject:
+    """Capture one object upload and return the record."""
+    rec = StoredObject(bucket=bucket, key=key, data=data, content_type=content_type)
+    _OBJECTS.append(rec)
+    return rec
+
+
+def objects() -> list[StoredObject]:
+    """Return a copy of all captured uploads, oldest first."""
+    return list(_OBJECTS)
+
+
+def last() -> StoredObject | None:
+    """Return the most-recent captured upload, or None if empty."""
+    return _OBJECTS[-1] if _OBJECTS else None
+
+
+def count() -> int:
+    """Total objects captured since the last reset."""
+    return len(_OBJECTS)
+
+
+def get(bucket: str, key: str) -> StoredObject | None:
+    """Return the most-recent object at (bucket, key), or None.
+
+    Most recent wins because re-uploads to the same key overwrite
+    in real GCS.
+    """
+    for obj in reversed(_OBJECTS):
+        if obj.bucket == bucket and obj.key == key:
+            return obj
+    return None
+
+
+def list_in(bucket: str) -> list[str]:
+    """Return all keys captured in ``bucket``, oldest first."""
+    return [obj.key for obj in _OBJECTS if obj.bucket == bucket]
+
+
+def reset() -> None:
+    """Clear the captured object list. Call from a test fixture
+    to keep uploads isolated between cases."""
+    _OBJECTS.clear()

--- a/docs/hermetic_test_doubles.md
+++ b/docs/hermetic_test_doubles.md
@@ -106,13 +106,45 @@ def test_welcome_email_sent_to_new_user():
 The autouse fixture resets the outbox between tests so captures
 don't leak.
 
+### Fake storage — `core/test_doubles/fake_storage.py`
+
+| | |
+|---|---|
+| Replaces | GCS upload in `core.billing.invoice_generator._upload_pdf` (and any future GCS upload sites) |
+| Activation | `AGENTICORG_TEST_FAKE_STORAGE=1` |
+| Default in tests | Yes — `tests/conftest.py` sets the flag at import time |
+| Capture | In-process `_OBJECTS` list — every upload becomes a `StoredObject` |
+| Inspection | `fake_storage.objects()`, `last()`, `count()`, `get(bucket, key)`, `list_in(bucket)` |
+| Cleanup between tests | `fake_storage.reset()` runs in the autouse conftest fixture |
+
+#### Adding a test that asserts a file was uploaded
+
+```python
+import asyncio, uuid
+from core.test_doubles import fake_storage
+from core.billing.invoice_generator import _upload_pdf
+
+
+def test_invoice_pdf_uploaded(monkeypatch):
+    monkeypatch.setenv("AGENTICORG_INVOICE_BUCKET", "billing-bucket")
+    tenant_id = uuid.uuid4()
+    url = asyncio.run(_upload_pdf(tenant_id, "INV-001", b"%PDF-1.4..."))
+    assert url == f"gs://billing-bucket/invoices/{tenant_id}/INV-001.pdf"
+    obj = fake_storage.get("billing-bucket", f"invoices/{tenant_id}/INV-001.pdf")
+    assert obj.content_type == "application/pdf"
+    assert obj.data.startswith(b"%PDF-")
+```
+
+Re-uploads to the same `(bucket, key)` overwrite — `get()` always
+returns the most-recent object, matching real GCS semantics.
+
 ## Planned doubles (Foundation #7 follow-up PRs)
 
 | Service | Double | Status |
 |---------|--------|--------|
 | LLM | Fake LLM | **Shipped (PR-A #357)** |
-| Mail | Fake mail | **Shipped (PR-B)** |
-| Object storage | LocalStack S3 / fake-gcs | PR-C |
+| Mail | Fake mail | **Shipped (PR-B #358)** |
+| Object storage | Fake storage | **Shipped (PR-C)** |
 | Connector APIs | Stub server (httpx mock app) | PR-D |
 | Celery worker | service container in CI | PR-E |
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,24 +21,22 @@ os.environ.setdefault("TMPDIR", str(_TEST_TMPDIR))
 # silent coverage gap. See docs/hermetic_test_doubles.md.
 os.environ.setdefault("AGENTICORG_TEST_FAKE_LLM", "1")
 os.environ.setdefault("AGENTICORG_TEST_FAKE_MAIL", "1")
+os.environ.setdefault("AGENTICORG_TEST_FAKE_STORAGE", "1")
 
 
 @pytest.fixture(autouse=True)
 def _reset_fake_doubles_between_tests():
     """Clear hermetic doubles' state before each test so captures
     + registrations don't bleed across cases."""
-    try:
-        from core.test_doubles import fake_llm
-
-        fake_llm.reset()
-    except ImportError:
-        pass
-    try:
-        from core.test_doubles import fake_mail
-
-        fake_mail.reset()
-    except ImportError:
-        pass
+    for _mod_name in ("fake_llm", "fake_mail", "fake_storage"):
+        try:
+            _mod = __import__(
+                f"core.test_doubles.{_mod_name}", fromlist=[_mod_name]
+            )
+            _mod.reset()
+        except ImportError:
+            # Module not yet shipped on this branch.
+            pass
     yield
 
 

--- a/tests/regression/test_fake_storage_seam.py
+++ b/tests/regression/test_fake_storage_seam.py
@@ -1,0 +1,132 @@
+"""Foundation #7 PR-C — fake storage hermetic seam regressions.
+
+Pinned behaviors:
+
+- ``is_active()`` reflects the env var.
+- ``upload``, ``get``, ``list_in``, ``count``, ``last``, ``reset``
+  work as documented.
+- The production ``_upload_pdf`` short-circuits to fake_storage
+  when the flag is set; no GCS client is constructed.
+- Re-uploads to the same key overwrite-by-recency semantics.
+- Conftest sets the flag by default; autouse fixture resets the
+  bucket between tests (paired bleed-check + parametrize).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import pytest
+
+from core.test_doubles import fake_storage
+
+
+def test_is_active_reflects_env_var(monkeypatch) -> None:
+    monkeypatch.delenv("AGENTICORG_TEST_FAKE_STORAGE", raising=False)
+    assert fake_storage.is_active() is False
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_STORAGE", "1")
+    assert fake_storage.is_active() is True
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_STORAGE", "true")
+    assert fake_storage.is_active() is True
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_STORAGE", "no")
+    assert fake_storage.is_active() is False
+
+
+def test_upload_records_object_and_returns_record() -> None:
+    rec = fake_storage.upload(
+        bucket="b1", key="path/to/x.pdf", data=b"hello", content_type="application/pdf"
+    )
+    assert rec.bucket == "b1"
+    assert rec.key == "path/to/x.pdf"
+    assert rec.data == b"hello"
+    assert rec.content_type == "application/pdf"
+    assert rec.gs_url == "gs://b1/path/to/x.pdf"
+    assert fake_storage.count() == 1
+    assert fake_storage.last() is rec
+
+
+def test_get_returns_most_recent_for_overwrite_semantics() -> None:
+    fake_storage.upload(bucket="b", key="k", data=b"v1")
+    fake_storage.upload(bucket="b", key="k", data=b"v2")
+    obj = fake_storage.get("b", "k")
+    assert obj is not None
+    assert obj.data == b"v2"
+
+
+def test_get_returns_none_when_not_found() -> None:
+    assert fake_storage.get("missing-bucket", "missing-key") is None
+
+
+def test_list_in_filters_by_bucket_oldest_first() -> None:
+    fake_storage.upload(bucket="a", key="k1", data=b"x")
+    fake_storage.upload(bucket="b", key="k2", data=b"x")
+    fake_storage.upload(bucket="a", key="k3", data=b"x")
+    assert fake_storage.list_in("a") == ["k1", "k3"]
+    assert fake_storage.list_in("b") == ["k2"]
+    assert fake_storage.list_in("nobody") == []
+
+
+def test_reset_clears_objects() -> None:
+    fake_storage.upload(bucket="b", key="k", data=b"x")
+    assert fake_storage.count() == 1
+    fake_storage.reset()
+    assert fake_storage.count() == 0
+    assert fake_storage.last() is None
+
+
+def test_invoice_upload_pdf_captures_under_fake(monkeypatch) -> None:
+    """End-to-end: production _upload_pdf path captures the PDF in
+    the fake bucket when the flag is on, never constructing a real
+    storage.Client."""
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_STORAGE", "1")
+    monkeypatch.setenv("AGENTICORG_INVOICE_BUCKET", "test-invoice-bucket")
+
+    from core.billing.invoice_generator import _upload_pdf
+
+    tenant_id = uuid.uuid4()
+    url = asyncio.run(_upload_pdf(tenant_id, "INV-2026-0001", b"%PDF-1.4 fake"))
+    assert url == f"gs://test-invoice-bucket/invoices/{tenant_id}/INV-2026-0001.pdf"
+    assert fake_storage.count() == 1
+
+    obj = fake_storage.get(
+        "test-invoice-bucket", f"invoices/{tenant_id}/INV-2026-0001.pdf"
+    )
+    assert obj is not None
+    assert obj.data == b"%PDF-1.4 fake"
+    assert obj.content_type == "application/pdf"
+
+
+def test_invoice_upload_pdf_returns_empty_when_no_bucket(monkeypatch) -> None:
+    """No-bucket env var → fake still no-ops cleanly + no capture."""
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_STORAGE", "1")
+    monkeypatch.delenv("AGENTICORG_INVOICE_BUCKET", raising=False)
+
+    from core.billing.invoice_generator import _upload_pdf
+
+    url = asyncio.run(_upload_pdf(uuid.uuid4(), "INV-X", b"x"))
+    assert url == ""
+    assert fake_storage.count() == 0
+
+
+def test_conftest_default_makes_fake_storage_active() -> None:
+    assert os.environ.get("AGENTICORG_TEST_FAKE_STORAGE") == "1"
+    assert fake_storage.is_active() is True
+
+
+def test_autouse_fixture_resets_storage_part_1() -> None:
+    fake_storage.upload(bucket="bleed", key="k", data=b"x")
+    assert fake_storage.count() == 1
+
+
+def test_autouse_fixture_resets_storage_part_2() -> None:
+    """Second half of the bleed-check pair — must see empty bucket."""
+    assert fake_storage.count() == 0
+
+
+@pytest.mark.parametrize("bucket", ["b1", "b2", "b3"])
+def test_each_param_starts_with_empty_storage(bucket) -> None:
+    assert fake_storage.count() == 0
+    fake_storage.upload(bucket=bucket, key="k", data=b"x")
+    assert fake_storage.count() == 1


### PR DESCRIPTION
## Summary

Foundation #7 PR-C — same shape as PR-A (fake LLM #357) and PR-B (fake mail #358): single env-var seam at the boundary, in-process capture sink, autouse reset fixture, regression suite pinning the contract.

**Stacked on PR-B (#358)** — depends on its conftest + docs additions. Will rebase if #358 requires changes during review.

## What lands

- **\`core/test_doubles/fake_storage.py\`** — \`is_active()\`, \`upload()\`, \`get(b,k)\`, \`list_in(b)\`, \`count()\`, \`last()\`, \`reset()\`, \`StoredObject.gs_url\`.
- **\`core/billing/invoice_generator.py\`** — \`_upload_pdf\` checks the flag FIRST and captures the PDF in-process; never constructs a real \`google.cloud.storage.Client\` under the fake.
- **\`tests/conftest.py\`** — sets \`AGENTICORG_TEST_FAKE_STORAGE=1\` at import time. Autouse fixture loop now resets all three doubles (fake_llm + fake_mail + fake_storage) via \`__import__\` so future doubles can be added with a one-line tuple update.
- **\`tests/regression/test_fake_storage_seam.py\`** — 12 tests including: env-var reflection, upload, get-overwrite-by-recency, list_in, count, reset, end-to-end \`_upload_pdf\` under fake, no-bucket no-op, conftest default pin, autouse-bleed verification (paired tests + parametrized).
- **\`docs/hermetic_test_doubles.md\`** — new fake-storage contract section.

## Verification

- \`pytest fake_storage + fake_mail + fake_llm seams\` → **38 passed**
- ruff + bandit clean

## Roadmap (Foundation #7)

| PR | Double | Status |
|----|--------|--------|
| PR-A | Fake LLM | Merged (#357) |
| PR-B | Fake mail | In flight (#358) |
| **PR-C** | **Fake storage** | **This PR** |
| PR-D | Connector stub server | Next |
| PR-E | Celery worker service | After |

@codex please review

## Test plan

- [x] 38 hermetic-double seam tests green locally
- [ ] CI green
- [ ] Will need to wait for #358 to merge then rebase before this PR is mergeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)