### PR TITLE
test(qa): Foundation #6 — Module 11 Sales Pipeline (9 TCs)

### DIFF
--- a/docs/qa_test_matrix.yml
+++ b/docs/qa_test_matrix.yml
@@ -539,57 +539,99 @@ entries:
 - id: TC-SALES-001
   module: 'Module 11: Sales Pipeline'
   title: Sales pipeline page loads
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P1
+  references:
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_001_pipeline_endpoint_returns_funnel_and_leads'
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_001_lead_dict_carries_required_fields'
+    - 'ui/e2e/qa-module-11-sales-pipeline.spec.ts::TC-SALES-001 GET /sales/pipeline returns funnel + total + leads'
+  notes: 'Foundation #6 burndown 2026-04-28: pipeline shape + lead-dict required fields pinned.'
 - id: TC-SALES-002
   module: 'Module 11: Sales Pipeline'
   title: Pipeline funnel visualization
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P1
+  references:
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_002_funnel_groups_by_stage'
+    - 'ui/e2e/qa-module-11-sales-pipeline.spec.ts::TC-SALES-002 GET /sales/pipeline?stage=new only returns ''new'' leads'
+  notes: 'Foundation #6 burndown 2026-04-28: GROUP BY stage + stage filter pinned.'
 - id: TC-SALES-003
   module: 'Module 11: Sales Pipeline'
   title: View lead details
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P0
+  references:
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_003_get_lead_endpoint_pinned'
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_003_lead_query_is_tenant_scoped'
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_003_static_routes_declared_before_lead_id_route'
+    - 'ui/e2e/qa-module-11-sales-pipeline.spec.ts::TC-SALES-003 GET /sales/pipeline/{nonexistent} returns 404'
+  notes: 'Foundation #6 burndown 2026-04-28: tenant-scoped query + FastAPI route ordering (static-before-dynamic) pinned.'
 - id: TC-SALES-004
   module: 'Module 11: Sales Pipeline'
   title: Run Sales Agent on lead
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P0
+  references:
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_004_process_lead_requires_lead_id'
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_004_process_lead_returns_only_safe_fields'
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_004_process_lead_swaps_error_for_400'
+    - 'ui/e2e/qa-module-11-sales-pipeline.spec.ts::TC-SALES-004 POST /sales/pipeline/process-lead missing lead_id returns 400'
+  notes: 'Foundation #6 burndown 2026-04-28: lead_id required + safe-fields-only response (NEVER forward agent internals) + agent-error → 400 pinned.'
 - id: TC-SALES-005
   module: 'Module 11: Sales Pipeline'
   title: Seed demo prospects
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P0
+  references:
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_005_seed_endpoint_refuses_outside_demo_dev'
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_005_seed_idempotency_via_email_dedupe'
+    - 'ui/e2e/qa-module-11-sales-pipeline.spec.ts::TC-SALES-005 POST /sales/seed-prospects either succeeds (demo/dev) or 403 (prod)'
+  notes: 'Foundation #6 burndown 2026-04-28: prod env-gate (403 outside demo/dev) + email-dedupe idempotency pinned. Closure plan: no fabricated data in prod.'
 - id: TC-SALES-006
   module: 'Module 11: Sales Pipeline'
   title: Import CSV leads
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P1
+  references:
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_006_csv_import_validates_extension'
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_006_csv_import_validates_empty_file'
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_006_csv_import_validates_encoding'
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_006_csv_import_requires_name_and_email_headers'
+    - 'ui/e2e/qa-module-11-sales-pipeline.spec.ts::TC-SALES-006 POST /sales/import-csv with non-CSV file is 422'
+    - 'ui/e2e/qa-module-11-sales-pipeline.spec.ts::TC-SALES-006b POST /sales/import-csv with empty CSV is 422'
+    - 'ui/e2e/qa-module-11-sales-pipeline.spec.ts::TC-SALES-006c POST /sales/import-csv with missing required headers is 422'
+  notes: 'Foundation #6 burndown 2026-04-28: extension + empty + encoding + required-header validations pinned (4 distinct 422 paths). Session 5 TC-002/TC-005 enforcement.'
 - id: TC-SALES-007
   module: 'Module 11: Sales Pipeline'
   title: Due follow-ups
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P1
+  references:
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_007_due_followups_excludes_closed_deals'
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_007_due_followups_ordered_by_score_desc'
+    - 'ui/e2e/qa-module-11-sales-pipeline.spec.ts::TC-SALES-007 GET /sales/pipeline/due-followups never returns closed deals'
+  notes: 'Foundation #6 burndown 2026-04-28: closed_won/closed_lost exclusion + score DESC order pinned.'
 - id: TC-SALES-008
   module: 'Module 11: Sales Pipeline'
   title: Sales metrics
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P1
+  references:
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_008_metrics_endpoint_returns_documented_keys'
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_008_stale_leads_excludes_new_and_closed_stages'
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_008_avg_score_excludes_zero_scored_leads'
+    - 'ui/e2e/qa-module-11-sales-pipeline.spec.ts::TC-SALES-008 GET /sales/metrics returns documented shape'
+  notes: 'Foundation #6 burndown 2026-04-28: 6-key shape + stale-excludes-new-and-closed + avg_score>0 filter pinned. No fabricated KPIs.'
 - id: TC-SALES-009
   module: 'Module 11: Sales Pipeline'
   title: Lead score color coding
