### PR TITLE
fix: close May 5 issue and security sweep

### DIFF
--- a/api/v1/_tds_routing.py
+++ b/api/v1/_tds_routing.py
@@ -65,25 +65,55 @@ _TDS_ACTION_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Amount patterns — covers "INR 50,000", "Rs. 50000", "₹50,000", and the
-# bare-number-after-amount-keyword case ("amount of 50000"). Captures
-# the numeric group in either alternation.
-_TDS_AMOUNT_RE = re.compile(
-    r"(?:(?:INR|Rs\.?|₹)\s*([\d,]+(?:\.\d+)?))"
-    r"|(?:\b(\d{1,3}(?:,\d{3})+(?:\.\d+)?|\d{4,}(?:\.\d+)?)\s*(?:INR|Rs\.?|rupees|/-)\b)"
-    r"|(?:(?:amount\s+of|payment\s+of|paid|paying)\s+(?:INR|Rs\.?|₹)?\s*([\d,]+(?:\.\d+)?))",
-    re.IGNORECASE,
+# Amount patterns cover "INR 50,000", "Rs. 50000", "₹50,000", and
+# "amount/payment of 50000". Keep these deliberately simple: chat
+# messages are untrusted input and CodeQL flags overlapping/nested
+# extraction regexes as ReDoS-prone.
+_TDS_AMOUNT_RES: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"(?:INR|Rs\.?|₹)\s*(?P<num>\d[\d,]*(?:\.\d+)?)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?P<num>\d[\d,]*(?:\.\d+)?)\s*(?:INR|Rs\.?|rupees|/-)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:amount\s+of|payment\s+of|paid|paying)\s+"
+        r"(?:INR|Rs\.?|₹)?\s*(?P<num>\d[\d,]*(?:\.\d+)?)",
+        re.IGNORECASE,
+    ),
 )
 
