### PR TITLE
test(qa): Foundation #6 — Module 12 Audit Log (6 TCs)

### DIFF
--- a/docs/qa_test_matrix.yml
+++ b/docs/qa_test_matrix.yml
@@ -593,39 +593,67 @@ entries:
 - id: TC-AUDIT-001
   module: 'Module 12: Audit Log'
   title: Audit log page loads
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P1
+  references:
+    - 'tests/unit/test_module_12_audit_log.py::test_tc_audit_001_get_endpoint_returns_paginated_response'
+    - 'tests/unit/test_module_12_audit_log.py::test_tc_audit_001_audit_to_dict_includes_required_fields'
+    - 'ui/e2e/qa-module-12-audit-log.spec.ts::TC-AUDIT-001 GET /audit returns paginated shape'
+    - 'ui/e2e/qa-module-12-audit-log.spec.ts::TC-AUDIT-001b Audit page renders with title + table headers'
+  notes: 'Foundation #6 burndown 2026-04-28: endpoint contract + UI render pinned.'
 - id: TC-AUDIT-002
   module: 'Module 12: Audit Log'
   title: Filter by event type
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P1
+  references:
+    - 'tests/unit/test_module_12_audit_log.py::test_tc_audit_002_event_type_uses_ilike_substring_pattern'
+    - 'ui/e2e/qa-module-12-audit-log.spec.ts::TC-AUDIT-002 GET /audit?event_type=auth substring filter accepted'
+    - 'ui/e2e/qa-module-12-audit-log.spec.ts::TC-AUDIT-002b UI filter input updates results'
+  notes: 'Foundation #6 burndown 2026-04-28: ILIKE substring + UI input pinned.'
 - id: TC-AUDIT-003
   module: 'Module 12: Audit Log'
   title: Pagination
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P1
+  references:
+    - 'tests/unit/test_module_12_audit_log.py::test_tc_audit_003_per_page_capped_at_100'
+    - 'tests/unit/test_module_12_audit_log.py::test_tc_audit_003_page_one_minimum_enforced'
+    - 'tests/unit/test_module_12_audit_log.py::test_tc_audit_003_results_ordered_desc_by_created_at'
+    - 'ui/e2e/qa-module-12-audit-log.spec.ts::TC-AUDIT-003 page < 1 returns 422'
+    - 'ui/e2e/qa-module-12-audit-log.spec.ts::TC-AUDIT-003b per_page > 100 is silently clamped to 100'
+    - 'ui/e2e/qa-module-12-audit-log.spec.ts::TC-AUDIT-003c UI pagination buttons render with Previous disabled on page 1'
+  notes: 'Foundation #6 burndown 2026-04-28: cap + minimum + ordering + UI buttons pinned.'
 - id: TC-AUDIT-004
   module: 'Module 12: Audit Log'
   title: Export as CSV
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P2
+  references:
+    - 'tests/unit/test_module_12_audit_log.py::test_tc_audit_004_csv_export_uses_blob_and_text_csv_mime'
+    - 'ui/e2e/qa-module-12-audit-log.spec.ts::TC-AUDIT-004 Download CSV button triggers a CSV download'
+  notes: 'Foundation #6 burndown 2026-04-28: client-side CSV blob + download trigger pinned.'
 - id: TC-AUDIT-005
   module: 'Module 12: Audit Log'
   title: Export evidence package (JSON)
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P1
+  references:
+    - 'tests/unit/test_module_12_audit_log.py::test_tc_audit_005_evidence_json_export_filename_is_pinned'
+    - 'ui/e2e/qa-module-12-audit-log.spec.ts::TC-AUDIT-005 Export Evidence Package button triggers a JSON download'
+  notes: 'Foundation #6 burndown 2026-04-28: SOC-2-runbook-referenced filename pinned.'
 - id: TC-AUDIT-006
   module: 'Module 12: Audit Log'
   title: "Auditor role \u2014 read-only access"
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P0
+  references:
+    - 'tests/unit/test_module_12_audit_log.py::test_tc_audit_006_auditor_bypasses_domain_filter'
+    - 'tests/unit/test_module_12_audit_log.py::test_tc_audit_006_audit_log_is_db_level_append_only'
+    - 'tests/unit/test_module_12_audit_log.py::test_tc_audit_006_compliance_evidence_endpoint_is_read_only'
+    - 'ui/e2e/qa-module-12-audit-log.spec.ts::TC-AUDIT-006 GET /audit returns rows for the auditing identity'
+    - 'ui/e2e/qa-module-12-audit-log.spec.ts::TC-AUDIT-006b /audit endpoint has no POST/PUT/DELETE handler'
+  notes: 'Foundation #6 burndown 2026-04-28: route RBAC + DB-level append-only trigger + verb-only-GET pinned.'
 - id: TC-COMP-001
   module: 'Module 13: Compliance (DSAR)'
   title: DSAR access request

