### PR TITLE
test(qa): Foundation #6 — Module 4 Agent Fleet Management (13 TCs)

### DIFF
--- a/docs/qa_test_matrix.yml
+++ b/docs/qa_test_matrix.yml
@@ -239,80 +239,128 @@ entries:
 - id: TC-AGT-001
   module: 'Module 4: Agent Fleet Management'
   title: "Agent list \u2014 displays all agents"
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P0
+  references:
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_001_list_endpoint_returns_paginated_response'
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_001_list_orders_desc_by_created_at'
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_001_list_per_page_capped_at_100_min_1'
+    - 'ui/e2e/qa-module-4-agent-fleet.spec.ts::TC-AGT-001 GET /agents returns paginated shape'
+  notes: 'Foundation #6 burndown 2026-04-28: paginated shape + desc order + per_page cap pinned.'
 - id: TC-AGT-002
   module: 'Module 4: Agent Fleet Management'
   title: "Agent list \u2014 filter by domain"
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P0
+  references:
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_002_domain_filter_pinned'
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_002_rbac_domain_filter_runs_before_explicit_filter'
+    - 'ui/e2e/qa-module-4-agent-fleet.spec.ts::TC-AGT-002 GET /agents?domain=Finance only returns Finance agents'
+  notes: 'Foundation #6 burndown 2026-04-28: domain filter (query+count) + RBAC ordering pinned.'
 - id: TC-AGT-003
   module: 'Module 4: Agent Fleet Management'
   title: "Agent list \u2014 filter by status"
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P1
+  references:
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_003_status_filter_pinned'
+    - 'ui/e2e/qa-module-4-agent-fleet.spec.ts::TC-AGT-003 GET /agents?status=shadow only returns shadow agents'
+  notes: 'Foundation #6 burndown 2026-04-28: status filter (query+count) pinned.'
 - id: TC-AGT-004
   module: 'Module 4: Agent Fleet Management'
   title: "Agent list \u2014 search by name"
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P2
+  references:
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_004_list_endpoint_returns_dict_with_name'
+  notes: 'Foundation #6 burndown 2026-04-28: name field present in response (UI filters client-side).'
 - id: TC-AGT-005
   module: 'Module 4: Agent Fleet Management'
   title: "Agent list \u2014 kill switch (pause active agent)"
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P0
+  references:
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_005_pause_endpoint_admin_gated'
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_005_pause_emits_lifecycle_event'
+    - 'ui/e2e/qa-module-4-agent-fleet.spec.ts::TC-AGT-005 POST /agents/{nonexistent}/pause returns 404'
+    - 'ui/e2e/qa-module-4-agent-fleet.spec.ts::TC-AGT-005b POST /agents/{id}/pause without auth is 401/403'
+  notes: 'Foundation #6 burndown 2026-04-28: admin gate + lifecycle event + 404/auth pinned.'
 - id: TC-AGT-006
   module: 'Module 4: Agent Fleet Management'
   title: "Agent detail \u2014 overview tab"
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P1
+  references:
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_006_get_endpoint_returns_full_agent_dict'
+    - 'ui/e2e/qa-module-4-agent-fleet.spec.ts::TC-AGT-006 GET /agents/{nonexistent} returns 404'
+  notes: 'Foundation #6 burndown 2026-04-28: detail-dict shape + 404 on missing pinned.'
 - id: TC-AGT-007
   module: 'Module 4: Agent Fleet Management'
   title: "Agent detail \u2014 config tab"
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P1
+  references:
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_007_patch_endpoint_admin_gated'
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_007_patch_uses_agentupdate_partial_schema'
+  notes: 'Foundation #6 burndown 2026-04-28: PATCH admin-gated + AgentUpdate (partial) schema pinned.'
 - id: TC-AGT-008
   module: 'Module 4: Agent Fleet Management'
   title: "Agent detail \u2014 prompt tab"
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P0
+  references:
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_008_put_endpoint_admin_gated'
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_008_put_enforces_prompt_lock_on_active_agents'
+  notes: 'Foundation #6 burndown 2026-04-28: PUT admin-gated + active-agent prompt-lock pinned.'
 - id: TC-AGT-009
   module: 'Module 4: Agent Fleet Management'
   title: "Agent detail \u2014 promote shadow to active"
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P0
+  references:
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_009_promote_endpoint_admin_gated'
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_009_promote_map_only_shadow_to_active'
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_009_promote_validates_min_samples'
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_009_promote_validates_accuracy_floor'
+    - 'ui/e2e/qa-module-4-agent-fleet.spec.ts::TC-AGT-009 POST /agents/{nonexistent}/promote returns 404'
+    - 'ui/e2e/qa-module-4-agent-fleet.spec.ts::TC-AGT-009b POST /agents/{id}/promote without auth is 401/403'
+  notes: 'Foundation #6 burndown 2026-04-28: closed _PROMOTE_MAP + min-samples + accuracy-floor + 404/auth pinned.'
 - id: TC-AGT-010
   module: 'Module 4: Agent Fleet Management'
   title: "Agent detail \u2014 rollback"
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P0
+  references:
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_010_rollback_endpoint_admin_gated'
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_010_rollback_picks_previous_not_current_version'
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_010_rollback_409_when_no_previous_version'
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_010_rollback_emits_lifecycle_event'
+    - 'ui/e2e/qa-module-4-agent-fleet.spec.ts::TC-AGT-010 POST /agents/{nonexistent}/rollback returns 404'
+    - 'ui/e2e/qa-module-4-agent-fleet.spec.ts::TC-AGT-010b POST /agents/{id}/rollback without auth is 401/403'
+  notes: 'Foundation #6 burndown 2026-04-28: previous-not-current pick + 409 on no-prior + status-preserved + lifecycle event pinned.'
 - id: TC-AGT-011
   module: 'Module 4: Agent Fleet Management'
   title: "Agent detail \u2014 shadow tab"
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P1
+  references:
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_011_shadow_min_samples_default_pinned'
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_011_shadow_accuracy_floor_default_pinned'
+    - 'tests/unit/test_module_4_agent_fleet.py::test_tc_agt_011_shadow_promotion_floor_check_uses_current_accuracy'
+  notes: 'Foundation #6 burndown 2026-04-28: shadow_min_samples=10 + shadow_accuracy_floor=0.800 defaults + accuracy_current pinned.'
 - id: TC-AGT-012
   module: 'Module 4: Agent Fleet Management'
   title: "Agent detail \u2014 cost tab"
   status: duplicate
