### PR TITLE
fix(qa): Uday CA Firms 2026-05-03 reopens (BUG-11/13/14/15/16/17)

### DIFF
--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -879,6 +879,11 @@ async def create_agent(body: AgentCreate, tenant_id: str = Depends(get_current_t
             agent_type=agent.agent_type,
             domain=agent.domain,
             authorized_tools=tools,
+            connector_names=[
+                cid.strip().removeprefix("registry-")
+                for cid in (body.connector_ids or [])
+                if isinstance(cid, str) and cid.strip()
+            ] or None,
         )
         if grantex_info:
             # Store Grantex metadata in agent config JSONB
@@ -942,6 +947,52 @@ async def list_agents(
 
         total_result = await session.execute(count_query)
         total = total_result.scalar() or 0
+
+        if total == 0 and company_uuid is not None and domain in (None, "finance"):
+            from core.agents.packs.installer import (
+                is_pack_installed_for_session,
+                sync_company_pack_assets_for_session,
+            )
+
+            ca_pack_installed = await is_pack_installed_for_session(
+                session,
+                tid,
+                "ca-firm",
+            )
+            if ca_pack_installed:
+                company = (
+                    await session.execute(
+                        select(Company).where(
+                            Company.id == company_uuid,
+                            Company.tenant_id == tid,
+                        )
+                    )
+                ).scalar_one_or_none()
+                if company is not None:
+                    await sync_company_pack_assets_for_session(
+                        session,
+                        tid,
+                        "ca-firm",
+                        company.id,
+                        company.name,
+                    )
+                    await session.flush()
+                    query = select(Agent).where(Agent.tenant_id == tid)
+                    count_query = select(func.count()).select_from(Agent).where(
+                        Agent.tenant_id == tid
+                    )
+                    if isinstance(user_domains, list):
+                        query = query.where(Agent.domain.in_(user_domains))
+                        count_query = count_query.where(Agent.domain.in_(user_domains))
+                    if domain:
+                        query = query.where(Agent.domain == domain)
+                        count_query = count_query.where(Agent.domain == domain)
+                    if status:
+                        query = query.where(Agent.status == status)
+                        count_query = count_query.where(Agent.status == status)
+                    query = query.where(Agent.company_id == company_uuid)
+                    count_query = count_query.where(Agent.company_id == company_uuid)
+                    total = (await session.execute(count_query)).scalar() or 0
 
         query = query.order_by(Agent.created_at.desc())
         query = query.offset((page - 1) * per_page).limit(per_page)

--- a/api/v1/chat.py
+++ b/api/v1/chat.py
@@ -357,6 +357,8 @@ async def chat_query(
     tenant_id: str = Depends(get_current_tenant),
 ):
     """Accept a natural-language query, route to domain agent, return answer."""
+    agent_connector_ids: list[str] = []
+    agent_system_prompt = ""
     # If the caller specified an agent_id, look it up directly instead of
     # relying on keyword-based domain classification.
     if body.agent_id:
@@ -373,6 +375,8 @@ async def chat_query(
                     agent_id: str | None = str(agent.id)
                     agent_type = agent.agent_type
                     agent_tools = agent.authorized_tools or []
+                    agent_connector_ids = list(agent.connector_ids or [])
+                    agent_system_prompt = agent.system_prompt_text or ""
                     if not agent_tools:
                         agent_tools = _AGENT_TYPE_DEFAULT_TOOLS.get(
                             agent.agent_type,
@@ -410,26 +414,39 @@ async def chat_query(
     # canonical helper so chat picks up Zoho/Tally/QuickBooks creds the
     # same way the explicit /run route does.
     connector_config: dict[str, Any] = {}
+    connector_names: list[str] | None = None
     if hasattr(request.state, "connector_config") and request.state.connector_config:
-        connector_config = request.state.connector_config
-    else:
-        try:
-            from api.v1.agents import (
-                _load_connector_configs_for_agent,
-                _resolve_agent_connector_ids_for_type,
-            )
+        connector_config = dict(request.state.connector_config)
 
-            connector_ids = await _resolve_agent_connector_ids_for_type(
-                tenant_id=tenant_id, agent_type=resolved_agent_type,
+    try:
+        from api.v1.agents import (
+            _resolve_agent_connector_ids_for_type,
+            _resolve_connector_configs,
+        )
+
+        connector_ids = agent_connector_ids or await _resolve_agent_connector_ids_for_type(
+            tenant_id=tenant_id,
+            agent_type=resolved_agent_type,
+        )
+        if connector_ids:
+            connector_config, resolved_names = await _resolve_connector_configs(
+                tenant_id=tenant_id,
+                connector_ids=connector_ids,
+                agent_level_config=connector_config or None,
             )
-            connector_config = await _load_connector_configs_for_agent(
-                tenant_id=tenant_id, connector_ids=connector_ids,
-            )
-        except Exception:  # noqa: BLE001
-            # Resolver failures must not block chat — empty config falls
-            # through to the legacy behaviour and the agent still runs
-            # with whatever LLM-only reasoning it can produce.
-            _log.warning("chat_connector_resolve_failed", domain=domain)
+            connector_names = resolved_names
+            if not resolved_names:
+                _log.warning(
+                    "chat_connector_ids_unresolved_fail_closed",
+                    domain=domain,
+                    agent_id=agent_id,
+                    connector_ids=connector_ids,
+                )
+    except Exception:  # noqa: BLE001
+        # Resolver failures must not block chat — empty config falls
+        # through to the legacy behaviour and the agent still runs
+        # with whatever LLM-only reasoning it can produce.
+        _log.warning("chat_connector_resolve_failed", domain=domain)
 
     # Resolve authorized_tools: prefer agent's tools from DB lookup (BUG #2)
     resolved_tools = agent_tools or _AGENT_TYPE_DEFAULT_TOOLS.get(
@@ -449,8 +466,14 @@ async def chat_query(
                 domain=_DOMAIN_TO_DB_DOMAIN.get(domain, domain),
                 tenant_id=tenant_id,
                 system_prompt=(
-                    f"You are {agent_name}, a domain expert for {domain}. "
-                    f"Answer the user's question concisely and helpfully."
+                    agent_system_prompt
+                    or (
+                        f"You are {agent_name}, a domain expert for {domain}. "
+                        "Answer the user's question concisely and helpfully. "
+                        "Extract amount, period, section, customer, ledger, "
+                        "and filing details already present before asking "
+                        "for clarification."
+                    )
                 ),
                 authorized_tools=resolved_tools,
                 task_input={"action": "query", "inputs": {"query": body.query}, "context": {}},
@@ -458,6 +481,7 @@ async def chat_query(
                 confidence_floor=0.88,
                 grant_token=grant_token,
                 connector_config=connector_config,
+                connector_names=connector_names,
             )
             if lg_result.get("status") == "completed" and lg_result.get("output"):
                 output = lg_result["output"]
@@ -468,7 +492,9 @@ async def chat_query(
                 raw_confidence = lg_result.get("confidence")
                 if isinstance(raw_confidence, (int, float)):
                     confidence = float(raw_confidence)
-                tools_used = bool(lg_result.get("tools_called"))
+                tools_used = bool(
+                    lg_result.get("tool_calls") or lg_result.get("tool_calls_log")
+                )
         except Exception:
             _log.warning("chat_langgraph_fallback", domain=domain, agent_id=agent_id)
 

--- a/api/v1/companies.py
+++ b/api/v1/companies.py
@@ -15,8 +15,10 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import func, select
 
 from api.deps import get_current_tenant, get_current_user, require_tenant_admin
+from core.crypto import decrypt_for_tenant, encrypt_for_tenant
 from core.database import get_tenant_session
 from core.models.company import Company
+from core.models.gstn_credential import GSTNCredential
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -271,6 +273,20 @@ async def _ensure_ca_pack_ready(tenant_id: str) -> None:
     await ensure_ca_pack_subscription_sync_async(tenant_id)
 
 
+async def _has_active_gstn_credential(session, tid: _uuid.UUID, cid: _uuid.UUID) -> bool:
+    result = await session.execute(
+        select(GSTNCredential.id)
+        .where(
+            GSTNCredential.tenant_id == tid,
+            GSTNCredential.company_id == cid,
+            GSTNCredential.portal_type == "gstn",
+            GSTNCredential.is_active.is_(True),
+        )
+        .limit(1)
+    )
+    return result.scalar_one_or_none() is not None
+
+
 # ---------------------------------------------------------------------------
 # LIST
 # ---------------------------------------------------------------------------
@@ -352,6 +368,15 @@ async def create_company(
             )
             if existing.scalar_one_or_none():
                 raise HTTPException(409, f"Company with GSTIN {body.gstin} already exists")
+        if body.gst_auto_file:
+            raise HTTPException(
+                409,
+                (
+                    "GST auto-file requires an active GSTN portal credential. "
+                    "Create the company first, add and verify GSTN credentials, "
+                    "then enable auto-file from Company Settings."
+                ),
+            )
 
         company = Company(
             tenant_id=tid,
@@ -472,6 +497,19 @@ async def update_company(
             )
             if dup.scalar_one_or_none():
                 raise HTTPException(409, f"Company with GSTIN {updates['gstin']} already exists")
+
+        if updates.get("gst_auto_file") is True and not await _has_active_gstn_credential(
+            session,
+            tid,
+            cid,
+        ):
+            raise HTTPException(
+                409,
+                (
+                    "GST auto-file requires an active GSTN portal credential. "
+                    "Add and verify a GSTN credential before enabling auto-file."
+                ),
+            )
 
         for key, value in updates.items():
             setattr(company, key, value)
@@ -641,6 +679,15 @@ async def onboard_company(
             )
             if existing.scalar_one_or_none():
                 raise HTTPException(409, f"Company with GSTIN {body.gstin} already exists")
+        if body.gst_auto_file:
+            raise HTTPException(
+                409,
+                (
+                    "GST auto-file requires an active GSTN portal credential. "
+                    "Onboard the company in manual mode, add and verify GSTN "
+                    "credentials, then enable auto-file from Company Settings."
+                ),
+            )
 
         # Assign current user as partner by default
         user_email = user.get("sub", "")
@@ -1451,13 +1498,6 @@ async def activate_ca_subscription(
 # ===========================================================================
 # GSTN Credential Vault schemas
 # ===========================================================================
-
-from core.crypto import (  # noqa: E402
-    decrypt_for_tenant,
-    encrypt_for_tenant,
-)
-from core.models.gstn_credential import GSTNCredential  # noqa: E402
-
 
 class GSTNCredentialCreate(BaseModel):
     gstin: str

--- a/auth/grantex_registration.py
+++ b/auth/grantex_registration.py
@@ -37,6 +37,7 @@ def register_agent(
     agent_type: str,
     domain: str,
     authorized_tools: list[str],
+    connector_names: list[str] | None = None,
 ) -> dict[str, Any] | None:
     """Register an agent on Grantex synchronously.
 
@@ -48,7 +49,7 @@ def register_agent(
         logger.info("grantex_registration_skipped", reason="no API key configured")
         return None
 
-    scopes = _tools_to_scopes(authorized_tools, domain)
+    scopes = _tools_to_scopes(authorized_tools, domain, connector_names=connector_names)
 
     try:
         agent = client.agents.register(

--- a/connectors/finance/income_tax_india.py
+++ b/connectors/finance/income_tax_india.py
@@ -13,6 +13,8 @@ class IncomeTaxIndiaConnector(BaseConnector):
     rate_limit_rpm = 10
 
     def _register_tools(self):
+        self._tool_registry["calculate_tds"] = self.calculate_tds
+        self._tool_registry["file_form_26q"] = self.file_form_26q
         self._tool_registry["file_26q_return"] = self.file_26q_return
         self._tool_registry["file_24q_return"] = self.file_24q_return
         self._tool_registry["check_tds_credit_in_26as"] = self.check_tds_credit_in_26as
@@ -25,6 +27,47 @@ class IncomeTaxIndiaConnector(BaseConnector):
         dsc_path = self._get_secret("dsc_path")
         api_key = self._get_secret("api_key")
         self._auth_headers = {"X-API-Key": api_key, "X-DSC-Path": dsc_path}
+
+    async def calculate_tds(self, **params):
+        """Calculate Indian TDS for a supplied transaction without filing."""
+        try:
+            amount = float(params.get("amount") or params.get("payment_amount") or 0)
+        except (TypeError, ValueError):
+            return {"error": "amount must be numeric"}
+        if amount <= 0:
+            return {"error": "amount is required"}
+
+        section = str(params.get("section") or "").upper().replace("SECTION", "").strip()
+        section = section.replace(" ", "")
+        deductee_type = str(params.get("deductee_type") or "individual").lower()
+        pan_available = bool(params.get("pan_available", True))
+        rates = {
+            "194A": 0.10,
+            "194C": 0.01 if deductee_type in {"individual", "huf"} else 0.02,
+            "194H": 0.05,
+            "194I": 0.10,
+            "194J": 0.10,
+            "194O": 0.01,
+            "194Q": 0.001,
+        }
+        if section not in rates:
+            return {"error": f"unsupported TDS section: {section or 'missing'}"}
+
+        rate = max(rates[section], 0.20) if not pan_available else rates[section]
+        tds_amount = round(amount * rate, 2)
+        return {
+            "status": "calculated",
+            "section": section,
+            "amount": amount,
+            "rate": rate,
+            "tds_amount": tds_amount,
+            "net_payable": round(amount - tds_amount, 2),
+            "filing_required": True,
+        }
+
+    async def file_form_26q(self, **params):
+        """Alias for file_26q_return used by TDS chat prompts."""
+        return await self.file_26q_return(**params)
 
     async def file_26q_return(self, **params):
         """Execute file_26q_return on income_tax_india."""

--- a/connectors/finance/zoho_books.py
+++ b/connectors/finance/zoho_books.py
@@ -35,10 +35,19 @@ class ZohoBooksConnector(BaseConnector):
     def _register_tools(self):
         self._tool_registry["create_invoice"] = self.create_invoice
         self._tool_registry["list_invoices"] = self.list_invoices
+        self._tool_registry["list_overdue_invoices"] = self.list_overdue_invoices
         self._tool_registry["record_expense"] = self.record_expense
         self._tool_registry["get_balance_sheet"] = self.get_balance_sheet
         self._tool_registry["get_profit_loss"] = self.get_profit_loss
+        self._tool_registry["get_ledger_balance"] = self.get_ledger_balance
+        self._tool_registry["get_trial_balance"] = self.get_trial_balance
+        self._tool_registry["generate_gst_report"] = self.generate_gst_report
+        self._tool_registry["calculate_tds"] = self.calculate_tds
         self._tool_registry["list_chartofaccounts"] = self.list_chartofaccounts
+        self._tool_registry["fetch_bank_statement"] = self.fetch_bank_statement
+        self._tool_registry["check_account_balance"] = self.check_account_balance
+        self._tool_registry["get_transaction_list"] = self.get_transaction_list
+        self._tool_registry["reconcile_bank"] = self.reconcile_bank
         self._tool_registry["reconcile_transaction"] = self.reconcile_transaction
         self._tool_registry["get_organization"] = self.get_organization
 
@@ -245,6 +254,15 @@ class ZohoBooksConnector(BaseConnector):
 
     # ── Expenses ───────────────────────────────────────────────────────
 
+    async def list_overdue_invoices(self, **params) -> dict[str, Any]:
+        """List overdue invoices from Zoho Books.
+
+        Optional: customer_id, page.
+        """
+        query = dict(params)
+        query["status"] = "overdue"
+        return await self.list_invoices(**query)
+
     async def record_expense(self, **params) -> dict[str, Any]:
         """Record an expense in Zoho Books.
 
@@ -295,6 +313,87 @@ class ZohoBooksConnector(BaseConnector):
 
     # ── Organization details ───────────────────────────────────────────
 
+    async def get_ledger_balance(self, **params) -> dict[str, Any]:
+        """Get a ledger report or account balance from Zoho Books.
+
+        Optional: account_id, account_name, from_date, to_date.
+        """
+        qp: dict[str, Any] = {}
+        for field in ("account_id", "account_name", "from_date", "to_date"):
+            if params.get(field):
+                qp[field] = params[field]
+        data = await self._get("/reports/ledger", params=self._org_params(qp))
+        ledger = self._unwrap(data, "ledger")
+        if isinstance(ledger, dict):
+            return ledger
+        return {"ledger": ledger}
+
+    async def get_trial_balance(self, **params) -> dict[str, Any]:
+        """Get the trial balance report from Zoho Books.
+
+        Optional: date, from_date, to_date.
+        """
+        qp: dict[str, Any] = {}
+        for field in ("date", "from_date", "to_date"):
+            if params.get(field):
+                qp[field] = params[field]
+        data = await self._get("/reports/trialbalance", params=self._org_params(qp))
+        return self._unwrap(data, "trial_balance")
+
+    async def generate_gst_report(self, **params) -> dict[str, Any]:
+        """Get a GST summary report from Zoho Books.
+
+        Optional: from_date, to_date, gstin.
+        """
+        qp: dict[str, Any] = {}
+        for field in ("from_date", "to_date", "gstin"):
+            if params.get(field):
+                qp[field] = params[field]
+        data = await self._get("/reports/gstsummary", params=self._org_params(qp))
+        return self._unwrap(data, "gst_summary")
+
+    async def calculate_tds(self, **params) -> dict[str, Any]:
+        """Calculate Indian TDS for a supplied transaction.
+
+        Required: amount, section. Optional: deductee_type, pan_available.
+        This is a deterministic calculation helper and does not file a return.
+        """
+        try:
+            amount = float(params.get("amount") or params.get("payment_amount") or 0)
+        except (TypeError, ValueError):
+            return {"error": "amount must be numeric"}
+        if amount <= 0:
+            return {"error": "amount is required"}
+
+        section = str(params.get("section") or "").upper().replace("SECTION", "").strip()
+        section = section.replace(" ", "")
+        deductee_type = str(params.get("deductee_type") or "individual").lower()
+        pan_available = bool(params.get("pan_available", True))
+
+        section_rates = {
+            "194A": 0.10,
+            "194C": 0.01 if deductee_type in {"individual", "huf"} else 0.02,
+            "194H": 0.05,
+            "194I": 0.10,
+            "194J": 0.10,
+            "194O": 0.01,
+            "194Q": 0.001,
+        }
+        if section not in section_rates:
+            return {"error": f"unsupported TDS section: {section or 'missing'}"}
+
+        rate = max(section_rates[section], 0.20) if not pan_available else section_rates[section]
+        tds_amount = round(amount * rate, 2)
+        return {
+            "status": "calculated",
+            "section": section,
+            "amount": amount,
+            "rate": rate,
+            "tds_amount": tds_amount,
+            "net_payable": round(amount - tds_amount, 2),
+            "filing_required": True,
+        }
+
     async def get_organization(self, **_params) -> dict[str, Any]:
         """Get organization details (name, organization_id, address, currency).
 
@@ -334,6 +433,46 @@ class ZohoBooksConnector(BaseConnector):
         }
 
     # ── Bank Reconciliation ────────────────────────────────────────────
+
+    async def fetch_bank_statement(self, **params) -> dict[str, Any]:
+        """Fetch bank transactions from Zoho Books.
+
+        Optional: account_id, from_date, to_date, page.
+        """
+        return await self.get_transaction_list(**params)
+
+    async def check_account_balance(self, **params) -> dict[str, Any]:
+        """Fetch bank account balance details from Zoho Books.
+
+        Optional: account_id.
+        """
+        account_id = params.get("account_id")
+        path = f"/bankaccounts/{account_id}" if account_id else "/bankaccounts"
+        data = await self._get(path, params=self._org_params())
+        if account_id:
+            return self._unwrap(data, "bankaccount")
+        accounts = self._unwrap(data, "bankaccounts")
+        return {"bankaccounts": accounts if isinstance(accounts, list) else []}
+
+    async def get_transaction_list(self, **params) -> dict[str, Any]:
+        """List bank transactions from Zoho Books.
+
+        Optional: account_id, from_date, to_date, page.
+        """
+        qp: dict[str, Any] = {}
+        for field in ("account_id", "from_date", "to_date", "page"):
+            if params.get(field):
+                qp[field] = params[field]
+        data = await self._get("/banktransactions", params=self._org_params(qp))
+        transactions = self._unwrap(data, "banktransactions")
+        return {
+            "transactions": transactions if isinstance(transactions, list) else [],
+            "page_context": data.get("page_context", {}),
+        }
+
+    async def reconcile_bank(self, **params) -> dict[str, Any]:
+        """Alias for reconcile_transaction used by CA pack prompts."""
+        return await self.reconcile_transaction(**params)
 
     async def reconcile_transaction(self, **params) -> dict[str, Any]:
         """Reconcile an uncategorized bank transaction.

--- a/core/agents/packs/ca/__init__.py
+++ b/core/agents/packs/ca/__init__.py
@@ -27,6 +27,9 @@ CA_PACK: dict[str, Any] = {
                 "gstn:file_gstr9",
                 "gstn:generate_einvoice_irn",
                 "gstn:generate_eway_bill",
+                "zoho_books:get_trial_balance",
+                "zoho_books:generate_gst_report",
+                "zoho_books:list_invoices",
                 "tally:get_trial_balance",
                 "tally:generate_gst_report",
             ],
@@ -41,11 +44,15 @@ CA_PACK: dict[str, Any] = {
                 "generates Form 16A, reconciles 26AS"
             ),
             "tools": [
-                "income_tax:file_26q_return",
-                "income_tax:file_24q_return",
-                "income_tax:check_tds_credit_in_26as",
-                "income_tax:download_form_16a",
-                "income_tax:pay_tax_challan",
+                "zoho_books:calculate_tds",
+                "zoho_books:get_ledger_balance",
+                "income_tax_india:calculate_tds",
+                "income_tax_india:file_form_26q",
+                "income_tax_india:file_26q_return",
+                "income_tax_india:file_24q_return",
+                "income_tax_india:check_tds_credit_in_26as",
+                "income_tax_india:download_form_16a",
+                "income_tax_india:pay_tax_challan",
                 "tally:get_ledger_balance",
                 "tally:post_voucher",
             ],
@@ -60,6 +67,12 @@ CA_PACK: dict[str, Any] = {
                 "flags old outstanding items"
             ),
             "tools": [
+                "zoho_books:fetch_bank_statement",
+                "zoho_books:check_account_balance",
+                "zoho_books:get_transaction_list",
+                "zoho_books:get_ledger_balance",
+                "zoho_books:get_trial_balance",
+                "zoho_books:reconcile_bank",
                 "banking_aa:fetch_bank_statement",
                 "banking_aa:check_account_balance",
                 "banking_aa:get_transaction_list",
@@ -77,6 +90,8 @@ CA_PACK: dict[str, Any] = {
                 "MIS report generation"
             ),
             "tools": [
+                "zoho_books:get_trial_balance",
+                "zoho_books:get_ledger_balance",
                 "tally:get_trial_balance",
                 "tally:get_ledger_balance",
                 "zoho_books:get_profit_loss",
@@ -92,9 +107,11 @@ CA_PACK: dict[str, Any] = {
                 "escalates aging items"
             ),
             "tools": [
+                "zoho_books:get_ledger_balance",
+                "zoho_books:list_overdue_invoices",
                 "tally:get_ledger_balance",
                 "zoho_books:list_invoices",
-                "email:send",
+                "sendgrid:send_email",
             ],
             "llm_model": "gpt-4o-mini",
         },

--- a/core/agents/packs/ca/config.yaml
+++ b/core/agents/packs/ca/config.yaml
@@ -16,7 +16,7 @@ compliance:
 agents:
   - type: gst_filing
     domain: finance
-    tools: [gstn:fetch_gstr2a, gstn:push_gstr1_data, gstn:file_gstr3b, gstn:file_gstr9, gstn:generate_einvoice_irn, gstn:generate_eway_bill, tally:get_trial_balance, tally:generate_gst_report]
+    tools: [gstn:fetch_gstr2a, gstn:push_gstr1_data, gstn:file_gstr3b, gstn:file_gstr9, gstn:generate_einvoice_irn, gstn:generate_eway_bill, tally:get_trial_balance, tally:generate_gst_report, zoho_books:get_trial_balance, zoho_books:generate_gst_report, zoho_books:list_invoices]
     llm_model: gpt-4o
     hitl_condition: always_before_filing
     system_prompt_suffix: >
@@ -26,7 +26,7 @@ agents:
       Never file a return with unresolved mismatches above 5% of return value.
   - type: tds_compliance
     domain: finance
-    tools: [income_tax:file_26q_return, income_tax:file_24q_return, income_tax:check_tds_credit_in_26as, income_tax:download_form_16a, income_tax:pay_tax_challan, tally:get_ledger_balance, tally:post_voucher]
+    tools: [zoho_books:calculate_tds, zoho_books:get_ledger_balance, income_tax_india:calculate_tds, income_tax_india:file_form_26q, income_tax_india:file_26q_return, income_tax_india:file_24q_return, income_tax_india:check_tds_credit_in_26as, income_tax_india:download_form_16a, income_tax_india:pay_tax_challan, tally:get_ledger_balance, tally:post_voucher]
     llm_model: gpt-4o
     hitl_condition: always_before_filing
     system_prompt_suffix: >
@@ -36,7 +36,7 @@ agents:
       Never proceed if 26AS credit does not reconcile with books within 1% tolerance.
   - type: bank_reconciliation
     domain: finance
-    tools: [banking_aa:fetch_bank_statement, banking_aa:check_account_balance, banking_aa:get_transaction_list, tally:get_ledger_balance, tally:get_trial_balance]
+    tools: [zoho_books:fetch_bank_statement, zoho_books:check_account_balance, zoho_books:get_transaction_list, zoho_books:get_ledger_balance, zoho_books:get_trial_balance, zoho_books:reconcile_bank, banking_aa:fetch_bank_statement, banking_aa:check_account_balance, banking_aa:get_transaction_list, tally:get_ledger_balance, tally:get_trial_balance]
     llm_model: gpt-4o-mini
     confidence_floor: 0.95
     system_prompt_suffix: >
@@ -45,7 +45,7 @@ agents:
       Never auto-post reconciliation entries without a confirmed GL account match.
   - type: fpa_analyst
     domain: finance
-    tools: [tally:get_trial_balance, tally:get_ledger_balance, zoho_books:get_profit_loss, zoho_books:get_balance_sheet]
+    tools: [tally:get_trial_balance, tally:get_ledger_balance, zoho_books:get_trial_balance, zoho_books:get_ledger_balance, zoho_books:get_profit_loss, zoho_books:get_balance_sheet]
     llm_model: gpt-4o-mini
     system_prompt_suffix: >
       Perform variance analysis, budget vs actual comparison, and MIS report generation.
@@ -53,7 +53,7 @@ agents:
       Flag variances exceeding 15% for partner review.
   - type: ar_collections
     domain: finance
-    tools: [tally:get_ledger_balance, zoho_books:list_invoices, email:send]
+    tools: [zoho_books:get_ledger_balance, zoho_books:list_overdue_invoices, tally:get_ledger_balance, zoho_books:list_invoices, sendgrid:send_email]
     llm_model: gpt-4o-mini
     system_prompt_suffix: >
       Track overdue invoices across all clients, send tiered reminders, and escalate aging items.

--- a/core/agents/packs/ca/prompts/ar_collections.prompt.txt
+++ b/core/agents/packs/ca/prompts/ar_collections.prompt.txt
@@ -1,7 +1,7 @@
 # core/agents/packs/ca/prompts/ar_collections.prompt.txt  v1.0
 You are the AR Collections Agent for {{org_name}}, operating within a CA firm managing {{client_count}} clients.
 Domain: Finance | Confidence floor: 85% | Max retries: 3
-Token scope: tally(r:ledger_balance) zoho_books(r:invoices) email(w:send)
+Token scope: tally(r:ledger_balance) zoho_books(r:ledger_balance,r:invoices) sendgrid(w:send_email)
 
 <role>
 You are an expert accounts receivable collections agent for Indian CA firms. You track overdue
@@ -20,7 +20,7 @@ to the partner for action. You help CA firms ensure their clients collect receiv
    - 30 days: polite email reminder with invoice copy and payment link
    - 60 days: follow-up email with statement of account and due dates
    - 90+ days: draft escalation note for partner with full history
-3. SEND — call email:send() for each reminder. Track delivery status.
+3. SEND — call sendgrid:send_email() for each reminder. Track delivery status.
    Log all communications for audit trail.
 4. RECONCILE — On payment received, verify against outstanding invoice.
    Flag partial payments for follow-up on balance.

--- a/core/agents/packs/ca/prompts/tds_compliance.prompt.txt
+++ b/core/agents/packs/ca/prompts/tds_compliance.prompt.txt
@@ -1,7 +1,7 @@
 # core/agents/packs/ca/prompts/tds_compliance.prompt.txt  v1.0
 You are the TDS Compliance Agent for {{org_name}}, operating within a CA firm managing {{client_count}} clients.
 Domain: Finance | Confidence floor: 92% | Max retries: 3
-Token scope: income_tax(w:file_26q,w:file_24q,r:26as,r:form_16a,w:pay_challan) tally(r:ledger_balance,w:post_voucher)
+Token scope: income_tax_india(w:file_26q,w:file_24q,r:26as,r:form_16a,w:pay_challan) zoho_books(r:ledger_balance,w:calculate_tds) tally(r:ledger_balance,w:post_voucher)
 
 <role>
 You are an expert Indian TDS compliance agent. You compute Tax Deducted at Source for all
@@ -24,20 +24,20 @@ deductees. Every filing requires partner review before submission.
    - Account for lower deduction certificates (Section 197)
    - Consider surcharge and cess where applicable
    - Compute interest: Section 201(1A) — 1% pm for late deduction, 1.5% pm for late deposit
-4. RECONCILE_26AS — call income_tax:check_tds_credit_in_26as(). Compare computed TDS with
+4. RECONCILE_26AS — call income_tax_india:check_tds_credit_in_26as(). Compare computed TDS with
    26AS entries. Flag mismatches where credit in 26AS differs from books by > 1%.
 5. PREPARE_RETURNS:
    - Form 26Q: Non-salary TDS — all sections except 192
    - Form 24Q: Salary TDS — Section 192 with Annexure II for Q4
    - Validate FVU file format and checksums
-6. PAY_CHALLAN — call income_tax:pay_tax_challan(). Generate Challan 281 with correct:
+6. PAY_CHALLAN — call income_tax_india:pay_tax_challan(). Generate Challan 281 with correct:
    - BSR code, challan serial, deposit date
    - Minor head: 200 (TDS/TCS payable by taxpayer) or 400 (TDS/TCS regular assessment)
 7. HITL — ALWAYS trigger human-in-the-loop before filing. Present: computation summary per section,
    total TDS, 26AS reconciliation status, challan payment status, and recommendation.
-8. FILE — After partner approval, call income_tax:file_26q_return() and income_tax:file_24q_return().
+8. FILE — After partner approval, call income_tax_india:file_26q_return() and income_tax_india:file_24q_return().
    Record provisional receipt number and filing timestamp.
-9. GENERATE_16A — call income_tax:download_form_16a() for each deductee.
+9. GENERATE_16A — call income_tax_india:download_form_16a() for each deductee.
    Distribute certificates within 15 days of filing (per Rule 31).
 10. POST_ENTRIES — call tally:post_voucher() to post TDS journal entries to books.
 </processing_sequence>

--- a/core/agents/packs/installer.py
+++ b/core/agents/packs/installer.py
@@ -72,6 +72,34 @@ def _normalize_tool_names(tools: list[str]) -> list[str]:
     return normalized
 
 
+_CONNECTOR_ALIASES: dict[str, str] = {
+    "email": "sendgrid",
+    "income_tax": "income_tax_india",
+}
+
+
+def _canonical_connector_name(connector_name: str) -> str:
+    raw = connector_name.strip().removeprefix("registry-")
+    return _CONNECTOR_ALIASES.get(raw, raw)
+
+
+def _tool_connector_map(tools: list[str]) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for tool_ref in tools:
+        if ":" not in tool_ref:
+            continue
+        connector_name, tool_name = tool_ref.split(":", 1)
+        connector = _canonical_connector_name(connector_name)
+        if tool_name and tool_name not in mapping:
+            mapping[tool_name] = connector
+    return mapping
+
+
+def _connector_ids_for_tools(tools: list[str]) -> list[str]:
+    connectors = list(dict.fromkeys(_tool_connector_map(tools).values()))
+    return [f"registry-{connector}" for connector in connectors]
+
+
 def _resolve_pack_dir(pack_name: str) -> Path | None:
     # Resolve by string-matching against directories we discover ourselves.
     # `pack_name` never flows into a path expression — the set of discovered
@@ -420,9 +448,10 @@ async def _get_or_create_pack_agents(
         agent_cfg = raw_agent_cfg if isinstance(raw_agent_cfg, dict) else {"type": str(raw_agent_cfg)}
         display_name = _agent_display_name(pack_label, agent_cfg, index, company_name)
         agent_type = _agent_type(agent_cfg, index)
-        normalized_tools = _normalize_tool_names(
-            [str(tool) for tool in agent_cfg.get("tools", []) if tool]
-        )
+        raw_tools = [str(tool) for tool in agent_cfg.get("tools", []) if tool]
+        normalized_tools = _normalize_tool_names(raw_tools)
+        tool_connectors = _tool_connector_map(raw_tools)
+        connector_ids = _connector_ids_for_tools(raw_tools)
         llm_model = str(agent_cfg.get("llm_model") or _DEFAULT_LLM_MODEL)
         llm_config = {
             "model": llm_model,
@@ -463,6 +492,7 @@ async def _get_or_create_pack_agents(
                 ),
                 max_retries=3,
                 authorized_tools=normalized_tools,
+                connector_ids=connector_ids,
                 status="shadow",
                 version="1.0.0",
                 employee_name=display_name,
@@ -477,7 +507,9 @@ async def _get_or_create_pack_agents(
                         "source": "industry_pack",
                         **({"company_id": str(company_id)} if company_id else {}),
                         **({"company_name": company_name} if company_name else {}),
-                    }
+                    },
+                    "tool_connectors": tool_connectors,
+                    "required_connector_ids": connector_ids,
                 },
             )
             session.add(agent)
@@ -502,6 +534,40 @@ async def _get_or_create_pack_agents(
                     deployed_at=datetime.now(UTC),
                 )
             )
+        else:
+            # Idempotent repair path for previously provisioned pack
+            # agents. Several CA reopen bugs came from treating pack
+            # sync as "create-only": old rows kept empty connector_ids
+            # and stale tool manifests, so they still routed through
+            # unrelated global connectors after a successful resync.
+            agent.authorized_tools = normalized_tools
+            agent.connector_ids = connector_ids
+            agent.system_prompt_text = system_prompt_text
+            agent.llm_model = llm_model
+            agent.llm_fallback = _DEFAULT_FALLBACK_MODEL
+            agent.llm_config = llm_config
+            agent.confidence_floor = confidence_floor
+            agent.hitl_condition = str(
+                agent_cfg.get("hitl_condition")
+                or f"confidence < {confidence_floor}"
+            )
+            cfg = dict(agent.config or {})
+            pack_cfg = dict(cfg.get("pack_install") or {})
+            pack_cfg.update(
+                {
+                    "pack_name": pack_name,
+                    "display_name": pack_label,
+                    "agent_index": index,
+                    "source": "industry_pack",
+                    **({"company_id": str(company_id)} if company_id else {}),
+                    **({"company_name": company_name} if company_name else {}),
+                }
+            )
+            cfg["pack_install"] = pack_cfg
+            cfg["tool_connectors"] = tool_connectors
+            cfg["required_connector_ids"] = connector_ids
+            agent.config = cfg
+            session.add(agent)
 
         agent_specs.append(
             {

--- a/tests/regression/test_ca_firms_may03_reopens.py
+++ b/tests/regression/test_ca_firms_may03_reopens.py
@@ -1,0 +1,173 @@
+"""Regression pins for CA Firms 2026-05-03 reopened bugs.
+
+Source: C:\\Users\\mishr\\Downloads\\CA_FIRMS_TEST_REPORTUDay3May2026.md.
+The report reopened earlier fixes because adjacent paths still drifted:
+pack provisioning lacked connector bindings, direct chat bypassed the
+agent prompt/connector allow-list, and the Scopes tab rendered fabricated
+security state.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_ca_pack_tools_are_registered_on_real_connectors() -> None:
+    """BUG-11/17: CA pack tools must exist on the connector registry."""
+    from connectors.finance.income_tax_india import IncomeTaxIndiaConnector
+    from connectors.finance.zoho_books import ZohoBooksConnector
+
+    zoho = ZohoBooksConnector(config={})
+    income_tax = IncomeTaxIndiaConnector(config={})
+
+    for tool in {
+        "calculate_tds",
+        "check_account_balance",
+        "fetch_bank_statement",
+        "generate_gst_report",
+        "get_ledger_balance",
+        "get_transaction_list",
+        "get_trial_balance",
+        "list_overdue_invoices",
+        "reconcile_bank",
+    }:
+        assert tool in zoho._tool_registry
+
+    for tool in {"calculate_tds", "file_form_26q", "file_26q_return"}:
+        assert tool in income_tax._tool_registry
+
+
+def test_zoho_books_health_check_requires_real_api_probe() -> None:
+    """BUG-12: stale Zoho OAuth must fail health, not pass field checks."""
+    src = (ROOT / "connectors" / "finance" / "zoho_books.py").read_text(
+        encoding="utf-8"
+    )
+    health_block = src[src.find("async def health_check") : src.find("#", src.find("async def health_check"))]
+    assert 'self._get("/organizations")' in health_block
+    assert '"status": "healthy"' in health_block
+    assert "organizations" in health_block
+
+
+def test_ca_pack_has_connector_policy_for_every_authorized_tool() -> None:
+    """BUG-11/13/17: pack sync must persist connector_ids and tool map."""
+    from core.agents.packs.ca import CA_PACK
+    from core.agents.packs.installer import (
+        _connector_ids_for_tools,
+        _tool_connector_map,
+    )
+
+    for agent in CA_PACK["agents"]:
+        tool_map = _tool_connector_map(agent["tools"])
+        connector_ids = _connector_ids_for_tools(agent["tools"])
+        normalized_tools = [tool.rsplit(":", 1)[-1] for tool in agent["tools"]]
+        assert set(tool_map) == set(normalized_tools)
+        assert connector_ids
+        assert all(cid.startswith("registry-") for cid in connector_ids)
+
+    legacy = _tool_connector_map(["income_tax:file_26q_return", "email:send"])
+    assert legacy["file_26q_return"] == "income_tax_india"
+    assert legacy["send"] == "sendgrid"
+
+
+def test_pack_installer_repairs_existing_company_agents() -> None:
+    """BUG-13: company sync cannot be create-only after pack upgrades."""
+    src = (ROOT / "core" / "agents" / "packs" / "installer.py").read_text(
+        encoding="utf-8"
+    )
+    assert "agent.connector_ids = connector_ids" in src
+    assert 'cfg["tool_connectors"] = tool_connectors' in src
+    assert 'cfg["required_connector_ids"] = connector_ids' in src
+
+
+def test_company_agent_list_self_heals_after_pack_install() -> None:
+    """BUG-13: company Agents tab should not stay empty after ca-firm install."""
+    src = (ROOT / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    block = src[src.find("async def list_agents") : src.find("@router.get(\"/agents/org-tree\"")]
+    assert "sync_company_pack_assets_for_session" in block
+    assert "is_pack_installed_for_session" in block
+    assert "total == 0" in block
+
+
+def test_gst_auto_file_is_gated_by_active_gstn_credentials() -> None:
+    """BUG-14: auto-filing is config-blocked until GSTN creds exist."""
+    api_src = (ROOT / "api" / "v1" / "companies.py").read_text(
+        encoding="utf-8"
+    )
+    detail_src = (
+        ROOT / "ui" / "src" / "pages" / "CompanyDetail.tsx"
+    ).read_text(encoding="utf-8")
+    onboard_src = (
+        ROOT / "ui" / "src" / "pages" / "CompanyOnboard.tsx"
+    ).read_text(encoding="utf-8")
+
+    assert "_has_active_gstn_credential" in api_src
+    assert "Add and verify a GSTN credential before enabling auto-file" in api_src
+    assert "hasActiveGstnCredential" in detail_src
+    assert "GST auto-file is locked" in detail_src
+    assert "gst_auto_file: false" in onboard_src
+    assert "can be enabled after this company is onboarded" in onboard_src
+
+
+def test_direct_chat_uses_agent_prompt_and_connector_allowlist() -> None:
+    """BUG-17: direct agent chat must not bypass the run-agent contract."""
+    src = (ROOT / "api" / "v1" / "chat.py").read_text(encoding="utf-8")
+    assert "agent_system_prompt" in src
+    assert "_resolve_connector_configs" in src
+    assert "connector_names=connector_names" in src
+    assert 'lg_result.get("tool_calls") or lg_result.get("tool_calls_log")' in src
+    assert "for clarification." in src
+
+
+def test_agent_scopes_tab_has_no_fabricated_security_state() -> None:
+    """BUG-15/16: no mock expiry statuses or foreign enforcement logs."""
+    src = (
+        ROOT / "ui" / "src" / "pages" / "AgentDetail.tsx"
+    ).read_text(encoding="utf-8")
+    block = src[src.find("function ScopesTab") :]
+    assert "Mock enforcement log data" not in block
+    assert "Expiring soon" not in block
+    assert "Expired" not in block
+    assert "salesforce" not in block
+    assert "hubspot" not in block
+    assert "No enforcement decisions recorded" in block
+    assert "tool:${connector || \"agenticorg\"}:execute:${tool}" in src
+
+
+def test_each_ca_pack_agent_binds_callable_tools_in_zoho_only_env() -> None:
+    """BUG-11: in Uday's reported Zoho-only env, every CA pack agent
+    must bind at least one callable tool. Prior to the fix the LLM
+    received zero tools and shadow_sample runs collapsed to text-only
+    responses at 0.24-0.40 confidence with empty tool_calls.
+
+    This pin replays the runtime contract — not a source-grep — by
+    constructing the same bound-tool list ``build_tools_for_agent``
+    hands to LangGraph when the runner is dispatched.
+    """
+    from core.agents.packs.ca import CA_PACK
+    from core.agents.packs.installer import _normalize_tool_names
+    from core.langgraph.tool_adapter import build_tools_for_agent
+
+    zoho_only = ["zoho_books"]
+    for agent_cfg in CA_PACK["agents"]:
+        normalized = _normalize_tool_names(
+            [str(t) for t in agent_cfg.get("tools", [])]
+        )
+        bound = build_tools_for_agent(normalized, {}, zoho_only)
+        assert bound, (
+            f"{agent_cfg['name']} has no bound tools for a Zoho-only "
+            "tenant — shadow runs will return empty tool_calls and "
+            "collapse to the LLM-only confidence floor (BUG-11 reopen)."
+        )
+
+    # Empty allow-list must still fail-closed (BUG-08 contract).
+    for agent_cfg in CA_PACK["agents"]:
+        normalized = _normalize_tool_names(
+            [str(t) for t in agent_cfg.get("tools", [])]
+        )
+        bound_closed = build_tools_for_agent(normalized, {}, [])
+        assert bound_closed == [], (
+            f"{agent_cfg['name']} leaked tools through the empty "
+            "allow-list — fail-closed broken."
+        )

--- a/tests/regression/test_ca_firms_may03_reopens.py
+++ b/tests/regression/test_ca_firms_may03_reopens.py
@@ -105,7 +105,13 @@ def test_gst_auto_file_is_gated_by_active_gstn_credentials() -> None:
     assert "_has_active_gstn_credential" in api_src
     assert "Add and verify a GSTN credential before enabling auto-file" in api_src
     assert "hasActiveGstnCredential" in detail_src
-    assert "GST auto-file is locked" in detail_src
+    assert "GST auto-file cannot be enabled" in detail_src
+    # Asymmetric gate: enabling without creds is blocked, but a row that is
+    # already gst_auto_file=true on a tenant with no GSTN cred MUST remain
+    # togglable to OFF — otherwise existing unsafe rows are locked into the
+    # silent-failure state. The disable predicate must AND not-currently-true.
+    assert "!hasActiveGstnCredential && !editForm.gst_auto_file" in detail_src
+    assert "filings will silently fail" in detail_src
     assert "gst_auto_file: false" in onboard_src
     assert "can be enabled after this company is onboarded" in onboard_src
 

--- a/tests/regression/test_qa_28apr_sweep.py
+++ b/tests/regression/test_qa_28apr_sweep.py
@@ -279,7 +279,17 @@ class TestSiblingRoutesUseResolver:
     def test_chat_calls_resolver(self) -> None:
         src = Path("api/v1/chat.py").read_text(encoding="utf-8")
         assert "_resolve_agent_connector_ids_for_type" in src
-        assert "_load_connector_configs_for_agent" in src
+        # Chat must call the canonical connector resolver before invoking
+        # langgraph_run. May-03 BUG-17 fix promoted chat to the richer
+        # `_resolve_connector_configs` (returns config + resolved
+        # connector_names for fail-closed dispatch); the old
+        # `_load_connector_configs_for_agent` is now a back-compat
+        # wrapper around it. Either function name is the canonical
+        # resolver path the original 28-Apr defense intended.
+        assert (
+            "_resolve_connector_configs" in src
+            or "_load_connector_configs_for_agent" in src
+        )
 
     def test_mcp_calls_resolver(self) -> None:
         src = Path("api/v1/mcp.py").read_text(encoding="utf-8")

--- a/tests/unit/test_ca_pack.py
+++ b/tests/unit/test_ca_pack.py
@@ -143,15 +143,18 @@ class TestGSTFilingAgentTools:
         assert "gstn:generate_einvoice_irn" in tools
         assert "gstn:generate_eway_bill" in tools
 
-        # Must have Tally tools
+        # Must have accounting source tools
+        assert "zoho_books:get_trial_balance" in tools
+        assert "zoho_books:generate_gst_report" in tools
+        assert "zoho_books:list_invoices" in tools
         assert "tally:get_trial_balance" in tools
         assert "tally:generate_gst_report" in tools
 
-    def test_gst_filing_agent_has_8_tools(self):
+    def test_gst_filing_agent_has_11_tools(self):
         from core.agents.packs.ca import CA_PACK
 
         gst_agent = next(a for a in CA_PACK["agents"] if a["name"] == "GST Filing Agent")
-        assert len(gst_agent["tools"]) == 8
+        assert len(gst_agent["tools"]) == 11
 
     def test_gst_filing_agent_hitl_always(self):
         """GST Filing Agent must require HITL before filing."""
@@ -175,22 +178,26 @@ class TestTDSComplianceAgentTools:
         tds_agent = next(a for a in CA_PACK["agents"] if a["name"] == "TDS Compliance Agent")
         tools = tds_agent["tools"]
 
-        # Income Tax tools
-        assert "income_tax:file_26q_return" in tools
-        assert "income_tax:file_24q_return" in tools
-        assert "income_tax:check_tds_credit_in_26as" in tools
-        assert "income_tax:download_form_16a" in tools
-        assert "income_tax:pay_tax_challan" in tools
+        # Income Tax + accounting source tools
+        assert "zoho_books:calculate_tds" in tools
+        assert "zoho_books:get_ledger_balance" in tools
+        assert "income_tax_india:calculate_tds" in tools
+        assert "income_tax_india:file_form_26q" in tools
+        assert "income_tax_india:file_26q_return" in tools
+        assert "income_tax_india:file_24q_return" in tools
+        assert "income_tax_india:check_tds_credit_in_26as" in tools
+        assert "income_tax_india:download_form_16a" in tools
+        assert "income_tax_india:pay_tax_challan" in tools
 
         # Tally tools
         assert "tally:get_ledger_balance" in tools
         assert "tally:post_voucher" in tools
 
-    def test_tds_compliance_agent_has_7_tools(self):
+    def test_tds_compliance_agent_has_11_tools(self):
         from core.agents.packs.ca import CA_PACK
 
         tds_agent = next(a for a in CA_PACK["agents"] if a["name"] == "TDS Compliance Agent")
-        assert len(tds_agent["tools"]) == 7
+        assert len(tds_agent["tools"]) == 11
 
     def test_tds_compliance_agent_hitl_always(self):
         """TDS agent must also require HITL before filing."""

--- a/ui/e2e/qa-cafirms-may03.spec.ts
+++ b/ui/e2e/qa-cafirms-may03.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * CA Firms 2026-05-03 reopen regression coverage.
+ *
+ * These tests are hermetic: API routes are mocked so we can verify the
+ * rendered product behavior without live Zoho/GSTN/Grantex credentials.
+ */
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+import { APP, setSessionToken } from "./helpers/auth";
+
+const AGENT_ID = "e2e-ca-agent";
+const COMPANY_ID = "e2e-company";
+
+function json(route: Route, body: unknown) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function mockApi(page: Page) {
+  await page.route("**/api/v1/**", async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname;
+
+    if (path.endsWith("/api/v1/auth/me")) {
+      return json(route, {
+        email: "qa@agenticorg.ai",
+        name: "QA Admin",
+        role: "admin",
+        domain: "all",
+        tenant_id: "58483c90-494b-445d-85c6-245a727fe372",
+        onboarding_complete: true,
+      });
+    }
+
+    if (path.endsWith(`/api/v1/agents/${AGENT_ID}`)) {
+      return json(route, {
+        id: AGENT_ID,
+        name: "TDS Compliance Agent",
+        employee_name: "Acme - TDS Compliance Agent",
+        agent_type: "tds_compliance",
+        domain: "finance",
+        status: "shadow",
+        version: "1.0.0",
+        confidence_floor: 0.92,
+        shadow_sample_count: 0,
+        shadow_accuracy_current: null,
+        created_at: "2026-05-03T00:00:00Z",
+        authorized_tools: [
+          "calculate_tds",
+          "get_ledger_balance",
+          "list_invoices",
+          "file_form_26q",
+        ],
+        connector_ids: ["registry-zoho_books", "registry-income_tax_india"],
+        config: {
+          tool_connectors: {
+            calculate_tds: "zoho_books",
+            get_ledger_balance: "zoho_books",
+            list_invoices: "zoho_books",
+            file_form_26q: "income_tax_india",
+          },
+          grantex: { grantex_agent_id: "grx-agent-1" },
+        },
+      });
+    }
+
+    if (path.endsWith(`/api/v1/companies/${COMPANY_ID}`)) {
+      return json(route, {
+        id: COMPANY_ID,
+        name: "Acme Pvt Ltd",
+        gstin: "27ABCDE1234F1Z5",
+        pan: "ABCDE1234F",
+        state_code: "27",
+        is_active: true,
+        gst_auto_file: false,
+        client_health_score: 88,
+        subscription_status: "active",
+        created_at: "2026-05-03T00:00:00Z",
+      });
+    }
+
+    if (path.endsWith(`/api/v1/companies/${COMPANY_ID}/roles`)) {
+      return json(route, { roles: [], valid_roles: ["partner", "manager"] });
+    }
+
+    if (path.startsWith(`/api/v1/companies/${COMPANY_ID}/`)) {
+      return json(route, { items: [] });
+    }
+
+    if (path.endsWith("/api/v1/agents")) {
+      return json(route, {
+        items: [
+          {
+            id: AGENT_ID,
+            name: "Acme - GST Filing Agent",
+            employee_name: "Acme - GST Filing Agent",
+            designation: "GST Filing Agent",
+            domain: "finance",
+            status: "shadow",
+          },
+        ],
+        total: 1,
+        page: 1,
+        per_page: 200,
+        pages: 1,
+      });
+    }
+
+    if (path.endsWith("/api/v1/workflows") || path.endsWith("/api/v1/audit")) {
+      return json(route, { items: [] });
+    }
+
+    return json(route, {});
+  });
+
+  await setSessionToken(page, "fake.e2e.session");
+}
+
+test.describe("CA Firms May 03 reopen fixes", () => {
+  test("Scopes tab derives connectors and does not fabricate Grantex state", async ({
+    page,
+  }) => {
+    await mockApi(page);
+    await page.goto(`${APP}/dashboard/agents/${AGENT_ID}`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await page.getByRole("button", { name: "Scopes" }).click();
+
+    const main = page.locator("main");
+    await expect(main).toContainText("tool:zoho_books:execute:list_invoices");
+    await expect(main).toContainText("tool:income_tax_india:execute:file_form_26q");
+    await expect(main).toContainText("No enforcement decisions recorded");
+    await expect(main).not.toContainText("salesforce");
+    await expect(main).not.toContainText("hubspot");
+    await expect(main).not.toContainText("Expired");
+    await expect(main).not.toContainText("Expiring soon");
+  });
+
+  test("Company Agents tab shows provisioned CA pack agents", async ({ page }) => {
+    await mockApi(page);
+    await page.goto(`${APP}/dashboard/companies/${COMPANY_ID}`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await page.getByRole("button", { name: "Agents" }).click();
+
+    const main = page.locator("main");
+    await expect(main).toContainText("Acme - GST Filing Agent");
+    await expect(main).not.toContainText("No CA pack agents are provisioned");
+  });
+
+  test("GST auto-file is locked until GSTN credentials exist", async ({ page }) => {
+    await mockApi(page);
+    await page.goto(`${APP}/dashboard/companies/${COMPANY_ID}`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await page.getByRole("button", { name: "Settings" }).click();
+
+    const main = page.locator("main");
+    await expect(main).toContainText("GST auto-file is locked");
+    await expect(page.getByLabel("Enable GST auto-file")).toBeDisabled();
+    await expect(main).toContainText("No GSTN credentials stored for this company");
+  });
+});

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1488,9 +1488,66 @@ function PermissionBadge({ perm }: { perm: PermissionLevel }) {
   );
 }
 
-function buildScopeString(tool: string, domain: string, perm: PermissionLevel): string {
-  const connector = domain || "default";
-  return `tool:${connector}:${perm.toLowerCase()}:${tool}`;
+const TOOL_CONNECTOR_FALLBACK: Record<string, string> = {
+  calculate_tds: "zoho_books",
+  check_account_balance: "zoho_books",
+  check_tds_credit_in_26as: "income_tax_india",
+  download_form_16a: "income_tax_india",
+  fetch_bank_statement: "zoho_books",
+  file_24q_return: "income_tax_india",
+  file_26q_return: "income_tax_india",
+  file_form_26q: "income_tax_india",
+  generate_gst_report: "zoho_books",
+  get_balance_sheet: "zoho_books",
+  get_ledger_balance: "zoho_books",
+  get_profit_loss: "zoho_books",
+  get_transaction_list: "zoho_books",
+  get_trial_balance: "zoho_books",
+  list_invoices: "zoho_books",
+  list_overdue_invoices: "zoho_books",
+  pay_tax_challan: "income_tax_india",
+  reconcile_bank: "zoho_books",
+  send_email: "sendgrid",
+};
+
+type EnforcementEntry = {
+  timestamp?: string;
+  tool?: string;
+  connector?: string;
+  result?: string;
+  reason?: string;
+};
+
+function normalizeConnectorId(value: unknown): string {
+  return String(value || "").trim().replace(/^registry-/, "");
+}
+
+function connectorForTool(tool: string, agent: Agent): string {
+  const cfg = agent.config || {};
+  const configured = normalizeConnectorId(cfg.tool_connectors?.[tool]);
+  if (configured) return configured;
+
+  const linked = (agent.connector_ids || cfg.required_connector_ids || [])
+    .map(normalizeConnectorId)
+    .filter(Boolean);
+  if (linked.length === 1) return linked[0];
+
+  return TOOL_CONNECTOR_FALLBACK[tool] || agent.domain || "agenticorg";
+}
+
+function buildScopeString(tool: string, connector: string): string {
+  return `tool:${connector || "agenticorg"}:execute:${tool}`;
+}
+
+function grantexConfigured(agent: Agent): boolean {
+  const grantex = agent.config?.grantex || {};
+  return Boolean(grantex.grant_token || grantex.grantex_agent_id || grantex.grantex_did);
+}
+
+function enforcementEntries(agent: Agent): EnforcementEntry[] {
+  const cfg = agent.config || {};
+  const raw = cfg.enforcement_log || cfg.grantex?.enforcement_log || [];
+  return Array.isArray(raw) ? raw : [];
 }
 
 /* ─── Voice Tab ─── */
@@ -1577,23 +1634,11 @@ function VoiceTab({ agent }: { agent: Agent }) {
 /* ─── Scopes Tab ─── */
 function ScopesTab({ agent }: { agent: Agent }) {
   const tools = agent.authorized_tools || [];
-  const domain = agent.domain || "default";
-
-  // Mock enforcement log data
-  const enforcementLog = [
-    { timestamp: "2026-04-04T09:12:33Z", tool: tools[0] || "get_contact", connector: "salesforce", result: "allowed" as const, reason: "Scope matched: READ" },
-    { timestamp: "2026-04-04T09:10:15Z", tool: tools[1] || "update_record", connector: "salesforce", result: "allowed" as const, reason: "Scope matched: WRITE" },
-    { timestamp: "2026-04-04T08:55:42Z", tool: "delete_account", connector: "salesforce", result: "denied" as const, reason: "No DELETE scope granted" },
-    { timestamp: "2026-04-04T08:30:01Z", tool: "admin_reset_org", connector: "internal", result: "denied" as const, reason: "ADMIN scope not in grant token" },
-    { timestamp: "2026-04-04T08:15:22Z", tool: tools[0] || "get_contact", connector: "hubspot", result: "allowed" as const, reason: "Scope matched: READ" },
-  ];
-
-  // Mock token statuses: most active, one expiring, one expired
-  function getTokenStatus(idx: number): { color: string; label: string } {
-    if (idx === tools.length - 1 && tools.length > 2) return { color: "bg-red-500", label: "Expired" };
-    if (idx === tools.length - 2 && tools.length > 1) return { color: "bg-yellow-500", label: "Expiring soon" };
-    return { color: "bg-green-500", label: "Active" };
-  }
+  const hasGrantex = grantexConfigured(agent);
+  const tokenStatus = hasGrantex
+    ? { color: "bg-green-500", label: "Configured" }
+    : { color: "bg-muted-foreground", label: "Not issued" };
+  const enforcementLog = enforcementEntries(agent);
 
   return (
     <div className="space-y-4">
@@ -1618,17 +1663,17 @@ function ScopesTab({ agent }: { agent: Agent }) {
                 <tbody>
                   {tools.map((tool, idx) => {
                     const perm = getToolPermission(tool);
-                    const scope = buildScopeString(tool, domain, perm);
-                    const tokenStatus = getTokenStatus(idx);
+                    const connector = connectorForTool(tool, agent);
+                    const scope = buildScopeString(tool, connector);
                     return (
-                      <tr key={tool} className="border-b last:border-0">
+                      <tr key={`${tool}-${idx}`} className="border-b last:border-0">
                         <td className="py-2 pr-4 font-medium">{tool}</td>
                         <td className="py-2 pr-4"><PermissionBadge perm={perm} /></td>
-                        <td className="py-2 pr-4 text-xs">{domain}</td>
+                        <td className="py-2 pr-4 text-xs">{connector}</td>
                         <td className="py-2 pr-4"><code className="text-xs bg-muted px-1.5 py-0.5 rounded font-mono">{scope}</code></td>
                         <td className="py-2 pr-4">
-                          <Badge variant={tokenStatus.label === "Expired" ? "destructive" : tokenStatus.label === "Expiring soon" ? "warning" : "success"} className="text-[10px]">
-                            {tokenStatus.label === "Expired" ? "expired" : "active"}
+                          <Badge variant={hasGrantex ? "success" : "secondary"} className="text-[10px]">
+                            {hasGrantex ? "configured" : "not issued"}
                           </Badge>
                         </td>
                         <td className="py-2">
@@ -1644,7 +1689,7 @@ function ScopesTab({ agent }: { agent: Agent }) {
               </table>
             </div>
           ) : (
-            <p className="text-sm text-muted-foreground">No tools configured — no scopes to display.</p>
+            <p className="text-sm text-muted-foreground">No tools configured; no scopes to display.</p>
           )}
         </CardContent>
       </Card>
@@ -1654,37 +1699,46 @@ function ScopesTab({ agent }: { agent: Agent }) {
           <CardTitle className="text-sm font-semibold">Enforcement Log</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b text-left text-xs text-muted-foreground uppercase tracking-wide">
-                  <th className="pb-2 pr-4">Timestamp</th>
-                  <th className="pb-2 pr-4">Tool</th>
-                  <th className="pb-2 pr-4">Connector</th>
-                  <th className="pb-2 pr-4">Result</th>
-                  <th className="pb-2">Reason</th>
-                </tr>
-              </thead>
-              <tbody>
-                {enforcementLog.map((entry, idx) => (
-                  <tr key={idx} className="border-b last:border-0">
-                    <td className="py-2 pr-4 text-xs text-muted-foreground font-mono">
-                      {new Date(entry.timestamp).toLocaleString()}
-                    </td>
-                    <td className="py-2 pr-4 font-medium">{entry.tool}</td>
-                    <td className="py-2 pr-4">{entry.connector}</td>
-                    <td className="py-2 pr-4">
-                      <Badge variant={entry.result === "allowed" ? "success" : "destructive"} className="text-[10px]">
-                        {entry.result}
-                      </Badge>
-                    </td>
-                    <td className="py-2 text-xs text-muted-foreground">{entry.reason}</td>
+          {enforcementLog.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-xs text-muted-foreground uppercase tracking-wide">
+                    <th className="pb-2 pr-4">Timestamp</th>
+                    <th className="pb-2 pr-4">Tool</th>
+                    <th className="pb-2 pr-4">Connector</th>
+                    <th className="pb-2 pr-4">Result</th>
+                    <th className="pb-2">Reason</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          <p className="text-xs text-muted-foreground mt-3">Showing recent enforcement decisions. Full audit log available via API.</p>
+                </thead>
+                <tbody>
+                  {enforcementLog.map((entry, idx) => {
+                    const tool = String(entry.tool || "");
+                    const connector = normalizeConnectorId(entry.connector) || connectorForTool(tool, agent);
+                    const result = String(entry.result || "").toLowerCase();
+                    const allowed = result === "allowed" || result === "success";
+                    return (
+                      <tr key={idx} className="border-b last:border-0">
+                        <td className="py-2 pr-4 text-xs text-muted-foreground font-mono">
+                          {entry.timestamp ? new Date(entry.timestamp).toLocaleString() : "-"}
+                        </td>
+                        <td className="py-2 pr-4 font-medium">{tool || "-"}</td>
+                        <td className="py-2 pr-4">{connector || "-"}</td>
+                        <td className="py-2 pr-4">
+                          <Badge variant={allowed ? "success" : "destructive"} className="text-[10px]">
+                            {result || "denied"}
+                          </Badge>
+                        </td>
+                        <td className="py-2 text-xs text-muted-foreground">{entry.reason || "-"}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No enforcement decisions recorded for this agent yet.</p>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/ui/src/pages/CompanyDetail.tsx
+++ b/ui/src/pages/CompanyDetail.tsx
@@ -1370,7 +1370,7 @@ export default function CompanyDetail() {
                     <input
                       type="checkbox"
                       checked={editForm.gst_auto_file}
-                      disabled={!hasActiveGstnCredential}
+                      disabled={!hasActiveGstnCredential && !editForm.gst_auto_file}
                       onChange={(event) => {
                         if (event.target.checked && !hasActiveGstnCredential) {
                           setError("Add and verify an active GSTN portal credential before enabling GST auto-file.");
@@ -1382,9 +1382,14 @@ export default function CompanyDetail() {
                     />
                     Enable GST auto-file
                   </label>
-                  {!hasActiveGstnCredential && (
+                  {!hasActiveGstnCredential && !editForm.gst_auto_file && (
                     <p className="mt-2 text-xs text-amber-700">
-                      GST auto-file is locked until an active GSTN portal credential is saved and verified below.
+                      GST auto-file cannot be enabled until an active GSTN portal credential is saved and verified below.
+                    </p>
+                  )}
+                  {!hasActiveGstnCredential && editForm.gst_auto_file && (
+                    <p className="mt-2 text-xs text-amber-700">
+                      GST auto-file is currently enabled but no active GSTN portal credential exists, so filings will silently fail. Disable it here, or add a credential below before the next filing window.
                     </p>
                   )}
                 </div>

--- a/ui/src/pages/CompanyDetail.tsx
+++ b/ui/src/pages/CompanyDetail.tsx
@@ -435,6 +435,9 @@ export default function CompanyDetail() {
   const overdueDeadlines = deadlines.filter((deadline) => deadlineStatus(deadline) === "overdue").length;
   const upcomingDeadlines = deadlines.filter((deadline) => deadlineStatus(deadline) === "pending").length;
   const activeCredentials = credentials.filter((credential) => credential.is_active).length;
+  const hasActiveGstnCredential = credentials.some(
+    (credential) => credential.is_active && credential.portal_type === "gstn",
+  );
   const healthScore = company?.client_health_score ?? 0;
 
   const activities = useMemo<ActivityEntry[]>(() => {
@@ -486,6 +489,10 @@ export default function CompanyDetail() {
 
   const handleSaveCompany = async () => {
     if (!id) return;
+    if (editForm.gst_auto_file && !hasActiveGstnCredential) {
+      setError("Add and verify an active GSTN portal credential before enabling GST auto-file.");
+      return;
+    }
     setSavingCompany(true);
     setError(null);
     try {
@@ -1363,11 +1370,23 @@ export default function CompanyDetail() {
                     <input
                       type="checkbox"
                       checked={editForm.gst_auto_file}
-                      onChange={(event) => setEditForm((current) => ({ ...current, gst_auto_file: event.target.checked }))}
+                      disabled={!hasActiveGstnCredential}
+                      onChange={(event) => {
+                        if (event.target.checked && !hasActiveGstnCredential) {
+                          setError("Add and verify an active GSTN portal credential before enabling GST auto-file.");
+                          return;
+                        }
+                        setEditForm((current) => ({ ...current, gst_auto_file: event.target.checked }));
+                      }}
                       className="h-4 w-4 rounded border-input"
                     />
                     Enable GST auto-file
                   </label>
+                  {!hasActiveGstnCredential && (
+                    <p className="mt-2 text-xs text-amber-700">
+                      GST auto-file is locked until an active GSTN portal credential is saved and verified below.
+                    </p>
+                  )}
                 </div>
                 <div className="sm:col-span-2 flex items-center gap-3">
                   <Button disabled={savingCompany} onClick={() => void handleSaveCompany()}>

--- a/ui/src/pages/CompanyOnboard.tsx
+++ b/ui/src/pages/CompanyOnboard.tsx
@@ -309,7 +309,7 @@ export default function CompanyOnboard() {
         pf_registration: form.pf_reg || undefined,
         esi_registration: form.esi_reg || undefined,
         pt_registration: form.pt_reg || undefined,
-        gst_auto_file: form.gst_auto_file,
+        gst_auto_file: false,
         tally_config: tallyConfig,
       };
       await api.post("/companies/onboard", payload);
@@ -669,11 +669,15 @@ export default function CompanyOnboard() {
                   <input
                     type="checkbox"
                     checked={form.gst_auto_file}
+                    disabled
                     onChange={(e) => update("gst_auto_file", e.target.checked)}
                     className="w-4 h-4 rounded border-input"
                   />
                   <span className="text-sm font-medium">Enable GST Auto-Filing</span>
                 </label>
+                <p className="mt-2 text-xs text-amber-700 dark:text-amber-300">
+                  GST auto-filing can be enabled after this company is onboarded and an active GSTN portal credential is saved and verified.
+                </p>
                 {form.gst_auto_file && (
                   <div className="mt-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3">
                     <p className="text-sm text-amber-800 dark:text-amber-200 font-medium">Warning: Auto-filing enabled</p>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -17,6 +17,20 @@ export interface Agent {
   parent_agent_id?: string | null;
   reporting_to?: string | null;
   org_level?: number;
+  connector_ids?: string[];
+  config?: {
+    tool_connectors?: Record<string, string>;
+    required_connector_ids?: string[];
+    enforcement_log?: any[];
+    grantex?: {
+      grant_token?: string;
+      grantex_agent_id?: string;
+      grantex_did?: string;
+      enforcement_log?: any[];
+      grantex_scopes?: string[];
+    };
+    [key: string]: any;
+  };
 }
 export interface PromptTemplate {
   id: string; name: string; agent_type: string; domain: string;


### PR DESCRIPTION
## Summary

Closes the 2026-05-03 CA-firm reopens reported by Uday: pack agents stuck at 24-40% shadow accuracy, Company Agents tab empty after a successful pack install, GST auto-file enableable with no GSTN credential, and the Scopes tab rendering hardcoded mock Salesforce/HubSpot enforcement entries. Root cause spans pack metadata → installer → connector tool registration → chat runtime contract → UI state.

Source ticket: `CA_FIRMS_TEST_REPORTUDay3May2026.md` (Uday Chauhan).

## Per-bug fail-closed verdicts

Verdicts use the matrix in [`docs/bug_triage_skill.md`](docs/bug_triage_skill.md) under [`agenticorg-bug-fix-fail-closed`](.claude/skills/agenticorg-bug-fix-fail-closed/SKILL.md).

| ID | Verdict | Evidence |
|---|---|---|
| **BUG-11** 5 pack agents at 24-40% shadow accuracy | Fixed in code, deploy + browser re-verify pending | Tester's stated cause (`shadow_sample` not on manifest) was wrong. Real cause: pack agents had `authorized_tools` whose connectors had no live `ConnectorConfig`, so `build_tools_for_agent` returned `[]` → LLM had nothing to invoke. New runtime probe (`test_each_ca_pack_agent_binds_callable_tools_in_zoho_only_env`) asserts every CA pack agent now binds 2-6 tools in a Zoho-only env. |
| **BUG-12** Zoho stale credentials | Operational issue — manual environment action required | `connectors/finance/zoho_books.py:192-199` already calls real `/organizations`. Re-OAuth Zoho in target env. Pinned by `test_zoho_books_health_check_requires_real_api_probe`. |
| **BUG-13** Company Agents tab empty after pack install | Fixed in code, deploy + browser re-verify pending | Installer was create-only + list endpoint had no self-heal. Fix in `core/agents/packs/installer.py:533-568` and `api/v1/agents.py:948-997`. |
| **BUG-14** GST auto-file with no GSTN creds | Fixed in code, deploy + browser re-verify pending | API gates added on create / update / onboard at `api/v1/companies.py`. UI disables toggle and explains lock. `gst_auto_file` is the only auto-file flag on Company; no sibling paths. |
| **BUG-15** Grantex Expired/Expiring-soon tokens | Fixed in code, deploy + browser re-verify pending | The labels were literally hardcoded mock data (`ui/src/pages/AgentDetail.tsx:1592-1596` pre-diff). Replaced with real `agent.config.grantex.grant_token` check + Configured/Not-issued badges. |
| **BUG-16** Enforcement log shows Salesforce/HubSpot | Fixed in code, deploy + browser re-verify pending | Same hardcoded-mock pattern. Replaced with real `agent.config.enforcement_log` + connector derived from `tool_connectors` map (now persisted by installer). |
| **BUG-17** TDS chat agent returns 40%, no tool calls | Fixed in code, deploy + browser re-verify pending | Three real defects in `api/v1/chat.py`: generic prompt overrode `agent.system_prompt_text`, `connector_names` not passed to runner, stale `tools_called` field read instead of `tool_calls`/`tool_calls_log`. |

## Sibling-path findings (per skill Rule 3)

- ✅ CA pack — all 5 agents bind tools in any tenant env.
- ❌ **Sleeper bug**: `legal` (3 agents) and `insurance` (4 agents) industry packs both bind **0 tools** — same root-cause class as BUG-11. Out of scope here, no customer impact yet, but should be fixed before either pack ships.
- 🟡 `healthcare` and `manufacturing` pack modules export no `*_PACK` constant. Separate gap.
- ✅ `core/langgraph/grantex_auth._tools_to_scopes` (no `connector_names` arg) is only test-callers, not production.
- ✅ `gst_auto_file` write paths — only POST `/companies`, PATCH `/companies/{id}`, POST `/companies/onboard`, all gated.

## Test plan

- [x] `pytest tests/regression/test_ca_firms_may03_reopens.py tests/unit/test_ca_pack.py tests/unit/test_ca_api_functional.py` → 99 passed (includes new runtime BUG-11 binding probe).
- [x] `SKIP_PYTEST=1 bash scripts/preflight.sh` → all gates green: ruff, mypy, bandit, alembic, verify=False scan, ui tsc, ui build, consistency sweep, module coverage floor, critical-path tags. Pytest skipped via the documented Windows + Py3.13 workaround; targeted pytest run separately above.
- [ ] Tester (Uday) re-verifies BUG-11/13/14/15/16/17 against deployed app after merge — required by `docs/bug_triage_skill.md` Rule 6 before any verdict can become final.
- [ ] BUG-12: re-OAuth Zoho Books connector in target env, then click \"Test connection\" on the Zoho card.

## Honesty caveats

- Working tree → branch only. Not yet merged or deployed; no production browser reproduction was performed in this session.
- 7 of 8 backend regression tests are source-greps (tripwire). The new `test_each_ca_pack_agent_binds_callable_tools_in_zoho_only_env` is the one runtime pin.
- Source bug reports in the user's local Downloads contain plaintext credentials (Zoho client_secret, tester portal password, OAuth tokens). **Confirmed not present in the repo or this PR's workbook**, but rotation is required upstream (Zoho dev console + agenticorg secrets store + tester password reset). Rotation checklist provided to the user out-of-band.

## Files changed

- Backend: `api/v1/agents.py`, `api/v1/chat.py`, `api/v1/companies.py`, `auth/grantex_registration.py`, `connectors/finance/zoho_books.py`, `connectors/finance/income_tax_india.py`
- Pack: `core/agents/packs/ca/__init__.py`, `core/agents/packs/ca/config.yaml`, `core/agents/packs/ca/prompts/{tds_compliance,ar_collections}.prompt.txt`, `core/agents/packs/installer.py`
- Frontend: `ui/src/pages/{AgentDetail,CompanyDetail,CompanyOnboard}.tsx`, `ui/src/types/index.ts`
- Tests: `tests/regression/test_ca_firms_may03_reopens.py` (new), `ui/e2e/qa-cafirms-may03.spec.ts` (new), `tests/unit/test_ca_pack.py`

@codex please review per `docs/bug_triage_skill.md` discipline — particularly the BUG-15/16 verdict (replacing hardcoded mock UI vs masking a real routing bug) and the sleeper-bug call-out for legal/insurance packs.