### PR TITLE
fix(infra): celery worker registers tasks via include= (autodiscover was a no-op)

### DIFF
--- a/core/tasks/celery_app.py
+++ b/core/tasks/celery_app.py
@@ -14,10 +14,28 @@ from celery.schedules import crontab
 
 _redis_url: str = os.getenv("AGENTICORG_REDIS_URL", "redis://localhost:6379/1")
 
+# ``include=`` is what actually registers the @app.task decorators with
+# the worker. The historical ``app.autodiscover_tasks(["core.tasks"])``
+# call below looks for a module literally named ``tasks`` inside the
+# ``core.tasks`` package (i.e. ``core/tasks/tasks.py``) and silently
+# does nothing when it can't find one — which is the case here, since
+# our tasks live in ``core/tasks/{report,workflow,budget,rpa,...}_tasks.py``.
+# Verified 2026-05-02: every beat-dispatched task hit the worker as
+# ``Received unregistered task of type 'core.tasks.budget_tasks...'``
+# until this list was set.
 app = Celery(
     "agenticorg",
     broker=_redis_url,
     backend=_redis_url,
+    include=[
+        "core.tasks.budget_tasks",
+        "core.tasks.health_snapshot",
+        "core.tasks.invoice_tasks",
+        "core.tasks.report_tasks",
+        "core.tasks.rpa_tasks",
+        "core.tasks.token_refresh",
+        "core.tasks.workflow_tasks",
+    ],
 )
 
 # ── Celery configuration ────────────────────────────────────────────

--- a/tests/regression/test_celery_runtime_wrappers.py
+++ b/tests/regression/test_celery_runtime_wrappers.py
@@ -284,3 +284,68 @@ def test_celery_beat_schedule_registers_all_seven_periodic_tasks() -> None:
         f"Periodic tasks expected in beat_schedule are missing: {sorted(missing)}. "
         "If a task was intentionally removed, update this test in the same PR."
     )
+
+
+def test_worker_registers_all_task_modules_on_startup() -> None:
+    """Verified 2026-05-02 in production: every beat-dispatched task hit
+    the worker as ``ERROR/MainProcess Received unregistered task of type
+    'core.tasks.budget_tasks.run_budget_evaluator'`` because the prior
+    ``app.autodiscover_tasks(["core.tasks"])`` looks for
+    ``core/tasks/tasks.py`` — a module named literally ``tasks`` —
+    which doesn't exist in this codebase. The actual task files are
+    ``core/tasks/{report,budget,rpa,health_snapshot,...}_tasks.py`` so
+    autodiscover swallowed the ImportError and registered nothing.
+
+    The fix passes an explicit ``include=`` to the ``Celery()``
+    constructor; that list is read by ``app.loader.import_default_modules()``
+    at worker startup, which is what makes every ``@app.task`` decorator
+    actually run.
+
+    These pins lock the contract:
+    - ``app.conf.include`` enumerates every tasks module that has tasks.
+    - Calling ``import_default_modules`` registers every periodic task
+      named in ``app.conf.beat_schedule`` (so beat-dispatched tasks
+      can't slip through as "unregistered" again).
+    """
+    from core.tasks.celery_app import app
+
+    expected_includes = {
+        "core.tasks.budget_tasks",
+        "core.tasks.health_snapshot",
+        "core.tasks.invoice_tasks",
+        "core.tasks.report_tasks",
+        "core.tasks.rpa_tasks",
+        "core.tasks.token_refresh",
+        "core.tasks.workflow_tasks",
+    }
+    actual_includes = set(app.conf.include or [])
+    missing = expected_includes - actual_includes
+    assert not missing, (
+        f"app.conf.include is missing tasks modules: {sorted(missing)}. "
+        "If a module is intentionally removed, update this test in the "
+        "same PR."
+    )
+
+    # Simulate the worker startup path so we exercise that include=
+    # actually imports + registers the tasks (not just stores the list
+    # in conf).
+    app.loader.import_default_modules()
+    registered = {t for t in app.tasks if not t.startswith("celery.")}
+
+    expected_periodic = {
+        "core.tasks.report_tasks.generate_scheduled_reports",
+        "core.tasks.report_tasks.cleanup_old_reports",
+        "core.tasks.report_tasks.generate_report",
+        "core.tasks.budget_tasks.run_budget_evaluator",
+        "core.tasks.token_refresh.refresh_expiring_tokens",
+        "core.tasks.invoice_tasks.generate_monthly_invoices",
+        "core.tasks.rpa_tasks.dispatch_due_rpa_schedules",
+        "core.tasks.health_snapshot.record_health_snapshot",
+    }
+    missing_tasks = expected_periodic - registered
+    assert not missing_tasks, (
+        f"Periodic tasks NOT registered after import_default_modules(): "
+        f"{sorted(missing_tasks)}. The worker would reject these as "
+        "'unregistered' on receipt — the same bug that fired in "
+        "production today."
+    )


### PR DESCRIPTION
## Summary

Verified in production today (2026-05-02 06:05 UTC) — beat is dispatching tasks every 5 min, worker rejects every one as **unregistered**:

```
ERROR/MainProcess Received unregistered task of type 
'core.tasks.budget_tasks.run_budget_evaluator'.
The message has been ignored and discarded.
Did you remember to import the module containing this task?
```

## Root cause

``app.autodiscover_tasks([\"core.tasks\"])`` looks for a module literally named ``tasks`` inside the ``core.tasks`` package — i.e. ``core/tasks/tasks.py``. We don't have one. Our task files are named ``core/tasks/{report,budget,rpa,health_snapshot,...}_tasks.py``.

Celery's autodiscover silently swallows the ImportError so nothing gets registered. The api request path was unaffected because each caller imports the relevant tasks module directly (e.g. ``from core.tasks.report_tasks import generate_report``) which runs the ``@app.task`` decorators as a side effect. The dedicated worker process never imports any tasks module, so its registry stays empty.

## Fix

Pass ``include=[...]`` to the ``Celery()`` constructor. This populates ``app.conf.include``, which ``app.loader.import_default_modules()`` reads at worker startup and imports each module — running every ``@app.task`` decorator as a side effect.

Verified locally: 12 tasks register after ``app.loader.import_default_modules()`` (compared to 0 pre-fix).

## Tests

New pin in ``tests/regression/test_celery_runtime_wrappers.py:test_worker_registers_all_task_modules_on_startup``:
- ``app.conf.include`` enumerates every tasks module
- ``app.loader.import_default_modules()`` registers every periodic task named in ``app.conf.beat_schedule``

Local: ``pytest tests/regression/test_celery_runtime_wrappers.py`` → **11 passed in 1.62s**.

## Why this got missed in PR #401

PR #401 added the wrappers but didn't actually deploy the services — that gap was tracked in ``celery_beat_not_deployed.md``. We deployed today (2026-05-02) and only then exercised the worker's import path against beat-dispatched tasks.

@codex please review