-  references: []
-  notes: 'audit: title >=85% similar to TC-AGT-007 in same module (master=TC-AGT-007)'
+  references:
+    - 'See Module 30 (TC-BUDGET-007/008) \u2014 full Cost tab coverage.'
+  notes: 'audit: title >=85% similar to TC-AGT-007; cross-pin: Module 30 already covers the Cost tab.'
 - id: TC-AGT-013
   module: 'Module 4: Agent Fleet Management'
   title: "Agent detail \u2014 prompt history"
   status: duplicate
-  references: []
+  references:
+    - 'See TC-AGT-008 (prompt tab) \u2014 prompt history is a sub-view of the prompt tab.'
   notes: 'audit: title >=85% similar to TC-AGT-008 in same module (master=TC-AGT-008)'
 - id: TC-CRT-001
   module: 'Module 5: Agent Creation Wizard'

--- a/tests/unit/test_module_4_agent_fleet.py
+++ b/tests/unit/test_module_4_agent_fleet.py
@@ -1,0 +1,342 @@
+"""Foundation #6 — Module 4 Agent Fleet Management.
+
+Source-pin tests for TC-AGT-001 through TC-AGT-013 (TC-AGT-012/013
+are documented duplicates of 007/008 — covered transitively).
+
+Agent CRUD + status lifecycle is the platform's primary surface
+— ten of these TCs guard the contracts that every dashboard,
+LangGraph runner, and SOP-driven workflow leans on.
+
+Pinned contracts:
+
+- GET /agents pages with default per_page=20, capped at 100,
+  ordered desc by created_at, with optional domain/status/
+  company_id filters AND RBAC domain restriction.
+- _PROMOTE_MAP defines the legal status transitions — only
+  shadow→active is supported from the lifecycle endpoint.
+  Any new transition must be added to the map deliberately.
+- Promote validates BOTH minimum sample count AND accuracy
+  floor before flipping shadow→active. Foundation #8 false-
+  green prevention: promote MUST refuse with 409 if either
+  is missing.
+- Rollback finds the previous AgentVersion (NOT the current
+  one) and restores prompt + tools + LLM config + confidence
+  floor + version. Status is intentionally preserved (rolling
+  back code shouldn't unpause a paused agent).
+- _PAUSE/_PROMOTE/rollback all emit AgentLifecycleEvent so
+  the audit trail and the UI activity feed stay in sync.
+- /agents/org-tree filters out deleted/error/broken agents
+  (BUG-28) so the org chart doesn't show orphan placeholders.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-AGT-001 — Agent list displays all agents (pagination shape)
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_agt_001_list_endpoint_returns_paginated_response() -> None:
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    assert '@router.get("/agents", response_model=PaginatedResponse)' in src
+
+
+def test_tc_agt_001_list_orders_desc_by_created_at() -> None:
+    """Newest agents at the top — UI dashboard contract.
+    Reversing this would silently rotate page contents under
+    every existing list view."""
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    list_block = src.split('@router.get("/agents", response_model=', 1)[1].split(
+        "@router.", 1
+    )[0]
+    assert "order_by(Agent.created_at.desc())" in list_block
+
+
+def test_tc_agt_001_list_per_page_capped_at_100_min_1() -> None:
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    list_block = src.split('@router.get("/agents", response_model=', 1)[1].split(
+        "@router.", 1
+    )[0]
+    assert "per_page = min(max(per_page, 1), 100)" in list_block
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-AGT-002 / TC-AGT-003 — Filter by domain / status
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_agt_002_domain_filter_pinned() -> None:
+    """Domain filter param is accepted AND applied to BOTH the
+    SELECT and the COUNT(*) — without it, ``total`` would be
+    the unfiltered count and the UI's "X of Y" would lie."""
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    list_block = src.split('@router.get("/agents", response_model=', 1)[1].split(
+        "@router.", 1
+    )[0]
+    assert "if domain:" in list_block
+    assert "Agent.domain == domain" in list_block
+    # Both query AND count_query must apply the filter.
+    domain_apply_count = list_block.count("Agent.domain == domain")
+    assert domain_apply_count >= 2, (
+        "domain filter must apply to both query and count_query — "
+        "otherwise total is wrong"
+    )
+
+
+def test_tc_agt_003_status_filter_pinned() -> None:
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    list_block = src.split('@router.get("/agents", response_model=', 1)[1].split(
+        "@router.", 1
+    )[0]
+    assert "if status:" in list_block
+    assert "Agent.status == status" in list_block
+    status_apply_count = list_block.count("Agent.status == status")
+    assert status_apply_count >= 2
+
+
+def test_tc_agt_002_rbac_domain_filter_runs_before_explicit_filter() -> None:
+    """The user_domains RBAC filter (from JWT) restricts to allowed
+    domains. The explicit ?domain= further narrows. If RBAC ran
+    AFTER the explicit filter, a CFO could pass ?domain=HR and
+    see HR rows. Pin that user_domains is applied first."""
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    list_block = src.split('@router.get("/agents", response_model=', 1)[1].split(
+        "@router.", 1
+    )[0]
+    rbac_idx = list_block.find("Agent.domain.in_(user_domains)")
+    explicit_idx = list_block.find("if domain:")
+    assert rbac_idx > 0 and explicit_idx > 0
+    assert rbac_idx < explicit_idx, (
+        "RBAC domain filter must run BEFORE the explicit ?domain= "
+        "filter so a domain-restricted user can't see other domains"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-AGT-004 — Search by name (UI-side filter; smoke for endpoint)
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_agt_004_list_endpoint_returns_dict_with_name() -> None:
+    """The UI filters by name client-side from the list response.
+    Pin that the agent dict contains the name field — otherwise
+    the search input matches nothing."""
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    assert '"name": agent.name' in src
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-AGT-005 — Kill switch (pause active agent)
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_agt_005_pause_endpoint_admin_gated() -> None:
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    pause_block = src.split('"/agents/{agent_id}/pause"', 1)[1][:300]
+    assert "require_tenant_admin" in pause_block
+
+
+def test_tc_agt_005_pause_emits_lifecycle_event() -> None:
+    """Every status transition emits an AgentLifecycleEvent —
+    audit trail + UI activity feed both depend on this. Pin
+    the lifecycle event creation in the pause path."""
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    pause_block = src.split('"/agents/{agent_id}/pause"', 1)[1].split(
+        "@router.", 1
+    )[0]
+    assert "AgentLifecycleEvent" in pause_block
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-AGT-006 — Agent detail overview tab (GET /agents/{id})
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_agt_006_get_endpoint_returns_full_agent_dict() -> None:
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    assert '@router.get("/agents/{agent_id}")' in src
+    # The dict-builder must include the fields the Overview tab
+    # renders: name, status, domain, created_at.
+    for field in ('"id":', '"name":', '"status":', '"domain":',
+                  '"created_at":'):
+        assert field in src
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-AGT-007 — Config tab (PATCH /agents/{id})
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_agt_007_patch_endpoint_admin_gated() -> None:
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    patch_block = src.split("@router.patch(\n", 1)[1][:400]
+    assert "require_tenant_admin" in patch_block or "require_scope" in patch_block
+
+
+def test_tc_agt_007_patch_uses_agentupdate_partial_schema() -> None:
+    """PATCH must take AgentUpdate (Optional fields) — NOT
+    AgentCreate. Otherwise a partial PATCH would 422 because
+    AgentCreate's required fields aren't supplied."""
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    patch_block = src.split("@router.patch(\n", 1)[1][:1200]
+    assert "AgentUpdate" in patch_block
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-AGT-008 — Prompt tab (PUT /agents/{id})
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_agt_008_put_endpoint_admin_gated() -> None:
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    put_block = src.split("@router.put(\n", 1)[1][:400]
+    assert "require_tenant_admin" in put_block or "require_scope" in put_block
+
+
+def test_tc_agt_008_put_enforces_prompt_lock_on_active_agents() -> None:
+    """Active agents have a prompt lock — PUT must reject with
+    400 + the documented message the UI parses for the Clone CTA.
+    Cross-pin with TC-CC-009 (Module 22)."""
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    assert (
+        "Prompt is locked on active agents. Clone this agent to make changes."
+        in src
+    )
+    # And the lock check is gated on prompt_changing AND status=='active'.
+    assert 'if prompt_changing and agent.status == "active":' in src
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-AGT-009 — Promote shadow to active
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_agt_009_promote_endpoint_admin_gated() -> None:
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    promote_block = src.split('"/agents/{agent_id}/promote"', 1)[1][:300]
+    assert "require_tenant_admin" in promote_block
+
+
+def test_tc_agt_009_promote_map_only_shadow_to_active() -> None:
+    """The legal-transition map is closed: shadow → active only.
+    Adding any other transition (e.g. paused → active) must go
+    through code review, not slip in via a typo."""
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    assert '_PROMOTE_MAP: dict[str, str] = {' in src
+    promote_map_block = src.split("_PROMOTE_MAP: dict[str, str] = {", 1)[1].split(
+        "}", 1
+    )[0]
+    assert '"shadow": "active"' in promote_map_block
+    # No other entries in the map — count the colons.
+    assert promote_map_block.count(":") == 1, (
+        "_PROMOTE_MAP must contain ONLY shadow→active. Adding new "
+        "transitions requires explicit code review."
+    )
+
+
+def test_tc_agt_009_promote_validates_min_samples() -> None:
+    """Foundation #8 false-green prevention: promote MUST refuse
+    with 409 when shadow_sample_count < shadow_min_samples.
+    Without this, an agent with 0 samples could go straight
+    to active."""
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    assert (
+        "if agent.shadow_sample_count < agent.shadow_min_samples:" in src
+    )
+    assert "cannot promote until minimum is met" in src
+
+
+def test_tc_agt_009_promote_validates_accuracy_floor() -> None:
+    """Sample count alone isn't enough — accuracy floor must
+    also be met. Both gates required to flip shadow→active."""
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    assert (
+        "if agent.shadow_accuracy_current < agent.shadow_accuracy_floor:" in src
+    )
+    assert "is below floor" in src
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-AGT-010 — Rollback to previous version
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_agt_010_rollback_endpoint_admin_gated() -> None:
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    rollback_block = src.split('"/agents/{agent_id}/rollback"', 1)[1][:300]
+    assert "require_tenant_admin" in rollback_block
+
+
+def test_tc_agt_010_rollback_picks_previous_not_current_version() -> None:
+    """The previous-version query MUST exclude the current
+    version. Otherwise a "rollback" would no-op (rolling back
+    to itself)."""
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    assert "AgentVersion.version != agent.version" in src
+    # And it picks the most recent of the remaining versions.
+    assert "order_by(AgentVersion.created_at.desc())" in src
+
+
+def test_tc_agt_010_rollback_409_when_no_previous_version() -> None:
+    """If there's no prior version (first-ever release), 409 with
+    the documented message — NOT a 500 / silent no-op."""
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    assert "No previous version to rollback to" in src
+    assert "HTTPException(409" in src.split("rollback_agent", 1)[1][:1500]
+
+
+def test_tc_agt_010_rollback_emits_lifecycle_event() -> None:
+    """The rollback emits a lifecycle event so the activity feed
+    shows "rolled back from version X to Y". Status is preserved
+    (to_status = old_status) — rolling back code shouldn't
+    unpause a paused agent."""
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    rollback_block = src.split("async def rollback_agent", 1)[1][:2500]
+    assert "AgentLifecycleEvent(" in rollback_block
+    assert "to_status=old_status" in rollback_block
+    assert "Rolled back from version" in rollback_block
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-AGT-011 — Shadow tab
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_agt_011_shadow_min_samples_default_pinned() -> None:
+    """shadow_min_samples default = 10 (Uday 2026-04-23 Bug 1
+    fix — was 20, stretched validation into a 20-click flow).
+    If this drifts back to 20, the QA validation flow regresses."""
+    src = (REPO / "core" / "models" / "agent.py").read_text(encoding="utf-8")
+    assert "shadow_min_samples: Mapped[int] = mapped_column(Integer, nullable=False, default=10)" in src
+
+
+def test_tc_agt_011_shadow_accuracy_floor_default_pinned() -> None:
+    """shadow_accuracy_floor default = 0.800 (BUG-012 fix —
+    0.95 was unreachable for LLM agents)."""
+    src = (REPO / "core" / "models" / "agent.py").read_text(encoding="utf-8")
+    assert 'default=Decimal("0.800")' in src
+
+
+def test_tc_agt_011_shadow_promotion_floor_check_uses_current_accuracy() -> None:
+    """The promote gate reads shadow_accuracy_current — the
+    rolling average. Pin the field name so a refactor can't
+    silently flip to a different (e.g. last-sample) metric."""
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    assert "agent.shadow_accuracy_current" in src
+
+
+# ─────────────────────────────────────────────────────────────────
+# Org tree — BUG-28 deleted/error/broken filter
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_org_tree_filters_out_deleted_error_broken_agents() -> None:
+    """BUG-28: org-tree was showing deleted/broken agent placeholders.
+    The status filter must exclude all three. Pin the exact set."""
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    assert 'Agent.status.notin_(["deleted", "error", "broken"])' in src

--- a/ui/e2e/qa-module-4-agent-fleet.spec.ts
+++ b/ui/e2e/qa-module-4-agent-fleet.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * Module 4: Agent Fleet Management — TC-AGT-001 through 013
+ * (012/013 are documented duplicates of 007/008).
+ *
+ * Mostly API contract tests against /agents/* endpoints. The
+ * UI tabs themselves are exercised by the per-feature module
+ * specs (Module 30 Cost tab, Module 28 hierarchy, Module 29 LLM
+ * picker, etc.); this spec pins the LIST + LIFECYCLE
+ * (pause/promote/rollback) contracts.
+ */
+import { expect, test } from "@playwright/test";
+
+import { APP, E2E_TOKEN, requireAuth } from "./helpers/auth";
+
+test.describe("Module 4: Agent Fleet Management @qa @agents @fleet", () => {
+  test.beforeEach(() => {
+    requireAuth();
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-AGT-001: Agent list returns paginated shape
+  // -------------------------------------------------------------------------
+
+  test("TC-AGT-001 GET /agents returns paginated shape", async ({ request }) => {
+    const resp = await request.get(`${APP}/api/v1/agents?per_page=5`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBeLessThan(300);
+    const body = await resp.json();
+    for (const k of ["items", "total", "page", "per_page", "pages"]) {
+      expect(body, `missing key ${k}`).toHaveProperty(k);
+    }
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(body.per_page).toBe(5);
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-AGT-002: Filter by domain
+  // -------------------------------------------------------------------------
+
+  test("TC-AGT-002 GET /agents?domain=Finance only returns Finance agents", async ({
+    request,
+  }) => {
+    const resp = await request.get(`${APP}/api/v1/agents?domain=Finance&per_page=10`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBeLessThan(300);
+    const body = await resp.json();
+    for (const a of body.items) {
+      expect(a.domain).toBe("Finance");
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-AGT-003: Filter by status
+  // -------------------------------------------------------------------------
+
+  test("TC-AGT-003 GET /agents?status=shadow only returns shadow agents", async ({
+    request,
+  }) => {
+    const resp = await request.get(`${APP}/api/v1/agents?status=shadow&per_page=10`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBeLessThan(300);
+    const body = await resp.json();
+    for (const a of body.items) {
+      expect(a.status).toBe("shadow");
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-AGT-005: Pause active agent
+  // -------------------------------------------------------------------------
+
+  test("TC-AGT-005 POST /agents/{nonexistent}/pause returns 404", async ({
+    request,
+  }) => {
+    const resp = await request.post(
+      `${APP}/api/v1/agents/00000000-0000-0000-0000-000000000000/pause`,
+      {
+        headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+        failOnStatusCode: false,
+      },
+    );
+    expect(resp.status()).toBe(404);
+  });
+
+  test("TC-AGT-005b POST /agents/{id}/pause without auth is 401/403", async ({
+    request,
+  }) => {
+    const resp = await request.post(
+      `${APP}/api/v1/agents/00000000-0000-0000-0000-000000000000/pause`,
+      { failOnStatusCode: false },
+    );
+    expect([401, 403]).toContain(resp.status());
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-AGT-006: Agent detail (overview)
+  // -------------------------------------------------------------------------
+
+  test("TC-AGT-006 GET /agents/{nonexistent} returns 404", async ({ request }) => {
+    const resp = await request.get(
+      `${APP}/api/v1/agents/00000000-0000-0000-0000-000000000000`,
+      {
+        headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+        failOnStatusCode: false,
+      },
+    );
+    expect(resp.status()).toBe(404);
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-AGT-009: Promote shadow → active (failure paths)
+  // -------------------------------------------------------------------------
+
+  test("TC-AGT-009 POST /agents/{nonexistent}/promote returns 404", async ({
+    request,
+  }) => {
+    const resp = await request.post(
+      `${APP}/api/v1/agents/00000000-0000-0000-0000-000000000000/promote`,
+      {
+        headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+        failOnStatusCode: false,
+      },
+    );
+    expect(resp.status()).toBe(404);
+  });
+
+  test("TC-AGT-009b POST /agents/{id}/promote without auth is 401/403", async ({
+    request,
+  }) => {
+    const resp = await request.post(
+      `${APP}/api/v1/agents/00000000-0000-0000-0000-000000000000/promote`,
+      { failOnStatusCode: false },
+    );
+    expect([401, 403]).toContain(resp.status());
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-AGT-010: Rollback (failure paths)
+  // -------------------------------------------------------------------------
+
+  test("TC-AGT-010 POST /agents/{nonexistent}/rollback returns 404", async ({
+    request,
+  }) => {
+    const resp = await request.post(
+      `${APP}/api/v1/agents/00000000-0000-0000-0000-000000000000/rollback`,
+      {
+        headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+        failOnStatusCode: false,
+      },
+    );
+    expect(resp.status()).toBe(404);
+  });
+
+  test("TC-AGT-010b POST /agents/{id}/rollback without auth is 401/403", async ({
+    request,
+  }) => {
+    const resp = await request.post(
+      `${APP}/api/v1/agents/00000000-0000-0000-0000-000000000000/rollback`,
+      { failOnStatusCode: false },
+    );
+    expect([401, 403]).toContain(resp.status());
+  });
+
+  // -------------------------------------------------------------------------
+  // Org tree (BUG-28 cross-pin)
+  // -------------------------------------------------------------------------
+
+  test("GET /agents/org-tree never returns deleted/error/broken statuses", async ({
+    request,
+  }) => {
+    const resp = await request.get(`${APP}/api/v1/agents/org-tree`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBeLessThan(300);
+    const body = await resp.json();
+    // The response shape may be {tree: [...]} or a flat list.
+    // Walk whatever's there and check no node has status in
+    // the excluded set.
+    const nodes = Array.isArray(body) ? body : body.tree || body.agents || [];
+    function walk(n: { status?: string; children?: unknown[] }) {
+      if (n.status) {
+        expect(["deleted", "error", "broken"]).not.toContain(n.status);
+      }
+      if (Array.isArray(n.children)) n.children.forEach((c) => walk(c as typeof n));
+    }
+    nodes.forEach(walk);
+  });
+});


### PR DESCRIPTION
## Summary

Foundation #6 burndown of Module 4 — **agent CRUD + status lifecycle**, the platform's primary surface. The contracts pinned here are what every dashboard, LangGraph runner, and SOP-driven workflow leans on.

13 TCs total: 11 automated + 2 documented duplicates (TC-AGT-012 → Module 30 Cost tab, TC-AGT-013 → TC-AGT-008 prompt tab).

**Six of eleven real TCs are P0**: list, domain filter, kill switch, prompt lock, promote, rollback.

## Backend pins (TC-AGT-001 through 011)

26 source-pinned tests in \`tests/unit/test_module_4_agent_fleet.py\`:

| TC | Pin |
|----|-----|
| 001 (P0) | GET /agents PaginatedResponse + desc-by-created_at + per_page cap |
| 002 (P0) | domain filter applies to BOTH query AND count_query (otherwise total lies); **RBAC user_domains runs BEFORE explicit ?domain=** so a CFO can't pass ?domain=HR and see HR |
| 003 (P1) | status filter applies to both query AND count |
| 004 (P2) | name field present in dict (UI filters client-side) |
| 005 (P0) | pause endpoint admin-gated + emits AgentLifecycleEvent |
| 006 (P1) | GET /agents/{id} returns full dict (id, name, status, domain, created_at) |
| 007 (P1) | PATCH /agents/{id} admin-gated + **AgentUpdate (Optional) schema** (NOT AgentCreate which would 422 on partial) |
| 008 (P0) | PUT /agents/{id} admin-gated + active-agent prompt-lock with EXACT message UI parses for Clone CTA |
| 009 (P0) | **_PROMOTE_MAP closed at {shadow→active}** (no other transitions); promote validates min_samples AND accuracy_floor (both gates required) |
| 010 (P0) | rollback picks **PREVIOUS** (not current) version + 409 on no-prior + status preserved (rolling back code shouldn't unpause) + lifecycle event |
| 011 (P1) | shadow_min_samples=10 default (Uday Bug 1) + shadow_accuracy_floor=0.800 default (BUG-012) |
| org-tree | BUG-28 fix — exclude deleted/error/broken from org chart |

## UI Playwright

10 specs in \`ui/e2e/qa-module-4-agent-fleet.spec.ts\`:

- **001/002/003**: paginated shape + domain/status filters return only matching rows
- **005/005b**: pause 404 on missing + 401/403 without auth
- **006**: GET 404 on missing
- **009/009b**: promote 404 + 401/403
- **010/010b**: rollback 404 + 401/403
- **org-tree**: never returns deleted/error/broken statuses

## Verification

- \`pytest tests/unit/test_module_4_agent_fleet.py\` → **26 passed**
- ruff clean
- YAML: **11/13 Module 4 automated, 2 duplicate**

## Foundation #6 progress (this session)

| Module | TCs | PR |
|--------|-----|-----|
| **4 (Agent Fleet)** | **13** | **This PR** |
| 12 (Audit Log) | 6 | #364 |
| 14 (Org Management) | 6 | #365 |
| 16 (Email System) | 6 | #370 |
| 19 (Health & API) | 6 | #368 |
| 22 (Cross-Cutting) | 12 | #366 |
| 27 (Negative & Edge) | 10 | #369 |
| 28 (Org Chart) | 7 | #367 |
| 30 (Per-Agent Budget) | 8 | #363 |

**74 TCs newly automated across 9 PRs this session.** ~301 manual TCs remain.

@codex please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)