### PR TITLE
fix(api): BUG-11 followup — populate tool_calls_log from message stream

### DIFF
--- a/core/langgraph/agent_graph.py
+++ b/core/langgraph/agent_graph.py
@@ -161,7 +161,7 @@ def build_agent_graph(
         """Extract structured output and compute confidence from the last AI message."""
         messages = state["messages"]
         trace = list(state.get("reasoning_trace") or [])
-        tool_calls_log = state.get("tool_calls_log") or []
+        tool_calls_log = list(state.get("tool_calls_log") or [])
 
         # Find the last AI message
         last_ai = None
@@ -175,6 +175,7 @@ def build_agent_graph(
                 "status": "failed",
                 "error": "No AI response received",
                 "reasoning_trace": [*trace, "ERROR: No AI message found"],
+                "tool_calls_log": tool_calls_log,
             }
 
         # Parse output — _parse_json_output guarantees a dict, but be
@@ -193,13 +194,45 @@ def build_agent_graph(
         from langchain_core.messages import ToolMessage
         tool_msg_count = 0
         tool_error_count = 0
+        # BUG-11 follow-up (2026-05-02): build tool_calls_log from the
+        # message stream. LangGraph's prebuilt ``ToolNode`` puts tool
+        # results into ``state["messages"]`` as ``ToolMessage`` objects
+        # — no other code path ever appended to ``tool_calls_log``, so
+        # the API response field stayed empty even when tools fired
+        # successfully. Pair each ToolMessage (the result) with its
+        # invoking AIMessage tool_call (the args) so the response
+        # carries both the call and the outcome.
+        ai_tool_calls_by_id: dict[str, dict[str, Any]] = {}
+        for msg in messages:
+            if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", None):
+                for tc in msg.tool_calls:
+                    if not isinstance(tc, dict):
+                        continue
+                    raw_id = tc.get("id")
+                    if isinstance(raw_id, str) and raw_id:
+                        ai_tool_calls_by_id[raw_id] = tc
         for msg in messages:
             if isinstance(msg, ToolMessage):
                 tool_msg_count += 1
                 msg_content = msg.content if isinstance(msg.content, str) else str(msg.content)
-                if "error" in msg_content.lower() or "failed" in msg_content.lower():
+                is_error = "error" in msg_content.lower() or "failed" in msg_content.lower()
+                if is_error:
                     tool_error_count += 1
                     any_tool_failed = True
+                tc_id: str | None = getattr(msg, "tool_call_id", None)
+                source = ai_tool_calls_by_id.get(tc_id, {}) if tc_id else {}
+                tool_calls_log.append(
+                    {
+                        "tool": getattr(msg, "name", None) or source.get("name", ""),
+                        "args": source.get("args", {}),
+                        "tool_call_id": tc_id,
+                        "status": "error" if is_error else "success",
+                        # Cap result body so a chatty connector response
+                        # doesn't bloat the agent run record. Operators
+                        # who need the full body get it from server logs.
+                        "result": (msg_content or "")[:2000],
+                    }
+                )
 
         output_incomplete = (
             not output
@@ -230,6 +263,7 @@ def build_agent_graph(
             "confidence": confidence,
             "status": "completed",
             "reasoning_trace": trace,
+            "tool_calls_log": tool_calls_log,
         }
 
     async def hitl_gate(state: AgentState) -> dict[str, Any]:

--- a/tests/regression/test_qa_cafirms_may01_runtime_path_bugs.py
+++ b/tests/regression/test_qa_cafirms_may01_runtime_path_bugs.py
@@ -714,3 +714,55 @@ def test_runner_run_agent_async_path_returns_both_keys() -> None:
         "BUG-11 fix dropped the ``tool_calls`` alias on the success "
         "return path — the API response field would be empty again."
     )
+
+
+def test_agent_graph_evaluate_populates_tool_calls_log_from_messages() -> None:
+    """BUG-11 root-cause pin (2026-05-02): the prior ``evaluate()``
+    in core/langgraph/agent_graph.py read ``tool_calls_log`` from
+    state but never wrote anything to it — and LangGraph's prebuilt
+    ``ToolNode`` records its results in ``state["messages"]`` as
+    ``ToolMessage`` objects, not in ``tool_calls_log``. Net effect:
+    ``tool_calls_log`` was always empty in the runner's return dict
+    even when tools fired successfully.
+
+    The fix: ``evaluate()`` now scans the message stream, pairs each
+    ``ToolMessage`` (result) with its invoking ``AIMessage.tool_calls``
+    entry (args), and returns a populated ``tool_calls_log`` in the
+    state-update dict so it survives to the runner + the api response.
+
+    Static pin: ``evaluate()`` is a closure inside ``build_agent_graph``
+    and LangGraph wraps the node so the function isn't reachable from
+    Python without refactoring. Pin the source file instead — assert
+    the population logic is present.
+    """
+    from pathlib import Path  # noqa: PLC0415
+
+    src = (
+        Path(__file__).resolve().parents[2]
+        / "core"
+        / "langgraph"
+        / "agent_graph.py"
+    ).read_text(encoding="utf-8")
+
+    # Pin: evaluate appends to tool_calls_log when iterating
+    # ToolMessage objects from the message stream.
+    assert "tool_calls_log.append(" in src, (
+        "evaluate() must append to tool_calls_log when iterating "
+        "ToolMessage objects from the message stream. The prior code "
+        "read tool_calls_log from state but never wrote — every API "
+        "response showed tool_calls: [] even when tools fired."
+    )
+    # Pin: evaluate returns tool_calls_log in the state-update dict so
+    # the populated list survives to the runner / api response.
+    assert '"tool_calls_log": tool_calls_log' in src, (
+        "evaluate() must return tool_calls_log in its state-update "
+        "dict so the populated list reaches the runner / API response."
+    )
+    # Pin: evaluate pairs each ToolMessage (result) with the invoking
+    # AIMessage.tool_calls entry (args) via tool_call_id.
+    assert "ai_tool_calls_by_id" in src, (
+        "evaluate() must build an AIMessage.tool_calls index keyed by "
+        "tool_call.id so each ToolMessage result can be paired with "
+        "the args of its invoking call (otherwise log entries lose the "
+        "args context the API response needs)."
+    )


### PR DESCRIPTION
## Summary

PR #426 added a dual-emit (``tool_calls`` alias for ``tool_calls_log``) in ``core/langgraph/runner.py`` so the api response carries the field the serializer reads. Verified live against the deployed Aryan FpaAgent on 2026-05-02 — the api response field correctly aliases ``tool_calls_log`` now, **but both keys are still empty** because ``tool_calls_log`` itself was never populated.

## Root cause (deeper than PR #426)

The agent state declares ``tool_calls_log: list[dict[str, Any]]`` and ``evaluate()`` reads it to compute ``any_tool_failed``. But **nothing ever wrote to it**. LangGraph's prebuilt ``ToolNode`` (used at line 301: ``graph.add_node("execute_tools", ToolNode(tools))``) stores tool results in ``state[\"messages\"]`` as ``ToolMessage`` objects, not in ``tool_calls_log``.

The May-01 verification end-to-end run shows this clearly:
- Cloud Run logs: ``tool_executed connector=zoho_books status=success tool=list_invoices`` ✅
- ``output.data.list_invoices_response`` populated with real Zoho API response ✅
- ``confidence: 0.97`` (the math counted the tool success) ✅
- BUT ``tool_calls: []`` ❌

## Fix

``evaluate()`` now scans ``state[\"messages\"]`` and builds ``tool_calls_log`` entries, pairing each ``ToolMessage`` (result) with its invoking ``AIMessage.tool_calls`` entry (args) via ``tool_call_id``. Each entry: ``{tool, args, tool_call_id, status, result[:2000]}``.

The ``evaluate`` state-update now includes ``tool_calls_log`` so it survives to the runner's return value and through the dual-emit added in PR #426.

## Tests

New static-pin in ``tests/regression/test_qa_cafirms_may01_runtime_path_bugs.py:test_agent_graph_evaluate_populates_tool_calls_log_from_messages`` asserting the source carries the population logic + the args-by-id index + the state-update key.

Local: 63 tests passed in regression + langgraph_runtime suites; mypy clean.

@codex please review