### PR TITLE
fix(chat): unwrap Python repr of {type:text, text:...} in chat answer

### DIFF
--- a/api/v1/chat.py
+++ b/api/v1/chat.py
@@ -267,6 +267,25 @@ def _format_agent_output(output: dict | str | Any) -> str:
     Never returns a raw JSON/Python dict repr as the user-facing answer.
     """
     if isinstance(output, str):
+        # Issue #438 (post-#434 prod observation 2026-05-03): the runner
+        # sometimes hands us a string that is the *Python repr* of a
+        # ``{"type": "text", "text": "..."}`` LangChain message wrapper —
+        # single quotes, escaped \n's. Returning it verbatim leaks the
+        # whole repr into the chat bubble. Try to parse it as JSON or a
+        # Python literal and recurse so the unwrapped text is what the
+        # user sees. Bare text strings fall through unchanged.
+        stripped = output.lstrip()
+        if stripped.startswith(("{", "[")):
+            import ast
+            import json as _json
+
+            for parser in (_json.loads, ast.literal_eval):
+                try:
+                    parsed = parser(output)
+                except (ValueError, SyntaxError):
+                    continue
+                if isinstance(parsed, (dict, list)):
+                    return _format_agent_output(parsed)
         return output
     if not isinstance(output, dict):
         text = _extract_readable(output)

--- a/scripts/inventory_stale_ca_pack_agents.py
+++ b/scripts/inventory_stale_ca_pack_agents.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Read-only inventory of CA-firm pack agents stuck on pre-PR-#434 state.
+
+Reports tenants where the CA-firm pack is installed but per-tenant
+agent rows still carry empty ``connector_ids``. These rows were
+created by the pre-#434 installer code and need PR #434's repair
+branch to fire (idempotent reinstall via ``POST /api/v1/packs/ca-firm/install``,
+or a one-shot ``sync_company_pack_assets_for_session`` job).
+
+Pure read — no UPDATE, no INSERT, no schema change. Safe to run any
+time. Intended to be deployed as a Cloud Run one-shot job alongside
+the existing ``agenticorg-bge-m3-backfill`` pattern.
+
+Outputs JSON-lines so a downstream remediation job can consume it
+without re-querying.
+
+Usage::
+
+    python scripts/inventory_stale_ca_pack_agents.py
+    # → one JSON line per affected tenant on stdout, plus a summary
+    #   line at the end.
+
+Requires the same environment as the api service (DATABASE_URL +
+the alembic-managed schema). When run as a Cloud Run job, attach the
+same CloudSQL instance and secret refs the api uses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from typing import Any
+
+from sqlalchemy import text
+
+from core.database import get_engine
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("inventory_stale_ca_pack_agents")
+
+CA_PACK_AGENT_TYPES = (
+    "gst_filing_agent",
+    "tds_compliance_agent",
+    "bank_reconciliation_agent",
+    "fp_a_analyst_agent",
+    "ar_collections_agent",
+)
+
+
+async def _inventory() -> int:
+    engine = get_engine()
+    affected_tenants = 0
+    total_stale_agents = 0
+
+    async with engine.connect() as conn:
+        # Find every tenant that has the CA-firm pack installed.
+        installs = await conn.execute(
+            text(
+                """
+                SELECT DISTINCT tenant_id
+                FROM industry_pack_installs
+                WHERE pack_name = 'ca-firm'
+                """
+            )
+        )
+        tenant_ids = [row[0] for row in installs.fetchall()]
+
+        for tenant_id in tenant_ids:
+            stale = await conn.execute(
+                text(
+                    """
+                    SELECT id, agent_type, company_id
+                    FROM agents
+                    WHERE tenant_id = :tenant_id
+                      AND agent_type = ANY(:agent_types)
+                      AND (
+                        connector_ids IS NULL
+                        OR connector_ids = '[]'::jsonb
+                        OR jsonb_array_length(connector_ids) = 0
+                      )
+                    ORDER BY company_id, agent_type
+                    """
+                ),
+                {"tenant_id": tenant_id, "agent_types": list(CA_PACK_AGENT_TYPES)},
+            )
+            rows = stale.fetchall()
+            if not rows:
+                continue
+            affected_tenants += 1
+            total_stale_agents += len(rows)
+            payload: dict[str, Any] = {
+                "tenant_id": str(tenant_id),
+                "stale_agent_count": len(rows),
+                "agents": [
+                    {
+                        "agent_id": str(r[0]),
+                        "agent_type": r[1],
+                        "company_id": str(r[2]) if r[2] else None,
+                    }
+                    for r in rows
+                ],
+            }
+            print(json.dumps(payload))
+
+    summary = {
+        "summary": True,
+        "tenants_with_ca_pack_installed": len(tenant_ids),
+        "tenants_with_stale_agents": affected_tenants,
+        "total_stale_agents": total_stale_agents,
+        "remediation": (
+            "POST /api/v1/packs/ca-firm/install per affected tenant — "
+            "the installer's else-branch (PR #434) repairs existing "
+            "agents idempotently. Verify before/after via "
+            "GET /api/v1/agents/{id} for connector_ids and "
+            "config.tool_connectors keys."
+        ),
+    }
+    print(json.dumps(summary))
+    logger.info(
+        "inventory_complete tenants_installed=%s tenants_stale=%s agents_stale=%s",
+        len(tenant_ids),
+        affected_tenants,
+        total_stale_agents,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(_inventory()))

--- a/tests/unit/test_bug_sweep_24apr.py
+++ b/tests/unit/test_bug_sweep_24apr.py
@@ -214,6 +214,55 @@ class TestChatFormatAgentOutput:
             assert "'" not in out or "ok" in out  # no {'..': '..'} dict repr
 
 
+class TestChatFormatAgentOutputStringDictRepr:
+    """Issue #438 (post-PR #434, prod observation 2026-05-03): TDS chat
+    rendered ``{'type': 'text', 'text': '...'}`` verbatim. Root cause:
+    ``_format_agent_output`` short-circuits on ``isinstance(output, str)``
+    and returned the Python repr without trying to unwrap it. Fix tries
+    JSON / ``ast.literal_eval`` on string-shaped dicts before treating
+    them as final text.
+    """
+
+    def test_python_repr_of_text_block_unwraps(self) -> None:
+        from api.v1.chat import _format_agent_output
+
+        out = _format_agent_output(
+            "{'type': 'text', 'text': 'I can help you file Form 26Q.'}"
+        )
+        assert out == "I can help you file Form 26Q."
+        assert "'type'" not in out
+
+    def test_json_text_block_string_unwraps(self) -> None:
+        from api.v1.chat import _format_agent_output
+
+        out = _format_agent_output('{"type": "text", "text": "Plain JSON answer"}')
+        assert out == "Plain JSON answer"
+
+    def test_python_repr_with_extras_unwraps_to_text_only(self) -> None:
+        from api.v1.chat import _format_agent_output
+
+        out = _format_agent_output(
+            "{'type': 'text', 'text': 'Hello', 'extras': {'signature': 'sig'}}"
+        )
+        assert out == "Hello"
+        assert "extras" not in out
+        assert "signature" not in out
+
+    def test_plain_string_passes_through_unchanged(self) -> None:
+        from api.v1.chat import _format_agent_output
+
+        out = _format_agent_output("Just a plain answer with no wrapper.")
+        assert out == "Just a plain answer with no wrapper."
+
+    def test_malformed_dict_string_falls_back_to_string(self) -> None:
+        """A near-dict-shaped string that doesn't actually parse must
+        not raise — fall through to the original string."""
+        from api.v1.chat import _format_agent_output
+
+        out = _format_agent_output("{not a real dict")
+        assert out == "{not a real dict"
+
+
 class TestConnectorHealthCheck:
     """Uday/Ramesh 2026-04-24 (UI-HEALTH-404): Gmail connector /test
     reported ``status=healthy, http_status=404`` because the base


