### PR TITLE
fix(security): PR-C — AA callback HMAC signing + replay protection (SEC-2026-05-P1-004)

### DIFF
--- a/api/v1/aa_callback.py
+++ b/api/v1/aa_callback.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import ValidationError
 
 from api.deps import get_current_tenant
+from auth.aa_callback_signing import (
+    NONCE_HEADER,
+    SIGNATURE_HEADER,
+    TIMESTAMP_HEADER,
+    verify_aa_callback,
+)
 from connectors.finance.aa_consent_types import AACallbackPayload
 
 logger = structlog.get_logger()
@@ -27,13 +35,75 @@ def _get_consent_manager(tenant_id: str):
     return _consent_managers[tenant_id]
 
 
-@router.post("/consent/callback")
-async def consent_callback(payload: AACallbackPayload) -> dict[str, str]:
-    """Webhook endpoint called by Finvu when consent status changes.
+def _get_redis():
+    """Lazy Redis client for nonce replay store. Mirrors api/v1/webhooks._get_redis."""
+    import os
 
-    This is a public endpoint (no auth) — Finvu sends callbacks here
-    after the user approves/rejects consent on their UI.
+    import redis.asyncio as aioredis
+
+    url = os.getenv("AGENTICORG_REDIS_URL", "redis://localhost:6379/1")
+    return aioredis.from_url(url, decode_responses=True)
+
+
+@router.post("/consent/callback")
+async def consent_callback(request: Request) -> dict[str, str]:
+    """Webhook endpoint called by AA providers (Finvu / Setu) when
+    consent status changes.
+
+    SEC-2026-05-P1-004 (PR-C): every inbound callback MUST carry a
+    valid HMAC-SHA256 signature, a fresh timestamp, and a previously-
+    unseen nonce. The endpoint is still public (the auth middleware
+    exempts it because the AA provider has no JWT to send), but it
+    is no longer unauthenticated — the HMAC IS the authentication.
+
+    Returns:
+      - 200 with ``{"status": "ok", ...}`` on a valid, non-replayed callback.
+      - 403 if the signature/secret/timestamp/nonce is missing or invalid.
+      - 409 if the nonce has been seen before (replay).
     """
+    raw_body = await request.body()
+
+    # Verify signature + timestamp + nonce BEFORE parsing the body
+    # into a Pydantic model. Don't even let an attacker probe Pydantic
+    # error shapes via unsigned requests.
+    redis_client = _get_redis()
+    try:
+        verdict = await verify_aa_callback(
+            timestamp_header=request.headers.get(TIMESTAMP_HEADER),
+            nonce_header=request.headers.get(NONCE_HEADER),
+            signature_header=request.headers.get(SIGNATURE_HEADER),
+            body=raw_body,
+            redis_client=redis_client,
+        )
+    finally:
+        # Best-effort close — don't raise if Redis was unreachable
+        # during the verify call.
+        try:
+            await redis_client.close()
+        except Exception as _close_exc:  # noqa: BLE001, S110 — close failures are non-fatal
+            logger.debug("aa_callback_redis_close_failed", error=str(_close_exc))
+
+    if verdict == "replay":
+        logger.warning(
+            "aa_consent_callback_replay_blocked",
+            nonce=request.headers.get(NONCE_HEADER),
+        )
+        raise HTTPException(status_code=409, detail="callback replayed")
+    if verdict != "ok":
+        logger.warning(
+            "aa_consent_callback_signature_invalid",
+            verdict=verdict,
+            timestamp=request.headers.get(TIMESTAMP_HEADER),
+        )
+        raise HTTPException(status_code=403, detail=f"callback rejected: {verdict}")
+
+    # Now safe to parse the body.
+    try:
+        payload = AACallbackPayload(**json.loads(raw_body))
+    except (ValidationError, json.JSONDecodeError) as exc:
+        logger.warning("aa_consent_callback_bad_payload", error=str(exc))
+        raise HTTPException(status_code=400, detail="invalid payload") from exc
+
     logger.info(
         "aa_consent_callback_received",
         consent_handle=payload.consent_handle,

--- a/auth/aa_callback_signing.py
+++ b/auth/aa_callback_signing.py
@@ -1,0 +1,219 @@
+"""Account Aggregator consent callback signing + replay protection.
+
+SEC-2026-05-P1-004 (docs/BRUTAL_SECURITY_SCAN_2026-05-01.md). Before
+this module, ``api/v1/aa_callback.py`` accepted Finvu/Setu callback
+payloads on a public endpoint with no HMAC, no timestamp, no nonce,
+and no replay protection. A guessed/leaked/replayed ``consent_handle``
+could forge consent lifecycle state — high-stakes because the AA flow
+authorizes financial-data fetches.
+
+This module brings AA callbacks to the same signed-webhook discipline
+as ``api/v1/webhooks.py`` (SendGrid/Mailchimp/MoEngage), with two
+extras the audit specifically asked for:
+
+1. **Timestamp freshness**: rejects requests with timestamps more than
+   ``MAX_TIMESTAMP_SKEW_SECONDS`` outside the server clock window.
+2. **Nonce replay protection**: every accepted nonce is recorded in
+   Redis with TTL = 2 × the skew window. A replayed nonce inside the
+   freshness window returns 409 (conflict — already processed).
+
+Signature scheme (matches the SendGrid pattern but with explicit
+nonce + version prefix so we can rotate the algorithm without
+ambiguity):
+
+    canonical_string = f"v1.{timestamp}.{nonce}.{raw_body_bytes_decoded}"
+    signature        = HMAC-SHA256(secret, canonical_string).hexdigest()
+
+Headers expected on the request:
+
+    X-AA-Timestamp: <unix_seconds>
+    X-AA-Nonce:     <opaque random string, max 128 chars>
+    X-AA-Signature: v1=<hex>
+
+Secret: ``AGENTICORG_AA_CALLBACK_SECRET`` env var. Like the other
+webhook secrets, the dev bypass ``AGENTICORG_WEBHOOK_ALLOW_UNSIGNED=1``
+opens the gate ONLY in local/dev/test envs (PR-A's env-guard already
+prevents misconfig in staging/production).
+
+Per-tenant secrets are a future hardening — the AA spec lets each
+tenant onboard their own provider partner, so a per-tenant secret
+table is the right long-term shape. PR-C ships the platform-shared
+secret (matches every other webhook in the codebase today) and leaves
+the per-tenant migration as a follow-up.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import time
+from typing import Final, Literal
+
+import structlog
+
+logger = structlog.get_logger()
+
+TIMESTAMP_HEADER: Final[str] = "X-AA-Timestamp"
+NONCE_HEADER: Final[str] = "X-AA-Nonce"
+SIGNATURE_HEADER: Final[str] = "X-AA-Signature"
+
+# Sites that issue AA callbacks (Finvu, Setu) typically retry within a
+# 5 minute window. Reject anything outside ±300s to keep the replay
+# attack surface tight while tolerating reasonable clock skew.
+MAX_TIMESTAMP_SKEW_SECONDS: Final[int] = 300
+
+# Nonce TTL in Redis. 2× the skew window so a replayed nonce inside the
+# acceptable timestamp window is always caught. After this TTL, the
+# timestamp check itself rejects the message — replay defense reduces
+# to timestamp freshness, which is correct.
+NONCE_TTL_SECONDS: Final[int] = 2 * MAX_TIMESTAMP_SKEW_SECONDS
+
+NONCE_MAX_LENGTH: Final[int] = 128
+SIGNATURE_VERSION: Final[str] = "v1"
+
+
+def _get_secret() -> str:
+    """Return the configured AA callback HMAC secret.
+
+    Empty string means no secret is configured. Callers fail closed
+    on empty unless the dev-bypass env-guard is open (local/dev/test
+    only — see ``api/v1/webhooks.py::_enforce_unsigned_bypass_env_guard``).
+    """
+    return os.getenv("AGENTICORG_AA_CALLBACK_SECRET", "").strip()
+
+
+def _local_dev_envs() -> frozenset[str]:
+    """Re-export the envs where the unsigned bypass is honored.
+
+    Single source of truth lives in ``api.v1.webhooks._LOCAL_DEV_ENVS``
+    so a future env-list change applies uniformly.
+    """
+    from api.v1.webhooks import _LOCAL_DEV_ENVS  # noqa: PLC0415
+
+    return _LOCAL_DEV_ENVS
+
+
+def _dev_bypass_active() -> bool:
+    """True iff ``AGENTICORG_WEBHOOK_ALLOW_UNSIGNED=1`` AND env is local/dev/test.
+
+    Mirrors ``api/v1/webhooks._dev_allow_unsigned`` exactly — same
+    flag, same env-guard, no separate AA-specific knob to misconfigure.
+    """
+    if os.getenv("AGENTICORG_WEBHOOK_ALLOW_UNSIGNED") != "1":
+        return False
+    env = (os.getenv("AGENTICORG_ENV") or "").strip().lower()
+    return env in _local_dev_envs()
+
+
+def _canonical_string(timestamp: str, nonce: str, body: bytes) -> bytes:
+    """Compose the bytes that get signed.
+
+    ``v1.<timestamp>.<nonce>.<body>`` — version prefix lets us rotate
+    the algorithm without breaking older signatures (the verifier
+    inspects the prefix on the X-AA-Signature header).
+    """
+    body_str = body.decode("utf-8", errors="strict")
+    return f"{SIGNATURE_VERSION}.{timestamp}.{nonce}.{body_str}".encode()
+
+
+def _compute_signature(secret: str, timestamp: str, nonce: str, body: bytes) -> str:
+    """Return the hex-encoded HMAC-SHA256 of the canonical string."""
+    canonical = _canonical_string(timestamp, nonce, body)
+    digest = hmac.new(secret.encode("utf-8"), canonical, hashlib.sha256).hexdigest()
+    return f"{SIGNATURE_VERSION}={digest}"
+
+
+VerifyResult = Literal[
+    "ok",
+    "missing_signature",
+    "missing_secret",
+    "bad_signature",
+    "stale_timestamp",
+    "replay",
+    "bad_nonce",
+]
+
+
+async def verify_aa_callback(
+    *,
+    timestamp_header: str | None,
+    nonce_header: str | None,
+    signature_header: str | None,
+    body: bytes,
+    redis_client,  # type: ignore[no-untyped-def]  # noqa: ANN001 — duck-typed Redis
+    now: float | None = None,
+) -> VerifyResult:
+    """Verify an inbound AA callback. Returns one of:
+
+    - ``"ok"``: signature valid, timestamp fresh, nonce never seen → caller proceeds.
+    - ``"missing_signature"``: required headers absent → 403.
+    - ``"missing_secret"``: ``AGENTICORG_AA_CALLBACK_SECRET`` unset and
+      dev bypass not active → 403 (fail closed).
+    - ``"bad_signature"``: HMAC mismatch → 403.
+    - ``"stale_timestamp"``: outside the freshness window → 403.
+    - ``"replay"``: nonce already in Redis → 409.
+    - ``"bad_nonce"``: nonce shape invalid (empty, too long, not ASCII) → 403.
+
+    All paths are best-effort tolerant of Redis outages: if Redis is
+    unreachable, replay defense degrades to timestamp-freshness only
+    (the message must still be within the 5-minute window). This is
+    the right tradeoff — refusing all callbacks during a Redis blip
+    would lose live consent updates with no security benefit (a
+    replayer would still need a fresh timestamp + valid HMAC).
+    """
+    secret = _get_secret()
+    if not secret:
+        if _dev_bypass_active():
+            logger.warning(
+                "aa_callback_secret_unset_dev_bypass",
+                note="AGENTICORG_AA_CALLBACK_SECRET unset; dev bypass active",
+            )
+            return "ok"
+        logger.error(
+            "aa_callback_secret_unset",
+            hint="Set AGENTICORG_AA_CALLBACK_SECRET. Fails closed in non-local envs.",
+        )
+        return "missing_secret"
+
+    if not timestamp_header or not nonce_header or not signature_header:
+        return "missing_signature"
+
+    # Validate nonce shape — protects against a Redis key explosion
+    # via huge attacker-supplied nonces.
+    nonce = nonce_header.strip()
+    if not nonce or len(nonce) > NONCE_MAX_LENGTH or not nonce.isascii():
+        return "bad_nonce"
+
+    # Timestamp freshness.
+    try:
+        ts = int(timestamp_header.strip())
+    except (TypeError, ValueError):
+        return "stale_timestamp"
+    current = now if now is not None else time.time()
+    if abs(current - ts) > MAX_TIMESTAMP_SKEW_SECONDS:
+        return "stale_timestamp"
+
+    # Constant-time signature compare. Constructing ``expected`` first
+    # keeps the timing flat regardless of where the input mismatches.
+    expected = _compute_signature(secret, str(ts), nonce, body)
+    if not hmac.compare_digest(expected, signature_header.strip()):
+        return "bad_signature"
+
+    # Replay check — best effort. Use SET NX EX for atomic
+    # "set-if-absent + expire" semantics. ``set(..., nx=True, ex=TTL)``
+    # returns ``True`` when the nonce is fresh, ``None`` when it
+    # already existed (replay).
+    nonce_key = f"aa_callback_nonce:{nonce}"
+    try:
+        was_set = await redis_client.set(nonce_key, "1", nx=True, ex=NONCE_TTL_SECONDS)
+        if was_set is None:
+            return "replay"
+    except Exception as exc:  # noqa: BLE001 — Redis blip ≠ refuse all callbacks
+        logger.warning(
+            "aa_callback_replay_store_unavailable",
+            error=str(exc),
+            note="Falling through to timestamp-freshness-only defense",
+        )
+
+    return "ok"

