### PR TITLE
fix(security): PR-B — CSRF middleware (double-submit cookie) for cookie-authed mutations

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -71,6 +71,7 @@ from api.v1 import (
     status as status_mod,
 )
 from api.websocket.feed import router as ws_feed_router
+from auth.csrf_middleware import CSRFMiddleware
 from auth.grantex_middleware import GrantexAuthMiddleware
 from bridge.server_handler import router as ws_bridge_router
 from core.config import settings
@@ -159,6 +160,14 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+# SEC-2026-05-P1-003: CSRF middleware sits BETWEEN CORS and the auth
+# middleware in the chain. Starlette runs ``add_middleware``-registered
+# middleware in reverse insertion order — the LAST add_middleware call
+# is the outermost (runs first on the request). So with this ordering:
+#   request flow: Deprecation → GrantexAuth → CSRF → CORS → route
+# CSRF runs AFTER auth (so it only checks already-validated requests)
+# and BEFORE the route handler.
+app.add_middleware(CSRFMiddleware)
 app.add_middleware(GrantexAuthMiddleware)
 app.add_middleware(DeprecationHeaderMiddleware)
 

--- a/api/v1/auth.py
+++ b/api/v1/auth.py
@@ -32,13 +32,18 @@ router = APIRouter(prefix="/auth", tags=["Auth"])
 
 
 def _set_session_cookie(response: Response, token: str, max_age_seconds: int) -> None:
-    """Set the HttpOnly session cookie used by the browser SPA.
+    """Set the HttpOnly session cookie + a paired CSRF token cookie.
 
     SECURITY_AUDIT-2026-04-19 CRITICAL-01 remediation: the access token
     is still returned in the JSON body so that API clients, SDKs, CI,
     and the SSO callback can continue to function, but the browser is
     encouraged to use the cookie. Frontend migration to cookie-only
     happens in a follow-up PR which removes ``localStorage`` writes.
