### PR TITLE
feat(api): Phase 1 enterprise gap closure — missing routes + contract drift test + UI error panels

### DIFF
--- a/api/v1/audit.py
+++ b/api/v1/audit.py
@@ -135,3 +135,173 @@ async def query_audit(
         per_page=per_page,
         pages=pages,
     )
+
+
+# ── GET /audit/enforce ───────────────────────────────────────────────────────
+#
+# Tool-gateway enforcement events. Every tool_call that the gateway evaluates
+# (whether allowed or denied) is written to AuditLog by
+# ``core.tool_gateway.audit_logger.AuditLogger.log()`` with
+# ``resource_type='tool_call'``, ``outcome`` ∈ {"allowed", "denied"}, and
+# ``details.enforcement_action`` set to the specific reason for denial
+# (scope_denied, rate_limited, idempotency_replay, etc.). This endpoint
+# projects those rows into the shape ``ui/src/pages/EnforceAuditLog.tsx``
+# and ``ui/src/pages/ScopeDashboard.tsx`` consume.
+#
+# Authz: same shape as ``GET /audit`` — tenant-scoped via ``get_current_tenant``,
+# RBAC domain filtering for non-auditor roles. Enforcement audit is part of the
+# governance posture — auditors see all, domain roles see only their agents'
+# events.
+
+
+def _enforce_to_dict(entry: AuditLog, agent_name_by_id: dict[str, str]) -> dict:
+    """Project an AuditLog row into the EnforceAuditLog UI shape.
+
+    UI fields (from ``EnforceAuditLog.tsx`` table headers + filter logic):
+    timestamp, agent_name, connector, tool, permission, result, reason.
+
+    Connector is parsed from ``event_type`` which the gateway writes as
+    ``tool.<tool_name>``; native tool names like ``get_profit_loss`` don't
+    encode the connector, so we look in ``details.connector`` first (the
+    gateway populates it) and fall back to "unknown" when absent.
+    """
+    details = entry.details or {}
+    agent_id_str = str(entry.agent_id) if entry.agent_id else ""
+    return {
+        "id": str(entry.id),
+        "timestamp": entry.created_at.isoformat() if entry.created_at else None,
+        "agent_id": agent_id_str or None,
+        "agent_name": agent_name_by_id.get(agent_id_str, ""),
+        "connector": details.get("connector") or details.get("connector_name") or "",
+        "tool": entry.resource_id or "",
+        "permission": details.get("permission") or details.get("scope") or "",
+        "result": entry.outcome or "",
+        "reason": (
+            details.get("enforcement_action")
+            or details.get("reason")
+            or (entry.outcome if entry.outcome != "allowed" else "")
+            or ""
+        ),
+        "trace_id": entry.trace_id or None,
+    }
+
+
+@router.get("/audit/enforce", response_model=PaginatedResponse)
+async def query_enforce_audit(
+    result: str | None = None,  # "allowed" | "denied"
+    agent_id: str | None = None,
+    connector: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    page: int = 1,
+    per_page: int = 50,
+    tenant_id: str = Depends(get_current_tenant),
+    user_domains: list[str] | None = Depends(get_user_domains),
+    user_role: str = Depends(get_user_role),
+):
+    """Tool-gateway enforcement events for the current tenant.
+
+    Returns the rows the EnforceAuditLog and ScopeDashboard pages render.
+    Same authz shape as ``/audit``: tenant-scoped, with RBAC domain filtering
+    for non-auditor roles so domain owners only see their own agents' events.
+    """
+    if page < 1:
+        raise HTTPException(422, "page must be >= 1")
+    if result is not None and result not in ("allowed", "denied"):
+        raise HTTPException(422, "result must be 'allowed' or 'denied'")
+    per_page = min(max(per_page, 1), 100)
+    tid = _uuid.UUID(tenant_id)
+
+    async with get_tenant_session(tid) as session:
+        base = (
+            select(AuditLog)
+            .where(AuditLog.tenant_id == tid)
+            .where(AuditLog.resource_type == "tool_call")
+        )
+        count_base = (
+            select(func.count())
+            .select_from(AuditLog)
+            .where(AuditLog.tenant_id == tid)
+            .where(AuditLog.resource_type == "tool_call")
+        )
+
+        # RBAC domain filter — same logic as ``GET /audit``.
+        if user_domains is not None and user_role != "auditor":
+            domain_agent_ids = (
+                select(Agent.id).where(Agent.domain.in_(user_domains)).scalar_subquery()
+            )
+            domain_filter = or_(
+                AuditLog.agent_id.in_(domain_agent_ids),
+                AuditLog.agent_id.is_(None),
+            )
+            base = base.where(domain_filter)
+            count_base = count_base.where(domain_filter)
+
+        if result:
+            base = base.where(AuditLog.outcome == result)
+            count_base = count_base.where(AuditLog.outcome == result)
+
+        if agent_id:
+            try:
+                agent_uuid = _uuid.UUID(agent_id)
+            except (ValueError, AttributeError) as e:
+                raise HTTPException(400, "Invalid agent_id format") from e
+            base = base.where(AuditLog.agent_id == agent_uuid)
+            count_base = count_base.where(AuditLog.agent_id == agent_uuid)
+
+        if connector:
+            # connector lives in details JSON (gateway writes
+            # ``details.connector``). Use a JSON path filter.
+            from sqlalchemy import cast  # noqa: PLC0415
+            from sqlalchemy.dialects.postgresql import JSONB  # noqa: PLC0415
+
+            base = base.where(
+                cast(AuditLog.details, JSONB)["connector"].astext == connector
+            )
+            count_base = count_base.where(
+                cast(AuditLog.details, JSONB)["connector"].astext == connector
+            )
+
+        if date_from:
+            try:
+                dt_from = datetime.fromisoformat(date_from)
+            except ValueError as e:
+                raise HTTPException(400, "Invalid date_from format — use ISO 8601") from e
+            base = base.where(AuditLog.created_at >= dt_from)
+            count_base = count_base.where(AuditLog.created_at >= dt_from)
+
+        if date_to:
+            try:
+                dt_to = datetime.fromisoformat(date_to)
+            except ValueError as e:
+                raise HTTPException(400, "Invalid date_to format — use ISO 8601") from e
+            base = base.where(AuditLog.created_at <= dt_to)
+            count_base = count_base.where(AuditLog.created_at <= dt_to)
+
+        total = (await session.execute(count_base)).scalar() or 0
+
+        entries_q = (
+            base.order_by(AuditLog.created_at.desc())
+            .offset((page - 1) * per_page)
+            .limit(per_page)
+        )
+        entries = (await session.execute(entries_q)).scalars().all()
+
+        # Resolve agent_id → agent_name in one round-trip rather than per-row.
+        agent_ids = {e.agent_id for e in entries if e.agent_id is not None}
+        agent_name_by_id: dict[str, str] = {}
+        if agent_ids:
+            name_rows = await session.execute(
+                select(Agent.id, Agent.name).where(Agent.id.in_(agent_ids))
+            )
+            for aid, name in name_rows.all():
+                agent_name_by_id[str(aid)] = name or ""
+
+    pages = max(1, (total + per_page - 1) // per_page)
+    return PaginatedResponse(
+        items=[_enforce_to_dict(e, agent_name_by_id) for e in entries],
+        total=total,
+        page=page,
+        per_page=per_page,
+        pages=pages,
+    )

--- a/api/v1/health.py
+++ b/api/v1/health.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from datetime import UTC, datetime
 
 import redis.asyncio as aioredis
 import structlog
@@ -100,6 +101,87 @@ async def health_readiness():
 async def liveness():
     """Lightweight liveness probe — just confirms the process is running."""
     return {"status": "alive"}
+
+
+# ── GET /health/checks ─────────────────────────────────────────────────────
+#
+# 2026-04-30 enterprise gap analysis: ``ui/src/pages/SLAMonitor.tsx`` calls
+# ``/health/checks`` and ``/health/uptime`` to render check history and an
+# uptime chart. Those routes didn't exist, so the SLA monitor showed empty
+# panels with no error.
+#
+# Honest Phase 1 implementation: the platform doesn't yet persist health
+# check history (no telemetry table; no periodic snapshot Celery task). So
+# rather than fabricate fake history, these endpoints return a single
+# live-probe snapshot wrapped in the list shape the UI expects, with
+# ``data_source: "live_snapshot"`` so the UI can render an honest banner
+# ("Telemetry history not yet persisted — showing live snapshot only").
+# Adding real persistence is tracked as a separate ops effort with
+# migration + Celery task.
+
+
+@router.get("/health/checks")
+async def health_checks():
+    """Recent health check history.
+
+    Phase 1: returns a single live snapshot — telemetry persistence is a
+    follow-up. ``data_source`` makes the limitation explicit so the UI can
+    render an honest banner instead of a misleading empty chart.
+
+    Acceptance criteria from the gap analysis: the route must exist (so
+    UI doesn't 404) and the response shape must be stable across the
+    eventual persistence rollout.
+    """
+    snapshot = await health_readiness()
+    now = datetime.now(UTC).isoformat()
+    return {
+        "data_source": "live_snapshot",
+        "note": (
+            "Telemetry history is not yet persisted. This response contains "
+            "only the current live snapshot. Wire a periodic /health "
+            "snapshot recorder + a health_check_history table to enable "
+            "true history."
+        ),
+        "items": [
+            {
+                "timestamp": now,
+                "status": snapshot["status"],
+                "checks": snapshot["checks"],
+                "version": snapshot.get("version"),
+                "commit": snapshot.get("commit"),
+            }
+        ],
+    }
+
+
+@router.get("/health/uptime")
+async def health_uptime():
+    """Uptime chart data.
+
+    Phase 1: telemetry history isn't persisted yet, so this returns the
+    current snapshot only with an explicit ``data_source`` field. Once
+    health_check_history is wired, this endpoint will aggregate to bucketed
+    uptime percentages across configurable windows.
+    """
+    snapshot = await health_readiness()
+    now = datetime.now(UTC).isoformat()
+    is_up = snapshot["status"] == "healthy"
+    return {
+        "data_source": "live_snapshot",
+        "note": (
+            "Telemetry history is not yet persisted. Uptime percentage "
+            "and bucketed series will be available once health snapshots "
+            "are recorded periodically."
+        ),
+        "items": [
+            {
+                "timestamp": now,
+                "up": is_up,
+                "status": snapshot["status"],
+            }
+        ],
+        "current_status": snapshot["status"],
+    }
 
 
 @router.get(

--- a/api/v1/workflows.py
+++ b/api/v1/workflows.py
@@ -680,6 +680,102 @@ async def get_replan_history(
     }
 
 
+# ── POST /workflows/runs/{run_id}/cancel ──────────────────────────────────
+#
+# Phase 1 of the 2026-04-30 enterprise gap analysis: the UI's "Cancel"
+# button on `ui/src/pages/WorkflowRun.tsx` was POST'ing to a route that
+# didn't exist, so the button silently failed. The engine already ships
+# a cancel primitive (`workflows/engine.py:WorkflowEngine.cancel`) — we
+# just need a route that invokes it, persists the new status, and writes
+# an audit trail.
+
+
+@router.post("/workflows/runs/{run_id}/cancel")
+async def cancel_workflow_run(
+    run_id: UUID,
+    tenant_id: str = Depends(get_current_tenant),
+):
+    """Cancel a running workflow run.
+
+    Idempotent: cancelling a run that's already terminal (completed,
+    failed, cancelled) is a 200 with the existing status — not a 409 —
+    so the UI button can be clicked twice without surfacing a confusing
+    error. The DB row + engine state both flip to ``cancelled`` for live
+    runs; an audit log entry is written for compliance traceability.
+    """
+    tid = _uuid.UUID(tenant_id)
+
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(WorkflowRun)
+            .options(selectinload(WorkflowRun.steps))
+            .where(WorkflowRun.id == run_id, WorkflowRun.tenant_id == tid)
+        )
+        run = result.scalar_one_or_none()
+        if not run:
+            raise HTTPException(404, "Workflow run not found")
+
+        terminal_states = {"completed", "failed", "cancelled"}
+        if run.status in terminal_states:
+            # Idempotent: don't error, just return current state.
+            return _run_to_dict(run, include_steps=True)
+
+        # 1. Tell the engine to stop pumping further steps. The engine
+        # holds its own state-store record keyed by ``engine_run_id``
+        # which the request handler persisted in ``run.context`` at
+        # start time.
+        engine_run_id = (run.context or {}).get("_engine_run_id")
+        if engine_run_id:
+            try:
+                from workflows.engine import WorkflowEngine  # noqa: PLC0415
+                from workflows.state_store import WorkflowStateStore  # noqa: PLC0415
+
+                state_store = WorkflowStateStore()
+                await state_store.init()
+                engine = WorkflowEngine(state_store)
+                await engine.cancel(engine_run_id)
+            except Exception as exc:  # noqa: BLE001 — engine cancel is best-effort
+                _log.warning(
+                    "workflow_engine_cancel_failed",
+                    run_id=str(run_id),
+                    engine_run_id=engine_run_id,
+                    error=str(exc),
+                )
+
+        # 2. Persist the new status on the DB row. Even if the engine
+        # call failed, this is the authoritative status the UI reads,
+        # so flip it now and let the engine reconcile lazily.
+        run.status = "cancelled"
+        run.error = run.error or "Cancelled by user request"
+        # Mark any pending steps as cancelled too, so the run-detail
+        # progress panel doesn't keep showing "running" cards.
+        for step in run.steps or []:
+            if step.status in ("pending", "running", "waiting_hitl"):
+                step.status = "cancelled"
+        await session.commit()
+        await session.refresh(run)
+
+    # 3. Audit log — control-plane action by a human user.
+    try:
+        from core.database import async_session_factory  # noqa: PLC0415
+        from core.tool_gateway.audit_logger import AuditLogger  # noqa: PLC0415
+
+        await AuditLogger(async_session_factory).log(
+            tenant_id=tenant_id,
+            workflow_run_id=str(run_id),
+            action="workflow_run.cancel",
+            outcome="success",
+            actor_type="user",
+            resource_type="workflow_run",
+            resource_id=str(run_id),
+            details={"run_id": str(run_id)},
+        )
+    except Exception as exc:  # noqa: BLE001 — audit best-effort, must not block cancel
+        _log.warning("workflow_cancel_audit_failed", run_id=str(run_id), error=str(exc))
+
+    return _run_to_dict(run, include_steps=True)
+
+
 # ── PUT /workflows/{wf_id}/replan-config ──────────────────────────────────
 
 

--- a/docs/ENTERPRISE_END_TO_END_GAP_ANALYSIS_2026-04-30.md
+++ b/docs/ENTERPRISE_END_TO_END_GAP_ANALYSIS_2026-04-30.md
@@ -1,0 +1,350 @@
+# Enterprise End-to-End Gap Analysis - 2026-04-30
+
+Audience: Claude Code or another implementation agent.
+
+Scope: code-level review plus local verification of frontend, backend, API contracts, and production-oriented Playwright smoke tests. This is intentionally blunt: the product has a large amount of functionality, but it is not yet enterprise-grade as a release candidate.
+
+## Executive Verdict
+
+Do not call this enterprise-ready yet.
+
+The app builds and many unit/integration tests pass, but there are release blockers:
+
+1. Frontend calls backend endpoints that do not exist: `/audit/enforce`, `/health/checks`, `/health/uptime`, and `POST /workflows/runs/{runId}/cancel`.
+2. Auth/session is split between the backend's HttpOnly-cookie direction and the frontend's continued `localStorage` bearer-token model.
+3. Full backend pytest is not a reliable release gate: one BGE-M3 test downloads model weights from Hugging Face at runtime and timed out, and the unit suite did not produce a clean full summary within 15 minutes.
+4. Authenticated Playwright E2E is not runnable without `E2E_TOKEN`; public routes passed, authenticated flows were not verified.
+5. Several UI flows silently swallow API errors and render empty states, which hides broken enterprise controls.
+6. Coverage is only 56% against an 80% target and 90% critical-path target.
+
+## Verification Results
+
+| Area | Command | Result | Notes |
+|---|---|---:|---|
+| Frontend typecheck | `npm run typecheck` in `ui/` | PASS | TypeScript compiles. |
+| Frontend lint | `npm run lint` in `ui/` | FAIL | `ui/src/components/ChatPanel.tsx:72` has `no-useless-assignment`; 16 hook-dependency warnings. |
+| Frontend unit tests | `npm run test` in `ui/` | PASS | 8 test files, 96 tests passed. |
+| Frontend build | `npm run build` in `ui/` | PASS | Vite build succeeded; generated sitemap and llms files. |
+| Backend ruff | `uv run ruff check api auth core workflows connectors scaling observability audit tests` | PASS | Required dependency hydration first. |
+| Backend full pytest | `uv run pytest -q` | FAIL/BLOCKED | Timed out in `tests/regression/test_bge_m3_pr_a.py::test_embed_with_bge_m3_returns_1024_dim_vectors` while downloading `BAAI/bge-m3`. |
+| Backend integration tests | `.venv\Scripts\python.exe -m pytest tests\integration ...` | PASS | 19 passed, 84 skipped. Coverage output from this scoped run is not meaningful. |
+| Backend unit suite | `.venv\Scripts\python.exe -m pytest tests\unit ...` | BLOCKED | Did not finish within 15 minutes. Targeted eval endpoint tests pass outside the filesystem sandbox. |
+| Playwright public routes | `npm run test:e2e -- e2e/app-routes.spec.ts ...` | PARTIAL | Public marketing/login/404/landing tests passed. Authenticated sections failed because `E2E_TOKEN` is not set. |
+
+## P0 Release Blockers
+
+### 1. Frontend/Backend API Contract Drift
+
+Observed by extracting 184 frontend API calls and 276 FastAPI routes.
+
+Missing or unmatched real endpoints:
+
+| Frontend call | Evidence | Backend state | Impact |
+|---|---|---|---|
+| `GET /audit/enforce` | `ui/src/pages/EnforceAuditLog.tsx:43`, `ui/src/pages/ScopeDashboard.tsx:68` | No route in `api/v1/audit.py`; only `GET /audit` exists. | Enforce Audit and Scope Dashboard can render false empty states instead of policy/audit data. |
+| `GET /health/checks` | `ui/src/pages/SLAMonitor.tsx:34` | No route in `api/v1/health.py`. | SLA monitor cannot show real check history. |
+| `GET /health/uptime` | `ui/src/pages/SLAMonitor.tsx:35` | No route in `api/v1/health.py`. | SLA chart is dead/unverifiable. |
+| `POST /workflows/runs/{runId}/cancel` | `ui/src/pages/WorkflowRun.tsx:59` | `api/v1/workflows.py` only has run detail and replan-history routes around lines 620 and 657. | Cancel button on running workflows is broken. |
+
+Acceptance criteria:
+
+- Add backend routes or remove/replace UI calls.
+- Add contract tests that enumerate frontend API calls and fail on missing backend routes.
+- Add Playwright assertions that these pages display real errors when the API fails, not silent empty states.
+
+### 2. Auth Session Model Is Not Enterprise-Grade Yet
+
+Backend is already moving toward HttpOnly cookies via `agenticorg_session` in `api/v1/auth.py`, but the frontend still treats `localStorage` as the source of truth:
+
+- `ui/src/contexts/AuthContext.tsx:30`, `48`, `70`, `88`, `99`
+- `ui/src/lib/api.ts:7`
+- `ui/src/pages/ReportScheduler.tsx:263`, `378`, `422`, `432`, `447`
+- `ui/src/pages/BillingCallback.tsx:12`, `27`
+
+Impact:
+
+- XSS can exfiltrate bearer tokens.
+- Cookie-only migration is incomplete.
+- Cross-origin deployments using `VITE_API_URL` will need `credentials: "include"` and Axios `withCredentials: true`; current code does not set this.
+- Authenticated Playwright tests seed `localStorage` directly, so they do not validate real login/session behavior.
+
+Acceptance criteria:
+
+- Make frontend session cookie-first.
+- Remove browser access-token persistence except for explicit SDK/API-key flows.
+- Set `credentials: "include"` / Axios `withCredentials` for browser API calls where required.
+- Update login/logout/me flows and E2E tests to use real auth or a controlled test-login endpoint.
+- Keep API-key bearer auth for SDK/MCP separate from browser session auth.
+
+### 3. Test Suite Is Not a Reliable Release Gate
+
+Problems:
+
+- Full pytest timed out in `test_embed_with_bge_m3_returns_1024_dim_vectors` because it downloads BGE-M3 weights at test runtime.
+- Full unit suite did not complete within 15 minutes.
+- Existing `coverage_report.json` before this audit shows 56% global coverage, floor 55%, target 80%, critical target 90%.
+- Coverage gaps are severe for enterprise-critical modules: `api/v1/auth.py` 50%, `api/v1/billing.py` 40%, `api/v1/connectors.py` 36%, `core/tasks/workflow_tasks.py` 15%.
+
+Acceptance criteria:
+
+- Mark the BGE-M3 model-load smoke test as opt-in, mocked, or CI-image-only. It must not download large external weights during normal unit/regression runs.
+- Split tests into fast unit, integration, slow/model, production E2E, and load suites.
+- Ensure `npm run lint`, `npm run test`, `npm run build`, backend ruff, fast pytest, and contract tests finish under a practical CI SLA.
+- Raise global coverage to at least 80%; raise auth, tenant isolation, billing, connector credential, workflow execution, and audit paths toward 90%.
+
+### 4. Authenticated E2E Is Not Verifiable Locally by Default
+
+`ui/e2e/app-routes.spec.ts` requires `E2E_TOKEN`. Without it, public routes passed but authenticated dashboard, sidebar, create-flow, and data-quality tests failed before entering the app.
+
+Acceptance criteria:
+
+- Provide a documented local E2E path that starts DB/Redis/API/UI, seeds a test tenant, logs in through the UI, and runs authenticated Playwright.
+- Do not rely on production tokens for normal PR validation.
+- Keep a separate production smoke suite for post-deploy validation.
+
+## UI/UX Flow Gap Analysis
+
+### Public Marketing, Pricing, Blog, Evals, Playground, Login
+
+Status: public route smoke passed.
+
+Gaps:
+
+- Demo-request forms use direct `fetch("/api/v1/demo-request")` across multiple pages. Confirm spam protection, rate limiting, validation, CRM handoff, and user-visible failure states.
+- Build output shows large public content chunks; ensure Core Web Vitals are measured, not guessed.
+- Some source/doc output shows mojibake in console (`â€”`, `â†’`). Verify source encoding and rendered production text.
+
+### Signup, Login, Password Reset, Invite, SSO
+
+Status: code exists, but E2E not verified.
+
+Gaps:
+
+- Token persistence remains in `localStorage`.
+- No complete cookie-only browser test.
+- No visible MFA enrollment/recovery flow, despite `mfa_enabled` in `/auth/me`.
+- Login/session expiry behavior relies on global 401 redirect and can discard context.
+
+Claude tasks:
+
+- Add full auth E2E: signup, login, logout, expired token, password reset, invite accept, SSO callback hydration, role-gated 403.
+- Add session-state UI for expired sessions and return-to-original-route behavior.
+
+### Dashboard and Navigation
+
+Status: role-filtered navigation exists in `Layout`.
+
+Gaps:
+
+- Company switching persists `company_id` in `localStorage` and calls `window.location.reload()` (`ui/src/components/CompanySwitcher.tsx:56`). This is a brittle UX and hides state/data invalidation bugs.
+- Header widgets fail silently when their APIs fail.
+- Navigation is role-hidden, but there is no centralized capability/permission manifest shared by UI and API.
+
+Claude tasks:
+
+- Replace reload-based company switching with context/query invalidation.
+- Add visible, actionable error states for header widgets.
+- Generate nav access from a shared role/capability manifest or test it against backend scopes.
+
+### Agents
+
+Status: agent CRUD/lifecycle API surface is broad and mostly matched by UI.
+
+Gaps:
+
+- Lint/hook warnings in agent pages mean stale closures are possible.
+- Some mutations use native `window.confirm`; enterprise UX should use accessible confirmation dialogs with irreversible-action wording.
+- Need E2E coverage for create, edit, promote, pause, resume, rollback, clone, delete, run, retest, feedback analysis, and prompt-history audit.
+
+### Workflows
+
+Status: create/list/run/detail APIs exist.
+
+Blocking gap:
+
+- Workflow run cancel UI calls a missing endpoint.
+
+Other gaps:
+
+- Background execution uses FastAPI background tasks; ensure durability across process restarts.
+- Cancellation, retry, replan, HITL resume, and partial-failure states need end-to-end tests.
+
+Claude tasks:
+
+- Add `POST /workflows/runs/{run_id}/cancel`, persist cancellation, stop/resume engine state safely, and test UI behavior.
+- Add workflow run E2E for running, waiting HITL, failed, cancelled, completed, and replan-history.
+
+### Approvals / HITL
+
+Status: endpoints and UI exist.
+
+Gaps:
+
+- Needs audited E2E for approve/reject, note requirements, expiry, assignee roles, notification delivery, and double-submit/idempotency.
+- UI should expose backend errors and stale approval decisions clearly.
+
+### Audit, Enforce Audit, Scope Dashboard
+
+Status: regular audit endpoint exists.
+
+Blocking gap:
+
+- Enforce audit endpoint does not exist, but two protected pages depend on it.
+
+Impact:
+
+- Enterprise governance posture is overstated until enforcement events are persisted and queryable.
+
+Claude tasks:
+
+- Decide data source for enforce decisions: audit log event type, dedicated table, or tool gateway event stream.
+- Implement `GET /audit/enforce` with filters, pagination, company/tenant isolation, and export.
+- Update Scope Dashboard to consume the same backend contract.
+
+### SLA / Health / Observability
+
+Status: `/health`, `/health/liveness`, and `/health/diagnostics` exist.
+
+Blocking gap:
+
+- SLA UI calls `/health/checks` and `/health/uptime`, which do not exist.
+- `/health` does not return `p95_latency`, `agent_success_rate`, or `hitl_response_time`, but the UI tries to render them.
+
+Claude tasks:
+
+- Implement real SLA metrics endpoints backed by telemetry/storage.
+- Add uptime/check history persistence or remove the chart.
+- Ensure diagnostics remains admin-gated and readiness remains safe for probes.
+
+### Billing
+
+Status: billing APIs and callback page exist.
+
+Gaps:
+
+- Billing callback uses `localStorage` to decide logged-in state and bearer auth. This will break or misclassify sessions under cookie-only auth.
+- Need E2E for India payment flow, Stripe flow, webhook idempotency, cancellation, portal, failed/pending payment, and callback replay.
+
+### Report Scheduler
+
+Status: UI and API exist.
+
+Gaps:
+
+- `ReportScheduler` bypasses shared Axios client and manually reads `localStorage` token.
+- Native `alert` and `confirm` are used for run/delete flows.
+- Need E2E around create/edit/toggle/delete/run-now and delivery-channel validation.
+
+### Knowledge Base / RAG
+
+Status: APIs and tests exist.
+
+Blocking test gap:
+
+- BGE-M3 smoke test loads real model weights at test runtime.
+
+Operational gaps:
+
+- TEI fallback behavior must be tested under warm, cold, timeout, and degraded keyword-search modes.
+- Backfill/cutover must be rehearsed with real data volume and rollback.
+
+### Connectors / Integrations / Composio / MCP / A2A
+
+Status: broad API surface exists.
+
+Gaps:
+
+- Need per-connector health, credential rotation, OAuth reconnect, and tool-call permission tests.
+- Public tool discovery endpoints should be explicitly threat-modeled and documented.
+- Connector test failures should be shown consistently in the UI, not hidden as empty lists.
+
+### Companies / CA Firm Flows
+
+Status: extensive company and partner-dashboard APIs exist.
+
+Gaps:
+
+- Company context is browser-local, not a first-class request/session context.
+- Need E2E for company onboarding, roles, credentials, Tally bridge generation, filing approvals, deadlines, GSTN upload, and deletion/deactivation.
+- Bank account and compliance identifiers need masking rules in UI and audit logs.
+
+## Frontend Engineering Gaps
+
+1. Lint is failing. Fix `ChatPanel.tsx:72` and resolve or intentionally document hook dependencies.
+2. Too many pages swallow errors with bare `catch { ... }`. Enterprise users need clear failure states and retry actions.
+3. Native `alert`/`confirm` appears in billing, report scheduler, agent delete, connector delete, company delete/deactivate, etc. Replace with accessible modal dialogs.
+4. Shared API client is not used consistently. `ReportScheduler`, auth, billing callback, public forms, and playground use direct `fetch`.
+5. No consistent request cancellation/loading/error pattern. Use React Query or a shared resource hook for app pages.
+6. `localStorage` stores security-sensitive session data and company context.
+7. Authenticated E2E relies on localStorage token seeding instead of real login.
+8. No automated visual/mobile regression output was reviewed in this audit.
+
+## Backend Engineering Gaps
+
+1. Missing endpoints called by UI.
+2. HTTP error response shapes are mixed: custom envelope in `api/error_handlers.py`, default FastAPI `detail` elsewhere, middleware JSON with `detail`, and some `{error: ...}` responses. Standardize.
+3. Cookie migration is half-done. Finish it before treating browser auth as enterprise-grade.
+4. Full pytest is non-hermetic and too slow.
+5. Coverage target is not enterprise-grade yet.
+6. Health/SLA endpoints need real telemetry backing, not UI placeholders.
+7. Background workflow and report execution need durability, idempotency, cancellation, retry, and observability tests.
+8. Sensitive data masking needs explicit tests across UI, audit, exports, and logs.
+9. Public unauthenticated endpoints and webhook endpoints need a reviewed threat model.
+
+## Claude Code Implementation Plan
+
+### Phase 1 - Stop Broken Flows
+
+- Fix frontend lint.
+- Add missing backend routes or remove dead UI calls:
+  - `GET /audit/enforce`
+  - `GET /health/checks`
+  - `GET /health/uptime`
+  - `POST /workflows/runs/{run_id}/cancel`
+- Add API contract test that fails on frontend/backend route drift.
+- Replace silent empty states on Enforce Audit, Scope Dashboard, SLA Monitor, and Workflow Run with explicit error panels.
+
+### Phase 2 - Auth and E2E Hardening
+
+- Move browser auth to cookie-first.
+- Add `withCredentials`/`credentials: "include"` where needed.
+- Remove access-token `localStorage` usage from browser flows.
+- Build local authenticated E2E with seeded tenant and real login.
+- Keep production E2E as separate post-deploy smoke with documented `E2E_TOKEN`.
+
+### Phase 3 - Test Gate Repair
+
+- Split pytest suites and mark slow/model/network tests.
+- Mock or opt-in the BGE-M3 model-load test.
+- Make fast backend suite complete under 10 minutes.
+- Enforce coverage thresholds per critical module.
+- Add Playwright coverage for each major app route and mutation flow.
+
+### Phase 4 - Enterprise UX Polish
+
+- Replace native alerts/confirms with accessible modals.
+- Replace hard reload company switching with state invalidation.
+- Standardize loading, empty, partial, and error states.
+- Add mobile and responsive E2E screenshots for all primary workflows.
+- Add audit/export masking for PII and financial identifiers.
+
+### Phase 5 - Operational Readiness
+
+- Implement real SLA metrics and uptime history.
+- Add workflow/report job durability and cancellation semantics.
+- Add webhook idempotency and replay protection tests.
+- Document and test backup/restore, tenant deletion/export, incident response, and secrets rotation.
+
+## Definition of Done
+
+The project can be considered enterprise-release candidate only when:
+
+- `npm run lint`, `npm run typecheck`, `npm run test`, and `npm run build` pass.
+- Backend ruff and fast pytest pass without network/model downloads.
+- Full authenticated local Playwright suite passes from a clean seed.
+- No frontend API call points to a missing backend route.
+- Browser session auth no longer stores access tokens in `localStorage`.
+- P0 pages show actionable failures instead of empty states.
+- Coverage is at least 80% global and materially higher on auth, tenant isolation, billing, connector credentials, workflows, audit, and governance.
+- SLA/health pages are backed by real telemetry.
+- A production smoke suite validates public routes, login, dashboard, agent run, workflow run, approval decision, connector health, billing callback, and audit export.

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -28,6 +28,7 @@ FAST=${FAST:-0}
 SKIP_UI=${SKIP_UI:-0}
 SKIP_BANDIT=${SKIP_BANDIT:-0}
 SKIP_PYTEST=${SKIP_PYTEST:-0}
+SKIP_MYPY=${SKIP_MYPY:-0}
 SKIP_MODULE_COV=${SKIP_MODULE_COV:-0}
 SKIP_CONSISTENCY=${SKIP_CONSISTENCY:-0}
 SKIP_TAG_CHECK=${SKIP_TAG_CHECK:-0}
@@ -86,6 +87,27 @@ branch_check() {
 # ---------------------------------------------------------------------------
 ruff_check() {
   python -m ruff check .
+}
+
+# ---------------------------------------------------------------------------
+# 2b. Mypy — same invocation as the CI lint job (.github/workflows/deploy.yml).
+# Without this here, type errors fail CI on the FIRST gate even though
+# every local preflight passed. PR #399 (2026-04-30) was caught by this
+# exact gap — local green, CI red on a missing constructor argument.
+# ---------------------------------------------------------------------------
+mypy_check() {
+  if [[ "$SKIP_MYPY" == "1" ]]; then
+    echo "[preflight] skipped (SKIP_MYPY=1)"
+    return 0
+  fi
+  # ``codex-pytest-basetemp/`` is pytest's per-run scratch directory
+  # left behind by previous local runs. CI starts from a fresh checkout
+  # so it never sees those files; locally they trigger spurious
+  # "Duplicate module" mypy errors. Exclude it explicitly so the local
+  # gate matches CI's effective scope.
+  python -m mypy --ignore-missing-imports \
+    --exclude '(codex-pytest-basetemp|codex-pytest-temp)' \
+    .
 }
 
 # ---------------------------------------------------------------------------
@@ -217,6 +239,7 @@ critical_tag_check() {
 # ---------------------------------------------------------------------------
 run_step "branch safety"          branch_check
 run_step "ruff (whole tree)"      ruff_check
+run_step "mypy (whole tree)"      mypy_check
 run_step "bandit (api/auth/core)" bandit_check
 run_step "alembic revision <=32"  alembic_id_check
 run_step "verify=False scan"      verify_false_scan

--- a/tests/regression/test_phase1_missing_routes.py
+++ b/tests/regression/test_phase1_missing_routes.py
@@ -1,0 +1,216 @@
+"""Phase 1 regression pins for the four routes added to close gaps from
+``docs/ENTERPRISE_END_TO_END_GAP_ANALYSIS_2026-04-30.md``.
+
+These tests pin behavior, not just registration:
+- ``GET /audit/enforce`` returns the expected shape and filters by tenant.
+- ``POST /workflows/runs/{run_id}/cancel`` flips run.status and is idempotent.
+- ``GET /health/checks`` returns ``data_source: live_snapshot`` with explicit note.
+- ``GET /health/uptime`` returns ``data_source: live_snapshot`` with current_status.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ─────────────────────────────────────────────────────────────────
+# /health/checks + /health/uptime — light shape pins (no DB needed)
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_health_checks_returns_live_snapshot_with_data_source_field(
+    monkeypatch,
+) -> None:
+    """The endpoint exists, returns 200, and is honest about being a live
+    snapshot (not persisted history). The ``data_source`` field is the
+    contract the UI uses to render the "history coming soon" banner.
+    """
+    from api.v1 import health as health_module
+
+    # Mock health_readiness to avoid touching real DB/Redis
+    fake_snapshot = {
+        "status": "healthy",
+        "version": "9.9.9-test",
+        "commit": "abc123",
+        "checks": {"db": "healthy", "redis": "healthy"},
+    }
+
+    async def _fake_readiness():
+        return fake_snapshot
+
+    monkeypatch.setattr(health_module, "health_readiness", _fake_readiness)
+
+    result = await health_module.health_checks()
+
+    assert result["data_source"] == "live_snapshot"
+    assert "Telemetry history" in result["note"]
+    assert isinstance(result["items"], list)
+    assert len(result["items"]) == 1
+    item = result["items"][0]
+    assert item["status"] == "healthy"
+    assert item["checks"] == {"db": "healthy", "redis": "healthy"}
+    assert "timestamp" in item
+
+
+@pytest.mark.asyncio
+async def test_health_uptime_returns_current_status_and_data_source(
+    monkeypatch,
+) -> None:
+    """Uptime must include current_status (UI uses this directly) and
+    must mark data_source as a live snapshot until persistence ships."""
+    from api.v1 import health as health_module
+
+    async def _fake_readiness():
+        return {
+            "status": "unhealthy",
+            "version": "9.9.9-test",
+            "commit": "abc",
+            "checks": {"db": "unhealthy: TimeoutError", "redis": "healthy"},
+        }
+
+    monkeypatch.setattr(health_module, "health_readiness", _fake_readiness)
+    result = await health_module.health_uptime()
+
+    assert result["data_source"] == "live_snapshot"
+    assert result["current_status"] == "unhealthy"
+    assert isinstance(result["items"], list)
+    assert len(result["items"]) == 1
+    assert result["items"][0]["up"] is False
+
+
+# ─────────────────────────────────────────────────────────────────
+# /audit/enforce — shape projection from AuditLog rows
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_enforce_to_dict_projects_audit_row_into_ui_shape() -> None:
+    """The projection helper pulls fields the UI consumes:
+    timestamp, agent_name, connector, tool, permission, result, reason.
+
+    The UI's filter logic (``EnforceAuditLog.tsx`` lines 67-73) keys on
+    these exact field names, so a typo here silently breaks filters.
+    """
+    from datetime import UTC, datetime
+
+    from api.v1.audit import _enforce_to_dict
+
+    agent_id = uuid.uuid4()
+    fake_row = MagicMock()
+    fake_row.id = uuid.uuid4()
+    fake_row.created_at = datetime(2026, 4, 30, 12, 0, 0, tzinfo=UTC)
+    fake_row.agent_id = agent_id
+    fake_row.outcome = "denied"
+    fake_row.resource_id = "get_profit_loss"
+    fake_row.trace_id = "trace-123"
+    fake_row.details = {
+        "connector": "zoho_books",
+        "permission": "read",
+        "enforcement_action": "scope_denied",
+    }
+
+    result = _enforce_to_dict(
+        fake_row,
+        agent_name_by_id={str(agent_id): "FPA Assistant"},
+    )
+
+    assert result["agent_id"] == str(agent_id)
+    assert result["agent_name"] == "FPA Assistant"
+    assert result["connector"] == "zoho_books"
+    assert result["tool"] == "get_profit_loss"
+    assert result["permission"] == "read"
+    assert result["result"] == "denied"
+    assert result["reason"] == "scope_denied"
+    assert result["timestamp"] == "2026-04-30T12:00:00+00:00"
+    assert result["trace_id"] == "trace-123"
+
+
+def test_enforce_to_dict_handles_missing_agent_name_and_details() -> None:
+    """When the AuditLog row lacks an agent (system events) or has empty
+    details, the projection still returns the contract shape — the UI
+    can't tolerate KeyError or None where it expects a string."""
+    from datetime import UTC, datetime
+
+    from api.v1.audit import _enforce_to_dict
+
+    fake_row = MagicMock()
+    fake_row.id = uuid.uuid4()
+    fake_row.created_at = datetime(2026, 4, 30, 12, 0, 0, tzinfo=UTC)
+    fake_row.agent_id = None
+    fake_row.outcome = "allowed"
+    fake_row.resource_id = "send_email"
+    fake_row.trace_id = None
+    fake_row.details = None
+
+    result = _enforce_to_dict(fake_row, agent_name_by_id={})
+
+    # Every field UI reads must be present and a defined value (no None)
+    # except trace_id and agent_id which the UI explicitly null-checks.
+    for required in (
+        "agent_name", "connector", "tool", "permission", "result", "reason"
+    ):
+        assert required in result
+        assert result[required] is not None
+        assert isinstance(result[required], str)
+    assert result["result"] == "allowed"
+    # An "allowed" outcome with no enforcement_action should produce an
+    # empty reason — not "allowed" — so the UI doesn't render
+    # "Reason: allowed" on every row.
+    assert result["reason"] == ""
+
+
+# ─────────────────────────────────────────────────────────────────
+# /workflows/runs/{run_id}/cancel — idempotency + status flip
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cancel_workflow_run_is_idempotent_for_terminal_runs() -> None:
+    """Cancelling a run that's already cancelled/completed/failed must
+    NOT 409 — the UI button can be clicked twice during slow network and
+    we don't want operators to see a confusing error.
+    """
+    from api.v1.workflows import cancel_workflow_run
+
+    fake_run = MagicMock()
+    fake_run.id = uuid.uuid4()
+    fake_run.tenant_id = uuid.uuid4()
+    fake_run.status = "completed"
+    fake_run.workflow_def_id = uuid.uuid4()
+    fake_run.steps = []
+    fake_run.context = {}
+    fake_run.trigger_payload = {}
+    fake_run.result = {}
+    fake_run.error = None
+    fake_run.company_id = None
+
+    async def _fake_session():
+        s = MagicMock()
+        s.execute = AsyncMock(return_value=MagicMock(
+            scalar_one_or_none=MagicMock(return_value=fake_run),
+        ))
+        s.commit = AsyncMock()
+        s.refresh = AsyncMock()
+        return s
+
+    class _FakeSessionCtx:
+        async def __aenter__(self):
+            return await _fake_session()
+
+        async def __aexit__(self, *args):
+            return None
+
+    with patch(
+        "api.v1.workflows.get_tenant_session",
+        return_value=_FakeSessionCtx(),
+    ):
+        result = await cancel_workflow_run(
+            run_id=fake_run.id,
+            tenant_id=str(fake_run.tenant_id),
+        )
+
+    # status untouched on terminal runs; UI sees the existing terminal state
+    assert result["status"] == "completed"
+    assert result["run_id"] == str(fake_run.id)

--- a/tests/regression/test_ui_api_contract.py
+++ b/tests/regression/test_ui_api_contract.py
@@ -1,0 +1,211 @@
+"""UI ↔ Backend API contract drift detection.
+
+Pin against the failure mode caught in the 2026-04-30 enterprise gap
+analysis: the UI was calling four routes that didn't exist on the
+backend (``/audit/enforce``, ``/health/checks``, ``/health/uptime``,
+``POST /workflows/runs/{run_id}/cancel``). Each silent 404 rendered as
+an empty page, hiding the bug from operators and customers.
+
+This test extracts every ``api.{get,post,put,patch,delete}(...)`` URL
+from ``ui/src/**/*.{ts,tsx}`` and asserts each one has a matching
+FastAPI route. Failures here block CI before the drift reaches a
+deployed surface.
+
+How matching works:
+- UI URLs may use template literals like ``/agents/${id}/run``.
+  We normalise ``${...}`` → ``{X}``.
+- FastAPI routes use bracketed params: ``/agents/{agent_id}/run``.
+  We normalise ``{whatever}`` → ``{X}`` for shape comparison.
+- Query strings are stripped (``?foo=bar``).
+- Hash fragments are stripped (``#section``).
+- A small allow-list at the bottom covers external/3rd-party paths
+  the UI calls that aren't on this FastAPI app (e.g. demo-request
+  proxied to a CRM webhook, OAuth provider callbacks).
+
+Add a new path to ``ALLOWLIST`` only with a specific reason and
+ideally a tracking issue link.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UI_SRC = REPO_ROOT / "ui" / "src"
+
+# Paths that are intentionally not on this FastAPI app's surface. Add
+# a reason next to each entry. Without an explicit allow-list, every
+# external URL would silently pass; with one, drift adds-only is
+# caught.
+ALLOWLIST: set[str] = {
+    # Future Phase-1 work tracked in docs/ENTERPRISE_END_TO_END_GAP_ANALYSIS_2026-04-30.md.
+    # Add entries here ONLY with a justification.
+}
+
+
+# Match either a plain string literal: api.get('/foo'), api.get("/foo")
+# or a template literal: api.get(`/foo/${bar}`)
+_API_CALL_RE = re.compile(
+    r"""api\.(?:get|post|put|patch|delete)\(\s*"""
+    r"""(?P<quote>['"`])"""
+    r"""(?P<url>/[^'"`]+)"""
+    r"""(?P=quote)""",
+    re.MULTILINE,
+)
+
+
+def _normalise_ui_path(raw: str) -> str:
+    """Drop query/hash and replace template-literal substitutions with {X}."""
+    # Strip literal query string and fragment.
+    for sep in ("?", "#"):
+        idx = raw.find(sep)
+        if idx >= 0:
+            raw = raw[:idx]
+    # Template-literal substitutions: ``${runId}`` or ``${ encodeURIComponent(x) }``
+    raw = re.sub(r"\$\{[^}]*\}", "{X}", raw)
+    # If a substitution was concatenated to the path WITHOUT a leading
+    # slash (e.g. ``/chat/history${params}`` where ``params`` is the whole
+    # query string), strip from the `{X}` onward — that's a query-string
+    # injection, not a path segment.
+    m = re.search(r"[^/]\{X\}", raw)
+    if m:
+        raw = raw[: m.start() + 1]
+    # Trim trailing slash for consistent comparison (FastAPI is /agents not /agents/).
+    if raw.endswith("/") and len(raw) > 1:
+        raw = raw[:-1]
+    return raw
+
+
+def _normalise_route_path(raw: str) -> str:
+    """Replace bracketed FastAPI path params with {X} for shape comparison."""
+    out = re.sub(r"\{[^}]+\}", "{X}", raw)
+    if out.endswith("/") and len(out) > 1:
+        out = out[:-1]
+    return out
+
+
+def _collect_ui_calls() -> dict[str, list[Path]]:
+    """Return ``{normalised_url: [files_that_call_it]}``."""
+    calls: dict[str, list[Path]] = {}
+    if not UI_SRC.exists():
+        return calls
+    for ext in ("ts", "tsx"):
+        for path in UI_SRC.rglob(f"*.{ext}"):
+            try:
+                src = path.read_text(encoding="utf-8")
+            except Exception:  # noqa: BLE001, S112 — best-effort UI scan, skip unreadable
+                continue
+            for m in _API_CALL_RE.finditer(src):
+                normalised = _normalise_ui_path(m.group("url"))
+                calls.setdefault(normalised, []).append(path)
+    return calls
+
+
+def _collect_backend_routes() -> set[str]:
+    """Return the set of normalised paths registered on the FastAPI app.
+
+    Imported lazily so this test doesn't pay the API import cost when
+    only the UI call extractor is used.
+    """
+    from api.main import app  # noqa: PLC0415
+
+    paths: set[str] = set()
+    for route in app.routes:
+        path = getattr(route, "path", None)
+        if not path:
+            continue
+        # FastAPI mounts /api/v1/* under a prefix; the UI calls the
+        # path WITHOUT the /api/v1 prefix because the shared Axios
+        # client adds it. Strip the prefix here so they compare.
+        if path.startswith("/api/v1/"):
+            path = path[len("/api/v1") :]
+        elif path.startswith("/api/v1"):
+            path = path[len("/api/v1") :] or "/"
+        paths.add(_normalise_route_path(path))
+    return paths
+
+
+def test_every_ui_api_call_has_a_matching_backend_route() -> None:
+    """Every ``api.<method>('/url')`` in ui/src must hit a real route.
+
+    Failure here means the UI is making requests that the API can't
+    answer — exactly the silent 404 + empty-state pattern the
+    2026-04-30 enterprise gap analysis flagged.
+    """
+    ui_calls = _collect_ui_calls()
+    backend_routes = _collect_backend_routes()
+
+    missing: dict[str, list[Path]] = {}
+    for url, callers in ui_calls.items():
+        if url in ALLOWLIST:
+            continue
+        if url not in backend_routes:
+            missing[url] = callers
+
+    if missing:
+        lines = ["UI calls these URLs but the backend has no matching route:"]
+        for url, callers in sorted(missing.items()):
+            rel_callers = sorted({str(p.relative_to(REPO_ROOT)) for p in callers})
+            lines.append(f"  {url}")
+            for c in rel_callers:
+                lines.append(f"    ← {c}")
+        lines.append("")
+        lines.append(
+            "Fix by either (a) adding the missing FastAPI route, "
+            "(b) updating the UI to call an existing route, or "
+            "(c) adding the path to ALLOWLIST in this file with "
+            "an explicit justification (rare — used only for paths "
+            "deliberately served by something other than this app)."
+        )
+        pytest.fail("\n".join(lines))
+
+
+def test_ui_call_extractor_finds_known_calls() -> None:
+    """Sanity check on the regex itself: a few well-known calls must be
+    detected, otherwise the test above would silently pass on an empty set.
+
+    These are stable — we ship these URLs from the UI today.
+    """
+    ui_calls = _collect_ui_calls()
+    for must_find in ("/audit", "/health", "/agents"):
+        assert must_find in ui_calls, (
+            f"UI URL extractor regression: {must_find!r} should have been "
+            "found in ui/src — the regex broke or the call site moved."
+        )
+
+
+def test_allowlist_entries_are_not_actually_in_backend() -> None:
+    """An ALLOWLIST entry that's actually on the backend is dead config —
+    drop it. This prevents the allow-list from masking real coverage."""
+    if not ALLOWLIST:
+        return
+    backend_routes = _collect_backend_routes()
+    stale = ALLOWLIST & backend_routes
+    assert not stale, (
+        f"These ALLOWLIST entries are now real backend routes — remove "
+        f"them from the allow-list so drift detection re-engages: "
+        f"{sorted(stale)}"
+    )
+
+
+def test_phase_1_endpoints_are_now_registered() -> None:
+    """Direct pin against the four routes the 2026-04-30 audit called out.
+
+    Even if the contract test above passes (e.g., because the UI call sites
+    were edited away), these four MUST exist on the backend going forward.
+    """
+    backend_routes = _collect_backend_routes()
+    required = {
+        "/audit/enforce",
+        "/health/checks",
+        "/health/uptime",
+        "/workflows/runs/{X}/cancel",
+    }
+    missing = required - backend_routes
+    assert not missing, (
+        f"Routes from the 2026-04-30 enterprise gap analysis are not "
+        f"registered on the FastAPI app: {sorted(missing)}"
+    )

--- a/ui/src/components/ChatPanel.tsx
+++ b/ui/src/components/ChatPanel.tsx
@@ -68,8 +68,10 @@ function extractReadableText(raw: unknown): string {
   const trimmed = raw.trim();
   if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return raw;
 
-  // Try JSON first.
-  let parsed: unknown = null;
+  // Try JSON first. Definite-assignment is enforced by the early returns
+  // in the catch path — TS tracks that ``parsed`` is set on every fall-
+  // through to the post-try block.
+  let parsed: unknown;
   try {
     parsed = JSON.parse(trimmed);
   } catch {
@@ -150,7 +152,7 @@ export default function ChatPanel({
     }).catch(() => {
       // history endpoint unavailable — start fresh
     });
-  }, [open, agentId]);
+  }, [open, agentId, companyId]);
 
   // Focus input when panel opens
   useEffect(() => {

--- a/ui/src/pages/EnforceAuditLog.tsx
+++ b/ui/src/pages/EnforceAuditLog.tsx
@@ -27,6 +27,7 @@ interface EnforceEntry {
 export default function EnforceAuditLog() {
   const [entries, setEntries] = useState<EnforceEntry[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [resultFilter, setResultFilter] = useState<"All" | "allowed" | "denied">("All");
   const [agentFilter, setAgentFilter] = useState("All");
   const [connectorFilter, setConnectorFilter] = useState("All");
@@ -39,12 +40,24 @@ export default function EnforceAuditLog() {
 
   async function fetchEntries() {
     setLoading(true);
+    setError(null);
     try {
       const { data } = await api.get("/audit/enforce");
       const items = Array.isArray(data) ? data : Array.isArray(data?.items) ? data.items : [];
       setEntries(items);
-    } catch {
+    } catch (e: any) {
+      // 2026-04-30 enterprise gap fix: never silently render an empty
+      // table when the backend call fails — operators can't tell
+      // "no enforcement events" apart from "the API is down". Surface
+      // a real, actionable error.
+      const status = e?.response?.status;
+      const detail = e?.response?.data?.detail || e?.response?.data?.message;
       setEntries([]);
+      setError(
+        status
+          ? `Failed to load enforcement events (HTTP ${status})${detail ? `: ${detail}` : ""}`
+          : `Failed to load enforcement events: ${e?.message || "network error"}`
+      );
     } finally {
       setLoading(false);
     }
@@ -166,12 +179,27 @@ export default function EnforceAuditLog() {
         </span>
       </div>
 
+      {/* Error banner — surfaced when the backend call fails so operators
+          don't mistake an outage for "no events". */}
+      {error && (
+        <div
+          role="alert"
+          className="rounded border border-destructive/40 bg-destructive/5 p-3 text-sm flex items-start gap-3"
+        >
+          <span className="font-medium text-destructive shrink-0">Error:</span>
+          <span className="flex-1">{error}</span>
+          <Button size="sm" variant="outline" onClick={fetchEntries}>
+            Retry
+          </Button>
+        </div>
+      )}
+
       {/* Table */}
       {loading ? (
         <p className="text-muted-foreground">Loading enforce audit entries...</p>
-      ) : paginated.length === 0 ? (
+      ) : paginated.length === 0 && !error ? (
         <p className="text-muted-foreground">No enforce audit entries found.</p>
-      ) : (
+      ) : paginated.length === 0 ? null : (
         <div className="border rounded overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="bg-muted">

--- a/ui/src/pages/SLAMonitor.tsx
+++ b/ui/src/pages/SLAMonitor.tsx
@@ -21,6 +21,11 @@ export default function SLAMonitor() {
   const [healthChecks, setHealthChecks] = useState<HealthCheck[]>([]);
   const [uptimeData, setUptimeData] = useState<{ hour: string; uptime: number }[]>([]);
   const [loading, setLoading] = useState(true);
+  const [errors, setErrors] = useState<string[]>([]);
+  // 2026-04-30 enterprise gap fix: surface the backend's
+  // ``data_source`` field so the page tells the truth about whether
+  // the chart shows real history or just a single live snapshot.
+  const [dataSourceNote, setDataSourceNote] = useState<string | null>(null);
 
   useEffect(() => {
     fetchSLAData();
@@ -28,6 +33,8 @@ export default function SLAMonitor() {
 
   async function fetchSLAData() {
     setLoading(true);
+    setErrors([]);
+    setDataSourceNote(null);
     try {
       const [healthRes, checksRes, uptimeRes] = await Promise.allSettled([
         api.get("/health"),
@@ -41,6 +48,30 @@ export default function SLAMonitor() {
         ? healthData.status === "ok" || healthData.status === "healthy"
         : null;
 
+      const fetchErrors: string[] = [];
+      if (healthRes.status === "rejected") {
+        const reason: any = healthRes.reason;
+        const status = reason?.response?.status;
+        fetchErrors.push(
+          `/health unavailable${status ? ` (HTTP ${status})` : ""} — current platform status cannot be determined.`
+        );
+      }
+      if (checksRes.status === "rejected") {
+        const reason: any = checksRes.reason;
+        const status = reason?.response?.status;
+        fetchErrors.push(
+          `/health/checks unavailable${status ? ` (HTTP ${status})` : ""} — check history shows live snapshot only.`
+        );
+      }
+      if (uptimeRes.status === "rejected") {
+        const reason: any = uptimeRes.reason;
+        const status = reason?.response?.status;
+        fetchErrors.push(
+          `/health/uptime unavailable${status ? ` (HTTP ${status})` : ""} — uptime chart will be empty.`
+        );
+      }
+      setErrors(fetchErrors);
+
       setMetrics([
         { label: "Uptime", current: isHealthy === null ? "N/A" : isHealthy ? "Healthy" : "Degraded", target: "99.9%", ok: isHealthy },
         { label: "API P95 Latency", current: healthData?.p95_latency || "N/A", target: "< 2s", ok: isHealthy },
@@ -48,14 +79,22 @@ export default function SLAMonitor() {
         { label: "HITL Response Time", current: healthData?.hitl_response_time || "N/A", target: "< 4 hrs", ok: isHealthy },
       ]);
 
-      // Parse health checks from API (if endpoint exists)
+      // The /health/checks contract returns either a bare array (legacy)
+      // or { data_source, note, items: [...] } (Phase 1 honest shape).
       if (checksRes.status === "fulfilled") {
-        const rawChecks = Array.isArray(checksRes.value.data)
-          ? checksRes.value.data
-          : checksRes.value.data?.items || [];
+        const body = checksRes.value.data;
+        const rawChecks = Array.isArray(body)
+          ? body
+          : (body?.items || []);
         setHealthChecks(rawChecks);
+        // Capture the backend's honest "this is a live snapshot, not
+        // history" note so the user sees it explicitly.
+        if (body && body.data_source === "live_snapshot" && body.note) {
+          setDataSourceNote(body.note);
+        }
       } else {
-        // Single health check from the /health endpoint
+        // Fall back to the /health snapshot when /health/checks isn't
+        // available — but mark it explicitly so the user knows.
         if (healthData) {
           setHealthChecks([{
             timestamp: new Date().toISOString(),
@@ -66,16 +105,14 @@ export default function SLAMonitor() {
         }
       }
 
-      // Parse uptime data from API (if endpoint exists)
       if (uptimeRes.status === "fulfilled") {
-        const rawUptime = Array.isArray(uptimeRes.value.data)
-          ? uptimeRes.value.data
-          : uptimeRes.value.data?.items || [];
+        const body = uptimeRes.value.data;
+        const rawUptime = Array.isArray(body) ? body : (body?.items || []);
         setUptimeData(rawUptime);
       } else {
         setUptimeData([]);
       }
-    } catch {
+    } catch (e: any) {
       setMetrics([
         { label: "Uptime", current: "N/A", target: "99.9%", ok: null },
         { label: "API P95 Latency", current: "N/A", target: "< 2s", ok: null },
@@ -84,6 +121,7 @@ export default function SLAMonitor() {
       ]);
       setHealthChecks([]);
       setUptimeData([]);
+      setErrors([`Failed to load SLA data: ${e?.message || "unknown error"}`]);
     } finally {
       setLoading(false);
     }
@@ -96,6 +134,35 @@ export default function SLAMonitor() {
       </Helmet>
 
       <h2 className="text-2xl font-bold">SLA Monitor</h2>
+
+      {/* Backend's honest data-source note (Phase 1: live snapshot only,
+          history persistence is a follow-up). Surface it so users
+          don't mistake the chart's single point for a flatlined system. */}
+      {dataSourceNote && (
+        <div
+          role="status"
+          className="rounded border border-amber-500/40 bg-amber-50 dark:bg-amber-950/30 p-3 text-sm flex items-start gap-3"
+        >
+          <span className="font-medium shrink-0">Note:</span>
+          <span className="flex-1">{dataSourceNote}</span>
+        </div>
+      )}
+
+      {/* Errors banners — surface partial outages so users can tell which
+          metrics below are real vs. fallback. */}
+      {errors.length > 0 && (
+        <div role="alert" className="space-y-2">
+          {errors.map((msg, i) => (
+            <div
+              key={i}
+              className="rounded border border-destructive/40 bg-destructive/5 p-3 text-sm flex items-start gap-3"
+            >
+              <span className="font-medium text-destructive shrink-0">Warning:</span>
+              <span className="flex-1">{msg}</span>
+            </div>
+          ))}
+        </div>
+      )}
 
       {loading ? (
         <p className="text-muted-foreground">Loading SLA data...</p>

--- a/ui/src/pages/ScopeDashboard.tsx
+++ b/ui/src/pages/ScopeDashboard.tsx
@@ -51,6 +51,7 @@ const PERMISSIONS = ["All", "READ", "WRITE", "DELETE", "ADMIN"];
 export default function ScopeDashboard() {
   const [scopes, setScopes] = useState<AgentScope[]>([]);
   const [loading, setLoading] = useState(true);
+  const [errors, setErrors] = useState<string[]>([]);
   const [connectorFilter, setConnectorFilter] = useState("All");
   const [permissionFilter, setPermissionFilter] = useState("All");
   const [agentSearch, setAgentSearch] = useState("");
@@ -61,12 +62,33 @@ export default function ScopeDashboard() {
 
   async function fetchData() {
     setLoading(true);
+    setErrors([]);
     try {
       // Attempt to load real data from both endpoints
       const [agentsRes, enforceRes] = await Promise.allSettled([
         api.get("/agents"),
         api.get("/audit/enforce"),
       ]);
+
+      // 2026-04-30 enterprise gap fix: when EITHER endpoint fails,
+      // record the failure so the user sees an actionable banner
+      // instead of a silently-empty scope dashboard.
+      const fetchErrors: string[] = [];
+      if (agentsRes.status === "rejected") {
+        const reason: any = agentsRes.reason;
+        const status = reason?.response?.status;
+        fetchErrors.push(
+          `Agents endpoint unavailable${status ? ` (HTTP ${status})` : ""} — agent metadata may be incomplete.`
+        );
+      }
+      if (enforceRes.status === "rejected") {
+        const reason: any = enforceRes.reason;
+        const status = reason?.response?.status;
+        fetchErrors.push(
+          `Enforcement events endpoint unavailable${status ? ` (HTTP ${status})` : ""} — scope rows below reflect only what could be loaded.`
+        );
+      }
+      setErrors(fetchErrors);
 
       const agents = agentsRes.status === "fulfilled"
         ? (Array.isArray(agentsRes.value.data) ? agentsRes.value.data : agentsRes.value.data?.items || [])
@@ -98,8 +120,9 @@ export default function ScopeDashboard() {
         if (entry.result === "denied") scope.denials_24h += 1;
       }
       setScopes(Array.from(scopeMap.values()));
-    } catch {
+    } catch (e: any) {
       setScopes([]);
+      setErrors([`Failed to build scope dashboard: ${e?.message || "unknown error"}`]);
     } finally {
       setLoading(false);
     }
@@ -141,6 +164,23 @@ export default function ScopeDashboard() {
         <h2 className="text-2xl font-bold">Scope Dashboard</h2>
         <Button variant="outline" onClick={fetchData}>Refresh</Button>
       </div>
+
+      {/* Error banners — surface partial failures so the user knows
+          which numbers below are real and which are zeroed because
+          a backend call failed. */}
+      {errors.length > 0 && (
+        <div role="alert" className="space-y-2">
+          {errors.map((msg, i) => (
+            <div
+              key={i}
+              className="rounded border border-destructive/40 bg-destructive/5 p-3 text-sm flex items-start gap-3"
+            >
+              <span className="font-medium text-destructive shrink-0">Warning:</span>
+              <span className="flex-1">{msg}</span>
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* Aggregate Stats */}
       <div className="grid grid-cols-4 gap-4">

--- a/ui/src/pages/WorkflowRun.tsx
+++ b/ui/src/pages/WorkflowRun.tsx
@@ -31,6 +31,8 @@ export default function WorkflowRun() {
   const { runId } = useParams();
   const [run, setRun] = useState<RunDetail | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [cancelInFlight, setCancelInFlight] = useState(false);
 
   useEffect(() => {
     if (runId) fetchRun();
@@ -45,19 +47,45 @@ export default function WorkflowRun() {
 
   async function fetchRun() {
     setLoading(true);
+    setError(null);
     try {
       const { data } = await api.get(`/workflows/runs/${runId}`);
       setRun(data?.run_id ? { ...data, id: data.run_id } : data?.id ? data : null);
-    } catch {
+    } catch (e: any) {
       setRun(null);
+      const status = e?.response?.status;
+      const detail = e?.response?.data?.detail || e?.response?.data?.message;
+      setError(
+        status === 404
+          ? "Run not found — it may have been deleted, or the URL is wrong."
+          : status
+            ? `Failed to load workflow run (HTTP ${status})${detail ? `: ${detail}` : ""}`
+            : `Failed to load workflow run: ${e?.message || "network error"}`
+      );
     } finally {
       setLoading(false);
     }
   }
 
   async function cancelRun() {
-    await api.post(`/workflows/runs/${runId}/cancel`);
-    fetchRun();
+    setCancelInFlight(true);
+    setError(null);
+    try {
+      await api.post(`/workflows/runs/${runId}/cancel`);
+      // Re-fetch immediately so the UI reflects the new status without
+      // waiting for the next auto-refresh tick.
+      await fetchRun();
+    } catch (e: any) {
+      const status = e?.response?.status;
+      const detail = e?.response?.data?.detail || e?.response?.data?.message;
+      setError(
+        status
+          ? `Cancel failed (HTTP ${status})${detail ? `: ${detail}` : ""}`
+          : `Cancel failed: ${e?.message || "network error"}`
+      );
+    } finally {
+      setCancelInFlight(false);
+    }
   }
 
   const statusColor: Record<string, string> = {
@@ -72,7 +100,24 @@ export default function WorkflowRun() {
   };
 
   if (loading) return <p className="text-muted-foreground">Loading workflow run...</p>;
-  if (!run) return <p className="text-muted-foreground">Run not found.</p>;
+  if (!run) {
+    // 2026-04-30 enterprise gap fix: distinguish "load failed" from
+    // "run truly doesn't exist" so operators can act on the difference.
+    return (
+      <div className="space-y-4">
+        <div
+          role="alert"
+          className="rounded border border-destructive/40 bg-destructive/5 p-4 flex items-start gap-3"
+        >
+          <span className="font-medium text-destructive shrink-0">Error:</span>
+          <span className="flex-1">{error || "Run not found."}</span>
+          <Button size="sm" variant="outline" onClick={fetchRun}>
+            Retry
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   const progress = run.steps_total > 0 ? Math.round((run.steps_completed / run.steps_total) * 100) : 0;
 
@@ -85,10 +130,30 @@ export default function WorkflowRun() {
         </div>
         <div className="flex gap-2 items-center">
           <Badge variant={(statusColor[run.status] || "default") as any}>{run.status}</Badge>
-          {run.status === "running" && <Button variant="destructive" size="sm" onClick={cancelRun}>Cancel</Button>}
+          {run.status === "running" && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={cancelRun}
+              disabled={cancelInFlight}
+            >
+              {cancelInFlight ? "Cancelling…" : "Cancel"}
+            </Button>
+          )}
           <Button variant="outline" size="sm" onClick={fetchRun}>Refresh</Button>
         </div>
       </div>
+
+      {/* Surface fetch / cancel errors so the buttons don't fail silently. */}
+      {error && (
+        <div
+          role="alert"
+          className="rounded border border-destructive/40 bg-destructive/5 p-3 text-sm flex items-start gap-3"
+        >
+          <span className="font-medium text-destructive shrink-0">Error:</span>
+          <span className="flex-1">{error}</span>
+        </div>
+      )}
 
       <div className="grid grid-cols-4 gap-4">
         <Card><CardHeader><CardTitle className="text-sm text-muted-foreground">Progress</CardTitle></CardHeader>


### PR DESCRIPTION
## Summary

Closes Phase 1 of `docs/ENTERPRISE_END_TO_END_GAP_ANALYSIS_2026-04-30.md`. The gap analysis flagged four UI calls that hit nonexistent backend routes, silently rendering empty pages instead of failing visibly:

- `GET /audit/enforce`
- `GET /health/checks`
- `GET /health/uptime`
- `POST /workflows/runs/{run_id}/cancel`

This PR adds all four with proper authz + tenant isolation, replaces the silent empty-state catches in the four affected UI pages with explicit error panels + retry, fixes the `ChatPanel.tsx` lint error that was blocking `npm run lint`, and pins everything against regression with two new test modules.

## Backend endpoints

- **`GET /audit/enforce`** — Tool-gateway enforcement events. Filters `AuditLog` where `resource_type='tool_call'`, projects to the shape `EnforceAuditLog.tsx` + `ScopeDashboard.tsx` consume (`timestamp, agent_name, connector, tool, permission, result, reason`). Same authz as `/audit` (tenant + RBAC domain filter). Source: `core/tool_gateway/audit_logger.AuditLogger.log()` already writes `outcome ∈ {allowed, denied}` and `details.enforcement_action` for every tool call — this just queries them.
- **`GET /health/checks` + `GET /health/uptime`** — Honest Phase 1: returns the current `/health` snapshot wrapped in a stable list shape with an explicit `data_source: 'live_snapshot'` field. The platform doesn't yet persist health history (no telemetry table; no periodic snapshot Celery task). Rather than fabricate fake history, the response includes a `note` field that the UI surfaces as a clear banner: *"Telemetry history is not yet persisted. This response contains only the current live snapshot."* Persistence is tracked as a separate ops effort.
- **`POST /workflows/runs/{run_id}/cancel`** — Reuses existing `WorkflowEngine.cancel()` primitive at `workflows/engine.py:363`. Idempotent for terminal runs (200 with current state, not 409), flips DB `status='cancelled'` even if the engine cancel call is best-effort, marks pending steps cancelled, writes an audit log entry. Tenant-scoped via `get_current_tenant`.

## Contract drift regression test (the actual prevention mechanism)

`tests/regression/test_ui_api_contract.py` walks `ui/src/**/*.{ts,tsx}`, extracts every `api.{get,post,put,patch,delete}('/...')` URL (handles template literals like `/agents/${id}/run` and query-string substitutions like `/chat/history${params}`), and asserts each URL matches a registered FastAPI route. **Fails CI on any new drift** — exactly the silent 404 + empty-state pattern this PR closes.

Plus a direct pin against the four routes the audit called out: `test_phase_1_endpoints_are_now_registered` asserts they exist on the FastAPI app even if the UI call sites are later edited away.

## UI changes

- **`ChatPanel.tsx`**: drop useless `null` assignment (`no-useless-assignment` ESLint error blocking `npm run lint`), add missing `companyId` `useEffect` dep.
- **`EnforceAuditLog`, `ScopeDashboard`, `SLAMonitor`, `WorkflowRun`**: replace silent `catch(){setX([])}` with explicit error state + `role='alert'` banners + Retry buttons. `SLAMonitor` also renders the backend's honest `data_source` note so users see *"Telemetry history is not yet persisted"* instead of a misleadingly-empty chart. `WorkflowRun` distinguishes "load failed" from "run truly doesn't exist".

## Verification

- `pytest tests/regression/test_phase1_missing_routes.py tests/regression/test_ui_api_contract.py` → **9 passed**
- Local preflight gate (ruff whole tree, bandit, alembic, verify=False, pytest regression+unit, tsc, ui build, consistency sweep, module coverage, critical-path tags, branch safety) → **all 11 passed**
- `npm run lint`: 0 errors (15 warnings, all pre-existing — down from 16 before this PR's `ChatPanel.tsx` fix)
- `npm run build`: green
- `npm run typecheck`: clean

## Out of scope (tracked for follow-up)

The audit's Phase 2-5 items — these stay for separate PRs:

- **Phase 2: Auth migration from `localStorage` to HttpOnly cookies.** Browser session is still split between the cookie path the backend supports and the `localStorage` bearer token the frontend reads as the source of truth. Significant frontend rework — separate PR.
- **Health snapshot persistence + Celery recorder.** The endpoints are honest about being a live snapshot today; making them real history needs a `health_check_history` migration + a periodic Celery task. Separate ops effort.
- **Phase 3: BGE-M3 e2e CI image baking + test-suite split (fast/slow/integration).** Partial fix already in `main` via PR #398; full audit-Phase-3 work is bigger.
- **Remaining 15 hook-dependency warnings.** Pre-existing, will be cleaned in a separate sweep.

## Verdict per the agenticorg-enterprise skill

- **Sign-off granted for the four routes that were 404'ing the UI** — they now exist, are tenant-scoped, return the contract the UI expects, and are pinned against regression by two distinct test mechanisms (route-existence pin + UI-to-backend drift detector).
- **Sign-off NOT granted for the broader \"enterprise-grade\" question** — Phase 2-5 items above remain. This PR closes the silent-404 class of failure; it does not close the auth, telemetry, or test-gate classes.

@codex please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)