--- a/tests/unit/test_module_12_audit_log.py
+++ b/tests/unit/test_module_12_audit_log.py
@@ -1,0 +1,165 @@
+"""Foundation #6 — Module 12 Audit Log.
+
+Source-pin tests for TC-AUDIT-001 through TC-AUDIT-006 from
+``docs/qa_test_matrix.yml``.
+
+The audit log is the compliance backbone — every other safety
+property in the platform leans on the assumption that audit
+entries are tamper-evident, queryable by event_type +
+date range, paginated, and exportable. These pins guard:
+
+- The /audit endpoint contract (params, RBAC, ILIKE semantics).
+- The page-size cap (so a request can't ask for 10k rows and
+  blow the API memory budget).
+- The append-only DB trigger that refuses UPDATE/DELETE on
+  audit_log rows.
+- The UI export contract (CSV + evidence-JSON filenames + mime).
+- The auditor-role bypass of the domain filter (auditor sees
+  cross-domain entries, all other roles get domain-scoped
+  results).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-AUDIT-001 — Audit log page loads (endpoint contract)
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_audit_001_get_endpoint_returns_paginated_response() -> None:
+    src = (REPO / "api" / "v1" / "audit.py").read_text(encoding="utf-8")
+    assert '@router.get("/audit", response_model=PaginatedResponse)' in src
+    # The handler must accept the documented filter params.
+    for param in ("event_type", "agent_id", "company_id",
+                  "date_from", "date_to", "page", "per_page"):
+        assert param in src, f"audit endpoint missing parameter: {param}"
+
+
+def test_tc_audit_001_audit_to_dict_includes_required_fields() -> None:
+    """Every audit row dict must carry the fields the UI renders.
+    A field rename here silently empties the table."""
+    src = (REPO / "api" / "v1" / "audit.py").read_text(encoding="utf-8")
+    for field in (
+        '"id"', '"event_type"', '"actor_type"', '"actor_id"',
+        '"agent_id"', '"resource_type"', '"resource_id"',
+        '"action"', '"outcome"', '"created_at"',
+    ):
+        assert field in src, f"_audit_to_dict missing key {field}"
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-AUDIT-002 — Filter by event type
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_audit_002_event_type_uses_ilike_substring_pattern() -> None:
+    """event_type filter is a CASE-INSENSITIVE substring match
+    (ILIKE '%pattern%') — not equality. If this is changed to
+    equality, "auth" would stop matching "auth.login" / "auth.logout"
+    and the audit page filter UX silently breaks."""
+    src = (REPO / "api" / "v1" / "audit.py").read_text(encoding="utf-8")
+    assert "AuditLog.event_type.ilike(pattern)" in src
+    assert 'pattern = f"%{event_type}%"' in src
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-AUDIT-003 — Pagination
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_audit_003_per_page_capped_at_100() -> None:
+    """per_page is clamped to [1, 100]. Without the cap a request
+    can ask for 10k rows and OOM the API process."""
+    src = (REPO / "api" / "v1" / "audit.py").read_text(encoding="utf-8")
+    assert "per_page = min(max(per_page, 1), 100)" in src
+
+
+def test_tc_audit_003_page_one_minimum_enforced() -> None:
+    """page < 1 is a 422, not silently coerced. Foundation #8
+    false-green: silent coercion would let the UI think it
+    received page 1's rows when it asked for page 0."""
+    src = (REPO / "api" / "v1" / "audit.py").read_text(encoding="utf-8")
+    assert 'raise HTTPException(422, "page must be >= 1")' in src
+
+
+def test_tc_audit_003_results_ordered_desc_by_created_at() -> None:
+    """Newest-first ordering is the contract — UI shows recent
+    activity at the top. Reversing this would silently rotate
+    the page contents under existing dashboards."""
+    src = (REPO / "api" / "v1" / "audit.py").read_text(encoding="utf-8")
+    assert "order_by(AuditLog.created_at.desc())" in src
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-AUDIT-004 — Export as CSV
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_audit_004_csv_export_uses_blob_and_text_csv_mime() -> None:
+    """The UI builds the CSV client-side via Blob with mime
+    'text/csv' and downloads as 'audit-log-{date}.csv'. Server
+    is NOT involved — this is intentional so an auditor
+    downloading the page they're viewing always gets the rows
+    they actually see, not a re-query that might race with new
+    inserts."""
+    src = (REPO / "ui" / "src" / "pages" / "Audit.tsx").read_text(
+        encoding="utf-8"
+    )
+    assert 'new Blob([csv], { type: "text/csv" })' in src
+    assert 'audit-log-${datestamp}.csv' in src
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-AUDIT-005 — Export evidence package (JSON)
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_audit_005_evidence_json_export_filename_is_pinned() -> None:
+    """The evidence-package JSON export uses filename
+    'audit-evidence-{date}.json' — this naming is referenced in
+    SOC-2 evidence-collection runbooks; renaming silently
+    breaks the auditor handoff."""
+    src = (REPO / "ui" / "src" / "pages" / "Audit.tsx").read_text(
+        encoding="utf-8"
+    )
+    assert "audit-evidence-${datestamp}.json" in src
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-AUDIT-006 — Auditor role: read-only access (DB-level + RBAC)
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_audit_006_auditor_bypasses_domain_filter() -> None:
+    """Auditor sees cross-domain entries; every other role gets
+    domain-scoped results. The check is ``user_role != 'auditor'``;
+    if the inversion drops, auditors silently lose visibility on
+    cross-domain entries — a real compliance regression."""
+    src = (REPO / "api" / "v1" / "audit.py").read_text(encoding="utf-8")
+    assert 'user_role != "auditor"' in src
+
+
+def test_tc_audit_006_audit_log_is_db_level_append_only() -> None:
+    """The DB has a trigger that rejects UPDATE/DELETE on
+    audit_log. Even if a route bug or an auditor session somehow
+    tried to mutate a row, postgres rejects with
+    ERRCODE='insufficient_privilege'. This is the deepest
+    defense — never let it disappear."""
+    src = (REPO / "core" / "database.py").read_text(encoding="utf-8")
+    assert "audit_log_reject_mutation" in src
+    assert "BEFORE UPDATE OR DELETE ON audit_log" in src
+    assert "audit_log is append-only" in src
+
+
+def test_tc_audit_006_compliance_evidence_endpoint_is_read_only() -> None:
+    """Cross-pin: the /compliance/evidence-package endpoint that
+    auditors read is a GET (not POST) — it cannot mutate
+    state. Pin the verb so a future refactor can't promote it
+    to POST without code review."""
+    src = (REPO / "api" / "v1" / "compliance.py").read_text(encoding="utf-8")
+    assert '@router.get("/compliance/evidence-package")' in src

