### PR TITLE
fix(qa): RU28-Bug-E — Zoho org tool, prompt-substitution typo (28x), fpa_agent default-tools drift

### DIFF
--- a/connectors/finance/zoho_books.py
+++ b/connectors/finance/zoho_books.py
@@ -40,6 +40,7 @@ class ZohoBooksConnector(BaseConnector):
         self._tool_registry["get_profit_loss"] = self.get_profit_loss
         self._tool_registry["list_chartofaccounts"] = self.list_chartofaccounts
         self._tool_registry["reconcile_transaction"] = self.reconcile_transaction
+        self._tool_registry["get_organization"] = self.get_organization
 
     async def _authenticate(self):
         """OAuth2 refresh token flow for Zoho Books."""
@@ -240,6 +241,30 @@ class ZohoBooksConnector(BaseConnector):
             qp["to_date"] = params["to_date"]
         data = await self._get("/reports/profitandloss", params=self._org_params(qp))
         return self._unwrap(data, "profit_and_loss")
+
+    # ── Organization details ───────────────────────────────────────────
+
+    async def get_organization(self, **_params) -> dict[str, Any]:
+        """Get organization details (name, organization_id, address, currency).
+
+        Returns the active organization from the connected Zoho Books
+        account. Useful for agents whose prompts reference the
+        company by name or need the organization_id for follow-up
+        calls. Takes no parameters; the connector's configured
+        organization_id selects which org to fetch when the account
+        spans multiple.
+        """
+        # _get auto-injects organization_id from the connector config
+        # (see _get override below). Zoho returns the matching org
+        # under the "organizations" array even for the singleton query.
+        data = await self._get("/organizations")
+        orgs = data.get("organizations", []) if isinstance(data, dict) else []
+        if not orgs:
+            return {"organizations": []}
+        # Active org first; callers that asked for "company name and
+        # organization_id" want the configured one, which Zoho lists
+        # filtered by the organization_id query param we injected.
+        return {"organizations": orgs}
 
     # ── Chart of Accounts ──────────────────────────────────────────────
 

--- a/core/agent_generator.py
+++ b/core/agent_generator.py
@@ -196,6 +196,10 @@ _AGENT_TYPE_DEFAULT_TOOLS: dict[str, list[str]] = {
         "get_balance", "search_content_fulltext",
     ],
     "fpa_agent": [
+        # Mirrors api/v1/agents.py:_AGENT_TYPE_DEFAULT_TOOLS — same agent
+        # type, same canonical tool list. Drift between these dicts means
+        # newly-created agents miss tools their handlers expect.
+        "get_profit_loss", "get_trial_balance",
         "list_invoices", "get_balance",
         "get_campaign_performance_metrics", "get_project_metrics",
     ],

--- a/core/langgraph/agents/abm_agent.py
+++ b/core/langgraph/agents/abm_agent.py
@@ -24,7 +24,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
     with open(path) as f:
         template = f.read()
     for key, val in (variables or {}).items():
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
     return template
 
 

--- a/core/langgraph/agents/ar_collections.py
+++ b/core/langgraph/agents/ar_collections.py
@@ -24,7 +24,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
     with open(path) as f:
         template = f.read()
     for key, val in (variables or {}).items():
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
     return template
 
 

--- a/core/langgraph/agents/brand_monitor.py
+++ b/core/langgraph/agents/brand_monitor.py
@@ -40,7 +40,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/campaign_pilot.py
+++ b/core/langgraph/agents/campaign_pilot.py
@@ -42,7 +42,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/close_agent.py
+++ b/core/langgraph/agents/close_agent.py
@@ -23,7 +23,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
     with open(path) as f:
         template = f.read()
     for key, val in (variables or {}).items():
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
     return template
 
 

--- a/core/langgraph/agents/competitive_intel.py
+++ b/core/langgraph/agents/competitive_intel.py
@@ -24,7 +24,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
     with open(path) as f:
         template = f.read()
     for key, val in (variables or {}).items():
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
     return template
 
 

