### PR TITLE
fix(security): CodeQL py/stack-trace-exposure — drop str(exc) from API responses

### DIFF
--- a/api/v1/connectors.py
+++ b/api/v1/connectors.py
@@ -777,7 +777,8 @@ async def test_connector(
         _log.exception("connector_test_failed conn_id=%s name=%s", conn_id, connector.name)
         err_name = type(exc).__name__
         err_msg = str(exc)[:240]
-        # Map common failure classes to actionable hints.
+        # Use the lowered string only for routing — the response
+        # below uses ONLY ``err_name`` + a hand-mapped hint.
         lowered = (err_name + " " + err_msg).lower()
         if "401" in lowered or "unauthor" in lowered or "invalid credentials" in lowered:
             hint = "Invalid credentials — verify username/password or API key in the credential vault."
@@ -794,7 +795,14 @@ async def test_connector(
         elif "timeout" in lowered:
             hint = "Request timed out — endpoint is slow or unreachable from the platform."
         else:
-            hint = f"{err_name}: {err_msg}" if err_msg else f"{err_name} (no detail)"
+            # CodeQL py/stack-trace-exposure (alert #68, 2026-05-02):
+            # was f"{err_name}: {err_msg}" which leaked str(exc) — the
+            # exception message can carry request URLs, header
+            # fragments, or stack-trace lines on common driver errors.
+            # The exception class alone is enough signal for the
+            # operator; full traceback is in server logs via
+            # ``_log.exception`` above.
+            hint = f"{err_name} (see server logs for details)"
         return {
             "tested": False,
             "name": connector.name,

--- a/api/v1/tenant_ai_credentials.py
+++ b/api/v1/tenant_ai_credentials.py
@@ -369,7 +369,13 @@ async def test_credential(
     except Exception as exc:
         logger.exception("tenant_ai_credential_probe_failed")
         status_value = "failing"
-        err = f"{type(exc).__name__}: {exc}"[:500]
+        # CodeQL py/stack-trace-exposure (alert #69, 2026-05-02): the
+        # exception class alone is enough signal for the operator to
+        # correlate with server logs. ``str(exc)`` may include
+        # request context (URLs, headers, payload fragments) that
+        # shouldn't surface in API responses. The full traceback is
+        # captured by ``logger.exception`` above.
+        err = type(exc).__name__
 
     async with get_tenant_session(tid) as session:
         result = await session.execute(

--- a/tests/regression/test_codeql_stack_trace_exposure.py
+++ b/tests/regression/test_codeql_stack_trace_exposure.py
@@ -1,0 +1,68 @@
+"""Pin the fix for CodeQL ``py/stack-trace-exposure`` alerts #68 + #69
+(reported 2026-04-28, addressed 2026-05-02).
+
+Before this fix two API endpoints returned exception messages directly
+in the response body:
+
+- ``api/v1/tenant_ai_credentials.py`` — ``error: f"{type(exc).__name__}: {exc}"[:500]``
+- ``api/v1/connectors.py`` — ``error: f"{err_name}: {err_msg}"`` in the
+  unmapped-failure-class fallback branch
+
+``str(exc)`` on common driver errors (httpx, asyncpg, smtplib) carries
+URL fragments, header values, and on some chained-exception traces a
+truncated stack frame. The CodeQL alert is correct: the operator
+testing a connector should NOT see internal exception text in the
+response — the exception class name plus the hand-mapped hint plus a
+"see server logs" pointer is enough signal. The full traceback is
+captured via ``logger.exception`` in both code paths.
+
+These pins are static — they assert the source files no longer carry
+the leaky string-format expressions. A future contributor reintroducing
+the leak will trip the test before CodeQL re-flags it.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def test_tenant_ai_credentials_error_field_does_not_leak_str_exc() -> None:
+    """``tenant_ai_credentials.py`` test-credential probe must NOT
+    expose ``str(exc)`` to the API response body. The exception class
+    name alone is enough for operator triage; details live in
+    server logs via ``logger.exception``.
+    """
+    src = (REPO / "api" / "v1" / "tenant_ai_credentials.py").read_text(
+        encoding="utf-8"
+    )
+    assert 'err = f"{type(exc).__name__}: {exc}"[:500]' not in src, (
+        "tenant_ai_credentials.py reintroduced the str(exc) leak. "
+        "CodeQL alert #69 will re-fire. The fix must keep err to "
+        "type(exc).__name__ only."
+    )
+    # Positive contract — the type-name-only assignment must be
+    # present so we don't regress to a different leaky shape.
+    assert "err = type(exc).__name__" in src, (
+        "tenant_ai_credentials.py probe error path must assign "
+        "``err = type(exc).__name__`` (no exception message)."
+    )
+
+
+def test_connectors_test_endpoint_does_not_leak_err_msg_in_fallback_branch() -> None:
+    """``connectors.py`` connector-test endpoint's unmapped-failure
+    fallback used to return ``f"{err_name}: {err_msg}"`` where
+    ``err_msg = str(exc)[:240]``. That's a stack-trace-exposure leak
+    (CodeQL alert #68). The fix returns ``f"{err_name} (see server
+    logs for details)"`` — class name only, no message body.
+    """
+    src = (REPO / "api" / "v1" / "connectors.py").read_text(encoding="utf-8")
+    assert 'hint = f"{err_name}: {err_msg}"' not in src, (
+        "connectors.py reintroduced the err_msg leak in the fallback "
+        "hint branch. CodeQL alert #68 will re-fire."
+    )
+    assert "see server logs for details" in src, (
+        "connectors.py test-endpoint fallback hint must point operators "
+        "at server logs (where the full traceback is) instead of "
+        "echoing the exception message."
+    )


### PR DESCRIPTION
## Summary

Closes CodeQL alerts **#68** (`api/v1/connectors.py:798`) and **#69** (`api/v1/tenant_ai_credentials.py:396`). Both endpoints serialised ``str(exc)`` (truncated) into the API response body, leaking URL fragments and driver-error context.

The exception class name + hand-mapped hint + a "see server logs" pointer is enough signal for operator triage. Full traceback already captured via ``logger.exception``.

## Other 2026-05-02 CodeQL alerts (separately dismissed)

| # | Rule | Path | Status |
|---|---|---|---|
| 73 | py/incomplete-url-substring-sanitization | tests/unit/test_module_16_email_system.py:161 | dismissed (false positive — test source-code substring assertion) |
| 72 | same | tests/unit/test_module_19_health_api.py:177 | dismissed (false positive) |
| 71 | same | tests/unit/test_module_19_health_api.py:176 | dismissed (false positive) |
| 70 | same | tests/regression/test_qa_uday_26apr.py:80 | dismissed (false positive) |
| 67 | py/stack-trace-exposure | api/v1/knowledge.py:1159 | dismissed (over-conservative flow analysis) |
| 66 | same | api/v1/abm.py:464 | dismissed (over-conservative) |
| 61 | same | api/v1/a2a.py:271 | dismissed (already sanitized via ``_sanitize()``) |

## Tests

New regression pins in ``tests/regression/test_codeql_stack_trace_exposure.py`` — static assertions on source files so a future contributor reintroducing the leaky format string trips the test before CodeQL re-flags it.

@codex please review