--- a/ui/e2e/qa-module-12-audit-log.spec.ts
+++ b/ui/e2e/qa-module-12-audit-log.spec.ts
@@ -1,0 +1,209 @@
+/**
+ * Module 12: Audit Log — TC-AUDIT-001 through TC-AUDIT-006.
+ *
+ * Mix of API contract tests (auth, RBAC, filters) and UI flow
+ * tests (page renders, filter input, pagination buttons,
+ * export buttons trigger downloads).
+ *
+ * Auth: Authorization Bearer header for API calls;
+ * page.goto for UI flows (the conftest sets up a real session
+ * via /auth/login fixture — see helpers/auth.ts).
+ */
+import { expect, test } from "@playwright/test";
+
+import { APP, E2E_TOKEN, requireAuth } from "./helpers/auth";
+
+test.describe("Module 12: Audit Log @qa @audit @compliance", () => {
+  test.beforeEach(() => {
+    requireAuth();
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-AUDIT-001: Audit log page loads
+  // -------------------------------------------------------------------------
+
+  test("TC-AUDIT-001 GET /audit returns paginated shape", async ({ request }) => {
+    const resp = await request.get(`${APP}/api/v1/audit?page=1&per_page=10`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(resp.status(), `unexpected status ${resp.status()}`).toBeLessThan(300);
+    const body = await resp.json();
+    for (const key of ["items", "total", "page", "per_page", "pages"]) {
+      expect(body, `missing key ${key}`).toHaveProperty(key);
+    }
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(body.page).toBe(1);
+    expect(body.per_page).toBe(10);
+  });
+
+  test("TC-AUDIT-001b Audit page renders with title + table headers", async ({
+    page,
+  }) => {
+    await page.goto(`${APP}/audit`);
+    await expect(page.getByRole("heading", { name: /audit log/i })).toBeVisible();
+    // Whether the table renders or the empty-state message renders
+    // depends on whether the test tenant has audit rows. Both paths
+    // are valid for this TC.
+    await Promise.race([
+      expect(
+        page.getByRole("columnheader", { name: /event type/i }),
+      ).toBeVisible(),
+      expect(
+        page.getByText(/No audit entries found/i),
+      ).toBeVisible(),
+    ]);
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-AUDIT-002: Filter by event type (substring, ILIKE)
+  // -------------------------------------------------------------------------
+
+  test("TC-AUDIT-002 GET /audit?event_type=auth substring filter accepted", async ({
+    request,
+  }) => {
+    // ILIKE %auth% matches both "auth.login" and "auth.logout".
+    const resp = await request.get(
+      `${APP}/api/v1/audit?event_type=auth&per_page=5`,
+      {
+        headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+        failOnStatusCode: false,
+      },
+    );
+    expect(resp.status()).toBeLessThan(300);
+    const body = await resp.json();
+    // Every returned row's event_type contains "auth" (case-
+    // insensitive) — proves substring match, not equality.
+    for (const item of body.items) {
+      expect(String(item.event_type).toLowerCase()).toContain("auth");
+    }
+  });
+
+  test("TC-AUDIT-002b UI filter input updates results", async ({ page }) => {
+    await page.goto(`${APP}/audit`);
+    const input = page.getByPlaceholder(/Filter by event type/i);
+    await expect(input).toBeVisible();
+    await input.fill("auth");
+    // The "Showing X of Y entries" indicator only renders when the
+    // filter is non-empty — that's the UX contract.
+    await expect(page.getByText(/Showing \d+ of \d+ entries/i)).toBeVisible();
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-AUDIT-003: Pagination
+  // -------------------------------------------------------------------------
+
+  test("TC-AUDIT-003 page < 1 returns 422", async ({ request }) => {
+    const resp = await request.get(`${APP}/api/v1/audit?page=0`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBe(422);
+  });
+
+  test("TC-AUDIT-003b per_page > 100 is silently clamped to 100", async ({
+    request,
+  }) => {
+    const resp = await request.get(`${APP}/api/v1/audit?per_page=10000`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBeLessThan(300);
+    const body = await resp.json();
+    expect(body.per_page).toBe(100);
+  });
+
+  test("TC-AUDIT-003c UI pagination buttons render with Previous disabled on page 1", async ({
+    page,
+  }) => {
+    await page.goto(`${APP}/audit`);
+    await expect(page.getByText(/Page 1/i)).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /previous/i }),
+    ).toBeDisabled();
+    await expect(page.getByRole("button", { name: /next/i })).toBeVisible();
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-AUDIT-004: Export as CSV
+  // -------------------------------------------------------------------------
+
+  test("TC-AUDIT-004 Download CSV button triggers a CSV download", async ({
+    page,
+  }) => {
+    await page.goto(`${APP}/audit`);
+    // Wait for the page to stop loading so filteredEntries is set.
+    await page
+      .getByText(/Loading audit entries|No audit entries|Event Type/i)
+      .first()
+      .waitFor({ state: "visible", timeout: 10000 });
+
+    const downloadPromise = page.waitForEvent("download", { timeout: 5000 });
+    await page.getByRole("button", { name: /download csv/i }).click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/^audit-log-\d{4}-\d{2}-\d{2}\.csv$/);
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-AUDIT-005: Export evidence package (JSON)
+  // -------------------------------------------------------------------------
+
+  test("TC-AUDIT-005 Export Evidence Package button triggers a JSON download", async ({
+    page,
+  }) => {
+    await page.goto(`${APP}/audit`);
+    await page
+      .getByText(/Loading audit entries|No audit entries|Event Type/i)
+      .first()
+      .waitFor({ state: "visible", timeout: 10000 });
+
+    const downloadPromise = page.waitForEvent("download", { timeout: 5000 });
+    await page.getByRole("button", { name: /export evidence package/i }).click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(
+      /^audit-evidence-\d{4}-\d{2}-\d{2}\.json$/,
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-AUDIT-006: Auditor role — read-only access
+  // -------------------------------------------------------------------------
+
+  test("TC-AUDIT-006 GET /audit returns rows for the auditing identity", async ({
+    request,
+  }) => {
+    // Auditor role is enforced server-side; the E2E session may
+    // not have the auditor role, but it MUST still get a 2xx
+    // (other roles see a domain-scoped subset; auditor sees
+    // everything). Either way the contract is "read works".
+    const resp = await request.get(`${APP}/api/v1/audit?per_page=1`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBeLessThan(300);
+  });
+
+  test("TC-AUDIT-006b /audit endpoint has no POST/PUT/DELETE handler", async ({
+    request,
+  }) => {
+    // Foundation #8 false-green prevention: pin the read-only
+    // contract by asserting the verbs are NOT registered.
+    // FastAPI returns 405 Method Not Allowed for an unregistered
+    // verb on a registered path.
+    for (const method of ["POST", "PUT", "DELETE"] as const) {
+      const resp = await request.fetch(`${APP}/api/v1/audit`, {
+        method,
+        headers: {
+          Authorization: `Bearer ${E2E_TOKEN}`,
+          "Content-Type": "application/json",
+        },
+        data: {},
+        failOnStatusCode: false,
+      });
+      expect(
+        resp.status(),
+        `${method} /audit should be 405 (read-only), got ${resp.status()}`,
+      ).toBe(405);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Foundation #6 burndown of Module 12 — the compliance backbone. Every other safety property in the platform leans on audit-log integrity (queryable, paginated, exportable, append-only).

All 6 TCs flip from \`needs-automation\` to \`automated\`.

## Backend pins (TC-AUDIT-001 through 006)

11 source-pinned tests in \`tests/unit/test_module_12_audit_log.py\`:

| TC | Pin |
|----|-----|
| 001 | GET /audit endpoint contract + dict shape |
| 002 | event_type uses \`ILIKE %pattern%\` (substring, case-insensitive) — not equality |
| 003 | per_page capped at 100, page < 1 returns 422, desc-by-created_at order |
| 004 | UI exportCSV uses Blob with \`text/csv\` mime + filename \`audit-log-{date}.csv\` |
| 005 | UI exportJSON uses filename \`audit-evidence-{date}.json\` (SOC-2 runbook reference) |
| 006 | Auditor bypasses domain filter + \`audit_log_reject_mutation\` DB trigger refuses UPDATE/DELETE + /compliance/evidence-package is GET-only |

## UI Playwright

10 specs in \`ui/e2e/qa-module-12-audit-log.spec.ts\`:

- **001**: API paginated shape + UI title + table headers
- **002**: API ILIKE works + UI filter input "Showing X of Y" indicator
- **003**: \`page=0\` → 422, \`per_page=10000\` → clamped to 100, UI "Page 1" + Previous disabled
- **004**: download event fires for \`audit-log-YYYY-MM-DD.csv\`
- **005**: download event fires for \`audit-evidence-YYYY-MM-DD.json\`
- **006**: GET works + POST/PUT/DELETE all return 405 (verb-only-GET pin)

## Verification

- \`pytest tests/unit/test_module_12_audit_log.py\` → **11 passed**
- ruff clean
- YAML: **6/6 Module 12 entries = automated**

## Foundation #6 progress

| Module | Status |
|--------|--------|
| 2 (Auth) | Done (earlier) |
| 9 (Connectors) | Done (earlier) |
| 12 (Audit Log) | **This PR** |
| 13 (Compliance/DSAR) | Done (earlier) |
| 30 (Per-Agent Budget) | Done (#363) |

~358 manual TCs remain across ~50 modules.

@codex please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)