### PR TITLE
deps(security): SEC-008 — pin litellm>=1.83.7, document ecdsa as residual

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,19 @@ dependencies = [
     "redis[hiredis]>=5.2.0",
     "pydantic>=2.13.3",
     "pydantic-settings>=2.14.0",
+    # SEC-2026-05-P2-008 RESIDUAL (ecdsa CVE-2024-23342): python-jose
+    # transitively pulls ``ecdsa>=0.15`` regardless of the
+    # ``[cryptography]`` extra. ecdsa 0.19.2 (current latest) carries
+    # CVE-2024-23342 ("Minerva timing attack on P-256") and the
+    # upstream maintainers have explicitly stated it will NOT be
+    # patched in the ecdsa lib — they recommend switching to a
+    # cryptography-backed JWT. We do that already: every JWT
+    # signature/verify path in this codebase uses python-jose's
+    # cryptography backend, and ecdsa is only loaded for legacy
+    # algorithm fallbacks we never select. The CVE is therefore not
+    # exploitable in our request-path, but the audit will continue to
+    # flag it until upstream excises the dep. Tracked as a non-blocker
+    # residual — pyjwt[crypto] migration is the long-term close.
     "python-jose[cryptography]>=3.3.0",
     "passlib[bcrypt]>=1.7.4",
     "httpx>=0.28.0",

--- a/requirements-v4.txt
+++ b/requirements-v4.txt
@@ -19,6 +19,15 @@ composio-core>=0.7.0
 # Without: All queries go to the agent's configured LLM model
 routellm>=0.2.0
 
+# SEC-2026-05-P2-008 (BRUTAL_SECURITY_SCAN_2026-05-01): pin transitive
+# litellm at the patched version. The 2026-05-01 nightly pip-audit
+# flagged litellm 1.83.0 GHSA-xqmj-j6mv-4862 (Server-Side Template
+# Injection in /prompts/test). routellm doesn't pin litellm itself,
+# so we constrain it explicitly here so resolution can't fall back to
+# the vulnerable release. Promote into pyproject.toml direct deps if
+# we ever add a request-path that imports litellm directly.
+litellm>=1.83.7
+
 # ─── Microsoft Presidio: Pre-LLM PII Redaction (MIT) ────────────────────────
 # Enables: Aadhaar, PAN, GSTIN, UPI, email, phone scrubbed BEFORE reaching LLM
 # Without: PII masking in logs only (post-LLM)


### PR DESCRIPTION
## Summary

Closes the SEC-2026-05-P2-008 (\"Python Dependency Scan Fails On Known CVEs\") item from `docs/BRUTAL_SECURITY_SCAN_2026-05-01.md`. The 2026-05-01 nightly Security Scan workflow confirmed only 4 findings (the brutal scan said 3; one new appeared overnight):

| Package | CVE | Status |
|---|---|---|
| `ecdsa 0.19.2` | CVE-2024-23342 (Minerva timing attack) | **Documented residual — no upstream fix** |
| `pillow 10.4.0` | CVE-2026-25990 | Already documented residual (composio-core constraint) |
| `pillow 10.4.0` | CVE-2026-40192 | Already documented residual |
| `litellm 1.83.0` | GHSA-xqmj-j6mv-4862 (SSTI on /prompts/test) | **Pinned to >=1.83.7 here** |

(My earlier post-deploy verification claimed "18 CVEs" — that was my local stale install. The actual project-level state has only the 4 above. Sorry.)

## Changes

### 1. `requirements-v4.txt` — explicit `litellm>=1.83.7` pin
`routellm` pulls litellm transitively without a version cap, so resolution could fall back to the vulnerable `1.83.0`. SSTI on `/prompts/test` isn't a request-path of ours today, but the lib is loaded into the worker process and the cap is the cheapest close.

### 2. `pyproject.toml` — document `ecdsa` CVE-2024-23342 as residual
`python-jose` pulls `ecdsa>=0.15` transitively regardless of the `[cryptography]` extra. ecdsa 0.19.2 is the current latest; upstream maintainers have explicitly stated they will NOT patch the Minerva timing attack — they recommend switching to a cryptography-backed JWT. We **already** use python-jose's cryptography backend for all signing/verifying; ecdsa is only loaded for legacy algorithms we never select. The CVE isn't exploitable in our request-path, but the audit will continue to flag it until upstream excises the dep. Long-term close is a `pyjwt[crypto]` migration (separate PR-sized effort).

## Verification

After merge + deploy, the next nightly Security Scan should drop from 4 findings to 3 (Pillow x2 + ecdsa, all documented). Pillow auto-clears whenever composio-core publishes a Pillow>=12 compatible release.

@codex please review