-  status: needs-automation
-  references: []
-  notes: 'audit: no existing test match; not flagged manual or deprecated'
+  status: automated
+  priority: P2
+  references:
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_009_score_color_thresholds_pinned'
+    - 'tests/unit/test_module_11_sales_pipeline.py::test_tc_sales_009_score_color_used_in_list_and_detail'
+    - 'ui/e2e/qa-module-11-sales-pipeline.spec.ts::TC-SALES-009 sales pipeline page renders without runtime errors'
+  notes: 'Foundation #6 burndown 2026-04-28: ≥70 emerald / ≥40 amber / else slate thresholds pinned + helper used in list/detail/agent-result.'
 - id: TC-AUDIT-001
   module: 'Module 12: Audit Log'
   title: Audit log page loads

--- a/tests/unit/test_module_11_sales_pipeline.py
+++ b/tests/unit/test_module_11_sales_pipeline.py
@@ -1,0 +1,366 @@
+"""Foundation #6 — Module 11 Sales Pipeline (9 TCs).
+
+Source-pin tests for TC-SALES-001 through TC-SALES-009.
+
+The sales pipeline is the platform's revenue surface — every
+metric, score, and stage transition must be derived from real
+data with no fabricated KPIs (P6.1 audit). Pipeline math also
+feeds the executive dashboard, so silent regressions here
+ripple up.
+
+Pinned contracts:
+
+- /sales/pipeline returns {funnel, total, leads}; funnel
+  groups by stage; leads ordered by score DESC then
+  created_at DESC.
+- _lead_to_dict carries every field the UI renders — schema
+  drops would silently empty UI columns.
+- /sales/metrics returns total, new-this-week, funnel,
+  avg_score, emails_sent_this_week, stale_leads. Each metric
+  is derived from a real query (no constants, no fakes).
+- Stale-lead query EXCLUDES "new" stage (a brand-new lead
+  isn't "stale" yet) AND closed_won/closed_lost (those are
+  done — their absence of contact isn't a stale signal).
+- Due-followups query EXCLUDES closed deals.
+- /sales/seed-prospects refuses outside demo/dev (production
+  must NEVER auto-seed prospects via API — fabricated data is
+  banned by the closure plan).
+- /sales/import-csv validates upload shape BEFORE parsing
+  (Session 5 TC-002/TC-005): non-CSV → 422, empty → 422,
+  bad encoding → 422, missing required headers → 422.
+- Lead-score color: ≥70=emerald, ≥40=amber, else slate.
+  These thresholds drive the UI heat-coding the sales team
+  reads at a glance.
+- /sales/pipeline/process-lead requires lead_id + never
+  forwards raw agent internals (Foundation #8 false-green
+  prevention — leaking internals would let consumers
+  sniff prompts/tool calls).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-SALES-001 — Sales pipeline page loads
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_sales_001_pipeline_endpoint_returns_funnel_and_leads() -> None:
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    assert '@router.get("/sales/pipeline")' in src
+    pipeline_block = src.split('@router.get("/sales/pipeline")', 1)[1].split(
+        "@router.", 1
+    )[0]
+    assert '"funnel": funnel' in pipeline_block
+    assert '"total": sum(funnel.values())' in pipeline_block
+    assert '"leads": [_lead_to_dict(lead)' in pipeline_block
+
+
+def test_tc_sales_001_lead_dict_carries_required_fields() -> None:
+    """Every field the UI renders must appear in the dict.
+    Schema drops would silently empty UI columns."""
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    for field in (
+        '"id":', '"name":', '"email":', '"company":', '"role":',
+        '"stage":', '"score":', '"score_factors":',
+        '"assigned_agent_id":', '"last_contacted_at":',
+        '"next_followup_at":', '"deal_value_usd":',
+    ):
+        assert field in src, f"_lead_to_dict missing key {field}"
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-SALES-002 — Pipeline funnel visualization
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_sales_002_funnel_groups_by_stage() -> None:
+    """Funnel data is GROUP BY stage with COUNT(*). Pin the
+    GROUP BY so a future refactor can't silently flatten the
+    funnel into a single number."""
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    assert "func.count().label(\"count\")" in src
+    assert "group_by(LeadPipeline.stage)" in src
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-SALES-003 — View lead details
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_sales_003_get_lead_endpoint_pinned() -> None:
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    assert '@router.get("/sales/pipeline/{lead_id}")' in src
+
+
+def test_tc_sales_003_lead_query_is_tenant_scoped() -> None:
+    """Lead lookup MUST filter by tenant_id — without it a
+    user could read any tenant's lead by guessing a UUID."""
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    get_lead_block = src.split("async def get_lead(", 1)[1].split(
+        "\n\n\n", 1
+    )[0]
+    assert "LeadPipeline.id == lead_id" in get_lead_block
+    assert "LeadPipeline.tenant_id == tid" in get_lead_block
+
+
+def test_tc_sales_003_static_routes_declared_before_lead_id_route() -> None:
+    """FastAPI matches routes top-to-bottom. /sales/pipeline/
+    due-followups + /sales/pipeline/process-lead MUST be
+    declared BEFORE /sales/pipeline/{lead_id} or those static
+    paths get swallowed as lead_ids and 404 because no UUID
+    matches the literal."""
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    static1 = src.find('"/sales/pipeline/due-followups"')
+    static2 = src.find('"/sales/pipeline/process-lead"')
+    dynamic = src.find('"/sales/pipeline/{lead_id}"')
+    assert static1 > 0 and static2 > 0 and dynamic > 0
+    assert static1 < dynamic, (
+        "due-followups route must come BEFORE the {lead_id} "
+        "route or it gets swallowed"
+    )
+    assert static2 < dynamic, (
+        "process-lead route must come BEFORE the {lead_id} "
+        "route or it gets swallowed"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-SALES-004 — Run Sales Agent on lead
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_sales_004_process_lead_requires_lead_id() -> None:
+    """Missing lead_id → 400, NOT 500 / silent ack."""
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    process_block = src.split("async def process_lead_with_agent(", 1)[1].split(
+        "\n\n\n", 1
+    )[0]
+    assert 'HTTPException(400, "lead_id is required")' in process_block
+
+
+def test_tc_sales_004_process_lead_returns_only_safe_fields() -> None:
+    """Foundation #8 false-green prevention: the response
+    surfaces ONLY status + lead_id + confidence. The raw
+    agent result (tool calls, prompt, internals) is NEVER
+    forwarded — leaking internals would let consumers sniff
+    proprietary prompts and tool sequences."""
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    process_block = src.split("async def process_lead_with_agent(", 1)[1].split(
+        "\n\n\n", 1
+    )[0]
+    assert "never forward raw agent internals" in process_block
+    assert '"status": str(result.get("status", "unknown"))' in process_block
+    assert '"lead_id": str(lead_id)' in process_block
+    assert '"confidence": result.get("confidence")' in process_block
+
+
+def test_tc_sales_004_process_lead_swaps_error_for_400() -> None:
+    """If the underlying agent fails (returns {"error": ...}),
+    the route returns 400 — NOT 500. The agent error is
+    logged but not echoed back, again to avoid leaking
+    internals to the caller."""
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    process_block = src.split("async def process_lead_with_agent(", 1)[1].split(
+        "\n\n\n", 1
+    )[0]
+    assert 'if "error" in result:' in process_block
+    assert 'HTTPException(400, "Sales agent processing failed")' in process_block
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-SALES-005 — Seed demo prospects
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_sales_005_seed_endpoint_refuses_outside_demo_dev() -> None:
+    """Production MUST NEVER auto-seed prospects via API.
+    Closure plan bans fabricated data from leaking into prod
+    metrics. Pin the env-gated 403."""
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    seed_block = src.split('@router.post("/sales/seed-prospects")', 1)[1].split(
+        "@router.", 1
+    )[0]
+    assert (
+        'os.getenv("AGENTICORG_ENV", "production").lower() not in '
+        '("demo", "development", "dev"):' in seed_block
+    )
+    assert 'HTTPException(403, "Seed prospects is only available in demo/dev environments")' in seed_block
+
+
+def test_tc_sales_005_seed_idempotency_via_email_dedupe() -> None:
+    """Re-seeding the same demo set must NOT create duplicate
+    leads — the endpoint dedupes by email (per tenant). Pin
+    the existence check so a refactor can't drop it and create
+    duplicate prospect rows on every re-seed."""
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    seed_block = src.split('@router.post("/sales/seed-prospects")', 1)[1].split(
+        "@router.", 1
+    )[0]
+    assert "LeadPipeline.email == prospect[\"email\"]" in seed_block
+    assert "skipped.append(prospect[\"email\"])" in seed_block
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-SALES-006 — Import CSV leads
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_sales_006_csv_import_validates_extension() -> None:
+    """Non-.csv uploads return 422 with actionable message —
+    Session 5 TC-005. Without this, a JSON or binary file
+    parses garbage rows + emits the misleading "Imported 0
+    leads from CSV" success banner."""
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    csv_block = src.split('@router.post("/sales/import-csv")', 1)[1].split(
+        "@router.", 1
+    )[0]
+    assert 'not filename.endswith(".csv"):' in csv_block
+    assert '"error": "invalid_file_type"' in csv_block
+
+
+def test_tc_sales_006_csv_import_validates_empty_file() -> None:
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    csv_block = src.split('@router.post("/sales/import-csv")', 1)[1].split(
+        "@router.", 1
+    )[0]
+    assert "if not content.strip():" in csv_block
+    assert '"error": "empty_file"' in csv_block
+
+
+def test_tc_sales_006_csv_import_validates_encoding() -> None:
+    """utf-8-sig handles BOM. Bad encoding returns 422, NOT
+    500 / silent skip."""
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    csv_block = src.split('@router.post("/sales/import-csv")', 1)[1].split(
+        "@router.", 1
+    )[0]
+    assert 'content.decode("utf-8-sig")' in csv_block
+    assert '"error": "invalid_encoding"' in csv_block
+
+
+def test_tc_sales_006_csv_import_requires_name_and_email_headers() -> None:
+    """Required-header check accepts ``name`` OR ``full_name``
+    aliases for the name field, plus ``email``. Pin the
+    allowed aliases — a future "rename to first_name" would
+    break every production CSV upload."""
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    csv_block = src.split('@router.post("/sales/import-csv")', 1)[1].split(
+        "@router.", 1
+    )[0]
+    assert 'required_headers_lower = {"name", "email"}' in csv_block
+    assert 'alt_name_headers = {"full_name"}' in csv_block
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-SALES-007 — Due follow-ups
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_sales_007_due_followups_excludes_closed_deals() -> None:
+    """Closed-won / closed-lost leads MUST NOT appear in the
+    due-followups list. Otherwise the sales team chases deals
+    they've already won or lost."""
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    df_block = src.split('@router.get("/sales/pipeline/due-followups")', 1)[1].split(
+        "@router.", 1
+    )[0]
+    assert "next_followup_at <= datetime.now(UTC)" in df_block
+    assert 'LeadPipeline.stage.not_in(["closed_won", "closed_lost"])' in df_block
+
+
+def test_tc_sales_007_due_followups_ordered_by_score_desc() -> None:
+    """Highest-score leads first — the sales team wants the
+    most-likely-to-close work at the top of the queue."""
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    df_block = src.split('@router.get("/sales/pipeline/due-followups")', 1)[1].split(
+        "@router.", 1
+    )[0]
+    assert "order_by(LeadPipeline.score.desc())" in df_block
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-SALES-008 — Sales metrics
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_sales_008_metrics_endpoint_returns_documented_keys() -> None:
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    metrics_block = src.split('@router.get("/sales/metrics")', 1)[1].split(
+        "@router.", 1
+    )[0]
+    for key in (
+        '"total_leads"', '"new_this_week"', '"funnel"',
+        '"avg_score"', '"emails_sent_this_week"', '"stale_leads"',
+    ):
+        assert key in metrics_block, f"metrics endpoint missing key {key}"
+
+
+def test_tc_sales_008_stale_leads_excludes_new_and_closed_stages() -> None:
+    """Stale = no contact in 7+ days AND not in (closed_won,
+    closed_lost, NEW). Excluding 'new' is critical — a lead
+    created today obviously has no prior contact, and counting
+    it as stale would inflate the metric on Day 1.
+
+    Closure plan rule: every metric must be derived from real
+    data; the stage exclusion list is the contract that
+    prevents bogus alerts."""
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    metrics_block = src.split('@router.get("/sales/metrics")', 1)[1].split(
+        "@router.", 1
+    )[0]
+    assert (
+        'LeadPipeline.stage.not_in(["closed_won", "closed_lost", "new"])'
+        in metrics_block
+    )
+
+
+def test_tc_sales_008_avg_score_excludes_zero_scored_leads() -> None:
+    """avg_score filters score > 0 — newly-imported leads
+    that haven't been scored yet shouldn't drag the average
+    to zero."""
+    src = (REPO / "api" / "v1" / "sales.py").read_text(encoding="utf-8")
+    metrics_block = src.split('@router.get("/sales/metrics")', 1)[1].split(
+        "@router.", 1
+    )[0]
+    assert "LeadPipeline.score > 0" in metrics_block
+
+
+# ─────────────────────────────────────────────────────────────────
+# TC-SALES-009 — Lead score color coding
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tc_sales_009_score_color_thresholds_pinned() -> None:
+    """Heat-coding: ≥70 = emerald (hot), ≥40 = amber (warm),
+    else slate (cold). The sales team reads this color at a
+    glance; shifting the thresholds silently changes their
+    perception of which leads to call first."""
+    src = (REPO / "ui" / "src" / "pages" / "SalesPipeline.tsx").read_text(
+        encoding="utf-8"
+    )
+    # Tight pin on the exact ternary — both thresholds + colors
+    # asserted together so a refactor can't shift one in
+    # isolation.
+    assert (
+        'score >= 70 ? "text-emerald-600" : score >= 40 ? '
+        '"text-amber-600" : "text-slate-500"'
+    ) in src
+
+
+def test_tc_sales_009_score_color_used_in_list_and_detail() -> None:
+    """The color helper is applied in BOTH the lead list and
+    the detail panel. A regression where one view used the
+    helper but the other hard-coded a color would silently
+    desynchronize the heat coding between views."""
+    src = (REPO / "ui" / "src" / "pages" / "SalesPipeline.tsx").read_text(
+        encoding="utf-8"
+    )
+    # scoreColor(lead.score) appears in at least 3 places (list
+    # row + detail panel + agent-result).
+    assert src.count("scoreColor(lead.score)") >= 2
+    assert "scoreColor(agentResult.output.lead_score)" in src

--- a/ui/e2e/qa-module-11-sales-pipeline.spec.ts
+++ b/ui/e2e/qa-module-11-sales-pipeline.spec.ts
@@ -1,0 +1,252 @@
+/**
+ * Module 11: Sales Pipeline — TC-SALES-001 through 009.
+ *
+ * API contract tests against /sales/* endpoints. Pinned in this
+ * spec: pipeline shape, due-followups exclusion of closed deals,
+ * metrics shape + stale-leads exclusions, CSV-import validation
+ * branches, seed-prospects environment gate, process-lead's
+ * safe-fields-only output.
+ */
+import { expect, test } from "@playwright/test";
+
+import { APP, E2E_TOKEN, requireAuth } from "./helpers/auth";
+
+test.describe("Module 11: Sales Pipeline @qa @sales", () => {
+  test.beforeEach(() => {
+    requireAuth();
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-SALES-001 / 002: Pipeline page + funnel visualization
+  // -------------------------------------------------------------------------
+
+  test("TC-SALES-001 GET /sales/pipeline returns funnel + total + leads", async ({
+    request,
+  }) => {
+    const resp = await request.get(`${APP}/api/v1/sales/pipeline`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBeLessThan(300);
+    const body = await resp.json();
+    expect(body).toHaveProperty("funnel");
+    expect(body).toHaveProperty("total");
+    expect(body).toHaveProperty("leads");
+    expect(typeof body.funnel).toBe("object");
+    expect(Array.isArray(body.leads)).toBe(true);
+    expect(typeof body.total).toBe("number");
+  });
+
+  test("TC-SALES-002 GET /sales/pipeline?stage=new only returns 'new' leads", async ({
+    request,
+  }) => {
+    const resp = await request.get(`${APP}/api/v1/sales/pipeline?stage=new`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBeLessThan(300);
+    const body = await resp.json();
+    for (const lead of body.leads) {
+      expect(lead.stage).toBe("new");
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-SALES-003: Lead detail
+  // -------------------------------------------------------------------------
+
+  test("TC-SALES-003 GET /sales/pipeline/{nonexistent} returns 404", async ({
+    request,
+  }) => {
+    const resp = await request.get(
+      `${APP}/api/v1/sales/pipeline/00000000-0000-0000-0000-000000000000`,
+      {
+        headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+        failOnStatusCode: false,
+      },
+    );
+    expect(resp.status()).toBe(404);
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-SALES-004: Run sales agent on lead
+  // -------------------------------------------------------------------------
+
+  test("TC-SALES-004 POST /sales/pipeline/process-lead missing lead_id returns 400", async ({
+    request,
+  }) => {
+    const resp = await request.post(`${APP}/api/v1/sales/pipeline/process-lead`, {
+      headers: {
+        Authorization: `Bearer ${E2E_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      data: {}, // no lead_id
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBe(400);
+    const body = await resp.json();
+    // The detail must mention lead_id so the caller knows what to fix.
+    expect(JSON.stringify(body).toLowerCase()).toContain("lead_id");
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-SALES-005: Seed prospects (env-gated)
+  // -------------------------------------------------------------------------
+
+  test("TC-SALES-005 POST /sales/seed-prospects either succeeds (demo/dev) or 403 (prod)", async ({
+    request,
+  }) => {
+    // The env gate determines the response. Foundation #8 false-
+    // green prevention: a 5xx here would mean the gate isn't
+    // wired; ANY of {200, 201, 403} proves the gate logic ran.
+    const resp = await request.post(`${APP}/api/v1/sales/seed-prospects`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect([200, 201, 403]).toContain(resp.status());
+    if (resp.status() === 403) {
+      const body = await resp.json();
+      expect(JSON.stringify(body).toLowerCase()).toContain("demo/dev");
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-SALES-006: CSV import validation
+  // -------------------------------------------------------------------------
+
+  test("TC-SALES-006 POST /sales/import-csv with non-CSV file is 422", async ({
+    request,
+  }) => {
+    const resp = await request.post(`${APP}/api/v1/sales/import-csv`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      multipart: {
+        file: {
+          name: "leads.json",
+          mimeType: "application/json",
+          buffer: Buffer.from('{"leads":[]}'),
+        },
+      },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBe(422);
+    const body = await resp.json();
+    expect(JSON.stringify(body).toLowerCase()).toContain("csv");
+  });
+
+  test("TC-SALES-006b POST /sales/import-csv with empty CSV is 422", async ({
+    request,
+  }) => {
+    const resp = await request.post(`${APP}/api/v1/sales/import-csv`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      multipart: {
+        file: {
+          name: "empty.csv",
+          mimeType: "text/csv",
+          buffer: Buffer.from(""),
+        },
+      },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBe(422);
+    const body = await resp.json();
+    expect(JSON.stringify(body).toLowerCase()).toContain("empty");
+  });
+
+  test("TC-SALES-006c POST /sales/import-csv with missing required headers is 422", async ({
+    request,
+  }) => {
+    // CSV with just a "phone" column — no name, no email.
+    const resp = await request.post(`${APP}/api/v1/sales/import-csv`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      multipart: {
+        file: {
+          name: "bad-headers.csv",
+          mimeType: "text/csv",
+          buffer: Buffer.from("phone\n555-1212\n"),
+        },
+      },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBe(422);
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-SALES-007: Due follow-ups
+  // -------------------------------------------------------------------------
+
+  test("TC-SALES-007 GET /sales/pipeline/due-followups never returns closed deals", async ({
+    request,
+  }) => {
+    const resp = await request.get(`${APP}/api/v1/sales/pipeline/due-followups`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBeLessThan(300);
+    const body = await resp.json();
+    expect(Array.isArray(body)).toBe(true);
+    for (const lead of body) {
+      // Closed deals must NEVER appear in the follow-up queue.
+      expect(["closed_won", "closed_lost"]).not.toContain(lead.stage);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-SALES-008: Sales metrics shape
+  // -------------------------------------------------------------------------
+
+  test("TC-SALES-008 GET /sales/metrics returns documented shape", async ({
+    request,
+  }) => {
+    const resp = await request.get(`${APP}/api/v1/sales/metrics`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(resp.status()).toBeLessThan(300);
+    const body = await resp.json();
+    for (const key of [
+      "total_leads",
+      "new_this_week",
+      "funnel",
+      "avg_score",
+      "emails_sent_this_week",
+      "stale_leads",
+    ]) {
+      expect(body, `metrics missing key ${key}`).toHaveProperty(key);
+    }
+    // Numeric metrics must be numbers (not "N/A" or null).
+    expect(typeof body.total_leads).toBe("number");
+    expect(typeof body.new_this_week).toBe("number");
+    expect(typeof body.avg_score).toBe("number");
+    expect(typeof body.emails_sent_this_week).toBe("number");
+    expect(typeof body.stale_leads).toBe("number");
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-SALES-009: Lead score color (UI-only — see source pin)
+  // -------------------------------------------------------------------------
+
+  test("TC-SALES-009 sales pipeline page renders without runtime errors", async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+    page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(msg.text());
+    });
+
+    await page.goto(`${APP}/dashboard/sales`);
+    await page.waitForLoadState("domcontentloaded");
+    // Wait briefly for first render.
+    await page.waitForTimeout(1500);
+
+    expect(
+      errors.filter(
+        (e) =>
+          !e.includes("ResizeObserver") &&
+          !e.includes("Failed to load resource") &&
+          !e.includes("favicon"),
+      ),
+      `unexpected page errors: ${errors.slice(0, 5).join(" | ")}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Foundation #6 burndown of Module 11 — **the platform's revenue surface**. Every metric, score, and stage transition derives from real data with no fabricated KPIs (P6.1 audit).

**Three of nine are P0**: lead-detail tenant scoping, sales-agent safe-fields-only response, prod seed-prospects gate.

## Backend pins (TC-SALES-001 through 009)

22 source-pinned tests in \`tests/unit/test_module_11_sales_pipeline.py\`:

| TC | Pin |
|----|-----|
| 001 (P1) | /sales/pipeline returns {funnel, total, leads}; \`_lead_to_dict\` carries every UI-rendered field |
| 002 (P1) | GROUP BY stage + COUNT(*) for funnel |
| 003 (P0) | tenant-scoped query (no cross-tenant lead read); **static /due-followups + /process-lead routes BEFORE /{lead_id}** so they don't get swallowed as UUIDs |
| 004 (P0) | lead_id required + **safe-fields-only response** (status + lead_id + confidence — NEVER raw agent internals which would leak prompts/tools) + agent-error → 400 |
| 005 (P0) | seed-prospects 403 outside demo/dev (closure-plan bans fabricated data in prod) + email-dedupe idempotency |
| 006 (P1) | CSV import **4 distinct 422 paths** — wrong extension / empty / bad encoding / missing headers |
| 007 (P1) | due-followups EXCLUDES closed_won/closed_lost; ordered by score DESC |
| 008 (P1) | metrics 6-key shape; **stale-leads EXCLUDES "new" stage** (Day-1 leads aren't stale) AND closed deals; avg_score filters score > 0 |
| 009 (P2) | score color thresholds (≥70 emerald / ≥40 amber / else slate); helper used in list + detail + agent-result |

## UI Playwright

10 specs in \`ui/e2e/qa-module-11-sales-pipeline.spec.ts\`:

- **001/002**: pipeline shape + ?stage=new filter
- **003**: GET nonexistent lead → 404
- **004**: process-lead missing lead_id → 400 + detail mentions lead_id
- **005**: seed-prospects → either 200/201 (demo) or 403 (prod)
- **006/006b/006c**: CSV import 422 for non-CSV / empty / bad headers
- **007**: due-followups never returns closed_won/closed_lost
- **008**: metrics 6-key numeric shape
- **009**: sales pipeline page renders without runtime errors

## Verification

- \`pytest tests/unit/test_module_11_sales_pipeline.py\` → **22 passed**
- ruff clean
- YAML: **9/9 Module 11 entries = automated**

## Foundation #6 progress (this session)

| Module | TCs | PR |
|--------|-----|-----|
| 3 (Dashboard) | 5 | #372 |
| 4 (Agent Fleet) | 13 | #371 |
| **11 (Sales Pipeline)** | **9** | **This PR** |
| 12 (Audit Log) | 6 | #364 |
| 14 (Org Management) | 6 | #365 |
| 16 (Email System) | 6 | #370 |
| 19 (Health & API) | 6 | #368 |
| 22 (Cross-Cutting) | 12 | #366 |
| 27 (Negative & Edge) | 10 | #369 |
| 28 (Org Chart) | 7 | #367 |
| 30 (Per-Agent Budget) | 8 | #363 |

**88 TCs newly automated across 11 PRs this session.** ~287 manual TCs remain.

@codex please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)