### PR TITLE
feat(observability): SLA telemetry persistence — health_check_history table + Celery recorder

### DIFF
--- a/api/v1/health.py
+++ b/api/v1/health.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import redis.asyncio as aioredis
 import structlog
@@ -105,43 +105,92 @@ async def liveness():
 
 # ── GET /health/checks ─────────────────────────────────────────────────────
 #
-# 2026-04-30 enterprise gap analysis: ``ui/src/pages/SLAMonitor.tsx`` calls
-# ``/health/checks`` and ``/health/uptime`` to render check history and an
-# uptime chart. Those routes didn't exist, so the SLA monitor showed empty
-# panels with no error.
+# 2026-04-30 enterprise gap analysis flagged that the SLA Monitor page
+# calls ``/health/checks`` and ``/health/uptime`` but the routes didn't
+# exist. Phase 1 (PR #399) added them as honest live-snapshot stubs with
+# a ``data_source: "live_snapshot"`` field. Phase 5 (this PR) wires them
+# to the new ``health_check_history`` table populated every 5 minutes by
+# ``core.tasks.health_snapshot.record_health_snapshot``.
 #
-# Honest Phase 1 implementation: the platform doesn't yet persist health
-# check history (no telemetry table; no periodic snapshot Celery task). So
-# rather than fabricate fake history, these endpoints return a single
-# live-probe snapshot wrapped in the list shape the UI expects, with
-# ``data_source: "live_snapshot"`` so the UI can render an honest banner
-# ("Telemetry history not yet persisted — showing live snapshot only").
-# Adding real persistence is tracked as a separate ops effort with
-# migration + Celery task.
+# When history is present → ``data_source: "persisted"`` and the response
+# returns real rows from the last N hours. When the table is empty (e.g.
+# right after a deploy before the first snapshot lands, or in a dev env
+# without the Celery beat running) → fall back to ``"live_snapshot"`` so
+# the UI's existing data-source-aware banner still renders an honest
+# explanation instead of a misleading empty chart.
+
+# Default window for the chart endpoints. The SLA monitor renders a
+# 24-hour view; tweak via the ``hours`` query parameter.
+_DEFAULT_HISTORY_HOURS = 24
+_MAX_HISTORY_HOURS = 7 * 24  # match the Celery task's RETENTION_DAYS
+
+
+async def _fetch_history(hours: int) -> list[dict]:
+    """Pull the last ``hours`` of recorded health snapshots, newest first.
+
+    Returns an empty list when the table doesn't exist yet (fresh env
+    without the migration), when no snapshots have landed yet, or when
+    the query fails for any reason. Callers fall back to the live
+    snapshot in those cases.
+    """
+    try:
+        async with async_session_factory() as session:
+            result = await session.execute(
+                text(
+                    "SELECT recorded_at, status, checks, version, commit "
+                    "FROM health_check_history "
+                    "WHERE recorded_at >= :cutoff "
+                    "ORDER BY recorded_at DESC"
+                ),
+                {"cutoff": datetime.now(UTC) - timedelta(hours=hours)},
+            )
+            rows = result.all()
+    except Exception as exc:  # noqa: BLE001 — table absent / db blip → live fallback
+        logger.warning("health_history_query_failed", error=str(exc))
+        return []
+
+    return [
+        {
+            "timestamp": r.recorded_at.isoformat() if r.recorded_at else None,
+            "status": r.status,
+            "checks": r.checks or {},
+            "version": r.version,
+            "commit": r.commit,
+        }
+        for r in rows
+    ]
 
 
 @router.get("/health/checks")
-async def health_checks():
-    """Recent health check history.
+async def health_checks(hours: int = _DEFAULT_HISTORY_HOURS):
+    """Recent health-check history (last ``hours`` of recorded snapshots).
 
