### PR TITLE
fix(qa): Aishwarya 2026-05-11 sweep — pagination, prompt validation, run result, rollback

### DIFF
--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -340,6 +340,82 @@ def _parse_company_id(company_id: str | None) -> _uuid.UUID | None:
         raise HTTPException(400, "Invalid company_id format") from exc
 
 
+def _has_meaningful_run_text(value: str) -> bool:
+    text = value.strip()
+    return len(text) >= 3 and any(ch.isalpha() for ch in text)
+
+
+def _iter_input_strings(value: Any) -> list[str]:
+    strings: list[str] = []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        for nested in value.values():
+            strings.extend(_iter_input_strings(nested))
+        return strings
+    if isinstance(value, (list, tuple, set)):
+        for nested in value:
+            strings.extend(_iter_input_strings(nested))
+        return strings
+    return strings
+
+
+def _validate_run_inputs(payload: dict) -> dict:
+    raw_inputs = payload.get("inputs", {})
+    if isinstance(raw_inputs, str):
+        inputs = {"task": raw_inputs}
+        payload["inputs"] = inputs
+    elif isinstance(raw_inputs, dict):
+        inputs = raw_inputs
+    else:
+        raise HTTPException(400, "inputs field must be an object")
+
+    if not inputs:
+        raise HTTPException(400, "inputs field is required and cannot be empty")
+
+    if payload.get("action") == "shadow_sample":
+        return inputs
+
+    if not any(_has_meaningful_run_text(s) for s in _iter_input_strings(inputs)):
+        raise HTTPException(400, "Please enter a valid task or prompt.")
+
+    return inputs
+
+
+def _next_agent_version(version: str | None) -> str:
+    raw = (version or "1.0.0").strip()
+    parts = raw.split(".")
+    if len(parts) >= 3 and all(part.isdigit() for part in parts[-3:]):
+        prefix = parts[:-3]
+        major, minor, patch = (int(part) for part in parts[-3:])
+        next_parts = [*prefix, str(major), str(minor), str(patch + 1)]
+        candidate = ".".join(next_parts)
+        return candidate[:20]
+    if raw and raw[-1].isdigit():
+        return f"{raw}.1"[:20]
+    return "1.0.1"
+
+
+def _agent_version_snapshot(
+    agent: Agent,
+    version: str,
+    *,
+    is_verified_good: bool = False,
+) -> AgentVersion:
+    return AgentVersion(
+        tenant_id=agent.tenant_id,
+        agent_id=agent.id,
+        version=version,
+        system_prompt=agent.system_prompt_ref,
+        authorized_tools=agent.authorized_tools,
+        hitl_policy={"condition": agent.hitl_condition},
+        llm_config=agent.llm_config,
+        confidence_floor=agent.confidence_floor,
+        is_verified_good=is_verified_good,
+        deployed_at=datetime.now(UTC),
+    )
+
+
 def _user_uuid_from_claims(user: dict | None) -> _uuid.UUID | None:
     """Extract a user UUID from JWT claims for audit-log ``edited_by``.
 
@@ -1727,10 +1803,7 @@ async def run_agent(
     """Instantiate agent from registry and execute against user input."""
     if payload is None:
         payload = {}
-    # Validate that inputs are not empty
-    inputs = payload.get("inputs", {})
-    if not inputs:
-        raise HTTPException(400, "inputs field is required and cannot be empty")
+    _validate_run_inputs(payload)
     tid = _uuid.UUID(tenant_id)
 
     # 1. Load agent config from DB
@@ -2481,7 +2554,38 @@ async def promote_agent(agent_id: UUID, tenant_id: str = Depends(get_current_ten
                 )
 
         old_status = agent.status
+        old_version = agent.version or "1.0.0"
+        new_version = _next_agent_version(old_version)
+        while (
+            await session.execute(
+                select(AgentVersion).where(
+                    AgentVersion.agent_id == agent.id,
+                    AgentVersion.version == new_version,
+                )
+            )
+        ).scalar_one_or_none():
+            new_version = _next_agent_version(new_version)
+
+        existing_shadow_snapshot = (
+            await session.execute(
+                select(AgentVersion).where(
+                    AgentVersion.agent_id == agent.id,
+                    AgentVersion.version == old_version,
+                )
+            )
+        ).scalar_one_or_none()
+        if existing_shadow_snapshot is None:
+            session.add(
+                _agent_version_snapshot(
+                    agent,
+                    old_version,
+                    is_verified_good=True,
+                )
+            )
+
         agent.status = new_status
+        agent.version = new_version
+        session.add(_agent_version_snapshot(agent, new_version, is_verified_good=True))
 
         event = AgentLifecycleEvent(
             tenant_id=tid,
@@ -2495,7 +2599,14 @@ async def promote_agent(agent_id: UUID, tenant_id: str = Depends(get_current_ten
         )
         session.add(event)
 
-    return {"id": str(agent_id), "promoted": True, "from": old_status, "to": new_status}
+    return {
+        "id": str(agent_id),
+        "promoted": True,
+        "from": old_status,
+        "to": new_status,
+        "from_version": old_version,
+        "to_version": new_version,
+    }
 
 
 # ── POST /agents/{id}/retire ───────────────────────────────────────────────────
@@ -2613,6 +2724,7 @@ async def rollback_agent(agent_id: UUID, tenant_id: str = Depends(get_current_te
         versions_result = await session.execute(
             select(AgentVersion)
             .where(
+                AgentVersion.tenant_id == tid,
                 AgentVersion.agent_id == agent_id,
                 AgentVersion.version != agent.version,
             )
@@ -2621,6 +2733,44 @@ async def rollback_agent(agent_id: UUID, tenant_id: str = Depends(get_current_te
         )
         prev_version = versions_result.scalar_one_or_none()
         if not prev_version:
+            transition = (
+                await session.execute(
+                    select(AgentLifecycleEvent)
+                    .where(
+                        AgentLifecycleEvent.tenant_id == tid,
+                        AgentLifecycleEvent.agent_id == agent_id,
+                        AgentLifecycleEvent.from_status == "shadow",
+                        AgentLifecycleEvent.to_status == "active",
+                    )
+                    .order_by(AgentLifecycleEvent.created_at.desc())
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+            if agent.status == "active" and transition is not None:
+                old_status = agent.status
+                agent.status = "shadow"
+                event = AgentLifecycleEvent(
+                    tenant_id=tid,
+                    agent_id=agent.id,
+                    from_status=old_status,
+                    to_status="shadow",
+                    triggered_by="api",
+                    reason=(
+                        "Rolled back active agent to shadow using lifecycle "
+                        "checkpoint; no prior version snapshot existed"
+                    ),
+                    shadow_accuracy=agent.shadow_accuracy_current,
+                    shadow_samples=agent.shadow_sample_count,
+                )
+                session.add(event)
+                return {
+                    "id": str(agent_id),
+                    "rolled_back": True,
+                    "from_version": agent.version,
+                    "to_version": agent.version,
+                    "from_status": old_status,
+                    "to_status": "shadow",
+                }
             raise HTTPException(409, "No previous version to rollback to")
 
         old_status = agent.status
@@ -2635,14 +2785,20 @@ async def rollback_agent(agent_id: UUID, tenant_id: str = Depends(get_current_te
         agent.llm_fallback = prev_version.llm_config.get("fallback_model", agent.llm_fallback)
         agent.confidence_floor = prev_version.confidence_floor
         agent.version = prev_version.version
+        new_status = "shadow" if old_status == "active" else old_status
+        agent.status = new_status
 
         event = AgentLifecycleEvent(
             tenant_id=tid,
             agent_id=agent.id,
             from_status=old_status,
-            to_status=old_status,  # status stays the same
+            to_status=new_status,
             triggered_by="api",
-            reason=f"Rolled back from version {old_version} to {prev_version.version}",
+            reason=(
+                f"Rolled back from version {old_version} to {prev_version.version}"
+            ),
+            shadow_accuracy=agent.shadow_accuracy_current,
+            shadow_samples=agent.shadow_sample_count,
         )
         session.add(event)
 
@@ -2651,6 +2807,8 @@ async def rollback_agent(agent_id: UUID, tenant_id: str = Depends(get_current_te
         "rolled_back": True,
         "from_version": old_version,
         "to_version": prev_version.version,
+        "from_status": old_status,
+        "to_status": new_status,
     }
 
 

--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -2556,14 +2556,20 @@ async def promote_agent(agent_id: UUID, tenant_id: str = Depends(get_current_ten
         old_status = agent.status
         old_version = agent.version or "1.0.0"
         new_version = _next_agent_version(old_version)
-        while (
-            await session.execute(
-                select(AgentVersion).where(
-                    AgentVersion.agent_id == agent.id,
-                    AgentVersion.version == new_version,
+        # The unique constraint on (agent_id, version) protects against duplicates;
+        # we still probe so promote returns a fresh version, but cap the probe at
+        # 100 attempts so a misbehaving session mock can't infinite-loop us.
+        for _ in range(100):
+            existing = (
+                await session.execute(
+                    select(AgentVersion).where(
+                        AgentVersion.agent_id == agent.id,
+                        AgentVersion.version == new_version,
+                    )
                 )
-            )
-        ).scalar_one_or_none():
+            ).scalar_one_or_none()
+            if not isinstance(existing, AgentVersion):
+                break
             new_version = _next_agent_version(new_version)
 
         existing_shadow_snapshot = (
@@ -2574,7 +2580,7 @@ async def promote_agent(agent_id: UUID, tenant_id: str = Depends(get_current_ten
                 )
             )
         ).scalar_one_or_none()
-        if existing_shadow_snapshot is None:
+        if not isinstance(existing_shadow_snapshot, AgentVersion):
             session.add(
                 _agent_version_snapshot(
                     agent,
@@ -2733,44 +2739,48 @@ async def rollback_agent(agent_id: UUID, tenant_id: str = Depends(get_current_te
         )
         prev_version = versions_result.scalar_one_or_none()
         if not prev_version:
-            transition = (
-                await session.execute(
-                    select(AgentLifecycleEvent)
-                    .where(
-                        AgentLifecycleEvent.tenant_id == tid,
-                        AgentLifecycleEvent.agent_id == agent_id,
-                        AgentLifecycleEvent.from_status == "shadow",
-                        AgentLifecycleEvent.to_status == "active",
+            # Only an active agent can be rolled back to shadow via the
+            # lifecycle-event checkpoint. Skip the extra query entirely
+            # for non-active agents — there is nothing to roll back to.
+            if agent.status == "active":
+                transition = (
+                    await session.execute(
+                        select(AgentLifecycleEvent)
+                        .where(
+                            AgentLifecycleEvent.tenant_id == tid,
+                            AgentLifecycleEvent.agent_id == agent_id,
+                            AgentLifecycleEvent.from_status == "shadow",
+                            AgentLifecycleEvent.to_status == "active",
+                        )
+                        .order_by(AgentLifecycleEvent.created_at.desc())
+                        .limit(1)
                     )
-                    .order_by(AgentLifecycleEvent.created_at.desc())
-                    .limit(1)
-                )
-            ).scalar_one_or_none()
-            if agent.status == "active" and transition is not None:
-                old_status = agent.status
-                agent.status = "shadow"
-                event = AgentLifecycleEvent(
-                    tenant_id=tid,
-                    agent_id=agent.id,
-                    from_status=old_status,
-                    to_status="shadow",
-                    triggered_by="api",
-                    reason=(
-                        "Rolled back active agent to shadow using lifecycle "
-                        "checkpoint; no prior version snapshot existed"
-                    ),
-                    shadow_accuracy=agent.shadow_accuracy_current,
-                    shadow_samples=agent.shadow_sample_count,
-                )
-                session.add(event)
-                return {
-                    "id": str(agent_id),
-                    "rolled_back": True,
-                    "from_version": agent.version,
-                    "to_version": agent.version,
-                    "from_status": old_status,
-                    "to_status": "shadow",
-                }
+                ).scalar_one_or_none()
+                if transition is not None:
+                    old_status = agent.status
+                    agent.status = "shadow"
+                    event = AgentLifecycleEvent(
+                        tenant_id=tid,
+                        agent_id=agent.id,
+                        from_status=old_status,
+                        to_status="shadow",
+                        triggered_by="api",
+                        reason=(
+                            "Rolled back active agent to shadow using lifecycle "
+                            "checkpoint; no prior version snapshot existed"
+                        ),
+                        shadow_accuracy=agent.shadow_accuracy_current,
+                        shadow_samples=agent.shadow_sample_count,
+                    )
+                    session.add(event)
+                    return {
+                        "id": str(agent_id),
+                        "rolled_back": True,
+                        "from_version": agent.version,
+                        "to_version": agent.version,
+                        "from_status": old_status,
+                        "to_status": "shadow",
+                    }
             raise HTTPException(409, "No previous version to rollback to")
 
         old_status = agent.status

--- a/tests/unit/test_module_3_dashboard.py
+++ b/tests/unit/test_module_3_dashboard.py
@@ -44,9 +44,33 @@ def test_tc_dash_001_dashboard_fetches_three_apis() -> None:
     src = (REPO / "ui" / "src" / "pages" / "Dashboard.tsx").read_text(
         encoding="utf-8"
     )
-    assert 'api.get("/agents")' in src
+    assert "agentsApi.listAll()" in src
     assert 'api.get("/approvals")' in src
     assert 'api.get("/audit"' in src
+
+
+def test_tc_dash_001_dashboard_fetches_all_agent_pages() -> None:
+    """Aishwarya 2026-05-11 TC_001: the dashboard must not stop at
+    the /agents default page of 20. It uses the shared listAll helper,
+    which walks every page at the backend cap of 100."""
+    api_src = (REPO / "ui" / "src" / "lib" / "api.ts").read_text(
+        encoding="utf-8"
+    )
+    dashboard_src = (REPO / "ui" / "src" / "pages" / "Dashboard.tsx").read_text(
+        encoding="utf-8"
+    )
+    agents_src = (REPO / "ui" / "src" / "pages" / "Agents.tsx").read_text(
+        encoding="utf-8"
+    )
+    playground_src = (REPO / "ui" / "src" / "pages" / "Playground.tsx").read_text(
+        encoding="utf-8"
+    )
+    assert "async function listAllPages" in api_src
+    assert 'per_page: perPage' in api_src
+    assert "agentsApi.listAll()" in dashboard_src
+    assert "await agentsApi.listAll(params)" in agents_src
+    assert "per_page=100" in playground_src
+    assert "per_page=50" not in playground_src
 
 
 def test_tc_dash_001_uses_promise_allsettled_not_all() -> None:

--- a/tests/unit/test_module_4_agent_fleet.py
+++ b/tests/unit/test_module_4_agent_fleet.py
@@ -283,22 +283,36 @@ def test_tc_agt_010_rollback_picks_previous_not_current_version() -> None:
 
 
 def test_tc_agt_010_rollback_409_when_no_previous_version() -> None:
-    """If there's no prior version (first-ever release), 409 with
-    the documented message — NOT a 500 / silent no-op."""
+    """If there's no prior version (first-ever release) AND no
+    shadow→active lifecycle checkpoint, the rollback returns 409
+    with the documented message — NOT a 500 / silent no-op.
+
+    Aishwarya 2026-05-11 TC_AGENT_007 expanded the no-previous-version
+    branch with a lifecycle-checkpoint fallback for active agents, so
+    the 409 raise now appears further down inside the rollback body.
+    """
     src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
     assert "No previous version to rollback to" in src
-    assert "HTTPException(409" in src.split("rollback_agent", 1)[1][:1500]
+    rollback_block = src.split("async def rollback_agent", 1)[1].split(
+        "async def clone_agent", 1
+    )[0]
+    assert "HTTPException(409" in rollback_block
 
 
 def test_tc_agt_010_rollback_emits_lifecycle_event() -> None:
-    """The rollback emits a lifecycle event so the activity feed
-    shows "rolled back from version X to Y". Status is preserved
-    (to_status = old_status) — rolling back code shouldn't
-    unpause a paused agent."""
+    """The rollback emits a lifecycle event so the activity feed shows
+    "rolled back from version X to Y". Aishwarya 2026-05-11 TC_AGENT_007
+    changed the semantics: an active agent now demotes to shadow on
+    rollback (giving the user time to revalidate before re-promoting),
+    while paused/other statuses are preserved.
+    """
     src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
-    rollback_block = src.split("async def rollback_agent", 1)[1][:2500]
+    rollback_block = src.split("async def rollback_agent", 1)[1].split(
+        "async def clone_agent", 1
+    )[0]
     assert "AgentLifecycleEvent(" in rollback_block
-    assert "to_status=old_status" in rollback_block
+    assert "to_status=new_status" in rollback_block
+    assert 'new_status = "shadow" if old_status == "active" else old_status' in rollback_block
     assert "Rolled back from version" in rollback_block
 
 

--- a/tests/unit/test_module_6_agent_execution.py
+++ b/tests/unit/test_module_6_agent_execution.py
@@ -66,11 +66,44 @@ def test_tc_exec_001_run_requires_non_empty_inputs() -> None:
     run_block = src.split('@router.post("/agents/{agent_id}/run")', 1)[1].split(
         "@router.", 1
     )[0]
-    assert "if not inputs:" in run_block
+    assert "_validate_run_inputs(payload)" in run_block
+    assert "def _validate_run_inputs" in src
     assert (
         'HTTPException(400, "inputs field is required and cannot be empty")'
-        in run_block
+        in src
     )
+
+
+def test_tc_exec_001_run_rejects_non_meaningful_prompts() -> None:
+    """Aishwarya 2026-05-11 TC_003/004/006: a non-empty inputs
+    object is not enough. Empty strings, numeric-only strings, and
+    punctuation-only strings must be stopped before LangGraph runs so
+    shadow metrics are not polluted."""
+    from fastapi import HTTPException
+
+    from api.v1.agents import _has_meaningful_run_text, _validate_run_inputs
+
+    assert not _has_meaningful_run_text("")
+    assert not _has_meaningful_run_text("@@@@@")
+    assert not _has_meaningful_run_text("123456")
+    assert _has_meaningful_run_text("Prepare TDS filing summary")
+
+    for payload in (
+        {"action": "run", "inputs": {"task": ""}},
+        {"action": "run", "inputs": {"task": "@@@@@"}},
+        {"action": "run", "inputs": {"task": "123456"}},
+    ):
+        try:
+            _validate_run_inputs(payload)
+        except HTTPException as exc:
+            assert exc.status_code == 400
+            assert "valid task or prompt" in str(exc.detail)
+        else:  # pragma: no cover - failure branch
+            raise AssertionError(f"payload unexpectedly accepted: {payload}")
+
+    assert _validate_run_inputs(
+        {"action": "run", "inputs": {"task": "Prepare TDS filing summary"}}
+    ) == {"task": "Prepare TDS filing summary"}
 
 
 def test_tc_exec_001_run_returns_404_on_missing_agent() -> None:
@@ -325,3 +358,25 @@ def test_tc_exec_008_budget_endpoint_pinned() -> None:
     for key in ('"monthly_cap_usd"', '"monthly_spent_usd"',
                 '"monthly_pct_used"', '"warnings"'):
         assert key in budget_block, f"budget endpoint missing key {key}"
+
+
+def test_aishwarya_20260511_promote_creates_rollback_checkpoint() -> None:
+    """Shadow-to-active promotion must leave rollback with a prior
+    shadow checkpoint and rollback must return active agents to shadow."""
+    from api.v1.agents import _next_agent_version
+
+    assert _next_agent_version("1.0.0") == "1.0.1"
+    assert _next_agent_version("2.3.9") == "2.3.10"
+
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    promote_block = src.split("async def promote_agent", 1)[1].split(
+        "async def retire_agent", 1
+    )[0]
+    rollback_block = src.split("async def rollback_agent", 1)[1].split(
+        "async def clone_agent", 1
+    )[0]
+    assert "existing_shadow_snapshot" in promote_block
+    assert "agent.version = new_version" in promote_block
+    assert "session.add(_agent_version_snapshot(agent, new_version" in promote_block
+    assert 'new_status = "shadow" if old_status == "active" else old_status' in rollback_block
+    assert '"to_status": new_status' in rollback_block

--- a/ui/e2e/aishwarya-11may2026.spec.ts
+++ b/ui/e2e/aishwarya-11may2026.spec.ts
@@ -1,0 +1,201 @@
+import { expect, Page, test } from "@playwright/test";
+
+type MockAgent = {
+  id: string;
+  name: string;
+  employee_name: string;
+  agent_type: string;
+  domain: string;
+  status: string;
+  version: string;
+  confidence_floor: number;
+  shadow_sample_count: number;
+  shadow_accuracy_current: number;
+  shadow_accuracy_floor: number;
+  shadow_min_samples: number;
+  authorized_tools: string[];
+  created_at: string;
+};
+
+function buildAgents(count: number): MockAgent[] {
+  return Array.from({ length: count }, (_, i) => {
+    const n = i + 1;
+    return {
+      id: n === 1 ? "agent-1" : `agent-${n}`,
+      name: `Agent ${n}`,
+      employee_name: `Agent ${n}`,
+      agent_type: "tax_compliance",
+      domain: n % 2 === 0 ? "finance" : "ops",
+      status: n % 3 === 0 ? "shadow" : "active",
+      version: n === 1 ? "1.0.1" : "1.0.0",
+      confidence_floor: 0.88,
+      shadow_sample_count: 12,
+      shadow_accuracy_current: 0.82,
+      shadow_accuracy_floor: 0.8,
+      shadow_min_samples: 10,
+      authorized_tools: ["calculate_tds"],
+      created_at: "2026-05-11T00:00:00Z",
+    };
+  });
+}
+
+async function installRoutes(page: Page, agents: MockAgent[]) {
+  let detailAgent = { ...agents[0], status: "active", version: "1.0.1" };
+
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+
+    if (path.endsWith("/auth/me")) {
+      await route.fulfill({
+        json: {
+          email: "qa@example.com",
+          name: "QA",
+          role: "admin",
+          domain: "all",
+          tenant_id: "tenant-1",
+          onboarding_complete: true,
+        },
+      });
+      return;
+    }
+
+    if (path.endsWith("/product-facts")) {
+      await route.fulfill({
+        json: {
+          version: "test",
+          connector_count: 10,
+          agent_count: agents.length,
+          tool_count: 20,
+        },
+      });
+      return;
+    }
+
+    if (path.endsWith("/agents/agent-1/run") && request.method() === "POST") {
+      await route.fulfill({
+        json: {
+          run_id: "run-1",
+          task_id: "run-1",
+          agent_id: "agent-1",
+          status: "completed",
+          confidence: 0.91,
+          output: { answer: "Generated compliance summary" },
+          reasoning_trace: ["validated task"],
+          tool_calls: [],
+          performance: { total_latency_ms: 10, llm_tokens_used: 0, llm_cost_usd: 0 },
+          hitl_trigger: null,
+          error: null,
+        },
+      });
+      return;
+    }
+
+    if (path.endsWith("/agents/agent-1/rollback") && request.method() === "POST") {
+      detailAgent = { ...detailAgent, status: "shadow", version: "1.0.0" };
+      await route.fulfill({
+        json: {
+          id: "agent-1",
+          rolled_back: true,
+          from_status: "active",
+          to_status: "shadow",
+          from_version: "1.0.1",
+          to_version: "1.0.0",
+        },
+      });
+      return;
+    }
+
+    if (path.endsWith("/agents/agent-1") && request.method() === "GET") {
+      await route.fulfill({ json: detailAgent });
+      return;
+    }
+
+    if (path.endsWith("/agents") && request.method() === "GET") {
+      const pageNum = Number(url.searchParams.get("page") || "1");
+      const perPage = Number(url.searchParams.get("per_page") || "20");
+      const domain = url.searchParams.get("domain");
+      const status = url.searchParams.get("status");
+      let filtered = agents;
+      if (domain) filtered = filtered.filter((agent) => agent.domain === domain);
+      if (status) filtered = filtered.filter((agent) => agent.status === status);
+      const start = (pageNum - 1) * perPage;
+      const items = filtered.slice(start, start + perPage);
+      await route.fulfill({
+        json: {
+          items,
+          total: filtered.length,
+          page: pageNum,
+          per_page: perPage,
+          pages: Math.max(1, Math.ceil(filtered.length / perPage)),
+        },
+      });
+      return;
+    }
+
+    if (path.endsWith("/approvals")) {
+      await route.fulfill({ json: { items: [], total: 0, page: 1, per_page: 20, pages: 1 } });
+      return;
+    }
+
+    if (path.endsWith("/audit")) {
+      await route.fulfill({ json: { items: [], total: 0, page: 1, per_page: 10, pages: 1 } });
+      return;
+    }
+
+    if (path.endsWith("/agents/agent-1/feedback")) {
+      await route.fulfill({ json: { feedback: [], count: 0 } });
+      return;
+    }
+
+    if (path.endsWith("/agents/agent-1/explanation/latest")) {
+      await route.fulfill({ json: { has_run: false, bullets: [], tools_cited: [] } });
+      return;
+    }
+
+    await route.fulfill({ json: {} });
+  });
+}
+
+test.describe("Aishwarya 11 May 2026 regressions", () => {
+  test("dashboard and agent fleet load every agent page, not just the first 20", async ({ page, baseURL }) => {
+    const agents = buildAgents(125);
+    await installRoutes(page, agents);
+
+    await page.goto(`${baseURL}/dashboard`, { waitUntil: "domcontentloaded" });
+    await expect(page.locator("main")).toContainText("Total Agents");
+    await expect(page.locator("main")).toContainText("125");
+
+    await page.goto(`${baseURL}/dashboard/agents`, { waitUntil: "domcontentloaded" });
+    await expect(page.locator("main")).toContainText("Agent Fleet");
+    await expect(page.locator("main")).toContainText("Agent 125");
+  });
+
+  test("run dialog rejects meaningless prompts and renders successful output", async ({ page, baseURL }) => {
+    const agents = buildAgents(25);
+    await installRoutes(page, agents);
+
+    await page.goto(`${baseURL}/dashboard/agents/agent-1`, { waitUntil: "domcontentloaded" });
+    await page.getByRole("button", { name: "Run Agent" }).click();
+    await page.getByPlaceholder("What should the agent do?").fill("@@@@@");
+    await expect(page.getByRole("button", { name: /^Run$/ })).toBeDisabled();
+    await expect(page.locator("main")).toContainText("Please enter a valid task or prompt.");
+
+    await page.getByPlaceholder("What should the agent do?").fill("Prepare TDS filing summary");
+    await page.getByRole("button", { name: /^Run$/ }).click();
+    await expect(page.getByTestId("agent-run-result")).toContainText("completed");
+    await expect(page.getByTestId("agent-run-result")).toContainText("Generated compliance summary");
+  });
+
+  test("active agent rollback button is enabled and returns the agent to shadow", async ({ page, baseURL }) => {
+    const agents = buildAgents(25);
+    await installRoutes(page, agents);
+
+    await page.goto(`${baseURL}/dashboard/agents/agent-1`, { waitUntil: "domcontentloaded" });
+    const rollback = page.getByRole("button", { name: "Rollback" });
+    await expect(rollback).toBeEnabled();
+    await rollback.click();
+    await expect(page.locator("main")).toContainText("shadow");
+  });
+});

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -96,8 +96,44 @@ export function extractApiError(e: unknown, fallback = "An error occurred"): str
   return fallback;
 }
 export default api;
+
+async function listAllPages<T>(
+  path: string,
+  params?: Record<string, string>,
+): Promise<T[]> {
+  const items: T[] = [];
+  let page = 1;
+  let pages = 1;
+  const perPage = "100";
+
+  do {
+    const { data } = await api.get(path, {
+      params: { ...(params || {}), page: String(page), per_page: perPage },
+    });
+    const pageItems: T[] = Array.isArray(data)
+      ? data
+      : Array.isArray(data?.items)
+        ? data.items
+        : [];
+
+    items.push(...pageItems);
+    pages = Number.isFinite(Number(data?.pages)) ? Number(data.pages) : page;
+
+    if (!data?.pages) {
+      const total = Number(data?.total ?? items.length);
+      if (items.length >= total || pageItems.length < Number(perPage)) break;
+      pages = page + 1;
+    }
+
+    page += 1;
+  } while (page <= pages);
+
+  return items;
+}
+
 export const agentsApi = {
   list: (params?: Record<string, string>) => api.get("/agents", { params }),
+  listAll: (params?: Record<string, string>) => listAllPages<any>("/agents", params),
   get: (id: string) => api.get(`/agents/${id}`),
   create: (data: any) => api.post("/agents", data),
   update: (id: string, data: any) => api.patch(`/agents/${id}`, data),

--- a/ui/src/pages/AgentCreate.tsx
+++ b/ui/src/pages/AgentCreate.tsx
@@ -128,10 +128,9 @@ export default function AgentCreate() {
 
   // Load available parent agents when domain changes
   useEffect(() => {
-    agentsApi.list({ domain, status: "active" }).then(({ data }) => {
-      const items = Array.isArray(data) ? data : data.items || [];
-      setAvailableParents(items);
-    }).catch(() => setAvailableParents([]));
+    agentsApi.listAll({ domain, status: "active" })
+      .then((items) => setAvailableParents(items))
+      .catch(() => setAvailableParents([]));
   }, [domain]);
 
   // Load available connectors for the picker (UR-Bug-1).

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -13,6 +13,26 @@ import {
 
 const ChatPanel = lazy(() => import("@/components/ChatPanel"));
 
+function isMeaningfulRunTask(value: string): boolean {
+  const task = value.trim();
+  return task.length >= 3 && /\p{L}/u.test(task);
+}
+
+function formatRunOutput(output: unknown): string {
+  if (output == null || output === "") return "No output returned.";
+  if (typeof output === "string") return output;
+  if (typeof output === "object") {
+    const record = output as Record<string, unknown>;
+    const preferred = record.answer || record.response || record.summary || record.message;
+    if (preferred) return String(preferred);
+  }
+  try {
+    return JSON.stringify(output, null, 2);
+  } catch {
+    return String(output);
+  }
+}
+
 export default function AgentDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -41,6 +61,7 @@ export default function AgentDetail() {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionNotice, setActionNotice] = useState<string | null>(null);
+  const [runResult, setRunResult] = useState<any | null>(null);
 
   // Run-task dialog (replaces window.prompt, which is blocked in
   // embedded browsers and some desktop shells).
@@ -108,23 +129,30 @@ export default function AgentDetail() {
     setRunTask("");
     setActionError(null);
     setActionNotice(null);
+    setRunResult(null);
     setRunDialogOpen(true);
   }
 
   async function submitRun() {
     const task = runTask.trim();
-    if (!task) return;
+    if (!isMeaningfulRunTask(task)) {
+      setActionError("Please enter a valid task or prompt.");
+      return;
+    }
 
     setRunDialogOpen(false);
     setActionLoading("run");
     setActionError(null);
     setActionNotice(null);
+    setRunResult(null);
     try {
-      await api.post(`/agents/${id}/run`, {
+      const { data } = await api.post(`/agents/${id}/run`, {
         action: "run",
         inputs: { task },
       });
-      setActionNotice("Agent run started successfully.");
+      setRunResult(data);
+      setActionNotice(`Agent run ${data?.status || "completed"}.`);
+      fetchAgent();
     } catch (err: any) {
       setActionError(err.response?.data?.detail || "Run failed");
     } finally {
@@ -147,6 +175,9 @@ export default function AgentDetail() {
 
   const confidenceFloor = agent.confidence_floor != null ? `${(agent.confidence_floor * 100).toFixed(0)}%` : "N/A";
   const shadowAccuracy = agent.shadow_accuracy_current != null ? `${(agent.shadow_accuracy_current * 100).toFixed(1)}%` : "N/A";
+  const runTaskError = runTask.trim() && !isMeaningfulRunTask(runTask)
+    ? "Please enter a valid task or prompt."
+    : "";
 
   const displayName = agent.employee_name || agent.name;
 
@@ -196,12 +227,12 @@ export default function AgentDetail() {
                 {actionLoading === "promote" ? "Promoting..." : "Promote"}
               </Button>
             )}
-            <span title={!agent.version || agent.version === "1.0" || (!agent.shadow_sample_count && agent.status === "active") ? "No previous version available" : undefined}>
+            <span>
               <Button
                 variant="outline"
                 size="sm"
                 onClick={handleRollback}
-                disabled={actionLoading !== null || (!agent.version || agent.version === "1.0" || (!agent.shadow_sample_count && agent.status === "active"))}
+                disabled={actionLoading !== null || agent.status !== "active"}
               >
                 {actionLoading === "rollback" ? "Rolling back..." : "Rollback"}
               </Button>
@@ -253,6 +284,31 @@ export default function AgentDetail() {
           <CardContent><p className="text-xl font-bold">{shadowAccuracy}</p></CardContent></Card>
       </div>
 
+      {runResult && (
+        <Card data-testid="agent-run-result">
+          <CardHeader>
+            <div className="flex items-center justify-between gap-3">
+              <CardTitle className="text-sm font-semibold">Run Result</CardTitle>
+              <div className="flex items-center gap-2">
+                <Badge variant={runResult.status === "completed" ? "success" : "secondary"}>
+                  {runResult.status || "completed"}
+                </Badge>
+                {runResult.confidence != null && (
+                  <span className="text-xs text-muted-foreground">
+                    Confidence {(Number(runResult.confidence) * 100).toFixed(1)}%
+                  </span>
+                )}
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <pre className="max-h-64 overflow-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs">
+              {formatRunOutput(runResult.output)}
+            </pre>
+          </CardContent>
+        </Card>
+      )}
+
       <div className="flex gap-4 border-b pb-2">
         {(["overview", "config", "prompt", "shadow", "cost", "scopes", "learning", "voice"] as const).map((tab) => (
           <button key={tab} onClick={() => { setActiveTab(tab); setActionError(null); }} className={`px-3 py-1 text-sm font-medium capitalize ${activeTab === tab ? "border-b-2 border-primary" : "text-muted-foreground"}`}>
@@ -298,6 +354,9 @@ export default function AgentDetail() {
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm min-h-[100px] focus:outline-none focus:ring-1 focus:ring-primary"
               autoFocus
             />
+            {runTaskError && (
+              <p className="mt-2 text-xs text-destructive">{runTaskError}</p>
+            )}
             <div className="flex justify-end gap-2 mt-4">
               <Button variant="outline" size="sm" onClick={() => setRunDialogOpen(false)}>
                 Cancel
@@ -306,7 +365,7 @@ export default function AgentDetail() {
                 variant="default"
                 size="sm"
                 onClick={() => void submitRun()}
-                disabled={!runTask.trim()}
+                disabled={!runTask.trim() || Boolean(runTaskError)}
               >
                 Run
               </Button>
@@ -327,10 +386,9 @@ function OverviewTab({ agent, onUpdated }: { agent: Agent; onUpdated: () => void
 
   useEffect(() => {
     if (editingParent) {
-      agentsApi.list({ domain: agent.domain, status: "active" }).then(({ data }) => {
-        const items = (Array.isArray(data) ? data : data.items || []).filter((a: Agent) => a.id !== agent.id);
-        setParentCandidates(items);
-      }).catch(() => setParentCandidates([]));
+      agentsApi.listAll({ domain: agent.domain, status: "active" })
+        .then((items) => setParentCandidates(items.filter((a: Agent) => a.id !== agent.id)))
+        .catch(() => setParentCandidates([]));
     }
   }, [editingParent, agent.domain, agent.id]);
 

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -4,7 +4,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import AgentCard from "@/components/AgentCard";
 import KillSwitch from "@/components/KillSwitch";
-import api, { agentsApi } from "@/lib/api";
+import { agentsApi } from "@/lib/api";
 import type { Agent } from "@/types";
 
 const DOMAINS = ["all", "finance", "hr", "marketing", "ops", "backoffice", "comms"];
@@ -33,10 +33,9 @@ export default function Agents() {
       const params: Record<string, string> = {};
       if (domainFilter !== "all") params.domain = domainFilter;
       if (statusFilter !== "all") params.status = statusFilter;
-      const { data } = await api.get("/agents", { params: { ...params, per_page: "500" } });
-      const items = Array.isArray(data) ? data : Array.isArray(data?.items) ? data.items : [];
+      const items = await agentsApi.listAll(params);
       setAgents(items);
-      if (data?.total !== undefined) setTotalCount(data.total);
+      setTotalCount(items.length);
     } catch {
       setAgents([]);
     } finally {

--- a/ui/src/pages/CompanyDetail.tsx
+++ b/ui/src/pages/CompanyDetail.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import api, { extractApiError } from "@/lib/api";
+import api, { agentsApi, extractApiError } from "@/lib/api";
 import { stateNameFromCode } from "@/lib/indianStates";
 
 interface CompanyInfo {
@@ -305,7 +305,7 @@ export default function CompanyDetail() {
       api.get(`/companies/${id}/gstn-uploads`),
       api.get(`/companies/${id}/roles`),
       api.get(`/companies/${id}/credentials`),
-      api.get("/agents", { params: { page: 1, per_page: 200, domain: "finance", company_id: id } }),
+      agentsApi.listAll({ domain: "finance", company_id: id }),
       api.get("/workflows", { params: { page: 1, per_page: 200, company_id: id } }),
       api.get("/audit", { params: { page: 1, per_page: 200, company_id: id } }),
     ]);
@@ -378,7 +378,7 @@ export default function CompanyDetail() {
     );
 
     if (agentsResult.status === "fulfilled") {
-      const agentItems = itemsFromResponse<Record<string, unknown>>(agentsResult.value.data);
+      const agentItems = agentsResult.value as Record<string, unknown>[];
       setAgents(
         agentItems
           .map((record) => ({

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -4,7 +4,7 @@ import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import api from "@/lib/api";
+import api, { agentsApi } from "@/lib/api";
 import type { Agent, HITLItem, AuditEntry } from "@/types";
 import { useProductFacts } from "@/lib/productFacts";
 import {
@@ -53,14 +53,13 @@ export default function Dashboard() {
     const warnings: string[] = [];
     try {
       const [agentsResp, approvalsResp, auditResp] = await Promise.allSettled([
-        api.get("/agents"),
+        agentsApi.listAll(),
         api.get("/approvals"),
         api.get("/audit", { params: { limit: 10 } }),
       ]);
 
       if (agentsResp.status === "fulfilled") {
-        const d = agentsResp.value.data;
-        setAgents(Array.isArray(d) ? d : Array.isArray(d?.items) ? d.items : []);
+        setAgents(agentsResp.value);
       } else {
         warnings.push("Agents data could not be loaded");
       }

--- a/ui/src/pages/Playground.tsx
+++ b/ui/src/pages/Playground.tsx
@@ -406,13 +406,26 @@ function UserAgentsSection({ onRun, running, selectedId }: { onRun: (uc: any) =>
     // session cookie automatically because of credentials: "include".
     // Server returns 401 when there is no session — we treat that as
     // "no custom agents to show" (anonymous Playground visitor).
-    fetch("/api/v1/agents?per_page=50", { credentials: "include" })
-      .then((r) => {
-        if (!r.ok) return { items: [] };
-        return r.json();
-      })
-      .then((data) => {
-        const items = data.items || [];
+    async function fetchAgents() {
+      const all: any[] = [];
+      let page = 1;
+      let pages = 1;
+      do {
+        const r = await fetch(`/api/v1/agents?page=${page}&per_page=100`, {
+          credentials: "include",
+        });
+        if (!r.ok) return [];
+        const data = await r.json();
+        const items = Array.isArray(data?.items) ? data.items : [];
+        all.push(...items);
+        pages = Number(data?.pages || page);
+        page += 1;
+      } while (page <= pages);
+      return all;
+    }
+
+    fetchAgents()
+      .then((items) => {
         // Filter to non-builtin agents only
         const custom = items.filter((a: any) => !a.is_builtin);
         setAgents(custom);

--- a/ui/src/pages/ScopeDashboard.tsx
+++ b/ui/src/pages/ScopeDashboard.tsx
@@ -3,7 +3,7 @@ import { Helmet } from "react-helmet-async";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import api from "@/lib/api";
+import api, { agentsApi } from "@/lib/api";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -66,7 +66,7 @@ export default function ScopeDashboard() {
     try {
       // Attempt to load real data from both endpoints
       const [agentsRes, enforceRes] = await Promise.allSettled([
-        api.get("/agents"),
+        agentsApi.listAll(),
         api.get("/audit/enforce"),
       ]);
 
@@ -90,9 +90,7 @@ export default function ScopeDashboard() {
       }
       setErrors(fetchErrors);
 
-      const agents = agentsRes.status === "fulfilled"
-        ? (Array.isArray(agentsRes.value.data) ? agentsRes.value.data : agentsRes.value.data?.items || [])
-        : [];
+      const agents = agentsRes.status === "fulfilled" ? agentsRes.value : [];
       const enforceData = enforceRes.status === "fulfilled"
         ? (Array.isArray(enforceRes.value.data) ? enforceRes.value.data : enforceRes.value.data?.items || [])
         : [];


### PR DESCRIPTION
## Summary

Closes the Aishwarya 2026-05-11 QA workbook. All six entries verified as real
product bugs, fixed at the runtime layer, regression-pinned, and Playwright-replayed.

@codex please re-review

### Bug-class fixes

- **Pagination (TC_DASH_001 + siblings):** Dashboard, Agent Fleet, Agent Create, Agent Detail, and Playground now walk every `/agents` page at the backend cap of 100 via a shared `agentsApi.listAll()` helper. **Sibling-sweep additions (not in the workbook):** `CompanyDetail.tsx` (was `per_page=200`, silently capped at 100) and `ScopeDashboard.tsx` (was unpaginated → 20). Found by `git grep 'api.get("/agents"'` after the workbook items were patched.
- **Prompt validation (TC_EXEC_003/004/006):** New `_validate_run_inputs()` on the backend rejects empty / punctuation-only / digits-only inputs before LangGraph runs, recursing into structured payloads. Bypassed only for `action="shadow_sample"` (system-driven traffic). `AgentDetail` Run dialog mirrors the rule inline.
- **Run result rendering (TC_EXEC_005):** AgentDetail now renders a `Run Result` Card with status, confidence, and output instead of a toast-only success.
- **Promote / Rollback lifecycle checkpoints (TC_AGENT_007):**
  - `promote_agent` bumps the version, snapshots both the prior shadow state and the new active state into `agent_versions`, and records shadow accuracy/samples on the lifecycle event. Bounded version-bump loop avoids infinite spin on misbehaving mocks.
  - `rollback_agent` filters `AgentVersion` by `tenant_id` (defence-in-depth over RLS), demotes active→shadow on rollback so the user has time to revalidate, and recovers via the shadow→active lifecycle event when no prior version snapshot exists.
  - AgentDetail rollback button enables on any active agent.

### Verification

| Gate | Result |
| --- | --- |
| ruff check . (whole tree) | pass |
| mypy (734 files) | pass |
| bandit -r api auth core -ll -iii | pass |
| verify=False scan | pass |
| alembic revision-id length | pass |
| consistency_sweep.py | pass |
| ui tsc + build | pass |
| pytest tests/unit/ tests/regression/ | pass (4084; 2 pre-existing Windows-local failures unrelated to this PR — cp1252 charmap in vitest subprocess + leftover .claude/worktrees scanned by env-read regression; CI on Linux unaffected) |

### Residual risk

- Code-grade + CI-green only. Not yet replayed by an actual tester on the deployed Cloud Run revision. Per `feedback_28apr_reopen_autopsy.md` Rule 7 the only honest closure signal is post-deploy login-as-tester reproduction; that step is pending operator action after this PR ships.
- impeccable /audit/critique/polish not invoked. The new UI is a single Card using existing primitives; no new aesthetic decisions were taken.

## Test plan

- [ ] CI green on Linux
- [ ] Deploy to Cloud Run (asia-southeast1) — agenticorg-api + agenticorg-ui-cloudrun
- [ ] Smoke /health on api revision
- [ ] Operator re-runs Aishwarya's 6 workbook entries against the live deploy