### PR TITLE
fix(security): PR-G — hardening sweep (SEC-010/011/012/013)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3.14-slim AS builder
+# SEC-010: production base images pinned by digest to keep rebuilds
+# reproducible. Refresh via scripts/refresh_image_digests.sh after a
+# Renovate/Dependabot bump confirms upstream is safe.
+# python:3.14-slim @ 2026-05-01
+FROM python:3.14-slim@sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033 AS builder
 WORKDIR /app
 # Build deps for Pillow (required by presidio) and other C extensions
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -23,7 +27,7 @@ RUN pip install --upgrade pip && pip install --no-cache-dir ".[v4]"
 # smallest English model into the image so PII redaction actually runs.
 RUN python -m spacy download en_core_web_sm
 
-FROM python:3.14-slim
+FROM python:3.14-slim@sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl libjpeg62-turbo zlib1g \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,4 +1,7 @@
-FROM node:25-slim AS builder
+# SEC-010: production base images pinned by digest. Refresh via
+# scripts/refresh_image_digests.sh after a Renovate/Dependabot bump.
+# node:25-slim @ 2026-05-01
+FROM node:25-slim@sha256:e49fd70491eb042270f974167c874d6245287263ffc16422fcf93b3c150409d8 AS builder
 WORKDIR /app
 COPY ui/package.json ui/package-lock.json* ./
 RUN npm install --legacy-peer-deps
@@ -11,7 +14,8 @@ ARG VITE_GA4_ID=""
 ENV VITE_GA4_ID=$VITE_GA4_ID
 RUN npm run build
 
-FROM nginx:alpine
+# nginx:alpine @ 2026-05-01
+FROM nginx:alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY ui/nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/Dockerfile.ui.cloudrun
+++ b/Dockerfile.ui.cloudrun
@@ -1,4 +1,7 @@
-FROM node:25-slim AS builder
+# SEC-010: production base images pinned by digest. Refresh via
+# scripts/refresh_image_digests.sh after a Renovate/Dependabot bump.
+# node:25-slim @ 2026-05-01
+FROM node:25-slim@sha256:e49fd70491eb042270f974167c874d6245287263ffc16422fcf93b3c150409d8 AS builder
 WORKDIR /app
 COPY ui/package.json ui/package-lock.json* ./
 RUN npm install --legacy-peer-deps
@@ -10,7 +13,8 @@ ARG VITE_GA4_ID=""
 ENV VITE_GA4_ID=$VITE_GA4_ID
 RUN npm run build
 
-FROM nginx:alpine
+# nginx:alpine @ 2026-05-01
+FROM nginx:alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY ui/nginx.cloudrun.conf.template /etc/nginx/templates/default.conf.template
 ENV NGINX_ENVSUBST_FILTER='^(API_BACKEND_HOST|PORT)$'

--- a/api/v1/evals.py
+++ b/api/v1/evals.py
@@ -1,4 +1,12 @@
-"""Evaluation scorecard endpoints — public, no auth required."""
+"""Evaluation scorecard endpoints — public, no auth required.
+
+SEC-013 (2026-05-01): the baseline fallback is now flagged with a
+top-level ``data_quality: "demo"`` field AND an ``X-Data-Quality:
+demo`` response header so customer dashboards (and enterprise security
+reviewers) can distinguish optimistic baseline numbers from actual
+measured benchmark output. Real scorecards are flagged
+``data_quality: "measured"``.
+"""
 
 from __future__ import annotations
 
@@ -6,7 +14,7 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Response
 
 router = APIRouter()
 
@@ -67,26 +75,32 @@ _DEFAULT_SCORECARD: dict = {
 }
 
 
-def _load_scorecard() -> dict:
+def _load_scorecard() -> tuple[dict, str]:
     """Load the most recent scorecard from disk, or return a baseline.
 
-    Previously raised 404 when the scorecard file was missing, which
-    blanked the public /evals page. Now falls back to a baseline so
-    the page always renders while the runner is pending.
+    Returns ``(scorecard, data_quality)`` where ``data_quality`` is
+    ``"measured"`` when the on-disk scorecard was loaded successfully,
+    or ``"demo"`` when the baseline fallback was served. Callers should
+    use ``data_quality`` to set the response's ``X-Data-Quality``
+    header (SEC-013).
     """
     if not _SCORECARD_PATH.exists():
         baseline = dict(_DEFAULT_SCORECARD)
         baseline["served_at"] = datetime.now(UTC).isoformat()
-        return baseline
+        baseline["data_quality"] = "demo"
+        return baseline, "demo"
     try:
         with open(_SCORECARD_PATH, encoding="utf-8") as f:
-            return json.load(f)
+            scorecard = json.load(f)
+        scorecard["data_quality"] = "measured"
+        return scorecard, "measured"
     except (OSError, json.JSONDecodeError) as exc:
         # If the on-disk file is corrupt, still don't blank the page.
         baseline = dict(_DEFAULT_SCORECARD)
         baseline["_load_error"] = str(exc)
         baseline["served_at"] = datetime.now(UTC).isoformat()
-        return baseline
+        baseline["data_quality"] = "demo"
+        return baseline, "demo"
 
 
 def _require_scorecard() -> dict:
@@ -104,13 +118,21 @@ def _require_scorecard() -> dict:
 
 
 @router.get("/evals")
-async def get_evals():
-    """Return the full evaluation scorecard."""
-    return _load_scorecard()
+async def get_evals(response: Response):
+    """Return the full evaluation scorecard.
+
+    SEC-013: response always includes ``data_quality`` in the body and
+    an ``X-Data-Quality`` header so dashboards (and security review
+    tooling) can distinguish baseline demo numbers from measured
+    benchmark output.
+    """
+    scorecard, data_quality = _load_scorecard()
+    response.headers["X-Data-Quality"] = data_quality
+    return scorecard
 
 
 @router.get("/evals/agent/{agent_type}")
-async def get_agent_evals(agent_type: str):
+async def get_agent_evals(agent_type: str, response: Response):
     """Return scores for a single agent type."""
     # Use the strict loader so callers asking for a specific agent
     # still get an honest 404 when no real measurements exist.
@@ -122,8 +144,10 @@ async def get_agent_evals(agent_type: str):
 
     case_results = [c for c in scorecard.get("case_results", []) if c["agent_type"] == agent_type]
 
+    response.headers["X-Data-Quality"] = "measured"
     return {
         "agent_type": agent_type,
         "aggregate": agent_agg,
         "cases": case_results,
+        "data_quality": "measured",
     }

--- a/core/config.py
+++ b/core/config.py
@@ -55,26 +55,56 @@ class Settings(BaseSettings):
     default_confidence_floor: float = 0.88
     max_agent_retries: int = 3
 
+    # SEC-012: every environment except local / dev / test is treated
+    # as strict. Staging is internet-accessible, used for demos, pilots,
+    # and enterprise security review — weak staging secrets become real
+    # incidents when staging has production-like integrations.
+    _STRICT_ENVS = frozenset({"production", "prod", "staging", "stage", "preview"})
+    _RELAXED_ENVS = frozenset({"local", "dev", "development", "test", "ci"})
+
     @model_validator(mode="after")
     def validate_production_secret(self) -> Settings:
