### PR TITLE
fix(chat): also unwrap python-repr inside raw_output (#438 part 2)

### DIFF
--- a/api/v1/chat.py
+++ b/api/v1/chat.py
@@ -218,6 +218,32 @@ _INTERNAL_FIELDS = {
 _READABLE_KEYS = ("text", "content", "answer", "response", "message", "summary", "result")
 
 
+def _try_parse_dict_string(raw: str) -> Any | None:
+    """If ``raw`` is the JSON/Python-repr text of a dict or list, return
+    the parsed object. Otherwise return ``None``.
+
+    Used to unwrap LangChain message blocks that the runner sometimes
+    serializes as ``"{'type': 'text', 'text': '...'}"`` (single-quoted
+    Python repr) or as JSON. ``ast.literal_eval`` is intentionally used
+    instead of ``eval`` — it accepts only literal types (dict, list,
+    str, int, etc.) and raises on anything that would execute code.
+    """
+    stripped = raw.lstrip()
+    if not stripped.startswith(("{", "[")):
+        return None
+    import ast
+    import json as _json
+
+    for parser in (_json.loads, ast.literal_eval):
+        try:
+            parsed = parser(raw)
+        except (ValueError, SyntaxError):
+            continue
+        if isinstance(parsed, (dict, list)):
+            return parsed
+    return None
+
+
 def _extract_readable(val: Any) -> str | None:
     """Best-effort extract of user-facing text from a nested LLM payload.
 
@@ -274,18 +300,9 @@ def _format_agent_output(output: dict | str | Any) -> str:
         # whole repr into the chat bubble. Try to parse it as JSON or a
         # Python literal and recurse so the unwrapped text is what the
         # user sees. Bare text strings fall through unchanged.
-        stripped = output.lstrip()
-        if stripped.startswith(("{", "[")):
-            import ast
-            import json as _json
-
-            for parser in (_json.loads, ast.literal_eval):
-                try:
-                    parsed = parser(output)
-                except (ValueError, SyntaxError):
-                    continue
-                if isinstance(parsed, (dict, list)):
-                    return _format_agent_output(parsed)
+        unwrapped = _try_parse_dict_string(output)
+        if unwrapped is not None:
+            return _format_agent_output(unwrapped)
         return output
     if not isinstance(output, dict):
         text = _extract_readable(output)
@@ -293,18 +310,18 @@ def _format_agent_output(output: dict | str | Any) -> str:
     # Free-text response (LLM didn't return JSON)
     if "raw_output" in output and output["raw_output"]:
         raw = output["raw_output"]
-        # The raw_output may itself be a JSON string — try to parse and
-        # extract a human-readable answer from it.
+        # The raw_output may itself be a JSON or Python-repr string — try
+        # both so the unwrap also works for runs where raw_output stores
+        # the LangChain {type, text} block as a Python repr (single
+        # quotes). Issue #438 part 2: prod-verified post-#439 deploy.
         if isinstance(raw, str):
-            try:
-                parsed = __import__("json").loads(raw)
-                if isinstance(parsed, dict):
-                    text = _extract_readable(parsed)
+            unwrapped = _try_parse_dict_string(raw)
+            if unwrapped is not None:
+                if isinstance(unwrapped, dict):
+                    text = _extract_readable(unwrapped)
                     if text:
                         return text
-                    return _format_agent_output(parsed)
-            except (ValueError, TypeError):
-                pass
+                return _format_agent_output(unwrapped)
             return raw
         text = _extract_readable(raw)
         if text:

--- a/tests/unit/test_bug_sweep_24apr.py
+++ b/tests/unit/test_bug_sweep_24apr.py
@@ -262,6 +262,42 @@ class TestChatFormatAgentOutputStringDictRepr:
         out = _format_agent_output("{not a real dict")
         assert out == "{not a real dict"
 
+    def test_raw_output_python_repr_unwraps(self) -> None:
+        """Issue #438 part 2 (prod-verified post-#439 deploy):
+        ``_format_agent_output({'raw_output': '<python repr>'})`` was
+        leaking the repr because the raw_output branch only tried
+        ``json.loads``. The shared helper now also tries
+        ``ast.literal_eval`` so single-quoted reprs unwrap.
+        """
+        from api.v1.chat import _format_agent_output
+
+        out = _format_agent_output(
+            {
+                "raw_output": (
+                    "{'type': 'text', 'text': 'I can help you with that.', "
+                    "'extras': {'signature': 'sig'}}"
+                )
+            }
+        )
+        assert out == "I can help you with that."
+        assert "'type'" not in out
+        assert "extras" not in out
+        assert "signature" not in out
+
+    def test_raw_output_json_string_still_unwraps(self) -> None:
+        from api.v1.chat import _format_agent_output
+
+        out = _format_agent_output(
+            {"raw_output": '{"type": "text", "text": "Plain JSON answer"}'}
+        )
+        assert out == "Plain JSON answer"
+
+    def test_raw_output_plain_text_passes_through(self) -> None:
+        from api.v1.chat import _format_agent_output
+
+        out = _format_agent_output({"raw_output": "Just a plain answer."})
+        assert out == "Just a plain answer."
+
 
 class TestConnectorHealthCheck:
     """Uday/Ramesh 2026-04-24 (UI-HEALTH-404): Gmail connector /test


### PR DESCRIPTION
Re-opens the symptom side of #438. Same chat Python-repr leak Uday hit pre-#434, observed *again* in production after PR #439 merged + deployed (\`agenticorg-api@5a6b643\`).

## Why #439 didn't actually close #438

PR #439 added the JSON / \`ast.literal_eval\` unwrap **only at the top-level** \`isinstance(output, str)\` branch of \`api/v1/chat.py::_format_agent_output\`. The runtime call site that actually leaks on prod is a different branch:

- The runner returns \`output = {"raw_output": "<python repr>"}\` — i.e. a dict whose \`raw_output\` value is the stringified \`{'type': 'text', 'text': '...', 'extras': {'signature': '...'}}\` block.
- That dict routes into the **\`raw_output\` sub-branch** (a few lines down), not the top-level string branch.
- The sub-branch tried only \`json.loads\` on the inner string. Python repr (single-quoted) doesn't parse as JSON, so the \`except\` caught and the code did \`return raw\` — leaking the wrapper verbatim.

Net effect post-#439 deploy: \`/api/v1/chat/query\` returned \`{"answer": "{'type': 'text', 'text': 'I can help...', 'extras': {'signature': 'CvwFAQw...'}}"}\` — exact same UX bug Uday originally reported.

## Fix

Refactor the parsing logic into a shared helper and call it from **both** call sites:

- \`_try_parse_dict_string(raw)\` — tries \`json.loads\` then \`ast.literal_eval\`. Returns the parsed dict/list, or \`None\`. \`ast.literal_eval\` is intentionally chosen over \`eval\`: it accepts only literal types and raises on anything that would execute code.
- Top-level string branch: replaces #439's inline parser with a call to the helper. Same behavior for the cases #439 already fixed.
- \`raw_output\` sub-branch: when the inner string starts with \`{\` or \`[\` and parses, recurse through \`_format_agent_output\`. If it doesn't parse, fall through to the original \`return raw\` path.

## Tests

Three new pins in \`tests/unit/test_bug_sweep_24apr.py::TestChatFormatAgentOutputStringDictRepr\` that **specifically exercise the deeper call site** that #439 missed:

- \`test_raw_output_python_repr_unwraps\` — \`{\"raw_output\": \"{'type': 'text', 'text': 'I can help...', 'extras': {'signature': 'sig'}}\"}\` → \`\"I can help...\"\` (no \`'type'\`, no \`extras\`, no \`signature\`)
- \`test_raw_output_json_string_still_unwraps\` — \`{\"raw_output\": '{\"type\": \"text\", \"text\": \"Plain JSON answer\"}'}\` → \`\"Plain JSON answer\"\` (regression-pin for the originally-handled case)
- \`test_raw_output_plain_text_passes_through\` — \`{\"raw_output\": \"Just a plain answer.\"}\` → unchanged (no over-eager parsing of bare text)

The 6 cases #439 added (top-level string branch) continue to pass through the shared helper.

## Test plan

- [x] \`pytest tests/unit/test_bug_sweep_24apr.py::TestChatFormatAgentOutput tests/unit/test_bug_sweep_24apr.py::TestChatFormatAgentOutputStringDictRepr\` → 14 passed locally
- [ ] Codex re-review on the PR head
- [ ] Required CI green
- [ ] Post-deploy: send the tester's exact TDS prompt via the chat panel and the API; assert the rendered text and the raw \`/api/v1/chat/query\` \`answer\` field both contain plain text (no \`{'type'\`, no \`'extras'\`)

## Out of scope

- CA BUG-11/17 prompt/runtime work (issue #440 — agents have bound tools but LLM doesn't reliably invoke them in shadow/chat). Separate problem layer, separate PR.
- Inventory script (already on main from PR #439). Will run post-this-deploy from the deployed image so we're using the same code surface customers see.

@codex review