--- a/tests/regression/test_security_pr_c_aa_callback_signing.py
+++ b/tests/regression/test_security_pr_c_aa_callback_signing.py
@@ -1,0 +1,431 @@
+"""SEC-2026-05-P1-004 PR-C: AA callback signing + replay protection pins.
+
+Pins the HMAC-SHA256 + timestamp-freshness + nonce-replay defense for
+the Account Aggregator consent callback so the bug class — a public,
+unsigned callback that updates financial-consent state — can't recur.
+
+Tested behaviors:
+
+- Unsigned callback (missing all three headers) → 403.
+- Wrong-secret signature → 403.
+- Stale timestamp (outside ±5 min) → 403.
+- Replayed nonce → 409.
+- Bad nonce shape (empty / too long / non-ASCII) → 403.
+- Missing AGENTICORG_AA_CALLBACK_SECRET in non-local env → 403 (fail closed).
+- Dev bypass works in local/dev/test env (matches PR-A's env-guard).
+- Valid signed callback → ``ok`` verdict (caller proceeds to parse body).
+- Constant-time compare is used (source-grep).
+
+Hermetic by design — no real Redis, no real AA provider. Uses an
+in-memory async fake that implements only the Redis ``set(key, value,
+nx=True, ex=...)`` semantics ``verify_aa_callback`` relies on.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+
+import pytest
+
+from auth.aa_callback_signing import (
+    MAX_TIMESTAMP_SKEW_SECONDS,
+    NONCE_TTL_SECONDS,
+    SIGNATURE_VERSION,
+    _compute_signature,
+    verify_aa_callback,
+)
+
+# ─────────────────────────────────────────────────────────────────
+# Test fixtures: fake Redis + signed-request builder
+# ─────────────────────────────────────────────────────────────────
+
+
+class _FakeRedis:
+    """Minimal async Redis double that supports set(nx=, ex=) atomically.
+
+    Real Redis ``SET k v NX EX <ttl>`` is atomic — the fake replicates
+    that contract for our replay test by holding a dict + recording
+    seen keys. TTL is stored but not enforced (tests are fast enough
+    that no key would expire mid-test).
+    """
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+        self.fail_next: bool = False
+
+    async def set(self, key: str, value: str, nx: bool = False, ex: int | None = None):
+        if self.fail_next:
+            self.fail_next = False
+            raise RuntimeError("simulated redis blip")
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        # Treat ex as advisory — fake doesn't expire keys.
+        _ = ex
+        return True
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest.fixture
+def redis_client():
+    return _FakeRedis()
+
+
+@pytest.fixture(autouse=True)
+def _set_aa_secret(monkeypatch: pytest.MonkeyPatch):
+    """Ensure every test starts with a known-good AA secret + test env.
+
+    Tests that explicitly want the secret unset / bypass active
+    monkeypatch from there.
+    """
+    monkeypatch.setenv("AGENTICORG_AA_CALLBACK_SECRET", "test-aa-secret-value")
+    monkeypatch.setenv("AGENTICORG_ENV", "test")
+    monkeypatch.delenv("AGENTICORG_WEBHOOK_ALLOW_UNSIGNED", raising=False)
+
+
+def _signed_request(
+    body: bytes = b'{"consent_handle":"abc","consent_status":"ACTIVE"}',
+    timestamp: int | None = None,
+    nonce: str = "test-nonce-001",
+    secret: str = "test-aa-secret-value",  # noqa: S107 — test fixture, not a real credential
+) -> tuple[str, str, str, bytes]:
+    """Return (timestamp_header, nonce_header, signature_header, body) for a valid request."""
+    ts = str(timestamp if timestamp is not None else int(time.time()))
+    sig = _compute_signature(secret, ts, nonce, body)
+    return ts, nonce, sig, body
+
+
+# ─────────────────────────────────────────────────────────────────
+# Happy path
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_valid_signed_callback_returns_ok(redis_client: _FakeRedis) -> None:
+    ts, nonce, sig, body = _signed_request()
+    verdict = await verify_aa_callback(
+        timestamp_header=ts,
+        nonce_header=nonce,
+        signature_header=sig,
+        body=body,
+        redis_client=redis_client,
+    )
+    assert verdict == "ok"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Missing / malformed input → 403 verdicts
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unsigned_callback_returns_missing_signature(redis_client: _FakeRedis) -> None:
+    """All three headers absent → caller returns 403."""
+    verdict = await verify_aa_callback(
+        timestamp_header=None,
+        nonce_header=None,
+        signature_header=None,
+        body=b"{}",
+        redis_client=redis_client,
+    )
+    assert verdict == "missing_signature"
+
+
+@pytest.mark.asyncio
+async def test_only_signature_header_returns_missing_signature(
+    redis_client: _FakeRedis,
+) -> None:
+    """One header present, others missing — still 403."""
+    verdict = await verify_aa_callback(
+        timestamp_header="123",
+        nonce_header=None,
+        signature_header="v1=deadbeef",
+        body=b"{}",
+        redis_client=redis_client,
+    )
+    assert verdict == "missing_signature"
+
+
+@pytest.mark.asyncio
+async def test_wrong_secret_signature_returns_bad_signature(
+    redis_client: _FakeRedis, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Compute signature with a different secret → bad_signature."""
+    ts, nonce, _good_sig, body = _signed_request()
+    bad_sig = _compute_signature("different-secret", ts, nonce, body)
+    verdict = await verify_aa_callback(
+        timestamp_header=ts,
+        nonce_header=nonce,
+        signature_header=bad_sig,
+        body=body,
+        redis_client=redis_client,
+    )
+    assert verdict == "bad_signature"
+
+
+@pytest.mark.asyncio
+async def test_tampered_body_returns_bad_signature(
+    redis_client: _FakeRedis,
+) -> None:
+    """Body changed after signing → bad_signature. Pins that the body
+    is part of the canonical string (not just headers)."""
+    ts, nonce, sig, _good_body = _signed_request()
+    tampered_body = b'{"consent_handle":"DIFFERENT","consent_status":"ACTIVE"}'
+    verdict = await verify_aa_callback(
+        timestamp_header=ts,
+        nonce_header=nonce,
+        signature_header=sig,
+        body=tampered_body,
+        redis_client=redis_client,
+    )
+    assert verdict == "bad_signature"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Timestamp freshness
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stale_timestamp_returns_stale_timestamp(redis_client: _FakeRedis) -> None:
+    """Timestamp older than the skew window → stale_timestamp."""
+    old_ts = int(time.time()) - (MAX_TIMESTAMP_SKEW_SECONDS + 60)
+    ts, nonce, sig, body = _signed_request(timestamp=old_ts)
+    verdict = await verify_aa_callback(
+        timestamp_header=ts,
+        nonce_header=nonce,
+        signature_header=sig,
+        body=body,
+        redis_client=redis_client,
+    )
+    assert verdict == "stale_timestamp"
+
+
+@pytest.mark.asyncio
+async def test_future_timestamp_outside_window_returns_stale(redis_client: _FakeRedis) -> None:
+    """Timestamps too far in the FUTURE are also rejected — protects
+    against attacker-controlled clocks."""
+    future_ts = int(time.time()) + (MAX_TIMESTAMP_SKEW_SECONDS + 60)
+    ts, nonce, sig, body = _signed_request(timestamp=future_ts)
+    verdict = await verify_aa_callback(
+        timestamp_header=ts,
+        nonce_header=nonce,
+        signature_header=sig,
+        body=body,
+        redis_client=redis_client,
+    )
+    assert verdict == "stale_timestamp"
+
+
+@pytest.mark.asyncio
+async def test_garbage_timestamp_returns_stale(redis_client: _FakeRedis) -> None:
+    """Non-numeric timestamp → stale_timestamp (not 500 / not bad_signature)."""
+    _, nonce, sig, body = _signed_request()
+    verdict = await verify_aa_callback(
+        timestamp_header="not-a-number",
+        nonce_header=nonce,
+        signature_header=sig,
+        body=body,
+        redis_client=redis_client,
+    )
+    assert verdict == "stale_timestamp"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Nonce shape + replay defense
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_empty_nonce_returns_missing_signature(redis_client: _FakeRedis) -> None:
+    """An empty header is treated the same as a missing one — falls
+    into ``missing_signature`` before the nonce-shape check. That's
+    correct: empty is functionally absent, not 'bad_nonce'."""
+    ts, _nonce, _sig, body = _signed_request(nonce="")
+    sig = _compute_signature("test-aa-secret-value", ts, "", body)
+    verdict = await verify_aa_callback(
+        timestamp_header=ts,
+        nonce_header="",
+        signature_header=sig,
+        body=body,
+        redis_client=redis_client,
+    )
+    assert verdict == "missing_signature"
+
+
+@pytest.mark.asyncio
+async def test_non_ascii_nonce_returns_bad_nonce(redis_client: _FakeRedis) -> None:
+    """Non-ASCII nonce → bad_nonce. Pins that the shape check runs
+    after the presence check."""
+    bad_nonce = "néonce"  # contains non-ASCII char
+    ts, _, _, body = _signed_request(nonce=bad_nonce)
+    sig = _compute_signature("test-aa-secret-value", ts, bad_nonce, body)
+    verdict = await verify_aa_callback(
+        timestamp_header=ts,
+        nonce_header=bad_nonce,
+        signature_header=sig,
+        body=body,
+        redis_client=redis_client,
+    )
+    assert verdict == "bad_nonce"
+
+
+@pytest.mark.asyncio
+async def test_overlong_nonce_returns_bad_nonce(redis_client: _FakeRedis) -> None:
+    """Nonce > 128 chars → bad_nonce. Protects Redis key namespace
+    against attacker key-explosion attempts."""
+    long_nonce = "a" * 200
+    ts, _, _, body = _signed_request(nonce=long_nonce)
+    sig = _compute_signature("test-aa-secret-value", ts, long_nonce, body)
+    verdict = await verify_aa_callback(
+        timestamp_header=ts,
+        nonce_header=long_nonce,
+        signature_header=sig,
+        body=body,
+        redis_client=redis_client,
+    )
+    assert verdict == "bad_nonce"
+
+
+@pytest.mark.asyncio
+async def test_replayed_nonce_returns_replay(redis_client: _FakeRedis) -> None:
+    """Same nonce twice in the freshness window → second call is replay."""
+    ts, nonce, sig, body = _signed_request()
+
+    first = await verify_aa_callback(
+        timestamp_header=ts,
+        nonce_header=nonce,
+        signature_header=sig,
+        body=body,
+        redis_client=redis_client,
+    )
+    assert first == "ok"
+
+    # Same nonce, same body — second attempt is a replay.
+    second = await verify_aa_callback(
+        timestamp_header=ts,
+        nonce_header=nonce,
+        signature_header=sig,
+        body=body,
+        redis_client=redis_client,
+    )
+    assert second == "replay"
+
+
+@pytest.mark.asyncio
+async def test_redis_outage_falls_back_to_timestamp_only(
+    redis_client: _FakeRedis,
+) -> None:
+    """Redis unreachable → degrade to timestamp-freshness defense, do
+    NOT refuse all callbacks. Pins the explicit best-effort design
+    note in verify_aa_callback's docstring."""
+    redis_client.fail_next = True
+    ts, nonce, sig, body = _signed_request()
+    verdict = await verify_aa_callback(
+        timestamp_header=ts,
+        nonce_header=nonce,
+        signature_header=sig,
+        body=body,
+        redis_client=redis_client,
+    )
+    # Replay defense degraded but the timestamp + signature checks
+    # still passed — caller proceeds.
+    assert verdict == "ok"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Secret-missing fail-closed + dev-bypass behavior
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_missing_secret_in_test_env_without_bypass_returns_missing_secret(
+    redis_client: _FakeRedis, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``AGENTICORG_AA_CALLBACK_SECRET`` unset + bypass not active →
+    missing_secret (caller returns 403). Fails CLOSED."""
+    monkeypatch.delenv("AGENTICORG_AA_CALLBACK_SECRET", raising=False)
+    monkeypatch.delenv("AGENTICORG_WEBHOOK_ALLOW_UNSIGNED", raising=False)
+    ts, nonce, sig, body = _signed_request()
+    verdict = await verify_aa_callback(
+        timestamp_header=ts,
+        nonce_header=nonce,
+        signature_header=sig,
+        body=body,
+        redis_client=redis_client,
+    )
+    assert verdict == "missing_secret"
+
+
+@pytest.mark.asyncio
+async def test_missing_secret_in_local_with_bypass_returns_ok(
+    redis_client: _FakeRedis, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Local dev with the bypass flag → secret unset is acceptable.
+    Mirrors the SendGrid/Mailchimp/MoEngage convention."""
+    monkeypatch.delenv("AGENTICORG_AA_CALLBACK_SECRET", raising=False)
+    monkeypatch.setenv("AGENTICORG_ENV", "local")
+    monkeypatch.setenv("AGENTICORG_WEBHOOK_ALLOW_UNSIGNED", "1")
+    ts, nonce, sig, body = _signed_request()
+    verdict = await verify_aa_callback(
+        timestamp_header=ts,
+        nonce_header=nonce,
+        signature_header=sig,
+        body=body,
+        redis_client=redis_client,
+    )
+    assert verdict == "ok"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Source pins — protect the contract from silent regression
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_signing_module_uses_constant_time_compare() -> None:
+    """SEC-2026-05-P1-004: a regular ``==`` on the signature would leak
+    bytes via timing. Pin that ``hmac.compare_digest`` is the only
+    primitive used."""
+    from pathlib import Path
+
+    src = (
+        Path(__file__).resolve().parents[2] / "auth" / "aa_callback_signing.py"
+    ).read_text(encoding="utf-8")
+    assert "hmac.compare_digest" in src
+    # Forbid a literal ``signature == expected`` style anywhere.
+    forbidden = ("signature == ", "expected == ", "== signature_header", "== expected")
+    for needle in forbidden:
+        assert needle not in src, (
+            f"auth/aa_callback_signing.py contains forbidden pattern "
+            f"{needle!r} — use hmac.compare_digest for constant-time compare."
+        )
+
+
+def test_canonical_string_includes_version_prefix() -> None:
+    """Pin that the signature scheme is versioned. The ``v1.`` prefix
+    lets us rotate the algorithm later (e.g. add a body-hash step)
+    without ambiguity — the verifier checks the prefix on the
+    signature header."""
+    sig = _compute_signature("k", "1700000000", "abc", b"body")
+    assert sig.startswith(f"{SIGNATURE_VERSION}=")
+
+
+def test_signature_is_hmac_sha256() -> None:
+    """Defensive pin: confirm the algorithm matches the docstring + the
+    SendGrid pattern. Future contributors can't silently swap in
+    SHA-1 / MD5 without breaking this test."""
+    body = b"hello"
+    expected = hmac.new(b"k", b"v1.1700000000.n.hello", hashlib.sha256).hexdigest()
+    actual = _compute_signature("k", "1700000000", "n", body)
+    assert actual == f"{SIGNATURE_VERSION}={expected}"
+
+
+def test_nonce_ttl_covers_2x_skew_window() -> None:
+    """The replay-store TTL must be ≥ 2× the timestamp skew so a
+    replay inside the freshness window can't slip through after the
+    nonce key expires."""
+    assert NONCE_TTL_SECONDS >= 2 * MAX_TIMESTAMP_SKEW_SECONDS


### PR DESCRIPTION
## Summary

Closes **SEC-2026-05-P1-004** from `docs/BRUTAL_SECURITY_SCAN_2026-05-01.md`.

The Account Aggregator consent callback (`api/v1/aa_callback.py`) was a **public** endpoint with **no HMAC, no signature, no timestamp, no nonce, and no replay protection**. A guessed/leaked/replayed `consent_handle` could forge consent lifecycle state — high-stakes because the AA flow authorizes financial-data fetches.

## Defense

HMAC-SHA256 over the canonical string `v1.<timestamp>.<nonce>.<body>`, signed with `AGENTICORG_AA_CALLBACK_SECRET`. Three headers expected:

```
X-AA-Timestamp: <unix_seconds>
X-AA-Nonce:     <opaque, ASCII, ≤128 chars>
X-AA-Signature: v1=<hex>
```

Plus three operational defenses on top of the HMAC:

- **Timestamp freshness**: ±300s skew window. Outside → 403 `stale_timestamp`.
- **Nonce replay protection**: every accepted nonce recorded in Redis with TTL = 600s (2× skew). Replayed nonce inside the freshness window → 409.
- **Best-effort replay store**: Redis blip degrades gracefully to timestamp-only defense (still requires fresh timestamp + valid HMAC — no security loss, just no double-fire dedup during the outage).

## Discipline pins (so the scheme can't silently regress)

- **Constant-time compare** — `hmac.compare_digest`. Source-grep test forbids `==` on signature/expected.
- **Versioned signature scheme** — `v1.` prefix lets the algorithm rotate later without ambiguity.
- **Algorithm pin** — explicit assertion that the digest is HMAC-SHA256 (not silently downgraded to SHA-1/MD5).
- **TTL invariant** — nonce TTL ≥ 2× timestamp skew, otherwise a replay inside the freshness window could slip through after the nonce key expires.
- **Fail closed** — secret unset in non-local env → 403 `missing_secret`. Local dev with `AGENTICORG_WEBHOOK_ALLOW_UNSIGNED=1` honored only when `AGENTICORG_ENV ∈ {local, dev, test}` (matches PR-A's env-guard).

## Files

- **`auth/aa_callback_signing.py`** (new, ~190 lines) — `verify_aa_callback()` returns one of 7 verdicts: `ok`, `missing_signature`, `missing_secret`, `bad_signature`, `stale_timestamp`, `replay`, `bad_nonce`. Caller maps verdict → HTTP code.
- **`api/v1/aa_callback.py`** — endpoint reads raw body via `Request`, runs verification **before** Pydantic parsing (no error-shape leak to unsigned probes), maps `replay` → 409 / others → 403, then proceeds to the consent manager.
- **`tests/regression/test_security_pr_c_aa_callback_signing.py`** (new, ~370 lines) — **19 pins** covering happy path, all 6 failure verdicts, body-tampering rejection, future-timestamp rejection, garbage-timestamp rejection, Redis-outage graceful degradation, secret-missing fail-closed, dev-bypass behavior, and 4 source pins (constant-time compare, versioned signature, HMAC-SHA256 algorithm, TTL ≥ 2× skew).

## Verification

- `pytest tests/regression/test_security_pr_c_aa_callback_signing.py` → **19 passed**
- Local preflight (12 gates) → **all 12 passed**
- `mypy --ignore-missing-imports` → clean
- `bandit -ll -iii` → 0 findings under api/auth/core/scripts

## Out of scope (deferred)

- **SEC-015 partial — durable consent state.** The audit also asked for moving the in-memory `_consent_managers` dict to a tenant-scoped DB table. That's an architecture refactor on top of an `AAConsentManager` class with its own state. Closing the SEC-004 P1 (unsigned/public callback) is the urgent risk; the durability refactor is its own PR.
- **Per-tenant secrets.** Today's pattern matches every other webhook in this codebase (single platform-shared secret). Per-tenant secrets need the durable state migration first.

## Roadmap (still queued)

- **PR-D**: file ingestion streaming + bounded parsers (SEC-005)
- **PR-E**: RPA egress allowlist + DNS rebinding defense (SEC-006)
- **PR-F**: localStorage → cookie auth migration (SEC-002, biggest scope; PR-B's CSRF foundation makes it viable)
- **PR-G**: CSP tightening + image digest pinning + Bandit/Ruff CI gates
- **PR-H**: strict env validation + public endpoint review

@codex please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)