-        """Prevent accidental use of development fallbacks in production."""
-        if self.env.lower() == "production":
-            if self.secret_key == "dev-only-secret-key":
-                raise ValueError(
-                    "AGENTICORG_SECRET_KEY must be explicitly set in production"
-                )
-            # Refuse to start with the dev DB URL — would silently use localhost
-            # with default credentials, causing data loss or auth bypass.
-            if "agenticorg_dev@localhost" in self.db_url:
-                raise ValueError(
-                    "AGENTICORG_DB_URL must be explicitly set in production "
-                    "(detected dev fallback with localhost credentials)"
-                )
-            if "localhost" in self.redis_url:
-                raise ValueError(
-                    "AGENTICORG_REDIS_URL must be explicitly set in production "
-                    "(detected localhost fallback)"
-                )
+        """Reject development fallbacks in any non-relaxed environment.
+
+        Strict envs (production, staging, preview) MUST set
+        AGENTICORG_SECRET_KEY, AGENTICORG_DB_URL, AGENTICORG_REDIS_URL
+        to explicit non-default values. Default placeholders, dev
+        credentials, and localhost-pinned URLs all fail closed.
+
+        Secret length is also enforced: minimum 32 chars (≈192 bits of
+        entropy) so JWT/HMAC operations don't operate over weak keys.
+        """
+        env_l = self.env.lower()
+        is_strict = env_l in self._STRICT_ENVS
+        # Anything not explicitly relaxed AND not explicitly strict
+        # ALSO fails strict — defaults to safe.
+        is_unknown = env_l not in self._RELAXED_ENVS and not is_strict
+        if not (is_strict or is_unknown):
+            return self
+
+        env_label = self.env  # preserve original casing in error msg
+        if self.secret_key == "dev-only-secret-key":
+            raise ValueError(
+                f"AGENTICORG_SECRET_KEY must be explicitly set in env={env_label!r} "
+                "(default 'dev-only-secret-key' is rejected outside local/dev/test)"
+            )
+        if len(self.secret_key) < 32:
+            raise ValueError(
+                f"AGENTICORG_SECRET_KEY must be at least 32 chars in env={env_label!r} "
+                f"(got {len(self.secret_key)}); JWT/HMAC need ≥192 bits of entropy"
+            )
+        # Refuse to start with the dev DB URL — would silently use localhost
+        # with default credentials, causing data loss or auth bypass.
+        if "agenticorg_dev@localhost" in self.db_url:
+            raise ValueError(
+                f"AGENTICORG_DB_URL must be explicitly set in env={env_label!r} "
+                "(detected dev fallback with localhost credentials)"
+            )
+        if "localhost" in self.redis_url or "127.0.0.1" in self.redis_url:
+            raise ValueError(
+                f"AGENTICORG_REDIS_URL must be explicitly set in env={env_label!r} "
+                "(detected localhost fallback)"
+            )
         return self
 
 

--- a/scripts/refresh_image_digests.sh
+++ b/scripts/refresh_image_digests.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SEC-010: regenerate digest pins for production base images.
+#
+# Run when Renovate / Dependabot bumps a base image AND CI image scan
+# (Trivy/Grype) confirms upstream is safe. Edits Dockerfile,
+# Dockerfile.ui, Dockerfile.ui.cloudrun in place — diff before commit.
+#
+# Usage:
+#   bash scripts/refresh_image_digests.sh
+#
+# Requires: curl, python3 (for JSON parsing). No docker daemon needed.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+resolve_digest() {
+    # Args: <library/image> <tag>
+    # Prints the linux/amd64 image digest from Docker Hub's public API.
+    local repo="$1" tag="$2"
+    curl -fsSL "https://hub.docker.com/v2/repositories/${repo}/tags/${tag}/" \
+      | python -c "
+import json, sys
+d = json.load(sys.stdin)
+print(d.get('digest', ''))
+"
+}
+
+declare -A IMAGES=(
+    ["python:3.14-slim"]="library/python|3.14-slim|Dockerfile"
+    ["node:25-slim"]="library/node|25-slim|Dockerfile.ui Dockerfile.ui.cloudrun"
+    ["nginx:alpine"]="library/nginx|alpine|Dockerfile.ui Dockerfile.ui.cloudrun"
+)
+
+echo "[refresh_image_digests] Resolving current digests from Docker Hub..."
+date -u +"=== %Y-%m-%dT%H:%M:%SZ ==="
+
+for label in "${!IMAGES[@]}"; do
+    IFS='|' read -r repo tag files <<< "${IMAGES[$label]}"
+    digest=$(resolve_digest "$repo" "$tag")
+    if [[ -z "$digest" ]]; then
+        echo "[refresh_image_digests] FAILED to resolve $label" >&2
+        exit 1
+    fi
+    printf "  %-25s -> %s\n" "$label" "$digest"
+    for f in $files; do
+        if [[ ! -f "$f" ]]; then
+            echo "[refresh_image_digests] missing file $f" >&2
+            continue
+        fi
+        # Replace any existing pin (with or without digest) to the new digest.
+        # Pattern: FROM ${tag}                       -> tag-only
+        #          FROM ${tag}@sha256:...             -> already pinned
+        sed -i -E "s|^(FROM ${repo#library/}:${tag})(@sha256:[a-f0-9]+)?(.*)$|\1@${digest}\3|" "$f"
+    done
+done
+
+echo "[refresh_image_digests] Done. Diff:"
+git diff --stat -- Dockerfile Dockerfile.ui Dockerfile.ui.cloudrun

--- a/scripts/run_beat.py
+++ b/scripts/run_beat.py
@@ -48,7 +48,11 @@ class _HealthHandler(BaseHTTPRequestHandler):
 
 def _serve_health() -> None:
     port = int(os.environ.get("PORT", "8080"))
-    server = HTTPServer(("0.0.0.0", port), _HealthHandler)  # noqa: S104
+    # nosec B104 — Cloud Run requires the container to bind 0.0.0.0 so
+    # the managed load balancer can reach the listening port. Container
+    # is already isolated behind the Cloud Run network boundary; only
+    # ingress that the platform routes can reach this socket.
+    server = HTTPServer(("0.0.0.0", port), _HealthHandler)  # noqa: S104  # nosec B104
     server.serve_forever()
 
 

--- a/scripts/run_worker.py
+++ b/scripts/run_worker.py
@@ -52,7 +52,11 @@ class _HealthHandler(BaseHTTPRequestHandler):
 
 def _serve_health() -> None:
     port = int(os.environ.get("PORT", "8080"))
-    server = HTTPServer(("0.0.0.0", port), _HealthHandler)  # noqa: S104 — Cloud Run binds 0.0.0.0
+    # nosec B104 — Cloud Run requires the container to bind 0.0.0.0 so
+    # the managed load balancer can reach the listening port. Container
+    # is already isolated behind the Cloud Run network boundary; only
+    # ingress that the platform routes can reach this socket.
+    server = HTTPServer(("0.0.0.0", port), _HealthHandler)  # noqa: S104  # nosec B104
     server.serve_forever()
 
 

--- a/tests/regression/test_pr_fixes_april2026.py
+++ b/tests/regression/test_pr_fixes_april2026.py
@@ -47,20 +47,41 @@ class TestSecretKeyHardening:
             Settings(env="production", secret_key="dev-only-secret-key", _env_file=None)
 
     def test_staging_with_explicit_key_works(self):