--- a/core/langgraph/agents/compliance_guard.py
+++ b/core/langgraph/agents/compliance_guard.py
@@ -42,7 +42,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/content_factory.py
+++ b/core/langgraph/agents/content_factory.py
@@ -42,7 +42,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/contract_intelligence.py
+++ b/core/langgraph/agents/contract_intelligence.py
@@ -30,7 +30,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/crm_intelligence.py
+++ b/core/langgraph/agents/crm_intelligence.py
@@ -44,7 +44,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/email_marketing.py
+++ b/core/langgraph/agents/email_marketing.py
@@ -25,7 +25,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
     with open(path) as f:
         template = f.read()
     for key, val in (variables or {}).items():
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
     return template
 
 

--- a/core/langgraph/agents/facilities_agent.py
+++ b/core/langgraph/agents/facilities_agent.py
@@ -30,7 +30,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/fpa_agent.py
+++ b/core/langgraph/agents/fpa_agent.py
@@ -9,6 +9,12 @@ from core.langgraph.agent_graph import build_agent_graph
 from core.langgraph.runner import run_agent
 
 DEFAULT_TOOLS = [
+    # Mirrors api/v1/agents.py:_AGENT_TYPE_DEFAULT_TOOLS["fpa_agent"] —
+    # same agent type, same canonical tool list. Drift here means the
+    # generic LangGraph runner binds a narrower toolset than the REST
+    # creation path advertises.
+    'get_profit_loss',
+    'get_trial_balance',
     'list_invoices',
     'get_balance',
     'get_campaign_performance_metrics',
@@ -23,7 +29,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
     with open(path) as f:
         template = f.read()
     for key, val in (variables or {}).items():
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
     return template
 
 

--- a/core/langgraph/agents/it_operations.py
+++ b/core/langgraph/agents/it_operations.py
@@ -26,7 +26,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
     with open(path) as f:
         template = f.read()
     for key, val in (variables or {}).items():
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
     return template
 
 

--- a/core/langgraph/agents/ld_coordinator.py
+++ b/core/langgraph/agents/ld_coordinator.py
@@ -30,7 +30,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/legal_ops.py
+++ b/core/langgraph/agents/legal_ops.py
@@ -42,7 +42,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/offboarding_agent.py
+++ b/core/langgraph/agents/offboarding_agent.py
@@ -40,7 +40,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/onboarding_agent.py
+++ b/core/langgraph/agents/onboarding_agent.py
@@ -42,7 +42,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/payroll_engine.py
+++ b/core/langgraph/agents/payroll_engine.py
@@ -42,7 +42,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/performance_coach.py
+++ b/core/langgraph/agents/performance_coach.py
@@ -30,7 +30,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/recon_agent.py
+++ b/core/langgraph/agents/recon_agent.py
@@ -23,7 +23,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
     with open(path) as f:
         template = f.read()
     for key, val in (variables or {}).items():
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
     return template
 
 

--- a/core/langgraph/agents/risk_sentinel.py
+++ b/core/langgraph/agents/risk_sentinel.py
@@ -42,7 +42,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/seo_strategist.py
+++ b/core/langgraph/agents/seo_strategist.py
@@ -40,7 +40,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/social_media.py
+++ b/core/langgraph/agents/social_media.py
@@ -24,7 +24,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
     with open(path) as f:
         template = f.read()
     for key, val in (variables or {}).items():
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
     return template
 
 

--- a/core/langgraph/agents/support_triage.py
+++ b/core/langgraph/agents/support_triage.py
@@ -27,7 +27,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
     with open(path) as f:
         template = f.read()
     for key, val in (variables or {}).items():
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
     return template
 
 

--- a/core/langgraph/agents/talent_acquisition.py
+++ b/core/langgraph/agents/talent_acquisition.py
@@ -44,7 +44,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/tax_compliance.py
+++ b/core/langgraph/agents/tax_compliance.py
@@ -44,7 +44,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/core/langgraph/agents/vendor_manager.py
+++ b/core/langgraph/agents/vendor_manager.py
@@ -42,7 +42,7 @@ def load_prompt(variables: dict[str, str] | None = None) -> str:
 
     for key, val in (variables or {}).items():
 
-        template = template.replace("{{}" + key + "}}", val)
+        template = template.replace("{{" + key + "}}", val)
 
     return template
 

--- a/tests/regression/test_bge_m3_pr_a.py
+++ b/tests/regression/test_bge_m3_pr_a.py
@@ -76,11 +76,41 @@ def test_embed_with_bge_m3_returns_1024_dim_vectors() -> None:
     ~2.3 GB of weights and PyTorch on first call, which we don't want
     to install just to satisfy a unit-test runner. The Cloud Run
     backfill image MUST install it.
+
+    Also skipped when FlagEmbedding *is* installed but the BGE-M3
+    weights aren't already in the local HuggingFace cache. Without
+    this gate, a fresh dev machine with FlagEmbedding installed
+    triggers an unbounded ~2.3 GB cold download mid-pytest which
+    hangs the preflight gate and looks like a code regression
+    rather than a missing-cache environment issue.
     """
     flag = pytest.importorskip(
         "FlagEmbedding", reason="FlagEmbedding not installed in this env"
     )
     del flag
+    # Honor the docstring intent: only run when the env can produce
+    # vectors quickly. Probe the HF cache for the actual weight file
+    # (the large pytorch_model.bin or its safetensors equivalent) —
+    # checking the small config.json alone isn't enough because a
+    # partial / interrupted download may have landed only the
+    # metadata files. If the weights aren't cached, FlagEmbedding's
+    # constructor would trigger a multi-GB cold download mid-pytest
+    # which isn't acceptable in a unit-test gate.
+    from huggingface_hub import try_to_load_from_cache  # noqa: PLC0415
+
+    weights_cached = any(
+        try_to_load_from_cache("BAAI/bge-m3", fname) is not None
+        for fname in ("pytorch_model.bin", "model.safetensors")
+    )
+    if not weights_cached:
+        pytest.skip(
+            "BGE-M3 model weights not in local HuggingFace cache "
+            "(config.json may be present but the large weight file "
+            "isn't). Pre-download with `python -c \"from huggingface_hub "
+            "import snapshot_download; snapshot_download('BAAI/bge-m3')\"` "
+            "to enable this test, or run it inside the Cloud Run "
+            "backfill image which has the weights baked in."
+        )
     from core.embeddings import embed_bge_m3
 
     vectors = embed_bge_m3(["hello world", "second sample"])

--- a/tests/regression/test_ru28_bug_e_zoho_org_and_prompt_substitution.py
+++ b/tests/regression/test_ru28_bug_e_zoho_org_and_prompt_substitution.py
@@ -1,0 +1,228 @@
+"""RU28-Bug-E regression pins.
+
+Original symptom (gunjan@gmail.com on 2026-04-29):
+    POST /agents/{id}/run on the Zoho Books FPA agent returned
+    confidence: 0.4, tool_calls: [], runtime: "langgraph". The LLM
+    refused with: "I cannot fulfill this request. The available tools
+    do not have the capability to fetch organization details such as
+    company name and organization ID."
+
+Investigation (2026-04-30) revealed three independent issues and
+fixed all three in a single PR:
+
+1. **Missing get_organization tool** — the agent's user-supplied
+   system_prompt_text literally said "fetch my organization details
+   including company name and organization ID", but the Zoho Books
+   connector exposed 7 tools and none returned org details. The
+   LLM was correctly stuck. Added `get_organization`.
+
+2. **Template substitution typo across 28 agent modules** —
+   `core/langgraph/agents/*.py` had `template.replace("{{}" + key + "}}", val)`
+   which builds the search string `"{{}org_name}}"` instead of
+   `"{{org_name}}"`. So the substitution never matched and the
+   LLM saw literal `{{org_name}}` placeholders in its system
+   prompt. Mass fix to all 28 sites; canonical version in
+   `api/v1/agents.py:1635` was already correct.
+
+3. **`_AGENT_TYPE_DEFAULT_TOOLS` drift for fpa_agent** — three
+   sites defined the default tool list with different contents:
+   `api/v1/agents.py:69-76` (canonical, 6 tools),
+   `core/agent_generator.py:198-201` (4 tools, missing
+   get_profit_loss + get_trial_balance), and
+   `core/langgraph/agents/fpa_agent.py:11-16` (same drift).
+   Same drift class as PR #386 Bug-D. Synced all three.
+
+These pins ensure none of the three regress.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from pathlib import Path
+
+import pytest
+
+# ─────────────────────────────────────────────────────────────────
+# Pin #1 — Zoho Books exposes get_organization as a registered tool
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_zoho_books_registers_get_organization_tool() -> None:
+    """get_organization must live in the connector's tool registry so
+    the LangGraph tool_adapter binds it for any agent whose
+    authorized_tools include it. Without this, a user prompt asking
+    for org details has no tool that can satisfy it and the LLM
+    refuses (the original RU28-Bug-E symptom).
+    """
+    from connectors.finance.zoho_books import ZohoBooksConnector
+
+    instance = ZohoBooksConnector(config={"organization_id": "test-org"})
+    assert "get_organization" in instance._tool_registry, (
+        "get_organization missing from Zoho Books tool registry — "
+        "agents asking for org details will be stuck again."
+    )
+    handler = instance._tool_registry["get_organization"]
+    assert callable(handler)
+    # Must be an async coroutine function (every other Zoho tool is)
+    assert inspect.iscoroutinefunction(handler)
+
+
+@pytest.mark.asyncio
+async def test_zoho_books_get_organization_routes_to_organizations_endpoint(
+    monkeypatch,
+) -> None:
+    """End-to-end: calling the tool hits GET /organizations on the
+    Zoho API and returns the organizations list. Uses fake_connectors
+    seam (Foundation #7 PR-D) so no real network."""
+    from connectors.finance.zoho_books import ZohoBooksConnector
+    from core.test_doubles import fake_connectors
+
+    fake_connectors.register(
+        method="GET",
+        url_contains="/organizations",
+        status=200,
+        json={
+            "organizations": [
+                {
+                    "organization_id": "60001234567",
+                    "name": "TechSolutions India Pvt Ltd",
+                    "currency_code": "INR",
+                }
+            ]
+        },
+    )
+
+    conn = ZohoBooksConnector(
+        config={
+            "organization_id": "60001234567",
+            "access_token": "fake-token",
+        }
+    )
+    await conn.connect()
+    try:
+        result = await conn.get_organization()
+    finally:
+        await conn.disconnect()
+
+    assert result == {
+        "organizations": [
+            {
+                "organization_id": "60001234567",
+                "name": "TechSolutions India Pvt Ltd",
+                "currency_code": "INR",
+            }
+        ]
+    }
+
+
+# ─────────────────────────────────────────────────────────────────
+# Pin #2 — Every agent module's load_prompt actually substitutes
+# ─────────────────────────────────────────────────────────────────
+
+
+def _list_agent_modules() -> list[str]:
+    """Return every agent module under core/langgraph/agents that
+    defines load_prompt. Discovered dynamically so a 29th agent
+    automatically inherits the regression pin."""
+    agents_dir = Path(__file__).parent.parent.parent / "core" / "langgraph" / "agents"
+    modules: list[str] = []
+    for p in sorted(agents_dir.glob("*.py")):
+        if p.name in ("__init__.py", "base_agent.py"):
+            continue
+        try:
+            mod = importlib.import_module(f"core.langgraph.agents.{p.stem}")
+        except Exception:  # noqa: BLE001, S112 — skip non-importable agent modules during discovery
+            continue
+        if hasattr(mod, "load_prompt"):
+            modules.append(p.stem)
+    return modules
+
+
+@pytest.mark.parametrize("agent_module", _list_agent_modules())
+def test_agent_load_prompt_substitutes_jinja_style_placeholders(
+    agent_module: str, tmp_path, monkeypatch
+) -> None:
+    """The pre-fix code had ``template.replace("{{}" + key + "}}", val)``
+    which builds the search string ``{{}key}}`` and never matches the
+    actual ``{{key}}`` placeholder in the prompt files. We pin every
+    agent module's load_prompt: given a prompt template containing
+    ``{{org_name}}`` and a substitution dict, the output must contain
+    the substituted value and must NOT contain the literal
+    ``{{org_name}}`` placeholder.
+
+    Auto-discovers all agent modules with load_prompt so this pin
+    keeps biting if a 29th file lands with the typo.
+    """
+    mod = importlib.import_module(f"core.langgraph.agents.{agent_module}")
+
+    # Point the agent module at a controlled prompt file containing
+    # a known placeholder. We monkeypatch the PROMPTS_DIR plus the
+    # specific filename the module reads. Most modules name the
+    # prompt after the agent_module itself.
+    prompt_dir = tmp_path / "prompts"
+    prompt_dir.mkdir()
+    # Modules pick the filename based on their own module name —
+    # write a dummy prompt at every plausible path so we don't have
+    # to know each module's wiring detail.
+    template_body = "Hello {{org_name}}, you are the {{role}} agent."
+    for stem in {agent_module, agent_module.replace("_agent", ""), "agent"}:
+        (prompt_dir / f"{stem}.prompt.txt").write_text(template_body)
+
+    monkeypatch.setattr(mod, "PROMPTS_DIR", str(prompt_dir), raising=True)
+
+    rendered = mod.load_prompt({"org_name": "Acme Corp", "role": "FP&A"})
+
+    assert "Acme Corp" in rendered, (
+        f"{agent_module}.load_prompt failed to substitute {{{{org_name}}}}"
+    )
+    assert "FP&A" in rendered, (
+        f"{agent_module}.load_prompt failed to substitute {{{{role}}}}"
+    )
+    assert "{{org_name}}" not in rendered, (
+        f"{agent_module}.load_prompt left {{{{org_name}}}} unsubstituted "
+        "— the {{}}-key-{{}} typo regressed"
+    )
+    assert "{{role}}" not in rendered, (
+        f"{agent_module}.load_prompt left {{{{role}}}} unsubstituted "
+        "— the {{}}-key-{{}} typo regressed"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────
+# Pin #3 — _AGENT_TYPE_DEFAULT_TOOLS for fpa_agent is consistent
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_fpa_agent_default_tools_match_across_definition_sites() -> None:
+    """fpa_agent default tools live in three places. Drift produces
+    silently-narrower agents on whichever creation path uses the
+    diverged dict (same drift class as PR #386 Bug-D). Pin all three
+    against the canonical api/v1/agents.py list.
+    """
+    from api.v1.agents import _AGENT_TYPE_DEFAULT_TOOLS as API_DEFAULTS  # noqa: N811
+    from core.agent_generator import (  # noqa: N811
+        _AGENT_TYPE_DEFAULT_TOOLS as GENERATOR_DEFAULTS,
+    )
+    from core.langgraph.agents.fpa_agent import DEFAULT_TOOLS as RUNTIME_FPA_TOOLS  # noqa: N811
+
+    canonical = set(API_DEFAULTS["fpa_agent"])
+    assert canonical == set(GENERATOR_DEFAULTS["fpa_agent"]), (
+        "core/agent_generator.py:_AGENT_TYPE_DEFAULT_TOOLS['fpa_agent'] "
+        "drifted from api/v1/agents.py — newly-created fpa_agents will "
+        "miss tools their handlers expect."
+    )
+    assert canonical == set(RUNTIME_FPA_TOOLS), (
+        "core/langgraph/agents/fpa_agent.py:DEFAULT_TOOLS drifted from "
+        "api/v1/agents.py — REST /run path binds a narrower toolset."
+    )
+    # Plus the specific tools that were missing from the drifted
+    # versions before this fix — they MUST be present:
+    for required in ("get_profit_loss", "get_trial_balance"):
+        assert required in RUNTIME_FPA_TOOLS, (
+            f"{required} missing from runtime DEFAULT_TOOLS — that was "
+            "exactly the gap RU28-Bug-E investigation surfaced."
+        )
+        assert required in GENERATOR_DEFAULTS["fpa_agent"], (
+            f"{required} missing from agent_generator DEFAULT_TOOLS"
+        )


### PR DESCRIPTION
## Summary

Three independent issues surfaced while triaging **RU28-Bug-E** (Ramesh CA Firms tester `gunjan@gmail.com`, 2026-04-29). The earlier 28-Apr diagnosis ("REST `/run` never dispatches to dedicated agent classes; FPA prompt asks for org-detail prefetch") was speculative — fixed in code only via guesswork. Honest reproduction against deployed prod (`8311d8c`) showed the agent has its own user-supplied 121-char `system_prompt_text`, not the FPA template, and the actual blockers are below.

## What's in this PR

### 1. Missing `get_organization` tool on Zoho Books

The agent's stored prompt literally says *"fetch my organization details including company name and organization ID"*. The Zoho Books connector exposed 7 tools and **none returned org details** — `health_check` hit `/organizations` internally but it wasn't an LLM-callable tool. The LLM correctly refused with `confidence:0.4`, `tool_calls:[]`. Added `get_organization` wrapping `GET /organizations` (`connectors/finance/zoho_books.py`).

### 2. Template substitution typo across 28 agent modules

Every agent module under `core/langgraph/agents/*.py` had:
```python
template = template.replace("{{}" + key + "}}", val)
```
This builds the search string `{{}org_name}}` and never matches the actual `{{org_name}}` placeholder. Any agent that fell through to the Path-3 prompt loader saw literal `{{key}}` markers in its system prompt. Mass fix to all 28 sites; canonical version in `api/v1/agents.py:1635` was already correct.

Doesn't bite this specific tester's agent (uses Path 1, custom text), but pre-positioned dynamite for any agent without `system_prompt_text`/`system_prompt_ref`.

### 3. `_AGENT_TYPE_DEFAULT_TOOLS` drift for `fpa_agent`

Three sites defined `fpa_agent` default tools differently:
- `api/v1/agents.py:69-76` — canonical, 6 tools
- `core/agent_generator.py:198-201` — missing `get_profit_loss` + `get_trial_balance`
- `core/langgraph/agents/fpa_agent.py:11-16` — same drift

Same drift class as PR #386 Bug-D. Synced both diverged sites to the canonical list.

### Bonus: BGE-M3 e2e test no longer hangs preflight

`tests/regression/test_bge_m3_pr_a.py::test_embed_with_bge_m3_returns_1024_dim_vectors` did `importorskip("FlagEmbedding")` but on dev machines where FlagEmbedding IS installed (for backfill work) it triggered a ~2.3 GB cold model download mid-pytest that hung preflight. Added a second skip path: probe HF cache for the actual weight file (`pytorch_model.bin` / `model.safetensors`) — `config.json` alone isn't sufficient because partial downloads land only metadata. Honors the test's stated intent without weakening it in environments that have weights baked in.

## Verdict per `/agenticorg-bug-fix-fail-closed` skill

- **RU28-Bug-E (the original symptom)**: **Enhancement, fixed in code, deploy pending.** The agent is configured with a prompt asking for a capability that didn't exist. Once deployed, the user can either (a) PATCH `/agents/{id}` to add `get_organization` to `authorized_tools`, or (b) keep the existing tools and adjust their prompt. Both are unblocked by the new tool.
- **Template substitution typo**: **Fixed.** Pre-positioned bug across 28 modules, never reached this specific tester but would silently corrupt any agent on Path 3.
- **Default-tools drift**: **Fixed.** Same drift class as PR #386 Bug-D — `_AGENT_TYPE_DEFAULT_TOOLS` is now identical across all three sites. Pinned by regression test.

## Regression tests (38 new pins)

`tests/regression/test_ru28_bug_e_zoho_org_and_prompt_substitution.py`:

1. `get_organization` is registered in Zoho Books `_tool_registry` and is a coroutine.
2. End-to-end: calling `get_organization()` routes through `GET /organizations` (uses Foundation #7 PR-D `fake_connectors` MockTransport seam — no real network).
3. Auto-discovers every agent module with `load_prompt` (35 of them) and parametrizes a substitution test: given `{{org_name}}` and `{{role}}` placeholders, the rendered output must contain the substituted values and must NOT contain unsubstituted `{{key}}` markers.
4. `_AGENT_TYPE_DEFAULT_TOOLS["fpa_agent"]` is identical across all three definition sites. `get_profit_loss` and `get_trial_balance` explicitly asserted present.

## Verification

- `pytest tests/regression/test_ru28_bug_e_zoho_org_and_prompt_substitution.py` → **38 passed**
- Local preflight gate (ruff, bandit, alembic, verify=False, pytest regression+unit, tsc, ui build, consistency sweep, module coverage, critical-path tags, branch safety) → **all 11 passed**
- BGE-M3 e2e test now skips cleanly (1 skipped, 0 hangs)

## Remaining

- **Deploy + tester re-verify** per Rule 7: post-deploy login as `gunjan@gmail.com`, PATCH the agent to add `get_organization` to `authorized_tools`, re-run the original `/agents/{id}/run` curl, expect `confidence > 0.6` and `tool_calls` containing `zoho_books.get_organization` and `zoho_books.get_profit_loss`.

@codex please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)