-    Phase 1: returns a single live snapshot — telemetry persistence is a
-    follow-up. ``data_source`` makes the limitation explicit so the UI can
-    render an honest banner instead of a misleading empty chart.
-
-    Acceptance criteria from the gap analysis: the route must exist (so
-    UI doesn't 404) and the response shape must be stable across the
-    eventual persistence rollout.
+    Returns ``data_source: "persisted"`` + real rows when the periodic
+    Celery task has populated ``health_check_history``. Falls back to
+    a single ``data_source: "live_snapshot"`` row + an honest banner
+    note when the table is empty (e.g. before the first snapshot
+    lands after deploy).
     """
+    hours = max(1, min(hours, _MAX_HISTORY_HOURS))
+    history = await _fetch_history(hours)
+    if history:
+        return {
+            "data_source": "persisted",
+            "window_hours": hours,
+            "items": history,
+        }
+
     snapshot = await health_readiness()
     now = datetime.now(UTC).isoformat()
     return {
         "data_source": "live_snapshot",
         "note": (
-            "Telemetry history is not yet persisted. This response contains "
-            "only the current live snapshot. Wire a periodic /health "
-            "snapshot recorder + a health_check_history table to enable "
-            "true history."
+            "No persisted snapshots in the last "
+            f"{hours}h yet. The periodic recorder may not have run "
+            "since deploy, or the health_check_history table is "
+            "empty. Showing live probe only."
         ),
+        "window_hours": hours,
         "items": [
             {
                 "timestamp": now,
@@ -155,24 +204,49 @@ async def health_checks():
 
 
 @router.get("/health/uptime")
-async def health_uptime():
-    """Uptime chart data.
+async def health_uptime(hours: int = _DEFAULT_HISTORY_HOURS):
+    """Uptime aggregate over the last ``hours``.
 
-    Phase 1: telemetry history isn't persisted yet, so this returns the
-    current snapshot only with an explicit ``data_source`` field. Once
-    health_check_history is wired, this endpoint will aggregate to bucketed
-    uptime percentages across configurable windows.
+    Returns ``data_source: "persisted"`` with real bucketed series and a
+    computed ``uptime_pct`` when ``health_check_history`` has rows.
+    Falls back to ``data_source: "live_snapshot"`` when empty.
     """
+    hours = max(1, min(hours, _MAX_HISTORY_HOURS))
+    history = await _fetch_history(hours)
     snapshot = await health_readiness()
+
+    if history:
+        up_count = sum(1 for r in history if r["status"] == "healthy")
+        uptime_pct = round(100.0 * up_count / len(history), 2)
+        return {
+            "data_source": "persisted",
+            "window_hours": hours,
+            "uptime_pct": uptime_pct,
+            "samples": len(history),
+            "current_status": snapshot["status"],
+            "items": [
+                {
+                    "timestamp": r["timestamp"],
+                    "up": r["status"] == "healthy",
+                    "status": r["status"],
+                }
+                for r in history
+            ],
+        }
+
     now = datetime.now(UTC).isoformat()
     is_up = snapshot["status"] == "healthy"
     return {
         "data_source": "live_snapshot",
         "note": (
-            "Telemetry history is not yet persisted. Uptime percentage "
-            "and bucketed series will be available once health snapshots "
-            "are recorded periodically."
+            "No persisted snapshots in the last "
+            f"{hours}h yet — uptime percentage will be available "
+            "once the periodic recorder has run."
         ),
+        "window_hours": hours,
+        "uptime_pct": None,
+        "samples": 0,
+        "current_status": snapshot["status"],
         "items": [
             {
                 "timestamp": now,
@@ -180,7 +254,6 @@ async def health_uptime():
                 "status": snapshot["status"],
             }
         ],
-        "current_status": snapshot["status"],
     }
 
 

--- a/core/tasks/celery_app.py
+++ b/core/tasks/celery_app.py
@@ -84,6 +84,15 @@ app.conf.beat_schedule = {
         "schedule": 300.0,
         "options": {"queue": "rpa"},
     },
+    "record-health-snapshot": {
+        # Phase 5 SLA telemetry: one /health snapshot recorded into
+        # health_check_history every 5 minutes so /health/checks +
+        # /health/uptime can return real history instead of a single
+        # live probe. See core/tasks/health_snapshot.py.
+        "task": "core.tasks.health_snapshot.record_health_snapshot",
+        "schedule": 300.0,  # every 5 minutes
+        "options": {"queue": "maintenance"},
+    },
     "shadow-reconciliation-report": {
         "task": "core.tasks.report_tasks.generate_report",
         "schedule": crontab(hour=8, minute=0, day_of_week="monday"),  # weekly Mon 8 AM IST

--- a/core/tasks/health_snapshot.py
+++ b/core/tasks/health_snapshot.py
@@ -1,0 +1,142 @@
+"""Periodic health snapshot recorder — Phase 5 SLA telemetry persistence.
+
+Wired into the Celery beat schedule at 5-minute intervals (see
+``core/tasks/celery_app.py:beat_schedule``). Each tick:
+
+1. Runs the same DB + Redis liveness probes as ``GET /health``.
+2. INSERTs a row into ``health_check_history`` with the result.
+3. Trims rows older than ``RETENTION_DAYS`` so the table stays bounded.
+
+The endpoints ``GET /health/checks`` and ``GET /health/uptime`` query
+this table to render real history on the SLA Monitor page. Without
+this task running, those endpoints fall back to the live snapshot
+(see ``api/v1/health.py``) — so a missing-task condition is visible
+to operators (the SLA page banner will still show ``data_source:
+live_snapshot``) rather than silently producing a stale chart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid as _uuid
+from datetime import UTC, datetime, timedelta
+
+import redis.asyncio as aioredis
+import structlog
+from sqlalchemy import text
+
+from core.config import settings
+from core.database import async_session_factory
+from core.tasks.celery_app import app
+
+logger = structlog.get_logger()
+
+# Keep ~7 days of snapshots @ one every 5 minutes ⇒ ~2,016 rows. Tiny.
+RETENTION_DAYS = 7
+
+
+def _deployed_commit() -> str:
+    for key in ("AGENTICORG_GIT_SHA", "GIT_SHA", "GIT_COMMIT", "K_REVISION"):
+        v = os.getenv(key, "").strip()
+        if v:
+            return v
+    return "unknown"
+
+
+async def _probe_db() -> str:
+    try:
+        async with async_session_factory() as session:
+            await session.execute(text("SELECT 1"))
+        return "healthy"
+    except Exception as e:  # noqa: BLE001 — capture the failure shape, not crash the snapshot
+        return f"unhealthy: {type(e).__name__}"
+
+
+async def _probe_redis() -> str:
+    try:
+        r = aioredis.from_url(settings.redis_url, decode_responses=True)
+        try:
+            await r.ping()
+        finally:
+            await r.close()
+        return "healthy"
+    except Exception as e:  # noqa: BLE001
+        return f"unhealthy: {type(e).__name__}"
+
+
+async def _record_snapshot_async() -> dict:
+    """Probe + insert + trim. Returns the inserted row's payload for logs."""
+    db_status = await _probe_db()
+    redis_status = await _probe_redis()
+    overall = "healthy" if (db_status == "healthy" and redis_status == "healthy") else "unhealthy"
+
+    snapshot_id = str(_uuid.uuid4())
+    recorded_at = datetime.now(UTC)
+    checks = {"db": db_status, "redis": redis_status}
+
+    # Lazy version pull — same source the /health endpoint uses.
+    try:
+        from api.v1.health import APP_VERSION  # noqa: PLC0415
+        version = APP_VERSION
+    except Exception:  # noqa: BLE001 — version is best-effort metadata
+        version = None
+
+    commit = _deployed_commit()
+
+    async with async_session_factory() as session:
+        await session.execute(
+            text(
+                "INSERT INTO health_check_history "
+                "(id, recorded_at, status, checks, version, commit) "
+                "VALUES (:id, :recorded_at, :status, CAST(:checks AS jsonb), :version, :commit)"
+            ),
+            {
+                "id": snapshot_id,
+                "recorded_at": recorded_at,
+                "status": overall,
+                "checks": __import__("json").dumps(checks),
+                "version": version,
+                "commit": commit,
+            },
+        )
+        # Trim. ``DELETE WHERE recorded_at < NOW() - INTERVAL`` is bounded
+        # by the index on recorded_at DESC + the small absolute volume.
+        await session.execute(
+            text(
+                "DELETE FROM health_check_history "
+                "WHERE recorded_at < :cutoff"
+            ),
+            {"cutoff": recorded_at - timedelta(days=RETENTION_DAYS)},
+        )
+        await session.commit()
+
+    return {
+        "id": snapshot_id,
+        "recorded_at": recorded_at.isoformat(),
+        "status": overall,
+        "checks": checks,
+        "version": version,
+        "commit": commit,
+    }
+
+
+@app.task(name="core.tasks.health_snapshot.record_health_snapshot")
+def record_health_snapshot() -> dict:
+    """Periodic: record one /health snapshot + trim old rows.
+
+    Scheduled every 5 minutes by Celery Beat (see celery_app.beat_schedule).
+    """
+    try:
+        result = asyncio.run(_record_snapshot_async())
+        logger.info(
+            "health_snapshot_recorded",
+            status=result["status"],
+            checks=result["checks"],
+        )
+        return result
+    except Exception as exc:  # noqa: BLE001
+        # Don't propagate — a failed snapshot is observable through
+        # the resulting gap in the chart, not by killing the worker.
+        logger.error("health_snapshot_failed", error=str(exc))
+        return {"status": "snapshot_failed", "error": str(exc)}

--- a/migrations/versions/v4_9_8_health_check_history.py
+++ b/migrations/versions/v4_9_8_health_check_history.py
@@ -1,0 +1,64 @@
+"""Phase 5 — health_check_history table for SLA telemetry persistence.
+
+Revision ID: v498_health_check_history
+Revises: v497_migration_progress
+Create Date: 2026-05-01
+
+Closes the "data_source: live_snapshot" honest note left in PR #399.
+The /health/checks and /health/uptime endpoints currently return only
+the current live probe; without persistence the SLA Monitor page can't
+show real history or compute uptime percentage.
+
+This migration creates ``health_check_history`` — a single platform-
+wide observability table (NOT tenant-scoped, so no RLS). A periodic
+Celery task records one row every 5 minutes via
+``core.tasks.health_snapshot.record_health_snapshot``. The rate-limit
+endpoints query this table for the last 24h.
+
+Schema choices:
+- ``recorded_at`` is the natural sort key for time-window queries.
+- ``status`` is the same string the live /health endpoint returns
+  (``"healthy"`` / ``"unhealthy"``) so endpoint logic stays consistent.
+- ``checks`` keeps the per-component dict (db, redis, ...) in JSONB
+  so we can extend without schema churn.
+- ``version`` and ``commit`` capture the running deploy at snapshot
+  time, useful for correlating health dips with deploys.
+
+Idempotent: CREATE TABLE / INDEX use IF NOT EXISTS so re-running on
+an environment that already has the table is a no-op. This matches
+the local pattern (see v497_migration_progress).
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v498_health_check_history"
+down_revision = "v497_migration_progress"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS health_check_history (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            status TEXT NOT NULL,
+            checks JSONB NOT NULL DEFAULT '{}'::jsonb,
+            version TEXT,
+            commit TEXT
+        );
+    """)
+    # DESC index — every read is "last N hours, newest first".
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_health_check_history_recorded_at
+            ON health_check_history (recorded_at DESC);
+    """)
+
+
+def downgrade() -> None:
+    # Reversible. Index is dropped implicitly with the table, but be
+    # explicit so a partial-state environment cleans up cleanly.
+    op.execute("DROP INDEX IF EXISTS ix_health_check_history_recorded_at;")
+    op.execute("DROP TABLE IF EXISTS health_check_history;")

--- a/tests/regression/test_phase1_missing_routes.py
+++ b/tests/regression/test_phase1_missing_routes.py
@@ -25,12 +25,16 @@ async def test_health_checks_returns_live_snapshot_with_data_source_field(
     monkeypatch,
 ) -> None:
     """The endpoint exists, returns 200, and is honest about being a live
-    snapshot (not persisted history). The ``data_source`` field is the
-    contract the UI uses to render the "history coming soon" banner.
+    snapshot when no persisted history is available. The ``data_source``
+    field is the contract the UI uses to render the right banner.
+
+    Note: the precise wording of the ``note`` field is pinned by the
+    Phase 5 tests in ``test_sla_telemetry_persistence.py``; here we
+    only assert the contract shape so this test stays robust across
+    note rewrites.
     """
     from api.v1 import health as health_module
 
-    # Mock health_readiness to avoid touching real DB/Redis
     fake_snapshot = {
         "status": "healthy",
         "version": "9.9.9-test",
@@ -41,12 +45,18 @@ async def test_health_checks_returns_live_snapshot_with_data_source_field(
     async def _fake_readiness():
         return fake_snapshot
 
+    async def _empty_history(_hours: int):
+        # Force the live-snapshot fallback path even on a host where
+        # health_check_history happens to have rows.
+        return []
+
     monkeypatch.setattr(health_module, "health_readiness", _fake_readiness)
+    monkeypatch.setattr(health_module, "_fetch_history", _empty_history)
 
     result = await health_module.health_checks()
 
     assert result["data_source"] == "live_snapshot"
-    assert "Telemetry history" in result["note"]
+    assert "note" in result and isinstance(result["note"], str) and result["note"]
     assert isinstance(result["items"], list)
     assert len(result["items"]) == 1
     item = result["items"][0]
@@ -59,8 +69,11 @@ async def test_health_checks_returns_live_snapshot_with_data_source_field(
 async def test_health_uptime_returns_current_status_and_data_source(
     monkeypatch,
 ) -> None:
-    """Uptime must include current_status (UI uses this directly) and
-    must mark data_source as a live snapshot until persistence ships."""
+    """Uptime must include current_status (UI uses this directly).
+
+    Phase 5 (test_sla_telemetry_persistence.py) covers the
+    persisted-history path; this test pins the live-snapshot
+    fallback contract by forcing _fetch_history → []."""
     from api.v1 import health as health_module
 
     async def _fake_readiness():
@@ -71,7 +84,11 @@ async def test_health_uptime_returns_current_status_and_data_source(
             "checks": {"db": "unhealthy: TimeoutError", "redis": "healthy"},
         }
 
+    async def _empty_history(_hours: int):
+        return []
+
     monkeypatch.setattr(health_module, "health_readiness", _fake_readiness)
+    monkeypatch.setattr(health_module, "_fetch_history", _empty_history)
     result = await health_module.health_uptime()
 
     assert result["data_source"] == "live_snapshot"

--- a/tests/regression/test_sla_telemetry_persistence.py
+++ b/tests/regression/test_sla_telemetry_persistence.py
@@ -1,0 +1,263 @@
+"""SLA telemetry persistence pins (Phase 5 of the 2026-04-30 gap analysis).
+
+Pins the contract Phase 5 introduces over Phase 1's honest stub:
+
+- When ``health_check_history`` has rows in the requested window, the
+  endpoint returns ``data_source: "persisted"`` + real items + a
+  computed ``uptime_pct`` (uptime endpoint).
+- When the table is empty (or its query fails — fresh deploy before the
+  first snapshot lands, or dev env without the Celery beat), the
+  endpoint falls back to ``data_source: "live_snapshot"`` + an honest
+  ``note`` so the UI's existing data-source-aware banner still renders
+  the right context.
+- Migration ``v498_health_check_history`` is registered.
+- The Celery beat schedule includes the periodic recorder.
+
+These pins are intentionally hermetic — no live DB. The endpoint queries
+``health_check_history`` via ``async_session_factory``; we monkeypatch
+the ``_fetch_history`` helper to control whether "history" is present.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+# ─────────────────────────────────────────────────────────────────
+# Migration + beat schedule registration pins
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_health_check_history_migration_exists() -> None:
+    """The Alembic migration that creates the table must be present
+    and have a revision id ≤ 32 chars (alembic_version.version_num
+    is VARCHAR(32))."""
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    migration = repo / "migrations" / "versions" / "v4_9_8_health_check_history.py"
+    assert migration.exists(), "v4_9_8_health_check_history.py is missing"
+
+    src = migration.read_text(encoding="utf-8")
+    assert 'revision = "v498_health_check_history"' in src
+    # Revision id length budget — VARCHAR(32) cap.
+    assert len("v498_health_check_history") <= 32
+
+    # Idempotent CREATE — must use IF NOT EXISTS so re-runs are safe.
+    assert "CREATE TABLE IF NOT EXISTS health_check_history" in src
+    assert "CREATE INDEX IF NOT EXISTS ix_health_check_history_recorded_at" in src
+
+    # Reversible — downgrade must drop both.
+    assert "DROP TABLE IF EXISTS health_check_history" in src
+    assert "DROP INDEX IF EXISTS ix_health_check_history_recorded_at" in src
+
+
+def test_celery_beat_schedule_registers_health_snapshot() -> None:
+    """The periodic snapshot must be in the beat schedule, otherwise the
+    table never gets populated and the endpoints stay in fallback mode
+    forever."""
+    from core.tasks.celery_app import app
+
+    schedule = app.conf.beat_schedule
+    assert "record-health-snapshot" in schedule
+    entry = schedule["record-health-snapshot"]
+    assert entry["task"] == "core.tasks.health_snapshot.record_health_snapshot"
+    # Must be ≤ 15 minutes — the SLA chart shows 24h, so any longer
+    # produces a sparse uptime sample (< 100 points).
+    assert entry["schedule"] <= 900.0
+
+
+# ─────────────────────────────────────────────────────────────────
+# /health/checks behavior pins
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_health_checks_returns_persisted_when_history_has_rows(
+    monkeypatch,
+) -> None:
+    """When the table has real rows, the endpoint returns
+    ``data_source: 'persisted'`` and the rows verbatim."""
+    from api.v1 import health as health_module
+
+    fake_rows = [
+        {
+            "timestamp": (datetime.now(UTC) - timedelta(minutes=5)).isoformat(),
+            "status": "healthy",
+            "checks": {"db": "healthy", "redis": "healthy"},
+            "version": "9.9.9",
+            "commit": "abc123",
+        },
+        {
+            "timestamp": (datetime.now(UTC) - timedelta(minutes=10)).isoformat(),
+            "status": "unhealthy",
+            "checks": {"db": "healthy", "redis": "unhealthy: TimeoutError"},
+            "version": "9.9.9",
+            "commit": "abc123",
+        },
+    ]
+
+    async def _fake_fetch(_hours: int):
+        return fake_rows
+
+    monkeypatch.setattr(health_module, "_fetch_history", _fake_fetch)
+
+    result = await health_module.health_checks()
+
+    assert result["data_source"] == "persisted"
+    assert result["items"] == fake_rows
+    assert result["window_hours"] == 24  # default
+    # No fallback note when persisted history is present
+    assert "note" not in result
+
+
+@pytest.mark.asyncio
+async def test_health_checks_falls_back_to_live_snapshot_when_history_empty(
+    monkeypatch,
+) -> None:
+    """Empty table → ``data_source: 'live_snapshot'`` + an honest note,
+    so the UI banner still renders the right explanation."""
+    from api.v1 import health as health_module
+
+    async def _empty_fetch(_hours: int):
+        return []
+
+    async def _fake_readiness():
+        return {
+            "status": "healthy",
+            "version": "9.9.9",
+            "commit": "abc123",
+            "checks": {"db": "healthy", "redis": "healthy"},
+        }
+
+    monkeypatch.setattr(health_module, "_fetch_history", _empty_fetch)
+    monkeypatch.setattr(health_module, "health_readiness", _fake_readiness)
+
+    result = await health_module.health_checks()
+
+    assert result["data_source"] == "live_snapshot"
+    assert "note" in result and "No persisted snapshots" in result["note"]
+    assert len(result["items"]) == 1
+    assert result["items"][0]["status"] == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_health_checks_clamps_hours_to_safe_range(monkeypatch) -> None:
+    """``hours`` must be clamped to [1, 168] so a malicious / bug call
+    can't ask for an unbounded range."""
+    from api.v1 import health as health_module
+
+    captured: list[int] = []
+
+    async def _fake_fetch(hours: int):
+        captured.append(hours)
+        return []
+
+    async def _fake_readiness():
+        return {"status": "healthy", "version": "x", "commit": "y", "checks": {}}
+
+    monkeypatch.setattr(health_module, "_fetch_history", _fake_fetch)
+    monkeypatch.setattr(health_module, "health_readiness", _fake_readiness)
+
+    await health_module.health_checks(hours=0)
+    await health_module.health_checks(hours=99999)
+    assert captured == [1, 7 * 24]
+
+
+# ─────────────────────────────────────────────────────────────────
+# /health/uptime behavior pins
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_health_uptime_computes_pct_from_persisted_rows(monkeypatch) -> None:
+    """Uptime % comes from the ratio of healthy rows in the window.
+
+    UI renders this number directly; the math has to be deterministic.
+    """
+    from api.v1 import health as health_module
+
+    # 3 healthy + 1 unhealthy → 75.0
+    fake_rows = [
+        {
+            "timestamp": (datetime.now(UTC) - timedelta(minutes=i * 5)).isoformat(),
+            "status": "healthy" if i != 2 else "unhealthy",
+            "checks": {"db": "healthy", "redis": "healthy"},
+            "version": "x",
+            "commit": "y",
+        }
+        for i in range(4)
+    ]
+
+    async def _fake_fetch(_hours: int):
+        return fake_rows
+
+    async def _fake_readiness():
+        return {"status": "healthy", "version": "x", "commit": "y", "checks": {}}
+
+    monkeypatch.setattr(health_module, "_fetch_history", _fake_fetch)
+    monkeypatch.setattr(health_module, "health_readiness", _fake_readiness)
+
+    result = await health_module.health_uptime()
+
+    assert result["data_source"] == "persisted"
+    assert result["uptime_pct"] == 75.0
+    assert result["samples"] == 4
+    assert result["current_status"] == "healthy"
+    assert len(result["items"]) == 4
+
+
+@pytest.mark.asyncio
+async def test_health_uptime_falls_back_with_null_pct_when_empty(monkeypatch) -> None:
+    """No history → uptime_pct is null (NOT 0), samples is 0, with note."""
+    from api.v1 import health as health_module
+
+    async def _empty(_hours: int):
+        return []
+
+    async def _fake_readiness():
+        return {"status": "unhealthy", "version": "x", "commit": "y", "checks": {}}
+
+    monkeypatch.setattr(health_module, "_fetch_history", _empty)
+    monkeypatch.setattr(health_module, "health_readiness", _fake_readiness)
+
+    result = await health_module.health_uptime()
+
+    assert result["data_source"] == "live_snapshot"
+    assert result["uptime_pct"] is None  # not 0 — null is "unknown"
+    assert result["samples"] == 0
+    assert result["current_status"] == "unhealthy"
+    assert "note" in result
+
+
+# ─────────────────────────────────────────────────────────────────
+# _fetch_history fail-safe — query failure must NOT 500 the endpoint
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fetch_history_returns_empty_on_query_error(monkeypatch) -> None:
+    """If the query raises (table missing, DB blip, RLS denial, ...) the
+    helper must return [] so the endpoint falls back to live snapshot
+    rather than 500-ing the entire SLA Monitor page."""
+    from api.v1 import health as health_module
+
+    # Force the session factory to raise inside the helper.
+    class _BoomSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def execute(self, *args, **kwargs):
+            raise RuntimeError("simulated db failure")
+
+    def _factory():
+        return _BoomSession()
+
+    monkeypatch.setattr(health_module, "async_session_factory", _factory)
+
+    rows = await health_module._fetch_history(24)
+    assert rows == []

--- a/tests/unit/test_module_19_health_api.py
+++ b/tests/unit/test_module_19_health_api.py
@@ -38,12 +38,20 @@ REPO = Path(__file__).resolve().parents[2]
 def test_tc_api_001_liveness_endpoint_is_lightweight() -> None:
     """Liveness must NOT touch DB or Redis — those are readiness
     concerns. K8s liveness probes that wait on external deps
-    cause cascading restarts when those deps blip."""
-    src = (REPO / "api" / "v1" / "health.py").read_text(encoding="utf-8")
-    # Find the liveness function block.
-    block = src.split('@router.get("/health/liveness")', 1)[1].split(
-        '@router.get(', 1
-    )[0]
+    cause cascading restarts when those deps blip.
+
+    Pin the actual liveness function body via ``inspect.getsource``,
+    not a brittle text-grep between decorators — sibling helpers
+    legitimately added to ``health.py`` (e.g. the Phase 5
+    ``_fetch_history`` helper that supports ``/health/checks``)
+    used to be captured by the previous "everything between
+    @router.get decorators" approach and produced false failures.
+    """
+    import inspect
+
+    from api.v1.health import liveness
+
+    block = inspect.getsource(liveness)
     assert '"status": "alive"' in block
     # Must NOT do DB or Redis work in liveness.
     assert "session" not in block


### PR DESCRIPTION
## Summary

Closes Phase 5 of `docs/ENTERPRISE_END_TO_END_GAP_ANALYSIS_2026-04-30.md` for the SLA Monitor surface. PR #399 added `/health/checks` + `/health/uptime` as honest live-snapshot stubs with a `data_source: live_snapshot` field and an explicit *"history not yet persisted"* note. **This PR wires them to real persistence** so the SLA Monitor page renders true 24h history and a computed uptime percentage.

## What lands

### 1. Migration `v498_health_check_history`

New platform-wide observability table (NOT tenant-scoped, no RLS — health is a system property, not tenant data):

```sql
CREATE TABLE health_check_history (
    id UUID PRIMARY KEY,
    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
    status TEXT NOT NULL,            -- "healthy" / "unhealthy"
    checks JSONB NOT NULL,           -- { "db": "...", "redis": "..." }
    version TEXT,
    commit TEXT
);
CREATE INDEX ix_health_check_history_recorded_at ON ... (recorded_at DESC);
```

Idempotent `CREATE IF NOT EXISTS`, reversible downgrade. Revision id = `v498_health_check_history` (25 chars, fits the VARCHAR(32) cap).

### 2. Periodic Celery beat task

`core/tasks/health_snapshot.py::record_health_snapshot` — runs every 5 minutes, probes DB + Redis (same checks as `GET /health`), INSERTs one row, trims rows older than `RETENTION_DAYS=7`. Failures are logged but never propagate (a missed snapshot is observable as a chart gap, not a worker crash). Wired via `celery_app.beat_schedule['record-health-snapshot']`.

### 3. `/health/checks` + `/health/uptime` updated

- **When the table has rows in the requested window** (default 24h, clamped `[1, 168]`): returns `data_source='persisted'` + real items. Uptime endpoint computes `uptime_pct` from the healthy/total ratio.
- **When empty** (fresh deploy before the first snapshot lands; dev env without the beat running): falls back to `data_source='live_snapshot'` + an honest note. The UI's existing data-source-aware banner logic handles both paths automatically.
- **`_fetch_history` fail-safe**: any query exception (table absent, RLS denial, DB blip) returns `[]` so the endpoint falls back to live snapshot rather than 500-ing the entire SLA Monitor page.

## Regression tests (8 new pins + 2 Phase 1 updates)

`tests/regression/test_sla_telemetry_persistence.py`:
- Migration file exists with correct shape (idempotent CREATEs, reversible downgrade, revision id ≤ 32 chars).
- Celery beat schedule includes the recorder at ≤ 15-min cadence.
- `/health/checks` returns `'persisted'` shape when history present.
- `/health/checks` falls back to `'live_snapshot'` when history empty.
- `/health/checks` clamps `hours` to `[1, 168]` (no unbounded ranges).
- `/health/uptime` computes deterministic `uptime_pct` from rows.
- `/health/uptime` returns `null` pct (NOT 0) when no history — null is the honest "unknown", 0 would imply a real outage.
- `_fetch_history` returns `[]` on query error (no 500 on missing table).

`tests/regression/test_phase1_missing_routes.py`: updated to mock `_fetch_history → []` to deterministically exercise the live-snapshot fallback contract; the literal `note` wording is now pinned only in the Phase 5 tests, leaving room to refine copy without breaking older pins.

`tests/unit/test_module_19_health_api.py`: replaced the brittle "everything between `@router.get` decorators" text-grep with `inspect.getsource(liveness)` so adding sibling helpers to `health.py` doesn't produce false failures (the previous approach captured my new `_fetch_history` helper as part of the "liveness block" and complained that liveness mentions `session`).

## Verification

- `pytest tests/regression/test_sla_telemetry_persistence.py + test_phase1_missing_routes.py + test_ui_api_contract.py + tests/unit/test_module_19_health_api.py` → **all green**
- Local preflight gate (12 checks: branch safety, ruff whole tree, mypy whole tree, bandit, alembic, verify=False, pytest regression+unit, tsc, ui build, consistency sweep, module coverage, critical-path tags) → **all 12 passed**

## Deploy notes

This PR ships a **schema change**. The deploy MUST run alembic migrate before the API rollout. Per `feedback_deploy_pipeline_state.md` (fixed 2026-04-30 after the previous incomplete recipe), the migrate job needs:

```
gcloud run jobs deploy agenticorg-migrate \
  --project=$PROJECT --region=asia-southeast1 \
  --image=$REGISTRY/agenticorg:$SHA \
  --command=python --args=scripts/alembic_migrate.py \
  --set-cloudsql-instances=$PROJECT:asia-southeast1:agenticorg-db-sg \
  --set-env-vars=AGENTICORG_DDL_MANAGED_BY_ALEMBIC=true \
  ... + DATABASE_URL env from agenticorg-api service ...
gcloud run jobs execute agenticorg-migrate --region=asia-southeast1 --wait
```

Then API rollout updates `agenticorg-api` to the new image with `AGENTICORG_GIT_SHA` env. Beat scheduler picks up the new task automatically on next worker restart.

@codex please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)