-        """Staging with a real secret key should work."""
+        """Staging with a real ≥32-char secret key + non-localhost
+        URLs works.
+
+        SEC-012 (PR-G, 2026-05-01) tightened this rule: staging is
+        now strict (was previously relaxed), and the secret_key must
+        be ≥32 chars (was ≥16). Staging is internet-accessible and
+        used for enterprise security review — weak staging defaults
+        become real incidents when the env has production-like
+        integrations.
+        """
         from core.config import Settings
 
-        s = Settings(env="staging", secret_key="a-real-production-secret-key-here")
-        assert s.secret_key == "a-real-production-secret-key-here"
+        secret = "a-real-production-secret-key-here-32-plus-chars"  # 47 chars
+        s = Settings(
+            env="staging",
+            secret_key=secret,
+            db_url="postgresql+asyncpg://app:pw@db.staging.internal:5432/agenticorg",
+            redis_url="redis://redis.staging.internal:6379/0",
+        )
+        assert s.secret_key == secret
 
     def test_production_with_explicit_key_works(self):
-        """Production with a real secret key should work."""
+        """Production with a real ≥32-char secret key + non-localhost
+        URLs works.
+
+        SEC-012 (PR-G) raised the secret_key minimum from 16 to 32
+        chars (≥192 bits entropy floor for JWT/HMAC).
+        """
         from core.config import Settings
 
-        # Production also requires explicit non-localhost db/redis URLs
+        # Production requires explicit non-localhost db/redis URLs
+        # AND a secret_key of at least 32 chars (was 16 before PR-G).
         s = Settings(
             env="production",
-            secret_key="prod-secret-minimum-16-chars",
+            secret_key="prod-secret-key-with-32-or-more-chars-here",
             db_url="postgresql+asyncpg://app:pw@db.prod.internal:5432/agenticorg",
             redis_url="redis://redis.prod.internal:6379/0",
         )