-# Period — month + year, quarter, or financial year.
-_TDS_PERIOD_RE = re.compile(
-    r"\b(?:January|February|March|April|May|June|July|August|"
-    r"September|October|November|December|Jan|Feb|Mar|Apr|Jun|"
-    r"Jul|Aug|Sep|Oct|Nov|Dec)[A-Za-z]*\s+\d{4}\b"
-    r"|\bQ[1-4]\s+(?:FY)?\s*\d{2,4}\b"
-    r"|\bFY\s*\d{2,4}(?:-\d{2,4})?\b",
-    re.IGNORECASE,
-)
+# Period: month + year, quarter, or financial year.
+_MONTH_YEAR_RE = re.compile(r"\b(?P<month>[A-Za-z]+)\s+(?P<year>\d{4})\b")
+_QUARTER_RE = re.compile(r"\bQ[1-4]\s+(?:FY)?\s*\d{2,4}\b", re.IGNORECASE)
+_FINANCIAL_YEAR_RE = re.compile(r"\bFY\s*\d{2,4}(?:-\d{2,4})?\b", re.IGNORECASE)
+_MONTH_TOKENS = {
+    "january",
+    "february",
+    "march",
+    "april",
+    "may",
+    "june",
+    "july",
+    "august",
+    "september",
+    "october",
+    "november",
+    "december",
+    "jan",
+    "feb",
+    "mar",
+    "apr",
+    "jun",
+    "jul",
+    "aug",
+    "sep",
+    "oct",
+    "nov",
+    "dec",
+}
 
 # Form 26Q / 24Q filing intent.
 _FILING_FORM_RE = re.compile(
@@ -112,10 +142,12 @@ _NO_PAN_RE = re.compile(
 
 
 def _extract_amount(query: str) -> float | None:
-    match = _TDS_AMOUNT_RE.search(query)
-    if not match:
-        return None
-    raw = next((g for g in match.groups() if g), None)
+    raw = None
+    for pattern in _TDS_AMOUNT_RES:
+        match = pattern.search(query)
+        if match:
+            raw = match.group("num")
+            break
     if not raw:
         return None
     try:
@@ -132,7 +164,13 @@ def _extract_section(query: str) -> str | None:
 
 
 def _extract_period(query: str) -> str | None:
-    match = _TDS_PERIOD_RE.search(query)
+    for match in _MONTH_YEAR_RE.finditer(query):
+        if match.group("month").lower() in _MONTH_TOKENS:
+            return match.group(0)
+    match = _QUARTER_RE.search(query)
+    if match:
+        return match.group(0)
+    match = _FINANCIAL_YEAR_RE.search(query)
     return match.group(0) if match else None
 
 

--- a/api/v1/_tds_routing.py
+++ b/api/v1/_tds_routing.py
@@ -86,9 +86,7 @@ _TDS_AMOUNT_RES: tuple[re.Pattern[str], ...] = (
 )
 
 # Period: month + year, quarter, or financial year.
-_MONTH_YEAR_RE = re.compile(r"\b(?P<month>[A-Za-z]+)\s+(?P<year>\d{4})\b")
-_QUARTER_RE = re.compile(r"\bQ[1-4]\s+(?:FY)?\s*\d{2,4}\b", re.IGNORECASE)
-_FINANCIAL_YEAR_RE = re.compile(r"\bFY\s*\d{2,4}(?:-\d{2,4})?\b", re.IGNORECASE)
+_PERIOD_TOKEN_RE = re.compile(r"[A-Za-z0-9-]+")
 _MONTH_TOKENS = {
     "january",
     "february",
@@ -163,15 +161,57 @@ def _extract_section(query: str) -> str | None:
     return match.group(1).upper()
 
 
+def _looks_like_year_token(token: str) -> bool:
+    parts = token.split("-")
+    return all(part.isdigit() and 2 <= len(part) <= 4 for part in parts)
+
+
+def _format_quarter_period(tokens: list[str], index: int) -> str | None:
+    quarter = tokens[index].upper()
+    if len(quarter) != 2 or quarter[0] != "Q" or quarter[1] not in "1234":
+        return None
+    if index + 1 >= len(tokens):
+        return None
+
+    next_token = tokens[index + 1]
+    next_upper = next_token.upper()
+    if next_upper == "FY" and index + 2 < len(tokens):
+        year_token = tokens[index + 2]
+        if _looks_like_year_token(year_token):
+            return f"{quarter} FY {year_token}"
+    if next_upper.startswith("FY") and _looks_like_year_token(next_token[2:]):
+        return f"{quarter} {next_token}"
+    if _looks_like_year_token(next_token):
+        return f"{quarter} {next_token}"
+    return None
+
+
+def _format_financial_year_period(tokens: list[str], index: int) -> str | None:
+    token = tokens[index]
+    upper = token.upper()
+    if upper == "FY" and index + 1 < len(tokens):
+        year_token = tokens[index + 1]
+        if _looks_like_year_token(year_token):
+            return f"FY {year_token}"
+    if upper.startswith("FY") and _looks_like_year_token(token[2:]):
+        return token
+    return None
+
+
 def _extract_period(query: str) -> str | None:
-    for match in _MONTH_YEAR_RE.finditer(query):
-        if match.group("month").lower() in _MONTH_TOKENS:
-            return match.group(0)
-    match = _QUARTER_RE.search(query)
-    if match:
-        return match.group(0)
-    match = _FINANCIAL_YEAR_RE.search(query)
-    return match.group(0) if match else None
+    tokens = _PERIOD_TOKEN_RE.findall(query)
+    for index, token in enumerate(tokens[:-1]):
+        if token.lower() in _MONTH_TOKENS and tokens[index + 1].isdigit() and len(tokens[index + 1]) == 4:
+            return f"{token} {tokens[index + 1]}"
+    for index in range(len(tokens)):
+        quarter = _format_quarter_period(tokens, index)
+        if quarter:
+            return quarter
+    for index in range(len(tokens)):
+        financial_year = _format_financial_year_period(tokens, index)
+        if financial_year:
+            return financial_year
+    return None
 
 
 def _extract_deductee_type(query: str) -> str | None:

--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -125,9 +125,9 @@ _AGENT_TYPE_DEFAULT_TOOLS: dict[str, list[str]] = {
         "create_page",
     ],
     "campaign_pilot": [
-        "get_campaign_performance_metrics",
-        "adjust_campaign_budget", "get_campaign_performance",
-        "reallocate_ad_budget", "get_reach_and_frequency_data",
+        "search_campaigns", "get_campaign_performance",
+        "mutate_campaign_budget", "get_search_terms",
+        "get_analytics", "get_stats",
     ],
     "seo_strategist": [
         "get_campaign_performance_metrics",
@@ -207,6 +207,14 @@ _AGENT_TYPE_DEFAULT_TOOLS: dict[str, list[str]] = {
     ],
     "chat_agent": [
         "slack_send_message", "send_email", "read_inbox",
+    ],
+}
+
+_AGENT_TYPE_DEFAULT_CONNECTOR_IDS: dict[str, list[str]] = {
+    "campaign_pilot": [
+        "registry-google_ads",
+        "registry-linkedin_ads",
+        "registry-sendgrid",
     ],
 }
 
@@ -711,6 +719,11 @@ async def create_agent(body: AgentCreate, tenant_id: str = Depends(get_current_t
             body.domain,
             body.connector_ids or None,
         )
+    connector_ids = (
+        list(body.connector_ids)
+        if body.connector_ids
+        else list(_AGENT_TYPE_DEFAULT_CONNECTOR_IDS.get(body.agent_type, []))
+    )
 
     # Validate user-provided tools against the registry (skip for auto-populated)
     if body.authorized_tools and tools:
@@ -835,7 +848,7 @@ async def create_agent(body: AgentCreate, tenant_id: str = Depends(get_current_t
             parent_agent_id=(
                 _uuid.UUID(body.parent_agent_id) if body.parent_agent_id else None
             ),
-            connector_ids=list(body.connector_ids) if body.connector_ids else [],
+            connector_ids=connector_ids,
         )
         session.add(agent)
         await session.flush()  # populate agent.id
@@ -1925,6 +1938,10 @@ async def run_agent(
     # connector with overlapping keys is a follow-up to scope into
     # per-connector dicts).
     raw_connector_ids = agent_config.get("connector_ids") or []
+    if not raw_connector_ids:
+        raw_connector_ids = list(
+            _AGENT_TYPE_DEFAULT_CONNECTOR_IDS.get(agent_config.get("agent_type"), [])
+        )
     resolved_connector_config, resolved_connector_names = await _resolve_connector_configs(
         tenant_id=tenant_id,
         connector_ids=raw_connector_ids,
@@ -1984,6 +2001,7 @@ async def run_agent(
         # the trusted server-side fixture path below.
         incoming_inputs.pop("shadow_prompt", None)
         incoming_inputs.pop("shadow_expected_tool", None)
+        incoming_inputs.pop("shadow_fixture_origin", None)
 
         cfg_block = agent_config.get("config") or {}
         if isinstance(cfg_block, dict):
@@ -2077,6 +2095,7 @@ async def run_agent(
             # Unconditional set — we already stripped any caller-
             # supplied shadow_prompt above.
             incoming_inputs["shadow_prompt"] = str(fixture["prompt"])
+            incoming_inputs["shadow_fixture_origin"] = True
             if fixture.get("expected_tool"):
                 incoming_inputs["shadow_expected_tool"] = str(
                     fixture["expected_tool"]

--- a/api/v1/connectors.py
+++ b/api/v1/connectors.py
@@ -85,23 +85,35 @@ router = APIRouter(dependencies=[require_tenant_admin])
 def _connector_to_dict(conn: Connector) -> dict:
     # Return a boolean flag for whether credentials are configured —
     # NEVER return the actual auth_config (secrets) in the API response.
-    has_creds = bool(conn.auth_config) or bool(getattr(conn, "secret_ref", None))
+    auth_config = getattr(conn, "auth_config", None)
+    tool_functions = getattr(conn, "tool_functions", None)
+    has_creds = bool(auth_config) or bool(getattr(conn, "secret_ref", None))
+    health_check_at = getattr(conn, "health_check_at", None)
+    created_at = getattr(conn, "created_at", None)
     return {
         "id": str(conn.id),
         "connector_id": str(conn.id),  # kept for backward compat
-        "name": conn.name,
-        "category": conn.category,
-        "description": conn.description,
-        "base_url": conn.base_url,
-        "auth_type": conn.auth_type,
+        "name": str(conn.name or ""),
+        "category": str(conn.category or ""),
+        "description": conn.description or "",
+        "base_url": conn.base_url or "",
+        "auth_type": str(conn.auth_type or ""),
         "has_credentials": has_creds,
-        "tool_functions": conn.tool_functions,
-        "data_schema_ref": conn.data_schema_ref,
-        "rate_limit_rpm": conn.rate_limit_rpm,
-        "timeout_ms": conn.timeout_ms,
-        "status": conn.status,
-        "health_check_at": conn.health_check_at.isoformat() if conn.health_check_at else None,
-        "created_at": conn.created_at.isoformat() if conn.created_at else None,
+        "tool_functions": tool_functions if isinstance(tool_functions, list) else [],
+        "data_schema_ref": conn.data_schema_ref or "",
+        "rate_limit_rpm": int(conn.rate_limit_rpm or 0),
+        "timeout_ms": int(conn.timeout_ms or 0),
+        "status": str(conn.status or "active"),
+        "health_check_at": (
+            health_check_at.isoformat()
+            if hasattr(health_check_at, "isoformat")
+            else None
+        ),
+        "created_at": (
+            created_at.isoformat()
+            if hasattr(created_at, "isoformat")
+            else None
+        ),
     }
 
 

--- a/api/v1/packs.py
+++ b/api/v1/packs.py
@@ -45,6 +45,8 @@ async def install(name: str, tenant_id: str = Depends(get_current_tenant)):
     try:
         result = await install_pack_async(name, tenant_id)
     except ValueError as exc:
+        if "not installable" in str(exc):
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     return result
 

--- a/api/v1/tenant_ai_credentials.py
+++ b/api/v1/tenant_ai_credentials.py
@@ -363,9 +363,11 @@ async def test_credential(
         status_value = "active" if probe_result["ok"] else "failing"
         err = None if probe_result["ok"] else probe_result.get("error", "")
     except ProviderNotConfigured as exc:
-        # Shouldn't happen — we just loaded the row — but surface honestly
+        # Shouldn't happen — we just loaded the row. Keep response details
+        # class-name-only; provider config details belong in server logs.
+        logger.warning("tenant_ai_credential_provider_not_configured")
         status_value = "failing"
-        err = str(exc)[:500]
+        err = type(exc).__name__
     except Exception as exc:
         logger.exception("tenant_ai_credential_probe_failed")
         status_value = "failing"

--- a/connectors/finance/zoho_books.py
+++ b/connectors/finance/zoho_books.py
@@ -349,6 +349,31 @@ class ZohoBooksConnector(BaseConnector):
         for field in ("from_date", "to_date", "gstin"):
             if params.get(field):
                 qp[field] = params[field]
+
+        if self.config.get("region") == "in" or self.base_url == _ZOHO_IN_BASE:
+            # Zoho Books India does not expose /reports/gstsummary on the
+            # regional API host. Build a read-only GST data slice from the
+            # supported invoices endpoint instead of advertising a tool that
+            # deterministically 404s for India tenants.
+            invoice_qp = {
+                "date_start": qp.get("from_date"),
+                "date_end": qp.get("to_date"),
+                "page": params.get("page"),
+            }
+            invoice_data = await self.list_invoices(
+                **{k: v for k, v in invoice_qp.items() if v is not None}
+            )
+            return {
+                "gst_summary": {
+                    "source": "invoices",
+                    "region": "in",
+                    "gstin": qp.get("gstin"),
+                    "from_date": qp.get("from_date"),
+                    "to_date": qp.get("to_date"),
+                    "invoices": invoice_data.get("invoices", []),
+                    "page_context": invoice_data.get("page_context", {}),
+                }
+            }
         data = await self._get("/reports/gstsummary", params=self._org_params(qp))
         return self._unwrap(data, "gst_summary")
 

--- a/core/agent_generator.py
+++ b/core/agent_generator.py
@@ -247,9 +247,9 @@ _AGENT_TYPE_DEFAULT_TOOLS: dict[str, list[str]] = {
         "manage_publishing_queue", "approve_draft_post", "create_page",
     ],
     "campaign_pilot": [
-        "get_campaign_performance_metrics", "adjust_campaign_budget",
-        "get_campaign_performance", "reallocate_ad_budget",
-        "get_reach_and_frequency_data",
+        "search_campaigns", "get_campaign_performance",
+        "mutate_campaign_budget", "get_search_terms",
+        "get_analytics", "get_stats",
     ],
     "seo_strategist": [
         "get_campaign_performance_metrics", "get_search_term_report",

--- a/core/agents/packs/installer.py
+++ b/core/agents/packs/installer.py
@@ -373,6 +373,8 @@ def list_packs() -> list[dict[str, Any]]:
                 "compliance": cfg.get("compliance", []),
                 "pricing": cfg.get("pricing", {}),
                 "version": cfg.get("version", "0.0.0"),
+                "installable": cfg.get("installable", True),
+                "install_disabled_reason": cfg.get("install_disabled_reason", ""),
             }
         )
 
@@ -391,6 +393,8 @@ def list_packs() -> list[dict[str, Any]]:
                 "compliance": pack_cfg.get("compliance", []),
                 "pricing": pack_cfg.get("pricing", {}),
                 "version": pack_cfg.get("version", "0.0.0"),
+                "installable": pack_cfg.get("installable", True),
+                "install_disabled_reason": pack_cfg.get("install_disabled_reason", ""),
             }
         )
 
@@ -410,6 +414,8 @@ def get_pack_detail(pack_name: str) -> dict[str, Any] | None:
             "compliance": cfg.get("compliance", []),
             "pricing": cfg.get("pricing", {}),
             "version": cfg.get("version", "0.0.0"),
+            "installable": cfg.get("installable", True),
+            "install_disabled_reason": cfg.get("install_disabled_reason", ""),
         }
 
     for pack in list_packs():
@@ -670,6 +676,9 @@ def install_pack(pack_name: str, tenant_id: str) -> dict[str, Any]:
     detail = get_pack_detail(pack_name)
     if detail is None:
         raise ValueError(f"Pack '{pack_name}' not found")
+    if detail.get("installable") is False:
+        reason = detail.get("install_disabled_reason") or "Pack is not installable"
+        raise ValueError(f"Pack '{pack_name}' is not installable: {reason}")
 
     tenant_packs = _installed.setdefault(tenant_id, set())
     if pack_name in tenant_packs:
@@ -928,6 +937,9 @@ async def install_pack_async(pack_name: str, tenant_id: str) -> dict[str, Any]:
     detail = get_pack_detail(pack_name)
     if detail is None:
         raise ValueError(f"Pack '{pack_name}' not found")
+    if detail.get("installable") is False:
+        reason = detail.get("install_disabled_reason") or "Pack is not installable"
+        raise ValueError(f"Pack '{pack_name}' is not installable: {reason}")
 
     tid = UUID(tenant_id)
 

--- a/core/agents/packs/insurance/config.yaml
+++ b/core/agents/packs/insurance/config.yaml
@@ -2,6 +2,8 @@ name: insurance
 display_name: Insurance Pack
 description: AI agents for underwriting, claims adjudication, policy management, and fraud detection
 version: "1.0.0"
+installable: false
+install_disabled_reason: "Insurance pack is gated until Composio insurance/CRM tool bindings are implemented."
 pricing:
   inr_monthly_per_client: 7999
   usd_monthly_per_client: 95

--- a/core/agents/packs/legal/config.yaml
+++ b/core/agents/packs/legal/config.yaml
@@ -2,6 +2,8 @@ name: legal
 display_name: Legal Pack
 description: AI agents for contract review, case research, document drafting, and compliance checking
 version: "1.0.0"
+installable: false
+install_disabled_reason: "Legal pack is gated until Composio legal/document tool bindings are implemented."
 pricing:
   inr_monthly_per_client: 7999
   usd_monthly_per_client: 95

--- a/core/config.py
+++ b/core/config.py
@@ -86,6 +86,8 @@ class Settings(BaseSettings):
 
     # Database
     db_url: str = "postgresql+asyncpg://agenticorg:agenticorg_dev@localhost:5432/agenticorg"
+    db_pool_size: int = Field(default=5, ge=1, le=100)
+    db_max_overflow: int = Field(default=5, ge=0, le=100)
 
     # Redis
     redis_url: str = "redis://localhost:6379/0"

--- a/core/database.py
+++ b/core/database.py
@@ -28,8 +28,8 @@ class Base(DeclarativeBase, MappedAsDataclass):
 engine: AsyncEngine = create_async_engine(
     settings.db_url,
     echo=settings.env == "development",
-    pool_size=20,
-    max_overflow=10,
+    pool_size=settings.db_pool_size,
+    max_overflow=settings.db_max_overflow,
     pool_pre_ping=True,
     pool_recycle=300,
 )

--- a/core/langgraph/agents/campaign_pilot.py
+++ b/core/langgraph/agents/campaign_pilot.py
@@ -12,15 +12,17 @@ from core.langgraph.runner import run_agent
 
 DEFAULT_TOOLS = [
 
-    'get_campaign_performance_metrics',
-
-    'adjust_campaign_budget',
+    'search_campaigns',
 
     'get_campaign_performance',
 
-    'reallocate_ad_budget',
+    'mutate_campaign_budget',
 
-    'get_reach_and_frequency_data',
+    'get_search_terms',
+
+    'get_analytics',
+
+    'get_stats',
 
 ]
 

--- a/core/langgraph/runner.py
+++ b/core/langgraph/runner.py
@@ -147,7 +147,14 @@ async def run_agent(
     # Apply redaction at the source (each task_input field) so no concatenation
     # ever sees raw PII.
     pii_token_map: dict[str, str] = {}
-    if pii_mode in ("before_llm", "before_log"):
+    trusted_shadow_fixture_prompt = (
+        isinstance(task_input, dict)
+        and task_input.get("action") == "shadow_sample"
+        and isinstance(task_input.get("inputs"), dict)
+        and task_input["inputs"].get("shadow_fixture_origin") is True
+        and isinstance(task_input["inputs"].get("shadow_prompt"), str)
+    )
+    if pii_mode in ("before_llm", "before_log") and not trusted_shadow_fixture_prompt:
         # Recursively redact all string values in task_input
         from copy import deepcopy
         redacted_input = deepcopy(task_input) if isinstance(task_input, dict) else task_input
@@ -164,6 +171,8 @@ async def run_agent(
         if pii_token_map:
             logger.info("pii_redacted_before_llm", entities=len(pii_token_map), agent_id=agent_id)
     else:
+        if trusted_shadow_fixture_prompt and pii_mode in ("before_llm", "before_log"):
+            logger.info("pii_redaction_skipped_for_shadow_fixture", agent_id=agent_id)
         user_message = _build_user_message(task_input)
 
     initial_state: AgentState = {

--- a/core/langgraph/tool_adapter.py
+++ b/core/langgraph/tool_adapter.py
@@ -49,6 +49,22 @@ _TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
 )
 
 
+def _flatten_structured_tool_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Unwrap LangChain's ``**kwargs`` schema artifact for var-kw tools.
+
+    Connector methods are registered as ``method(**params)``. LangChain's
+    schema inference can expose that signature as one argument named
+    ``kwargs`` and then call the wrapper with ``{"kwargs": {...}}``.
+    Passing that through unchanged sends a bogus ``kwargs`` query param to
+    upstream APIs. Flatten the single-field wrapper at the LangGraph
+    boundary so connectors receive the params they declared.
+    """
+    nested = kwargs.get("kwargs")
+    if len(kwargs) == 1 and isinstance(nested, dict):
+        return dict(nested)
+    return kwargs
+
+
 async def _build_connector(
     connector_cls: type[BaseConnector],
     config: dict[str, Any] | None,
@@ -208,7 +224,8 @@ def build_tools_for_agent(
         # Create an async wrapper that calls the connector
         def _make_tool_fn(cn: str, tn: str, desc: str):
             async def _tool_fn(**kwargs: Any) -> dict[str, Any]:
-                return await _execute_connector_tool(cn, tn, kwargs, connector_config)
+                params = _flatten_structured_tool_kwargs(kwargs)
+                return await _execute_connector_tool(cn, tn, params, connector_config)
             _tool_fn.__name__ = tn
             _tool_fn.__doc__ = desc or f"Execute {tn} on {cn} connector"
             return _tool_fn

--- a/migrations/versions/v4_9_9_pool_config_noop.py
+++ b/migrations/versions/v4_9_9_pool_config_noop.py
@@ -1,0 +1,25 @@
+"""Runtime DB pool configuration guard migration.
+
+Revision ID: v499_pool_config_noop
+Revises: v498_health_check_history
+Create Date: 2026-05-05
+
+The paired code change only wires SQLAlchemy pool sizing from settings.
+No database schema changes are required, but CI requires an Alembic
+revision whenever ``core/database.py`` changes.
+"""
+
+from __future__ import annotations
+
+revision = "v499_pool_config_noop"
+down_revision = "v498_health_check_history"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/tests/regression/test_codeql_stack_trace_exposure.py
+++ b/tests/regression/test_codeql_stack_trace_exposure.py
@@ -41,6 +41,10 @@ def test_tenant_ai_credentials_error_field_does_not_leak_str_exc() -> None:
         "CodeQL alert #69 will re-fire. The fix must keep err to "
         "type(exc).__name__ only."
     )
+    assert "err = str(exc)" not in src, (
+        "tenant_ai_credentials.py must not return exception messages "
+        "through the probe error field."
+    )
     # Positive contract — the type-name-only assignment must be
     # present so we don't regress to a different leaky shape.
     assert "err = type(exc).__name__" in src, (

--- a/tests/regression/test_may05_github_issue_closures.py
+++ b/tests/regression/test_may05_github_issue_closures.py
@@ -42,6 +42,16 @@ def test_zoho_india_gst_report_avoids_missing_gstsummary_endpoint() -> None:
     assert '"/reports/gstsummary"' not in india_branch
 
 
+def test_tds_period_parser_avoids_redos_prone_quarter_regex() -> None:
+    from api.v1._tds_routing import _extract_period
+
+    src = _read("api/v1/_tds_routing.py")
+    assert "_QUARTER_RE" not in src
+    assert _extract_period("Calculate TDS for Q1 FY26") == "Q1 FY26"
+    assert _extract_period("Calculate TDS for Q2 FY 2026") == "Q2 FY 2026"
+    assert _extract_period("Calculate TDS for April 2026") == "April 2026"
+
+
 def test_db_pool_size_is_settings_configurable() -> None:
     config_src = _read("core/config.py")
     database_src = _read("core/database.py")

--- a/tests/regression/test_may05_github_issue_closures.py
+++ b/tests/regression/test_may05_github_issue_closures.py
@@ -1,0 +1,123 @@
+"""Regression pins for the May 5 GitHub issue/security sweep."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_structured_tool_kwargs_are_flattened() -> None:
+    from core.langgraph.tool_adapter import _flatten_structured_tool_kwargs
+
+    assert _flatten_structured_tool_kwargs({"kwargs": {"page": 1}}) == {"page": 1}
+    assert _flatten_structured_tool_kwargs({"page": 1}) == {"page": 1}
+
+
+def test_shadow_fixture_prompts_are_marked_trusted_and_skip_redaction() -> None:
+    agents_src = _read("api/v1/agents.py")
+    runner_src = _read("core/langgraph/runner.py")
+
+    assert 'incoming_inputs["shadow_fixture_origin"] = True' in agents_src
+    assert 'incoming_inputs.pop("shadow_fixture_origin", None)' in agents_src
+    assert "trusted_shadow_fixture_prompt" in runner_src
+    assert "pii_redaction_skipped_for_shadow_fixture" in runner_src
+
+
+def test_zoho_india_gst_report_avoids_missing_gstsummary_endpoint() -> None:
+    src = _read("connectors/finance/zoho_books.py")
+    india_branch = src.split("async def generate_gst_report", 1)[1].split(
+        'data = await self._get("/reports/gstsummary"',
+        1,
+    )[0]
+
+    assert 'self.config.get("region") == "in"' in india_branch
+    assert 'await self.list_invoices(' in india_branch
+    assert '"/reports/gstsummary"' not in india_branch
+
+
+def test_db_pool_size_is_settings_configurable() -> None:
+    config_src = _read("core/config.py")
+    database_src = _read("core/database.py")
+
+    assert "db_pool_size: int = Field(default=5" in config_src
+    assert "db_max_overflow: int = Field(default=5" in config_src
+    assert "pool_size=settings.db_pool_size" in database_src
+    assert "max_overflow=settings.db_max_overflow" in database_src
+
+
+def test_legal_and_insurance_packs_are_gated_until_tools_exist() -> None:
+    from core.agents.packs.installer import get_pack_detail, install_pack
+
+    for pack_name in ("legal", "insurance"):
+        detail = get_pack_detail(pack_name)
+        assert detail is not None
+        assert detail["installable"] is False
+        assert "Composio" in detail["install_disabled_reason"]
+        try:
+            install_pack(pack_name, "tenant-test")
+        except ValueError as exc:
+            assert "not installable" in str(exc)
+        else:  # pragma: no cover - failure path only
+            raise AssertionError(f"{pack_name} unexpectedly installed")
+
+
+def test_industry_packs_ui_exposes_repair_not_only_uninstall() -> None:
+    src = _read("ui/src/pages/IndustryPacks.tsx")
+
+    assert "handleRepair" in src
+    assert "Repair Pack" in src
+    assert "Use Repair to refresh metadata while preserving history" in src
+
+
+def test_campaign_pilot_defaults_bind_real_connectors() -> None:
+    import connectors  # noqa: F401 - register connector classes
+    from api.v1.agents import (
+        _AGENT_TYPE_DEFAULT_CONNECTOR_IDS,
+        _AGENT_TYPE_DEFAULT_TOOLS,
+    )
+    from core.langgraph.tool_adapter import _build_tool_index
+
+    defaults = _AGENT_TYPE_DEFAULT_TOOLS["campaign_pilot"]
+    index = _build_tool_index()
+    assert defaults
+    assert [tool for tool in defaults if tool not in index] == []
+    assert _AGENT_TYPE_DEFAULT_CONNECTOR_IDS["campaign_pilot"] == [
+        "registry-google_ads",
+        "registry-linkedin_ads",
+        "registry-sendgrid",
+    ]
+
+
+def test_connectors_list_serializer_tolerates_malformed_optional_fields() -> None:
+    from api.v1.connectors import _connector_to_dict
+
+    row = SimpleNamespace(
+        id=uuid4(),
+        name="broken-row",
+        category=None,
+        description=None,
+        base_url=None,
+        auth_type=None,
+        auth_config={},
+        secret_ref=None,
+        tool_functions=None,
+        data_schema_ref=None,
+        rate_limit_rpm=None,
+        timeout_ms=None,
+        status=None,
+        health_check_at="not-a-datetime",
+        created_at="not-a-datetime",
+    )
+
+    serialized = _connector_to_dict(row)  # type: ignore[arg-type]
+    assert serialized["tool_functions"] == []
+    assert serialized["health_check_at"] is None
+    assert serialized["created_at"] is None
+    assert serialized["status"] == "active"

--- a/tests/unit/test_industry_packs.py
+++ b/tests/unit/test_industry_packs.py
@@ -50,11 +50,11 @@ def test_install_creates_agents_in_shadow():
 
 def test_uninstall_removes_agents():
     """Uninstalling a pack removes agents and workflows."""
-    install_pack("legal", "tenant-002")
-    result = uninstall_pack("legal", "tenant-002")
+    install_pack("healthcare", "tenant-002")
+    result = uninstall_pack("healthcare", "tenant-002")
     assert result["status"] == "uninstalled"
     assert len(result["agents_removed"]) >= 1
-    assert "legal" not in get_installed_packs("tenant-002")
+    assert "healthcare" not in get_installed_packs("tenant-002")
 
 
 def test_healthcare_has_hipaa_prompts():
@@ -79,12 +79,12 @@ def test_pack_detail_returns_config():
 def test_installed_packs_per_tenant():
     """Installed packs are tracked per tenant — no cross-tenant leakage."""
     install_pack("healthcare", "tenant-A")
-    install_pack("legal", "tenant-B")
+    install_pack("manufacturing", "tenant-B")
 
     assert "healthcare" in get_installed_packs("tenant-A")
-    assert "legal" not in get_installed_packs("tenant-A")
+    assert "manufacturing" not in get_installed_packs("tenant-A")
 
-    assert "legal" in get_installed_packs("tenant-B")
+    assert "manufacturing" in get_installed_packs("tenant-B")
     assert "healthcare" not in get_installed_packs("tenant-B")
 
 

--- a/ui/src/pages/IndustryPacks.tsx
+++ b/ui/src/pages/IndustryPacks.tsx
@@ -28,6 +28,8 @@ interface IndustryPack {
   workflows: PackWorkflow[];
   required_connectors: string[];
   installed: boolean;
+  installable: boolean;
+  install_disabled_reason: string;
 }
 
 const ICON_COLORS: Record<string, string> = {
@@ -141,6 +143,8 @@ function normalizePack(rawPack: unknown, installedIds: Set<string>): IndustryPac
     workflows,
     required_connectors: deriveRequiredConnectors(record, agents),
     installed: installedIds.has(id),
+    installable: record.installable !== false,
+    install_disabled_reason: String(record.install_disabled_reason || ""),
   };
 }
 
@@ -203,6 +207,7 @@ export default function IndustryPacks() {
   }, [fetchData]);
 
   const handleInstall = async (pack: IndustryPack) => {
+    if (!pack.installable) return;
     setActionLoading(pack.id);
     try {
       await api.post(`/packs/${pack.id}/install`);
@@ -214,7 +219,22 @@ export default function IndustryPacks() {
     setActionLoading(null);
   };
 
+  const handleRepair = async (pack: IndustryPack) => {
+    if (!pack.installable) return;
+    setActionLoading(pack.id);
+    try {
+      await api.post(`/packs/${pack.id}/install`);
+      await fetchData();
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
   const handleUninstall = async (pack: IndustryPack) => {
+    const confirmed = window.confirm(
+      `Uninstalling ${pack.name} permanently deletes its pack agents and shadow history for this tenant. Use Repair to refresh metadata while preserving history. Continue?`
+    );
+    if (!confirmed) return;
     setActionLoading(pack.id);
     try {
       await api.delete(`/packs/${pack.id}`);
@@ -266,21 +286,36 @@ export default function IndustryPacks() {
               <div className="flex items-center justify-between">
                 <span className="text-xs text-muted-foreground">{pack.agent_count} agents</span>
                 {pack.installed ? (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={actionLoading === pack.id}
-                    onClick={(e) => { e.stopPropagation(); handleUninstall(pack); }}
-                  >
-                    {actionLoading === pack.id ? "..." : "Uninstall"}
-                  </Button>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      title="Refresh pack metadata, connectors, and prompts in place while preserving agent IDs and history."
+                      disabled={actionLoading === pack.id || !pack.installable}
+                      onClick={(e) => { e.stopPropagation(); handleRepair(pack); }}
+                    >
+                      {actionLoading === pack.id ? "..." : "Repair"}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      title="Remove pack agents and history for this tenant."
+                      disabled={actionLoading === pack.id}
+                      onClick={(e) => { e.stopPropagation(); handleUninstall(pack); }}
+                    >
+                      Uninstall
+                    </Button>
+                  </div>
                 ) : (
                   <Button
                     size="sm"
-                    disabled={actionLoading === pack.id}
+                    title={pack.install_disabled_reason || undefined}
+                    disabled={actionLoading === pack.id || !pack.installable}
                     onClick={(e) => { e.stopPropagation(); handleInstall(pack); }}
                   >
-                    {actionLoading === pack.id ? "Installing..." : "Install"}
+                    {pack.installable
+                      ? actionLoading === pack.id ? "Installing..." : "Install"
+                      : "Unavailable"}
                   </Button>
                 )}
               </div>
@@ -301,7 +336,12 @@ export default function IndustryPacks() {
                 </div>
                 <div>
                   <h3 className="text-xl font-bold">{selectedPack.name}</h3>
-                  <p className="text-sm text-muted-foreground">{selectedPack.agent_count} agents</p>
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm text-muted-foreground">{selectedPack.agent_count} agents</p>
+                    {!selectedPack.installable && (
+                      <Badge variant="secondary">Unavailable</Badge>
+                    )}
+                  </div>
                 </div>
               </div>
               <button onClick={() => setSelectedPack(null)} className="p-1 rounded hover:bg-muted" aria-label="Close">
@@ -310,6 +350,11 @@ export default function IndustryPacks() {
             </div>
 
             <p className="text-sm text-muted-foreground mb-4">{selectedPack.description}</p>
+            {selectedPack.install_disabled_reason && (
+              <p className="text-sm text-muted-foreground mb-4">
+                {selectedPack.install_disabled_reason}
+              </p>
+            )}
 
             {/* Agents */}
             <h4 className="text-sm font-semibold mb-2">Agents</h4>
@@ -355,19 +400,32 @@ export default function IndustryPacks() {
             <div className="flex justify-end gap-2 pt-2 border-t">
               <Button variant="outline" onClick={() => setSelectedPack(null)}>Close</Button>
               {selectedPack.installed ? (
-                <Button
-                  variant="destructive"
-                  disabled={actionLoading === selectedPack.id}
-                  onClick={() => handleUninstall(selectedPack)}
-                >
-                  {actionLoading === selectedPack.id ? "Removing..." : "Uninstall Pack"}
-                </Button>
+                <>
+                  <Button
+                    variant="outline"
+                    title="Refresh pack metadata, connectors, and prompts in place while preserving agent IDs and history."
+                    disabled={actionLoading === selectedPack.id || !selectedPack.installable}
+                    onClick={() => handleRepair(selectedPack)}
+                  >
+                    {actionLoading === selectedPack.id ? "Repairing..." : "Repair Pack"}
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    disabled={actionLoading === selectedPack.id}
+                    onClick={() => handleUninstall(selectedPack)}
+                  >
+                    {actionLoading === selectedPack.id ? "Removing..." : "Uninstall Pack"}
+                  </Button>
+                </>
               ) : (
                 <Button
-                  disabled={actionLoading === selectedPack.id}
+                  title={selectedPack.install_disabled_reason || undefined}
+                  disabled={actionLoading === selectedPack.id || !selectedPack.installable}
                   onClick={() => handleInstall(selectedPack)}
                 >
-                  {actionLoading === selectedPack.id ? "Installing..." : "Install Pack"}
+                  {selectedPack.installable
+                    ? actionLoading === selectedPack.id ? "Installing..." : "Install Pack"
+                    : "Unavailable"}
                 </Button>
               )}
             </div>


### PR DESCRIPTION
## Summary
- fix open CodeQL alerts for TDS regex ReDoS and tenant AI credential exception leakage
- close the current open issue set: structured tool kwargs, shadow fixture marker handling, Zoho India GST fallback, configurable DB pool sizing, connector serialization hardening, industry pack repair/gating, and campaign pilot connector defaults
- add regression coverage for the GitHub issue sweep and update industry pack tests

## Local verification
- `uv run pytest -q tests/regression/test_may05_github_issue_closures.py tests/regression/test_ca_firms_may03_reopens.py tests/regression/test_codeql_stack_trace_exposure.py tests/unit/test_industry_packs.py`
- `uv run ruff check api/v1/_tds_routing.py api/v1/agents.py api/v1/connectors.py api/v1/packs.py api/v1/tenant_ai_credentials.py connectors/finance/zoho_books.py core/agent_generator.py core/config.py core/database.py core/langgraph/agents/campaign_pilot.py core/langgraph/runner.py core/langgraph/tool_adapter.py core/agents/packs/installer.py tests/regression/test_may05_github_issue_closures.py tests/regression/test_codeql_stack_trace_exposure.py tests/unit/test_industry_packs.py`
- `cd ui; npm run typecheck`
- `cd ui; npm run build`
- `cd ui; npm test -- --run`

Note: full `uv run pytest -q` was attempted twice but did not complete within the local timeout window; PR CI is the full gate before merge.