### PR TITLE
test(qa): Foundation #6 — Module 19 Health & API (6 TCs)

### DIFF
--- a/docs/qa_test_matrix.yml
+++ b/docs/qa_test_matrix.yml
@@ -797,39 +797,71 @@ entries:
 - id: TC-API-001
   module: 'Module 19: Health & API'
   title: "Health check \u2014 liveness"
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P0
+  references:
+    - 'tests/unit/test_module_19_health_api.py::test_tc_api_001_liveness_endpoint_is_lightweight'
+    - 'ui/e2e/qa-module-19-health-api.spec.ts::TC-API-001 GET /health/liveness is unauthenticated and returns alive'
+    - 'ui/e2e/qa-module-19-health-api.spec.ts::TC-API-001b GET /health/liveness is fast (under 2s)'
+  notes: 'Foundation #6 burndown 2026-04-28: liveness no-DB / no-Redis pinned + 2s SLO smoke. K8s liveness probe.'
 - id: TC-API-002
   module: 'Module 19: Health & API'
   title: "Health check \u2014 full"
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P0
+  references:
+    - 'tests/unit/test_module_19_health_api.py::test_tc_api_002_readiness_checks_db_and_redis'
+    - 'tests/unit/test_module_19_health_api.py::test_tc_api_002_readiness_returns_only_healthy_when_all_green'
+    - 'tests/unit/test_module_19_health_api.py::test_tc_api_002_readiness_includes_version_and_commit'
+    - 'tests/unit/test_module_19_health_api.py::test_tc_api_002_diagnostics_endpoint_is_admin_only'
+    - 'ui/e2e/qa-module-19-health-api.spec.ts::TC-API-002 GET /health includes db + redis check status'
+    - 'ui/e2e/qa-module-19-health-api.spec.ts::TC-API-002b GET /health/diagnostics requires admin auth'
+    - 'ui/e2e/qa-module-19-health-api.spec.ts::TC-API-002c GET /health/diagnostics with admin token returns connector roster'
+  notes: 'Foundation #6 burndown 2026-04-28: readiness DB+Redis check + admin-gated diagnostics + version/commit fields pinned. Health gate accepts only "healthy".'
 - id: TC-API-003
   module: 'Module 19: Health & API'
   title: API versioning
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P1
+  references:
+    - 'tests/unit/test_module_19_health_api.py::test_tc_api_003_all_routers_mount_under_v1_prefix'
+    - 'tests/unit/test_module_19_health_api.py::test_tc_api_003_app_carries_version_string'
+    - 'ui/e2e/qa-module-19-health-api.spec.ts::TC-API-003 OpenAPI doc carries a non-empty version string'
+    - 'ui/e2e/qa-module-19-health-api.spec.ts::TC-API-003b /api/v1 prefix is honored \u2014 root /api is a 404'
+  notes: 'Foundation #6 burndown 2026-04-28: /api/v1 prefix coverage ratchet + OpenAPI version pinned.'
 - id: TC-API-004
   module: 'Module 19: Health & API'
   title: CORS headers
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P0
+  references:
+    - 'tests/unit/test_module_19_health_api.py::test_tc_api_004_cors_dev_allows_wildcard'
+    - 'tests/unit/test_module_19_health_api.py::test_tc_api_004_cors_prod_uses_allowlist'
+    - 'tests/unit/test_module_19_health_api.py::test_tc_api_004_cors_middleware_added_with_credentials_true'
+    - 'ui/e2e/qa-module-19-health-api.spec.ts::TC-API-004 OPTIONS preflight returns CORS headers'
+  notes: 'Foundation #6 burndown 2026-04-28: env-conditional CORS + credentials=True + preflight smoke pinned.'
 - id: TC-API-005
   module: 'Module 19: Health & API'
   title: "Pagination \u2014 default parameters"
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P1
+  references:
+    - 'tests/unit/test_module_19_health_api.py::test_tc_api_005_paginated_response_default_per_page_is_20'
+    - 'tests/unit/test_module_19_health_api.py::test_tc_api_005_paginated_response_default_page_is_1'
+    - 'tests/unit/test_module_19_health_api.py::test_tc_api_005_paginated_response_carries_total_and_pages'
+    - 'ui/e2e/qa-module-19-health-api.spec.ts::TC-API-005 GET /audit with NO page/per_page uses defaults page=1, per_page=20'
+  notes: 'Foundation #6 burndown 2026-04-28: PaginatedResponse defaults + total/pages fields pinned.'
 - id: TC-API-006
   module: 'Module 19: Health & API'
   title: "Pagination \u2014 custom page size"
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P1
+  references:
+    - 'tests/unit/test_module_19_health_api.py::test_tc_api_006_audit_per_page_caps_at_100'
+    - 'tests/unit/test_module_19_health_api.py::test_tc_api_006_paginated_response_accepts_arbitrary_per_page_field'
+    - 'ui/e2e/qa-module-19-health-api.spec.ts::TC-API-006 GET /audit?per_page=10 honors the custom page size'
+    - 'ui/e2e/qa-module-19-health-api.spec.ts::TC-API-006b GET /audit?per_page=10000 is silently clamped to 100'
+  notes: 'Foundation #6 burndown 2026-04-28: per_page custom value + 100 cap pinned (cross-pin with TC-AUDIT-003b).'
 - id: TC-TEAM-001
   module: 'Module 20: Agent Teams'
   title: Create agent team

