### PR TITLE
feat(test): Foundation #7 PR-D — fake connectors hermetic seam

### DIFF
--- a/connectors/framework/base_connector.py
+++ b/connectors/framework/base_connector.py
@@ -94,11 +94,25 @@ class BaseConnector(abc.ABC):
                 "connector_skip_auth_no_credentials",
                 connector=self.name,
             )
+
+        # Foundation #7 PR-D: hermetic-CI seam. When the env flag
+        # is set, route every connector HTTP call through the
+        # fake-connectors MockTransport so PR CI never touches a
+        # real third-party API. See docs/hermetic_test_doubles.md.
+        from core.test_doubles import fake_connectors  # noqa: PLC0415 — lazy keeps prod cold-path lean
+
+        transport = (
+            fake_connectors.build_transport()
+            if fake_connectors.is_active()
+            else None
+        )
+
         # Create client with whatever auth headers were set (may be empty)
         self._client = httpx.AsyncClient(
             base_url=self.base_url,
             timeout=self.timeout_ms / 1000,
             headers=self._auth_headers,
+            transport=transport,
         )
 
     async def disconnect(self) -> None:

--- a/core/test_doubles/fake_connectors.py
+++ b/core/test_doubles/fake_connectors.py
@@ -1,0 +1,202 @@
+"""Hermetic fake connector HTTP layer (Foundation #7 PR-D).
+
+Connectors call third-party APIs (Gmail, Tally, GSTN, Stripe,
+Salesforce, ...) through ``httpx.AsyncClient`` instances built
+in ``connectors.framework.base_connector.BaseConnector.connect()``.
+
+Real calls are slow, flaky, charge money, and require credentials
+that PR CI can't (and shouldn't) carry. This module provides a
+single stub-server seam: every connector's AsyncClient gets a
+``httpx.MockTransport`` whose router consults an in-process
+registry of ``(method, url_pattern) -> response`` rules.
+
+Activation: ``AGENTICORG_TEST_FAKE_CONNECTORS=1``. The conftest
+sets this by default for every test run.
+
+Default behavior for unregistered URLs: **404**, not 200. Tests
+that hit an endpoint they didn't mock should fail loudly so the
+gap is visible — not silently succeed with a generic body. Tests
+that legitimately don't care about a particular call can register
+a wildcard rule.
+
+Registration::
+
+    from core.test_doubles import fake_connectors
+
+    fake_connectors.register(
+        method="GET",
+        url_contains="/api/customers",
+        status=200,
+        json={"customers": [{"id": 1, "name": "Acme"}]},
+    )
+
+    # Or for the wildcard match-all per connector:
+    fake_connectors.register(
+        method="*",
+        url_contains="api.gmail.com",
+        status=200,
+        json={"messages": []},
+    )
+
+Inspection::
+
+    fake_connectors.request_log()  # list of every call attempted
+    fake_connectors.count()        # how many requests made
+    fake_connectors.reset()        # clear registry + log
+
+The autouse fixture in tests/conftest.py calls ``reset()`` before
+each test so registrations + the request log don't leak.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+
+@dataclass
+class StubRule:
+    """One registered stub response."""
+
+    method: str  # "GET", "POST", "*" for any
+    url_contains: str  # case-insensitive substring match
+    status: int = 200
+    json_body: Any = None
+    text_body: str | None = None
+    headers: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class CapturedRequest:
+    """One captured outbound HTTP attempt."""
+
+    method: str
+    url: str
+    matched_rule_index: int | None = None  # None = default 404
+    timestamp: float = field(default_factory=time.time)
+
+
+_RULES: list[StubRule] = []
+_REQUEST_LOG: list[CapturedRequest] = []
+
+
+def is_active() -> bool:
+    """True iff ``AGENTICORG_TEST_FAKE_CONNECTORS`` is truthy."""
+    return os.getenv("AGENTICORG_TEST_FAKE_CONNECTORS", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def register(
+    *,
+    method: str,
+    url_contains: str,
+    status: int = 200,
+    json: Any = None,
+    text: str | None = None,
+    headers: dict[str, str] | None = None,
+) -> None:
+    """Register a stub response for any request matching the rule.
+
+    Match precedence: most-recently-registered wins. The ``method``
+    can be ``"*"`` for any HTTP verb. ``url_contains`` is a
+    case-insensitive substring match.
+
+    If both ``json`` and ``text`` are given, ``text`` wins.
+    """
+    if not url_contains.strip():
+        raise ValueError("url_contains must be non-empty")
+    _RULES.append(
+        StubRule(
+            method=method.upper(),
+            url_contains=url_contains.lower(),
+            status=status,
+            json_body=json,
+            text_body=text,
+            headers=headers or {},
+        )
+    )
+
+
+def request_log() -> list[CapturedRequest]:
+    """Return a copy of every captured request, oldest first."""
+    return list(_REQUEST_LOG)
+
+
+def count() -> int:
+    """Total requests captured since the last reset."""
+    return len(_REQUEST_LOG)
+
+
+def reset() -> None:
+    """Clear the rule registry + request log."""
+    _RULES.clear()
+    _REQUEST_LOG.clear()
+
+
+# ─────────────────────────────────────────────────────────────────
+# The MockTransport handler
+# ─────────────────────────────────────────────────────────────────
+
+
+def _match(request: httpx.Request) -> tuple[int | None, StubRule | None]:
+    url_l = str(request.url).lower()
+    method_u = request.method.upper()
+    # Most-recently-registered wins → walk in reverse.
+    for i in range(len(_RULES) - 1, -1, -1):
+        rule = _RULES[i]
+        if rule.method != "*" and rule.method != method_u:
+            continue
+        if rule.url_contains in url_l:
+            return i, rule
+    return None, None
+
+
+def _handler(request: httpx.Request) -> httpx.Response:
+    idx, rule = _match(request)
+    _REQUEST_LOG.append(
+        CapturedRequest(
+            method=request.method,
+            url=str(request.url),
+            matched_rule_index=idx,
+        )
+    )
+    if rule is None:
+        # Default: 404 with a marker body so tests see a clear
+        # "you didn't mock this" signal rather than a silent 200.
+        return httpx.Response(
+            404,
+            json={
+                "fake_connectors_error": "no_rule_matched",
+                "method": request.method,
+                "url": str(request.url),
+                "hint": (
+                    "Add a fake_connectors.register(method=, "
+                    "url_contains=, ...) call in your test."
+                ),
+            },
+        )
+    if rule.text_body is not None:
+        return httpx.Response(
+            rule.status, text=rule.text_body, headers=rule.headers
+        )
+    return httpx.Response(
+        rule.status, json=rule.json_body, headers=rule.headers
+    )
+
+
+def build_transport() -> httpx.MockTransport:
+    """Return a MockTransport bound to the in-process registry.
+
+    Every connector AsyncClient that wants hermetic mode constructs
+    one of these and passes it as ``transport=``. The handler
+    closure references the module-level _RULES + _REQUEST_LOG so a
+    single transport works for the whole process.
+    """
+    return httpx.MockTransport(_handler)

--- a/core/test_doubles/fake_connectors.py
+++ b/core/test_doubles/fake_connectors.py
@@ -200,3 +200,48 @@ def build_transport() -> httpx.MockTransport:
     single transport works for the whole process.
     """
     return httpx.MockTransport(_handler)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Global httpx patch — covers auth-time + one-off clients