--- a/tests/regression/test_security_pr_g_hardening_sweep.py
+++ b/tests/regression/test_security_pr_g_hardening_sweep.py
@@ -1,0 +1,303 @@
+"""PR-G regression pins for the 2026-05-01 security hardening sweep.
+
+Closes:
+
+- SEC-010 (P2): production base image digest pinning.
+- SEC-011 (P2): Bandit medium clean (run_beat / run_worker bind-all
+  noqa annotations carry both Ruff S104 and Bandit B104).
+- SEC-012 (P2): strict env validation rejects dev-default secrets
+  outside local/dev/test, requires ≥32-char secret_key, and treats
+  unknown environments as strict (default-safe).
+- SEC-013 (P2): /api/v1/evals returns ``data_quality`` in the body
+  AND an ``X-Data-Quality`` response header so callers can distinguish
+  baseline demo data from measured benchmark output.
+
+Tests use the live Settings class + the FastAPI router and rely on
+the existing test conftest hermetic seam (no real env, no real DB).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# ─────────────────────────────────────────────────────────────────
+# SEC-010: production base images pinned by digest
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "dockerfile",
+    ["Dockerfile", "Dockerfile.ui", "Dockerfile.ui.cloudrun"],
+)
+def test_sec_010_dockerfile_pins_base_images_by_digest(dockerfile: str) -> None:
+    """Every ``FROM`` line in production Dockerfiles must reference a
+    digest. Pure tag-only references (``FROM python:3.14-slim``) are
+    not reproducible across rebuilds and are rejected here.
+    """
+    root = Path(__file__).resolve().parent.parent.parent
+    text = (root / dockerfile).read_text(encoding="utf-8")
+    lines = [
+        line.strip()
+        for line in text.splitlines()
+        if line.strip().startswith("FROM ")
+    ]
+    assert lines, f"{dockerfile} has no FROM lines"
+    for line in lines:
+        # Allow internal images (asia-south1-docker.pkg.dev/...) that aren't
+        # subject to Renovate but ARE pinned by tag in the registry.
+        if "asia-south1-docker.pkg.dev" in line:
+            continue
+        assert "@sha256:" in line, (
+            f"{dockerfile}: base image not digest-pinned: {line!r}. "
+            f"Run `bash scripts/refresh_image_digests.sh` to update."
+        )
+
+
+def test_sec_010_refresh_script_exists_and_documented() -> None:
+    """The digest-refresh helper must be present + executable."""
+    root = Path(__file__).resolve().parent.parent.parent
+    script = root / "scripts" / "refresh_image_digests.sh"
+    assert script.exists(), "scripts/refresh_image_digests.sh missing"
+    text = script.read_text(encoding="utf-8")
+    assert "Renovate" in text or "Dependabot" in text
+    assert "Docker Hub" in text
+
+
+# ─────────────────────────────────────────────────────────────────
+# SEC-011: Bandit medium clean — run_beat / run_worker
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "script_name", ["run_beat.py", "run_worker.py"]
+)
+def test_sec_011_cloud_run_health_bind_carries_both_lint_and_security_noqa(
+    script_name: str,
+) -> None:
+    """The ``HTTPServer(('0.0.0.0', port), ...)`` line in the Cloud
+    Run health stubs must carry BOTH ``# noqa: S104`` (for Ruff) AND
+    ``# nosec B104`` (for Bandit). Bandit's parser recognises only
+    ``nosec``; Ruff recognises only ``noqa``.
+    """
+    root = Path(__file__).resolve().parent.parent.parent
+    text = (root / "scripts" / script_name).read_text(encoding="utf-8")
+    bind_lines = [
+        line for line in text.splitlines() if 'HTTPServer(("0.0.0.0"' in line
+    ]
+    assert bind_lines, f"{script_name} no longer has the 0.0.0.0 bind"
+    for line in bind_lines:
+        assert "noqa: S104" in line, (
+            f"{script_name}: missing # noqa: S104 on 0.0.0.0 bind: {line!r}"
+        )
+        assert "nosec B104" in line, (
+            f"{script_name}: missing # nosec B104 on 0.0.0.0 bind: {line!r}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────
+# SEC-012: strict env validation
+# ─────────────────────────────────────────────────────────────────
+
+
+def _import_settings_cls():
+    # Settings reads env vars at instantiation; import the class (not
+    # the module-level singleton) so we can construct fresh instances
+    # per test.
+    from core.config import Settings
+    return Settings
+
+
+def test_sec_012_relaxed_env_accepts_default_secret() -> None:
+    """``env=local|dev|test|ci`` keep working with the dev fallback."""
+    Settings = _import_settings_cls()
+    for env in ("local", "dev", "development", "test", "ci"):
+        s = Settings(env=env, secret_key="dev-only-secret-key")
+        assert s.secret_key == "dev-only-secret-key"
+
+
+def test_sec_012_production_rejects_default_secret() -> None:
+    Settings = _import_settings_cls()
+    with pytest.raises(ValueError, match="AGENTICORG_SECRET_KEY"):
+        Settings(env="production", secret_key="dev-only-secret-key")
+
+
+def test_sec_012_staging_also_rejects_default_secret() -> None:
+    """Staging must be strict — it's internet-accessible and used for
+    enterprise security review."""
+    Settings = _import_settings_cls()
+    with pytest.raises(ValueError, match="AGENTICORG_SECRET_KEY"):
+        Settings(env="staging", secret_key="dev-only-secret-key")
+
+
+def test_sec_012_preview_also_rejects_default_secret() -> None:
+    Settings = _import_settings_cls()
+    with pytest.raises(ValueError, match="AGENTICORG_SECRET_KEY"):
+        Settings(env="preview", secret_key="dev-only-secret-key")
+
+
+def test_sec_012_unknown_env_is_strict_by_default() -> None:
+    """An env value we don't recognise should default to STRICT, not
+    relaxed — fail-closed posture."""
+    Settings = _import_settings_cls()
+    with pytest.raises(ValueError, match="AGENTICORG_SECRET_KEY"):
+        Settings(env="qa-cluster-3", secret_key="dev-only-secret-key")
+
+
+def test_sec_012_secret_key_min_length_enforced_in_strict_envs() -> None:
+    Settings = _import_settings_cls()
+    short_secret = "x" * 31  # one byte short of 32
+    with pytest.raises(ValueError, match="32 chars"):
+        Settings(env="production", secret_key=short_secret)
+
+
+def test_sec_012_secret_key_length_ok_with_32() -> None:
+    Settings = _import_settings_cls()
+    s = Settings(
+        env="production",
+        secret_key="x" * 32,
+        db_url="postgresql+asyncpg://app:pass@prod-db/agenticorg",
+        redis_url="redis://prod-redis:6379/0",
+    )
+    assert len(s.secret_key) == 32
+
+
+def test_sec_012_localhost_redis_rejected_in_strict_envs() -> None:
+    Settings = _import_settings_cls()
+    with pytest.raises(ValueError, match="REDIS_URL"):
+        Settings(
+            env="production",
+            secret_key="x" * 32,
+            db_url="postgresql+asyncpg://app:pass@prod-db/agenticorg",
+            redis_url="redis://localhost:6379/0",
+        )
+
+
+def test_sec_012_127001_redis_also_rejected_in_strict_envs() -> None:
+    """``127.0.0.1`` is the same fallback as ``localhost``."""
+    Settings = _import_settings_cls()
+    with pytest.raises(ValueError, match="REDIS_URL"):
+        Settings(
+            env="production",
+            secret_key="x" * 32,
+            db_url="postgresql+asyncpg://app:pass@prod-db/agenticorg",
+            redis_url="redis://127.0.0.1:6379/0",
+        )
+
+
+def test_sec_012_dev_db_rejected_in_strict_envs() -> None:
+    Settings = _import_settings_cls()
+    with pytest.raises(ValueError, match="DB_URL"):
+        Settings(
+            env="production",
+            secret_key="x" * 32,
+            db_url=(
+                "postgresql+asyncpg://agenticorg:agenticorg_dev@localhost:5432/"
+                "agenticorg"
+            ),
+        )
+
+
+# ─────────────────────────────────────────────────────────────────
+# SEC-013: evals data_quality marker
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_sec_013_evals_baseline_marks_data_quality_demo(monkeypatch) -> None:
+    """When the on-disk scorecard is missing, /api/v1/evals must
+    return ``data_quality: "demo"`` in the body AND set
+    ``X-Data-Quality: demo`` on the response."""
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    from api.v1 import evals
+
+    # Force the scorecard path to a non-existent file so the baseline
+    # branch fires, regardless of the runtime CWD.
+    monkeypatch.setattr(
+        evals,
+        "_SCORECARD_PATH",
+        Path("/nonexistent/scorecard.json"),
+    )
+
+    app = FastAPI()
+    app.include_router(evals.router, prefix="/api/v1")
+    client = TestClient(app)
+    resp = client.get("/api/v1/evals")
+    assert resp.status_code == 200
+    assert resp.headers["X-Data-Quality"] == "demo"
+    body = resp.json()
+    assert body["data_quality"] == "demo"
+    assert body.get("_is_baseline") is True
+
+
+def test_sec_013_evals_measured_marks_data_quality_measured(
+    monkeypatch, tmp_path
+) -> None:
+    """When a real scorecard exists on disk, the response must say
+    ``measured`` — never silently fall back to baseline mid-flight."""
+    import json
+
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    from api.v1 import evals
+
+    real_scorecard = tmp_path / "scorecard.json"
+    real_scorecard.write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "platform_metrics": {"stp_rate": 0.9},
+                "agent_aggregates": {},
+                "case_results": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(evals, "_SCORECARD_PATH", real_scorecard)
+
+    app = FastAPI()
+    app.include_router(evals.router, prefix="/api/v1")
+    client = TestClient(app)
+    resp = client.get("/api/v1/evals")
+    assert resp.status_code == 200
+    assert resp.headers["X-Data-Quality"] == "measured"
+    body = resp.json()
+    assert body["data_quality"] == "measured"
+    # The baseline marker must NOT appear when real data is served
+    assert body.get("_is_baseline") is not True
+
+
+# ─────────────────────────────────────────────────────────────────
+# CSP regression — no unsafe-eval, no wildcard
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "config",
+    ["ui/nginx.conf", "ui/nginx.cloudrun.conf.template"],
+)
+def test_csp_disallows_unsafe_eval_and_wildcard(config: str) -> None:
+    """Cheap regression: even if SEC-009 (full inline removal) ships
+    later, neither nginx config should ever contain ``unsafe-eval`` or
+    a wildcard ``*`` in script-src or default-src."""
+    root = Path(__file__).resolve().parent.parent.parent
+    text = (root / config).read_text(encoding="utf-8")
+    csp_lines = [
+        line for line in text.splitlines()
+        if "Content-Security-Policy" in line
+    ]
+    assert csp_lines, f"{config} has no CSP header"
+    csp = " ".join(csp_lines)
+    assert "'unsafe-eval'" not in csp, (
+        f"{config}: CSP must not allow 'unsafe-eval'"
+    )
+    # Any ``script-src ... *`` would let any origin run code; same
+    # for default-src.
+    assert not re.search(r"script-src[^;]*\*[^;]*;", csp), (
+        f"{config}: CSP script-src must not include wildcard"
+    )
+    assert not re.search(r"default-src[^;]*\*[^;]*;", csp), (
+        f"{config}: CSP default-src must not include wildcard"
+    )

--- a/tests/regression/test_security_pr_g_hardening_sweep.py
+++ b/tests/regression/test_security_pr_g_hardening_sweep.py
@@ -112,14 +112,14 @@ def _import_settings_cls():
 
 def test_sec_012_relaxed_env_accepts_default_secret() -> None:
     """``env=local|dev|test|ci`` keep working with the dev fallback."""
-    Settings = _import_settings_cls()
+    Settings = _import_settings_cls()  # noqa: N806
     for env in ("local", "dev", "development", "test", "ci"):
         s = Settings(env=env, secret_key="dev-only-secret-key")
         assert s.secret_key == "dev-only-secret-key"
 
 
 def test_sec_012_production_rejects_default_secret() -> None:
-    Settings = _import_settings_cls()
+    Settings = _import_settings_cls()  # noqa: N806
     with pytest.raises(ValueError, match="AGENTICORG_SECRET_KEY"):
         Settings(env="production", secret_key="dev-only-secret-key")
 
@@ -127,13 +127,13 @@ def test_sec_012_production_rejects_default_secret() -> None:
 def test_sec_012_staging_also_rejects_default_secret() -> None:
     """Staging must be strict — it's internet-accessible and used for
     enterprise security review."""
-    Settings = _import_settings_cls()
+    Settings = _import_settings_cls()  # noqa: N806
     with pytest.raises(ValueError, match="AGENTICORG_SECRET_KEY"):
         Settings(env="staging", secret_key="dev-only-secret-key")
 
 
 def test_sec_012_preview_also_rejects_default_secret() -> None:
-    Settings = _import_settings_cls()
+    Settings = _import_settings_cls()  # noqa: N806
     with pytest.raises(ValueError, match="AGENTICORG_SECRET_KEY"):
         Settings(env="preview", secret_key="dev-only-secret-key")
 
@@ -141,20 +141,20 @@ def test_sec_012_preview_also_rejects_default_secret() -> None:
 def test_sec_012_unknown_env_is_strict_by_default() -> None:
     """An env value we don't recognise should default to STRICT, not
     relaxed — fail-closed posture."""
-    Settings = _import_settings_cls()
+    Settings = _import_settings_cls()  # noqa: N806
     with pytest.raises(ValueError, match="AGENTICORG_SECRET_KEY"):
         Settings(env="qa-cluster-3", secret_key="dev-only-secret-key")
 
 
 def test_sec_012_secret_key_min_length_enforced_in_strict_envs() -> None:
-    Settings = _import_settings_cls()
+    Settings = _import_settings_cls()  # noqa: N806
     short_secret = "x" * 31  # one byte short of 32
     with pytest.raises(ValueError, match="32 chars"):
         Settings(env="production", secret_key=short_secret)
 
 
 def test_sec_012_secret_key_length_ok_with_32() -> None:
-    Settings = _import_settings_cls()
+    Settings = _import_settings_cls()  # noqa: N806
     s = Settings(
         env="production",
         secret_key="x" * 32,
@@ -165,7 +165,7 @@ def test_sec_012_secret_key_length_ok_with_32() -> None:
 
 
 def test_sec_012_localhost_redis_rejected_in_strict_envs() -> None:
-    Settings = _import_settings_cls()
+    Settings = _import_settings_cls()  # noqa: N806
     with pytest.raises(ValueError, match="REDIS_URL"):
         Settings(
             env="production",
@@ -177,7 +177,7 @@ def test_sec_012_localhost_redis_rejected_in_strict_envs() -> None:
 
 def test_sec_012_127001_redis_also_rejected_in_strict_envs() -> None:
     """``127.0.0.1`` is the same fallback as ``localhost``."""
-    Settings = _import_settings_cls()
+    Settings = _import_settings_cls()  # noqa: N806
     with pytest.raises(ValueError, match="REDIS_URL"):
         Settings(
             env="production",
@@ -188,7 +188,7 @@ def test_sec_012_127001_redis_also_rejected_in_strict_envs() -> None:
 
 
 def test_sec_012_dev_db_rejected_in_strict_envs() -> None:
-    Settings = _import_settings_cls()
+    Settings = _import_settings_cls()  # noqa: N806
     with pytest.raises(ValueError, match="DB_URL"):
         Settings(
             env="production",
@@ -209,8 +209,9 @@ def test_sec_013_evals_baseline_marks_data_quality_demo(monkeypatch) -> None:
     """When the on-disk scorecard is missing, /api/v1/evals must
     return ``data_quality: "demo"`` in the body AND set
     ``X-Data-Quality: demo`` on the response."""
-    from fastapi.testclient import TestClient
     from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
     from api.v1 import evals
 
     # Force the scorecard path to a non-existent file so the baseline
@@ -239,8 +240,9 @@ def test_sec_013_evals_measured_marks_data_quality_measured(
     ``measured`` — never silently fall back to baseline mid-flight."""
     import json
 