--- a/tests/unit/test_module_19_health_api.py
+++ b/tests/unit/test_module_19_health_api.py
@@ -1,0 +1,235 @@
+"""Foundation #6 — Module 19 Health & API.
+
+Source-pin tests for TC-API-001 through TC-API-006. Deploy-readiness
+contract — K8s probes, Cloud Run health checks, and SRE dashboards
+all key off the response shapes pinned here.
+
+Pinned contracts:
+
+- /health/liveness is the lightweight probe (no DB / no Redis).
+- /health is the readiness probe — checks DB + Redis ONLY,
+  returns "healthy"/"unhealthy" + version + commit + per-check
+  status.
+- /health/diagnostics is the heavyweight admin-only probe with
+  full connector + composio detail.
+- All routers mounted under ``/api/v1`` prefix — versioned URL
+  is the public-API contract.
+- CORS origins: in dev=*, in prod=allowlisted domains.
+- PaginatedResponse default per_page is 20 (NOT 50, NOT 100 —
+  changing this breaks every paginated UI list).
+- Health gate accepts ONLY "healthy" — Foundation #5/#8 lesson:
+  the prod health gate must reject "degraded" / "unhealthy"
+  / anything else as failed, since the gate is what keeps a
+  bad rollout from receiving traffic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-API-001 — Liveness
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_api_001_liveness_endpoint_is_lightweight() -> None:
+    """Liveness must NOT touch DB or Redis — those are readiness
+    concerns. K8s liveness probes that wait on external deps
+    cause cascading restarts when those deps blip."""
+    src = (REPO / "api" / "v1" / "health.py").read_text(encoding="utf-8")
+    # Find the liveness function block.
+    block = src.split('@router.get("/health/liveness")', 1)[1].split(
+        '@router.get(', 1
+    )[0]
+    assert '"status": "alive"' in block
+    # Must NOT do DB or Redis work in liveness.
+    assert "session" not in block
+    assert "redis" not in block.lower()
+    assert "aioredis" not in block
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-API-002 — Full readiness
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_api_002_readiness_checks_db_and_redis() -> None:
+    """Readiness must probe BOTH DB and Redis — Cloud Run / K8s
+    keys off this to decide whether to send traffic."""
+    src = (REPO / "api" / "v1" / "health.py").read_text(encoding="utf-8")
+    block = src.split('@router.get("/health")', 1)[1].split(
+        '@router.get(', 1
+    )[0]
+    assert "session.execute(text" in block
+    assert "aioredis.from_url" in block
+    # Returns the per-check status so dashboards can show which
+    # subsystem broke.
+    assert '"checks":' in block
+
+
+def test_tc_api_002_readiness_returns_only_healthy_when_all_green() -> None:
+    """Foundation #5/#8 lesson: the prod health gate accepts ONLY
+    'healthy'. Anything else (unhealthy, degraded) must NOT
+    surface as a passing readiness check — otherwise a bad
+    deploy keeps receiving traffic."""
+    src = (REPO / "api" / "v1" / "health.py").read_text(encoding="utf-8")
+    block = src.split('@router.get("/health")', 1)[1].split(
+        '@router.get(', 1
+    )[0]
+    # The status branch is `"healthy" if core_healthy else "unhealthy"`.
+    assert '"healthy" if core_healthy else "unhealthy"' in block
+    assert (
+        "core_healthy = checks[\"db\"] == \"healthy\" "
+        "and checks[\"redis\"] == \"healthy\""
+    ) in block
+
+
+def test_tc_api_002_readiness_includes_version_and_commit() -> None:
+    """Operators need version + commit in the readiness response
+    so a "wrong version is serving" outage is one curl away from
+    diagnosis. Codex 2026-04-23 prod incident — pin the field
+    presence so a refactor can't silently drop them."""
+    src = (REPO / "api" / "v1" / "health.py").read_text(encoding="utf-8")
+    block = src.split('@router.get("/health")', 1)[1].split(
+        '@router.get(', 1
+    )[0]
+    assert '"version": APP_VERSION' in block
+    assert '"commit": _deployed_commit()' in block
+
+
+def test_tc_api_002_diagnostics_endpoint_is_admin_only() -> None:
+    """The full diagnostics endpoint includes connector + env
+    detail — must be admin-gated. A public endpoint here would
+    leak operational topology."""
+    src = (REPO / "api" / "v1" / "health.py").read_text(encoding="utf-8")
+    assert (
+        '"/health/diagnostics",\n'
+        "    dependencies=[require_scope(\"agenticorg:admin\")],"
+    ) in src or 'require_scope("agenticorg:admin")' in src.split(
+        '"/health/diagnostics"', 1
+    )[1][:200]
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-API-003 — API versioning
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_api_003_all_routers_mount_under_v1_prefix() -> None:
+    """Every public router is mounted under ``/api/v1``. Without
+    the version prefix, breaking changes can't be rolled out
+    behind a /api/v2 — every client breaks at the same time."""
+    src = (REPO / "api" / "main.py").read_text(encoding="utf-8")
+    # Count include_router calls AND assert all carry the prefix.
+    include_lines = [line for line in src.splitlines() if "include_router" in line]
+    assert len(include_lines) > 10, "expected many routers; got too few"
+    # Every line that includes a router must declare the v1 prefix
+    # (a few exceptions exist for non-versioned endpoints — each
+    # must be explicit). Check that at least 90% have /api/v1.
+    v1_lines = [line for line in include_lines if 'prefix="/api/v1"' in line]
+    coverage = len(v1_lines) / len(include_lines)
+    assert coverage >= 0.9, (
+        f"only {coverage*100:.0f}% of routers use /api/v1 prefix — "
+        f"versioning contract slipping"
+    )
+
+
+def test_tc_api_003_app_carries_version_string() -> None:
+    """FastAPI's ``version=`` arg shows up in OpenAPI + the docs
+    page header. SDK consumers parse OpenAPI to detect breaking
+    changes — without a version string they can't pin compat."""
+    src = (REPO / "api" / "main.py").read_text(encoding="utf-8")
+    assert "version=product_facts._version_from_pyproject()" in src
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-API-004 — CORS headers
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_api_004_cors_dev_allows_wildcard() -> None:
+    """In development we open CORS so localhost UIs can hit a
+    deployed API. Without this, every dev needs to fiddle with
+    a proxy."""
+    src = (REPO / "api" / "main.py").read_text(encoding="utf-8")
+    # Pin the dev branch.
+    assert 'if settings.env == "development"' in src
+    assert '_cors_origins = (\n    ["*"]' in src
+
+
+def test_tc_api_004_cors_prod_uses_allowlist() -> None:
+    """In prod we MUST allowlist origins — a wildcard CORS in
+    prod is an XSS-via-third-party-site vector."""
+    src = (REPO / "api" / "main.py").read_text(encoding="utf-8")
+    # The else branch falls back to a domain allowlist:
+    assert "https://agenticorg.ai" in src
+    assert "https://app.agenticorg.ai" in src
+
+
+def test_tc_api_004_cors_middleware_added_with_credentials_true() -> None:
+    """credentials=True is required for cookie-bearing requests
+    from the UI. If this is False, the UI session breaks."""
+    src = (REPO / "api" / "main.py").read_text(encoding="utf-8")
+    cors_block = src.split("CORSMiddleware,", 1)[1][:500]
+    assert "allow_credentials=True" in cors_block
+    assert 'allow_origins=_cors_origins' in cors_block
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-API-005 — Pagination defaults
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_api_005_paginated_response_default_per_page_is_20() -> None:
+    """The default per_page is 20. Changing this silently doubles
+    or halves response sizes for every paginated endpoint, with
+    real impact on UI list rendering + memory."""
+    src = (REPO / "core" / "schemas" / "api.py").read_text(encoding="utf-8")
+    # The model defines per_page: int = 20.
+    block = src.split("class PaginatedResponse(BaseModel):", 1)[1][:300]
+    assert "per_page: int = 20" in block
+
+
+def test_tc_api_005_paginated_response_default_page_is_1() -> None:
+    src = (REPO / "core" / "schemas" / "api.py").read_text(encoding="utf-8")
+    block = src.split("class PaginatedResponse(BaseModel):", 1)[1][:300]
+    assert "page: int = 1" in block
+
+
+def test_tc_api_005_paginated_response_carries_total_and_pages() -> None:
+    """``total`` and ``pages`` let UIs render "showing X-Y of Z"
+    + pagination controls. Without them every UI builds its own
+    incompatible math."""
+    src = (REPO / "core" / "schemas" / "api.py").read_text(encoding="utf-8")
+    block = src.split("class PaginatedResponse(BaseModel):", 1)[1][:300]
+    assert "total: int" in block
+    assert "pages: int" in block
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-API-006 — Custom page size (per_page)
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_api_006_audit_per_page_caps_at_100() -> None:
+    """Custom per_page is supported but capped at 100 (Module 12
+    test pinned this from the audit angle; cross-pin here from
+    the API-contract angle)."""
+    src = (REPO / "api" / "v1" / "audit.py").read_text(encoding="utf-8")
+    assert "per_page = min(max(per_page, 1), 100)" in src
+
+
+def test_tc_api_006_paginated_response_accepts_arbitrary_per_page_field() -> None:
+    """The PaginatedResponse model just stores per_page — no
+    upper-bound at the schema layer. Caps happen per-endpoint
+    at the handler. Pin the model's permissiveness so handler
+    caps remain the only enforcement point."""
+    from core.schemas.api import PaginatedResponse
+
+    # 1000 is fine as a stored value; the handler rejects 1000+
+    # before constructing the response.
+    p = PaginatedResponse(items=[], total=0, page=1, per_page=1000, pages=0)
+    assert p.per_page == 1000

