### PR TITLE
fix(security): PR-F2 — cookie-first e2e auth fixtures (SEC-002 residual)

### DIFF
--- a/tests/regression/test_security_pr_f2_e2e_cookie_sweep.py
+++ b/tests/regression/test_security_pr_f2_e2e_cookie_sweep.py
@@ -1,0 +1,113 @@
+"""PR-F2 regression pins for SEC-002 — e2e fixtures use cookie-first
+auth instead of ``localStorage.setItem("token", ...)``.
+
+Closes the residual called out in PR-F: the production code was
+already cookie-first, but Playwright e2e specs still seeded auth via
+``page.evaluate(() => localStorage.setItem("token", ...))``. PR-F2
+swept all 27 spec files + the shared ``helpers/auth.ts`` to use
+``page.context().addCookies(...)`` (via the new ``setSessionToken``
+helper). The fixtures now match the production cookie-based posture
+exactly, so a Playwright pass means cookie auth actually works
+end-to-end.
+
+The test below greps the entire ``ui/e2e`` tree for the forbidden
+patterns. Doc-comment occurrences in ``helpers/auth.ts`` are
+explicitly excluded — they describe the migration. Any setItem /
+getItem of token/user OUTSIDE that helper file fails the test with
+file + line + offending snippet.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+UI_E2E = REPO_ROOT / "ui" / "e2e"
+
+# Forbidden: setItem / getItem on token or user keys.
+# (removeItem is allowed — used for cleanup of legacy state.)
+_FORBIDDEN = [
+    re.compile(r'localStorage\s*\.\s*setItem\s*\(\s*["\']token["\']'),
+    re.compile(r'localStorage\s*\.\s*getItem\s*\(\s*["\']token["\']'),
+    re.compile(r'localStorage\s*\.\s*setItem\s*\(\s*["\']user["\']'),
+    re.compile(r'localStorage\s*\.\s*getItem\s*\(\s*["\']user["\']'),
+]
+
+# helpers/auth.ts has doc-comment references that explain the
+# migration. They are not code; allow them.
+_DOCSTRING_OK_FILES = {
+    str((UI_E2E / "helpers" / "auth.ts").relative_to(REPO_ROOT)).replace("\\", "/"),
+}
+
+
+def _walk_e2e() -> list[Path]:
+    if not UI_E2E.exists():
+        pytest.skip(f"ui/e2e not present in checkout at {UI_E2E}")
+    return [
+        p
+        for p in UI_E2E.rglob("*")
+        if p.is_file() and p.suffix == ".ts"
+    ]
+
+
+def test_sec_002_pr_f2_no_localstorage_token_set_or_get_in_e2e_specs() -> None:
+    offenders: list[str] = []
+    for path in _walk_e2e():
+        rel = str(path.relative_to(REPO_ROOT)).replace("\\", "/")
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            stripped = line.strip()
+            # Skip TypeScript / JS line comments and JSDoc lines that
+            # mention the legacy pattern in passing.
+            if stripped.startswith(("//", "*", "/*")):
+                continue
+            for pattern in _FORBIDDEN:
+                if pattern.search(line):
+                    offenders.append(f"{rel}:{lineno}: {stripped}")
+    assert not offenders, (
+        "SEC-002 (PR-F2): e2e specs must not seed auth via localStorage. "
+        "Use ``setSessionToken(page, token)`` from helpers/auth instead. "
+        "Offending lines:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_sec_002_pr_f2_helpers_export_cookie_setter() -> None:
+    """The shared helper must export ``setSessionToken`` so spec files
+    have one place to convert if the cookie name ever changes."""
+    helper = (UI_E2E / "helpers" / "auth.ts").read_text(encoding="utf-8")
+    assert "export async function setSessionToken" in helper, (
+        "helpers/auth.ts must export setSessionToken for cookie-first "
+        "session seeding."
+    )
+    assert "agenticorg_session" in helper, (
+        "setSessionToken must seed the production session cookie name."
+    )
+    assert "addCookies" in helper, (
+        "setSessionToken must use page.context().addCookies(...) "
+        "rather than page.evaluate(...localStorage...)."
+    )
+
+
+def test_sec_002_pr_f2_authenticate_uses_cookie_helper() -> None:
+    """The shared ``authenticate`` helper must call ``setSessionToken``
+    rather than writing to localStorage directly."""
+    helper = (UI_E2E / "helpers" / "auth.ts").read_text(encoding="utf-8")
+    # Find the authenticate function body.
+    m = re.search(
+        r"export async function authenticate\([^)]*\)\s*:\s*Promise<void>\s*\{(.*?)\n\}",
+        helper,
+        re.DOTALL,
+    )
+    assert m, "authenticate() helper not found in helpers/auth.ts"
+    body = m.group(1)
+    assert "setSessionToken" in body, (
+        "authenticate() must delegate to setSessionToken so the cookie "
+        "fixture matches production posture."
+    )
+    assert 'localStorage.setItem("token"' not in body, (
+        "authenticate() must not write to localStorage anymore."
+    )

--- a/tests/unit/test_connector_real_paths.py
+++ b/tests/unit/test_connector_real_paths.py
@@ -158,6 +158,458 @@ class TestZohoBooksRealPaths:
         args = c._client.get.call_args
         assert args[0][0] == "/reports/balancesheet"
 
+    @pytest.mark.asyncio
+    async def test_get_profit_loss_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"profit_and_loss": {"revenue": 1000}})
+        await c.get_profit_loss(from_date="2026-04-01", to_date="2026-04-30")
+        args = c._client.get.call_args
+        assert args[0][0] == "/reports/profitandloss"
+
+    @pytest.mark.asyncio
+    async def test_list_chartofaccounts_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"chartofaccounts": [{"account_id": "a1"}]})
+        out = await c.list_chartofaccounts(filter_by="AccountType.asset")
+        args = c._client.get.call_args
+        assert args[0][0] == "/chartofaccounts"
+        assert isinstance(out["chartofaccounts"], list)
+
+    @pytest.mark.asyncio
+    async def test_reconcile_transaction_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"bank_transaction": {"transaction_id": "T1"}})
+        await c.reconcile_transaction(
+            account_id="a1", amount=1000, date="2026-05-01", reference_number="R1"
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/banktransactions/uncategorized"
+
+    @pytest.mark.asyncio
+    async def test_get_organization_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"organizations": [{"organization_id": "1", "name": "Acme"}]}
+        )
+        out = await c.get_organization()
+        args = c._client.get.call_args
+        assert args[0][0] == "/organizations"
+        assert out["organizations"][0]["name"] == "Acme"
+
+    @pytest.mark.asyncio
+    async def test_get_organization_empty(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"organizations": []})
+        out = await c.get_organization()
+        assert out == {"organizations": []}
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_org_count(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"organizations": [{"organization_id": "1"}, {"organization_id": "2"}]}
+        )
+        out = await c.health_check()
+        assert out["status"] == "healthy"
+        assert out["organizations"] == 2
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_invoice(line_items=[{"item_id": "i"}])
+        b = await c.create_invoice(customer_id="c")
+        assert "customer_id" in a["error"]
+        assert "line_items" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_record_expense_validates_required(self):
+        c = self._make_connector()
+        a = await c.record_expense(amount=100, date="2026-05-01")
+        b = await c.record_expense(account_id="a", date="2026-05-01")
+        d = await c.record_expense(account_id="a", amount=100)
+        assert "account_id" in a["error"]
+        assert "amount" in b["error"]
+        assert "date" in d["error"]
+
+    @pytest.mark.asyncio
+    async def test_reconcile_transaction_validates_required(self):
+        c = self._make_connector()
+        out = await c.reconcile_transaction(amount=100, date="2026-05-01")
+        assert "account_id" in out["error"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# QuickBooks Online — every tool method against a mocked AsyncClient
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestQuickbooksRealPaths:
+    """Verify QuickBooks Online connector hits correct QBO REST v3 paths."""
+
+    def _make_connector(self):
+        from connectors.finance.quickbooks import QuickbooksConnector
+        c = QuickbooksConnector(
+            {"access_token": "fake", "realm_id": "9341452961234567"}
+        )
+        c._client = MagicMock()
+        return c
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"Invoice": {"Id": "1", "TotalAmt": 100}})
+        out = await c.create_invoice(
+            Line=[{"Amount": 100, "DetailType": "SalesItemLineDetail"}],
+            CustomerRef={"value": "cust1"},
+            TxnDate="2026-05-01",
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/company/9341452961234567/invoice"
+        assert out.get("Id") == "1"
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_normalises_string_customer_ref(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"Invoice": {"Id": "2"}})
+        out = await c.create_invoice(
+            Line=[{"Amount": 50}], CustomerRef="cust-string"
+        )
+        assert out.get("Id") == "2"
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_invoice(CustomerRef={"value": "c"})
+        b = await c.create_invoice(Line=[{}])
+        assert "Line" in a["error"]
+        assert "CustomerRef" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_record_payment_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"Payment": {"Id": "P1", "TotalAmt": 100}})
+        out = await c.record_payment(
+            TotalAmt=100,
+            CustomerRef={"value": "c"},
+            PaymentMethodRef={"value": "1"},
+            DepositToAccountRef={"value": "33"},
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/company/9341452961234567/payment"
+        assert out.get("Id") == "P1"
+
+    @pytest.mark.asyncio
+    async def test_record_payment_validates_required(self):
+        c = self._make_connector()
+        a = await c.record_payment(CustomerRef={"value": "c"})
+        b = await c.record_payment(TotalAmt=50)
+        assert "TotalAmt" in a["error"]
+        assert "CustomerRef" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_record_payment_normalises_string_customer_ref(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"Payment": {"Id": "P2"}})
+        out = await c.record_payment(TotalAmt=200, CustomerRef="cust-string")
+        assert out.get("Id") == "P2"
+
+    @pytest.mark.asyncio
+    async def test_get_profit_loss_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"Header": {"ReportName": "ProfitAndLoss"}, "Rows": {}}
+        )
+        out = await c.get_profit_loss(start_date="2026-04-01", end_date="2026-04-30")
+        args = c._client.get.call_args
+        assert args[0][0] == "/company/9341452961234567/reports/ProfitAndLoss"
+        assert out["Header"]["ReportName"] == "ProfitAndLoss"
+
+    @pytest.mark.asyncio
+    async def test_get_balance_sheet_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"Header": {"ReportName": "BalanceSheet"}, "Rows": {}}
+        )
+        out = await c.get_balance_sheet(date="2026-04-30")
+        args = c._client.get.call_args
+        assert args[0][0] == "/company/9341452961234567/reports/BalanceSheet"
+        assert out["Header"]["ReportName"] == "BalanceSheet"
+
+    @pytest.mark.asyncio
+    async def test_query_path_unwraps_query_response(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {
+                "QueryResponse": {"Invoice": [{"Id": "1"}, {"Id": "2"}]},
+                "time": "2026-05-01",
+            }
+        )
+        out = await c.query(query="SELECT * FROM Invoice")
+        args = c._client.get.call_args
+        assert args[0][0] == "/company/9341452961234567/query"
+        assert isinstance(out, list)
+        assert len(out) == 2
+
+    @pytest.mark.asyncio
+    async def test_query_validates_required(self):
+        c = self._make_connector()
+        out = await c.query()
+        assert "query is required" in out["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_company_info_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"CompanyInfo": {"CompanyName": "Acme Corp"}}
+        )
+        out = await c.get_company_info()
+        args = c._client.get.call_args
+        assert (
+            args[0][0]
+            == "/company/9341452961234567/companyinfo/9341452961234567"
+        )
+        assert out.get("CompanyName") == "Acme Corp"
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_company_name(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"CompanyInfo": {"CompanyName": "Acme Corp"}}
+        )
+        out = await c.health_check()
+        assert out["status"] == "healthy"
+        assert out["company_name"] == "Acme Corp"
+
+    @pytest.mark.asyncio
+    async def test_health_check_unhealthy_on_error(self):
+        c = self._make_connector()
+        c._client.get = AsyncMock(side_effect=RuntimeError("boom"))
+        out = await c.health_check()
+        assert out["status"] == "unhealthy"
+
+    def test_company_path_embeds_realm_id(self):
+        c = self._make_connector()
+        assert c._company_path("invoice") == "/company/9341452961234567/invoice"
+
+    def test_unwrap_handles_query_response_envelope(self):
+        c = self._make_connector()
+        out = c._unwrap({"QueryResponse": {"Invoice": [{"Id": "1"}]}})
+        assert out == [{"Id": "1"}]
+
+    def test_unwrap_handles_direct_entity_envelope(self):
+        c = self._make_connector()
+        out = c._unwrap({"Invoice": {"Id": "1"}}, "Invoice")
+        assert out == {"Id": "1"}
+
+    def test_unwrap_skips_time_metadata_key(self):
+        c = self._make_connector()
+        out = c._unwrap({"time": "2026-05-01", "Invoice": {"Id": "1"}})
+        assert out == {"Id": "1"}
+
+    def test_unwrap_passes_through_non_dict(self):
+        c = self._make_connector()
+        assert c._unwrap("not a dict") == "not a dict"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# NetSuite — every tool method against a mocked AsyncClient
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestNetsuiteRealPaths:
+    """Verify NetSuite SuiteTalk REST connector hits correct record paths."""
+
+    def _make_connector(self):
+        from connectors.finance.netsuite import NetsuiteConnector
+        c = NetsuiteConnector(
+            {"account_id": "TSTDRV1234567", "access_token": "fake-token"}
+        )
+        c._client = MagicMock()
+        return c
+
+    def test_base_url_built_from_account_id(self):
+        c = self._make_connector()
+        assert c.base_url.startswith("https://tstdrv1234567.suitetalk.api.netsuite.com")
+
+    def test_base_url_lowercases_and_replaces_dots(self):
+        from connectors.finance.netsuite import NetsuiteConnector
+        c = NetsuiteConnector({"account_id": "TSTDRV.1234.567", "access_token": "x"})
+        assert "tstdrv_1234_567.suitetalk.api.netsuite.com" in c.base_url
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"id": "inv1"})
+        await c.create_invoice(
+            entity="cust1",
+            item=[{"item": {"id": "42"}, "quantity": 2, "rate": 150}],
+            tranDate="2026-05-01",
+            memo="May invoice",
+            department="DEPT-1",
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/invoice"
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_invoice(item=[{}])
+        b = await c.create_invoice(entity="cust1")
+        assert "entity" in a["error"]
+        assert "item" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_invoice_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"id": "inv1"})
+        await c.get_invoice(id="inv1", expandSubResources=True)
+        args = c._client.get.call_args
+        assert args[0][0] == "/invoice/inv1"
+
+    @pytest.mark.asyncio
+    async def test_get_invoice_validates_required(self):
+        c = self._make_connector()
+        out = await c.get_invoice()
+        assert "id" in out["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"id": "je1"})
+        await c.create_journal_entry(
+            subsidiary="1",
+            line=[
+                {"account": {"id": "10"}, "debit": 1000, "memo": "Rev"},
+                {"account": {"id": "20"}, "credit": 1000, "memo": "Cash"},
+            ],
+            tranDate="2026-05-01",
+            memo="Adj entry",
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/journalEntry"
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_journal_entry(line=[{}])
+        b = await c.create_journal_entry(subsidiary="1")
+        assert "subsidiary" in a["error"]
+        assert "line" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_account_balance_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"id": "10", "balance": 5000})
+        await c.get_account_balance(id="10")
+        args = c._client.get.call_args
+        assert args[0][0] == "/account/10"
+
+    @pytest.mark.asyncio
+    async def test_get_account_balance_validates_required(self):
+        c = self._make_connector()
+        out = await c.get_account_balance()
+        assert "id" in out["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_vendor_bill_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"id": "vb1"})
+        await c.create_vendor_bill(
+            entity="vendor1",
+            item=[{"item": {"id": "55"}, "quantity": 1, "rate": 500}],
+            tranDate="2026-05-01",
+            memo="Office supplies",
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/vendorBill"
+
+    @pytest.mark.asyncio
+    async def test_create_vendor_bill_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_vendor_bill(item=[{}])
+        b = await c.create_vendor_bill(entity="v")
+        assert "entity" in a["error"]
+        assert "item" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_purchase_order_path(self):
+        c = self._make_connector()
+        c._client.post = _async_response({"id": "po1"})
+        await c.create_purchase_order(
+            entity="vendor1",
+            item=[{"item": {"id": "77"}, "quantity": 10, "rate": 25}],
+            tranDate="2026-05-01",
+            memo="Bulk order",
+            shipTo="100",
+        )
+        args = c._client.post.call_args
+        assert args[0][0] == "/purchaseOrder"
+
+    @pytest.mark.asyncio
+    async def test_create_purchase_order_validates_required(self):
+        c = self._make_connector()
+        a = await c.create_purchase_order(item=[{}])
+        b = await c.create_purchase_order(entity="v")
+        assert "entity" in a["error"]
+        assert "item" in b["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_trial_balance_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {
+                "items": [
+                    {
+                        "id": "10",
+                        "acctName": "Cash",
+                        "acctNumber": "1000",
+                        "acctType": {"refName": "Bank"},
+                        "balance": 50000,
+                    }
+                ],
+                "totalResults": 1,
+            }
+        )
+        out = await c.get_trial_balance(period="P1", subsidiary="1")
+        args = c._client.get.call_args
+        assert args[0][0] == "/account"
+        assert out["accounts"][0]["acctName"] == "Cash"
+        assert out["accounts"][0]["acctType"] == "Bank"
+
+    @pytest.mark.asyncio
+    async def test_search_records_path(self):
+        c = self._make_connector()
+        c._client.get = _async_response(
+            {"items": [{"id": "1"}], "totalResults": 1, "hasMore": False}
+        )
+        out = await c.search_records(
+            record_type="invoice", q="status='open'", limit=50, offset=0
+        )
+        args = c._client.get.call_args
+        assert args[0][0] == "/invoice"
+        assert out["records"][0]["id"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_search_records_validates_required(self):
+        c = self._make_connector()
+        out = await c.search_records()
+        assert "record_type" in out["error"]
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_total_results(self):
+        c = self._make_connector()
+        c._client.get = _async_response({"totalResults": 7})
+        out = await c.health_check()
+        assert out["status"] == "healthy"
+        assert out["total_results"] == 7
+
+    @pytest.mark.asyncio
+    async def test_health_check_unhealthy_on_error(self):
+        c = self._make_connector()
+        c._client.get = AsyncMock(side_effect=RuntimeError("boom"))
+        out = await c.health_check()
+        assert out["status"] == "unhealthy"
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Oracle Fusion

--- a/tests/unit/test_connector_real_paths.py
+++ b/tests/unit/test_connector_real_paths.py
@@ -428,13 +428,19 @@ class TestNetsuiteRealPaths:
         return c
 
     def test_base_url_built_from_account_id(self):
+        from urllib.parse import urlparse
         c = self._make_connector()
-        assert c.base_url.startswith("https://tstdrv1234567.suitetalk.api.netsuite.com")
+        parsed = urlparse(c.base_url)
+        assert parsed.scheme == "https"
+        assert parsed.hostname == "tstdrv1234567.suitetalk.api.netsuite.com"
 
     def test_base_url_lowercases_and_replaces_dots(self):
+        from urllib.parse import urlparse
+
         from connectors.finance.netsuite import NetsuiteConnector
         c = NetsuiteConnector({"account_id": "TSTDRV.1234.567", "access_token": "x"})
-        assert "tstdrv_1234_567.suitetalk.api.netsuite.com" in c.base_url
+        parsed = urlparse(c.base_url)
+        assert parsed.hostname == "tstdrv_1234_567.suitetalk.api.netsuite.com"
 
     @pytest.mark.asyncio
     async def test_create_invoice_path(self):

--- a/ui/e2e/app-routes.spec.ts
+++ b/ui/e2e/app-routes.spec.ts
@@ -83,9 +83,7 @@ test.describe("Dashboard Routes — Auth Required", () => {
   test.beforeEach(async ({ page }) => {
     requireAuth();
     await page.goto(`${APP}/login`);
-    await page.evaluate((token) => {
-      localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    }, E2E_TOKEN);
+    await setSessionToken(page, E2E_TOKEN);
   });
 
   for (const route of dashboardRoutes) {
@@ -152,9 +150,7 @@ test.describe("Dashboard — Sidebar Navigation", () => {
   test.beforeEach(async ({ page }) => {
     requireAuth();
     await page.goto(`${APP}/login`);
-    await page.evaluate((token) => {
-      localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    }, E2E_TOKEN);
+    await setSessionToken(page, E2E_TOKEN);
   });
 
   for (const link of sidebarLinks) {
@@ -190,9 +186,7 @@ test.describe("Create Flows", () => {
   test.beforeEach(async ({ page }) => {
     requireAuth();
     await page.goto(`${APP}/login`);
-    await page.evaluate((token) => {
-      localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    }, E2E_TOKEN);
+    await setSessionToken(page, E2E_TOKEN);
   });
 
   test("Agents page → Create Agent button works", async ({ page }) => {
@@ -230,9 +224,7 @@ test.describe("Data Display Quality", () => {
   test.beforeEach(async ({ page }) => {
     requireAuth();
     await page.goto(`${APP}/login`);
-    await page.evaluate((token) => {
-      localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    }, E2E_TOKEN);
+    await setSessionToken(page, E2E_TOKEN);
   });
 
   const pages = [

--- a/ui/e2e/ca-firms.spec.ts
+++ b/ui/e2e/ca-firms.spec.ts
@@ -27,30 +27,21 @@ function requireAuth(): void {
 // -- Helper: authenticate via localStorage token --
 async function authenticate(page: Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
-  await page.evaluate((token) => {
-    localStorage.setItem("token", token);
-    localStorage.setItem(
-      "user",
-      JSON.stringify({
-        email: "demo@cafirm.agenticorg.ai",
-        name: "Demo Partner",
-        role: "admin",
-        domain: "all",
-        tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
-        onboardingComplete: true,
-      }),
-    );
-  }, E2E_TOKEN);
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 // -- Helper: fetch the first real company ID from the API --
 let _cachedCompanyId: string | null = null;
 async function getCompanyId(page: Page): Promise<string> {
   if (_cachedCompanyId) return _cachedCompanyId;
-  const token = await page.evaluate(() => localStorage.getItem("token"));
+  // SEC-002 (PR-F2): page.request shares the BrowserContext cookies,
+  // so the agenticorg_session cookie is sent automatically. Keeping
+  // the explicit Bearer header as a belt-and-braces (the backend
+  // accepts both) so the request still works against API endpoints
+  // that haven't yet been audited for cookie-only acceptance.
   const resp = await page.request.get(
     `${APP}/api/v1/companies?page=1&per_page=1`,
-    { headers: { Authorization: `Bearer ${token}` } },
+    { headers: { Authorization: `Bearer ${E2E_TOKEN}` } },
   );
   if (resp.ok()) {
     const data = await resp.json();

--- a/ui/e2e/cfo-demo.spec.ts
+++ b/ui/e2e/cfo-demo.spec.ts
@@ -69,10 +69,7 @@ test.describe("CFO Demo: Dashboard (auth required)", () => {
   test.beforeEach(async ({ page }) => {
     requireAuth();
     await page.goto("/", { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => {
-      localStorage.setItem("token", t);
-      localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));
-    }, E2E_TOKEN);
+    await setSessionToken(page, E2E_TOKEN);
   });
 
   test("agent fleet page loads", async ({ page }) => {

--- a/ui/e2e/connector-edit.spec.ts
+++ b/ui/e2e/connector-edit.spec.ts
@@ -31,20 +31,7 @@ function requireAuth(): void {
 
 async function seedSession(page: import("@playwright/test").Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
-  await page.evaluate((t) => {
-    localStorage.setItem("token", t);
-    localStorage.setItem(
-      "user",
-      JSON.stringify({
-        email: "demo@cafirm.agenticorg.ai",
-        name: "Demo Partner",
-        role: "admin",
-        domain: "all",
-        tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
-        onboardingComplete: true,
-      }),
-    );
-  }, E2E_TOKEN);
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 test.describe("Connector detail + Edit @connector", () => {

--- a/ui/e2e/connectors-catalog.spec.ts
+++ b/ui/e2e/connectors-catalog.spec.ts
@@ -31,20 +31,7 @@ function requireAuth(): void {
 
 async function seedSession(page: import("@playwright/test").Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
-  await page.evaluate((t) => {
-    localStorage.setItem("token", t);
-    localStorage.setItem(
-      "user",
-      JSON.stringify({
-        email: "demo@cafirm.agenticorg.ai",
-        name: "Demo Partner",
-        role: "admin",
-        domain: "all",
-        tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
-        onboardingComplete: true,
-      }),
-    );
-  }, E2E_TOKEN);
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 test.describe("Native-connector catalog @connector", () => {

--- a/ui/e2e/dashboard-403.spec.ts
+++ b/ui/e2e/dashboard-403.spec.ts
@@ -31,23 +31,7 @@ async function seedSession(
   role: string,
 ): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
-  await page.evaluate(
-    ([t, r]) => {
-      localStorage.setItem("token", t);
-      localStorage.setItem(
-        "user",
-        JSON.stringify({
-          email: "demo@cafirm.agenticorg.ai",
-          name: "Demo Partner",
-          role: r,
-          domain: r === "admin" ? "all" : "finance",
-          tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
-          onboardingComplete: true,
-        }),
-      );
-    },
-    [E2E_TOKEN, role],
-  );
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 test.describe("Dashboard metrics — no hardcoded KPIs", () => {

--- a/ui/e2e/decorative-state.spec.ts
+++ b/ui/e2e/decorative-state.spec.ts
@@ -31,20 +31,7 @@ function requireAuth(): void {
 
 async function seedSession(page: import("@playwright/test").Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
-  await page.evaluate((t) => {
-    localStorage.setItem("token", t);
-    localStorage.setItem(
-      "user",
-      JSON.stringify({
-        email: "demo@cafirm.agenticorg.ai",
-        name: "Demo Partner",
-        role: "admin",
-        domain: "all",
-        tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
-        onboardingComplete: true,
-      }),
-    );
-  }, E2E_TOKEN);
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 test.describe("Decorative-state freeze (P1.2)", () => {

--- a/ui/e2e/error-handling.spec.ts
+++ b/ui/e2e/error-handling.spec.ts
@@ -7,6 +7,7 @@
  * NO page.route() mocking -- all responses are real.
  */
 import { test, expect, Page } from "@playwright/test";
+import { setSessionToken } from "./helpers/auth";
 
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
@@ -23,20 +24,7 @@ function requireAuth(): void {
 
 async function ensureAuth(page: Page, baseURL: string) {
   await page.goto(baseURL, { waitUntil: "domcontentloaded" });
-  await page.evaluate((token) => {
-    localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    localStorage.setItem(
-      "user",
-      JSON.stringify({
-        email: "e2e@agenticorg.ai",
-        name: "E2E Runner",
-        role: "admin",
-        domain: "all",
-        tenant_id: "t-001",
-        onboardingComplete: true,
-      }),
-    );
-  }, E2E_TOKEN);
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 // ===========================================================================
@@ -192,13 +180,10 @@ test.describe("Token Expiry", () => {
     baseURL,
   }) => {
     await page.goto(baseURL!, { waitUntil: "domcontentloaded" });
-    await page.evaluate(() => {
-      localStorage.setItem("token", "expired.invalid.token");
-    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));      localStorage.setItem(
-        "user",
-        JSON.stringify({ email: "x@x.x", name: "X", role: "admin" }),
-      );
-    });
+    // SEC-002 (PR-F2): seed an invalid session cookie so the
+    // /auth/me hydration on the dashboard route returns 401 and
+    // ProtectedRoute redirects to /login.
+    await setSessionToken(page, "expired.invalid.token");
 
     await page.goto(`${baseURL}/dashboard/cfo`, {
       waitUntil: "domcontentloaded",

--- a/ui/e2e/explainer-real.spec.ts
+++ b/ui/e2e/explainer-real.spec.ts
@@ -31,20 +31,7 @@ function requireAuth(): void {
 
 async function seedSession(page: import("@playwright/test").Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
-  await page.evaluate((t) => {
-    localStorage.setItem("token", t);
-    localStorage.setItem(
-      "user",
-      JSON.stringify({
-        email: "demo@cafirm.agenticorg.ai",
-        name: "Demo Partner",
-        role: "admin",
-        domain: "all",
-        tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
-        onboardingComplete: true,
-      }),
-    );
-  }, E2E_TOKEN);
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 test.describe("Agent detail explainer — real trace data", () => {

--- a/ui/e2e/flows.spec.ts
+++ b/ui/e2e/flows.spec.ts
@@ -20,9 +20,7 @@ function requireAuth(): void {
 // Helper: authenticate via localStorage token
 async function authenticate(page: import("@playwright/test").Page) {
   await page.goto(`${APP}/login`);
-  await page.evaluate((token) => {
-    localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));  }, E2E_TOKEN);
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 // ============================================================================

--- a/ui/e2e/full-app.spec.ts
+++ b/ui/e2e/full-app.spec.ts
@@ -18,9 +18,7 @@ function requireAuth(): void {
 
 async function authenticate(page: Page) {
   await page.goto(`${APP}/login`);
-  await page.evaluate((token) => {
-    localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));  }, E2E_TOKEN);
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 // ---------------------------------------------------------------------------

--- a/ui/e2e/helpers/auth.ts
+++ b/ui/e2e/helpers/auth.ts
@@ -50,23 +50,71 @@ let _cachedProfile: AuthUser | null = null;
 let _cachedCompanyId: string | null = null;
 
 /**
- * Authenticate the page by seeding the real demo profile into localStorage.
+ * Authenticate the page by seeding the agenticorg_session HttpOnly cookie
+ * + the paired agenticorg_csrf cookie.
  *
- * Resolves the profile from `/api/v1/auth/me` the first time so the seeded
- * `user` matches what ProtectedRoute would have hydrated naturally — most
- * critically, the real `role` so sidebar filtering works.
+ * SEC-002 (PR-F2, 2026-05-01): production browser auth no longer reads a
+ * bearer token from localStorage. The HttpOnly session cookie is the only
+ * valid carrier, so the e2e fixtures match that posture exactly. Specs that
+ * called this helper get cookie-based auth automatically; specs that wrote
+ * ``localStorage.setItem("token", ...)`` directly should switch to
+ * ``setSessionToken`` (below).
+ *
+ * The CSRF cookie is also seeded here so mutating-method specs (POST/PUT
+ * /PATCH/DELETE) automatically attach the X-CSRF-Token header via the same
+ * double-submit pattern the app uses in production.
  */
 export async function authenticate(page: Page): Promise<void> {
   requireAuth();
+  await setSessionToken(page, E2E_TOKEN);
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
-  const profile = await getProfile(page);
-  await page.evaluate(
-    ([tkn, user]) => {
-      localStorage.setItem("token", tkn as string);
-      localStorage.setItem("user", JSON.stringify(user));
+}
+
+function _appHost(): string {
+  // Strip protocol + path so Playwright's addCookies receives a bare host.
+  return APP.replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+}
+
+/**
+ * Seed the agenticorg_session + agenticorg_csrf cookies into the browser
+ * context so subsequent navigations behave as if the user has a live
+ * session. Replaces the old ``localStorage.setItem("token", ...)``
+ * pattern that SEC-002 forbids.
+ */
+export async function setSessionToken(
+  page: Page,
+  token: string,
+  csrfToken: string = "e2e-csrf-token",
+): Promise<void> {
+  const host = _appHost();
+  const isHttps = APP.startsWith("https://");
+  await page.context().addCookies([
+    {
+      name: "agenticorg_session",
+      value: token,
+      domain: host,
+      path: "/",
+      httpOnly: true,
+      secure: isHttps,
+      sameSite: "Lax",
     },
-    [E2E_TOKEN, profile],
-  );
+    {
+      name: "agenticorg_csrf",
+      value: csrfToken,
+      domain: host,
+      path: "/",
+      // CSRF cookie is intentionally NOT HttpOnly — the SPA needs to
+      // read it to echo back as X-CSRF-Token. Matches production.
+      httpOnly: false,
+      secure: isHttps,
+      sameSite: "Lax",
+    },
+  ]);
+}
+
+/** Clear all cookies for the current page context — use to simulate logout. */
+export async function clearSession(page: Page): Promise<void> {
+  await page.context().clearCookies();
 }
 
 /**

--- a/ui/e2e/login-e2e.spec.ts
+++ b/ui/e2e/login-e2e.spec.ts
@@ -91,9 +91,7 @@ test.describe("Login Page — Auth Flow @auth", () => {
   test("authenticated user can access dashboard via token", async ({ page }) => {
     requireAuth();
     await page.goto(`${APP}/login`);
-    await page.evaluate((token) => {
-      localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    }, E2E_TOKEN);
+    await setSessionToken(page, E2E_TOKEN);
     await page.goto(`${APP}/dashboard`, { waitUntil: "networkidle" });
     await expect(page.getByText("Dashboard").first()).toBeVisible({ timeout: 10000 });
   });

--- a/ui/e2e/negative-cases.spec.ts
+++ b/ui/e2e/negative-cases.spec.ts
@@ -24,20 +24,7 @@ function requireAuth(): void {
 
 async function ensureAuth(page: Page, baseURL: string) {
   await page.goto(baseURL, { waitUntil: "domcontentloaded" });
-  await page.evaluate((token) => {
-    localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    localStorage.setItem(
-      "user",
-      JSON.stringify({
-        email: "e2e@agenticorg.ai",
-        name: "E2E Runner",
-        role: "admin",
-        domain: "all",
-        tenant_id: "t-001",
-        onboardingComplete: true,
-      }),
-    );
-  }, E2E_TOKEN);
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 // ===========================================================================

--- a/ui/e2e/onboarding-e2e.spec.ts
+++ b/ui/e2e/onboarding-e2e.spec.ts
@@ -22,20 +22,7 @@ const UNIQUE = Date.now().toString(36);
 
 async function ensureAuth(page: Page, baseURL: string) {
   await page.goto(baseURL, { waitUntil: "domcontentloaded" });
-  await page.evaluate((token) => {
-    localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    localStorage.setItem(
-      "user",
-      JSON.stringify({
-        email: "e2e@agenticorg.ai",
-        name: "E2E Runner",
-        role: "admin",
-        domain: "all",
-        tenant_id: "t-001",
-        onboardingComplete: true,
-      }),
-    );
-  }, E2E_TOKEN);
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 // ===========================================================================
@@ -143,14 +130,18 @@ test.describe("Onboarding Wizard", () => {
     baseURL,
   }) => {
     requireAuth();
-    await ensureAuth(page, baseURL!);
-
-    // Override onboardingComplete to false so onboarding page renders
-    await page.evaluate(() => {
-      const user = JSON.parse(localStorage.getItem("user") || "{}");
-      user.onboardingComplete = false;
-      localStorage.setItem("user", JSON.stringify(user));
+    // SEC-002 (PR-F2): the AuthContext now hydrates onboarding state
+    // from /auth/me, not localStorage. Intercept that endpoint to
+    // force onboarding_complete=false so the onboarding page renders.
+    await page.route("**/api/v1/auth/me", async (route) => {
+      const upstream = await route.fetch();
+      const body = await upstream.json().catch(() => ({}));
+      await route.fulfill({
+        response: upstream,
+        json: { ...body, onboarding_complete: false },
+      });
     });
+    await ensureAuth(page, baseURL!);
 
     await page.goto(`${baseURL}/onboarding`, {
       waitUntil: "domcontentloaded",

--- a/ui/e2e/product-claims.spec.ts
+++ b/ui/e2e/product-claims.spec.ts
@@ -83,20 +83,7 @@ test.describe("Product claims consistency", () => {
     const facts = await fetchFacts(request);
 
     await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => {
-      localStorage.setItem("token", t);
-      localStorage.setItem(
-        "user",
-        JSON.stringify({
-          email: "demo@cafirm.agenticorg.ai",
-          name: "Demo Partner",
-          role: "admin",
-          domain: "all",
-          tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
-          onboardingComplete: true,
-        }),
-      );
-    }, E2E_TOKEN);
+    await setSessionToken(page, E2E_TOKEN);
 
     await page.goto(`${APP}/dashboard`, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle").catch(() => {});

--- a/ui/e2e/production-full.spec.ts
+++ b/ui/e2e/production-full.spec.ts
@@ -25,9 +25,7 @@ function requireAuth(): void {
 async function injectAuth(page: Page): Promise<void> {
   const token = process.env.E2E_TOKEN!;
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
-  await page.evaluate((t) => {
-    localStorage.setItem("token", t);
-    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));  }, token);
+  await setSessionToken(page, token);
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/ui/e2e/qa-28apr-fpa-shadow.spec.ts
+++ b/ui/e2e/qa-28apr-fpa-shadow.spec.ts
@@ -27,16 +27,16 @@
  *     npx playwright test tests/regression/test_qa_28apr_fpa_shadow.spec.ts
  */
 import { test, expect, Page } from "@playwright/test";
+import { setSessionToken } from "./helpers/auth";
 
 const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
 
 async function authenticate(page: Page): Promise<void> {
+  // SEC-002 (PR-F2): cookie-first session seeding.
+  await setSessionToken(page, E2E_TOKEN);
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
-  await page.evaluate((token) => {
-    localStorage.setItem("token", token);
-  }, E2E_TOKEN);
 }
 
 test.describe("FPA agent — shadow accuracy after 28-Apr tool-plumbing fix", () => {

--- a/ui/e2e/qa-bugs-8apr2026.spec.ts
+++ b/ui/e2e/qa-bugs-8apr2026.spec.ts
@@ -27,20 +27,7 @@ function requireAuth(): void {
 
 async function authenticate(page: Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
-  await page.evaluate((token) => {
-    localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    localStorage.setItem(
-      "user",
-      JSON.stringify({
-        email: "e2e@agenticorg.ai",
-        name: "E2E Runner",
-        role: "admin",
-        domain: "all",
-        tenant_id: "t-001",
-        onboardingComplete: true,
-      }),
-    );
-  }, E2E_TOKEN);
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 async function goTo(page: Page, path: string): Promise<void> {

--- a/ui/e2e/qa-bugs-regression.spec.ts
+++ b/ui/e2e/qa-bugs-regression.spec.ts
@@ -25,20 +25,7 @@ function requireAuth(): void {
 
 async function ensureAuth(page: Page, baseURL: string) {
   await page.goto(baseURL, { waitUntil: "domcontentloaded" });
-  await page.evaluate((token) => {
-    localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));    localStorage.setItem(
-      "user",
-      JSON.stringify({
-        email: "e2e@agenticorg.ai",
-        name: "E2E Runner",
-        role: "admin",
-        domain: "all",
-        tenant_id: "t-001",
-        onboardingComplete: true,
-      }),
-    );
-  }, E2E_TOKEN);
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 // ===========================================================================

--- a/ui/e2e/scope-enforcement.spec.ts
+++ b/ui/e2e/scope-enforcement.spec.ts
@@ -23,9 +23,7 @@ function requireAuth(): void {
 
 async function authenticate(page: Page) {
   await page.goto(`${APP}/login`);
-  await page.evaluate((token) => {
-    localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));  }, E2E_TOKEN);
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/ui/e2e/sdk-examples.spec.ts
+++ b/ui/e2e/sdk-examples.spec.ts
@@ -26,20 +26,7 @@ test.describe("Integrations page SDK snippet @sdk @mcp", () => {
     requireAuth();
 
     await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => {
-      localStorage.setItem("token", t);
-      localStorage.setItem(
-        "user",
-        JSON.stringify({
-          email: "demo@cafirm.agenticorg.ai",
-          name: "Demo Partner",
-          role: "admin",
-          domain: "all",
-          tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
-          onboardingComplete: true,
-        }),
-      );
-    }, E2E_TOKEN);
+    await setSessionToken(page, E2E_TOKEN);
 
     await page.goto(`${APP}/dashboard/integrations`, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle").catch(() => {});

--- a/ui/e2e/session5-bugs.spec.ts
+++ b/ui/e2e/session5-bugs.spec.ts
@@ -7,7 +7,7 @@
  * mutate delete what they create at the end.
  */
 import { expect, test, type Page } from "@playwright/test";
-import { APP, authenticate, canAuth, requireAuth } from "./helpers/auth";
+import { APP, E2E_TOKEN, authenticate, canAuth, requireAuth } from "./helpers/auth";
 
 /**
  * Selector helper — scope to <main> so the sidebar "Voice Agents" /
@@ -257,9 +257,14 @@ test.describe("Tally test-connection", () => {
   });
 
   test("BUG-S5-001 /companies/test-tally responds with 2xx or handled error, never 405", async ({ page }) => {
-    const token = await page.evaluate(() => localStorage.getItem("token"));
+    // SEC-002 (PR-F2): the cookie is automatically attached by
+    // page.request, so we no longer need to pull a bearer out of
+    // localStorage. The Authorization header still works for explicit
+    // API-client calls (the backend accepts both), so we keep it for
+    // tests that hit endpoints which haven't yet been audited for
+    // cookie-only acceptance.
     const resp = await page.request.post(`${APP}/api/v1/companies/test-tally`, {
-      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${E2E_TOKEN}` },
       data: { bridge_url: "http://localhost:65535" },
     });
     expect(resp.status()).not.toBe(405);

--- a/ui/e2e/settings-governance.spec.ts
+++ b/ui/e2e/settings-governance.spec.ts
@@ -28,20 +28,7 @@ function requireAuth(): void {
 
 async function seedSession(page: import("@playwright/test").Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
-  await page.evaluate((t) => {
-    localStorage.setItem("token", t);
-    localStorage.setItem(
-      "user",
-      JSON.stringify({
-        email: "demo@cafirm.agenticorg.ai",
-        name: "Demo Partner",
-        role: "admin",
-        domain: "all",
-        tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
-        onboardingComplete: true,
-      }),
-    );
-  }, E2E_TOKEN);
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 test.describe("Settings → Compliance & Data governance @governance @audit", () => {

--- a/ui/e2e/sop-flow.spec.ts
+++ b/ui/e2e/sop-flow.spec.ts
@@ -24,10 +24,7 @@ test.describe("SOP: Page Access (auth required)", () => {
   test.beforeEach(async ({ page }) => {
     requireAuth();
     await page.goto("/login", { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => {
-      localStorage.setItem("token", t);
-      localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));
-    }, E2E_TOKEN);
+    await setSessionToken(page, E2E_TOKEN);
   });
 
   test("SOP upload page renders heading and description", async ({ page }) => {
@@ -151,10 +148,7 @@ test.describe("SOP: Dashboard v3.0 (auth required)", () => {
   test.beforeEach(async ({ page }) => {
     requireAuth();
     await page.goto("/login", { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => {
-      localStorage.setItem("token", t);
-      localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));
-    }, E2E_TOKEN);
+    await setSessionToken(page, E2E_TOKEN);
   });
 
   test("Dashboard shows LangGraph + Grantex + External Access cards", async ({ page }) => {

--- a/ui/e2e/v4-features.spec.ts
+++ b/ui/e2e/v4-features.spec.ts
@@ -29,9 +29,7 @@ function requireAuth(): void {
 // ── Helper: authenticate via localStorage token ────────────────────────
 async function authenticate(page: Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
-  await page.evaluate((token) => {
-    localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));  }, E2E_TOKEN);
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/ui/e2e/video-recordings.spec.ts
+++ b/ui/e2e/video-recordings.spec.ts
@@ -44,10 +44,7 @@ test.describe("Video Flows: Platform Overview (auth required)", () => {
   test.beforeEach(async ({ page }) => {
     requireAuth();
     await page.goto("/", { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => {
-      localStorage.setItem("token", t);
-      localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));
-    }, E2E_TOKEN);
+    await setSessionToken(page, E2E_TOKEN);
   });
 
   test("dashboard loads", async ({ page }) => {
@@ -89,10 +86,7 @@ test.describe("Video Flows: CFO Finance (auth required)", () => {
   test.beforeEach(async ({ page }) => {
     requireAuth();
     await page.goto("/", { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => {
-      localStorage.setItem("token", t);
-      localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));
-    }, E2E_TOKEN);
+    await setSessionToken(page, E2E_TOKEN);
   });
 
   test("agents page loads with agent content", async ({ page }) => {
@@ -114,10 +108,7 @@ test.describe("Video Flows: CHRO HR (auth required)", () => {
   test.beforeEach(async ({ page }) => {
     requireAuth();
     await page.goto("/", { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => {
-      localStorage.setItem("token", t);
-      localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));
-    }, E2E_TOKEN);
+    await setSessionToken(page, E2E_TOKEN);
   });
 
   test("agents page loads", async ({ page }) => {
@@ -139,10 +130,7 @@ test.describe("Video Flows: CMO Marketing (auth required)", () => {
   test.beforeEach(async ({ page }) => {
     requireAuth();
     await page.goto("/", { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => {
-      localStorage.setItem("token", t);
-      localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));
-    }, E2E_TOKEN);
+    await setSessionToken(page, E2E_TOKEN);
   });
 
   test("agents page loads for marketing agents", async ({ page }) => {
@@ -159,10 +147,7 @@ test.describe("Video Flows: COO Operations (auth required)", () => {
   test.beforeEach(async ({ page }) => {
     requireAuth();
     await page.goto("/", { waitUntil: "domcontentloaded" });
-    await page.evaluate((t) => {
-      localStorage.setItem("token", t);
-      localStorage.setItem("user", JSON.stringify({ email: "demo@cafirm.agenticorg.ai", name: "Demo Partner", role: "admin", domain: "all", tenant_id: "58483c90-494b-445d-85c6-245a727fe372", onboardingComplete: true }));
-    }, E2E_TOKEN);
+    await setSessionToken(page, E2E_TOKEN);
   });
 
   test("agents page loads for ops agents", async ({ page }) => {

--- a/ui/e2e/workflow-templates.spec.ts
+++ b/ui/e2e/workflow-templates.spec.ts
@@ -26,20 +26,7 @@ function requireAuth(): void {
 
 async function seedSession(page: import("@playwright/test").Page): Promise<void> {
   await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
-  await page.evaluate((t) => {
-    localStorage.setItem("token", t);
-    localStorage.setItem(
-      "user",
-      JSON.stringify({
-        email: "demo@cafirm.agenticorg.ai",
-        name: "Demo Partner",
-        role: "admin",
-        domain: "all",
-        tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
-        onboardingComplete: true,
-      }),
-    );
-  }, E2E_TOKEN);
+  await setSessionToken(page, E2E_TOKEN);
 }
 
 test.describe("Workflow templates — backend-driven catalog", () => {


### PR DESCRIPTION
## Summary

Closes the residual called out in PR-F (#410): the production code was already cookie-first, but Playwright e2e specs still seeded auth via `page.evaluate(() => localStorage.setItem(\"token\", ...))`. PR-F2 sweeps all 27 spec files + the shared `helpers/auth.ts` to use `page.context().addCookies(...)` via the new `setSessionToken` helper.

After this lands, a green Playwright run actually proves cookie auth works end-to-end — not just that some legacy localStorage shim is still tolerated by older clients.

## What changed

- `ui/e2e/helpers/auth.ts` — new `setSessionToken(page, token, csrfToken?)` helper. `authenticate()` delegates to it. `clearSession()` for logout simulation.
- 24 spec files auto-rewritten by a Python sweep — `page.evaluate(...localStorage.setItem(\"token\"...))` blocks become `await setSessionToken(page, ...)`.
- 5 spec files manually fixed up: error-handling.spec.ts (deduped duplicate setItem blocks + expired-token test), qa-28apr-fpa-shadow.spec.ts (local authenticate), session5-bugs.spec.ts (Bearer from E2E_TOKEN), ca-firms.spec.ts (getCompanyId helper), onboarding-e2e.spec.ts (override onboarding_complete via `page.route(/auth/me)`).
- `tests/regression/test_security_pr_f2_e2e_cookie_sweep.py` — 3 pins (whole-tree e2e grep / helpers exports / authenticate delegation).

## Test plan

- [x] `pytest tests/regression/test_security_pr_f2_e2e_cookie_sweep.py` → 3 passed
- [x] `ui/ tsc --noEmit` → clean
- [x] `ruff check .` → clean
- [ ] CI green
- [ ] @codex review
- [ ] Post-deploy: run Playwright spec subset against deployed app → confirm cookie auth works (specifically `error-handling.spec.ts \"Token Expiry\"` test which seeds an invalid cookie)

## Migration notes

Specs run against PRODUCTION by default. The new helper sets `httpOnly: true` on the session cookie (matches production); JavaScript can't read it, but `page.request` calls automatically attach it because they share the BrowserContext cookies. `page.evaluate(() => fetch(...))` calls work too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)