+
+    SEC-2026-05-P1-003 (PR-B): every browser session also gets a
+    ``agenticorg_csrf`` cookie. Non-HttpOnly so the SPA can read it and
+    echo via ``X-CSRF-Token`` on mutating requests. Enforced by
+    ``auth/csrf_middleware.CSRFMiddleware``.
     """
     is_prod = os.getenv("AGENTICORG_ENV", "development").lower() == "production"
     response.set_cookie(
@@ -51,10 +56,20 @@ def _set_session_cookie(response: Response, token: str, max_age_seconds: int) ->
         path="/",
     )
 
+    # Pair a CSRF token cookie with every session cookie. The middleware
+    # only enforces when BOTH cookies are present, so issuing here ties
+    # CSRF protection automatically to the session lifecycle.
+    from auth.csrf import generate_csrf_token, set_csrf_cookie  # noqa: PLC0415
+
+    set_csrf_cookie(response, generate_csrf_token(), max_age_seconds=max_age_seconds)
+
 
 def _clear_session_cookie(response: Response) -> None:
-    """Clear the HttpOnly session cookie on logout."""
+    """Clear the HttpOnly session cookie + paired CSRF cookie on logout."""
     response.delete_cookie(key="agenticorg_session", path="/")
+    from auth.csrf import clear_csrf_cookie  # noqa: PLC0415
+
+    clear_csrf_cookie(response)
 
 
 # Signup rate limiting now in core.auth_state (Redis-backed)

--- a/auth/csrf.py
+++ b/auth/csrf.py
@@ -1,0 +1,85 @@
+"""CSRF token generation + cookie helpers (PR-B / SEC-2026-05-P1-003).
+
+The browser SPA authenticates via the HttpOnly ``agenticorg_session``
+cookie. SameSite=lax helps but is not a complete CSRF defense — it
+allows top-level GET/POST navigations from other origins, doesn't
+reliably cover legacy browsers, and breaks down around redirects /
+subdomain trust / payment flows.
+
+The double-submit cookie pattern below pairs the HttpOnly session
+cookie with a non-HttpOnly CSRF cookie + a header echo:
+
+  Login response sets:
+    Set-Cookie: agenticorg_session=...; HttpOnly; SameSite=Lax
+    Set-Cookie: agenticorg_csrf=<token>;            SameSite=Lax  ← JS-readable
+
+  SPA on every mutating fetch:
+    Cookie: agenticorg_session=...; agenticorg_csrf=<token>
+    X-CSRF-Token: <token>                                          ← from cookie
+
+  Server checks (csrf_middleware.py):
+    csrf cookie value == X-CSRF-Token header (constant-time compare)
+
+A cross-site forgery cannot read the victim's ``agenticorg_csrf``
+cookie (cross-origin reads are blocked by the SOP), so it cannot
+echo the value into the header. The session cookie alone is then
+useless for mutating requests.
+
+Bearer-token API clients (SDKs, CI, MCP) don't carry browser cookies,
+so they bypass this layer cleanly — covered explicitly in
+``csrf_middleware.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+from typing import Final
+
+from fastapi import Response
+
+CSRF_COOKIE_NAME: Final[str] = "agenticorg_csrf"
+CSRF_HEADER_NAME: Final[str] = "X-CSRF-Token"
+
+# 256-bit token. ``secrets.token_urlsafe(32)`` returns a 43-character
+# URL-safe base64 string — short enough to ship in headers, long
+# enough that brute-force is infeasible.
+_CSRF_TOKEN_BYTES: Final[int] = 32
+
+
+def generate_csrf_token() -> str:
+    """Return a fresh URL-safe random CSRF token.
+
+    Uses ``secrets`` (CSPRNG-backed) — never ``random`` (PRNG, predictable).
+    """
+    return secrets.token_urlsafe(_CSRF_TOKEN_BYTES)
+
+
+def set_csrf_cookie(response: Response, token: str, max_age_seconds: int = 86400) -> None:
+    """Attach the CSRF cookie to ``response``.
+
+    Pairs with ``api.v1.auth._set_session_cookie``. Two divergences from
+    the session cookie:
+
+    1. ``httponly=False`` — the SPA's Axios interceptor must read this
+       cookie to populate ``X-CSRF-Token`` on every mutating request.
+       That's the whole point of double-submit.
+    2. Same ``samesite='lax'`` + ``secure=is_prod`` — even though JS
+       reads it, the browser still won't ship it cross-origin in the
+       cases SameSite covers, providing defense-in-depth.
+    """
+    is_prod = os.getenv("AGENTICORG_ENV", "development").lower() == "production"
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=token,
+        max_age=max_age_seconds,
+        httponly=False,  # SPA reads this — the double-submit contract
+        secure=is_prod,
+        samesite="lax",
+        path="/",
+    )
+
+
+def clear_csrf_cookie(response: Response) -> None:
+    """Clear the CSRF cookie on logout. Mirrors session-cookie cleanup."""
+    response.delete_cookie(key=CSRF_COOKIE_NAME, path="/")