+# ─────────────────────────────────────────────────────────────────
+#
+# BaseConnector.connect() attaches the MockTransport to the long-
+# lived ``self._client``, but many connectors build their own
+# short-lived ``httpx.AsyncClient`` inside ``_authenticate`` (OAuth
+# refresh in Gmail, Google Calendar, Salesforce) or in one-off
+# helpers (GSTN, ServiceNow, Brandwatch, ...). Those clients bypass
+# the per-instance transport and would hit the real network.
+#
+# We patch ``httpx.AsyncClient.__init__`` once so that whenever the
+# flag is active AND the caller didn't pass an explicit
+# ``transport=``, the MockTransport is injected. Activation is re-
+# checked on every call, so per-test opt-out
+# (``AGENTICORG_TEST_FAKE_CONNECTORS=""``) still works. Explicit
+# ``transport=`` arguments are preserved.
+
+_original_async_client_init: Any = None
+_patch_installed = False
+
+
+def install_global_patch() -> None:
+    """Patch ``httpx.AsyncClient`` so auth-time clients also stub.
+
+    Idempotent. Called once from ``tests/conftest.py`` at import
+    time. Outside the test suite this is never installed, so the
+    production cold path is untouched.
+    """
+    global _original_async_client_init, _patch_installed
+    if _patch_installed:
+        return
+    _original_async_client_init = httpx.AsyncClient.__init__
+
+    def _patched_init(
+        self: httpx.AsyncClient, *args: Any, **kwargs: Any
+    ) -> None:
+        if is_active() and "transport" not in kwargs:
+            kwargs["transport"] = build_transport()
+        _original_async_client_init(self, *args, **kwargs)
+
+    httpx.AsyncClient.__init__ = _patched_init  # type: ignore[method-assign]
+    _patch_installed = True

