### PR TITLE
fix(security): BUG-08 — tool gateway fail-closed when connector_ids unresolved

### DIFF
--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -499,32 +499,26 @@ async def _resolve_agent_connector_ids_for_type(
         return []
 
 
-async def _load_connector_configs_for_agent(
+async def _resolve_connector_configs(
     tenant_id: str,
     connector_ids: list[str],
     agent_level_config: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    """Resolve an agent's ``connector_ids`` into a flat config dict.
+) -> tuple[dict[str, Any], list[str]]:
+    """Resolve an agent's ``connector_ids`` into (merged_config, resolved_names).
 
-    For each ``connector_id`` (with optional ``registry-`` prefix
-    stripped), look up the matching :class:`ConnectorConfig` row,
-    decrypt ``credentials_encrypted``, merge with the row's non-secret
-    ``config`` JSONB, and merge into a single dict. Tools downstream
-    pull individual keys from this dict via ``config.get("api_key")``
-    etc.
-
-    The agent-level ``config`` (almost always None) is overlaid LAST
-    so an explicit override on the agent row wins. Failures on any
-    one connector log + skip — never block the run, since the LLM
-    can still call connectors that loaded successfully.
-
-    Per-connector namespacing (``{conn_name: {creds}}``) is the
-    next iteration; today the flat-merge shape matches what the
-    existing tools expect (single-connector agents, which are the
-    common case for shadow tests).
+    Same lookup contract as :func:`_load_connector_configs_for_agent`,
+    but additionally returns the list of connector_names that actually
+    resolved to a live ``ConnectorConfig`` for this tenant. The runtime
+    uses that list as the **fail-closed allow-list** for the tool
+    index (BUG-08, RU-May01 verification): if an agent declares
+    ``connector_ids=["registry-zoho_books"]`` but no matching
+    ConnectorConfig exists for the tenant, ``resolved_names`` is empty
+    and the tool index is built empty too — no fall-through to
+    globally-registered connectors that happen to expose
+    ``list_invoices``.
     """
     if not connector_ids:
-        return dict(agent_level_config or {})
+        return dict(agent_level_config or {}), []
 
     import json as _json
     import uuid as _uuid
@@ -541,9 +535,10 @@ async def _load_connector_configs_for_agent(
             "load_connector_configs_invalid_tenant",
             tenant_id=str(tenant_id),
         )
-        return dict(agent_level_config or {})
+        return dict(agent_level_config or {}), []
 
     merged: dict[str, Any] = {}
+    resolved_names: list[str] = []
     async with get_tenant_session(tid) as session:
         for raw_id in connector_ids:
             if not isinstance(raw_id, str) or not raw_id.strip():
@@ -615,6 +610,10 @@ async def _load_connector_configs_for_agent(
                         creds = _json.loads(raw)
                     if isinstance(creds, dict):
                         merged.update(creds)
+                # Record the connector name that actually resolved so the
+                # caller can use it as the BUG-08 fail-closed allow-list.
+                if cc.connector_name and cc.connector_name not in resolved_names:
+                    resolved_names.append(cc.connector_name)
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "connector_config_load_failed",
@@ -627,6 +626,27 @@ async def _load_connector_configs_for_agent(
 
     if agent_level_config:
         merged.update(agent_level_config)
+    return merged, resolved_names
+
+
+async def _load_connector_configs_for_agent(
+    tenant_id: str,
+    connector_ids: list[str],
+    agent_level_config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Backward-compatible wrapper around :func:`_resolve_connector_configs`.
+
+    Returns just the merged config dict, preserving the contract used by
+    a2a.py / chat.py / mcp.py call sites. New runtime callers should use
+    ``_resolve_connector_configs`` directly so they can plumb the
+    resolved connector names through to the tool index for BUG-08
+    fail-closed dispatch.
+    """
+    merged, _names = await _resolve_connector_configs(
+        tenant_id=tenant_id,
+        connector_ids=connector_ids,
+        agent_level_config=agent_level_config,
+    )
     return merged
 
 
@@ -1794,11 +1814,34 @@ async def run_agent(
     # for their auth (single-connector case is the common one — multi-
     # connector with overlapping keys is a follow-up to scope into
     # per-connector dicts).
-    resolved_connector_config = await _load_connector_configs_for_agent(
+    raw_connector_ids = agent_config.get("connector_ids") or []
+    resolved_connector_config, resolved_connector_names = await _resolve_connector_configs(
         tenant_id=tenant_id,
-        connector_ids=agent_config.get("connector_ids") or [],
+        connector_ids=raw_connector_ids,
         agent_level_config=agent_config.get("config"),
     )
+    # BUG-08 (RU-May01 verification, 2026-05-02): when an agent has
+    # connector_ids declared but none resolve to a live ConnectorConfig
+    # (wrong UUID stored, OAuth never completed, tenant_id mismatch),
+    # the tool index must be built empty rather than fall through to
+    # every globally-registered connector that exposes the same tool
+    # name. The empty list is the explicit fail-closed signal to
+    # ``build_tools_for_agent`` (vs. ``None`` which means "no
+    # constraint — include all"). Agents that declare zero
+    # connector_ids still get the unconstrained behaviour, since for
+    # them the runtime has no signal that *should* have constrained
+    # tools.
+    if raw_connector_ids:
+        connector_names_for_tools: list[str] | None = resolved_connector_names
+        if not resolved_connector_names:
+            logger.warning(
+                "agent_run_connector_ids_unresolved_fail_closed",
+                agent_id=str(agent_id),
+                tenant_id=tenant_id,
+                declared_connector_ids=raw_connector_ids,
+            )
+    else:
+        connector_names_for_tools = None
 
     try:
         lg_result = await langgraph_run(
@@ -1818,6 +1861,7 @@ async def run_agent(
             hitl_condition=agent_config.get("hitl_condition", ""),
             grant_token=grant_token,
             connector_config=resolved_connector_config,
+            connector_names=connector_names_for_tools,
         )
     except Exception as exc:
         # Surface enough information for the caller to act on without

--- a/core/langgraph/agent_graph.py
+++ b/core/langgraph/agent_graph.py
@@ -108,6 +108,7 @@ def build_agent_graph(
     confidence_floor: float = 0.88,
     hitl_condition: str = "",
     connector_config: dict[str, Any] | None = None,
+    connector_names: list[str] | None = None,
 ) -> StateGraph:
     """Build a compiled LangGraph agent graph.
 
@@ -118,12 +119,17 @@ def build_agent_graph(
         confidence_floor: Minimum confidence before HITL triggers.
         hitl_condition: Additional HITL condition expression.
         connector_config: Config dict passed to connectors for auth/secrets.
+        connector_names: BUG-08 fail-closed allow-list. When the runtime
+            has resolved the agent's ``connector_ids`` it passes the
+            resolved names here so ``list_invoices`` only matches the
+            agent's authorized connectors instead of falling through to
+            any globally-registered connector with the same tool name.
 
     Returns:
         A compiled LangGraph graph ready for invocation.
     """
     # Build LangChain tools from authorized tools
-    tools = build_tools_for_agent(authorized_tools, connector_config)
+    tools = build_tools_for_agent(authorized_tools, connector_config, connector_names)
 
     # LLM is created lazily on first call to avoid API key validation at build time
     _llm_cache: dict[str, Any] = {}

--- a/core/langgraph/runner.py
+++ b/core/langgraph/runner.py
@@ -53,6 +53,7 @@ async def run_agent(
     hitl_condition: str = "",
     grant_token: str = "",
     connector_config: dict[str, Any] | None = None,
+    connector_names: list[str] | None = None,
     thread_id: str | None = None,
 ) -> dict[str, Any]:
     """Run a LangGraph agent and return the result.
@@ -124,6 +125,7 @@ async def run_agent(
         confidence_floor=confidence_floor,
         hitl_condition=hitl_condition,
         connector_config=connector_config,
+        connector_names=connector_names,
     )
 
     # Compile with checkpointer
@@ -421,6 +423,7 @@ async def resume_agent(
     confidence_floor: float = 0.88,
     hitl_condition: str = "",
     connector_config: dict[str, Any] | None = None,
+    connector_names: list[str] | None = None,
 ) -> dict[str, Any]:
     """Resume a paused agent after HITL decision.
 
@@ -436,6 +439,7 @@ async def resume_agent(
         confidence_floor=confidence_floor,
         hitl_condition=hitl_condition,
         connector_config=connector_config,
+        connector_names=connector_names,
     )
     compiled = graph.compile(checkpointer=_checkpointer)
 

--- a/core/langgraph/tool_adapter.py
+++ b/core/langgraph/tool_adapter.py
@@ -170,6 +170,7 @@ async def _execute_connector_tool(
 def build_tools_for_agent(
     authorized_tools: list[str],
     connector_config: dict[str, Any] | None = None,
+    connector_names: list[str] | None = None,
 ) -> list[StructuredTool]:
     """Build LangChain tools from an agent's authorized_tools list.
 
@@ -177,13 +178,21 @@ def build_tools_for_agent(
     "create_payment_intent") is matched to a connector and wrapped as a
     LangChain StructuredTool.
 
+    ``connector_names`` (BUG-08, RU-May01 verification 2026-05-02) is
+    the agent runtime's resolved connector allow-list. ``None`` means
+    "no caller constraint" (used by tests and a few synthetic call
+    sites); ``[]`` is the fail-closed signal — the agent had
+    ``connector_ids`` but none resolved to a live ConnectorConfig, so
+    the index must be empty rather than fall back to every globally
+    registered connector.
+
     Returns a list of callable LangChain tools ready for LangGraph.
     """
     tools: list[StructuredTool] = []
     seen: set[str] = set()
 
     # Build a reverse index: tool_name -> (connector_name, handler_doc)
-    tool_index = _build_tool_index(connector_config)
+    tool_index = _build_tool_index(connector_config, connector_names)
 
     for tool_ref in authorized_tools:
         if tool_ref in seen:
@@ -230,8 +239,20 @@ def _build_tool_index(
     creation UI can populate authorized_tools with exactly the
     connectors the user picked, instead of every tool in the product.
     """
+    # BUG-08 (RU-May01 verification, 2026-05-02): the agent runtime is
+    # the security boundary that decides which connectors an agent may
+    # call. ``connector_names=None`` means "caller did not constrain";
+    # ``connector_names=[]`` means "caller explicitly resolved zero
+    # connectors for this agent". Treating those identically (the prior
+    # behaviour) was a fail-OPEN: an FpaAgent with
+    # connector_ids=["registry-zoho_books"] but no live Zoho
+    # ConnectorConfig fell back to *every* globally-registered native
+    # connector, so the LLM cheerfully called ``stripe.list_invoices``
+    # with no credentials and got 401-capped. Use ``is not None`` so
+    # the explicit-empty case fails closed (empty tool index → no
+    # tools → LLM has nothing to invoke).
     allowed: set[str] | None = None
-    if connector_names:
+    if connector_names is not None:
         # Normalise — strip any "registry-" UI prefix and lowercase.
         allowed = {
             n.removeprefix("registry-").strip().lower()

--- a/tests/regression/test_bug_08_tool_gateway_fail_closed.py
+++ b/tests/regression/test_bug_08_tool_gateway_fail_closed.py
@@ -1,0 +1,261 @@
+"""BUG-08 (RU-May01 verification, 2026-05-02): tool gateway fail-closed.
+
+Discovered while running the post-deploy honesty check on PR #406's fix
+for the Ramesh/Uday CA Firms BUG-01..04 May-01 reopens. The PR-#406
+code fixes ARE deployed and firing (the ``tool_execution_failed_after_
+reconnect`` log message — which is a NEW marker introduced by the
+BUG-01 cache-eviction path — appears on every prod run). Yet the agent
+still reproduces the pre-fix shape:
+
+  confidence: 0.24
+  tool_calls: []
+  reasoning_trace: ["...", "Confidence capped to 0.5 (tool_call_failed)"]
+
+Cloud Run logs from the failing run show *Stripe* being called, not
+Zoho Books::
+
+    tool_execution_failed_after_reconnect connector=stripe
+        error="Illegal header value b'Bearer '"  tool=list_invoices
+
+The Aryan FpaAgent (id=02ca34a7-...) had
+``connector_ids = ["registry-zoho_books"]``.  The runtime queried
+``ConnectorConfig WHERE tenant_id=tid AND connector_name='zoho_books'``,
+got nothing back (the tenant has no live Zoho ConnectorConfig — only a
+Connector row), then continued the run with no resolved configs.  At
+``build_tools_for_agent`` time, ``connector_names`` was never plumbed
+in, so ``_build_tool_index`` scanned **every** globally-registered
+native connector.  Both Zoho Books and Stripe register
+``list_invoices``; the dict-assignment loop overwrites the prior entry,
+and Stripe (alphabetically later — but order isn't load-bearing for
+the bug, just for which provider wins) ended up as the resolver for
+``list_invoices``.  The LLM then called ``stripe.list_invoices`` with
+no creds → 401 → tool_call_failed → confidence cap.
+
+The fix: ``api/v1/agents.py:run_agent`` now uses the new
+``_resolve_connector_configs`` helper that returns both the merged
+config dict AND the list of connector names that actually resolved.
+That list is passed through ``runner.run_agent`` →
+``build_agent_graph`` → ``build_tools_for_agent`` →
+``_build_tool_index``.  In ``_build_tool_index`` the ``None`` vs
+``[]`` distinction is now load-bearing:
+
+  ``connector_names is None``  → no caller constraint, scan all
+                                  connectors (existing behaviour, used
+                                  by tests + a few synthetic call sites).
+  ``connector_names == []``    → fail-CLOSED: the runtime explicitly
+                                  resolved zero connectors for this
+                                  agent's declared ``connector_ids``.
+                                  Build an empty tool index.  No
+                                  fallback to global connectors.
+  ``connector_names == ["zoho_books"]``
+                               → tool index restricted to Zoho's
+                                  registered tools only.  Other
+                                  connectors that also expose
+                                  ``list_invoices`` are excluded.
+
+These pins lock that contract into place so a future refactor can't
+silently restore the fail-open behaviour.
+"""
+from __future__ import annotations
+
+import pytest
+
+from core.langgraph.tool_adapter import (
+    _build_tool_index,
+    build_tools_for_agent,
+)
+
+
+class TestBuildToolIndexFailClosed:
+    """``_build_tool_index`` must distinguish None from [] for connector_names."""
+
+    def test_none_connector_names_scans_all_connectors(self):
+        """``connector_names=None`` → no caller constraint, every native
+        connector contributes its tools.  This is the existing behaviour
+        for the few synthetic call sites (tests, ad-hoc scripts) that
+        don't go through the agent runtime.
+        """
+        index = _build_tool_index(connector_config={}, connector_names=None)
+        # Many tools register under multiple connectors. We just want to
+        # confirm the index is non-empty when no constraint is given.
+        assert len(index) > 0, (
+            "connector_names=None should be 'no constraint, scan all' — "
+            "an empty index here means a regression in the default path."
+        )
+
+    def test_empty_connector_names_yields_empty_index(self):
+        """``connector_names=[]`` → fail-closed.
+
+        This is the BUG-08 contract.  The agent runtime hands an empty
+        list when an agent has ``connector_ids`` but none resolve to a
+        live ConnectorConfig.  The tool index MUST be empty so the LLM
+        has no tools to call.  Falling through to globally-registered
+        connectors is the prior bug.
+        """
+        index = _build_tool_index(connector_config={}, connector_names=[])
+        assert index == {}, (
+            f"connector_names=[] should fail-closed (empty index), but got "
+            f"{len(index)} tools: {list(index.keys())[:10]}.  This is the "
+            "BUG-08 fail-OPEN regression — Stripe.list_invoices etc. would "
+            "be reachable from agents that explicitly resolved zero "
+            "ConnectorConfigs."
+        )
+
+    def test_single_connector_name_restricts_to_that_connector(self):
+        """A non-empty list filters the tool index to only the named
+        connectors.  Scoped fix for the May-01 Aryan agent: with
+        ``connector_names=['zoho_books']``, ``list_invoices`` resolves
+        to Zoho even though Stripe and QuickBooks also register the
+        same tool name.
+        """
+        index = _build_tool_index(connector_config={}, connector_names=["zoho_books"])
+        # The index should contain at least one Zoho tool.
+        zoho_tools = [
+            tn for tn, (cn, _desc) in index.items() if cn == "zoho_books"
+        ]
+        non_zoho_tools = [
+            tn for tn, (cn, _desc) in index.items() if cn != "zoho_books"
+        ]
+        assert len(zoho_tools) > 0, (
+            "Filtering on connector_names=['zoho_books'] returned zero "
+            "Zoho tools — either the connector isn't registered or the "
+            "filter regressed."
+        )
+        assert non_zoho_tools == [], (
+            f"Filter leaked tools from other connectors: {non_zoho_tools[:5]}. "
+            "When connector_names is specified the index must contain only "
+            "those connectors' tools."
+        )
+
+    def test_registry_prefix_is_stripped_for_filter_matching(self):
+        """Agents store ``connector_ids`` as ``["registry-zoho_books"]``.
+        ``_build_tool_index`` must strip the prefix so the lookup matches
+        the underlying ``ConnectorRegistry.all_names()`` entries.
+        """
+        index = _build_tool_index(
+            connector_config={}, connector_names=["registry-zoho_books"]
+        )
+        zoho_tools = [
+            tn for tn, (cn, _desc) in index.items() if cn == "zoho_books"
+        ]
+        assert len(zoho_tools) > 0, (
+            "registry- prefix wasn't stripped before filter match — agents "
+            "with the UI-flavoured connector_ids will fail to bind tools."
+        )
+
+
+class TestBuildToolsForAgentFailClosed:
+    """The public surface used by the runtime: ``build_tools_for_agent``."""
+
+    def test_empty_connector_names_produces_zero_tools(self):
+        """Agent with ``authorized_tools=['list_invoices']`` and
+        ``connector_names=[]`` (i.e. runtime resolved zero
+        ConnectorConfigs) must end up with **zero** built tools.
+
+        Pre-fix: ``build_tools_for_agent`` ignored ``connector_names``
+        entirely, called ``_build_tool_index(connector_config)`` with
+        no filter, and ``list_invoices`` resolved to whichever
+        connector registered it last (Stripe in prod).  The LLM then
+        had a callable ``list_invoices`` tool that fired against
+        Stripe with no auth.
+
+        Post-fix: empty list propagates through; tool index is empty;
+        no StructuredTool is built; the LLM has nothing to call.
+        """
+        tools = build_tools_for_agent(
+            authorized_tools=["list_invoices"],
+            connector_config={},
+            connector_names=[],
+        )
+        assert tools == [], (
+            f"Agent with authorized_tools=['list_invoices'] and zero "
+            f"resolved connectors got {len(tools)} tool(s) instead of 0. "
+            "This is the BUG-08 fail-OPEN — the LLM would dispatch "
+            "list_invoices to whichever connector won the global "
+            "registration race."
+        )
+
+    def test_zoho_only_filter_excludes_stripe_list_invoices(self):
+        """The May-01 reproducer in pin form.
+
+        Aryan FpaAgent's authorized_tools include ``list_invoices``.
+        Both ``zoho_books`` and ``stripe`` connectors register that
+        tool name.  With ``connector_names=['zoho_books']`` the built
+        tool MUST resolve to Zoho's handler, not Stripe's.
+        """
+        tools = build_tools_for_agent(
+            authorized_tools=["list_invoices"],
+            connector_config={},
+            connector_names=["zoho_books"],
+        )
+        assert len(tools) == 1, (
+            f"Expected exactly one tool, got {len(tools)}.  Either Zoho "
+            "stopped exposing list_invoices or the filter is leaking."
+        )
+        assert tools[0].name == "list_invoices"
+
+    def test_none_connector_names_preserves_legacy_unconstrained_behaviour(self):
+        """Tests + a few synthetic callers pass ``connector_names=None``
+        (the default).  That MUST keep the unconstrained behaviour so
+        we don't break those call sites.  Only the explicit empty-list
+        signal is the new fail-closed path.
+        """
+        tools = build_tools_for_agent(
+            authorized_tools=["list_invoices"],
+            connector_config={},
+            connector_names=None,
+        )
+        # Some tool should resolve in the unconstrained path.
+        assert len(tools) >= 1, (
+            "connector_names=None used to scan all connectors and bind a "
+            "list_invoices tool; an empty result means the legacy path "
+            "regressed."
+        )
+
+
+class TestResolveConnectorConfigsReturnsResolvedNames:
+    """``_resolve_connector_configs`` is the new helper that drives the
+    fail-closed allow-list for the runtime.  It must return ``[]`` (not
+    ``None``, not the input names) when no ConnectorConfig matches.
+
+    These pins use a stub session so the test is hermetic — the goal is
+    to lock the *return shape* of the helper, not to re-run the full
+    DB round-trip (covered elsewhere by ``test_bugs_april06_2026``).
+    """
+
+    @pytest.mark.asyncio
+    async def test_empty_connector_ids_returns_empty_names_list(self):
+        """No connector_ids declared → ``([config or {}], [])``.
+
+        The agent has nothing to resolve, so the runtime should NOT
+        impose a fail-closed restriction (returning ``[]`` would block
+        every tool, but the agent never asked for any tenant
+        connectors).  The runtime layer is responsible for translating
+        ``[]`` into "no constraint".
+        """
+        from api.v1.agents import _resolve_connector_configs
+
+        merged, names = await _resolve_connector_configs(
+            tenant_id="11111111-1111-1111-1111-111111111111",
+            connector_ids=[],
+            agent_level_config={"k": "v"},
+        )
+        assert merged == {"k": "v"}
+        assert names == []
+
+    @pytest.mark.asyncio
+    async def test_invalid_tenant_returns_empty_names(self):
+        """Invalid tenant_id → fail-closed.  Used to return just a
+        dict; now must also return an empty resolved-names list so the
+        runtime treats this case as ``connector_ids declared but none
+        resolved`` and builds an empty tool index.
+        """
+        from api.v1.agents import _resolve_connector_configs
+
+        merged, names = await _resolve_connector_configs(
+            tenant_id="not-a-uuid",
+            connector_ids=["registry-zoho_books"],
+            agent_level_config=None,
+        )
+        assert merged == {}
+        assert names == []

--- a/tests/regression/test_qa_27apr_sweep.py
+++ b/tests/regression/test_qa_27apr_sweep.py
@@ -145,11 +145,19 @@ def test_ramesh_agents_loads_connector_configs_for_shadow_runs() -> None:
     call hits the connector with empty auth and shadow accuracy
     stays stuck at ~40%."""
     src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
-    # Loader function must exist.
+    # Loader functions must exist. Both the public-API
+    # ``_load_connector_configs_for_agent`` (used by a2a/chat/mcp) and
+    # the new ``_resolve_connector_configs`` helper (BUG-08 2026-05-02:
+    # also returns the resolved connector-name list so the runtime can
+    # build a fail-closed tool index instead of dispatching list_invoices
+    # to whichever connector registered last).
     assert "_load_connector_configs_for_agent" in src
+    assert "_resolve_connector_configs" in src
     # The langgraph_run call must use the resolved config, NOT the
-    # vestigial top-level agent_config.get("config").
-    assert "resolved_connector_config = await _load_connector_configs_for_agent" in src
+    # vestigial top-level agent_config.get("config"). After BUG-08 the
+    # runtime call site unpacks both the merged config AND the resolved
+    # connector names from the new helper.
+    assert "resolved_connector_config, resolved_connector_names = await _resolve_connector_configs" in src
     assert "connector_config=resolved_connector_config" in src
     # The loader must read encrypted credentials and decrypt them.
     assert "decrypt_for_tenant" in src
@@ -157,6 +165,11 @@ def test_ramesh_agents_loads_connector_configs_for_shadow_runs() -> None:
     # The "registry-" prefix stripping (Ramesh's TC body shows this
     # is the shape connector_ids arrive in).
     assert 'removeprefix("registry-")' in src
+    # BUG-08 fail-closed contract: the runtime must explicitly pass the
+    # resolved-names list down to the runner so the tool index can be
+    # restricted, otherwise list_invoices falls back to globally
+    # registered connectors (Stripe in the May-01 reproducer).
+    assert "connector_names=connector_names_for_tools" in src
 
 
 # ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Tool gateway used to fail-OPEN: when an agent declared `connector_ids` but none resolved to a live `ConnectorConfig`, the runtime built the tool index from **every** globally-registered native connector. So an agent with `connector_ids=["registry-zoho_books"]` and no Zoho ConnectorConfig still got a callable `list_invoices` — bound to whichever connector won the registration race (Stripe in prod), with empty Bearer header, returning 401.

This was discovered today (2026-05-02) running the May-01 BUG-01..04 honesty verification against the deployed PR #421 SHA (`5d799aa`):

```
confidence: 0.24
tool_calls:  []
reasoning_trace: ["...", "Confidence capped to 0.5 (tool_call_failed)"]
```

Same shape Uday reported pre-PR-#406. Cloud Run logs showed:

```
tool_execution_failed_after_reconnect connector=stripe
  error="Illegal header value b'Bearer '"  tool=list_invoices
```

The PR-#406 BUG-01 cache-eviction fix IS deployed and firing — the `tool_execution_failed_after_reconnect` log marker is new in that PR. The bug above lives one layer up.

## Fix

Plumb the runtime's resolved connector-name allow-list through to the tool index so it can fail-CLOSED:

- `api/v1/agents.py`: new `_resolve_connector_configs()` returns `(merged_config, resolved_names)`. Existing `_load_connector_configs_for_agent` becomes a thin wrapper for a2a/chat/mcp call sites (preserves their contract).
- `run_agent` computes the fail-closed signal:
  - declared zero `connector_ids` → `connector_names=None` (no constraint, legacy)
  - declared but resolved zero → `connector_names=[]` (explicit fail-closed, logs `agent_run_connector_ids_unresolved_fail_closed`)
  - resolved >0 → `connector_names=<resolved>`
- `core/langgraph/{runner,agent_graph,tool_adapter}.py`: pass `connector_names` through.
- `_build_tool_index` now distinguishes `None` (no constraint) from `[]` (fail-closed → empty index). The prior `if connector_names:` truthy check collapsed those into the same case — that was the root of the fail-OPEN.

## Tests — `tests/regression/test_bug_08_tool_gateway_fail_closed.py`

Nine pins covering:
- `_build_tool_index`: `None` → all-connectors, `[]` → empty, `['zoho_books']` → Zoho-only
- `registry-` prefix stripped before filter match
- `build_tools_for_agent`: empty list yields zero tools (the May-01 reproducer)
- `_resolve_connector_configs`: returns `[]` for empty-input and invalid-tenant cases

Local:
```
pytest tests/regression/test_bug_08_tool_gateway_fail_closed.py \
  tests/regression/test_qa_cafirms_may01_runtime_path_bugs.py \
  tests/regression/test_bugs_april06_2026.py \
  tests/unit/test_workflow_engine.py tests/unit/test_langgraph_runtime.py
```
→ **99 passed, 1 warning in 5.17s**.

## Residual / next steps

This unblocks the BUG-08 fail-OPEN class. It does NOT by itself close May-01 BUG-01..04 — those still need the tester's tenant to have a live Zoho Books `ConnectorConfig` (Track B in the post-deploy investigation: walk the OAuth flow for `uday.chauhan@edumatica.io`'s tenant). Until that data is set up, this agent will now correctly fail-closed (no tools, LLM responds "I can't") instead of silently calling Stripe — which is the right behaviour.

@codex please review