--- a/auth/csrf_middleware.py
+++ b/auth/csrf_middleware.py
@@ -1,0 +1,120 @@
+"""CSRF middleware — double-submit cookie enforcement for browser sessions.
+
+SEC-2026-05-P1-003 (docs/BRUTAL_SECURITY_SCAN_2026-05-01.md).
+
+This middleware enforces that every cookie-authenticated mutating request
+(POST / PUT / PATCH / DELETE) presents a matching ``X-CSRF-Token`` header
+whose value equals the ``agenticorg_csrf`` cookie value. See
+``auth/csrf.py`` for the rationale + token issuance.
+
+Bypass conditions (request unaffected):
+
+- Safe HTTP methods (GET, HEAD, OPTIONS) — no state change, no CSRF risk.
+- Pure bearer-token API clients — they don't carry the
+  ``agenticorg_session`` cookie, so they're not browser sessions and
+  CSRF doesn't apply. SDKs, CI, the MCP server, and any other non-
+  browser caller works unchanged.
+- Webhook endpoints — they have provider HMAC signing (or the
+  SEC-2026-05-P1-007 dev bypass guard for unsigned local dev). CSRF
+  on webhooks is the wrong defense for the wrong threat model.
+- Auth bootstrap endpoints — login / signup / SSO callback — there's
+  no prior session cookie to enforce against.
+
+The middleware is positioned AFTER auth in the request chain (it runs
+on already-authenticated requests) so we don't waste cycles checking
+CSRF on requests that will fail auth anyway. See ``api/main.py`` for
+the wiring order.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Final
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+from auth.csrf import CSRF_COOKIE_NAME, CSRF_HEADER_NAME
+
+_UNSAFE_METHODS: Final[frozenset[str]] = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+# Path PREFIXES that bypass CSRF. Each entry must have a non-CSRF
+# defense in place (HMAC signing, OAuth state, rate-limiting + auth
+# throttling, etc.) — list updates require justification in code review.
+_EXEMPT_PREFIXES: Final[tuple[str, ...]] = (
+    "/api/v1/webhooks/",          # provider HMAC signing
+    "/api/v1/billing/webhook/",   # Plural & Stripe HMAC
+    "/api/v1/aa/consent/callback",  # SEC-004 will sign this in PR-C
+)
+
+# Exact path EXEMPTIONS — auth bootstrap endpoints with no prior session.
+_EXEMPT_PATHS: Final[frozenset[str]] = frozenset({
+    "/api/v1/auth/login",
+    "/api/v1/auth/signup",
+    "/api/v1/auth/sso/callback",
+    "/api/v1/auth/sso/login",
+    "/api/v1/auth/refresh",       # session refresh — verified by refresh-cookie + token
+})
+
+# The session cookie name MUST stay in sync with ``api/v1/auth.py:
+# _set_session_cookie``. Centralizing as a constant so a future rename
+# breaks loudly here instead of silently disabling CSRF.
+_SESSION_COOKIE_NAME: Final[str] = "agenticorg_session"
+
+
+class CSRFMiddleware(BaseHTTPMiddleware):
+    """Enforce double-submit CSRF tokens on browser-cookie sessions.
+
+    The dispatch path is intentionally short — most requests bypass
+    cleanly (safe methods, bearer-token clients, webhooks, auth
+    bootstrap). Only cookie-authed mutating requests pay the cost of
+    the constant-time header compare.
+    """
+
+    async def dispatch(self, request: Request, call_next):  # noqa: ANN001
+        if request.method not in _UNSAFE_METHODS:
+            return await call_next(request)
+
+        path = request.url.path
+        if path in _EXEMPT_PATHS:
+            return await call_next(request)
+        if any(path.startswith(prefix) for prefix in _EXEMPT_PREFIXES):
+            return await call_next(request)
+
+        # Bearer-token API clients (no session cookie) bypass cleanly.
+        # CSRF is a browser-cookie defense; bearer tokens already
+        # require explicit per-request transport.
+        session_cookie = request.cookies.get(_SESSION_COOKIE_NAME)
+        if not session_cookie:
+            return await call_next(request)
+
+        # Cookie-authed mutating request — enforce.
+        csrf_cookie = request.cookies.get(CSRF_COOKIE_NAME)
+        if not csrf_cookie:
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "detail": (
+                        "Missing CSRF token cookie. Re-authenticate to "
+                        "receive a fresh token. (SEC-2026-05-P1-003)"
+                    ),
+                },
+            )
+
+        header_token = request.headers.get(CSRF_HEADER_NAME, "")
+        # Constant-time compare — avoid leaking token length / prefix
+        # via timing oracles.
+        if not secrets.compare_digest(csrf_cookie, header_token):
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "detail": (
+                        "CSRF token mismatch. The X-CSRF-Token header "
+                        "must equal the agenticorg_csrf cookie value. "
+                        "(SEC-2026-05-P1-003)"
+                    ),
+                },
+            )
+
+        return await call_next(request)

--- a/tests/regression/test_security_pr_b_csrf.py
+++ b/tests/regression/test_security_pr_b_csrf.py
@@ -1,0 +1,304 @@
+"""SEC-2026-05-P1-003 PR-B: CSRF middleware contract pins.
+
+Pin the double-submit cookie CSRF protection so the bug class — a
+cookie-authed mutating request without CSRF protection — can't recur.
+
+Tested behaviors:
+
+- Cookie-authed mutating request **without** ``X-CSRF-Token`` → 403.
+- Cookie-authed mutating request **with mismatched** ``X-CSRF-Token`` → 403.
+- Cookie-authed mutating request **with matching** token → bypasses CSRF
+  middleware (still hits auth / route logic).
+- Bearer-token API client with no cookie → bypasses CSRF cleanly.
+- Safe HTTP methods (GET, HEAD, OPTIONS) → bypass cleanly.
+- Webhook routes (``/api/v1/webhooks/...``) → bypass cleanly (HMAC).
+- Auth bootstrap routes (``/api/v1/auth/login``) → bypass (no prior session).
+- Login response sets the ``agenticorg_csrf`` cookie alongside the
+  ``agenticorg_session`` cookie.
+- The CSRF cookie is **non-HttpOnly** (the SPA must read it).
+- Constant-time compare is used (no timing oracle).
+
+Hermetic by design — uses Starlette's ``TestClient`` directly against a
+minimal test app with the CSRFMiddleware mounted, so we don't require
+the full FastAPI app + DB + auth stack to verify the middleware contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from auth.csrf import (
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+    clear_csrf_cookie,
+    generate_csrf_token,
+    set_csrf_cookie,
+)
+from auth.csrf_middleware import CSRFMiddleware
+
+# ─────────────────────────────────────────────────────────────────
+# Test app — minimal FastAPI + CSRFMiddleware, no auth/DB required
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    """A bare FastAPI app with only the CSRFMiddleware mounted, plus a
+    handful of routes spanning the bypass / enforcement matrix.
+    """
+    a = FastAPI()
+    a.add_middleware(CSRFMiddleware)
+
+    @a.get("/api/v1/some-resource")
+    def _get_resource():
+        return {"ok": True}
+
+    @a.post("/api/v1/some-resource")
+    def _post_resource():
+        return {"created": True}
+
+    @a.put("/api/v1/some-resource/{rid}")
+    def _put_resource(rid: str):
+        return {"updated": rid}
+
+    @a.delete("/api/v1/some-resource/{rid}")
+    def _delete_resource(rid: str):
+        return {"deleted": rid}
+
+    @a.post("/api/v1/webhooks/email/sendgrid")
+    def _webhook_sendgrid():
+        return {"webhook": "ok"}
+
+    @a.post("/api/v1/auth/login")
+    def _login():
+        return {"login": "ok"}
+
+    @a.post("/api/v1/auth/sso/callback")
+    def _sso_callback():
+        return {"sso": "ok"}
+
+    return a
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Bypass paths — these MUST not enforce CSRF
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_safe_methods_bypass_csrf(client: TestClient) -> None:
+    """GET / HEAD / OPTIONS never enforce CSRF — they don't change state."""
+    resp = client.get("/api/v1/some-resource")
+    assert resp.status_code == 200
+
+
+def test_bearer_token_client_bypasses_csrf(client: TestClient) -> None:
+    """No session cookie → no CSRF enforcement. SDKs / CI / MCP work
+    unchanged because they don't carry browser cookies."""
+    resp = client.post("/api/v1/some-resource", headers={"Authorization": "Bearer abc"})
+    assert resp.status_code == 200
+
+
+def test_webhook_routes_bypass_csrf(client: TestClient) -> None:
+    """Webhook routes have HMAC signing — CSRF doesn't apply."""
+    # Even with a session cookie + no CSRF token, webhook bypasses.
+    resp = client.post(
+        "/api/v1/webhooks/email/sendgrid",
+        cookies={"agenticorg_session": "fake-session-token"},
+        json=[{"event": "open"}],
+    )
+    assert resp.status_code == 200
+
+
+def test_login_route_bypasses_csrf(client: TestClient) -> None:
+    """Auth bootstrap — no prior session to enforce against."""
+    resp = client.post("/api/v1/auth/login", json={})
+    assert resp.status_code == 200
+
+
+def test_sso_callback_bypasses_csrf(client: TestClient) -> None:
+    """SSO callback can't carry a CSRF token (the OIDC redirect comes
+    from the IdP, not from our SPA)."""
+    resp = client.post("/api/v1/auth/sso/callback")
+    assert resp.status_code == 200
+
+
+# ─────────────────────────────────────────────────────────────────
+# Enforcement paths — cookie-authed mutating requests
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_cookie_authed_post_without_csrf_returns_403(client: TestClient) -> None:
+    """The core threat: an attacker site forces the victim's browser to
+    POST with the session cookie. Without the X-CSRF-Token (which the
+    attacker can't read), the server must refuse."""
+    resp = client.post(
+        "/api/v1/some-resource",
+        cookies={"agenticorg_session": "fake-session-token"},
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert "CSRF" in body["detail"]
+
+
+def test_cookie_authed_put_without_csrf_returns_403(client: TestClient) -> None:
+    """All unsafe methods are enforced — POST, PUT, PATCH, DELETE."""
+    resp = client.put(
+        "/api/v1/some-resource/abc",
+        cookies={"agenticorg_session": "fake-session-token"},
+    )
+    assert resp.status_code == 403
+
+
+def test_cookie_authed_delete_without_csrf_returns_403(client: TestClient) -> None:
+    resp = client.delete(
+        "/api/v1/some-resource/abc",
+        cookies={"agenticorg_session": "fake-session-token"},
+    )
+    assert resp.status_code == 403
+
+
+def test_cookie_authed_post_with_mismatched_csrf_returns_403(client: TestClient) -> None:
+    """A fixed/guessed/old token in the cookie that doesn't match the
+    header still fails — protects against cookie-fixation attacks
+    where an attacker tries to set a known CSRF cookie."""
+    resp = client.post(
+        "/api/v1/some-resource",
+        cookies={
+            "agenticorg_session": "fake-session-token",
+            CSRF_COOKIE_NAME: "cookie-value",
+        },
+        headers={CSRF_HEADER_NAME: "header-value-different"},
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert "mismatch" in body["detail"].lower()
+
+
+def test_cookie_authed_post_with_only_cookie_no_header_returns_403(
+    client: TestClient,
+) -> None:
+    """The double-submit pattern requires BOTH the cookie and the
+    matching header. Cookie alone is insufficient — that's the
+    state of any cross-site forged request."""
+    resp = client.post(
+        "/api/v1/some-resource",
+        cookies={
+            "agenticorg_session": "fake-session-token",
+            CSRF_COOKIE_NAME: "valid-token",
+        },
+        # No X-CSRF-Token header
+    )
+    assert resp.status_code == 403
+
+
+def test_cookie_authed_post_with_matching_csrf_passes_middleware(
+    client: TestClient,
+) -> None:
+    """Happy path: cookie value == header value → middleware passes the
+    request to the route. The 200 from the test route confirms CSRF
+    didn't block it.
+    """
+    token = generate_csrf_token()
+    resp = client.post(
+        "/api/v1/some-resource",
+        cookies={
+            "agenticorg_session": "fake-session-token",
+            CSRF_COOKIE_NAME: token,
+        },
+        headers={CSRF_HEADER_NAME: token},
+    )
+    assert resp.status_code == 200
+
+
+def test_session_cookie_without_csrf_cookie_returns_403(client: TestClient) -> None:
+    """A session cookie present but CSRF cookie missing means the
+    user's session predates the CSRF rollout (or the cookie was
+    cleared client-side). Re-auth required — fail closed."""
+    resp = client.post(
+        "/api/v1/some-resource",
+        cookies={"agenticorg_session": "fake-session-token"},
+        headers={CSRF_HEADER_NAME: "anything"},
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert "missing" in body["detail"].lower()
+
+
+# ─────────────────────────────────────────────────────────────────
+# Cookie issuance — login flow sets the CSRF cookie
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_set_csrf_cookie_writes_non_httponly_cookie() -> None:
+    """The CSRF cookie MUST be readable from JS — the SPA's interceptor
+    needs to copy it into the X-CSRF-Token header on mutating
+    requests. HttpOnly would break the entire double-submit pattern.
+    """
+    from fastapi import Response
+
+    response = Response()
+    set_csrf_cookie(response, "test-token-value", max_age_seconds=3600)
+    cookie_header = response.headers.get("set-cookie", "")
+    assert "agenticorg_csrf=test-token-value" in cookie_header
+    # Critical: must NOT have HttpOnly (case-insensitive — Starlette
+    # may emit either "HttpOnly" or "httponly").
+    assert "httponly" not in cookie_header.lower()
+    # Should still have SameSite=lax for defense in depth
+    assert "samesite=lax" in cookie_header.lower()
+
+
+def test_clear_csrf_cookie_emits_deletion_header() -> None:
+    """Logout must clear the CSRF cookie too — orphaned tokens shouldn't
+    persist after the session ends."""
+    from fastapi import Response
+
+    response = Response()
+    clear_csrf_cookie(response)
+    cookie_header = response.headers.get("set-cookie", "")
+    assert "agenticorg_csrf=" in cookie_header
+    # An expired cookie has Max-Age=0 / past Expires.
+    assert (
+        "Max-Age=0" in cookie_header
+        or "max-age=0" in cookie_header
+        or "1970" in cookie_header
+        or "expires=" in cookie_header.lower()
+    )
+
+
+def test_generate_csrf_token_is_csprng_backed() -> None:
+    """Tokens MUST come from ``secrets``, not ``random`` — predictable
+    tokens make the whole defense pointless. Verify by checking the
+    distribution is sufficiently random and tokens don't repeat.
+    """
+    tokens = {generate_csrf_token() for _ in range(100)}
+    # 100 tokens, each 256 bits — the probability of any collision is
+    # effectively 0. If we see < 100 unique values, generation is broken.
+    assert len(tokens) == 100
+    # Each token is at least 32 chars (32 bytes urlsafe-b64 = 43 chars).
+    for t in tokens:
+        assert len(t) >= 32
+
+
+def test_constant_time_compare_used() -> None:
+    """Pin that ``secrets.compare_digest`` is the comparison primitive.
+    A regular ``==`` would leak the matching prefix length via timing,
+    letting an attacker discover the token byte-by-byte (Bleichenbacher-
+    style). The pin grep-checks the source so a future refactor can't
+    silently downgrade the check.
+    """
+    from pathlib import Path
+
+    src = (
+        Path(__file__).resolve().parents[2] / "auth" / "csrf_middleware.py"
+    ).read_text(encoding="utf-8")
+    assert "secrets.compare_digest" in src, (
+        "auth/csrf_middleware.py must use secrets.compare_digest for the "
+        "token comparison — a regular == leaks token bytes via timing."
+    )

--- a/tests/unit/test_auth_and_core.py
+++ b/tests/unit/test_auth_and_core.py
@@ -188,7 +188,17 @@ class TestLogout:
             result = await logout(mock_request, mock_response)
             mock_blacklist.assert_called_once_with("some-token-value")
             assert result == {"status": "logged_out"}
-            mock_response.delete_cookie.assert_called_once()
+            # SEC-2026-05-P1-003 (PR-B): logout now clears BOTH the
+            # HttpOnly session cookie AND the paired CSRF cookie. An
+            # orphaned CSRF cookie post-logout is a stale token that
+            # should never have been left in place.
+            assert mock_response.delete_cookie.call_count == 2
+            cookie_keys = {
+                call.kwargs.get("key") or (call.args[0] if call.args else None)
+                for call in mock_response.delete_cookie.call_args_list
+            }
+            assert "agenticorg_session" in cookie_keys
+            assert "agenticorg_csrf" in cookie_keys
 
     @pytest.mark.asyncio
     async def test_logout_missing_header(self):

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -2,10 +2,44 @@ import axios from "axios";
 const API_BASE = import.meta.env.VITE_API_URL
   ? `${import.meta.env.VITE_API_URL}/api/v1`
   : "/api/v1";
-const api = axios.create({ baseURL: API_BASE, timeout: 30000 });
+// withCredentials=true is required so the browser ships the
+// agenticorg_session + agenticorg_csrf cookies on every request, even
+// for cross-origin deploys (VITE_API_URL set). Without this the
+// cookies stay on the document and CSRF middleware sees the request
+// as a bearer-only client.
+const api = axios.create({
+  baseURL: API_BASE,
+  timeout: 30000,
+  withCredentials: true,
+});
+
+// SEC-2026-05-P1-003 (PR-B): read the CSRF token from the
+// agenticorg_csrf cookie and echo it back via X-CSRF-Token on every
+// mutating request. The double-submit pattern relies on this — the
+// server compares the cookie value against the header value with a
+// constant-time check. ``document.cookie`` is the only JS-readable
+// store; the session cookie remains HttpOnly and stays unreadable.
+function readCookie(name: string): string {
+  const match = document.cookie.match(
+    new RegExp("(?:^|; )" + name.replace(/[$()*+./?[\]\\^{|}]/g, "\\$&") + "=([^;]*)"),
+  );
+  return match ? decodeURIComponent(match[1]) : "";
+}
+
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem("token");
   if (token) config.headers.Authorization = `Bearer ${token}`;
+
+  // CSRF: only attach for mutating methods. The server-side middleware
+  // exempts safe methods + bearer-only API clients, but sending the
+  // header on a GET is harmless and aligns with future hardening.
+  const method = (config.method || "get").toLowerCase();
+  if (method === "post" || method === "put" || method === "patch" || method === "delete") {
+    const csrf = readCookie("agenticorg_csrf");
+    if (csrf) {
+      config.headers["X-CSRF-Token"] = csrf;
+    }
+  }
   return config;
 });
 


### PR DESCRIPTION
## Summary

Closes **SEC-2026-05-P1-003** from `docs/BRUTAL_SECURITY_SCAN_2026-05-01.md`.

The browser SPA authenticates via the HttpOnly `agenticorg_session` cookie. `SameSite=lax` helps but isn't a complete CSRF defense — top-level POSTs from other origins still ship the cookie, and complex SSO/payment redirects can break SameSite assumptions. Once browser auth becomes cookie-first (PR-F), CSRF becomes a hard release blocker.

This PR ships the **double-submit cookie pattern** so PR-F can land cleanly later.

## How it works

Login response sets **both** cookies:

```
Set-Cookie: agenticorg_session=...; HttpOnly; SameSite=Lax   ← JS-unreadable
Set-Cookie: agenticorg_csrf=<token>;            SameSite=Lax  ← JS-readable
```

The SPA's Axios interceptor copies `agenticorg_csrf` from `document.cookie` into an `X-CSRF-Token` header on every mutating request. Server middleware does a constant-time compare (`secrets.compare_digest`) of cookie vs header and returns 403 on mismatch. A cross-site attacker can't read the victim's `agenticorg_csrf` cookie (cross-origin reads blocked by SOP), so they can't forge the header.

## Files

- **`auth/csrf.py`** — `secrets.token_urlsafe(32)` token generation (256-bit) + cookie set/clear helpers. CSRF cookie is non-HttpOnly **by design** (the SPA must read it for the double-submit pattern).
- **`auth/csrf_middleware.py`** — `CSRFMiddleware`. Bypasses safe methods (GET/HEAD/OPTIONS), bearer-only API clients (no session cookie), webhook routes (HMAC), and auth bootstrap (login/signup/sso/refresh).
- **`api/v1/auth.py`** — `_set_session_cookie` now sets the paired CSRF cookie automatically. `_clear_session_cookie` clears both. Every login/signup/refresh path gets CSRF protection by default.
- **`api/main.py`** — middleware wired between CORS and GrantexAuth. Starlette runs `add_middleware`-registered middleware in reverse insertion order, so this places CSRF *after* auth (only validated requests pay the check) and *before* the route.
- **`ui/src/lib/api.ts`** — `withCredentials: true` on the Axios instance (cookies ship cross-origin when `VITE_API_URL` is set), plus an interceptor that reads `agenticorg_csrf` from `document.cookie` and echoes it on POST/PUT/PATCH/DELETE.
- **`tests/unit/test_auth_and_core.py::TestLogout::test_logout_success`** — updated to pin the new contract (logout deletes BOTH cookies).

## Regression pins (16 new tests)

`tests/regression/test_security_pr_b_csrf.py`:

**Bypass behaviors (5)** — must NOT enforce CSRF:
- Safe methods (GET / HEAD / OPTIONS)
- Bearer-only API clients (no session cookie)
- Webhook routes (`/api/v1/webhooks/...`)
- Auth bootstrap (`/api/v1/auth/login`, `/api/v1/auth/sso/callback`)

**Enforcement behaviors (7)** — MUST 403 on cookie-authed mutations:
- POST/PUT/DELETE without `X-CSRF-Token`
- Mismatched cookie vs header
- Cookie present, header missing
- Session cookie without paired CSRF cookie (orphaned session)
- Matching token → middleware passes (200 from test route)

**Cookie issuance (3)**:
- `set_csrf_cookie` writes a non-HttpOnly cookie
- `clear_csrf_cookie` emits a deletion header
- `generate_csrf_token` is CSPRNG-backed (100 unique 256-bit tokens, no collisions)

**Timing-safety pin (1)**:
- Source-grep that `secrets.compare_digest` is the comparison primitive (so a future `==` regression can't sneak in and create a timing oracle)

## Verification

- `pytest tests/regression/test_security_pr_b_csrf.py + test_security_pr_a_pins.py + tests/unit/test_auth_and_core.py::TestLogout + test_tier1_features::TestWebhookParsing` → **32 passed**
- Local preflight (12 gates: branch safety, ruff, mypy, bandit, alembic, verify=False, pytest regression+unit, tsc, ui build, consistency sweep, module coverage, critical-path tags) → **all 12 passed**

## Out of scope (still queued)

- **PR-C**: AA callback HMAC signing + replay protection + durable consent state (SEC-004 + SEC-015 partial)
- **PR-D**: file ingestion streaming + bounded parsers (SEC-005)
- **PR-E**: RPA egress allowlist + DNS rebinding defense (SEC-006)
- **PR-F**: localStorage → cookie auth migration (SEC-002, biggest scope — this PR's CSRF foundation makes cookie-only viable)
- **PR-G**: CSP tightening + image digest pinning + Bandit/Ruff CI gates (SEC-009/010/011 remainder)
- **PR-H**: strict env validation + public endpoint review (SEC-012/013)

@codex please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)