### PR TITLE
fix(security): PR-G2 — CSP unsafe-inline removal via JSON-LD hash pinning (SEC-009)

### DIFF
--- a/scripts/refresh_csp_hashes.sh
+++ b/scripts/refresh_csp_hashes.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# SEC-2026-05-P2-009: regenerate the SHA-256 hash list embedded in
+# the CSP ``script-src`` directive of ui/nginx.conf and
+# ui/nginx.cloudrun.conf.template.
+#
+# Run after editing any inline ``<script type="application/ld+json">``
+# block in ui/index.html. The corresponding regression test
+# (tests/regression/test_security_pr_g2_csp_hash_pinning.py) fails if
+# the hashes drift, so this script is your fix path.
+#
+# Usage:
+#   bash scripts/refresh_csp_hashes.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+INDEX_HTML="ui/index.html"
+NGINX_CONF="ui/nginx.conf"
+NGINX_TEMPLATE="ui/nginx.cloudrun.conf.template"
+
+if [[ ! -f "$INDEX_HTML" ]]; then
+    echo "[refresh_csp_hashes] $INDEX_HTML not found" >&2
+    exit 1
+fi
+
+echo "[refresh_csp_hashes] computing SHA-256 of inline JSON-LD blocks in $INDEX_HTML"
+
+HASH_LIST=$(python <<'PY'
+import hashlib, base64, re, sys
+text = open("ui/index.html", encoding="utf-8").read()
+# Match the exact body content of every inline JSON-LD script block.
+# CSP hashes the bytes BETWEEN the opening and closing tags, exactly
+# as the browser sees them.
+pattern = re.compile(
+    r'<script type="application/ld\+json">\n(.*?)\n  </script>',
+    re.DOTALL,
+)
+hashes = []
+for m in pattern.finditer(text):
+    content = m.group(1)
+    digest = hashlib.sha256(content.encode("utf-8")).digest()
+    b64 = base64.b64encode(digest).decode("ascii")
+    hashes.append(f"'sha256-{b64}'")
+if not hashes:
+    print("ERROR: no inline JSON-LD blocks found in ui/index.html", file=sys.stderr)
+    sys.exit(1)
+print(" ".join(hashes))
+PY
+)
+
+echo "[refresh_csp_hashes] new hash list:"
+echo "  $HASH_LIST"
+
+# In-place rewrite of the script-src clause in both nginx files. The
+# pattern below matches everything from "script-src 'self'" up to the
+# next non-hash external (https://accounts.google.com) and replaces
+# the hash sequence in between.
+python <<PY
+import re, sys
+hash_list = """$HASH_LIST"""
+
+for path in ("$NGINX_CONF", "$NGINX_TEMPLATE"):
+    text = open(path, encoding="utf-8").read()
+    new_text, n = re.subn(
+        r"(script-src 'self')(?: '(?:sha256-[A-Za-z0-9+/=]+|unsafe-inline)')*( https://accounts\.google\.com)",
+        rf"\1 {hash_list}\2",
+        text,
+    )
+    if n != 1:
+        print(f"ERROR: expected exactly one CSP script-src in {path}, found {n}", file=sys.stderr)
+        sys.exit(2)
+    open(path, "w", encoding="utf-8").write(new_text)
+    print(f"  rewrote {path}")
+PY
+
+echo "[refresh_csp_hashes] done. Diff:"
+git diff --stat -- "$NGINX_CONF" "$NGINX_TEMPLATE"

