### PR TITLE
fix(chat): TDS Compliance Agent deterministic runtime route (#440)

### DIFF
--- a/api/v1/_tds_routing.py
+++ b/api/v1/_tds_routing.py
@@ -40,10 +40,22 @@ from typing import Any
 # Detection patterns
 # ----------------------------------------------------------------------
 
-# Indian TDS sections the calculator supports (per
-# connectors.finance.zoho_books.calculate_tds rate table).
+# Indian TDS section detector. Matches any ``194<letter>`` form (and
+# 194A-Q variants). Codex P1 on PR #445: an earlier allowlist regex
+# (``194[ACHIJOQ]``) silently dropped unsupported variants like
+# ``194ZZZ`` to ``section=None`` → route returned None → fell through
+# to the LLM, contradicting the "never silently fall through" promise.
+# Now: detect any 194-series mention, let the calculator surface a
+# clear "unsupported section" error to the user.
+#
+# Section 192 (salary TDS) is intentionally NOT in this regex — Codex
+# P2: ``ZohoBooksConnector.calculate_tds`` has no 192 rate (salary TDS
+# is slab-based with HRA/standard-deduction/regime variants the
+# deterministic helper can't model). Salary prompts must fall through
+# to the LLM which can reason about slab tiers. Including 192 here
+# would intercept salary queries and surface a useless error.
 _TDS_SECTION_RE = re.compile(
-    r"\b(?:section\s+)?(194[ACHIJOQ]|192)\b",
+    r"\b(?:section\s+)?(194[A-Z]+)\b",
     re.IGNORECASE,
 )
 

--- a/api/v1/_tds_routing.py
+++ b/api/v1/_tds_routing.py
@@ -1,0 +1,317 @@
+"""TDS Compliance Agent deterministic chat route — issue #440.
+
+The TDS Compliance Agent's user-visible BUG-17 symptom kept reproducing
+even after PR #434 (tool binding) + PR #443 (prompt extraction language
++ backfill across 5 tenants × 85 agents). gpt-4o was treating the
+prompt's worked example as a clarification template instead of as an
+extraction guide:
+
+    USER: Calculate TDS for vendor payment of INR 50,000 under Section 194C
+          for April 2026 and file Form 26Q
+    AGENT: Please provide the following details:
+           1. Amount of payment (e.g., INR 50,000)   ← parroting the example
+           2. Applicable TDS section (e.g., 194C)    ← parroting the example
+           ...
+
+This module implements a **narrowly-scoped runtime route** that bypasses
+the LLM for the calculation step when the user's chat message clearly
+contains the required parameters. Scope:
+
+- TDS Compliance Agent ONLY (gated on agent_type)
+- calculate_tds is a pure deterministic computation (no Zoho API call,
+  just rate × amount math); safe to call without OAuth
+- Form 26Q filing is NEVER invoked here — that requires HITL + GSTN
+  credentials. If the user requests filing, this route returns the
+  calculated TDS plus a fail-closed blocker enumerating what's missing
+- If detection fails (no amount, no section, no action verb), returns
+  None and the chat handler falls through to the existing LLM path
+
+The point is to make BUG-11/17 closure independent of LLM behavior
+tuning, not to replace the LLM globally. No tool_choice="required",
+no global runtime change, no impact on any other agent.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# ----------------------------------------------------------------------
+# Detection patterns
+# ----------------------------------------------------------------------
+
+# Indian TDS sections the calculator supports (per
+# connectors.finance.zoho_books.calculate_tds rate table).
+_TDS_SECTION_RE = re.compile(
+    r"\b(?:section\s+)?(194[ACHIJOQ]|192)\b",
+    re.IGNORECASE,
+)
+
+# Action verbs that signal computation/filing intent.
+_TDS_ACTION_RE = re.compile(
+    r"\b(calculate|compute|compute\s+tds|file|filing|submit|prepare|deduct|withhold)\b",
+    re.IGNORECASE,
+)
+
+# Amount patterns — covers "INR 50,000", "Rs. 50000", "₹50,000", and the
+# bare-number-after-amount-keyword case ("amount of 50000"). Captures
+# the numeric group in either alternation.
+_TDS_AMOUNT_RE = re.compile(
+    r"(?:(?:INR|Rs\.?|₹)\s*([\d,]+(?:\.\d+)?))"
+    r"|(?:\b(\d{1,3}(?:,\d{3})+(?:\.\d+)?|\d{4,}(?:\.\d+)?)\s*(?:INR|Rs\.?|rupees|/-)\b)"
+    r"|(?:(?:amount\s+of|payment\s+of|paid|paying)\s+(?:INR|Rs\.?|₹)?\s*([\d,]+(?:\.\d+)?))",
+    re.IGNORECASE,
+)
+
+# Period — month + year, quarter, or financial year.
+_TDS_PERIOD_RE = re.compile(
+    r"\b(?:January|February|March|April|May|June|July|August|"
+    r"September|October|November|December|Jan|Feb|Mar|Apr|Jun|"
+    r"Jul|Aug|Sep|Oct|Nov|Dec)[A-Za-z]*\s+\d{4}\b"
+    r"|\bQ[1-4]\s+(?:FY)?\s*\d{2,4}\b"
+    r"|\bFY\s*\d{2,4}(?:-\d{2,4})?\b",
+    re.IGNORECASE,
+)
+
+# Form 26Q / 24Q filing intent.
+_FILING_FORM_RE = re.compile(
+    r"\bform\s*(26[A-Z]|24[A-Z])\b|\b(26[A-Z]|24[A-Z])\s*return\b",
+    re.IGNORECASE,
+)
+
+# Deductee type.
+_DEDUCTEE_TYPE_RE = re.compile(
+    r"\b(individual|huf|company|firm|partnership|trust)\b",
+    re.IGNORECASE,
+)
+
+# PAN — 5 letters, 4 digits, 1 letter.
+_PAN_RE = re.compile(r"\b[A-Z]{5}\d{4}[A-Z]\b")
+
+# Explicit "PAN unavailable" signal in the prompt — without this we
+# treat PAN as available for calculation purposes and surface a
+# 206AA caveat. This avoids the wrong-rate trap where every
+# "calculate TDS for X" query without a PAN would silently apply
+# the 20% penalty rate instead of the section rate.
+_NO_PAN_RE = re.compile(
+    r"\b(no\s+pan|without\s+pan|pan\s+(?:not|un)\s*(?:available|provided|furnished)|missing\s+pan)\b",
+    re.IGNORECASE,
+)
+
+
+def _extract_amount(query: str) -> float | None:
+    match = _TDS_AMOUNT_RE.search(query)
+    if not match:
+        return None
+    raw = next((g for g in match.groups() if g), None)
+    if not raw:
+        return None
+    try:
+        return float(raw.replace(",", ""))
+    except ValueError:
+        return None
+
+
+def _extract_section(query: str) -> str | None:
+    match = _TDS_SECTION_RE.search(query)
+    if not match:
+        return None
+    return match.group(1).upper()
+
+
+def _extract_period(query: str) -> str | None:
+    match = _TDS_PERIOD_RE.search(query)
+    return match.group(0) if match else None
+
+
+def _extract_deductee_type(query: str) -> str | None:
+    match = _DEDUCTEE_TYPE_RE.search(query)
+    return match.group(1).lower() if match else None
+
+
+def _extract_pan(query: str) -> str | None:
+    match = _PAN_RE.search(query)
+    return match.group(0) if match else None
+
+
+def _filing_requested(query: str) -> str | None:
+    """Return the form name if filing is requested, else None."""
+    match = _FILING_FORM_RE.search(query)
+    if not match:
+        return None
+    return (match.group(1) or match.group(2) or "").upper() or None
+
+
+# ----------------------------------------------------------------------
+# Public entrypoint
+# ----------------------------------------------------------------------
+
+
+# Agent types for which this route is active. Single-element tuple today;
+# explicit so adding a sibling agent later is a one-line change.
+TDS_ROUTE_AGENT_TYPES: tuple[str, ...] = ("tds_compliance_agent",)
+
+
+async def try_tds_deterministic_route(
+    *,
+    agent_type: str | None,
+    query: str,
+) -> dict[str, Any] | None:
+    """Issue #440 / BUG-17: if this is the TDS Compliance Agent and the
+    user's message contains amount + section + an action verb, invoke
+    calculate_tds deterministically (pure math, no Zoho API), construct
+    a tool_calls trace, and return early with a fully-formed answer.
+
+    Returns ``None`` when:
+      * agent isn't TDS Compliance, or
+      * query lacks any required signal (amount, section, action verb).
+
+    When ``None``, the caller falls through to the existing LLM path.
+
+    NEVER invokes the actual filing API. If the user requested Form
+    26Q/24Q filing, the response includes a fail-closed blocker that
+    enumerates the genuinely-missing fields (PAN, deductee_type,
+    challan, HITL approval, GSTN credential) — without re-asking for
+    amount/section/period that were already in the prompt.
+    """
+    if agent_type not in TDS_ROUTE_AGENT_TYPES:
+        return None
+    if not query or not _TDS_ACTION_RE.search(query):
+        return None
+
+    amount = _extract_amount(query)
+    section = _extract_section(query)
+    if amount is None or section is None:
+        return None
+
+    period = _extract_period(query)
+    deductee_type = _extract_deductee_type(query) or "individual"
+    pan = _extract_pan(query)
+    requested_form = _filing_requested(query)
+
+    # PAN handling: only treat PAN as unavailable when the user
+    # *explicitly* says so. A query like "calculate TDS for INR 50,000
+    # under Section 194C" is asking for the section rate, not the
+    # Section 206AA penalty rate that would apply if PAN were missing.
+    # Surface the 206AA caveat as a separate warning instead of baking
+    # it into the rate silently.
+    pan_explicitly_missing = bool(_NO_PAN_RE.search(query))
+    pan_available_for_calc = bool(pan) or not pan_explicitly_missing
+
+    # Pure-math deterministic helper — same code path as the connector's
+    # calculate_tds tool, no OAuth or network needed for the calculation.
+    from connectors.finance.zoho_books import ZohoBooksConnector
+
+    conn = ZohoBooksConnector(config={})
+    calc = await conn.calculate_tds(
+        amount=amount,
+        section=section,
+        deductee_type=deductee_type,
+        pan_available=pan_available_for_calc,
+    )
+    if "error" in calc:
+        # Section unsupported or other input error — surface and bail
+        # so the LLM path is never silently reached without telling the
+        # user we tried.
+        answer = (
+            f"Unable to calculate TDS deterministically: {calc['error']}. "
+            "Please rephrase with a supported section "
+            "(194A, 194C, 194H, 194I, 194J, 194O, 194Q)."
+        )
+        return {
+            "answer": answer,
+            "tool_calls": [],
+            "confidence": 0.45,
+            "tools_used": False,
+        }
+
+    # Build a tool_calls trace mirroring what the LangGraph runner
+    # would emit for a calculate_tds invocation. Downstream consumers
+    # (audit log, chat-history persistence, future analytics) read this
+    # field expecting the same shape.
+    tool_call = {
+        "tool": "calculate_tds",
+        "connector": "zoho_books",
+        "arguments": {
+            "amount": amount,
+            "section": section,
+            "deductee_type": deductee_type,
+            "pan_available": pan_available_for_calc,
+        },
+        "result": calc,
+        "deterministic_route": True,
+        "route_reason": "issue_440_tds_runtime_routing",
+    }
+
+    parts: list[str] = []
+    parts.append(
+        f"Calculated TDS deterministically for amount=INR {amount:,.0f} "
+        f"under Section {section}"
+        + (f" (period: {period})" if period else "")
+        + ":"
+    )
+    parts.append(
+        f"  • Rate applied: {calc['rate'] * 100:.2f}%\n"
+        f"  • TDS amount: INR {calc['tds_amount']:,.2f}\n"
+        f"  • Net payable to vendor: INR {calc['net_payable']:,.2f}"
+    )
+    if not pan:
+        if pan_explicitly_missing:
+            parts.append(
+                "  • PAN explicitly missing — Section 206AA HIGHER rate "
+                "of 20% applied above (already reflected in tds_amount)."
+            )
+        else:
+            parts.append(
+                "  • PAN not specified in the prompt — calculation used "
+                "the Section "
+                + section
+                + " rate. If PAN is unavailable for the deductee, "
+                "Section 206AA would apply a higher 20% rate; re-send "
+                "with 'PAN not available' if that's the case."
+            )
+
+    if requested_form:
+        # Filing was requested. We do NOT call the real filing API.
+        # Enumerate genuinely-missing fields (those NOT already in the
+        # prompt). Never re-ask for amount, section, or period — those
+        # were extracted above.
+        missing: list[str] = []
+        if not pan:
+            missing.append("PAN of the deductee")
+        if deductee_type == "individual" and not _DEDUCTEE_TYPE_RE.search(query):
+            missing.append("deductee type (individual / HUF / company / firm)")
+        # Always required for filing, never extractable from chat:
+        missing.extend(
+            [
+                "TAN of the deductor",
+                "BSR code + challan serial + deposit date "
+                "(Challan 281 payment evidence)",
+                "explicit human-in-the-loop approval (filings cannot "
+                "auto-submit per CA pack policy)",
+                "active GSTN/Income-Tax portal credential for the "
+                "filing endpoint",
+            ]
+        )
+        parts.append(
+            f"\nForm {requested_form} filing requested but blocked "
+            "fail-closed. The calculation above is final; filing "
+            "requires the following fields/conditions before any "
+            "submission attempt:"
+        )
+        parts.extend(f"  ✗ {item}" for item in missing)
+        parts.append(
+            "\nNo actual filing call was made. Re-send the request "
+            "with the missing fields and route through the partner-"
+            "review (HITL) queue to proceed."
+        )
+        confidence = 0.85  # Calculation is exact; filing is correctly blocked
+    else:
+        confidence = 0.92  # Pure calculation, no follow-up gate needed
+
+    return {
+        "answer": "\n".join(parts),
+        "tool_calls": [tool_call],
+        "confidence": confidence,
+        "tools_used": True,
+    }

--- a/api/v1/chat.py
+++ b/api/v1/chat.py
@@ -369,6 +369,12 @@ class ChatQueryResponse(BaseModel):
     agent: str
     confidence: float
     domain: str
+    # Issue #440 (TDS deterministic route): when the chat handler bypasses
+    # the LLM and invokes a tool deterministically, the tool_calls trace
+    # is surfaced here so audit/regression/UI can verify a real tool
+    # invocation happened. ``None`` means "LLM path was used" — that
+    # path persists tool_calls in the langgraph_run result instead.
+    tool_calls: list[dict] | None = None
 
 
 class ChatMessage(BaseModel):
@@ -437,9 +443,46 @@ async def chat_query(
     # still showed 60% even when the LLM had high-quality reasoning.
     tools_used = False
     confidence: float | None = None
+    deterministic_tool_calls: list[dict] | None = None
 
     # Resolve agent_type: prefer DB value, fall back to domain keyword (BUG #3)
     resolved_agent_type = agent_type or domain
+
+    # Issue #440 / BUG-17 closure: TDS Compliance Agent gets a narrow
+    # deterministic route. When the user message clearly contains the
+    # parameters calculate_tds needs (amount + section + an action verb),
+    # bypass the LLM, invoke the calculator directly (pure math, no
+    # Zoho API), and surface a tool_calls trace + a fail-closed filing
+    # blocker if Form 26Q was requested. Behavior independent of LLM
+    # tuning — closes the "agent asks for fields already in the same
+    # sentence" symptom that survived prompt-extraction fixes
+    # (PR #443) because gpt-4o was treating the worked example as a
+    # clarification template.
+    #
+    # Scope is intentionally narrow: only TDS Compliance Agent, only
+    # when all required signals are present, never invokes the actual
+    # filing API. If detection fails, returns None and the LLM path
+    # below runs unchanged.
+    try:
+        from api.v1._tds_routing import try_tds_deterministic_route
+
+        det = await try_tds_deterministic_route(
+            agent_type=resolved_agent_type,
+            query=body.query,
+        )
+    except Exception:  # noqa: BLE001
+        # Detection failure must never block the chat path. Fall through
+        # to the LLM and let the user get an answer somehow.
+        _log.warning("chat_tds_route_helper_raised", exc_info=True)
+        det = None
+    if det is not None:
+        return ChatQueryResponse(
+            answer=det["answer"],
+            agent=agent_name,
+            confidence=float(det["confidence"]),
+            domain=domain,
+            tool_calls=det.get("tool_calls") or None,
+        )
 
     # Build connector config (Ramesh/Uday 2026-04-28). Previously chat
     # only checked `request.state.connector_config` — but no middleware

--- a/api/v1/chat.py
+++ b/api/v1/chat.py
@@ -443,7 +443,6 @@ async def chat_query(
     # still showed 60% even when the LLM had high-quality reasoning.
     tools_used = False
     confidence: float | None = None
-    deterministic_tool_calls: list[dict] | None = None
 
     # Resolve agent_type: prefer DB value, fall back to domain keyword (BUG #3)
     resolved_agent_type = agent_type or domain

--- a/tests/regression/test_ca_firms_may03_reopens.py
+++ b/tests/regression/test_ca_firms_may03_reopens.py
@@ -351,3 +351,205 @@ def test_built_tds_system_prompt_includes_extraction_instruction() -> None:
     assert "Section 234E" in built  # from the existing <tds_rules> block
     # Tool list still appended (sanity)
     assert "Authorized tools" in built
+
+
+# ----------------------------------------------------------------------
+# Issue #440 — TDS Compliance Agent deterministic chat route. The
+# tester's exact prompt must produce a calculate_tds tool_call without
+# asking for amount, section, or period. Filing must fail-closed
+# without invoking the real filing API.
+# ----------------------------------------------------------------------
+
+
+def _canonical_tester_prompt() -> str:
+    return (
+        "Calculate TDS for vendor payment of INR 50,000 under Section 194C "
+        "for April 2026 and file Form 26Q"
+    )
+
+
+def test_tds_route_returns_none_for_other_agents() -> None:
+    """Issue #440 scope: deterministic route must NEVER fire for non-TDS
+    agents. Bank reconciliation, AR collections, FP&A, GST filing all
+    keep the existing LLM path."""
+    import asyncio
+
+    from api.v1._tds_routing import try_tds_deterministic_route
+
+    for other in (
+        "gst_filing_agent",
+        "bank_reconciliation_agent",
+        "fp_a_analyst_agent",
+        "ar_collections_agent",
+        "campaign_pilot",
+        None,
+    ):
+        result = asyncio.run(
+            try_tds_deterministic_route(
+                agent_type=other,
+                query=_canonical_tester_prompt(),
+            )
+        )
+        assert result is None, (
+            f"Deterministic TDS route fired for agent_type={other!r} — "
+            "scope leak. The route must only fire for "
+            "'tds_compliance_agent'."
+        )
+
+
+def test_tds_route_returns_none_when_signals_missing() -> None:
+    """Issue #440: the route must fall through to the LLM whenever a
+    required signal is missing. Three negative cases."""
+    import asyncio
+
+    from api.v1._tds_routing import try_tds_deterministic_route
+
+    cases = [
+        # No section
+        "Calculate TDS for vendor payment of INR 50,000 for April 2026",
+        # No amount
+        "Calculate TDS under Section 194C for April 2026",
+        # No action verb
+        "Vendor payment of INR 50,000 under Section 194C in April 2026",
+        # Empty
+        "",
+    ]
+    for query in cases:
+        result = asyncio.run(
+            try_tds_deterministic_route(
+                agent_type="tds_compliance_agent",
+                query=query,
+            )
+        )
+        assert result is None, (
+            f"Route fired for incomplete query {query!r} — should fall "
+            "through to LLM."
+        )
+
+
+def test_tds_route_canonical_tester_prompt_invokes_calculate_tds() -> None:
+    """Issue #440 / BUG-17 closure: the exact tester prompt produces a
+    calculate_tds tool_call with the extracted arguments, no asks for
+    amount/section/period that were already in the prompt, and a
+    fail-closed Form 26Q filing blocker (no real filing call)."""
+    import asyncio
+
+    from api.v1._tds_routing import try_tds_deterministic_route
+
+    result = asyncio.run(
+        try_tds_deterministic_route(
+            agent_type="tds_compliance_agent",
+            query=_canonical_tester_prompt(),
+        )
+    )
+    assert result is not None, "Route must fire for the canonical prompt"
+
+    # tool_calls evidence
+    tool_calls = result["tool_calls"]
+    assert len(tool_calls) == 1
+    tc = tool_calls[0]
+    assert tc["tool"] == "calculate_tds"
+    assert tc["connector"] == "zoho_books"
+    assert tc["arguments"]["amount"] == 50000.0
+    assert tc["arguments"]["section"] == "194C"
+    # The route's deterministic-marker is what audit/forensics will look
+    # for to distinguish runtime-routed calls from LLM-decided ones.
+    assert tc.get("deterministic_route") is True
+    assert tc.get("route_reason") == "issue_440_tds_runtime_routing"
+
+    # The TDS calculation result is in the tool_call.
+    assert tc["result"]["status"] == "calculated"
+    assert tc["result"]["tds_amount"] == 500.0  # 50000 * 0.01 (194C individual)
+    assert tc["result"]["rate"] == 0.01
+
+    # tools_used flag must be true so downstream audit treats this as a
+    # tool-backed answer.
+    assert result["tools_used"] is True
+
+    # Confidence must NOT be the LLM-only floor (~0.4). The deterministic
+    # path has hard evidence; floor here is much higher.
+    assert result["confidence"] >= 0.85
+
+    # Answer text — anti-clarification + fail-closed blocker
+    answer = result["answer"]
+    answer_lower = answer.lower()
+
+    # Calculation reported
+    assert "500" in answer  # tds_amount
+    assert "1.00%" in answer or "1.0%" in answer or "1%" in answer
+    assert "49,500" in answer or "49500" in answer  # net_payable
+
+    # NO clarification ask for already-provided fields. These exact
+    # phrases would be the BUG-17 symptom resurfacing.
+    forbidden = (
+        "what is the payment amount",
+        "please provide the payment amount",
+        "please provide the amount",
+        "what is the section",
+        "please provide the section",
+        "please provide the period",
+        "what period",
+        "amount of payment",
+    )
+    for phrase in forbidden:
+        assert phrase not in answer_lower, (
+            f"BUG-17 clarification phrase {phrase!r} appeared in the "
+            "deterministic route answer — should never re-ask for "
+            "fields that were extracted from the prompt."
+        )
+
+    # Form 26Q filing was requested → fail-closed blocker present
+    assert "26Q" in answer
+    assert "blocked" in answer_lower or "not made" in answer_lower
+    # Enumerate the genuinely-missing fields (nothing about amount/section)
+    assert "PAN" in answer or "pan" in answer_lower
+    assert "TAN" in answer or "tan" in answer_lower
+    assert "HITL" in answer or "human-in-the-loop" in answer_lower
+
+
+def test_tds_route_calculation_only_when_no_filing_requested() -> None:
+    """Issue #440: a calculate-only prompt (no Form 26Q) returns the
+    calculation cleanly with NO filing blocker noise."""
+    import asyncio
+
+    from api.v1._tds_routing import try_tds_deterministic_route
+
+    result = asyncio.run(
+        try_tds_deterministic_route(
+            agent_type="tds_compliance_agent",
+            query="Calculate TDS for INR 100,000 under Section 194J",
+        )
+    )
+    assert result is not None
+    assert result["tool_calls"][0]["arguments"]["amount"] == 100000.0
+    assert result["tool_calls"][0]["arguments"]["section"] == "194J"
+    answer = result["answer"]
+    # Calculation present
+    assert "10,000" in answer or "10000" in answer  # 194J = 10%
+    # No filing blocker noise when filing wasn't asked for
+    assert "26Q" not in answer
+    assert "TAN" not in answer
+    assert "HITL" not in answer
+
+
+def test_tds_route_unsupported_section_returns_clear_error() -> None:
+    """Issue #440: if the section is one we don't have a rate for,
+    surface a clear error and a list of supported sections — never
+    silently fall through to the LLM (which would just hallucinate
+    the rate)."""
+    import asyncio
+
+    from api.v1._tds_routing import try_tds_deterministic_route
+
+    result = asyncio.run(
+        try_tds_deterministic_route(
+            agent_type="tds_compliance_agent",
+            query="Calculate TDS for INR 50,000 under Section 194ZZZ",
+        )
+    )
+    # 194ZZZ matches the section regex but isn't in the rate table
+    if result is not None:
+        # The route fired — must surface an error, not hallucinate
+        answer = result["answer"].lower()
+        assert "unsupported" in answer or "error" in answer
+        assert "194a" in answer  # supported list mentioned

--- a/tests/regression/test_ca_firms_may03_reopens.py
+++ b/tests/regression/test_ca_firms_may03_reopens.py
@@ -533,10 +533,16 @@ def test_tds_route_calculation_only_when_no_filing_requested() -> None:
 
 
 def test_tds_route_unsupported_section_returns_clear_error() -> None:
-    """Issue #440: if the section is one we don't have a rate for,
-    surface a clear error and a list of supported sections — never
-    silently fall through to the LLM (which would just hallucinate
-    the rate)."""
+    """Issue #440 (Codex P1 on PR #445): if the section is a 194-series
+    code we don't have a rate for, the route MUST fire and surface an
+    explicit unsupported-section error. Never silently fall through to
+    the LLM — that would let the LLM hallucinate a rate.
+
+    Pre-fix: an allowlist regex (``194[ACHIJOQ]``) skipped ``194ZZZ``
+    entirely, so ``_extract_section`` returned None and the route
+    returned None too. Now the regex matches any ``194<letter>+`` and
+    the calculator's "unsupported TDS section" error reaches the user.
+    """
     import asyncio
 
     from api.v1._tds_routing import try_tds_deterministic_route
@@ -547,9 +553,44 @@ def test_tds_route_unsupported_section_returns_clear_error() -> None:
             query="Calculate TDS for INR 50,000 under Section 194ZZZ",
         )
     )
-    # 194ZZZ matches the section regex but isn't in the rate table
-    if result is not None:
-        # The route fired — must surface an error, not hallucinate
-        answer = result["answer"].lower()
-        assert "unsupported" in answer or "error" in answer
-        assert "194a" in answer  # supported list mentioned
+    assert result is not None, (
+        "Route must fire for any 194-series code (even unsupported ones) "
+        "and surface the calculator's error — never silently fall "
+        "through to the LLM where a hallucinated rate would slip past."
+    )
+    answer = result["answer"].lower()
+    assert "unsupported" in answer or "unable" in answer
+    assert "194a" in answer  # supported list mentioned
+    # Tools NOT used (calculator rejected the input)
+    assert result["tools_used"] is False
+    assert result["tool_calls"] == []
+
+
+def test_tds_route_section_192_falls_through_to_llm() -> None:
+    """Issue #440 (Codex P2 on PR #445): Section 192 (salary TDS) is
+    slab-based with HRA / standard-deduction / regime variants that
+    the deterministic calculator can't model. The route gate must
+    NOT include 192; salary-TDS prompts must reach the LLM which can
+    reason about the slabs.
+    """
+    import asyncio
+
+    from api.v1._tds_routing import try_tds_deterministic_route
+
+    for query in (
+        "Calculate TDS on salary of INR 50,00,000 under Section 192 for FY26",
+        "Compute Section 192 TDS for an employee earning INR 80,000/month",
+    ):
+        result = asyncio.run(
+            try_tds_deterministic_route(
+                agent_type="tds_compliance_agent",
+                query=query,
+            )
+        )
+        assert result is None, (
+            f"Section 192 prompt {query!r} must fall through to the LLM. "
+            "The deterministic calculator has no slab support; "
+            "intercepting it would surface a useless 'unsupported "
+            "section' error instead of letting the LLM walk the user "
+            "through salary-TDS slab math."
+        )


### PR DESCRIPTION
Closes #440 (BUG-11/17 prompt-runtime residual). Pivots from prompt tuning to **targeted runtime routing** for the TDS Compliance Agent only — per direction after PR #443's prompt-side fix shipped clean but didn't flip the user-visible symptom.

## Why prompt tuning alone wasn't enough

PR #443 wired \`prompt_file\` references for all 5 CA agents and added an INTERACTIVE EXTRACTION clause + canonical worked-example to every \`system_prompt_text\` (85 agents refreshed across 5 tenants). On prod, gpt-4o then treated the worked example as a clarification template:

> USER: Calculate TDS for vendor payment of INR 50,000 under Section 194C for April 2026 and file Form 26Q
> AGENT: Please provide:
>   1. Amount of payment (e.g., INR 50,000)   ← parroting the example
>   2. Applicable TDS section (e.g., 194C)    ← parroting the example

Same symptom Uday hit pre-#434. Prompt-only fixes hit a ceiling; the LLM is being conservative on TDS computation specifically.

## Fix — narrow runtime route

\`api/v1/_tds_routing.py\` (new). Detection requires **all four** signals:

| Signal | Matches |
|---|---|
| agent_type | \`tds_compliance_agent\` (scope gate — single-element tuple) |
| Action verb | \`calculate\` / \`compute\` / \`file\` / \`submit\` / \`prepare\` |
| TDS section | \`194A\` / \`194C\` / \`194H\` / \`194I\` / \`194J\` / \`194O\` / \`194Q\` / \`192\` |
| Amount | \`INR 50,000\` / \`Rs. 50000\` / \`₹50,000\` / \`amount of N\` |

When all four fire, the chat handler bypasses the LLM and invokes \`calculate_tds\` deterministically (pure rate × amount math, no Zoho API), synthesizes a tool_calls trace, and:

- Returns the calculated TDS amount, rate, and net payable.
- If Form 26Q/24Q filing was requested, **never invokes the actual filing API** — instead returns a fail-closed blocker enumerating the genuinely-missing fields (deductee PAN, TAN, Challan 281 evidence, HITL approval, GSTN credential).
- If PAN isn't in the prompt, surfaces the Section 206AA caveat as a separate warning rather than baking the 20% penalty rate into the calculation silently.

## Scope discipline

- **TDS Compliance Agent ONLY** — no global \`tool_choice\` change, no impact on bank-recon / FP&A / GST / AR agents
- Detection requires all four signals — single-signal queries fall through to the existing LLM path
- Real filing API never called
- Section 206AA handled as a warning, not as a silent rate change
- New \`ChatQueryResponse.tool_calls\` is an OPTIONAL field (defaults None for the LLM path); backward-compatible

## Regression coverage (5 new pins)

- \`test_tds_route_returns_none_for_other_agents\` — scope gate. Bank-recon / AR / FP&A / GST / unrelated agents must NEVER fire the deterministic route.
- \`test_tds_route_returns_none_when_signals_missing\` — falls through to LLM whenever amount, section, or action verb is absent.
- \`test_tds_route_canonical_tester_prompt_invokes_calculate_tds\` — **the EXACT tester prompt** produces a \`calculate_tds\` tool_call with \`amount=50000\` + \`section=194C\`, no clarification ask for the fields already in the prompt, and a fail-closed Form 26Q blocker citing PAN/TAN/HITL.
- \`test_tds_route_calculation_only_when_no_filing_requested\` — pure calculation prompts return cleanly without filing-blocker noise.
- \`test_tds_route_unsupported_section_returns_clear_error\` — surfaces explicit error and lists supported sections rather than silently falling through.

## Test plan

- [x] \`pytest tests/regression/test_ca_firms_may03_reopens.py tests/unit/test_ca_pack.py tests/unit/test_inventory_stale_ca_pack_agents.py tests/unit/test_ca_api_functional.py tests/unit/test_bug_sweep_24apr.py tests/regression/test_qa_28apr_sweep.py\` → 187 passed
- [x] \`SKIP_PYTEST=1 bash scripts/preflight.sh\` → all gates green
- [ ] After deploy: re-walk the canonical tester prompt against Uday's TDS agent, capture tool_calls evidence + verify no clarification ask
- [ ] Run several shadow samples on the TDS agent — note that the runtime route only fires for chat queries; \`shadow_sample\` uses a different prompt sentinel, so movement off the no-tool-call floor would be a bonus, not the primary closure signal

## Out of scope

- \`tool_choice=\"required\"\` / global runtime change (would affect every agent — too broad for one agent's behavior)
- Connector-side actual filing implementation (intentionally fail-closed per CA pack policy)
- Shadow-runner per-agent fixtures (separate concern; this PR closes the chat path, the shadow path is the next iteration if BUG-11's no-tool-call floor doesn't move)

@codex review