### PR TITLE
fix: sanitize provider probe errors

### DIFF
--- a/core/ai_providers/health.py
+++ b/core/ai_providers/health.py
@@ -151,7 +151,13 @@ async def probe_provider(
     try:
         resolved = await get_provider_credential(tenant_id, provider, kind)
     except ProviderNotConfigured as exc:
-        return {"ok": False, "error": f"Resolver refused: {exc}"}
+        logger.warning(
+            "provider_probe_resolver_refused",
+            provider=provider,
+            kind=kind,
+            error_type=type(exc).__name__,
+        )
+        return {"ok": False, "error": type(exc).__name__}
 
     secret = resolved.secret
     base_url = (
@@ -198,6 +204,6 @@ async def probe_provider(
             "provider_probe_failed",
             provider=provider,
             kind=kind,
-            error=str(exc),
+            error_type=type(exc).__name__,
         )
-        return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+        return {"ok": False, "error": type(exc).__name__}

--- a/tests/regression/test_codeql_stack_trace_exposure.py
+++ b/tests/regression/test_codeql_stack_trace_exposure.py
@@ -22,7 +22,11 @@ the leak will trip the test before CodeQL re-flags it.
 """
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 REPO = Path(__file__).resolve().parents[2]
 
@@ -51,6 +55,65 @@ def test_tenant_ai_credentials_error_field_does_not_leak_str_exc() -> None:
         "tenant_ai_credentials.py probe error path must assign "
         "``err = type(exc).__name__`` (no exception message)."
     )
+
+
+def test_probe_provider_errors_do_not_leak_exception_messages() -> None:
+    """``probe_provider`` feeds tenant_ai_credentials.py's response.
+
+    It must not format provider/resolver exception text into the
+    returned ``error`` field.
+    """
+    src = (REPO / "core" / "ai_providers" / "health.py").read_text(
+        encoding="utf-8"
+    )
+    assert 'f"Resolver refused: {exc}"' not in src, (
+        "probe_provider must not return ProviderNotConfigured details "
+        "to the tenant credential test endpoint."
+    )
+    assert 'f"{type(exc).__name__}: {exc}"' not in src, (
+        "probe_provider must not return provider exception messages "
+        "to the tenant credential test endpoint."
+    )
+    assert "error=str(exc)" not in src, (
+        "probe_provider should log stable exception metadata only."
+    )
+
+
+@pytest.mark.asyncio
+async def test_probe_provider_resolver_error_is_type_name_only(monkeypatch) -> None:
+    from core.ai_providers import health
+    from core.ai_providers.resolver import ProviderNotConfigured
+
+    async def refused(*_args, **_kwargs):
+        raise ProviderNotConfigured(
+            "tenant=7 secret=sk-live-internal traceback=/srv/app/core.py:42"
+        )
+
+    monkeypatch.setattr(health, "get_provider_credential", refused)
+
+    result = await health.probe_provider(uuid.uuid4(), "openai", "default")
+
+    assert result == {"ok": False, "error": "ProviderNotConfigured"}
+
+
+@pytest.mark.asyncio
+async def test_probe_provider_runtime_error_is_type_name_only(monkeypatch) -> None:
+    from core.ai_providers import health
+
+    async def resolved(*_args, **_kwargs):
+        return SimpleNamespace(secret="sk-test", provider_config={})
+
+    async def failing_probe(*_args, **_kwargs):
+        raise RuntimeError(
+            "Authorization: Bearer sk-live-internal at /srv/app/core.py:42"
+        )
+
+    monkeypatch.setattr(health, "get_provider_credential", resolved)
+    monkeypatch.setattr(health, "_probe_openai", failing_probe)
+
+    result = await health.probe_provider(uuid.uuid4(), "openai", "default")
+
+    assert result == {"ok": False, "error": "RuntimeError"}
 
 
 def test_connectors_test_endpoint_does_not_leak_err_msg_in_fallback_branch() -> None:


### PR DESCRIPTION
## Summary
- sanitize `probe_provider()` resolver/provider exception responses to type names only
- remove exception message text from provider probe logs
- add regression coverage for the remaining CodeQL `py/stack-trace-exposure` alert #69

## Verification
- `uv run pytest -q tests/regression/test_codeql_stack_trace_exposure.py`
- `uv run ruff check core/ai_providers/health.py tests/regression/test_codeql_stack_trace_exposure.py`

generated by Codex