--- a/tests/regression/test_security_pr_g2_csp_hash_pinning.py
+++ b/tests/regression/test_security_pr_g2_csp_hash_pinning.py
@@ -1,0 +1,143 @@
+"""PR-G2 regression pins for SEC-009 (CSP unsafe-inline removal).
+
+Closes:
+
+- SEC-2026-05-P2-009 — script-src no longer carries 'unsafe-inline'.
+  Each inline ``<script type="application/ld+json">`` block in
+  ``ui/index.html`` is whitelisted via a ``'sha256-...'`` token in
+  the CSP. If a contributor edits a JSON-LD block, this test fails
+  with the new hash they need to add (run
+  ``bash scripts/refresh_csp_hashes.sh`` to regenerate).
+
+style-src retains 'unsafe-inline' on purpose (Tailwind utility class
+output generates inline styles; the residual XSS impact via styles
+alone is materially smaller than via scripts).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+INDEX_HTML = REPO_ROOT / "ui" / "index.html"
+NGINX_CONFIGS = (
+    REPO_ROOT / "ui" / "nginx.conf",
+    REPO_ROOT / "ui" / "nginx.cloudrun.conf.template",
+)
+
+_INLINE_JSON_LD = re.compile(
+    r'<script type="application/ld\+json">\n(.*?)\n  </script>',
+    re.DOTALL,
+)
+
+
+def _compute_inline_script_hashes(html: str) -> list[str]:
+    hashes: list[str] = []
+    for m in _INLINE_JSON_LD.finditer(html):
+        content = m.group(1)
+        digest = hashlib.sha256(content.encode("utf-8")).digest()
+        hashes.append("sha256-" + base64.b64encode(digest).decode("ascii"))
+    return hashes
+
+
+def _extract_csp_header(text: str) -> str:
+    for line in text.splitlines():
+        if "Content-Security-Policy" in line:
+            return line
+    pytest.fail("Content-Security-Policy header not found in nginx config")
+    return ""  # unreachable
+
+
+def _extract_script_src_tokens(csp_line: str) -> list[str]:
+    """Return the list of script-src tokens (single-quoted)."""
+    m = re.search(r"script-src\s+([^;]*);", csp_line)
+    if not m:
+        pytest.fail("script-src directive not found in CSP")
+    return re.findall(r"'([^']*)'", m.group(1))
+
+
+@pytest.mark.parametrize("config", NGINX_CONFIGS, ids=lambda p: p.name)
+def test_sec_009_script_src_does_not_allow_unsafe_inline(config: Path) -> None:
+    """``script-src`` must not contain ``'unsafe-inline'`` — that's
+    the SEC-009 fix. Hashes replace it."""
+    csp = _extract_csp_header(config.read_text(encoding="utf-8"))
+    tokens = _extract_script_src_tokens(csp)
+    assert "unsafe-inline" not in tokens, (
+        f"{config.name}: script-src must not contain 'unsafe-inline'. "
+        "The PR-G2 fix replaces it with sha256 hashes of the inline "
+        "JSON-LD blocks. Run scripts/refresh_csp_hashes.sh if you've "
+        "edited ui/index.html."
+    )
+
+
+@pytest.mark.parametrize("config", NGINX_CONFIGS, ids=lambda p: p.name)
+def test_sec_009_script_src_does_not_allow_unsafe_eval(config: Path) -> None:
+    csp = _extract_csp_header(config.read_text(encoding="utf-8"))
+    tokens = _extract_script_src_tokens(csp)
+    assert "unsafe-eval" not in tokens, (
+        f"{config.name}: script-src must not contain 'unsafe-eval'."
+    )
+
+
+@pytest.mark.parametrize("config", NGINX_CONFIGS, ids=lambda p: p.name)
+def test_sec_009_script_src_includes_every_inline_jsonld_hash(
+    config: Path,
+) -> None:
+    """Every inline JSON-LD block in ``ui/index.html`` must have a
+    matching ``'sha256-...'`` token in the script-src directive. If
+    this fails, the source HTML drifted from the pinned hashes — run
+    ``bash scripts/refresh_csp_hashes.sh`` to regenerate.
+    """
+    expected = _compute_inline_script_hashes(
+        INDEX_HTML.read_text(encoding="utf-8")
+    )
+    assert expected, "no inline JSON-LD blocks found in ui/index.html"
+    csp = _extract_csp_header(config.read_text(encoding="utf-8"))
+    tokens = set(_extract_script_src_tokens(csp))
+    missing = [h for h in expected if h not in tokens]
+    assert not missing, (
+        f"{config.name}: the following CSP hashes are missing — the "
+        "inline JSON-LD content drifted. Run "
+        "scripts/refresh_csp_hashes.sh to fix:\n  "
+        + "\n  ".join(f"'{h}'" for h in missing)
+    )
+
+
+def test_sec_009_nginx_configs_have_identical_script_src() -> None:
+    """The two nginx configs (local + Cloud Run template) must carry
+    the same script-src directive so the deployed CSP doesn't drift
+    between environments."""
+    sources = [
+        _extract_script_src_tokens(_extract_csp_header(p.read_text(encoding="utf-8")))
+        for p in NGINX_CONFIGS
+    ]
+    a, b = sources
+    assert sorted(a) == sorted(b), (
+        "nginx.conf and nginx.cloudrun.conf.template have diverging "
+        "script-src directives. They must stay aligned — run "
+        "scripts/refresh_csp_hashes.sh after any edit."
+    )
+
+
+def test_sec_009_refresh_script_exists_and_documented() -> None:
+    """The hash-refresh helper must exist + describe the workflow."""
+    script = REPO_ROOT / "scripts" / "refresh_csp_hashes.sh"
+    assert script.exists(), "scripts/refresh_csp_hashes.sh missing"
+    text = script.read_text(encoding="utf-8")
+    assert "JSON-LD" in text or "json-ld" in text or "json+ld" in text
+    assert "ui/index.html" in text
+
+
+def test_sec_009_csp_does_not_have_wildcard_in_script_src() -> None:
+    for config in NGINX_CONFIGS:
+        csp = _extract_csp_header(config.read_text(encoding="utf-8"))
+        m = re.search(r"script-src\s+([^;]*);", csp)
+        assert m, f"{config.name}: script-src directive not found"
+        assert " * " not in (" " + m.group(1) + " "), (
+            f"{config.name}: script-src must not include a wildcard."
+        )

--- a/tests/unit/test_connector_real_paths.py
+++ b/tests/unit/test_connector_real_paths.py
@@ -158,6 +158,458 @@ class TestZohoBooksRealPaths:
         args = c._client.get.call_args
         assert args[0][0] == "/reports/balancesheet"
 
+    @pytest.mark.asyncio
+    async def test_get_profit_loss_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"profit_and_loss": {"revenue": 1000}})
+        await c.get_profit_loss(from_date="2026-04-01", to_date="2026-04-30")
+        args = c._client.get.call_args
+        assert args[0][0] == "/reports/profitandloss"
+
+    @pytest.mark.asyncio
+    async def test_list_chartofaccounts_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"chartofaccounts": [{"account_id": "a1"}]})
+        out = await c.list_chartofaccounts(filter_by="AccountType.asset")
+        args = c._client.get.call_args
+        assert args[0][0] == "/chartofaccounts"
+        assert isinstance(out["chartofaccounts"], list)
+
+    @pytest.mark.asyncio
+    async def test_reconcile_transaction_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"bank_transaction": {"transaction_id": "T1"}})
+        await c.reconcile_transaction(
+            account_id="a1", amount=1000, date="2026-05-01", reference_number="R1"
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/banktransactions/uncategorized"
+
+    @pytest.mark.asyncio
+    async def test_get_organization_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"organizations": [{"organization_id": "1", "name": "Acme"}]}
+        )
+        out = await c.get_organization()
+        args = c._client.get.call_args
+        assert args[0][0] == "/organizations"
+        assert out["organizations"][0]["name"] == "Acme"
+
+    @pytest.mark.asyncio
+    async def test_get_organization_empty(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"organizations": []})
+        out = await c.get_organization()
+        assert out == {"organizations": []}
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_org_count(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"organizations": [{"organization_id": "1"}, {"organization_id": "2"}]}
+        )
+        out = await c.health_check()
+        assert out["status"] == "healthy"
+        assert out["organizations"] == 2
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_invoice(line_items=[{"item_id": "i"}])
+        b = await c.create_invoice(customer_id="c")
+        assert "customer_id" in a["error"]
+        assert "line_items" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_record_expense_validates_required(self):
+        c = self._make_connector()
+        a = await c.record_expense(amount=100, date="2026-05-01")
+        b = await c.record_expense(account_id="a", date="2026-05-01")
+        d = await c.record_expense(account_id="a", amount=100)
+        assert "account_id" in a["error"]
+        assert "amount" in b["error"]
+        assert "date" in d["error"]
+
+    @pytest.mark.asyncio
+    async def test_reconcile_transaction_validates_required(self):
+        c = self._make_connector()
+        out = await c.reconcile_transaction(amount=100, date="2026-05-01")
+        assert "account_id" in out["error"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# QuickBooks Online — every tool method against a mocked AsyncClient
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestQuickbooksRealPaths:
+    """Verify QuickBooks Online connector hits correct QBO REST v3 paths."""
+
+    def _make_connector(self):
+        from connectors.finance.quickbooks import QuickbooksConnector
+        c = QuickbooksConnector(
+            {"access_token": "fake", "realm_id": "9341452961234567"}
+        )
+        c._client = MagicMock()
+        return c
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"Invoice": {"Id": "1", "TotalAmt": 100}})
+        out = await c.create_invoice(
+            Line=[{"Amount": 100, "DetailType": "SalesItemLineDetail"}],
+            CustomerRef={"value": "cust1"},
+            TxnDate="2026-05-01",
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/company/9341452961234567/invoice"
+        assert out.get("Id") == "1"
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_normalises_string_customer_ref(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"Invoice": {"Id": "2"}})
+        out = await c.create_invoice(
+            Line=[{"Amount": 50}], CustomerRef="cust-string"
+        )
+        assert out.get("Id") == "2"
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_invoice(CustomerRef={"value": "c"})
+        b = await c.create_invoice(Line=[{}])
+        assert "Line" in a["error"]
+        assert "CustomerRef" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_record_payment_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"Payment": {"Id": "P1", "TotalAmt": 100}})
+        out = await c.record_payment(
+            TotalAmt=100,
+            CustomerRef={"value": "c"},
+            PaymentMethodRef={"value": "1"},
+            DepositToAccountRef={"value": "33"},
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/company/9341452961234567/payment"
+        assert out.get("Id") == "P1"
+
+    @pytest.mark.asyncio
+    async def test_record_payment_validates_required(self):
+        c = self._make_connector()
+        a = await c.record_payment(CustomerRef={"value": "c"})
+        b = await c.record_payment(TotalAmt=50)
+        assert "TotalAmt" in a["error"]
+        assert "CustomerRef" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_record_payment_normalises_string_customer_ref(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"Payment": {"Id": "P2"}})
+        out = await c.record_payment(TotalAmt=200, CustomerRef="cust-string")
+        assert out.get("Id") == "P2"
+
+    @pytest.mark.asyncio
+    async def test_get_profit_loss_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"Header": {"ReportName": "ProfitAndLoss"}, "Rows": {}}
+        )
+        out = await c.get_profit_loss(start_date="2026-04-01", end_date="2026-04-30")
+        args = c._client.get.call_args
+        assert args[0][0] == "/company/9341452961234567/reports/ProfitAndLoss"
+        assert out["Header"]["ReportName"] == "ProfitAndLoss"
+
+    @pytest.mark.asyncio
+    async def test_get_balance_sheet_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"Header": {"ReportName": "BalanceSheet"}, "Rows": {}}
+        )
+        out = await c.get_balance_sheet(date="2026-04-30")
+        args = c._client.get.call_args
+        assert args[0][0] == "/company/9341452961234567/reports/BalanceSheet"
+        assert out["Header"]["ReportName"] == "BalanceSheet"
+
+    @pytest.mark.asyncio
+    async def test_query_path_unwraps_query_response(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {
+                "QueryResponse": {"Invoice": [{"Id": "1"}, {"Id": "2"}]},
+                "time": "2026-05-01",
+            }
+        )
+        out = await c.query(query="SELECT * FROM Invoice")
+        args = c._client.get.call_args
+        assert args[0][0] == "/company/9341452961234567/query"
+        assert isinstance(out, list)
+        assert len(out) == 2
+
+    @pytest.mark.asyncio
+    async def test_query_validates_required(self):
+        c = self._make_connector()
+        out = await c.query()
+        assert "query is required" in out["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_company_info_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"CompanyInfo": {"CompanyName": "Acme Corp"}}
+        )
+        out = await c.get_company_info()
+        args = c._client.get.call_args
+        assert (
+            args[0][0]
+            == "/company/9341452961234567/companyinfo/9341452961234567"
+        )
+        assert out.get("CompanyName") == "Acme Corp"
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_company_name(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"CompanyInfo": {"CompanyName": "Acme Corp"}}
+        )
+        out = await c.health_check()
+        assert out["status"] == "healthy"
+        assert out["company_name"] == "Acme Corp"
+
+    @pytest.mark.asyncio
+    async def test_health_check_unhealthy_on_error(self):
+        c = self._make_connector()
+        c._client.get = AsyncMock(side_effect=RuntimeError("boom"))
+        out = await c.health_check()
+        assert out["status"] == "unhealthy"
+
+    def test_company_path_embeds_realm_id(self):
+        c = self._make_connector()
+        assert c._company_path("invoice") == "/company/9341452961234567/invoice"
+
+    def test_unwrap_handles_query_response_envelope(self):
+        c = self._make_connector()
+        out = c._unwrap({"QueryResponse": {"Invoice": [{"Id": "1"}]}})
+        assert out == [{"Id": "1"}]
+
+    def test_unwrap_handles_direct_entity_envelope(self):
+        c = self._make_connector()
+        out = c._unwrap({"Invoice": {"Id": "1"}}, "Invoice")
+        assert out == {"Id": "1"}
+
+    def test_unwrap_skips_time_metadata_key(self):
+        c = self._make_connector()
+        out = c._unwrap({"time": "2026-05-01", "Invoice": {"Id": "1"}})
+        assert out == {"Id": "1"}
+
+    def test_unwrap_passes_through_non_dict(self):
+        c = self._make_connector()
+        assert c._unwrap("not a dict") == "not a dict"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# NetSuite — every tool method against a mocked AsyncClient
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestNetsuiteRealPaths:
+    """Verify NetSuite SuiteTalk REST connector hits correct record paths."""
+
+    def _make_connector(self):
+        from connectors.finance.netsuite import NetsuiteConnector
+        c = NetsuiteConnector(
+            {"account_id": "TSTDRV1234567", "access_token": "fake-token"}
+        )
+        c._client = MagicMock()
+        return c
+
+    def test_base_url_built_from_account_id(self):
+        c = self._make_connector()
+        assert c.base_url.startswith("https://tstdrv1234567.suitetalk.api.netsuite.com")
+
+    def test_base_url_lowercases_and_replaces_dots(self):
+        from connectors.finance.netsuite import NetsuiteConnector
+        c = NetsuiteConnector({"account_id": "TSTDRV.1234.567", "access_token": "x"})
+        assert "tstdrv_1234_567.suitetalk.api.netsuite.com" in c.base_url
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"id": "inv1"})
+        await c.create_invoice(
+            entity="cust1",
+            item=[{"item": {"id": "42"}, "quantity": 2, "rate": 150}],
+            tranDate="2026-05-01",
+            memo="May invoice",
+            department="DEPT-1",
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/invoice"
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_invoice(item=[{}])
+        b = await c.create_invoice(entity="cust1")
+        assert "entity" in a["error"]
+        assert "item" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_invoice_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"id": "inv1"})
+        await c.get_invoice(id="inv1", expandSubResources=True)
+        args = c._client.get.call_args
+        assert args[0][0] == "/invoice/inv1"
+
+    @pytest.mark.asyncio
+    async def test_get_invoice_validates_required(self):
+        c = self._make_connector()
+        out = await c.get_invoice()
+        assert "id" in out["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"id": "je1"})
+        await c.create_journal_entry(
+            subsidiary="1",
+            line=[
+                {"account": {"id": "10"}, "debit": 1000, "memo": "Rev"},
+                {"account": {"id": "20"}, "credit": 1000, "memo": "Cash"},
+            ],
+            tranDate="2026-05-01",
+            memo="Adj entry",
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/journalEntry"
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_journal_entry(line=[{}])
+        b = await c.create_journal_entry(subsidiary="1")
+        assert "subsidiary" in a["error"]
+        assert "line" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_account_balance_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"id": "10", "balance": 5000})
+        await c.get_account_balance(id="10")
+        args = c._client.get.call_args
+        assert args[0][0] == "/account/10"
+
+    @pytest.mark.asyncio
+    async def test_get_account_balance_validates_required(self):
+        c = self._make_connector()
+        out = await c.get_account_balance()
+        assert "id" in out["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_vendor_bill_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"id": "vb1"})
+        await c.create_vendor_bill(
+            entity="vendor1",
+            item=[{"item": {"id": "55"}, "quantity": 1, "rate": 500}],
+            tranDate="2026-05-01",
+            memo="Office supplies",
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/vendorBill"
+
+    @pytest.mark.asyncio
+    async def test_create_vendor_bill_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_vendor_bill(item=[{}])
+        b = await c.create_vendor_bill(entity="v")
+        assert "entity" in a["error"]
+        assert "item" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_purchase_order_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"id": "po1"})
+        await c.create_purchase_order(
+            entity="vendor1",
+            item=[{"item": {"id": "77"}, "quantity": 10, "rate": 25}],
+            tranDate="2026-05-01",
+            memo="Bulk order",
+            shipTo="100",
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/purchaseOrder"
+
+    @pytest.mark.asyncio
+    async def test_create_purchase_order_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_purchase_order(item=[{}])
+        b = await c.create_purchase_order(entity="v")
+        assert "entity" in a["error"]
+        assert "item" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_trial_balance_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {
+                "items": [
+                    {
+                        "id": "10",
+                        "acctName": "Cash",
+                        "acctNumber": "1000",
+                        "acctType": {"refName": "Bank"},
+                        "balance": 50000,
+                    }
+                ],
+                "totalResults": 1,
+            }
+        )
+        out = await c.get_trial_balance(period="P1", subsidiary="1")
+        args = c._client.get.call_args
+        assert args[0][0] == "/account"
+        assert out["accounts"][0]["acctName"] == "Cash"
+        assert out["accounts"][0]["acctType"] == "Bank"
+
+    @pytest.mark.asyncio
+    async def test_search_records_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"items": [{"id": "1"}], "totalResults": 1, "hasMore": False}
+        )
+        out = await c.search_records(
+            record_type="invoice", q="status='open'", limit=50, offset=0
+        )
+        args = c._client.get.call_args
+        assert args[0][0] == "/invoice"
+        assert out["records"][0]["id"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_search_records_validates_required(self):
+        c = self._make_connector()
+        out = await c.search_records()
+        assert "record_type" in out["error"]
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_total_results(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"totalResults": 7})
+        out = await c.health_check()
+        assert out["status"] == "healthy"
+        assert out["total_results"] == 7
+
+    @pytest.mark.asyncio
+    async def test_health_check_unhealthy_on_error(self):
+        c = self._make_connector()
+        c._client.get = AsyncMock(side_effect=RuntimeError("boom"))
+        out = await c.health_check()
+        assert out["status"] == "unhealthy"
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Oracle Fusion

--- a/tests/unit/test_connector_real_paths.py
+++ b/tests/unit/test_connector_real_paths.py
@@ -428,13 +428,19 @@ class TestNetsuiteRealPaths:
         return c
 
     def test_base_url_built_from_account_id(self):
+        from urllib.parse import urlparse
         c = self._make_connector()
-        assert c.base_url.startswith("https://tstdrv1234567.suitetalk.api.netsuite.com")
+        parsed = urlparse(c.base_url)
+        assert parsed.scheme == "https"
+        assert parsed.hostname == "tstdrv1234567.suitetalk.api.netsuite.com"
 
     def test_base_url_lowercases_and_replaces_dots(self):
+        from urllib.parse import urlparse
+
         from connectors.finance.netsuite import NetsuiteConnector
         c = NetsuiteConnector({"account_id": "TSTDRV.1234.567", "access_token": "x"})
-        assert "tstdrv_1234_567.suitetalk.api.netsuite.com" in c.base_url
+        parsed = urlparse(c.base_url)
+        assert parsed.hostname == "tstdrv_1234_567.suitetalk.api.netsuite.com"
 
     @pytest.mark.asyncio
     async def test_create_invoice_path(self):

--- a/ui/nginx.cloudrun.conf.template
+++ b/ui/nginx.cloudrun.conf.template
@@ -32,7 +32,10 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://apis.google.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://accounts.google.com; img-src 'self' data: blob: https://*.googleusercontent.com https://www.google-analytics.com; font-src 'self' data:; connect-src 'self' wss: ws: https://accounts.google.com https://oauth2.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none';" always;
+    # SEC-2026-05-P2-009 (PR-G2): see ui/nginx.conf for the rationale.
+    # Hashes must match those in nginx.conf — kept in sync by
+    # scripts/refresh_csp_hashes.sh + the PR-G2 regression test.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-silDIMUzIKrZq4B8I/NYBH4Ic7prd8raP5PJeutQckU=' 'sha256-wQU8MF/7cTNkXkniFP5d4yS1lI7m9vSxDrFND7S5GMM=' 'sha256-y9ZZesBGLi8D5oZ75ilyd3jjqKx5ttGPp6uuyshRixk=' 'sha256-aYTMCdCcFWDgMLWpudyh/kYDQNuAW0E2KOmFtnvp/ZQ=' 'sha256-R/Z95IwKFgil2Ms/1UNrSYrHZzBKm3FlxjAl+RYEDX8=' 'sha256-AxFnxwoAtckVibGP4rshZMGuWGlHTQpcply4CbMuii0=' 'sha256-0nBVhm4XYImcYyrpyw6KLo+p0RTLwEuMZeyUlsBLQdQ=' https://accounts.google.com https://apis.google.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://accounts.google.com; img-src 'self' data: blob: https://*.googleusercontent.com https://www.google-analytics.com; font-src 'self' data:; connect-src 'self' wss: ws: https://accounts.google.com https://oauth2.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none';" always;
 
     location /assets/ {
         expires 1y;

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -47,11 +47,18 @@ server {
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
     # SECURITY_AUDIT-2026-04-19 MEDIUM-13: dropped 'unsafe-eval' from
     # script-src — the SPA does not call eval() or new Function() and
-    # none of the runtime dependencies use eval-based evaluation.
-    # 'unsafe-inline' on script-src is retained only for inline GA /
-    # GTM boot snippets; a follow-up will move those to nonce-based
-    # injection once the build pipeline emits CSP nonces.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://apis.google.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://accounts.google.com; img-src 'self' data: blob: https://*.googleusercontent.com https://www.google-analytics.com; font-src 'self' data:; connect-src 'self' wss: ws: https://accounts.google.com https://oauth2.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none';" always;
+    # SEC-2026-05-P2-009 (PR-G2, 2026-05-01): script-src no longer
+    # carries 'unsafe-inline'. The seven 'sha256-...' tokens below
+    # whitelist exactly the inline JSON-LD blocks in ui/index.html
+    # (used for SEO structured data). Any edit to those blocks
+    # requires regenerating the hash via:
+    #   bash scripts/refresh_csp_hashes.sh
+    # The corresponding regression test
+    # tests/regression/test_security_pr_g2_csp_hash_pinning.py
+    # fails if the source JSON-LD content drifts from the hashes here.
+    # style-src retains 'unsafe-inline' (Tailwind utility class output
+    # generates inline styles; documented residual, low-XSS-impact).
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-silDIMUzIKrZq4B8I/NYBH4Ic7prd8raP5PJeutQckU=' 'sha256-wQU8MF/7cTNkXkniFP5d4yS1lI7m9vSxDrFND7S5GMM=' 'sha256-y9ZZesBGLi8D5oZ75ilyd3jjqKx5ttGPp6uuyshRixk=' 'sha256-aYTMCdCcFWDgMLWpudyh/kYDQNuAW0E2KOmFtnvp/ZQ=' 'sha256-R/Z95IwKFgil2Ms/1UNrSYrHZzBKm3FlxjAl+RYEDX8=' 'sha256-AxFnxwoAtckVibGP4rshZMGuWGlHTQpcply4CbMuii0=' 'sha256-0nBVhm4XYImcYyrpyw6KLo+p0RTLwEuMZeyUlsBLQdQ=' https://accounts.google.com https://apis.google.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://accounts.google.com; img-src 'self' data: blob: https://*.googleusercontent.com https://www.google-analytics.com; font-src 'self' data:; connect-src 'self' wss: ws: https://accounts.google.com https://oauth2.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none';" always;
 
     # ── Static assets — long cache (hashed filenames from Vite/Webpack) ───────
     # If a chunk is missing (stale index.html references old build), serve


### PR DESCRIPTION
## Summary

Closes **SEC-2026-05-P2-009** — the last open P2 from the 2026-05-01 brutal security scan. `script-src` no longer carries `'unsafe-inline'`. Each of the 7 inline `<script type=\"application/ld+json\">` blocks in `ui/index.html` (used for SEO structured data) is whitelisted via a `'sha256-...'` token.

## Files

- `ui/nginx.conf` + `ui/nginx.cloudrun.conf.template` — CSP `script-src` updated
- `scripts/refresh_csp_hashes.sh` — auto-refresh helper for when JSON-LD content changes
- `tests/regression/test_security_pr_g2_csp_hash_pinning.py` — 9 pins (no unsafe-inline / no unsafe-eval / no wildcard / hashes match source / configs identical / refresh script exists)

## Why hash-pinning vs. external-file or nonce

- External JSON-LD file (`<script src=...>`): Google's structured-data parser does NOT reliably support `src` on JSON-LD; would silently break SEO.
- Per-request nonce: needs Cloud Run nginx envsubst gymnastics that buy little extra security over hash-pinning of static blocks.
- SHA-256 hash-pinning: chosen. Static blocks → static hashes. Refresh script + regression test catch any drift instantly.

## Test plan

- [x] `pytest tests/regression/test_security_pr_g2_csp_hash_pinning.py` → 9 passed
- [x] `bash scripts/refresh_csp_hashes.sh` → idempotent (re-run = no-op)
- [x] `ruff check .` → clean
- [ ] CI green
- [ ] @codex review
- [ ] Post-deploy: open `/dashboard` and `/blog` → verify no `Content-Security-Policy` violations in browser console

## Residual

`style-src` retains `'unsafe-inline'` — Tailwind utility-class output emits inline styles in many components; pinning them all by hash is not feasible without a CSS architecture change. Inline-style XSS impact is materially smaller than inline-script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)