### PR DESCRIPTION
Closes #438.

## Symptom (prod, 2026-05-03)

After PR #434 + Uday's CA-firm pack backfill, the TDS Compliance chat panel rendered:

\`\`\`
{'type': 'text', 'text': 'I can help you file Form 26Q, but I need some more information. ...'}
\`\`\`

The actual answer text is in there, but wrapped in the LangChain message dict's Python repr (single quotes, escaped \n's).

## Root cause

\`api/v1/chat.py::_format_agent_output\` short-circuits on \`isinstance(output, str)\` and returns the string verbatim. The runner sometimes hands us a STRING that is the Python repr of a \`{type, text}\` block — never reaches the dict-unwrap branch added for TC_008 (Aishwarya 2026-04-24).

## Fix

Two-layer string parser: when an output string starts with \`{\` or \`[\`, try \`json.loads\` then \`ast.literal_eval\`. If either yields a dict/list, recurse through the existing extractor so the TC_008 unwrap path applies. Bare text strings still pass through unchanged.

## Bonus: stale-pack inventory script

Bundled \`scripts/inventory_stale_ca_pack_agents.py\` — pure read-only JSON-lines inventory of tenants where the CA-firm pack is installed but agent rows still carry empty \`connector_ids\` (the pre-PR-#434 stuck state). Intended to be deployed as a one-shot Cloud Run job mirroring the \`agenticorg-bge-m3-backfill\` pattern, so any tenant other than Uday's can be found and remediated via the idempotent \`POST /api/v1/packs/ca-firm/install\` endpoint without touching the DB directly.

## Test plan

- [x] \`pytest tests/unit/test_bug_sweep_24apr.py::TestChatFormatAgentOutput tests/unit/test_bug_sweep_24apr.py::TestChatFormatAgentOutputStringDictRepr\` → 11 passed
- [x] 5 new pins: python-repr unwrap, JSON unwrap, extras-stripped unwrap, plain-string passthrough, malformed-dict graceful fallback
- [ ] Tester re-checks chat panel post-deploy and sees plain text only
- [ ] Inventory job: deploy as a one-shot Cloud Run job, run, capture stdout — surfaces any tenant in the post-#434-pre-backfill stuck state

## Out of scope

This is the visible follow-up bug surfaced during PR #434's post-deploy walk; not introduced by #434. The runner has emitted this shape for some time, but PR #434 made chat actually reach the runner with a bound tool list, which exposed the rendering bug for the first time on prod.

@codex review