### PR TITLE
feat(infra): Celery worker + beat wrappers for Cloud Run Service deployment

### DIFF
--- a/scripts/run_beat.py
+++ b/scripts/run_beat.py
@@ -1,0 +1,84 @@
+"""Celery beat entrypoint for the ``agenticorg-beat`` Cloud Run Service.
+
+Same shape as ``run_worker.py`` (HTTP stub + foreground celery process)
+but invokes ``celery beat`` instead of ``celery worker``. Beat is the
+*scheduler* — it dispatches tasks defined in ``celery_app.beat_schedule``
+to the broker on their cron / interval triggers. Workers (the
+``agenticorg-worker`` service) consume from the broker and execute.
+
+Critical operational note: beat MUST be a singleton. Two beat instances
+running concurrently produce duplicate triggers (the same scheduled
+task fires twice every interval). For Cloud Run that means deploying
+this with ``--min-instances=1 --max-instances=1``.
+
+Schedule state: Celery's default beat scheduler stores last-run times
+in a local file (``celerybeat-schedule.db``). On Cloud Run with a fresh
+container per revision, that state resets each deploy. For our workload
+(periodic 5-15 min tasks + a few daily/monthly crons) the cost is at
+most one duplicate fire per deploy, which the underlying tasks already
+handle (idempotency on monthly invoices, etc.) or won't notice (health
+snapshot, budget evaluator). When this becomes a problem, switch to
+``--scheduler core.tasks.beat_redis_scheduler.RedisScheduler`` or
+``celery-redbeat``.
+
+Local smoke test::
+
+    PORT=8080 python scripts/run_beat.py
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class _HealthHandler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802 — BaseHTTPRequestHandler convention
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(b"ok\n")
+
+    def log_message(self, *_args, **_kwargs):
+        return
+
+
+def _serve_health() -> None:
+    port = int(os.environ.get("PORT", "8080"))
+    server = HTTPServer(("0.0.0.0", port), _HealthHandler)  # noqa: S104
+    server.serve_forever()
+
+
+def _run_celery_beat() -> int:
+    # Eager import to surface task-registration errors in the container
+    # log before Celery's own startup, matching run_worker.py.
+    from core.tasks import celery_app  # noqa: F401, PLC0415
+
+    from celery.__main__ import main as celery_main  # noqa: PLC0415
+
+    sys.argv = [
+        "celery",
+        "-A",
+        "core.tasks.celery_app",
+        "beat",
+        "--loglevel=info",
+        # PersistentScheduler is the default — it keeps last-run state
+        # in a local file. Across Cloud Run revision swaps the state
+        # resets, but missed cron fires are not replayed (Celery beat
+        # only schedules forward), so this is safe even for daily/
+        # monthly tasks.
+    ]
+    return celery_main()
+
+
+def main() -> int:
+    threading.Thread(target=_serve_health, daemon=True).start()
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+    return _run_celery_beat() or 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_worker.py
+++ b/scripts/run_worker.py
@@ -1,0 +1,101 @@
+"""Celery worker entrypoint for the ``agenticorg-worker`` Cloud Run Service.
+
+Cloud Run Services require a process that listens on ``$PORT`` for HTTP.
+A bare ``celery worker`` doesn't — it long-polls the broker. This script
+serves a tiny ``/`` and ``/health`` HTTP endpoint on a background thread
+purely to satisfy the Cloud Run startup probe, then runs ``celery worker``
+in the foreground (so SIGTERM propagates cleanly during scale-down /
+revision swap).
+
+Why not a Cloud Run Job: workers are long-lived consumers of a broker
+queue. Jobs have a 1-hour ceiling and are designed for one-shot batch
+work. A Service with ``--min-instances=1 --no-cpu-throttling`` is the
+right primitive — it stays warm and CPU-active even without HTTP traffic.
+
+Queues consumed: every queue declared in
+``core.tasks.celery_app:task_routes`` plus the implicit default queue.
+Override with ``CELERY_QUEUES`` env var (comma-separated) for narrow
+worker pools.
+
+Local smoke test::
+
+    PORT=8080 python scripts/run_worker.py
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+DEFAULT_QUEUES = "celery,reports,maintenance,workflows,delivery,rpa"
+
+
+class _HealthHandler(BaseHTTPRequestHandler):
+    """Minimal health probe — only ever returns 200 once the process is
+    up. The worker's actual readiness (broker connection, task imports)
+    is logged by Celery; we don't need to expose it on /health because
+    Cloud Run revives the container if the process exits."""
+
+    def do_GET(self):  # noqa: N802 — BaseHTTPRequestHandler convention
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(b"ok\n")
+
+    def log_message(self, *_args, **_kwargs):
+        # Suppress access log spam — Cloud Run probes hit / every few seconds.
+        return
+
+
+def _serve_health() -> None:
+    port = int(os.environ.get("PORT", "8080"))
+    server = HTTPServer(("0.0.0.0", port), _HealthHandler)  # noqa: S104 — Cloud Run binds 0.0.0.0
+    server.serve_forever()
+
+
+def _run_celery_worker() -> int:
+    queues = os.environ.get("CELERY_QUEUES", DEFAULT_QUEUES)
+
+    # Importing the celery_app first makes any task-import error visible
+    # in the container logs immediately, instead of after Celery's own
+    # later registration step. Faster failure = faster rollback.
+    from core.tasks import celery_app  # noqa: F401, PLC0415
+
+    from celery.__main__ import main as celery_main  # noqa: PLC0415
+
+    # Inject the equivalent CLI ``celery -A core.tasks.celery_app worker ...``.
+    sys.argv = [
+        "celery",
+        "-A",
+        "core.tasks.celery_app",
+        "worker",
+        "--loglevel=info",
+        "--without-gossip",  # smaller mem footprint for single-replica setups
+        "--without-mingle",
+        "-Q",
+        queues,
+    ]
+    return celery_main()
+
+
+def main() -> int:
+    # Health server runs as a daemon thread so it dies cleanly when the
+    # main worker process exits. Celery worker runs in the foreground so
+    # signals (SIGTERM from Cloud Run scale-down) reach Celery directly
+    # and it shuts down gracefully — partially-processed tasks are NACK'd
+    # back to the broker.
+    threading.Thread(target=_serve_health, daemon=True).start()
+
+    # Be explicit about signal handling so a misconfigured signal handler
+    # in some imported module doesn't swallow SIGTERM. Default is fine
+    # for celery — just don't override it.
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+
+    return _run_celery_worker() or 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/regression/test_celery_runtime_wrappers.py
+++ b/tests/regression/test_celery_runtime_wrappers.py
@@ -1,0 +1,233 @@
+"""Pin the contract of ``scripts/run_worker.py`` and ``scripts/run_beat.py``.
+
+These wrappers exist because Cloud Run Services require an HTTP listener
+on ``$PORT``, but ``celery worker`` and ``celery beat`` are long-running
+broker daemons that don't serve HTTP. The wrappers add a minimal
+``HTTPServer`` on a daemon thread so the Cloud Run startup probe
+succeeds, then run celery in the foreground so SIGTERM propagates.
+
+Pinned behavior:
+- The wrappers import successfully (no syntax / module errors).
+- They reference ``core.tasks.celery_app`` so all 7 periodic tasks
+  register at startup.
+- ``run_worker.py`` invokes the ``celery worker`` subcommand with the
+  expected queue list (or the ``CELERY_QUEUES`` override).
+- ``run_beat.py`` invokes the ``celery beat`` subcommand.
+- Both wrappers serve a 200 ``ok`` response on ``/`` and ``/health``.
+- The wrappers don't accidentally swallow SIGTERM (Cloud Run uses it
+  to drain pods during scale-down / revision swap).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import threading
+import time
+from http.client import HTTPConnection
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _load_module(name: str, path: Path):
+    """Load a script as a module without executing its ``__main__`` block."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def run_worker_module():
+    return _load_module("run_worker", REPO / "scripts" / "run_worker.py")
+
+
+@pytest.fixture(scope="module")
+def run_beat_module():
+    return _load_module("run_beat", REPO / "scripts" / "run_beat.py")
+
+
+# ─────────────────────────────────────────────────────────────────
+# Module structure pins
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_run_worker_exports_main_and_health_handler(run_worker_module) -> None:
+    """The wrapper must expose ``main`` (Cloud Run entrypoint) and the
+    private health-server function so the deploy script + this test
+    can both reach them."""
+    assert callable(getattr(run_worker_module, "main", None))
+    assert callable(getattr(run_worker_module, "_serve_health", None))
+    assert callable(getattr(run_worker_module, "_run_celery_worker", None))
+
+
+def test_run_beat_exports_main_and_health_handler(run_beat_module) -> None:
+    assert callable(getattr(run_beat_module, "main", None))
+    assert callable(getattr(run_beat_module, "_serve_health", None))
+    assert callable(getattr(run_beat_module, "_run_celery_beat", None))
+
+
+def test_run_worker_imports_celery_app_and_uses_correct_celery_argv(
+    run_worker_module, monkeypatch
+) -> None:
+    """The wrapper must (a) successfully import ``core.tasks.celery_app``
+    so all task modules register, (b) build an argv that runs
+    ``celery worker -A core.tasks.celery_app`` with the right queue
+    list. Without this, the worker would idle on the wrong queues
+    and our beat-emitted tasks would never be consumed."""
+    captured_argv: list[list[str]] = []
+    captured_celery_main_calls: list[None] = []
+
+    def _fake_celery_main():
+        # Record the argv shape Celery would have used.
+        import sys as _sys  # noqa: PLC0415
+        captured_argv.append(list(_sys.argv))
+        captured_celery_main_calls.append(None)
+        return 0
+
+    # Stub out the celery CLI so we don't actually start a worker.
+    import celery.__main__ as celery_main_mod
+    monkeypatch.setattr(celery_main_mod, "main", _fake_celery_main)
+
+    rc = run_worker_module._run_celery_worker()
+    assert rc == 0
+    assert captured_celery_main_calls == [None]
+    assert len(captured_argv) == 1
+    argv = captured_argv[0]
+    assert argv[0] == "celery"
+    assert "-A" in argv and "core.tasks.celery_app" in argv
+    assert "worker" in argv
+    # All five queues used by celery_app.task_routes plus the implicit
+    # default — without ``celery`` (the default) the worker would skip
+    # tasks that don't carry an explicit queue routing.
+    queues_arg = argv[argv.index("-Q") + 1]
+    for q in ("celery", "reports", "maintenance", "workflows", "delivery", "rpa"):
+        assert q in queues_arg, f"queue {q!r} missing from -Q list"
+
+
+def test_run_worker_honors_celery_queues_env_override(
+    run_worker_module, monkeypatch
+) -> None:
+    """Operators can narrow the queue list via the ``CELERY_QUEUES``
+    env var (useful for splitting workers per workload)."""
+    monkeypatch.setenv("CELERY_QUEUES", "reports,workflows")
+    captured: list[str] = []
+
+    def _fake_celery_main():
+        import sys as _sys  # noqa: PLC0415
+        captured.append(_sys.argv[_sys.argv.index("-Q") + 1])
+        return 0
+
+    import celery.__main__ as celery_main_mod
+    monkeypatch.setattr(celery_main_mod, "main", _fake_celery_main)
+
+    run_worker_module._run_celery_worker()
+    assert captured == ["reports,workflows"]
+
+
+def test_run_beat_uses_correct_celery_argv(run_beat_module, monkeypatch) -> None:
+    captured_argv: list[list[str]] = []
+
+    def _fake_celery_main():
+        import sys as _sys  # noqa: PLC0415
+        captured_argv.append(list(_sys.argv))
+        return 0
+
+    import celery.__main__ as celery_main_mod
+    monkeypatch.setattr(celery_main_mod, "main", _fake_celery_main)
+
+    rc = run_beat_module._run_celery_beat()
+    assert rc == 0
+    argv = captured_argv[0]
+    assert argv[0] == "celery"
+    assert "-A" in argv and "core.tasks.celery_app" in argv
+    assert "beat" in argv
+
+
+# ─────────────────────────────────────────────────────────────────
+# HTTP health stub pin — Cloud Run startup probe contract
+# ─────────────────────────────────────────────────────────────────
+
+
+def _start_health_thread(serve_fn, port: int) -> threading.Thread:
+    t = threading.Thread(target=serve_fn, daemon=True)
+    t.start()
+    # Tiny wait for the listener to bind.
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        try:
+            conn = HTTPConnection("127.0.0.1", port, timeout=0.5)
+            conn.request("GET", "/")
+            resp = conn.getresponse()
+            resp.read()
+            conn.close()
+            return t
+        except OSError:
+            time.sleep(0.05)
+    pytest.fail("HTTP health server never started")
+
+
+def test_run_worker_health_stub_serves_200(run_worker_module, monkeypatch) -> None:
+    """Cloud Run probes the ``$PORT`` HTTP listener on startup. The stub
+    must respond 200 even before celery_app finishes registering tasks
+    (otherwise the container never reaches Ready)."""
+    port = 18021
+    monkeypatch.setenv("PORT", str(port))
+    _start_health_thread(run_worker_module._serve_health, port)
+
+    conn = HTTPConnection("127.0.0.1", port, timeout=2)
+    conn.request("GET", "/")
+    resp = conn.getresponse()
+    body = resp.read()
+    conn.close()
+
+    assert resp.status == 200
+    assert b"ok" in body
+
+
+def test_run_beat_health_stub_serves_200(run_beat_module, monkeypatch) -> None:
+    port = 18022
+    monkeypatch.setenv("PORT", str(port))
+    _start_health_thread(run_beat_module._serve_health, port)
+
+    conn = HTTPConnection("127.0.0.1", port, timeout=2)
+    conn.request("GET", "/health")
+    resp = conn.getresponse()
+    resp.read()
+    conn.close()
+
+    assert resp.status == 200
+
+
+# ─────────────────────────────────────────────────────────────────
+# Beat schedule registration — every periodic task that should
+# fire must be registered when celery_app loads
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_celery_beat_schedule_registers_all_seven_periodic_tasks() -> None:
+    """If the wrappers ship but a periodic task isn't registered with
+    beat, that task silently never runs. This pins every task that
+    was already in ``celery_app.beat_schedule`` plus the new
+    health-snapshot recorder."""
+    from core.tasks.celery_app import app
+
+    schedule = app.conf.beat_schedule
+    expected = {
+        "generate-scheduled-reports",
+        "cleanup-old-reports",
+        "run-budget-evaluator",
+        "refresh-expiring-tokens",
+        "generate-monthly-invoices",
+        "dispatch-due-rpa-schedules",
+        "shadow-reconciliation-report",
+        "record-health-snapshot",
+    }
+    missing = expected - set(schedule.keys())
+    assert not missing, (
+        f"Periodic tasks expected in beat_schedule are missing: {sorted(missing)}. "
+        "If a task was intentionally removed, update this test in the same PR."
+    )


