### PR TITLE
fix(api): BUG-11 — emit tool_calls alongside tool_calls_log on agent run

### DIFF
--- a/core/langgraph/runner.py
+++ b/core/langgraph/runner.py
@@ -305,12 +305,25 @@ async def run_agent(
             except Exception as exc:
                 logger.warning("explanation_generation_failed", error=str(exc))
 
+        # BUG-11 (RU-May01 verification, 2026-05-02): the api response
+        # serializer at api/v1/agents.py:run_agent reads
+        # ``lg_result.get("tool_calls", [])`` while we emit the
+        # log under the key ``tool_calls_log``. Result: every agent
+        # run response showed ``tool_calls: []`` even when tools
+        # actually executed (verified live against Zoho Books on
+        # 2026-05-02 — the run wrote a ``list_invoices_response`` to
+        # output but the response field was empty). Dual-emit both
+        # keys so the api serializer stays accurate without a
+        # cross-module rename. ``tool_calls_log`` stays the canonical
+        # internal name.
+        tool_log = result.get("tool_calls_log", [])
         return {
             "status": run_status,
             "output": result.get("output", {}),
             "confidence": result.get("confidence", 0.0),
             "reasoning_trace": result.get("reasoning_trace", []),
-            "tool_calls_log": result.get("tool_calls_log", []),
+            "tool_calls_log": tool_log,
+            "tool_calls": tool_log,
             "hitl_trigger": result.get("hitl_trigger", ""),
             "error": result.get("error", ""),
             "explanation": explanation,
@@ -345,12 +358,15 @@ async def run_agent(
                     if hitl_trigger:
                         break
 
+        # BUG-11 dual-emit (see comment above): keep both keys.
+        hitl_tool_log = state_values.get("tool_calls_log", [])
         return {
             "status": state_values.get("status", "hitl_triggered"),
             "output": state_values.get("output", {}),
             "confidence": state_values.get("confidence", 0.0),
             "reasoning_trace": state_values.get("reasoning_trace", []),
-            "tool_calls_log": state_values.get("tool_calls_log", []),
+            "tool_calls_log": hitl_tool_log,
+            "tool_calls": hitl_tool_log,
             "hitl_trigger": hitl_trigger,
             "error": "",
             "thread_id": config["configurable"]["thread_id"],
@@ -374,6 +390,7 @@ async def run_agent(
             "confidence": 0.0,
             "reasoning_trace": ["Agent exceeded maximum allowed duration"],
             "tool_calls_log": [],
+            "tool_calls": [],  # BUG-11 dual-emit
             "hitl_trigger": "",
             "error": f"timeout: agent exceeded {MAX_AGENT_DURATION_SEC}s",
             "explanation": {},
@@ -402,6 +419,7 @@ async def run_agent(
             "confidence": 0.0,
             "reasoning_trace": fail_trace,
             "tool_calls_log": [],
+            "tool_calls": [],  # BUG-11 dual-emit
             "hitl_trigger": "",
             "error": str(e),
             "explanation": fail_explanation,

--- a/tests/regression/test_qa_cafirms_may01_runtime_path_bugs.py
+++ b/tests/regression/test_qa_cafirms_may01_runtime_path_bugs.py
@@ -618,3 +618,99 @@ async def test_tool_adapter_initial_connect_failure_returns_error() -> None:
     # Cache should NOT contain a half-built instance after a failed
     # initial connect.
     assert 'fake:{}' not in tool_adapter._connector_cache
+
+
+# ──────────────────────────────────────────────────────────────────
+# BUG-11 (RU-May01 verification, 2026-05-02): the api response
+# serializer reads ``lg_result.get("tool_calls", [])`` but the
+# runner emits the log under ``tool_calls_log``. Result: every agent
+# run response showed ``tool_calls: []`` even when tools fired —
+# verified live against Zoho Books on 2026-05-02 with
+# ``tool_executed connector=zoho_books status=success`` in Cloud Run
+# logs but the API response field empty.
+#
+# The fix dual-emits ``tool_calls`` alongside ``tool_calls_log`` from
+# every return path in core.langgraph.runner.run_agent. These pins
+# lock that contract so a future refactor can't silently drop the
+# alias and reintroduce the empty-field bug.
+# ──────────────────────────────────────────────────────────────────
+
+
+def test_runner_dual_emits_tool_calls_alongside_tool_calls_log() -> None:
+    """Static-pin the runner module: every return-shape that emits
+    ``tool_calls_log`` also emits ``tool_calls``. Catches a future
+    contributor adding a new return path and forgetting the dual-emit.
+    """
+    from pathlib import Path  # noqa: PLC0415
+
+    src = (
+        Path(__file__).resolve().parents[2]
+        / "core"
+        / "langgraph"
+        / "runner.py"
+    ).read_text(encoding="utf-8")
+    log_emits = src.count('"tool_calls_log":')
+    alias_emits = src.count('"tool_calls":')
+    # The initial state dict only seeds ``tool_calls_log`` (it doesn't
+    # produce a return-shape, so the alias isn't needed there). All
+    # OTHER ``tool_calls_log`` emissions must be paired with a
+    # ``tool_calls`` emission. Off-by-one tolerance accounts for the
+    # state-seed line.
+    assert alias_emits >= log_emits - 1, (
+        f"runner.py emits tool_calls_log {log_emits} times but only "
+        f"{alias_emits} matching tool_calls aliases. Every return-shape "
+        "that ships tool_calls_log to the api caller must also ship "
+        "tool_calls (BUG-11 dual-emit) so the api response field at "
+        "api/v1/agents.py:2059 isn't silently empty."
+    )
+
+
+def test_runner_run_agent_async_path_returns_both_keys() -> None:
+    """Stub the langgraph compile + invoke surface so we can run
+    ``runner.run_agent`` end-to-end without a real broker/LLM, and
+    assert the returned dict carries BOTH ``tool_calls`` and
+    ``tool_calls_log``.
+    """
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock
+
+    from core.langgraph import runner
+
+    sentinel_log = [{"tool": "list_invoices", "status": "success"}]
+
+    fake_state = {
+        "status": "completed",
+        "output": {"data": "ok"},
+        "confidence": 0.9,
+        "reasoning_trace": ["did a thing"],
+        "tool_calls_log": sentinel_log,
+        "hitl_trigger": "",
+        "error": "",
+    }
+
+    fake_compiled = MagicMock()
+    fake_compiled.ainvoke = AsyncMock(return_value=fake_state)
+    fake_graph = MagicMock()
+    fake_graph.compile = MagicMock(return_value=fake_compiled)
+
+    with (
+        patch.object(runner, "build_agent_graph", return_value=fake_graph),
+        patch.object(runner, "generate_explanation", new=AsyncMock(return_value={})),
+    ):
+        result = asyncio.run(
+            runner.run_agent(
+                agent_id="a-id",
+                agent_type="t",
+                domain="ops",
+                tenant_id="00000000-0000-0000-0000-000000000000",
+                system_prompt="hi",
+                authorized_tools=["list_invoices"],
+                task_input={"action": "process", "inputs": {}, "context": {}},
+            )
+        )
+
+    assert result["tool_calls_log"] == sentinel_log
+    assert result["tool_calls"] == sentinel_log, (
+        "BUG-11 fix dropped the ``tool_calls`` alias on the success "
+        "return path — the API response field would be empty again."
+    )


### PR DESCRIPTION
## Summary

The api response serializer at ``api/v1/agents.py:2059`` reads ``lg_result.get(\"tool_calls\", [])`` while ``core/langgraph/runner.py`` emits the log under the key ``tool_calls_log``. Every agent run response showed ``tool_calls: []`` even when tools actually executed.

Verified live against the deployed Aryan FpaAgent on 2026-05-02:

```
Cloud Run logs:
  INFO tool_executed connector=zoho_books status=success tool=list_invoices

API response:
  \"tool_calls\": []          ← always empty
  \"output\": {\"data\": {\"list_invoices_response\": {...}}}  ← actual tool output present
```

The May-01 Playwright spec at ``ui/e2e/qa-cafirms-may01.spec.ts:100`` (``tool_calls.length > 0``) would fail-RED post-fix even though the fix had clearly deployed and was firing.

## Fix

Dual-emit ``tool_calls`` alongside ``tool_calls_log`` from every return path in ``core/langgraph/runner.py:run_agent``:

| Line | Path |
|---|---|
| 313 | success |
| 353 | HITL-triggered |
| 376 | timeout |
| 404 | exception |

``tool_calls_log`` stays the canonical internal name; ``tool_calls`` is the alias the api response serializer reads. Cross-module rename avoided to keep the runner's contract stable for callers that already consume ``tool_calls_log``.

## Tests

Two new pins in ``tests/regression/test_qa_cafirms_may01_runtime_path_bugs.py``:
- ``test_runner_dual_emits_tool_calls_alongside_tool_calls_log`` — static-analysis pin
- ``test_runner_run_agent_async_path_returns_both_keys`` — end-to-end stubbed-graph pin

Local: **23 passed in 4.83s**.

@codex please review