--- a/docs/hermetic_test_doubles.md
+++ b/docs/hermetic_test_doubles.md
@@ -138,14 +138,57 @@ def test_invoice_pdf_uploaded(monkeypatch):
 Re-uploads to the same `(bucket, key)` overwrite — `get()` always
 returns the most-recent object, matching real GCS semantics.
 
+### Fake connectors — `core/test_doubles/fake_connectors.py`
+
+| | |
+|---|---|
+| Replaces | All third-party HTTP calls in `connectors.framework.base_connector.BaseConnector.connect()` |
+| Activation | `AGENTICORG_TEST_FAKE_CONNECTORS=1` |
+| Default in tests | Yes — `tests/conftest.py` sets the flag at import time |
+| Mechanism | `httpx.MockTransport` injected into every connector AsyncClient |
+| Default for unmatched URL | **404** with `no_rule_matched` body (Foundation #8 false-green prevention — surface gaps loudly) |
+| Inspection | `fake_connectors.request_log()`, `count()` |
+| Cleanup between tests | `fake_connectors.reset()` runs in the autouse conftest fixture |
+
+#### Adding a test that asserts a connector hit a specific endpoint
+
+```python
+from core.test_doubles import fake_connectors
+
+def test_gmail_connector_lists_messages():
+    fake_connectors.register(
+        method="GET",
+        url_contains="gmail.googleapis.com/gmail/v1/users/me/messages",
+        status=200,
+        json={"messages": [{"id": "m1"}, {"id": "m2"}]},
+    )
+    out = my_gmail_tool.list_messages()
+    assert len(out) == 2
+    # Optional: assert the URL the connector actually hit.
+    log = fake_connectors.request_log()
+    assert any("messages" in c.url for c in log)
+```
+
+Match precedence: most-recently-registered wins; `method="*"`
+matches any verb. Substring match is case-insensitive on the URL.
+
+#### Why 404 (not 200) for unmatched URLs
+
+The default response for an unregistered URL is a **404 with a
+"no_rule_matched" marker body**, NOT a generic 200. A test that
+hits an endpoint it didn't mock should fail loudly so the gap is
+visible. A silent 200 would hide the missing assertion — exactly
+the false-green pattern Foundation #8's claude-mistakes test
+forbids.
+
 ## Planned doubles (Foundation #7 follow-up PRs)
 
 | Service | Double | Status |
 |---------|--------|--------|
 | LLM | Fake LLM | **Shipped (PR-A #357)** |
 | Mail | Fake mail | **Shipped (PR-B #358)** |
-| Object storage | Fake storage | **Shipped (PR-C)** |
-| Connector APIs | Stub server (httpx mock app) | PR-D |
+| Object storage | Fake storage | **Shipped (PR-C #359)** |
+| Connector APIs | Fake connectors | **Shipped (PR-D)** |
 | Celery worker | service container in CI | PR-E |
 
 Each follow-up follows the same shape: env-var seam at the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,16 @@ os.environ.setdefault("AGENTICORG_TEST_FAKE_MAIL", "1")
 os.environ.setdefault("AGENTICORG_TEST_FAKE_STORAGE", "1")
 os.environ.setdefault("AGENTICORG_TEST_FAKE_CONNECTORS", "1")
 
+# Foundation #7 PR-D: install the global httpx.AsyncClient patch so
+# auth-time + one-off clients (e.g. OAuth token refresh inside
+# connector ``_authenticate``) also route through MockTransport, not
+# just the long-lived BaseConnector.self._client. Re-checks the env
+# flag per call → per-test opt-out still works.
+__import__(
+    "core.test_doubles.fake_connectors",
+    fromlist=["install_global_patch"],
+).install_global_patch()
+
 
 @pytest.fixture(autouse=True)
 def _reset_fake_doubles_between_tests():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,13 +22,14 @@ os.environ.setdefault("TMPDIR", str(_TEST_TMPDIR))
 os.environ.setdefault("AGENTICORG_TEST_FAKE_LLM", "1")
 os.environ.setdefault("AGENTICORG_TEST_FAKE_MAIL", "1")
 os.environ.setdefault("AGENTICORG_TEST_FAKE_STORAGE", "1")
+os.environ.setdefault("AGENTICORG_TEST_FAKE_CONNECTORS", "1")
 
 
 @pytest.fixture(autouse=True)
 def _reset_fake_doubles_between_tests():
     """Clear hermetic doubles' state before each test so captures
     + registrations don't bleed across cases."""
-    for _mod_name in ("fake_llm", "fake_mail", "fake_storage"):
+    for _mod_name in ("fake_llm", "fake_mail", "fake_storage", "fake_connectors"):
         try:
             _mod = __import__(
                 f"core.test_doubles.{_mod_name}", fromlist=[_mod_name]

--- a/tests/regression/test_fake_connectors_seam.py
+++ b/tests/regression/test_fake_connectors_seam.py
@@ -1,0 +1,216 @@
+"""Foundation #7 PR-D — fake connectors hermetic seam regressions.
+
+Pinned behaviors:
+
+- ``is_active()`` reflects the env var.
+- ``register()`` accepts json/text/headers and most-recent wins.
+- Empty ``url_contains`` is rejected.
+- The MockTransport routes by case-insensitive substring +
+  method (``*`` = any).
+- Unmatched requests return 404 with a clear "no_rule_matched"
+  body so tests fail loudly on missing mocks (NOT silently
+  succeed with a generic 200 — Foundation #8 false-green
+  prevention).
+- ``request_log()`` records every call attempt including
+  unmatched ones.
+- ``reset()`` clears rules + log.
+- The conftest enables the seam by default; autouse fixture
+  resets between tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import httpx
+import pytest
+
+from core.test_doubles import fake_connectors
+
+
+def test_is_active_reflects_env_var(monkeypatch) -> None:
+    monkeypatch.delenv("AGENTICORG_TEST_FAKE_CONNECTORS", raising=False)
+    assert fake_connectors.is_active() is False
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_CONNECTORS", "1")
+    assert fake_connectors.is_active() is True
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_CONNECTORS", "true")
+    assert fake_connectors.is_active() is True
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_CONNECTORS", "no")
+    assert fake_connectors.is_active() is False
+
+
+def test_register_empty_url_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        fake_connectors.register(method="GET", url_contains="   ")
+
+
+def test_register_json_response_round_trips() -> None:
+    fake_connectors.register(
+        method="GET",
+        url_contains="/api/customers",
+        status=200,
+        json={"customers": [{"id": 1, "name": "Acme"}]},
+    )
+    transport = fake_connectors.build_transport()
+
+    async def _go():
+        async with httpx.AsyncClient(
+            base_url="https://example.com", transport=transport
+        ) as client:
+            return await client.get("/api/customers")
+
+    resp = asyncio.run(_go())
+    assert resp.status_code == 200
+    assert resp.json() == {"customers": [{"id": 1, "name": "Acme"}]}
+    assert fake_connectors.count() == 1
+
+
+def test_unmatched_request_returns_404_with_clear_marker() -> None:
+    """Foundation #8 false-green prevention — an unmocked URL
+    must NOT silently succeed. The 404 + no_rule_matched body
+    forces the test author to register a stub explicitly."""
+    transport = fake_connectors.build_transport()
+
+    async def _go():
+        async with httpx.AsyncClient(
+            base_url="https://example.com", transport=transport
+        ) as client:
+            return await client.get("/api/never-mocked")
+
+    resp = asyncio.run(_go())
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["fake_connectors_error"] == "no_rule_matched"
+    assert "/api/never-mocked" in body["url"]
+    assert "register" in body["hint"]
+
+
+def test_method_wildcard_matches_any_verb() -> None:
+    fake_connectors.register(
+        method="*", url_contains="api.gmail.com", status=200, json={"ok": True}
+    )
+    transport = fake_connectors.build_transport()
+
+    async def _go():
+        async with httpx.AsyncClient(transport=transport) as client:
+            r1 = await client.get("https://api.gmail.com/messages")
+            r2 = await client.post("https://api.gmail.com/messages", json={})
+            r3 = await client.delete("https://api.gmail.com/messages/1")
+            return r1, r2, r3
+
+    r1, r2, r3 = asyncio.run(_go())
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r3.status_code == 200
+
+
+def test_method_specific_rule_does_not_match_other_verbs() -> None:
+    fake_connectors.register(
+        method="GET", url_contains="/api/x", status=200, json={"got": True}
+    )
+    transport = fake_connectors.build_transport()
+
+    async def _go():
+        async with httpx.AsyncClient(
+            base_url="https://example.com", transport=transport
+        ) as client:
+            return await client.post("/api/x", json={})
+
+    resp = asyncio.run(_go())
+    assert resp.status_code == 404
+
+
+def test_most_recently_registered_rule_wins() -> None:
+    fake_connectors.register(
+        method="GET", url_contains="/api/x", status=200, json={"v": 1}
+    )
+    fake_connectors.register(
+        method="GET", url_contains="/api/x", status=200, json={"v": 2}
+    )
+    transport = fake_connectors.build_transport()
+
+    async def _go():
+        async with httpx.AsyncClient(
+            base_url="https://example.com", transport=transport
+        ) as client:
+            return await client.get("/api/x")
+
+    resp = asyncio.run(_go())
+    assert resp.json() == {"v": 2}
+
+
+def test_text_response_overrides_json() -> None:
+    fake_connectors.register(
+        method="GET",
+        url_contains="/csv",
+        status=200,
+        json={"ignored": True},
+        text="a,b,c\n1,2,3\n",
+        headers={"Content-Type": "text/csv"},
+    )
+    transport = fake_connectors.build_transport()
+
+    async def _go():
+        async with httpx.AsyncClient(transport=transport) as client:
+            return await client.get("https://example.com/csv")
+
+    resp = asyncio.run(_go())
+    assert resp.text.startswith("a,b,c")
+    assert resp.headers["content-type"].startswith("text/csv")
+
+
+def test_request_log_records_unmatched_too() -> None:
+    transport = fake_connectors.build_transport()
+
+    async def _go():
+        async with httpx.AsyncClient(
+            base_url="https://example.com", transport=transport
+        ) as client:
+            await client.get("/api/missing")
+
+    asyncio.run(_go())
+    log = fake_connectors.request_log()
+    assert len(log) == 1
+    assert log[0].matched_rule_index is None
+    assert log[0].method == "GET"
+    assert "/api/missing" in log[0].url
+
+
+def test_reset_clears_both_rules_and_log() -> None:
+    fake_connectors.register(method="GET", url_contains="/x", status=200)
+    transport = fake_connectors.build_transport()
+
+    async def _go():
+        async with httpx.AsyncClient(transport=transport) as client:
+            await client.get("https://example.com/x")
+
+    asyncio.run(_go())
+    assert fake_connectors.count() == 1
+    fake_connectors.reset()
+    assert fake_connectors.count() == 0
+    # Re-running with no rules → 404 (not the prior 200).
+    asyncio.run(_go())
+    assert fake_connectors.request_log()[0].matched_rule_index is None
+
+
+def test_conftest_default_makes_fake_connectors_active() -> None:
+    assert os.environ.get("AGENTICORG_TEST_FAKE_CONNECTORS") == "1"
+    assert fake_connectors.is_active() is True
+
+
+def test_autouse_fixture_resets_part_1() -> None:
+    fake_connectors.register(method="GET", url_contains="/bleed", status=200)
+    transport = fake_connectors.build_transport()
+
+    async def _go():
+        async with httpx.AsyncClient(transport=transport) as client:
+            await client.get("https://example.com/bleed")
+
+    asyncio.run(_go())
+    assert fake_connectors.count() == 1
+
+
+def test_autouse_fixture_resets_part_2() -> None:
+    """Bleed-check second half — must see clean state."""
+    assert fake_connectors.count() == 0

--- a/tests/regression/test_fake_connectors_seam.py
+++ b/tests/regression/test_fake_connectors_seam.py
@@ -214,3 +214,82 @@ def test_autouse_fixture_resets_part_1() -> None:
 def test_autouse_fixture_resets_part_2() -> None:
     """Bleed-check second half — must see clean state."""
     assert fake_connectors.count() == 0
+
+
+def test_global_patch_intercepts_auth_time_one_off_client() -> None:
+    """Codex PR-D P1: connectors that build their own short-lived
+    ``httpx.AsyncClient`` inside ``_authenticate`` (Gmail OAuth
+    refresh, Salesforce, GSTN, ServiceNow, ...) must also be
+    intercepted — not just BaseConnector.self._client. The global
+    patch in conftest installs ``install_global_patch()`` so any
+    AsyncClient built without an explicit ``transport=`` kwarg
+    gets the MockTransport injected automatically.
+    """
+    fake_connectors.register(
+        method="POST",
+        url_contains="oauth2.googleapis.com",
+        status=200,
+        json={"access_token": "fake-token"},
+    )
+
+    async def _refresh_oauth_like_gmail_does():
+        # Note: NO transport= kwarg. This is the exact shape of
+        # connectors/comms/gmail.py:38 and similar OAuth refresh
+        # paths. Without the global patch this would hit real
+        # network (or fail in CI).
+        async with httpx.AsyncClient() as client:
+            return await client.post(
+                "https://oauth2.googleapis.com/token",
+                data={"grant_type": "refresh_token"},
+            )
+
+    resp = asyncio.run(_refresh_oauth_like_gmail_does())
+    assert resp.status_code == 200
+    assert resp.json() == {"access_token": "fake-token"}
+    assert fake_connectors.count() == 1
+
+
+def test_global_patch_preserves_explicit_transport() -> None:
+    """If a caller passes ``transport=`` explicitly, the global
+    patch must NOT override it. This protects test code that
+    deliberately wants a custom transport (or another MockTransport
+    bound to a different registry)."""
+    custom_transport = httpx.MockTransport(
+        lambda req: httpx.Response(418, json={"explicit": True})
+    )
+
+    async def _go():
+        async with httpx.AsyncClient(transport=custom_transport) as client:
+            return await client.get("https://example.com/anything")
+
+    resp = asyncio.run(_go())
+    assert resp.status_code == 418
+    assert resp.json() == {"explicit": True}
+    # The fake_connectors registry is untouched — the request
+    # went through the explicit transport, not the global one.
+    assert fake_connectors.count() == 0
+
+
+def test_global_patch_respects_per_test_opt_out(monkeypatch) -> None:
+    """Per-test opt-out via env-var unset must still work — the
+    patch re-checks ``is_active()`` on every AsyncClient
+    construction, so clearing the flag in a single test routes
+    that test's clients through the original (real) httpx path."""
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_CONNECTORS", "")
+    assert fake_connectors.is_active() is False
+
+    # Build a client with no transport — without the env flag,
+    # the global patch is a no-op and the real httpx default
+    # transport is used. We don't actually make a network call;
+    # we just verify the transport wasn't auto-injected.
+    client = httpx.AsyncClient()
+    try:
+        # The MockTransport from build_transport() would be an
+        # instance of httpx.MockTransport. The default httpx
+        # transport is httpx.AsyncHTTPTransport. Confirm we got
+        # the real one.
+        assert not isinstance(
+            client._transport, httpx.MockTransport
+        ), "Global patch should not inject MockTransport when flag is off"
+    finally:
+        asyncio.run(client.aclose())


### PR DESCRIPTION
## Summary

Foundation #7 PR-D — same shape as PR-A/B/C: one env-var seam at the boundary, this time at \`connectors.framework.base_connector.BaseConnector.connect()\` where every connector AsyncClient is built. Under the flag, the client gets an \`httpx.MockTransport\` whose router consults the in-process registry of stub rules.

**Stacked on PR-C (#359) which is stacked on PR-B (#358).** Includes the cherry-picked fix for \`TestSendEmail.test_sends_when_valid\` (opts out of fake-mail) so this branch's CI is independent.

## What lands

- **\`core/test_doubles/fake_connectors.py\`** — \`is_active()\`, \`register(method=, url_contains=, status=, json=, text=, headers=)\`, \`build_transport()\`, \`request_log()\`, \`count()\`, \`reset()\`. Last-registered wins, \`method="*"\` matches any verb.
- **\`connectors/framework/base_connector.py\`** — \`connect()\` passes \`transport=\` when the flag is set; every connector inherits the seam for free.
- **\`tests/conftest.py\`** — sets \`AGENTICORG_TEST_FAKE_CONNECTORS=1\` at import time. Autouse fixture loop now resets all 4 doubles.
- **\`tests/regression/test_fake_connectors_seam.py\`** — 13 tests including unmatched URL → 404 with marker (Foundation #8 false-green prevention), method wildcard, last-wins precedence, text-overrides-json, request_log including unmatched, autouse-bleed pair.
- **\`docs/hermetic_test_doubles.md\`** — fake-connectors section + roadmap update.

## Why default-404 (not 200) for unmatched URLs

A test that hits an endpoint it didn't mock should fail loudly. A silent 200 with a generic body would hide the missing assertion — exactly the false-green pattern Foundation #8's \`claude_mistakes\` test forbids.

## Verification

- \`pytest 4 hermetic seams\` → **51 passed** (12 LLM + 12 mail + 12 storage + 13 connectors + 2 cross-bleed)
- ruff + bandit clean

## Roadmap (Foundation #7)

| PR | Double | Status |
|----|--------|--------|
| PR-A | Fake LLM | Merged (#357) |
| PR-B | Fake mail | In flight (#358) |
| PR-C | Fake storage | In flight (#359) |
| **PR-D** | **Fake connectors** | **This PR** |
| PR-E | Celery worker service | Last |

@codex please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)