### PR TITLE
fix(billing): rename Plural-callback redirect var to satisfy mypy

### DIFF
--- a/api/v1/billing.py
+++ b/api/v1/billing.py
@@ -439,17 +439,21 @@ async def plural_callback(request: Request) -> RedirectResponse:
             tenant_id=tenant_id,
         )
 
-    # Redirect to frontend callback page with server-verified result
+    # Redirect to frontend callback page with server-verified result.
+    # Use a distinct local name (qs) — the function already binds
+    # `params: dict[str, str]` for the inbound query+form parser,
+    # and reusing the same name for the outbound query string trips
+    # mypy with "Unsupported left operand type for + (dict[str, str])".
     fe_url = "/dashboard/billing/callback"
-    params = f"?payment={verified_status}&provider=plural"
+    qs = f"?payment={verified_status}&provider=plural"
     if tenant_id:
-        params += f"&tenant_id={tenant_id}"
+        qs += f"&tenant_id={tenant_id}"
     if plan:
-        params += f"&plan={plan}"
+        qs += f"&plan={plan}"
     if effective_order_id:
-        params += f"&order_id={effective_order_id}"
+        qs += f"&order_id={effective_order_id}"
 
-    return RedirectResponse(url=f"{fe_url}{params}", status_code=303)
+    return RedirectResponse(url=f"{fe_url}{qs}", status_code=303)
 
 
 # ── Stripe Callback (Checkout Return) ────────────────────────────────


### PR DESCRIPTION
## Summary

**Type-only fix.** PR #473 (Stripe paid subscriptions in place) reused the local name `params` inside `plural_callback` for an outbound redirect query string, but the same function already binds `params: dict[str, str]` upstream (line 377, the inbound query+form parser). That tripped mypy:

```
api/v1/billing.py:446: error: Unsupported left operand type for + (dict[str, str])
api/v1/billing.py:448: ...
api/v1/billing.py:450: ...
```

PR #473's PR-level CI did not gate on mypy, so the issue landed on `main` and broke the post-merge `lint` job on `b6f84f5` (the Aishwarya May 6 merge commit), which now blocks the production deploy gate.

## Change

Rename the redirect-builder local from `params` to `qs` (query string). No behavior change. Stripe callback below uses the same pattern but is in a separate function without the dict annotation in scope, so it stays as-is.

## Verification

- mypy --ignore-missing-imports api/v1/billing.py: clean
- pytest -k "billing or stripe or plural" --no-cov: 47 passed
- Local preflight: all 12 gates passed

## Test plan
- [x] Targeted mypy
- [x] Targeted pytest
- [x] Full local preflight
- [ ] CI green
- [ ] Production deploy gate green on new main HEAD

@codex please review.