### PR DESCRIPTION
## Summary

Closes the operational gap discovered while deploying PR #400 (per memory `celery_beat_not_deployed.md`): no `agenticorg-worker` or `agenticorg-beat` service runs in production, so every periodic task in `core.tasks.celery_app:beat_schedule` is silently dormant — token refresh, budget evaluator, monthly invoices, RPA dispatch, scheduled reports, shadow recon, plus PR #400's new health snapshot.

This PR ships the **wrapper code only**. The actual deploy is a separate `gcloud` step after merge (Cloud Run service creation, secret bindings, Cloud SQL annotation, signal-handling verification).

## Why a wrapper

Cloud Run Services require an HTTP listener on `$PORT` for startup probes. `celery worker` and `celery beat` are long-running broker daemons that don't serve HTTP. Each wrapper:

1. Starts a tiny `HTTPServer` on `$PORT` in a daemon thread (responds 200 to `/` and `/health` so Cloud Run's startup probe succeeds).
2. Eager-imports `core.tasks.celery_app` so task-registration errors surface in container logs **before** Celery's own startup (faster failure → faster rollback).
3. Runs `celery worker` / `celery beat` in the **foreground** so SIGTERM propagates cleanly — Cloud Run uses SIGTERM to drain pods during scale-down/revision swap.

## Why Cloud Run Services (not Jobs)

Workers long-poll the broker — they're consumers that need to stay warm. Cloud Run Jobs have a 1-hour ceiling and are designed for one-shot batch work, which would force a re-spin every hour with cold-start gaps. Services with `--min-instances=1 --no-cpu-throttling` keep workers warm continuously, and beat (which **must** be a singleton — concurrent beats produce duplicate triggers) gets `--min-instances=1 --max-instances=1`.

## Files

- **`scripts/run_worker.py`** — celery worker entrypoint, consumes `celery,reports,maintenance,workflows,delivery,rpa` (override via `CELERY_QUEUES` env var). Includes the implicit default `celery` queue so tasks without explicit routing aren't dropped.
- **`scripts/run_beat.py`** — celery beat scheduler entrypoint.
- **`tests/regression/test_celery_runtime_wrappers.py`** — 8 pins:
  - Module exports (`main`, `_serve_health`, `_run_celery_worker` / `_run_celery_beat`).
  - Celery argv shape — `-A core.tasks.celery_app worker -Q ...`.
  - `CELERY_QUEUES` env var override works.
  - HTTP stub returns 200 on `/` and `/health` (live socket binding, real HTTP request).
  - All 8 expected periodic tasks are registered in `beat_schedule` (regression-locks the dormant-tasks list).

## Pre-flight risk surfaced for the deploy step

Two periodic tasks (`dispatch_due_rpa_schedules`, `generate_scheduled_reports`) sweep DB rows with `next_run_at` in the past. Production may have **accumulated stale schedules over months of beat-not-running**. The first beat tick after deploy could dispatch a flurry.

**Mitigation in deploy procedure (NOT in this PR's code):**

1. Deploy `agenticorg-worker` first — workers consume from broker; with no beat running yet, broker stays empty so worker idles harmlessly.
2. Audit DB for past-due `next_run_at` rows in `scheduled_reports` + `rpa_schedules` before deploying beat.
3. Then deploy beat with eyes open.

Daily / monthly tasks (`cleanup-old-reports` daily 2am IST, `generate-monthly-invoices` 1st-of-month 1am IST, `shadow-reconciliation-report` Mon 8am IST) won't replay missed fires — Celery beat only schedules forward.

## Verification

- `pytest tests/regression/test_celery_runtime_wrappers.py` → **8 passed**
- Local preflight gate (12 checks: branch safety, ruff, mypy, bandit, alembic, verify=False, pytest regression+unit, tsc, ui build, consistency sweep, module coverage, critical-path tags) → **all 12 passed**

## Deploy commands (post-merge — manual gcloud per `feedback_deploy_pipeline_state.md`)

```bash
SHA=$(git rev-parse origin/main)
PROJECT=perfect-period-305406
REGION=asia-southeast1
REGISTRY=asia-south1-docker.pkg.dev/$PROJECT/agenticorg

# Worker (deploy first — idle-safe with no beat running)
gcloud run deploy agenticorg-worker --project=$PROJECT --region=$REGION \
  --image=$REGISTRY/agenticorg:$SHA \
  --command=python --args=scripts/run_worker.py \
  --set-cloudsql-instances=$PROJECT:$REGION:agenticorg-db-sg \
  --set-secrets=AGENTICORG_REDIS_URL=...,AGENTICORG_DB_URL=...,AGENTICORG_SECRET_KEY=... \
  --min-instances=1 --max-instances=3 \
  --no-cpu-throttling --no-allow-unauthenticated

# Beat (singleton — deploy after worker logs clean)
gcloud run deploy agenticorg-beat --project=$PROJECT --region=$REGION \
  --image=$REGISTRY/agenticorg:$SHA \
  --command=python --args=scripts/run_beat.py \
  --set-cloudsql-instances=$PROJECT:$REGION:agenticorg-db-sg \
  --set-secrets=AGENTICORG_REDIS_URL=...,AGENTICORG_DB_URL=...,AGENTICORG_SECRET_KEY=... \
  --min-instances=1 --max-instances=1 \
  --no-cpu-throttling --no-allow-unauthenticated
```

After both are up, `/health/checks` (PR #400) should flip from `data_source: live_snapshot` to `data_source: persisted` within 10 minutes — that's the user-visible signal that the loop is closed.

@codex please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)