-    from fastapi.testclient import TestClient
     from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
     from api.v1 import evals
 
     real_scorecard = tmp_path / "scorecard.json"

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -176,31 +176,45 @@ _SAMPLE_SCORECARD = {
 
 class TestEvalsEndpoints:
 
+    # SEC-013 (PR-G): get_evals() and get_agent_evals() now take a
+    # FastAPI ``Response`` parameter so the handler can set the
+    # ``X-Data-Quality`` header. Tests pass a stub Response.
+
     @pytest.mark.asyncio
     async def test_get_evals_returns_full_scorecard(self, tmp_path):
+        from fastapi import Response
         from api.v1.evals import get_evals
 
         scorecard_file = tmp_path / "scorecard.json"
         scorecard_file.write_text(json.dumps(_SAMPLE_SCORECARD))
 
+        response = Response()
         with patch("api.v1.evals._SCORECARD_PATH", scorecard_file):
-            resp = await get_evals()
+            resp = await get_evals(response)
 
-        assert resp == _SAMPLE_SCORECARD
+        # The body still surfaces the on-disk scorecard plus a
+        # data_quality marker that didn't exist pre-PR-G.
+        assert {k: resp[k] for k in _SAMPLE_SCORECARD} == _SAMPLE_SCORECARD
+        assert resp["data_quality"] == "measured"
+        assert response.headers["X-Data-Quality"] == "measured"
 
     @pytest.mark.asyncio
     async def test_get_evals_file_not_found_returns_baseline(self, tmp_path):
         """Post-2026-04-23 contract: /api/v1/evals serves a baseline
         scorecard when evals/scorecard.json is missing instead of
-        404'ing. The old behaviour blanked the public /evals page and
-        tripped the evals-thorough e2e smoke."""
+        404'ing. PR-G also marks the response ``data_quality: "demo"``
+        so customer dashboards can flag baseline numbers honestly."""
+        from fastapi import Response
         from api.v1.evals import get_evals
 
         missing = tmp_path / "no_such_file.json"
+        response = Response()
         with patch("api.v1.evals._SCORECARD_PATH", missing):
-            result = await get_evals()
+            result = await get_evals(response)
 
         assert result["_is_baseline"] is True
+        assert result["data_quality"] == "demo"
+        assert response.headers["X-Data-Quality"] == "demo"
         assert "platform_metrics" in result
         pm = result["platform_metrics"]
         # The UI reads these four fields to render the "%" metrics.
@@ -209,41 +223,47 @@ class TestEvalsEndpoints:
 
     @pytest.mark.asyncio
     async def test_get_agent_evals_happy(self, tmp_path):
+        from fastapi import Response
         from api.v1.evals import get_agent_evals
 
         scorecard_file = tmp_path / "scorecard.json"
         scorecard_file.write_text(json.dumps(_SAMPLE_SCORECARD))
 
+        response = Response()
         with patch("api.v1.evals._SCORECARD_PATH", scorecard_file):
-            resp = await get_agent_evals("finance")
+            resp = await get_agent_evals("finance", response)
 
         assert resp["agent_type"] == "finance"
         assert resp["aggregate"] == {"accuracy": 0.95}
         assert len(resp["cases"]) == 2
+        assert resp["data_quality"] == "measured"
 
     @pytest.mark.asyncio
     async def test_get_agent_evals_not_found(self, tmp_path):
-        from fastapi import HTTPException
+        from fastapi import HTTPException, Response
 
         from api.v1.evals import get_agent_evals
 
         scorecard_file = tmp_path / "scorecard.json"
         scorecard_file.write_text(json.dumps(_SAMPLE_SCORECARD))
 
+        response = Response()
         with patch("api.v1.evals._SCORECARD_PATH", scorecard_file):
             with pytest.raises(HTTPException) as exc_info:
-                await get_agent_evals("nonexistent")
+                await get_agent_evals("nonexistent", response)
             assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
     async def test_get_agent_evals_filters_cases_correctly(self, tmp_path):
+        from fastapi import Response
         from api.v1.evals import get_agent_evals
 
         scorecard_file = tmp_path / "scorecard.json"
         scorecard_file.write_text(json.dumps(_SAMPLE_SCORECARD))
 
+        response = Response()
         with patch("api.v1.evals._SCORECARD_PATH", scorecard_file):
-            resp = await get_agent_evals("hr")
+            resp = await get_agent_evals("hr", response)
 
         assert len(resp["cases"]) == 1
         assert resp["cases"][0]["agent_type"] == "hr"
@@ -2286,6 +2306,11 @@ class TestCreateDsarAuditEntry:
 # ============================================================================
 
 class TestLoadScorecard:
+    """SEC-013 (PR-G): _load_scorecard now returns a tuple
+    ``(scorecard_dict, data_quality)`` where data_quality is
+    ``"measured"`` or ``"demo"``. The dict carries an additional
+    ``data_quality`` field too so dashboards consuming the body alone
+    still see the marker."""
 
     def test_load_scorecard_happy(self, tmp_path):
         from api.v1.evals import _load_scorecard
@@ -2294,9 +2319,10 @@ class TestLoadScorecard:
         scorecard_file.write_text(json.dumps({"test": True}))
 
         with patch("api.v1.evals._SCORECARD_PATH", scorecard_file):
-            data = _load_scorecard()
+            data, quality = _load_scorecard()
 
-        assert data == {"test": True}
+        assert data == {"test": True, "data_quality": "measured"}
+        assert quality == "measured"
 
     def test_load_scorecard_missing_file_returns_baseline(self, tmp_path):
         """Post-2026-04-23: _load_scorecard returns a labeled baseline
@@ -2305,9 +2331,11 @@ class TestLoadScorecard:
 
         missing = tmp_path / "nope.json"
         with patch("api.v1.evals._SCORECARD_PATH", missing):
-            result = _load_scorecard()
+            result, quality = _load_scorecard()
 
         assert result["_is_baseline"] is True
+        assert result["data_quality"] == "demo"
+        assert quality == "demo"
 
     def test_load_scorecard_reads_latest(self, tmp_path):
         from api.v1.evals import _load_scorecard
@@ -2316,12 +2344,12 @@ class TestLoadScorecard:
         scorecard_file.write_text(json.dumps({"version": 1}))
 
         with patch("api.v1.evals._SCORECARD_PATH", scorecard_file):
-            data1 = _load_scorecard()
+            data1, _ = _load_scorecard()
 
         scorecard_file.write_text(json.dumps({"version": 2}))
 
         with patch("api.v1.evals._SCORECARD_PATH", scorecard_file):
-            data2 = _load_scorecard()
+            data2, _ = _load_scorecard()
 
         assert data1["version"] == 1
         assert data2["version"] == 2

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -183,6 +183,7 @@ class TestEvalsEndpoints:
     @pytest.mark.asyncio
     async def test_get_evals_returns_full_scorecard(self, tmp_path):
         from fastapi import Response
+
         from api.v1.evals import get_evals
 
         scorecard_file = tmp_path / "scorecard.json"
@@ -205,6 +206,7 @@ class TestEvalsEndpoints:
         404'ing. PR-G also marks the response ``data_quality: "demo"``
         so customer dashboards can flag baseline numbers honestly."""
         from fastapi import Response
+
         from api.v1.evals import get_evals
 
         missing = tmp_path / "no_such_file.json"
@@ -224,6 +226,7 @@ class TestEvalsEndpoints:
     @pytest.mark.asyncio
     async def test_get_agent_evals_happy(self, tmp_path):
         from fastapi import Response
+
         from api.v1.evals import get_agent_evals
 
         scorecard_file = tmp_path / "scorecard.json"
@@ -256,6 +259,7 @@ class TestEvalsEndpoints:
     @pytest.mark.asyncio
     async def test_get_agent_evals_filters_cases_correctly(self, tmp_path):
         from fastapi import Response
+
         from api.v1.evals import get_agent_evals
 
         scorecard_file = tmp_path / "scorecard.json"

--- a/tests/unit/test_connector_real_paths.py
+++ b/tests/unit/test_connector_real_paths.py
@@ -436,6 +436,7 @@ class TestNetsuiteRealPaths:
 
     def test_base_url_lowercases_and_replaces_dots(self):
         from urllib.parse import urlparse
+
         from connectors.finance.netsuite import NetsuiteConnector
         c = NetsuiteConnector({"account_id": "TSTDRV.1234.567", "access_token": "x"})
         parsed = urlparse(c.base_url)

--- a/tests/unit/test_connector_real_paths.py
+++ b/tests/unit/test_connector_real_paths.py
@@ -428,13 +428,18 @@ class TestNetsuiteRealPaths:
         return c
 
     def test_base_url_built_from_account_id(self):
+        from urllib.parse import urlparse
         c = self._make_connector()
-        assert c.base_url.startswith("https://tstdrv1234567.suitetalk.api.netsuite.com")
+        parsed = urlparse(c.base_url)
+        assert parsed.scheme == "https"
+        assert parsed.hostname == "tstdrv1234567.suitetalk.api.netsuite.com"
 
     def test_base_url_lowercases_and_replaces_dots(self):
+        from urllib.parse import urlparse
         from connectors.finance.netsuite import NetsuiteConnector
         c = NetsuiteConnector({"account_id": "TSTDRV.1234.567", "access_token": "x"})
-        assert "tstdrv_1234_567.suitetalk.api.netsuite.com" in c.base_url
+        parsed = urlparse(c.base_url)
+        assert parsed.hostname == "tstdrv_1234_567.suitetalk.api.netsuite.com"
 
     @pytest.mark.asyncio
     async def test_create_invoice_path(self):

--- a/tests/unit/test_connector_real_paths.py
+++ b/tests/unit/test_connector_real_paths.py
@@ -158,6 +158,458 @@ class TestZohoBooksRealPaths:
         args = c._client.get.call_args
         assert args[0][0] == "/reports/balancesheet"
 
+    @pytest.mark.asyncio
+    async def test_get_profit_loss_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"profit_and_loss": {"revenue": 1000}})
+        await c.get_profit_loss(from_date="2026-04-01", to_date="2026-04-30")
+        args = c._client.get.call_args
+        assert args[0][0] == "/reports/profitandloss"
+
+    @pytest.mark.asyncio
+    async def test_list_chartofaccounts_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"chartofaccounts": [{"account_id": "a1"}]})
+        out = await c.list_chartofaccounts(filter_by="AccountType.asset")
+        args = c._client.get.call_args
+        assert args[0][0] == "/chartofaccounts"
+        assert isinstance(out["chartofaccounts"], list)
+
+    @pytest.mark.asyncio
+    async def test_reconcile_transaction_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"bank_transaction": {"transaction_id": "T1"}})
+        await c.reconcile_transaction(
+            account_id="a1", amount=1000, date="2026-05-01", reference_number="R1"
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/banktransactions/uncategorized"
+
+    @pytest.mark.asyncio
+    async def test_get_organization_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"organizations": [{"organization_id": "1", "name": "Acme"}]}
+        )
+        out = await c.get_organization()
+        args = c._client.get.call_args
+        assert args[0][0] == "/organizations"
+        assert out["organizations"][0]["name"] == "Acme"
+
+    @pytest.mark.asyncio
+    async def test_get_organization_empty(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"organizations": []})
+        out = await c.get_organization()
+        assert out == {"organizations": []}
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_org_count(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"organizations": [{"organization_id": "1"}, {"organization_id": "2"}]}
+        )
+        out = await c.health_check()
+        assert out["status"] == "healthy"
+        assert out["organizations"] == 2
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_invoice(line_items=[{"item_id": "i"}])
+        b = await c.create_invoice(customer_id="c")
+        assert "customer_id" in a["error"]
+        assert "line_items" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_record_expense_validates_required(self):
+        c = self._make_connector()
+        a = await c.record_expense(amount=100, date="2026-05-01")
+        b = await c.record_expense(account_id="a", date="2026-05-01")
+        d = await c.record_expense(account_id="a", amount=100)
+        assert "account_id" in a["error"]
+        assert "amount" in b["error"]
+        assert "date" in d["error"]
+
+    @pytest.mark.asyncio
+    async def test_reconcile_transaction_validates_required(self):
+        c = self._make_connector()
+        out = await c.reconcile_transaction(amount=100, date="2026-05-01")
+        assert "account_id" in out["error"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# QuickBooks Online — every tool method against a mocked AsyncClient
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestQuickbooksRealPaths:
+    """Verify QuickBooks Online connector hits correct QBO REST v3 paths."""
+
+    def _make_connector(self):
+        from connectors.finance.quickbooks import QuickbooksConnector
+        c = QuickbooksConnector(
+            {"access_token": "fake", "realm_id": "9341452961234567"}
+        )
+        c._client = MagicMock()
+        return c
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"Invoice": {"Id": "1", "TotalAmt": 100}})
+        out = await c.create_invoice(
+            Line=[{"Amount": 100, "DetailType": "SalesItemLineDetail"}],
+            CustomerRef={"value": "cust1"},
+            TxnDate="2026-05-01",
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/company/9341452961234567/invoice"
+        assert out.get("Id") == "1"
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_normalises_string_customer_ref(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"Invoice": {"Id": "2"}})
+        out = await c.create_invoice(
+            Line=[{"Amount": 50}], CustomerRef="cust-string"
+        )
+        assert out.get("Id") == "2"
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_invoice(CustomerRef={"value": "c"})
+        b = await c.create_invoice(Line=[{}])
+        assert "Line" in a["error"]
+        assert "CustomerRef" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_record_payment_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"Payment": {"Id": "P1", "TotalAmt": 100}})
+        out = await c.record_payment(
+            TotalAmt=100,
+            CustomerRef={"value": "c"},
+            PaymentMethodRef={"value": "1"},
+            DepositToAccountRef={"value": "33"},
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/company/9341452961234567/payment"
+        assert out.get("Id") == "P1"
+
+    @pytest.mark.asyncio
+    async def test_record_payment_validates_required(self):
+        c = self._make_connector()
+        a = await c.record_payment(CustomerRef={"value": "c"})
+        b = await c.record_payment(TotalAmt=50)
+        assert "TotalAmt" in a["error"]
+        assert "CustomerRef" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_record_payment_normalises_string_customer_ref(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"Payment": {"Id": "P2"}})
+        out = await c.record_payment(TotalAmt=200, CustomerRef="cust-string")
+        assert out.get("Id") == "P2"
+
+    @pytest.mark.asyncio
+    async def test_get_profit_loss_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"Header": {"ReportName": "ProfitAndLoss"}, "Rows": {}}
+        )
+        out = await c.get_profit_loss(start_date="2026-04-01", end_date="2026-04-30")
+        args = c._client.get.call_args
+        assert args[0][0] == "/company/9341452961234567/reports/ProfitAndLoss"
+        assert out["Header"]["ReportName"] == "ProfitAndLoss"
+
+    @pytest.mark.asyncio
+    async def test_get_balance_sheet_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"Header": {"ReportName": "BalanceSheet"}, "Rows": {}}
+        )
+        out = await c.get_balance_sheet(date="2026-04-30")
+        args = c._client.get.call_args
+        assert args[0][0] == "/company/9341452961234567/reports/BalanceSheet"
+        assert out["Header"]["ReportName"] == "BalanceSheet"
+
+    @pytest.mark.asyncio
+    async def test_query_path_unwraps_query_response(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {
+                "QueryResponse": {"Invoice": [{"Id": "1"}, {"Id": "2"}]},
+                "time": "2026-05-01",
+            }
+        )
+        out = await c.query(query="SELECT * FROM Invoice")
+        args = c._client.get.call_args
+        assert args[0][0] == "/company/9341452961234567/query"
+        assert isinstance(out, list)
+        assert len(out) == 2
+
+    @pytest.mark.asyncio
+    async def test_query_validates_required(self):
+        c = self._make_connector()
+        out = await c.query()
+        assert "query is required" in out["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_company_info_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"CompanyInfo": {"CompanyName": "Acme Corp"}}
+        )
+        out = await c.get_company_info()
+        args = c._client.get.call_args
+        assert (
+            args[0][0]
+            == "/company/9341452961234567/companyinfo/9341452961234567"
+        )
+        assert out.get("CompanyName") == "Acme Corp"
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_company_name(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"CompanyInfo": {"CompanyName": "Acme Corp"}}
+        )
+        out = await c.health_check()
+        assert out["status"] == "healthy"
+        assert out["company_name"] == "Acme Corp"
+
+    @pytest.mark.asyncio
+    async def test_health_check_unhealthy_on_error(self):
+        c = self._make_connector()
+        c._client.get = AsyncMock(side_effect=RuntimeError("boom"))
+        out = await c.health_check()
+        assert out["status"] == "unhealthy"
+
+    def test_company_path_embeds_realm_id(self):
+        c = self._make_connector()
+        assert c._company_path("invoice") == "/company/9341452961234567/invoice"
+
+    def test_unwrap_handles_query_response_envelope(self):
+        c = self._make_connector()
+        out = c._unwrap({"QueryResponse": {"Invoice": [{"Id": "1"}]}})
+        assert out == [{"Id": "1"}]
+
+    def test_unwrap_handles_direct_entity_envelope(self):
+        c = self._make_connector()
+        out = c._unwrap({"Invoice": {"Id": "1"}}, "Invoice")
+        assert out == {"Id": "1"}
+
+    def test_unwrap_skips_time_metadata_key(self):
+        c = self._make_connector()
+        out = c._unwrap({"time": "2026-05-01", "Invoice": {"Id": "1"}})
+        assert out == {"Id": "1"}
+
+    def test_unwrap_passes_through_non_dict(self):
+        c = self._make_connector()
+        assert c._unwrap("not a dict") == "not a dict"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# NetSuite — every tool method against a mocked AsyncClient
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestNetsuiteRealPaths:
+    """Verify NetSuite SuiteTalk REST connector hits correct record paths."""
+
+    def _make_connector(self):
+        from connectors.finance.netsuite import NetsuiteConnector
+        c = NetsuiteConnector(
+            {"account_id": "TSTDRV1234567", "access_token": "fake-token"}
+        )
+        c._client = MagicMock()
+        return c
+
+    def test_base_url_built_from_account_id(self):
+        c = self._make_connector()
+        assert c.base_url.startswith("https://tstdrv1234567.suitetalk.api.netsuite.com")
+
+    def test_base_url_lowercases_and_replaces_dots(self):
+        from connectors.finance.netsuite import NetsuiteConnector
+        c = NetsuiteConnector({"account_id": "TSTDRV.1234.567", "access_token": "x"})
+        assert "tstdrv_1234_567.suitetalk.api.netsuite.com" in c.base_url
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"id": "inv1"})
+        await c.create_invoice(
+            entity="cust1",
+            item=[{"item": {"id": "42"}, "quantity": 2, "rate": 150}],
+            tranDate="2026-05-01",
+            memo="May invoice",
+            department="DEPT-1",
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/invoice"
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_invoice(item=[{}])
+        b = await c.create_invoice(entity="cust1")
+        assert "entity" in a["error"]
+        assert "item" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_invoice_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"id": "inv1"})
+        await c.get_invoice(id="inv1", expandSubResources=True)
+        args = c._client.get.call_args
+        assert args[0][0] == "/invoice/inv1"
+
+    @pytest.mark.asyncio
+    async def test_get_invoice_validates_required(self):
+        c = self._make_connector()
+        out = await c.get_invoice()
+        assert "id" in out["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"id": "je1"})
+        await c.create_journal_entry(
+            subsidiary="1",
+            line=[
+                {"account": {"id": "10"}, "debit": 1000, "memo": "Rev"},
+                {"account": {"id": "20"}, "credit": 1000, "memo": "Cash"},
+            ],
+            tranDate="2026-05-01",
+            memo="Adj entry",
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/journalEntry"
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_journal_entry(line=[{}])
+        b = await c.create_journal_entry(subsidiary="1")
+        assert "subsidiary" in a["error"]
+        assert "line" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_account_balance_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"id": "10", "balance": 5000})
+        await c.get_account_balance(id="10")
+        args = c._client.get.call_args
+        assert args[0][0] == "/account/10"
+
+    @pytest.mark.asyncio
+    async def test_get_account_balance_validates_required(self):
+        c = self._make_connector()
+        out = await c.get_account_balance()
+        assert "id" in out["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_vendor_bill_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"id": "vb1"})
+        await c.create_vendor_bill(
+            entity="vendor1",
+            item=[{"item": {"id": "55"}, "quantity": 1, "rate": 500}],
+            tranDate="2026-05-01",
+            memo="Office supplies",
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/vendorBill"
+
+    @pytest.mark.asyncio
+    async def test_create_vendor_bill_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_vendor_bill(item=[{}])
+        b = await c.create_vendor_bill(entity="v")
+        assert "entity" in a["error"]
+        assert "item" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_purchase_order_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"id": "po1"})
+        await c.create_purchase_order(
+            entity="vendor1",
+            item=[{"item": {"id": "77"}, "quantity": 10, "rate": 25}],
+            tranDate="2026-05-01",
+            memo="Bulk order",
+            shipTo="100",
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/purchaseOrder"
+
+    @pytest.mark.asyncio
+    async def test_create_purchase_order_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_purchase_order(item=[{}])
+        b = await c.create_purchase_order(entity="v")
+        assert "entity" in a["error"]
+        assert "item" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_trial_balance_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {
+                "items": [
+                    {
+                        "id": "10",
+                        "acctName": "Cash",
+                        "acctNumber": "1000",
+                        "acctType": {"refName": "Bank"},
+                        "balance": 50000,
+                    }
+                ],
+                "totalResults": 1,
+            }
+        )
+        out = await c.get_trial_balance(period="P1", subsidiary="1")
+        args = c._client.get.call_args
+        assert args[0][0] == "/account"
+        assert out["accounts"][0]["acctName"] == "Cash"
+        assert out["accounts"][0]["acctType"] == "Bank"
+
+    @pytest.mark.asyncio
+    async def test_search_records_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"items": [{"id": "1"}], "totalResults": 1, "hasMore": False}
+        )
+        out = await c.search_records(
+            record_type="invoice", q="status='open'", limit=50, offset=0
+        )
+        args = c._client.get.call_args
+        assert args[0][0] == "/invoice"
+        assert out["records"][0]["id"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_search_records_validates_required(self):
+        c = self._make_connector()
+        out = await c.search_records()
+        assert "record_type" in out["error"]
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_total_results(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"totalResults": 7})
+        out = await c.health_check()
+        assert out["status"] == "healthy"
+        assert out["total_results"] == 7
+
+    @pytest.mark.asyncio
+    async def test_health_check_unhealthy_on_error(self):
+        c = self._make_connector()
+        c._client.get = AsyncMock(side_effect=RuntimeError("boom"))
+        out = await c.health_check()
+        assert out["status"] == "unhealthy"
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Oracle Fusion

--- a/tests/unit/test_signoff_remaining_blockers.py
+++ b/tests/unit/test_signoff_remaining_blockers.py
@@ -18,9 +18,14 @@ class TestEvalsBaselineFallback:
 
         # Point the module's scorecard path at a non-existent location.
         monkeypatch.setattr(evals, "_SCORECARD_PATH", tmp_path / "nothere.json")
-        result = evals._load_scorecard()
+        # SEC-013 (PR-G): _load_scorecard now returns
+        # ``(scorecard, data_quality)``; data_quality is "demo" when
+        # the baseline branch fires.
+        result, quality = evals._load_scorecard()
 
         assert result["_is_baseline"] is True
+        assert quality == "demo"
+        assert result["data_quality"] == "demo"
         # The UI renders percentages from these four fields.
         pm = result["platform_metrics"]
         for key in ("stp_rate", "hitl_rate", "mean_confidence", "uptime_sla"):


### PR DESCRIPTION
## Summary

Closes 4 of the 5 P2 findings from the 2026-05-01 brutal security scan in a single hardening sweep:

- **SEC-2026-05-P2-010** — Production base images pinned by digest (Dockerfile, Dockerfile.ui, Dockerfile.ui.cloudrun) + ``scripts/refresh_image_digests.sh``
- **SEC-2026-05-P2-011** — Bandit medium clean; `run_beat`/`run_worker` 0.0.0.0 binds carry both `# noqa: S104` (Ruff) AND `# nosec B104` (Bandit)
- **SEC-2026-05-P2-012** — Strict env validation rejects dev defaults outside local/dev/test/ci; secret_key minimum 32 chars; staging + preview + unknown envs treated as strict (fail-closed)
- **SEC-2026-05-P2-013** — `/api/v1/evals` returns `data_quality: "demo" | "measured"` in body + `X-Data-Quality` response header

**Deferred** to PR-G2: SEC-2026-05-P2-009 (CSP unsafe-inline). Removing inline scripts requires Vite-build-aware SHA-256 hash infrastructure for the 7 JSON-LD blocks in `ui/index.html` — out of scope for this PR.

## Test plan

- [x] `pytest tests/regression/test_security_pr_g_hardening_sweep.py` → 20 passed locally
- [x] `bandit -r api auth core scripts -ll -iii` → No issues identified
- [x] Local preflight gate ran clean against base
- [ ] CI green
- [ ] @codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)