### PR TITLE
fix(ca-pack): wire prompt_file + interactive-extraction suffix (#440)

### DIFF
--- a/core/agents/packs/ca/__init__.py
+++ b/core/agents/packs/ca/__init__.py
@@ -20,6 +20,7 @@ CA_PACK: dict[str, Any] = {
                 "Automates GSTR-1/3B/9 preparation, "
                 "2A reconciliation, and DSC-signed filing"
             ),
+            "prompt_file": "prompts/gst_filing.prompt.txt",
             "tools": [
                 "gstn:fetch_gstr2a",
                 "gstn:push_gstr1_data",
@@ -35,6 +36,14 @@ CA_PACK: dict[str, Any] = {
             ],
             "llm_model": "gpt-4o",
             "hitl_condition": "always_before_filing",
+            "system_prompt_suffix": (
+                "INTERACTIVE EXTRACTION (issue #440): When the user message "
+                "already names gstin, period (month/quarter), or return type "
+                "(GSTR-1/3B/9/2A), extract those values and call the relevant "
+                "tool directly with those arguments. Do not ask the user to "
+                "repeat values that are already in the prompt. Only ask for "
+                "clarification when a required parameter is genuinely missing."
+            ),
         },
         {
             "name": "TDS Compliance Agent",
@@ -43,6 +52,7 @@ CA_PACK: dict[str, Any] = {
                 "Computes TDS, files Form 26Q/24Q, "
                 "generates Form 16A, reconciles 26AS"
             ),
+            "prompt_file": "prompts/tds_compliance.prompt.txt",
             "tools": [
                 "zoho_books:calculate_tds",
                 "zoho_books:get_ledger_balance",
@@ -58,6 +68,26 @@ CA_PACK: dict[str, Any] = {
             ],
             "llm_model": "gpt-4o",
             "hitl_condition": "always_before_filing",
+            "system_prompt_suffix": (
+                "INTERACTIVE EXTRACTION (issue #440): When the user message "
+                "already provides amount, section (194A/194C/194H/194I/194J/"
+                "194O/194Q), deductee_type (individual/huf/company/firm), "
+                "pan_available, or period (e.g. 'April 2026'), extract those "
+                "values and invoke calculate_tds directly with the extracted "
+                "arguments. PAN can be requested separately ONLY if it is "
+                "genuinely needed for the filing step. Never ask the user to "
+                "repeat the amount, section, or period when they are already "
+                "in the prompt — that is the BUG-17 failure pattern.\n\n"
+                "Worked example for the canonical tester prompt 'Calculate "
+                "TDS for vendor payment of INR 50,000 under Section 194C for "
+                "April 2026 and file Form 26Q':\n"
+                "  1. Extract: amount=50000, section=194C, period=April 2026\n"
+                "  2. Call calculate_tds(amount=50000, section=\"194C\")\n"
+                "  3. Report the computed tds_amount, rate, net_payable\n"
+                "  4. For the Form 26Q step, ask only for PAN + deductee_type "
+                "if those are genuinely missing — do NOT re-ask for amount/"
+                "section."
+            ),
         },
         {
             "name": "Bank Reconciliation Agent",
@@ -66,6 +96,7 @@ CA_PACK: dict[str, Any] = {
                 "Auto-matches bank statement with books, "
                 "flags old outstanding items"
             ),
+            "prompt_file": "prompts/bank_reconciliation.prompt.txt",
             "tools": [
                 "zoho_books:fetch_bank_statement",
                 "zoho_books:check_account_balance",
@@ -81,6 +112,13 @@ CA_PACK: dict[str, Any] = {
             ],
             "llm_model": "gpt-4o-mini",
             "confidence_floor": 0.95,
+            "system_prompt_suffix": (
+                "INTERACTIVE EXTRACTION (issue #440): When the user message "
+                "already names account_id, from_date, or to_date, call "
+                "fetch_bank_statement / check_account_balance / "
+                "get_transaction_list directly with those arguments. Don't "
+                "ask the user to restate values already provided."
+            ),
         },
         {
             "name": "FP&A Analyst Agent",
@@ -89,6 +127,7 @@ CA_PACK: dict[str, Any] = {
                 "Variance analysis, budget vs actual, "
                 "MIS report generation"
             ),
+            "prompt_file": "prompts/fpa_analyst.prompt.txt",
             "tools": [
                 "zoho_books:get_trial_balance",
                 "zoho_books:get_ledger_balance",
@@ -98,6 +137,13 @@ CA_PACK: dict[str, Any] = {
                 "zoho_books:get_balance_sheet",
             ],
             "llm_model": "gpt-4o-mini",
+            "system_prompt_suffix": (
+                "INTERACTIVE EXTRACTION (issue #440): When the user names a "
+                "date range or period (e.g., 'Q1 FY26', 'April 2026'), call "
+                "get_profit_loss / get_balance_sheet / get_trial_balance "
+                "directly with the converted from_date / to_date / date "
+                "arguments. Don't re-prompt for the period."
+            ),
         },
         {
             "name": "AR Collections Agent",
@@ -106,6 +152,7 @@ CA_PACK: dict[str, Any] = {
                 "Tracks overdue invoices, sends reminders, "
                 "escalates aging items"
             ),
+            "prompt_file": "prompts/ar_collections.prompt.txt",
             "tools": [
                 "zoho_books:get_ledger_balance",
                 "zoho_books:list_overdue_invoices",
@@ -114,6 +161,12 @@ CA_PACK: dict[str, Any] = {
                 "sendgrid:send_email",
             ],
             "llm_model": "gpt-4o-mini",
+            "system_prompt_suffix": (
+                "INTERACTIVE EXTRACTION (issue #440): When the user names a "
+                "customer_id or invoice number, call list_invoices / "
+                "list_overdue_invoices directly with those filters. Don't "
+                "re-prompt for values already in the message."
+            ),
         },
     ],
     "workflows": [

--- a/core/agents/packs/ca/__init__.py
+++ b/core/agents/packs/ca/__init__.py
@@ -163,9 +163,14 @@ CA_PACK: dict[str, Any] = {
             "llm_model": "gpt-4o-mini",
             "system_prompt_suffix": (
                 "INTERACTIVE EXTRACTION (issue #440): When the user names a "
-                "customer_id or invoice number, call list_invoices / "
-                "list_overdue_invoices directly with those filters. Don't "
-                "re-prompt for values already in the message."
+                "customer_id, call list_invoices / list_overdue_invoices "
+                "directly with that filter (the Zoho list_invoices method "
+                "supports status/customer_id/date_start/date_end/page — do "
+                "NOT pass an invoice-number filter, the connector will "
+                "silently ignore it). When the user names a specific "
+                "invoice (e.g. \"INV-123\"), fetch the customer's invoice "
+                "list first and locate the target client-side before acting. "
+                "Don't re-prompt for values already in the message."
             ),
         },
     ],

--- a/core/agents/packs/ca/config.yaml
+++ b/core/agents/packs/ca/config.yaml
@@ -16,6 +16,7 @@ compliance:
 agents:
   - type: gst_filing
     domain: finance
+    prompt_file: prompts/gst_filing.prompt.txt
     tools: [gstn:fetch_gstr2a, gstn:push_gstr1_data, gstn:file_gstr3b, gstn:file_gstr9, gstn:generate_einvoice_irn, gstn:generate_eway_bill, tally:get_trial_balance, tally:generate_gst_report, zoho_books:get_trial_balance, zoho_books:generate_gst_report, zoho_books:list_invoices]
     llm_model: gpt-4o
     hitl_condition: always_before_filing
@@ -24,8 +25,15 @@ agents:
       ALWAYS trigger human-in-the-loop before any filing submission.
       Reconcile every inward supply against the purchase register before proceeding.
       Never file a return with unresolved mismatches above 5% of return value.
+
+      INTERACTIVE EXTRACTION (issue #440): When the user message already names
+      gstin, period (month/quarter), or return type (GSTR-1/3B/9/2A), extract
+      those values and call the relevant tool directly with those arguments.
+      Do not ask the user to repeat values that are already in the prompt.
+      Only ask for clarification when a required parameter is genuinely missing.
   - type: tds_compliance
     domain: finance
+    prompt_file: prompts/tds_compliance.prompt.txt
     tools: [zoho_books:calculate_tds, zoho_books:get_ledger_balance, income_tax_india:calculate_tds, income_tax_india:file_form_26q, income_tax_india:file_26q_return, income_tax_india:file_24q_return, income_tax_india:check_tds_credit_in_26as, income_tax_india:download_form_16a, income_tax_india:pay_tax_challan, tally:get_ledger_balance, tally:post_voucher]
     llm_model: gpt-4o
     hitl_condition: always_before_filing
@@ -34,8 +42,27 @@ agents:
       ALWAYS trigger human-in-the-loop before filing returns or paying challans.
       Validate PAN and section applicability for every deductee before computing TDS.
       Never proceed if 26AS credit does not reconcile with books within 1% tolerance.
+
+      INTERACTIVE EXTRACTION (issue #440): When the user message already
+      provides amount, section (194A/194C/194H/194I/194J/194O/194Q),
+      deductee_type (individual/huf/company/firm), pan_available, or period
+      (e.g., "April 2026"), extract those values and invoke calculate_tds
+      directly with the extracted arguments. PAN can be requested separately
+      ONLY if it is genuinely needed for the filing step. Never ask the user
+      to repeat the amount, section, or period when they are already in the
+      prompt — that is the BUG-17 failure pattern.
+
+      Worked example for the canonical tester prompt
+      "Calculate TDS for vendor payment of INR 50,000 under Section 194C
+      for April 2026 and file Form 26Q":
+        1. Extract: amount=50000, section=194C, period=April 2026
+        2. Call calculate_tds(amount=50000, section="194C")
+        3. Report the computed tds_amount, rate, and net_payable
+        4. For the Form 26Q step, ask only for PAN + deductee_type if
+           those are genuinely missing — do NOT re-ask for amount/section.
   - type: bank_reconciliation
     domain: finance
+    prompt_file: prompts/bank_reconciliation.prompt.txt
     tools: [zoho_books:fetch_bank_statement, zoho_books:check_account_balance, zoho_books:get_transaction_list, zoho_books:get_ledger_balance, zoho_books:get_trial_balance, zoho_books:reconcile_bank, banking_aa:fetch_bank_statement, banking_aa:check_account_balance, banking_aa:get_transaction_list, tally:get_ledger_balance, tally:get_trial_balance]
     llm_model: gpt-4o-mini
     confidence_floor: 0.95
@@ -43,22 +70,38 @@ agents:
       Auto-match bank statement entries with book entries using amount, date, and reference.
       Flag items outstanding for more than 30 days for review.
       Never auto-post reconciliation entries without a confirmed GL account match.
+
+      INTERACTIVE EXTRACTION (issue #440): When the user message already names
+      account_id, from_date, or to_date, call fetch_bank_statement /
+      check_account_balance / get_transaction_list directly with those
+      arguments. Don't ask the user to restate values already provided.
   - type: fpa_analyst
     domain: finance
+    prompt_file: prompts/fpa_analyst.prompt.txt
     tools: [tally:get_trial_balance, tally:get_ledger_balance, zoho_books:get_trial_balance, zoho_books:get_ledger_balance, zoho_books:get_profit_loss, zoho_books:get_balance_sheet]
     llm_model: gpt-4o-mini
     system_prompt_suffix: >
       Perform variance analysis, budget vs actual comparison, and MIS report generation.
       Label all forecast outputs as MODEL_OUTPUT, not ACTUALS.
       Flag variances exceeding 15% for partner review.
+
+      INTERACTIVE EXTRACTION (issue #440): When the user names a date range
+      or period (e.g., "Q1 FY26", "April 2026"), call get_profit_loss /
+      get_balance_sheet / get_trial_balance directly with the converted
+      from_date / to_date / date arguments. Don't re-prompt for the period.
   - type: ar_collections
     domain: finance
+    prompt_file: prompts/ar_collections.prompt.txt
     tools: [zoho_books:get_ledger_balance, zoho_books:list_overdue_invoices, tally:get_ledger_balance, zoho_books:list_invoices, sendgrid:send_email]
     llm_model: gpt-4o-mini
     system_prompt_suffix: >
       Track overdue invoices across all clients, send tiered reminders, and escalate aging items.
       Day 30: email reminder. Day 60: follow-up with payment link. Day 90+: escalate to partner.
       Never send communications without verifying the invoice is still outstanding.
+
+      INTERACTIVE EXTRACTION (issue #440): When the user names a customer_id
+      or invoice number, call list_invoices / list_overdue_invoices directly
+      with those filters. Don't re-prompt for values already in the message.
 workflows:
   - gstr_filing_monthly
   - tds_quarterly_filing

--- a/core/agents/packs/ca/config.yaml
+++ b/core/agents/packs/ca/config.yaml
@@ -99,9 +99,14 @@ agents:
       Day 30: email reminder. Day 60: follow-up with payment link. Day 90+: escalate to partner.
       Never send communications without verifying the invoice is still outstanding.
 
-      INTERACTIVE EXTRACTION (issue #440): When the user names a customer_id
-      or invoice number, call list_invoices / list_overdue_invoices directly
-      with those filters. Don't re-prompt for values already in the message.
+      INTERACTIVE EXTRACTION (issue #440): When the user names a customer_id,
+      call list_invoices / list_overdue_invoices directly with that filter
+      (the Zoho list_invoices method supports status/customer_id/date_start/
+      date_end/page — do NOT pass an invoice-number filter, the connector
+      will silently ignore it). When the user names a specific invoice
+      (e.g. "INV-123"), fetch the customer's invoice list first and locate
+      the target client-side before acting. Don't re-prompt for values
+      already in the message.
 workflows:
   - gstr_filing_monthly
   - tds_quarterly_filing

--- a/core/agents/packs/ca/prompts/tds_compliance.prompt.txt
+++ b/core/agents/packs/ca/prompts/tds_compliance.prompt.txt
@@ -10,6 +10,29 @@ salary), reconcile with Form 26AS, pay challans, and generate Form 16A certifica
 deductees. Every filing requires partner review before submission.
 </role>
 
+<interactive_extraction>
+Issue #440 (BUG-17 closure): When the user message already provides amount, section,
+deductee_type, pan_available, or period, EXTRACT those values and invoke
+calculate_tds(amount=..., section="...") directly. Never restate-and-ask for values
+that are already in the prompt — that is the BUG-17 failure mode where the agent
+asked the user to repeat 'INR 50,000 under Section 194C for April 2026' that was
+literally in the same sentence.
+
+Worked example for the canonical tester prompt:
+  USER: "Calculate TDS for vendor payment of INR 50,000 under Section 194C for April 2026 and file Form 26Q"
+  STEP 1 — extract: amount=50000, section=194C, period="April 2026"
+  STEP 2 — call calculate_tds(amount=50000, section="194C")
+  STEP 3 — report tds_amount, rate, net_payable from the tool response
+  STEP 4 — for the Form 26Q step, request ONLY the genuinely missing fields:
+           PAN of deductee, deductee_type (individual/huf/company/firm),
+           and TAN of deductor. Do NOT re-ask for amount or section.
+
+Use the procedural sequence below (EXTRACT → VALIDATE_DEDUCTEES → ...) only when
+the user has not yet provided enough information for a direct calculate_tds call.
+For ad-hoc calculation queries with all fields present, the direct path above is
+the right behavior.
+</interactive_extraction>
+
 <processing_sequence>
 1. EXTRACT — call tally:get_ledger_balance() for all TDS-applicable ledgers. Extract transactions
    grouped by TDS section (194A, 194C, 194H, 194I, 194J, 194O, 192, etc.).

--- a/tests/regression/test_ca_firms_may03_reopens.py
+++ b/tests/regression/test_ca_firms_may03_reopens.py
@@ -177,3 +177,145 @@ def test_each_ca_pack_agent_binds_callable_tools_in_zoho_only_env() -> None:
             f"{agent_cfg['name']} leaked tools through the empty "
             "allow-list — fail-closed broken."
         )
+
+
+# ----------------------------------------------------------------------
+# Issue #440 — BUG-11/17 prompt-runtime residual: every CA pack agent
+# must carry an interactive-extraction instruction so the LLM extracts
+# already-provided fields (amount/section/period/etc.) and calls the
+# tool directly instead of asking the user to repeat them. The TDS
+# agent additionally carries a worked example of the canonical tester
+# prompt → calculate_tds invocation.
+# ----------------------------------------------------------------------
+
+
+def test_every_ca_pack_agent_has_prompt_file_and_extraction_suffix() -> None:
+    """Issue #440: each CA pack agent must wire a prompt_file (so the
+    SOP-level prompt is loaded into system_prompt_text by the installer)
+    AND carry the INTERACTIVE EXTRACTION instruction in its
+    system_prompt_suffix. Without these, BUG-17's 'agent asks for
+    fields already in the user prompt' symptom can't close even after
+    the tool-binding repair."""
+    from core.agents.packs.ca import CA_PACK
+
+    for agent_cfg in CA_PACK["agents"]:
+        name = agent_cfg.get("name", "?")
+        prompt_file = agent_cfg.get("prompt_file") or ""
+        suffix = agent_cfg.get("system_prompt_suffix") or ""
+        assert prompt_file.endswith(".prompt.txt"), (
+            f"{name} is missing prompt_file — installer's _build_system_prompt "
+            "won't pick up the SOP. Issue #440."
+        )
+        assert "INTERACTIVE EXTRACTION" in suffix, (
+            f"{name} is missing INTERACTIVE EXTRACTION clause — LLM will keep "
+            "asking the user to repeat already-provided fields. Issue #440."
+        )
+        # Pin the wording reviewer should not regress.
+        assert "issue #440" in suffix.lower() or "440" in suffix, (
+            f"{name} suffix should reference issue #440 so a future cleanup "
+            "doesn't drop the extraction clause silently."
+        )
+
+
+def test_tds_compliance_suffix_carries_canonical_tester_example() -> None:
+    """Issue #440: the TDS Compliance agent's suffix must carry the
+    exact canonical tester prompt + the explicit extraction → tool-call
+    walkthrough so the LLM has a concrete pattern to mimic, not just an
+    abstract instruction."""
+    from core.agents.packs.ca import CA_PACK
+
+    tds = next(
+        a for a in CA_PACK["agents"] if a.get("name") == "TDS Compliance Agent"
+    )
+    suffix = tds.get("system_prompt_suffix") or ""
+    # Canonical tester prompt fragments
+    assert "INR 50,000" in suffix
+    assert "Section 194C" in suffix
+    assert "April 2026" in suffix
+    assert "Form 26Q" in suffix
+    # Concrete extraction → tool-call walkthrough
+    assert "amount=50000" in suffix
+    assert 'section="194C"' in suffix or "section='194C'" in suffix
+    assert "calculate_tds" in suffix
+    # Explicit anti-pattern callout
+    assert "BUG-17" in suffix
+
+
+def test_tds_compliance_prompt_file_has_interactive_extraction_section() -> None:
+    """Issue #440: the SOP prompt itself must carry the extraction
+    section so the LLM sees it whether it landed via the prompt_file
+    path or the suffix path. Belt-and-braces — the procedural sequence
+    that follows is correct for filing flows but was driving BUG-17 for
+    ad-hoc calculate-only chat queries."""
+    src = (
+        ROOT / "core" / "agents" / "packs" / "ca" / "prompts"
+        / "tds_compliance.prompt.txt"
+    ).read_text(encoding="utf-8")
+    assert "<interactive_extraction>" in src
+    assert "Issue #440" in src
+    # The worked example mirrors the suffix
+    assert "INR 50,000" in src
+    assert "Section 194C" in src
+    assert "calculate_tds(amount=50000" in src
+    # Anti-restate-and-ask language
+    assert "Never restate-and-ask" in src or "do NOT re-ask" in src.lower()
+
+
+def test_ca_pack_agent_types_match_existing_db_rows() -> None:
+    """Issue #440 wiring guard: ``_agent_type`` is the value the
+    installer's lookup key (Agent.agent_type) is compared against.
+    Existing prod rows have agent_types derived from the pre-PR-#434
+    slugified-name path: ``gst_filing_agent``, ``tds_compliance_agent``,
+    ``bank_reconciliation_agent``, ``fp_a_analyst_agent``,
+    ``ar_collections_agent``. Adding an explicit ``type:`` to any pack
+    agent dict (a tempting refactor) would change ``_agent_type`` output
+    and miss every existing row on backfill, creating duplicate agents.
+    Pin the derived types to the live DB convention so this stays
+    impossible without an explicit migration."""
+    from core.agents.packs.ca import CA_PACK
+    from core.agents.packs.installer import _agent_type
+
+    expected_types = {
+        "GST Filing Agent": "gst_filing_agent",
+        "TDS Compliance Agent": "tds_compliance_agent",
+        "Bank Reconciliation Agent": "bank_reconciliation_agent",
+        "FP&A Analyst Agent": "fp_a_analyst_agent",
+        "AR Collections Agent": "ar_collections_agent",
+    }
+    for index, agent_cfg in enumerate(CA_PACK["agents"]):
+        name = agent_cfg["name"]
+        derived = _agent_type(agent_cfg, index)
+        assert derived == expected_types[name], (
+            f"_agent_type({name!r}) returned {derived!r}, expected "
+            f"{expected_types[name]!r}. This drift would create duplicate "
+            "agents on the next idempotent backfill — the Agent.agent_type "
+            "lookup key would no longer match existing rows. If you really "
+            "need to rename, ship a data migration first."
+        )
+
+
+def test_built_tds_system_prompt_includes_extraction_instruction() -> None:
+    """Issue #440 runtime contract: the actual string the installer
+    persists to ``agent.system_prompt_text`` (and that the LLM sees
+    on every chat / shadow turn) must contain BOTH the suffix's
+    INTERACTIVE EXTRACTION clause AND the SOP's worked example. This
+    pins the wiring end-to-end — if a refactor breaks _build_system_prompt
+    or _read_pack_prompt or the prompt_file path resolution, this fires."""
+    from core.agents.packs.ca import CA_PACK
+    from core.agents.packs.installer import _build_system_prompt, get_pack_detail
+
+    detail = get_pack_detail("ca-firm")
+    assert detail is not None, "CA pack must resolve via get_pack_detail"
+    tds_index, tds_cfg = next(
+        (i, a) for i, a in enumerate(CA_PACK["agents"])
+        if a.get("name") == "TDS Compliance Agent"
+    )
+    built = _build_system_prompt("ca-firm", detail, tds_cfg, tds_index)
+    # Suffix signals
+    assert "INTERACTIVE EXTRACTION" in built
+    assert "calculate_tds" in built
+    # SOP signals (proves prompt_file was loaded)
+    assert "<interactive_extraction>" in built
+    assert "Section 234E" in built  # from the existing <tds_rules> block
+    # Tool list still appended (sanity)
+    assert "Authorized tools" in built

--- a/tests/regression/test_ca_firms_may03_reopens.py
+++ b/tests/regression/test_ca_firms_may03_reopens.py
@@ -217,6 +217,38 @@ def test_every_ca_pack_agent_has_prompt_file_and_extraction_suffix() -> None:
         )
 
 
+def test_ar_collections_suffix_does_not_recommend_unsupported_filter() -> None:
+    """Issue #440 follow-up (Codex P2 on PR #443): the AR Collections
+    suffix must NOT instruct the LLM to filter ``list_invoices`` by
+    invoice number. The Zoho ``list_invoices`` method only accepts
+    status/customer_id/date_start/date_end/page; an invoice-number arg
+    gets silently ignored, the LLM receives a broad list, and may act
+    on the wrong record. Pin the supported-fields language and the
+    fetch-then-filter-client-side fallback for invoice-specific asks."""
+    from core.agents.packs.ca import CA_PACK
+
+    ar = next(
+        a for a in CA_PACK["agents"] if a.get("name") == "AR Collections Agent"
+    )
+    suffix = ar.get("system_prompt_suffix") or ""
+    # Hard-stop: no language asking the LLM to "filter by invoice number"
+    # (regardless of casing) — that's the unsupported-arg trap.
+    lower = suffix.lower()
+    assert "invoice number" not in lower or "do not pass" in lower or "do NOT pass" in suffix, (
+        "AR suffix tells the LLM to use an invoice-number filter without "
+        "the explicit 'do NOT pass' caveat. Zoho list_invoices doesn't "
+        "support that field; the LLM will pass an unsupported arg and "
+        "the connector will silently ignore it. Either remove the "
+        "instruction or call out the unsupported arg explicitly."
+    )
+    # Pin the safer fetch-then-filter-client-side fallback for
+    # invoice-specific asks like 'remind for INV-123'.
+    assert "client-side" in lower or "client side" in lower
+    # Pin the supported-fields list as documentation so a reader can
+    # verify against the connector signature.
+    assert "customer_id" in suffix
+
+
 def test_tds_compliance_suffix_carries_canonical_tester_example() -> None:
     """Issue #440: the TDS Compliance agent's suffix must carry the
     exact canonical tester prompt + the explicit extraction → tool-call


### PR DESCRIPTION
Closes #440. Closes the BUG-11 / BUG-17 prompt-runtime residual that PR #434 + the post-deploy backfills of 5 tenants did not address.

## What still leaked after PR #434 + 4 backfill rounds

Even with all 5 CA pack agents on Uday's primary tenant having connector_ids populated, tool_connectors map present, and calculate_tds bound at runtime, the canonical tester prompt:

> "Calculate TDS for vendor payment of INR 50,000 under Section 194C for April 2026 and file Form 26Q"

still produced:

> "I can help with that. What is the payment amount for which TDS needs to be calculated for INR 50,000 under Section 194C by TDS for April 2026?"

The agent had \`calculate_tds\` available but didn't invoke it — it asked the user to repeat fields that were literally in the same sentence.

## Two missing pieces

1. **No \`prompt_file:\`** on any CA pack agent. The rich SOP prompts in \`core/agents/packs/ca/prompts/*.prompt.txt\` were never wired into the built \`system_prompt_text\`. Agents were running on suffix + boilerplate only. \`_build_system_prompt\` checks for \`prompt_file\` then falls through; with no reference, the SOP text was never loaded.

2. **Suffix didn't tell the LLM to extract first**. The procedural sequence in the SOP is correct for filing flows (EXTRACT → VALIDATE_DEDUCTEES → COMPUTE → ...) but for ad-hoc calculate-only chat queries it drove the BUG-17 symptom.

## Fix

- Add \`prompt_file\` for all 5 CA agents in \`core/agents/packs/ca/__init__.py\` (the runtime source-of-truth via \`_REGISTERED_PACKS\`).
- Add an INTERACTIVE EXTRACTION clause to every agent's \`system_prompt_suffix\`. TDS gets the canonical tester prompt with the explicit extraction → \`calculate_tds(amount=50000, section=\"194C\")\` → report walkthrough.
- Strengthen \`prompts/tds_compliance.prompt.txt\` with an \`<interactive_extraction>\` section so the SOP itself carries the pattern (belt-and-braces — landed via \`prompt_file\` path AND suffix).
- Mirror in \`config.yaml\` for human readability (this file is YAML mirror only — \`_REGISTERED_PACKS\` in \`__init__.py\` is the runtime source).

The installer's existing repair branch (\`installer.py:545\`) refreshes \`agent.system_prompt_text\` on resync, so the existing 5 backfilled tenants will pick up the new prompt the next time \`sync_company_pack_assets_for_session\` runs against them. **Operational follow-up**: after deploy, re-run the same Cloud Run job for each tenant. Idempotent — same agent IDs, same companies, just refreshes the stored prompt.

## Near-miss caught during implementation

Initially added explicit \`type:\` fields to each agent dict. Realized this would change \`_agent_type\` output from \`fp_a_analyst_agent\` (slugified name) to \`fpa_analyst\` (explicit). Lookup by \`agent_type\` would miss every existing row → 85+ duplicate agents on next backfill. **Reverted** and added \`test_ca_pack_agent_types_match_existing_db_rows\` to pin the derived types to the live DB convention so this stays impossible without an explicit data migration.

## Regression coverage (5 new pins)

- \`test_every_ca_pack_agent_has_prompt_file_and_extraction_suffix\` — all 5 agents wire a \`.prompt.txt\` AND carry the INTERACTIVE EXTRACTION clause AND reference issue #440.
- \`test_tds_compliance_suffix_carries_canonical_tester_example\` — TDS suffix has the canonical fragments (\`INR 50,000\`, \`Section 194C\`, \`April 2026\`, \`Form 26Q\`) and the explicit \`calculate_tds(amount=50000, section=\"194C\")\` walkthrough.
- \`test_tds_compliance_prompt_file_has_interactive_extraction_section\` — the SOP file itself carries the extraction section + worked example.
- \`test_built_tds_system_prompt_includes_extraction_instruction\` — **end-to-end runtime contract**: the actual string the installer persists to \`agent.system_prompt_text\` contains BOTH the suffix's INTERACTIVE EXTRACTION clause AND the SOP's worked example AND the existing \`<tds_rules>\` body. Pins the wiring (prompt_file resolution + system_prompt_suffix concatenation + tool listing).
- \`test_ca_pack_agent_types_match_existing_db_rows\` — pin the derived \`_agent_type\` values to the live DB convention. Stops the type-rename foot-gun.

## Test plan

- [x] \`pytest tests/regression/test_ca_firms_may03_reopens.py tests/unit/test_ca_pack.py tests/unit/test_inventory_stale_ca_pack_agents.py tests/unit/test_ca_api_functional.py\` → 108 passed (up from 99; 5 new pins + 1 idempotency guard).
- [x] \`SKIP_PYTEST=1 bash scripts/preflight.sh\` → all gates green.
- [ ] After merge + deploy, re-run \`sync_company_pack_assets_for_session\` for the 5 already-backfilled tenants (Uday primary, Uday secondary, Demo CA Firm, Aishwarya, FinanceTest) so their \`system_prompt_text\` picks up the new extraction instruction.
- [ ] Post-prompt-refresh, re-send the canonical TDS tester prompt to Uday's TDS Compliance Agent on prod and verify the API \`answer\` field contains a \`calculate_tds\` outcome (not a clarification ask).

## Out of scope

- **Shadow-runner per-agent fixtures**: the sentinel prompt at \`runner.py:482-517\` is generic. Improving it for shadow-accuracy gating toward 80% is a separate concern. Filing follow-up if the suffix change alone doesn't move the needle.
- **Backfill of the new prompt to existing agents**: operational, post-deploy. Same Cloud Run job pattern as the connector_ids backfill — unchanged code path, just rerun.
- **External-tenant backfills** (\`fa387ecf\` Gunjan, \`0661ea19\` Roni) remain held until owner approval (per your instruction).

@codex review