--- a/ui/e2e/qa-module-19-health-api.spec.ts
+++ b/ui/e2e/qa-module-19-health-api.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * Module 19: Health & API — TC-API-001 through TC-API-006.
+ *
+ * All API contract tests — no UI navigation. K8s probes,
+ * Cloud Run health checks, and SDK consumers all hit these
+ * endpoints. The shapes pinned here are the public-API
+ * contract.
+ */
+import { expect, test } from "@playwright/test";
+
+import { APP, E2E_TOKEN, requireAuth } from "./helpers/auth";
+
+test.describe("Module 19: Health & API @qa @health @api", () => {
+  test.beforeEach(() => {
+    requireAuth();
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-API-001: Liveness
+  // -------------------------------------------------------------------------
+
+  test("TC-API-001 GET /health/liveness is unauthenticated and returns alive", async ({
+    request,
+  }) => {
+    // No Authorization header — liveness must work BEFORE auth
+    // is even configured. K8s probes can't carry tokens.
+    const resp = await request.get(`${APP}/api/v1/health/liveness`, {
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe("alive");
+  });
+
+  test("TC-API-001b GET /health/liveness is fast (under 2s)", async ({
+    request,
+  }) => {
+    // Liveness must not touch any external service. Two seconds
+    // is generous; if it's slower than that something's wrong
+    // with the lightweight contract.
+    const t0 = Date.now();
+    const resp = await request.get(`${APP}/api/v1/health/liveness`, {
+      failOnStatusCode: false,
+    });
+    const elapsed = Date.now() - t0;
+    expect(resp.status()).toBe(200);
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-API-002: Full readiness
+  // -------------------------------------------------------------------------
+
+  test("TC-API-002 GET /health includes db + redis check status", async ({
+    request,
+  }) => {
+    const resp = await request.get(`${APP}/api/v1/health`, {
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body).toHaveProperty("checks");
+    expect(body.checks).toHaveProperty("db");
+    expect(body.checks).toHaveProperty("redis");
+    expect(body).toHaveProperty("version");
+    expect(body).toHaveProperty("commit");
+    // status MUST be one of the documented values.
+    expect(["healthy", "unhealthy"]).toContain(body.status);
+  });
+
+  test("TC-API-002b GET /health/diagnostics requires admin auth", async ({
+    request,
+  }) => {
+    // No token → 401/403. The diagnostics endpoint leaks
+    // operational topology (connector health, env), so it MUST
+    // be admin-gated.
+    const resp = await request.get(`${APP}/api/v1/health/diagnostics`, {
+      failOnStatusCode: false,
+    });
+    expect([401, 403]).toContain(resp.status());
+  });
+
+  test("TC-API-002c GET /health/diagnostics with admin token returns connector roster", async ({
+    request,
+  }) => {
+    const resp = await request.get(`${APP}/api/v1/health/diagnostics`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBeLessThan(300);
+    const body = await resp.json();
+    expect(body.checks).toHaveProperty("connectors");
+    expect(body.checks.connectors).toHaveProperty("registered");
+    expect(body.checks.connectors).toHaveProperty("healthy");
+    expect(body.checks.connectors).toHaveProperty("unhealthy");
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-API-003: API versioning
+  // -------------------------------------------------------------------------
+
+  test("TC-API-003 OpenAPI doc carries a non-empty version string", async ({
+    request,
+  }) => {
+    // SDK consumers parse OpenAPI to detect breaking changes.
+    // /openapi.json must serve and must include info.version.
+    const resp = await request.get(`${APP}/openapi.json`, {
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBeLessThan(300);
+    const spec = await resp.json();
+    expect(spec).toHaveProperty("info");
+    expect(spec.info).toHaveProperty("version");
+    expect(typeof spec.info.version).toBe("string");
+    expect(spec.info.version.length).toBeGreaterThan(0);
+  });
+
+  test("TC-API-003b /api/v1 prefix is honored — root /api is a 404", async ({
+    request,
+  }) => {
+    // Without the version prefix, requests should NOT match any
+    // versioned route. (404 confirms versioned routing is in
+    // place; a 2xx here would mean a router is registered
+    // without a prefix.)
+    const resp = await request.get(`${APP}/api/health`, {
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBe(404);
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-API-004: CORS headers
+  // -------------------------------------------------------------------------
+
+  test("TC-API-004 OPTIONS preflight returns CORS headers", async ({
+    request,
+  }) => {
+    const resp = await request.fetch(`${APP}/api/v1/health/liveness`, {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://app.agenticorg.ai",
+        "Access-Control-Request-Method": "GET",
+      },
+      failOnStatusCode: false,
+    });
+    // 200 or 204 is the valid preflight response. The CORS
+    // middleware must respond — anything else means CORS isn't
+    // wired and browsers will reject every UI request.
+    expect([200, 204]).toContain(resp.status());
+    const acao = resp.headers()["access-control-allow-origin"];
+    expect(acao, "Access-Control-Allow-Origin header missing").toBeTruthy();
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-API-005: Pagination defaults
+  // -------------------------------------------------------------------------
+
+  test("TC-API-005 GET /audit with NO page/per_page uses defaults page=1, per_page=20", async ({
+    request,
+  }) => {
+    // Don't pass any pagination params; assert the defaults
+    // come back. Foundation #6 cross-pin: PaginatedResponse
+    // defaults are part of the contract every paginated UI
+    // depends on.
+    const resp = await request.get(`${APP}/api/v1/audit`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBeLessThan(300);
+    const body = await resp.json();
+    expect(body.page).toBe(1);
+    // The /audit endpoint declares its own per_page default of
+    // 50 (overrides the schema's 20). Pin the actual default
+    // — if it changes, every UI page that doesn't pass per_page
+    // explicitly will see a different page size.
+    expect(body.per_page).toBe(50);
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-API-006: Custom page size
+  // -------------------------------------------------------------------------
+
+  test("TC-API-006 GET /audit?per_page=10 honors the custom page size", async ({
+    request,
+  }) => {
+    const resp = await request.get(`${APP}/api/v1/audit?per_page=10`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBeLessThan(300);
+    const body = await resp.json();
+    expect(body.per_page).toBe(10);
+    // items is bounded by per_page (may be fewer if the tenant
+    // has fewer rows, but never more).
+    expect(body.items.length).toBeLessThanOrEqual(10);
+  });
+
+  test("TC-API-006b GET /audit?per_page=10000 is silently clamped to 100", async ({
+    request,
+  }) => {
+    // The boundary defense: per_page is clamped at the handler.
+    // Pin the cap so a future refactor can't lift it (would
+    // OOM the worker on a single request).
+    const resp = await request.get(`${APP}/api/v1/audit?per_page=10000`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBeLessThan(300);
+    const body = await resp.json();
+    expect(body.per_page).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary

Foundation #6 burndown of Module 19 — **deploy-readiness contract**. K8s probes, Cloud Run health checks, and SDK consumers all key off these endpoints. **Three of six are P0** (liveness, readiness, CORS).

## Backend pins (TC-API-001 through 006)

15 source-pinned tests in \`tests/unit/test_module_19_health_api.py\`:

| TC | Pin |
|----|-----|
| 001 (P0) | /health/liveness MUST NOT touch DB or Redis (function body has no \`session\` / \`aioredis\`) |
| 002 (P0) | Readiness checks DB+Redis + accepts ONLY \`"healthy"\` (Foundation #5/#8: gate must reject "degraded"/"unhealthy") + version+commit fields + diagnostics admin-gated |
| 003 (P1) | ≥90% of routers mount under /api/v1 + FastAPI \`app.version=\` reads from pyproject |
| 004 (P0) | dev=\`*\`, prod=allowlist (https://app.agenticorg.ai + siblings) + \`credentials=True\` |
| 005 (P1) | PaginatedResponse defaults page=1, per_page=20 + total/pages fields present |
| 006 (P1) | per_page capped at 100 + schema permissive (caps are per-handler) |

## UI Playwright

10 specs in \`ui/e2e/qa-module-19-health-api.spec.ts\`:

- **001**: liveness unauth + 200 + \`alive\` + <2s SLO
- **002**: readiness shape; diagnostics 401/403 without auth, full connector roster with admin
- **003**: openapi.json carries info.version; /api/health is 404 (proves /api/v1 gates routing)
- **004**: OPTIONS preflight returns \`Access-Control-Allow-Origin\`
- **005**: GET /audit with no params uses page=1, per_page=50 (audit endpoint overrides schema default — pinned the actual value)
- **006**: per_page=10 honored; per_page=10000 clamped to 100

## Verification

- \`pytest tests/unit/test_module_19_health_api.py\` → **15 passed**
- ruff clean
- YAML: **6/6 Module 19 entries = automated**

## Foundation #6 progress (this session)

| Module | TCs | PR |
|--------|-----|-----|
| 12 (Audit Log) | 6 | #364 |
| 14 (Org Management) | 6 | #365 |
| **19 (Health & API)** | **6** | **This PR** |
| 22 (Cross-Cutting) | 12 | #366 |
| 28 (Org Chart) | 7 | #367 |
| 30 (Per-Agent Budget) | 8 | #363 |

**45 TCs newly automated across 6 PRs this session.** ~328 manual TCs remain.

@codex please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)