### PR TITLE
fix: update Stripe paid subscriptions in place

### DIFF
--- a/api/v1/billing.py
+++ b/api/v1/billing.py
@@ -267,6 +267,29 @@ async def subscribe_stripe(
     import asyncio
 
     try:
+        from core.async_redis import get_async_redis
+
+        redis = await get_async_redis()
+        if redis is not None:
+            current_plan_raw = await redis.get(f"tenant:{tenant_id}:plan")
+            current_plan = (
+                current_plan_raw.decode()
+                if isinstance(current_plan_raw, bytes)
+                else current_plan_raw
+            ) or "free"
+            sub_id_raw = await redis.get(f"tenant:{tenant_id}:stripe_subscription_id")
+            sub_id = (
+                sub_id_raw.decode() if isinstance(sub_id_raw, bytes) else sub_id_raw
+            ) or ""
+            if sub_id and current_plan != "free":
+                from core.billing.stripe_client import change_subscription_plan
+
+                return await asyncio.to_thread(
+                    change_subscription_plan,
+                    tenant_id=tenant_id,
+                    plan=body.plan,
+                )
+
         result = await asyncio.to_thread(
             create_checkout_session,
             tenant_id=tenant_id,

--- a/core/billing/stripe_client.py
+++ b/core/billing/stripe_client.py
@@ -45,6 +45,8 @@ PLAN_AMOUNT_USD: dict[str, int] = {
     "enterprise": 499_00,  # $499/mo
 }
 
+ACTIVE_SUBSCRIPTION_STATUSES = {"active", "trialing"}
+
 _APP_BASE_URL = os.getenv("AGENTICORG_APP_URL", "https://app.agenticorg.ai")
 
 _API_CALLBACK_URL = os.getenv(
@@ -59,6 +61,43 @@ def _get_stripe():
         raise RuntimeError("stripe package is not installed — run: pip install stripe")
     _stripe.api_key = _STRIPE_SECRET_KEY
     return _stripe
+
+
+def _get_value(obj: Any, key: str, default: Any = None) -> Any:
+    """Read ``key`` from StripeObject-like or dict payloads."""
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _price_to_plan(price_id: str) -> str:
+    for plan, mapped_price_id in PLAN_PRICE_MAP.items():
+        if mapped_price_id and mapped_price_id == price_id:
+            return plan
+    return ""
+
+
+def _first_subscription_item_id(subscription: Any) -> str:
+    items = _get_value(subscription, "items", {})
+    data = _get_value(items, "data", [])
+    if not data:
+        return ""
+    return _get_value(data[0], "id", "")
+
+
+def _plan_from_subscription(subscription: Any) -> str:
+    metadata = _get_value(subscription, "metadata", {}) or {}
+    plan = metadata.get("plan", "") if isinstance(metadata, dict) else ""
+    if plan:
+        return plan
+
+    items = _get_value(subscription, "items", {})
+    data = _get_value(items, "data", [])
+    if not data:
+        return ""
+    price = _get_value(data[0], "price", {})
+    price_id = _get_value(price, "id", "")
+    return _price_to_plan(price_id)
 
 
 # ── Create Customer ─────────────────────────────────────────────────
@@ -278,12 +317,19 @@ def handle_webhook(payload: bytes, sig_header: str) -> dict[str, Any]:
     elif event_type == "customer.subscription.updated":
         tenant_id = data_obj.get("metadata", {}).get("tenant_id", "")
         status = data_obj.get("status", "")
+        plan = _sync_subscription_state(data_obj)
         result.update(
             processed=True,
             tenant_id=tenant_id,
+            plan=plan,
             subscription_status=status,
         )
-        logger.info("stripe_subscription_updated", tenant_id=tenant_id, status=status)
+        logger.info(
+            "stripe_subscription_updated",
+            tenant_id=tenant_id,
+            plan=plan,
+            status=status,
+        )
 
     elif event_type == "customer.subscription.deleted":
         tenant_id = data_obj.get("metadata", {}).get("tenant_id", "")
@@ -313,6 +359,7 @@ def _activate_subscription(
     redis.set(f"tenant_tier:{tenant_id}", plan)
     redis.set(f"tenant:{tenant_id}:plan", plan)
     redis.set(f"tenant:{tenant_id}:billing_provider", "stripe")
+    redis.set(f"tenant:{tenant_id}:billing_order_id", subscription_id)
     redis.set(f"tenant:{tenant_id}:stripe_subscription_id", subscription_id)
     redis.set(f"tenant:{tenant_id}:stripe_customer_id", customer_id)
 
@@ -332,6 +379,7 @@ def _deactivate_subscription(tenant_id: str) -> None:
     redis = _get_redis()
     redis.set(f"tenant_tier:{tenant_id}", "free")
     redis.set(f"tenant:{tenant_id}:plan", "free")
+    redis.delete(f"tenant:{tenant_id}:billing_order_id")
     redis.delete(f"tenant:{tenant_id}:stripe_subscription_id")
 
     logger.info("subscription_deactivated", tenant_id=tenant_id)
@@ -347,6 +395,108 @@ def cancel_subscription(subscription_id: str) -> bool:
     except Exception:
         logger.exception("stripe_cancel_failed", subscription_id=subscription_id)
         return False
+
+
+def _sync_subscription_state(
+    subscription: Any,
+    *,
+    fallback_tenant_id: str = "",
+    fallback_plan: str = "",
+) -> str:
+    """Mirror a Stripe subscription object into Redis billing state.
+
+    Stripe sends plan changes through ``customer.subscription.updated``.
+    We derive the plan from metadata first, then from the active price id.
+    """
+    from core.billing.usage_tracker import _get_redis
+
+    metadata = _get_value(subscription, "metadata", {}) or {}
+    tenant_id = (
+        metadata.get("tenant_id", "")
+        if isinstance(metadata, dict)
+        else fallback_tenant_id
+    ) or fallback_tenant_id
+    plan = _plan_from_subscription(subscription) or fallback_plan
+    status = _get_value(subscription, "status", "")
+    subscription_id = _get_value(subscription, "id", "")
+    customer_id = _get_value(subscription, "customer", "")
+
+    if not tenant_id:
+        logger.warning(
+            "stripe_subscription_sync_missing_tenant",
+            subscription_id=subscription_id,
+            status=status,
+        )
+        return plan
+
+    if status in ACTIVE_SUBSCRIPTION_STATUSES and plan:
+        redis = _get_redis()
+        redis.set(f"tenant_tier:{tenant_id}", plan)
+        redis.set(f"tenant:{tenant_id}:plan", plan)
+        redis.set(f"tenant:{tenant_id}:billing_provider", "stripe")
+        if subscription_id:
+            redis.set(f"tenant:{tenant_id}:billing_order_id", subscription_id)
+            redis.set(f"tenant:{tenant_id}:stripe_subscription_id", subscription_id)
+        if customer_id:
+            redis.set(f"tenant:{tenant_id}:stripe_customer_id", customer_id)
+        logger.info(
+            "subscription_synced",
+            tenant_id=tenant_id,
+            plan=plan,
+            provider="stripe",
+            status=status,
+            subscription_id=subscription_id,
+        )
+    elif status in {"canceled", "incomplete_expired", "unpaid"}:
+        _deactivate_subscription(tenant_id)
+
+    return plan
+
+
+def change_subscription_plan(tenant_id: str, plan: str) -> dict[str, Any]:
+    """Change an existing Stripe subscription to a different paid plan.
+
+    This updates the stored subscription in place. Creating a new Checkout
+    Session for paid-to-paid changes can leave the old subscription active.
+    """
+    s = _get_stripe()
+    price_id = PLAN_PRICE_MAP.get(plan)
+    if not price_id:
+        raise ValueError(f"Unknown plan or missing price ID: {plan}")
+
+    from core.billing.usage_tracker import _get_redis
+
+    redis = _get_redis()
+    stored = redis.get(f"tenant:{tenant_id}:stripe_subscription_id")
+    subscription_id = stored if isinstance(stored, str) else (stored or b"").decode()
+    if not subscription_id:
+        raise ValueError(f"No active Stripe subscription found for tenant {tenant_id}")
+
+    current = s.Subscription.retrieve(subscription_id)
+    item_id = _first_subscription_item_id(current)
+    if not item_id:
+        raise ValueError(f"No subscription item found for subscription {subscription_id}")
+
+    updated = s.Subscription.modify(
+        subscription_id,
+        items=[{"id": item_id, "price": price_id}],
+        metadata={"tenant_id": tenant_id, "plan": plan},
+        proration_behavior="create_prorations",
+    )
+    synced_plan = _sync_subscription_state(
+        updated,
+        fallback_tenant_id=tenant_id,
+        fallback_plan=plan,
+    )
+
+    return {
+        "updated": True,
+        "tenant_id": tenant_id,
+        "plan": synced_plan or plan,
+        "subscription_id": _get_value(updated, "id", subscription_id),
+        "status": _get_value(updated, "status", ""),
+        "provider": "stripe",
+    }
 
 
 # ── Customer Portal ─────────────────────────────────────────────────

--- a/tests/unit/test_billing.py
+++ b/tests/unit/test_billing.py
@@ -859,6 +859,103 @@ class TestStripeWebhookActivation:
         mock_deactivate.assert_called_once_with("t1")
 
 
+class TestStripeSubscriptionPlanChanges:
+    """Stripe paid-to-paid plan changes update the existing subscription."""
+
+    @patch("core.billing.stripe_client._get_stripe")
+    @patch("core.billing.usage_tracker._get_redis")
+    def test_change_subscription_plan_modifies_existing_subscription(
+        self, mock_redis_fn, mock_get_stripe
+    ):
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = "sub_existing"
+        mock_redis_fn.return_value = mock_redis
+
+        mock_stripe = MagicMock()
+        mock_stripe.Subscription.retrieve.return_value = {
+            "id": "sub_existing",
+            "items": {"data": [{"id": "si_existing", "price": {"id": "price_pro"}}]},
+            "metadata": {"tenant_id": "t1", "plan": "pro"},
+        }
+        mock_stripe.Subscription.modify.return_value = {
+            "id": "sub_existing",
+            "status": "active",
+            "customer": "cus_existing",
+            "items": {
+                "data": [{"id": "si_existing", "price": {"id": "price_enterprise"}}]
+            },
+            "metadata": {"tenant_id": "t1", "plan": "enterprise"},
+        }
+        mock_get_stripe.return_value = mock_stripe
+
+        from core.billing.stripe_client import change_subscription_plan
+
+        with patch(
+            "core.billing.stripe_client.PLAN_PRICE_MAP",
+            {"pro": "price_pro", "enterprise": "price_enterprise"},
+        ):
+            result = change_subscription_plan("t1", "enterprise")
+
+        assert result["updated"] is True
+        assert result["plan"] == "enterprise"
+        mock_stripe.checkout.Session.create.assert_not_called()
+        mock_stripe.Subscription.modify.assert_called_once_with(
+            "sub_existing",
+            items=[{"id": "si_existing", "price": "price_enterprise"}],
+            metadata={"tenant_id": "t1", "plan": "enterprise"},
+            proration_behavior="create_prorations",
+        )
+        mock_redis.set.assert_any_call("tenant_tier:t1", "enterprise")
+        mock_redis.set.assert_any_call("tenant:t1:plan", "enterprise")
+        mock_redis.set.assert_any_call("tenant:t1:stripe_subscription_id", "sub_existing")
+
+    @patch("core.billing.stripe_client._get_stripe")
+    @patch("core.billing.usage_tracker._get_redis")
+    def test_subscription_updated_webhook_syncs_plan_from_price(
+        self, mock_redis_fn, mock_get_stripe
+    ):
+        mock_redis = MagicMock()
+        mock_redis_fn.return_value = mock_redis
+
+        mock_stripe = MagicMock()
+        mock_stripe.Webhook.construct_event.return_value = {
+            "type": "customer.subscription.updated",
+            "created": int(time.time()),
+            "data": {
+                "object": {
+                    "id": "sub_updated",
+                    "status": "active",
+                    "customer": "cus_updated",
+                    "metadata": {"tenant_id": "t1"},
+                    "items": {
+                        "data": [
+                            {
+                                "id": "si_updated",
+                                "price": {"id": "price_enterprise"},
+                            }
+                        ]
+                    },
+                }
+            },
+        }
+        mock_get_stripe.return_value = mock_stripe
+
+        from core.billing.stripe_client import handle_webhook
+
+        with patch(
+            "core.billing.stripe_client.PLAN_PRICE_MAP",
+            {"pro": "price_pro", "enterprise": "price_enterprise"},
+        ):
+            result = handle_webhook(b'{"type":"customer.subscription.updated"}', "sig")
+
+        assert result["processed"] is True
+        assert result["tenant_id"] == "t1"
+        assert result["plan"] == "enterprise"
+        mock_redis.set.assert_any_call("tenant_tier:t1", "enterprise")
+        mock_redis.set.assert_any_call("tenant:t1:plan", "enterprise")
+        mock_redis.set.assert_any_call("tenant:t1:billing_order_id", "sub_updated")
+
+
 class TestStripeCustomerPortal:
     """Stripe Customer Portal session creation."""
 

--- a/ui/src/pages/Billing.tsx
+++ b/ui/src/pages/Billing.tsx
@@ -97,8 +97,14 @@ export default function Billing() {
       const resp = await api.post("/billing/subscribe", { plan });
       const data = resp.data;
       const url = data.challenge_url || data.checkout_url;
-      if (url) window.location.href = url;
-      else setError("No payment URL returned");
+      if (url) {
+        window.location.href = url;
+      } else if (data.updated) {
+        const sub = await api.get("/billing/subscription").then((r) => r.data);
+        setSubscription(sub);
+      } else {
+        setError("No payment URL returned");
+      }
     } catch (e: any) {
       setError(e?.response?.data?.detail || "Failed to start payment");
     } finally {
@@ -228,8 +234,8 @@ export default function Billing() {
                 {!isCurrent && p.plan !== "free" && subscription?.is_paid && (
                   <p className="text-xs text-muted-foreground mb-2 bg-muted rounded px-2 py-1">
                     {isUpgrade
-                      ? "You'll be charged the price difference for the remaining billing period."
-                      : "Your account will be credited the difference on your next invoice."}
+                      ? "Stripe applies prorated charges according to your billing settings."
+                      : "Stripe applies prorated credits according to your billing settings."}
                   </p>
                 )}
 


### PR DESCRIPTION
## Summary
- update existing Stripe subscriptions in place for paid-to-paid plan changes instead of creating a second Checkout subscription
- sync tenant billing state from `customer.subscription.updated` events and store the Stripe subscription id as the billing order id
- refresh the Billing UI after in-place plan changes and make the proration copy accurate
- add regression coverage for Stripe plan changes and subscription update webhooks

## Verification
- `uv run pytest -q tests/unit/test_billing.py`
- `uv run pytest -q tests/regression/test_codex_round4_blockers.py::test_k_f_billing_async_routes_wrap_sync_calls`
- `uv run ruff check api/v1/billing.py core/billing/stripe_client.py tests/unit/test_billing.py`
- `cd ui; npm run typecheck`
- `cd ui; npm run build`

generated by Codex