### PR TITLE
Fix security hardening sweep findings

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -74,7 +74,7 @@ from api.websocket.feed import router as ws_feed_router
 from auth.csrf_middleware import CSRFMiddleware
 from auth.grantex_middleware import GrantexAuthMiddleware
 from bridge.server_handler import router as ws_bridge_router
-from core.config import settings
+from core.config import is_strict_runtime_env, settings
 
 
 @asynccontextmanager
@@ -119,7 +119,7 @@ async def lifespan(app: FastAPI):
     await close_db()
 
 
-_is_production = settings.env == "production"
+_is_strict_runtime = is_strict_runtime_env(settings.env)
 
 app = FastAPI(
     title="AgenticOrg",
@@ -129,8 +129,9 @@ app = FastAPI(
     ),
     version=product_facts._version_from_pyproject(),
     lifespan=lifespan,
-    docs_url=None if _is_production else "/docs",
-    redoc_url=None if _is_production else "/redoc",
+    docs_url=None if _is_strict_runtime else "/docs",
+    redoc_url=None if _is_strict_runtime else "/redoc",
+    openapi_url=None if _is_strict_runtime else "/openapi.json",
 )
 
 # CORS: open in dev, explicit allowlist in production.
@@ -138,7 +139,7 @@ app = FastAPI(
 # and log a warning rather than crashing the process — a hard crash here
 # would prevent rolling deploys from completing (discovered in prod deploy
 # of GAP-15 fix).
-if settings.env in ("production", "staging") and not settings.cors_allowed_origins:
+if _is_strict_runtime and not settings.cors_allowed_origins:
     _logging.getLogger("agenticorg.cors").warning(
         "CORS_ALLOWED_ORIGINS not set in %s — falling back to default allowlist. "
         "Set the env var to silence this warning.",

--- a/api/v1/abm.py
+++ b/api/v1/abm.py
@@ -23,11 +23,13 @@ from sqlalchemy.exc import IntegrityError
 
 from api.deps import get_current_tenant
 from core.database import get_tenant_session
+from core.file_ingestion.limits import cleanup_tempfile, stream_to_tempfile
 from core.marketing.intent_aggregator import IntentAggregator
 from core.models.abm import ABMAccount, ABMCampaign
 
 logger = structlog.get_logger()
 router = APIRouter(prefix="/abm", tags=["ABM"])
+MAX_ABM_CSV_UPLOAD_BYTES = 2 * 1024 * 1024
 
 _aggregator = IntentAggregator()
 
@@ -310,7 +312,11 @@ async def upload_accounts(
     if not file.filename or not file.filename.lower().endswith(".csv"):
         raise HTTPException(400, "Only CSV files are accepted")
 
-    content = await file.read()
+    upload_path, _ = await stream_to_tempfile(file, max_bytes=MAX_ABM_CSV_UPLOAD_BYTES, suffix=".csv")
+    try:
+        content = upload_path.read_bytes()
+    finally:
+        cleanup_tempfile(upload_path)
     if not content.strip():
         # TC_019: bytes-empty file — never even reaches the CSV parser.
         raise HTTPException(400, "CSV file is empty or contains no valid records")

--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -22,6 +22,7 @@ from api.deps import (
     require_tenant_admin,
 )
 from core.database import get_tenant_session
+from core.file_ingestion.limits import cleanup_tempfile, stream_to_tempfile
 from core.models.agent import Agent, AgentCostLedger, AgentLifecycleEvent, AgentVersion
 from core.models.audit import AuditLog
 from core.models.company import Company
@@ -35,6 +36,8 @@ from core.schemas.api import (
     FleetLimits,
     PaginatedResponse,
 )
+
+MAX_AGENT_CSV_IMPORT_BYTES = 2 * 1024 * 1024
 
 _AGENT_TYPE_DEFAULT_TOOLS: dict[str, list[str]] = {
     # Finance
@@ -1088,8 +1091,20 @@ async def import_agents_csv(
 ):
     """Import agents from CSV with two-pass parent linking."""
     tid = _uuid.UUID(tenant_id)
-    content = await file.read()
-    text_content = content.decode("utf-8-sig")
+    filename = (file.filename or "").lower()
+    if filename and not filename.endswith(".csv"):
+        raise HTTPException(422, detail="Only .csv files are supported for agent import")
+    upload_path, _ = await stream_to_tempfile(file, max_bytes=MAX_AGENT_CSV_IMPORT_BYTES, suffix=".csv")
+    try:
+        content = upload_path.read_bytes()
+    finally:
+        cleanup_tempfile(upload_path)
+    if not content.strip():
+        raise HTTPException(422, detail="CSV missing required columns. Expected: name, agent_type, domain")
+    try:
+        text_content = content.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise HTTPException(422, detail="CSV must be UTF-8 encoded") from exc
     reader = csv.DictReader(io.StringIO(text_content))
 
     # TC-009: Validate CSV has proper headers

--- a/api/v1/auth.py
+++ b/api/v1/auth.py
@@ -19,7 +19,12 @@ from sqlalchemy import func, select
 from auth.jwt import blacklist_token, create_access_token, validate_local_token
 from auth.one_time_codes import consume as consume_code
 from auth.one_time_codes import issue as issue_code
-from core.config import is_strict_runtime_env, redis_url_from_env, settings
+from core.config import (
+    is_strict_runtime_env,
+    redis_socket_timeout_kwargs,
+    redis_url_from_env,
+    settings,
+)
 from core.database import async_session_factory
 from core.email import send_password_reset_email, send_welcome_email
 from core.models.tenant import Tenant
@@ -248,8 +253,7 @@ async def _get_throttle_redis():
         _throttle_redis = aioredis.from_url(
             url,
             decode_responses=True,
-            socket_connect_timeout=0.5,
-            socket_timeout=0.5,
+            **redis_socket_timeout_kwargs(),
         )
         await _throttle_redis.ping()
         return _throttle_redis

--- a/api/v1/auth.py
+++ b/api/v1/auth.py
@@ -19,7 +19,7 @@ from sqlalchemy import func, select
 from auth.jwt import blacklist_token, create_access_token, validate_local_token
 from auth.one_time_codes import consume as consume_code
 from auth.one_time_codes import issue as issue_code
-from core.config import settings
+from core.config import is_strict_runtime_env, redis_url_from_env, settings
 from core.database import async_session_factory
 from core.email import send_password_reset_email, send_welcome_email
 from core.models.tenant import Tenant
@@ -45,7 +45,7 @@ def _set_session_cookie(response: Response, token: str, max_age_seconds: int) ->
     echo via ``X-CSRF-Token`` on mutating requests. Enforced by
     ``auth/csrf_middleware.CSRFMiddleware``.
     """
-    is_prod = os.getenv("AGENTICORG_ENV", "development").lower() == "production"
+    is_prod = is_strict_runtime_env(os.getenv("AGENTICORG_ENV", settings.env))
     response.set_cookie(
         key="agenticorg_session",
         value=token,
@@ -244,8 +244,13 @@ async def _get_throttle_redis():
     try:
         import redis.asyncio as aioredis
 
-        url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
-        _throttle_redis = aioredis.from_url(url, decode_responses=True)
+        url = redis_url_from_env(default_db=0)
+        _throttle_redis = aioredis.from_url(
+            url,
+            decode_responses=True,
+            socket_connect_timeout=0.5,
+            socket_timeout=0.5,
+        )
         await _throttle_redis.ping()
         return _throttle_redis
     except Exception as exc:
@@ -553,7 +558,7 @@ async def reset_password(body: ResetPasswordRequest):
         await session.commit()
 
     # Blacklist the reset token so it can't be reused
-    blacklist_token(body.token)
+    blacklist_token(token_value)
 
     return {"status": "ok", "message": "Password has been reset. You can now sign in."}
 

--- a/api/v1/chat.py
+++ b/api/v1/chat.py
@@ -15,6 +15,7 @@ from sqlalchemy import select
 
 from api.deps import get_current_tenant
 from api.v1.agents import _AGENT_TYPE_DEFAULT_TOOLS, _DOMAIN_DEFAULT_TOOLS
+from core.config import redis_url_from_env
 from core.database import get_tenant_session
 from core.models.agent import Agent
 
@@ -150,8 +151,13 @@ _redis_client: Any = None
 try:
     import redis.asyncio as _aioredis
 
-    _redis_url = __import__("os").environ.get("REDIS_URL", "redis://localhost:6379/0")
-    _redis_client = _aioredis.from_url(_redis_url, decode_responses=True)
+    _redis_url = redis_url_from_env(default_db=0)
+    _redis_client = _aioredis.from_url(
+        _redis_url,
+        decode_responses=True,
+        socket_connect_timeout=0.5,
+        socket_timeout=0.5,
+    )
 except Exception:
     _log.info("chat_redis_unavailable_using_memory_fallback")
 

--- a/api/v1/chat.py
+++ b/api/v1/chat.py
@@ -15,7 +15,7 @@ from sqlalchemy import select
 
 from api.deps import get_current_tenant
 from api.v1.agents import _AGENT_TYPE_DEFAULT_TOOLS, _DOMAIN_DEFAULT_TOOLS
-from core.config import redis_url_from_env
+from core.config import redis_socket_timeout_kwargs, redis_url_from_env
 from core.database import get_tenant_session
 from core.models.agent import Agent
 
@@ -155,8 +155,7 @@ try:
     _redis_client = _aioredis.from_url(
         _redis_url,
         decode_responses=True,
-        socket_connect_timeout=0.5,
-        socket_timeout=0.5,
+        **redis_socket_timeout_kwargs(),
     )
 except Exception:
     _log.info("chat_redis_unavailable_using_memory_fallback")

--- a/api/v1/sales.py
+++ b/api/v1/sales.py
@@ -17,6 +17,7 @@ from sqlalchemy import func, select
 from api.deps import get_current_tenant
 from core.agents.registry import AgentRegistry
 from core.database import get_tenant_session
+from core.file_ingestion.limits import cleanup_tempfile, stream_to_tempfile
 from core.models.audit import AuditLog
 from core.models.lead_pipeline import EmailSequence, LeadPipeline
 from core.schemas.messages import (
@@ -29,6 +30,7 @@ from core.schemas.messages import (
 
 logger = structlog.get_logger()
 router = APIRouter()
+MAX_CSV_IMPORT_BYTES = 2 * 1024 * 1024
 
 
 # ── Schemas ──
@@ -525,7 +527,11 @@ async def import_leads_csv(
             },
         )
 
-    content = await file.read()
+    upload_path, _ = await stream_to_tempfile(file, max_bytes=MAX_CSV_IMPORT_BYTES, suffix=".csv")
+    try:
+        content = upload_path.read_bytes()
+    finally:
+        cleanup_tempfile(upload_path)
     if not content.strip():
         raise HTTPException(
             422,

--- a/api/v1/sop.py
+++ b/api/v1/sop.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import os
 import re
-import tempfile
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
 from pydantic import BaseModel
 
 from api.deps import get_current_tenant
+from core.file_ingestion.limits import cleanup_tempfile, stream_to_tempfile
 
 router = APIRouter()
 _log = structlog.get_logger()
@@ -56,19 +56,12 @@ async def upload_and_parse_sop(
             400, f"Unsupported file type '{ext}'. Allowed: {', '.join(ALLOWED_EXTENSIONS)}"
         )
 
-    content = await file.read()
-    if len(content) > MAX_FILE_SIZE:
-        raise HTTPException(400, f"File too large (max {MAX_FILE_SIZE // 1024 // 1024}MB)")
-
-    # Save to temp file for parsing
-    with tempfile.NamedTemporaryFile(delete=False, suffix=ext) as tmp:
-        tmp.write(content)
-        tmp_path = tmp.name
+    tmp_path, _ = await stream_to_tempfile(file, max_bytes=MAX_FILE_SIZE, suffix=ext)
 
     try:
         from core.langgraph.sop_parser import extract_text_from_document, parse_sop_document
 
-        document_text = extract_text_from_document(tmp_path, file.content_type or "")
+        document_text = extract_text_from_document(str(tmp_path), file.content_type or "")
         if not document_text.strip():
             raise HTTPException(400, "Could not extract text from document")
 
@@ -94,7 +87,7 @@ async def upload_and_parse_sop(
             "config": parsed,
         }
     finally:
-        os.unlink(tmp_path)
+        cleanup_tempfile(tmp_path)
 
 
 # ── POST /sop/parse-text — Parse plain text SOP ────────────────────────────

--- a/auth/csrf.py
+++ b/auth/csrf.py
@@ -38,6 +38,8 @@ from typing import Final
 
 from fastapi import Response
 
+from core.config import is_strict_runtime_env
+
 CSRF_COOKIE_NAME: Final[str] = "agenticorg_csrf"
 CSRF_HEADER_NAME: Final[str] = "X-CSRF-Token"
 
@@ -68,7 +70,7 @@ def set_csrf_cookie(response: Response, token: str, max_age_seconds: int = 86400
        reads it, the browser still won't ship it cross-origin in the
        cases SameSite covers, providing defense-in-depth.
     """
-    is_prod = os.getenv("AGENTICORG_ENV", "development").lower() == "production"
+    is_prod = is_strict_runtime_env(os.getenv("AGENTICORG_ENV", "development"))
     response.set_cookie(
         key=CSRF_COOKIE_NAME,
         value=token,

--- a/core/async_redis.py
+++ b/core/async_redis.py
@@ -13,7 +13,7 @@ import logging
 
 import redis.asyncio as aioredis
 
-from core.config import redis_url_from_env
+from core.config import redis_socket_timeout_kwargs, redis_url_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -31,8 +31,7 @@ async def get_async_redis() -> aioredis.Redis | None:
             url,
             decode_responses=True,
             max_connections=20,
-            socket_connect_timeout=0.5,
-            socket_timeout=0.5,
+            **redis_socket_timeout_kwargs(),
         )
         await _pool.ping()
         return _pool

--- a/core/async_redis.py
+++ b/core/async_redis.py
@@ -10,9 +10,10 @@ Usage in async handlers:
 from __future__ import annotations
 
 import logging
-import os
 
 import redis.asyncio as aioredis
+
+from core.config import redis_url_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -25,11 +26,13 @@ async def get_async_redis() -> aioredis.Redis | None:
     if _pool is not None:
         return _pool
     try:
-        url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+        url = redis_url_from_env(default_db=0)
         _pool = aioredis.from_url(
             url,
             decode_responses=True,
             max_connections=20,
+            socket_connect_timeout=0.5,
+            socket_timeout=0.5,
         )
         await _pool.ping()
         return _pool

--- a/core/auth_state.py
+++ b/core/auth_state.py
@@ -23,7 +23,7 @@ from collections import defaultdict
 
 import redis.asyncio as aioredis
 
-from core.config import redis_url_from_env
+from core.config import redis_socket_timeout_kwargs, redis_url_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -48,8 +48,7 @@ async def _get_redis() -> aioredis.Redis | None:
         _redis = aioredis.from_url(
             url,
             decode_responses=True,
-            socket_connect_timeout=0.5,
-            socket_timeout=0.5,
+            **redis_socket_timeout_kwargs(),
         )
         await _redis.ping()
         return _redis

--- a/core/auth_state.py
+++ b/core/auth_state.py
@@ -23,6 +23,8 @@ from collections import defaultdict
 
 import redis.asyncio as aioredis
 
+from core.config import redis_url_from_env
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -42,8 +44,13 @@ async def _get_redis() -> aioredis.Redis | None:
     if _redis is not None:
         return _redis
     try:
-        url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
-        _redis = aioredis.from_url(url, decode_responses=True)
+        url = redis_url_from_env(default_db=0)
+        _redis = aioredis.from_url(
+            url,
+            decode_responses=True,
+            socket_connect_timeout=0.5,
+            socket_timeout=0.5,
+        )
         await _redis.ping()
         return _redis
     except Exception as exc:

--- a/core/config.py
+++ b/core/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings
@@ -26,16 +27,51 @@ def is_strict_runtime_env(env: str | None) -> bool:
     return not is_relaxed_env(env)
 
 
+def _redis_url_with_default_db(url: str, default_db: int) -> str:
+    """Return *url* with ``default_db`` applied without changing hosts.
+
+    ``redis_url_from_env(default_db=1)`` must not jump back to localhost
+    when the configured settings URL points at a production Redis host.
+    Explicit environment URLs stay authoritative; this only adjusts the
+    settings fallback path.
+    """
+    if default_db == 0:
+        return url
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return url
+    if parsed.scheme not in {"redis", "rediss"}:
+        return url
+    return urlunsplit(parsed._replace(path=f"/{default_db}"))
+
+
 def redis_url_from_env(default_db: int = 0) -> str:
     """Resolve the Redis URL using the app's canonical env var first."""
     default_url = f"redis://localhost:6379/{default_db}"
+    env_url = os.getenv("AGENTICORG_REDIS_URL") or os.getenv("REDIS_URL")
+    if env_url:
+        return env_url
     configured_settings = globals().get("settings")
     settings_url = getattr(configured_settings, "redis_url", default_url)
-    return (
-        os.getenv("AGENTICORG_REDIS_URL")
-        or os.getenv("REDIS_URL")
-        or (settings_url if default_db == 0 else default_url)
-    )
+    return _redis_url_with_default_db(settings_url, default_db)
+
+
+def redis_socket_timeout_kwargs() -> dict[str, float]:
+    """Return bounded Redis socket timeouts, configurable per deploy.
+
+    The defaults intentionally allow more room than the previous 500ms
+    cap so real production p99 latency and brief cross-zone jitter do not
+    force avoidable in-memory fallback. Deploys can tune these with
+    AGENTICORG_REDIS_SOCKET_* env vars.
+    """
+    configured_settings = globals().get("settings")
+    return {
+        "socket_connect_timeout": getattr(
+            configured_settings, "redis_socket_connect_timeout_seconds", 2.0
+        ),
+        "socket_timeout": getattr(configured_settings, "redis_socket_timeout_seconds", 2.0),
+    }
 
 
 class Settings(BaseSettings):
@@ -53,6 +89,8 @@ class Settings(BaseSettings):
 
     # Redis
     redis_url: str = "redis://localhost:6379/0"
+    redis_socket_connect_timeout_seconds: float = Field(default=2.0, ge=0.1, le=30.0)
+    redis_socket_timeout_seconds: float = Field(default=2.0, ge=0.1, le=30.0)
 
     # Object Storage (GCS / S3-compatible)
     storage_bucket: str = "agenticorg-docs-dev"

--- a/core/config.py
+++ b/core/config.py
@@ -2,8 +2,40 @@
 
 from __future__ import annotations
 
+import os
+
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings
+
+STRICT_ENVS = frozenset({"production", "prod", "staging", "stage", "preview"})
+RELAXED_ENVS = frozenset({"local", "dev", "development", "test", "ci"})
+
+
+def normalize_env(env: str | None) -> str:
+    """Return the canonical lowercase runtime environment label."""
+    return (env or "").strip().lower()
+
+
+def is_relaxed_env(env: str | None) -> bool:
+    """Return True for explicitly local/test runtimes only."""
+    return normalize_env(env) in RELAXED_ENVS
+
+
+def is_strict_runtime_env(env: str | None) -> bool:
+    """Return True for every non-local runtime, including unknown labels."""
+    return not is_relaxed_env(env)
+
+
+def redis_url_from_env(default_db: int = 0) -> str:
+    """Resolve the Redis URL using the app's canonical env var first."""
+    default_url = f"redis://localhost:6379/{default_db}"
+    configured_settings = globals().get("settings")
+    settings_url = getattr(configured_settings, "redis_url", default_url)
+    return (
+        os.getenv("AGENTICORG_REDIS_URL")
+        or os.getenv("REDIS_URL")
+        or (settings_url if default_db == 0 else default_url)
+    )
 
 
 class Settings(BaseSettings):
@@ -59,8 +91,8 @@ class Settings(BaseSettings):
     # as strict. Staging is internet-accessible, used for demos, pilots,
     # and enterprise security review — weak staging secrets become real
     # incidents when staging has production-like integrations.
-    _STRICT_ENVS = frozenset({"production", "prod", "staging", "stage", "preview"})
-    _RELAXED_ENVS = frozenset({"local", "dev", "development", "test", "ci"})
+    _STRICT_ENVS = STRICT_ENVS
+    _RELAXED_ENVS = RELAXED_ENVS
 
     @model_validator(mode="after")
     def validate_production_secret(self) -> Settings:
@@ -74,12 +106,8 @@ class Settings(BaseSettings):
         Secret length is also enforced: minimum 32 chars (≈192 bits of
         entropy) so JWT/HMAC operations don't operate over weak keys.
         """
-        env_l = self.env.lower()
-        is_strict = env_l in self._STRICT_ENVS
-        # Anything not explicitly relaxed AND not explicitly strict
-        # ALSO fails strict — defaults to safe.
-        is_unknown = env_l not in self._RELAXED_ENVS and not is_strict
-        if not (is_strict or is_unknown):
+        is_strict = is_strict_runtime_env(self.env)
+        if not is_strict:
             return self
 
         env_label = self.env  # preserve original casing in error msg

--- a/core/file_ingestion/limits.py
+++ b/core/file_ingestion/limits.py
@@ -174,7 +174,7 @@ def validate_upload(file: UploadFile) -> None:
 
 
 async def stream_to_tempfile(
-    file: UploadFile, max_bytes: int = MAX_UPLOAD_BYTES
+    file: UploadFile, max_bytes: int = MAX_UPLOAD_BYTES, suffix: str = ""
 ) -> tuple[Path, int]:
     """Copy the upload to a NamedTemporaryFile in chunks; abort if
     the running total exceeds ``max_bytes``.
@@ -192,7 +192,7 @@ async def stream_to_tempfile(
     don't leak disk on the rejection path.
     """
     total = 0
-    fd, tmp_path_str = tempfile.mkstemp(prefix="agenticorg-upload-")
+    fd, tmp_path_str = tempfile.mkstemp(prefix="agenticorg-upload-", suffix=suffix)
     tmp_path = Path(tmp_path_str)
     try:
         with os.fdopen(fd, "wb") as out:

--- a/core/pii/redactor.py
+++ b/core/pii/redactor.py
@@ -235,7 +235,8 @@ class PIIRedactor:
             token_map[token] = original
             text = text[:result.start] + token + text[result.end:]
 
-        logger.debug("pii_redacted", entities_found=len(token_map))
+        if os.environ.get("AGENTICORG_PII_DEBUG", "").lower() in ("1", "true", "yes"):
+            logger.debug("pii_redacted", entities_found=len(token_map))
         return text, token_map
 
     def deanonymize(self, text: str, token_map: dict[str, str]) -> str:

--- a/tests/regression/test_security_pr_f_cookie_auth.py
+++ b/tests/regression/test_security_pr_f_cookie_auth.py
@@ -114,6 +114,17 @@ def test_sec_002_api_client_does_not_inject_bearer_from_localstorage() -> None:
     )
 
 
+def test_sec_002_onboarding_uses_cookie_api_client_not_context_token() -> None:
+    """Onboarding must not send ``Authorization: Bearer null`` after
+    AuthContext made browser ``token`` intentionally null."""
+    onboarding = (UI_SRC / "pages" / "Onboarding.tsx").read_text(encoding="utf-8")
+    assert "import api from" in onboarding
+    assert "const { user, token } = useAuth()" not in onboarding
+    assert "Authorization: `Bearer ${token}`" not in onboarding
+    assert 'api.post("/org/invite"' in onboarding
+    assert 'api.put("/org/onboarding"' in onboarding
+
+
 def test_sec_002_authcontext_purges_legacy_token_storage() -> None:
     """First-render cleanup must remove any legacy localStorage left
     over from pre-PR-F clients so the regression-test grep stays

--- a/tests/regression/test_security_push_service_worker.py
+++ b/tests/regression/test_security_push_service_worker.py
@@ -1,0 +1,26 @@
+"""Push service-worker security regression pins."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SW = REPO / "ui" / "public" / "sw.js"
+
+
+def test_push_service_worker_does_not_store_or_send_bearer_tokens() -> None:
+    src = SW.read_text(encoding="utf-8")
+    assert "Authorization" not in src
+    assert "Bearer" not in src
+    assert "payload.data?.token" not in src
+    assert "notification.data?.token" not in src
+    assert "token:" not in src
+
+
+def test_push_service_worker_restricts_notification_urls_to_relative_paths() -> None:
+    src = SW.read_text(encoding="utf-8")
+    assert "function safeNotificationUrl" in src
+    assert "!value.startsWith(\"/\")" in src
+    assert "value.startsWith(\"//\")" in src
+    assert "safeNotificationUrl(payload.data?.url)" in src
+    assert "safeNotificationUrl(notification.data?.url)" in src

--- a/tests/regression/test_security_runtime_hardening_sweep.py
+++ b/tests/regression/test_security_runtime_hardening_sweep.py
@@ -73,7 +73,25 @@ def test_redis_url_resolution_uses_settings_fallback(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(config, "settings", _Settings())
 
     assert config.redis_url_from_env() == "redis://settings:6379/8"
-    assert config.redis_url_from_env(default_db=1) == "redis://localhost:6379/1"
+    assert config.redis_url_from_env(default_db=1) == "redis://settings:6379/1"
+
+
+def test_redis_url_resolution_preserves_settings_host_for_nonzero_default_db(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import core.config as config
+
+    class _Settings:
+        redis_url = "rediss://:secret@prod-redis.internal:6380/0?ssl_cert_reqs=required"
+
+    monkeypatch.delenv("AGENTICORG_REDIS_URL", raising=False)
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.setattr(config, "settings", _Settings())
+
+    assert (
+        config.redis_url_from_env(default_db=1)
+        == "rediss://:secret@prod-redis.internal:6380/1?ssl_cert_reqs=required"
+    )
 
 
 def test_redis_helpers_do_not_read_legacy_redis_url_directly() -> None:
@@ -97,8 +115,24 @@ def test_redis_clients_use_bounded_socket_timeouts() -> None:
         "api/v1/chat.py",
     ):
         src = (REPO / rel).read_text(encoding="utf-8")
-        assert "socket_connect_timeout=0.5" in src
-        assert "socket_timeout=0.5" in src
+        assert "redis_socket_timeout_kwargs" in src
+        assert "socket_connect_timeout=0.5" not in src
+        assert "socket_timeout=0.5" not in src
+
+
+def test_redis_socket_timeouts_are_configurable(monkeypatch: pytest.MonkeyPatch) -> None:
+    import core.config as config
+
+    class _Settings:
+        redis_socket_connect_timeout_seconds = 3.5
+        redis_socket_timeout_seconds = 4.5
+
+    monkeypatch.setattr(config, "settings", _Settings())
+
+    assert config.redis_socket_timeout_kwargs() == {
+        "socket_connect_timeout": 3.5,
+        "socket_timeout": 4.5,
+    }
 
 
 def test_reset_password_blacklists_the_resolved_token_value() -> None:

--- a/tests/regression/test_security_runtime_hardening_sweep.py
+++ b/tests/regression/test_security_runtime_hardening_sweep.py
@@ -1,0 +1,107 @@
+"""Regression pins for the May 2026 runtime hardening sweep."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+from fastapi import Response
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def test_strict_runtime_env_covers_aliases_and_unknown_values() -> None:
+    from core.config import is_strict_runtime_env
+
+    for env in ("production", "prod", "staging", "stage", "preview", "qa-cluster-3"):
+        assert is_strict_runtime_env(env), f"{env} must receive production hardening"
+    for env in ("local", "dev", "development", "test", "ci"):
+        assert not is_strict_runtime_env(env), f"{env} should keep local-dev behavior"
+
+
+def test_fastapi_disables_docs_redoc_and_openapi_in_strict_runtime_source() -> None:
+    src = (REPO / "api" / "main.py").read_text(encoding="utf-8")
+    assert "is_strict_runtime_env(settings.env)" in src
+    assert "docs_url=None if _is_strict_runtime else" in src
+    assert "redoc_url=None if _is_strict_runtime else" in src
+    assert "openapi_url=None if _is_strict_runtime else" in src
+    assert "settings.env == \"production\"" not in src
+
+
+def test_session_cookie_secure_for_prod_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTICORG_ENV", "prod")
+    auth_mod = importlib.import_module("api.v1.auth")
+    response = Response()
+
+    auth_mod._set_session_cookie(response, "jwt-value", 60)
+
+    cookie_header = response.headers.get("set-cookie", "").lower()
+    assert "agenticorg_session=" in cookie_header
+    assert "secure" in cookie_header
+
+
+def test_csrf_cookie_secure_for_stage_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTICORG_ENV", "stage")
+    from auth.csrf import set_csrf_cookie
+
+    response = Response()
+    set_csrf_cookie(response, "csrf-value", max_age_seconds=60)
+
+    cookie_header = response.headers.get("set-cookie", "").lower()
+    assert "agenticorg_csrf=" in cookie_header
+    assert "secure" in cookie_header
+
+
+def test_redis_url_resolution_prefers_agenticorg_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from core.config import redis_url_from_env
+
+    monkeypatch.setenv("AGENTICORG_REDIS_URL", "redis://canonical:6379/9")
+    monkeypatch.setenv("REDIS_URL", "redis://legacy:6379/0")
+
+    assert redis_url_from_env(default_db=1) == "redis://canonical:6379/9"
+
+
+def test_redis_url_resolution_uses_settings_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    import core.config as config
+
+    class _Settings:
+        redis_url = "redis://settings:6379/8"
+
+    monkeypatch.delenv("AGENTICORG_REDIS_URL", raising=False)
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.setattr(config, "settings", _Settings())
+
+    assert config.redis_url_from_env() == "redis://settings:6379/8"
+    assert config.redis_url_from_env(default_db=1) == "redis://localhost:6379/1"
+
+
+def test_redis_helpers_do_not_read_legacy_redis_url_directly() -> None:
+    for rel in (
+        "core/auth_state.py",
+        "core/async_redis.py",
+        "api/v1/auth.py",
+        "api/v1/chat.py",
+    ):
+        src = (REPO / rel).read_text(encoding="utf-8")
+        assert "redis_url_from_env" in src, f"{rel} must use canonical Redis resolution"
+        assert 'os.environ.get("REDIS_URL"' not in src
+        assert '__import__("os").environ.get("REDIS_URL"' not in src
+
+
+def test_redis_clients_use_bounded_socket_timeouts() -> None:
+    for rel in (
+        "core/auth_state.py",
+        "core/async_redis.py",
+        "api/v1/auth.py",
+        "api/v1/chat.py",
+    ):
+        src = (REPO / rel).read_text(encoding="utf-8")
+        assert "socket_connect_timeout=0.5" in src
+        assert "socket_timeout=0.5" in src
+
+
+def test_reset_password_blacklists_the_resolved_token_value() -> None:
+    src = (REPO / "api" / "v1" / "auth.py").read_text(encoding="utf-8")
+    assert "blacklist_token(token_value)" in src
+    assert "blacklist_token(body.token)" not in src

--- a/tests/regression/test_security_upload_bounds_sweep.py
+++ b/tests/regression/test_security_upload_bounds_sweep.py
@@ -1,0 +1,28 @@
+"""Regression pins for upload paths outside the knowledge-ingestion flow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def test_upload_endpoints_stream_to_tempfile_instead_of_unbounded_read() -> None:
+    upload_routes = {
+        "api/v1/sop.py": "stream_to_tempfile(file, max_bytes=MAX_FILE_SIZE",
+        "api/v1/agents.py": "stream_to_tempfile(file, max_bytes=MAX_AGENT_CSV_IMPORT_BYTES",
+        "api/v1/sales.py": "stream_to_tempfile(file, max_bytes=MAX_CSV_IMPORT_BYTES",
+        "api/v1/abm.py": "stream_to_tempfile(file, max_bytes=MAX_ABM_CSV_UPLOAD_BYTES",
+    }
+    for rel, expected_call in upload_routes.items():
+        src = (REPO / rel).read_text(encoding="utf-8")
+        assert expected_call in src, f"{rel} must copy uploads with a byte cap"
+        assert "await file.read()" not in src, f"{rel} must not read the full upload into memory"
+        assert "cleanup_tempfile" in src, f"{rel} must remove temporary uploads"
+
+
+def test_agent_csv_import_rejects_non_csv_empty_and_non_utf8_source() -> None:
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    assert "not filename.endswith(\".csv\")" in src
+    assert "not content.strip()" in src
+    assert "UnicodeDecodeError" in src

--- a/tests/unit/test_agents_and_sales.py
+++ b/tests/unit/test_agents_and_sales.py
@@ -44,6 +44,14 @@ def _make_tenant_session_ctx(mock_session):
     return ctx
 
 
+def _mock_upload_file(content: bytes, filename: str = "import.csv"):
+    """Return an upload mock that streams content once, then EOF."""
+    file = MagicMock()
+    file.filename = filename
+    file.read = AsyncMock(side_effect=[content, b""])
+    return file
+
+
 def make_mock_agent(**overrides):
     agent = MagicMock()
     agent.id = overrides.get("id", uuid.uuid4())
@@ -1241,8 +1249,7 @@ class TestImportAgentsCsv:
             "Agent1,ap_processor,finance,Analyst,1\n"
             "Agent2,hr_assistant,hr,Manager,0\n"
         )
-        file = MagicMock()
-        file.read = AsyncMock(return_value=csv_content.encode("utf-8"))
+        file = _mock_upload_file(csv_content.encode("utf-8"))
 
         with patch("api.v1.agents.get_tenant_session") as mock_gts:
             mock_gts.return_value = _make_tenant_session_ctx(mock_session)
@@ -1256,8 +1263,7 @@ class TestImportAgentsCsv:
         from api.v1.agents import import_agents_csv
 
         csv_content = "name,agent_type,domain\n,ap_processor,finance\n"
-        file = MagicMock()
-        file.read = AsyncMock(return_value=csv_content.encode("utf-8"))
+        file = _mock_upload_file(csv_content.encode("utf-8"))
 
         with patch("api.v1.agents.get_tenant_session") as mock_gts:
             mock_gts.return_value = _make_tenant_session_ctx(mock_session)
@@ -1275,8 +1281,7 @@ class TestImportAgentsCsv:
             "name,agent_type,domain,reporting_to_name\n"
             "Agent1,ap_processor,finance,Agent1\n"
         )
-        file = MagicMock()
-        file.read = AsyncMock(return_value=csv_content.encode("utf-8"))
+        file = _mock_upload_file(csv_content.encode("utf-8"))
 
         # For the second pass (parent linking), mock all_agents
         all_agents_result = MagicMock()
@@ -1318,8 +1323,7 @@ class TestImportAgentsCsv:
             "Boss,manager,finance,\n"
             "Worker,ap_processor,finance,Boss\n"
         )
-        file = MagicMock()
-        file.read = AsyncMock(return_value=csv_content.encode("utf-8"))
+        file = _mock_upload_file(csv_content.encode("utf-8"))
 
         boss_id = uuid.uuid4()
         worker_id = uuid.uuid4()
@@ -2164,8 +2168,7 @@ class TestImportLeadsCsv:
             "Amit Sharma,amit@test.com,TestCo,VP,+91-123\n"
             "Priya Mehta,priya@test.com,OtherCo,CFO,+91-456\n"
         )
-        file = MagicMock()
-        file.read = AsyncMock(return_value=csv_content.encode("utf-8"))
+        file = _mock_upload_file(csv_content.encode("utf-8"))
 
         # No duplicates
         exists_result = MagicMock()
@@ -2190,8 +2193,7 @@ class TestImportLeadsCsv:
             ",missing@test.com,X\n"
             "NoEmail,,Y\n"
         )
-        file = MagicMock()
-        file.read = AsyncMock(return_value=csv_content.encode("utf-8"))
+        file = _mock_upload_file(csv_content.encode("utf-8"))
 
         with patch("api.v1.sales.get_tenant_session") as mock_gts:
             mock_gts.return_value = _make_tenant_session_ctx(mock_session)
@@ -2210,8 +2212,7 @@ class TestImportLeadsCsv:
             "name,email,company\n"
             "Dup Lead,dup@test.com,Co\n"
         )
-        file = MagicMock()
-        file.read = AsyncMock(return_value=csv_content.encode("utf-8"))
+        file = _mock_upload_file(csv_content.encode("utf-8"))
 
         exists_result = MagicMock()
         exists_result.scalar_one_or_none.return_value = uuid.uuid4()  # exists
@@ -2233,8 +2234,7 @@ class TestImportLeadsCsv:
 
         # Encode with utf-8-sig to add a BOM prefix (no \ufeff in the string itself)
         csv_content = "name,email,company\nBOM Lead,bom@test.com,BomCo\n"
-        file = MagicMock()
-        file.read = AsyncMock(return_value=csv_content.encode("utf-8-sig"))
+        file = _mock_upload_file(csv_content.encode("utf-8-sig"))
 
         exists_result = MagicMock()
         exists_result.scalar_one_or_none.return_value = None

--- a/ui/public/sw.js
+++ b/ui/public/sw.js
@@ -1,6 +1,6 @@
 // AgenticOrg Push Notification Service Worker
 
-self.addEventListener("install", (event) => {
+self.addEventListener("install", () => {
   self.skipWaiting();
 });
 
@@ -8,13 +8,20 @@ self.addEventListener("activate", (event) => {
   event.waitUntil(self.clients.claim());
 });
 
+function safeNotificationUrl(value) {
+  if (typeof value !== "string" || !value.startsWith("/") || value.startsWith("//")) {
+    return "/dashboard/approvals";
+  }
+  return value;
+}
+
 self.addEventListener("push", (event) => {
   if (!event.data) return;
 
   let payload;
   try {
     payload = event.data.json();
-  } catch (e) {
+  } catch {
     payload = { title: "AgenticOrg", body: event.data.text() };
   }
 
@@ -25,8 +32,7 @@ self.addEventListener("push", (event) => {
     badge: "/favicon-32x32.png",
     data: {
       hitl_id: hitlId,
-      url: payload.data?.url || "/dashboard/approvals",
-      token: payload.data?.token || "",
+      url: safeNotificationUrl(payload.data?.url),
     },
     actions: [
       { action: "approve", title: "Approve" },
@@ -44,55 +50,36 @@ self.addEventListener("push", (event) => {
 self.addEventListener("notificationclick", (event) => {
   const notification = event.notification;
   const hitlId = notification.data?.hitl_id;
-  const token = notification.data?.token;
-  const url = notification.data?.url || "/dashboard/approvals";
+  const url = safeNotificationUrl(notification.data?.url);
   const action = event.action;
 
   notification.close();
 
   if (action === "approve" || action === "reject") {
-    const decision = action;
-    const notes =
-      decision === "approve"
-        ? "Approved via push notification"
-        : "Rejected via push notification";
-
     event.waitUntil(
-      fetch("/api/v1/approvals/" + hitlId + "/decide", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(token ? { Authorization: "Bearer " + token } : {}),
-        },
-        body: JSON.stringify({ decision: decision, notes: notes }),
-      })
-        .then((response) => {
-          if (!response.ok) {
-            // If the inline action fails, open the approvals page
-            return self.clients.matchAll({ type: "window" }).then((clients) => {
-              if (clients.length > 0) {
-                return clients[0].focus();
-              }
-              return self.clients.openWindow("/dashboard/approvals");
-            });
-          }
-        })
-        .catch(() => {
-          return self.clients.openWindow("/dashboard/approvals");
-        })
-    );
-  } else {
-    // Default click — open the target URL
-    event.waitUntil(
-      self.clients.matchAll({ type: "window" }).then((windowClients) => {
-        // Focus existing window if one is already open
-        for (const client of windowClients) {
-          if (client.url.includes(url) && "focus" in client) {
+      self.clients.matchAll({ type: "window" }).then((clients) => {
+        const approvalUrl = hitlId
+          ? "/dashboard/approvals?hitl=" + encodeURIComponent(hitlId)
+          : url;
+        for (const client of clients) {
+          if (client.url.includes("/dashboard/approvals") && "focus" in client) {
             return client.focus();
           }
         }
-        return self.clients.openWindow(url);
+        return self.clients.openWindow(approvalUrl);
       })
     );
+    return;
   }
+
+  event.waitUntil(
+    self.clients.matchAll({ type: "window" }).then((windowClients) => {
+      for (const client of windowClients) {
+        if (client.url.includes(url) && "focus" in client) {
+          return client.focus();
+        }
+      }
+      return self.clients.openWindow(url);
+    })
+  );
 });

--- a/ui/src/pages/Onboarding.tsx
+++ b/ui/src/pages/Onboarding.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useAuth } from "../contexts/AuthContext";
+import api from "../lib/api";
 
 /* ── Milestone Tracker Types ──────────────────────────────────────────── */
 interface MilestoneTask {
@@ -82,7 +83,7 @@ interface InviteRow {
 }
 
 export default function Onboarding() {
-  const { user, token } = useAuth();
+  const { user } = useAuth();
   const navigate = useNavigate();
   const [step, setStep] = useState(1);
   const [industry, setIndustry] = useState("");
@@ -134,13 +135,10 @@ export default function Onboarding() {
     try {
       const filled = invites.filter((r) => r.email.trim());
       for (const invite of filled) {
-        await fetch("/api/v1/org/invite", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({ role: invite.role.toLowerCase(), name: invite.name, email: invite.email }),
+        await api.post("/org/invite", {
+          role: invite.role.toLowerCase(),
+          name: invite.name,
+          email: invite.email,
         });
       }
       setInviteSuccess(true);
@@ -154,14 +152,7 @@ export default function Onboarding() {
 
   const finishOnboarding = async () => {
     try {
-      await fetch("/api/v1/org/onboarding", {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({ complete: true }),
-      });
+      await api.put("/org/onboarding", { complete: true });
     } catch {
       // best-effort
     }


### PR DESCRIPTION
## Summary
- Treat production-like and unknown runtime labels as strict: disable FastAPI docs/redoc/OpenAPI, apply secure cookies, and keep CORS warnings aligned with strict runtime behavior.
- Centralize Redis URL resolution on `AGENTICORG_REDIS_URL` first, preserve configured Redis hosts when applying `default_db`, and remove direct legacy `REDIS_URL` reads from auth/chat Redis consumers.
- Replace hard-coded 500ms Redis socket caps with configurable 2s defaults via `AGENTICORG_REDIS_SOCKET_CONNECT_TIMEOUT_SECONDS` and `AGENTICORG_REDIS_SOCKET_TIMEOUT_SECONDS`.
- Fix reset-password token reuse handling so one-time-code resets blacklist the resolved token value instead of `None`.
- Bound CSV/SOP upload memory usage by streaming uploads to capped tempfiles across SOP, sales lead import, agent import, and ABM account upload paths.
- Repair cookie-first frontend auth regressions in onboarding and remove push-service-worker Bearer-token action handling/open-window trust of payload URLs.
- Reduce PII redaction hot-path debug logging overhead so the PII performance gate remains stable.

## Findings fixed
1. Strict runtime aliases were only partially hardened; `prod`, `stage`, `preview`, and unknown internet-facing labels could expose docs/OpenAPI and insecure cookie behavior.
2. Several Redis consumers ignored the canonical `AGENTICORG_REDIS_URL` and could hang on unavailable Redis because connection attempts were unbounded.
3. `redis_url_from_env(default_db=N)` could fall back to localhost when settings already pointed at a non-local Redis host; the helper now rewrites only the configured URL DB path when no explicit env URL is set.
4. Password reset via one-time code blacklisted `body.token`, which is `None` on that path, instead of the resolved reset token.
5. Multiple upload endpoints used unbounded `await file.read()`, allowing memory pressure from large uploads outside the already-hardened knowledge ingestion path.
6. Onboarding still sent `Authorization: Bearer ${token}` even though browser auth is cookie-first and `AuthContext.token` is intentionally `null`.
7. The service worker accepted pushed bearer tokens and attempted approval/reject mutations from notification actions; it also trusted notification payload URLs.
8. PII redaction emitted debug logs on every redaction call, making a security hot path slower and noisy under debug logging.

## Validation
- Full pre-push gate passed: Ruff whole tree, mypy whole tree, Bandit api/auth/core, Alembic revision check, verify=False scan, pytest regression+unit, UI tsc, UI build, consistency sweep, module coverage floor, and critical-path tag check.
- Review follow-up checks passed: Redis hardening regression tests, targeted Ruff, targeted mypy, and auth/chat Redis affected unit slices.
- Targeted checks also run: security regression slice, affected CSV import unit tests, chat Redis fallback test, and PII redaction performance test.