### PR TITLE
fix(qa): Ramesh 2026-05-11 CA/Zoho sweep — 14 reopens (Zoho India, connector health, tool routing, prod floor 60%)

### DIFF
--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -263,6 +263,8 @@ _PROMOTE_MAP: dict[str, str] = {
     "shadow": "active",
 }
 
+_MIN_PRODUCTION_SHADOW_ACCURACY = Decimal("0.600")
+
 
 def _agent_to_dict(agent: Agent) -> dict:
     """Convert an Agent ORM instance to a JSON-serialisable dict."""
@@ -469,8 +471,37 @@ def _validate_authorized_tools(tools: list[str]) -> list[str]:
     """
     from core.langgraph.tool_adapter import _build_tool_index
 
-    index = _build_tool_index()
+    index = _build_tool_index(include_connector_aliases=True)
     return [t for t in tools if t not in index]
+
+
+def _tool_ref_matches(tool_ref: str, expected_tool: str) -> bool:
+    raw = str(tool_ref or "").strip()
+    expected = str(expected_tool or "").strip()
+    if not raw or not expected:
+        return False
+    if raw == expected:
+        return True
+    if ":" in raw and not raw.startswith("tool:"):
+        return raw.split(":", 1)[1] == expected
+    if "__" in raw:
+        return raw.split("__", 1)[1] == expected
+    return False
+
+
+def _is_tool_authorized(authorized_tools: list[str], expected_tool: str) -> bool:
+    return any(_tool_ref_matches(tool_ref, expected_tool) for tool_ref in authorized_tools or [])
+
+
+def _effective_shadow_accuracy_floor(agent: Agent) -> Decimal:
+    floor = agent.shadow_accuracy_floor or Decimal("0")
+    return max(Decimal(str(floor)), _MIN_PRODUCTION_SHADOW_ACCURACY)
+
+
+def _active_agent_below_production_floor(agent: Agent) -> bool:
+    if agent.status != "active" or agent.shadow_accuracy_current is None:
+        return False
+    return Decimal(str(agent.shadow_accuracy_current)) < _effective_shadow_accuracy_floor(agent)
 
 
 def _derive_default_tools(
@@ -1030,6 +1061,9 @@ async def list_agents(
         if status:
             query = query.where(Agent.status == status)
             count_query = count_query.where(Agent.status == status)
+        else:
+            query = query.where(Agent.status.notin_(["deleted", "error", "broken"]))
+            count_query = count_query.where(Agent.status.notin_(["deleted", "error", "broken"]))
         if company_uuid is not None:
             query = query.where(Agent.company_id == company_uuid)
             count_query = count_query.where(Agent.company_id == company_uuid)
@@ -1079,6 +1113,11 @@ async def list_agents(
                     if status:
                         query = query.where(Agent.status == status)
                         count_query = count_query.where(Agent.status == status)
+                    else:
+                        query = query.where(Agent.status.notin_(["deleted", "error", "broken"]))
+                        count_query = count_query.where(
+                            Agent.status.notin_(["deleted", "error", "broken"])
+                        )
                     query = query.where(Agent.company_id == company_uuid)
                     count_query = count_query.where(Agent.company_id == company_uuid)
                     total = (await session.execute(count_query)).scalar() or 0
@@ -1816,6 +1855,16 @@ async def run_agent(
             raise HTTPException(404, "Agent not found")
         if agent_row.status == "retired":
             raise HTTPException(409, "Cannot run a retired agent")
+        if _active_agent_below_production_floor(agent_row):
+            raise HTTPException(
+                409,
+                (
+                    "Active agent is below the production shadow-accuracy "
+                    f"floor ({agent_row.shadow_accuracy_current} < "
+                    f"{_effective_shadow_accuracy_floor(agent_row)}). "
+                    "Rollback to shadow and retest before running live work."
+                ),
+            )
 
         agent_config = _agent_to_dict(agent_row)
 
@@ -2095,7 +2144,7 @@ async def run_agent(
         fixture_tool_authorized = bool(
             isinstance(fixture_expected, str)
             and fixture_expected
-            and fixture_expected in (authorized_tools or [])
+            and _is_tool_authorized(authorized_tools or [], fixture_expected)
         )
         if fixture and not fixture_tool_authorized:
             logger.warning(
@@ -2494,6 +2543,15 @@ async def resume_agent(agent_id: UUID, tenant_id: str = Depends(get_current_tena
                     f"floor {agent.shadow_accuracy_floor}; "
                     f"use /agents/{agent_id}/retest to re-evaluate",
                 )
+        elif resume_to == "active" and _active_agent_below_production_floor(agent):
+            raise HTTPException(
+                409,
+                (
+                    "Cannot resume to active: shadow accuracy "
+                    f"{agent.shadow_accuracy_current} is below production "
+                    f"floor {_effective_shadow_accuracy_floor(agent)}"
+                ),
+            )
 
         agent.status = resume_to
 
@@ -2547,10 +2605,11 @@ async def promote_agent(agent_id: UUID, tenant_id: str = Depends(get_current_ten
                     409,
                     "Shadow accuracy not yet computed; run shadow samples first",
                 )
-            if agent.shadow_accuracy_current < agent.shadow_accuracy_floor:
+            required_accuracy = _effective_shadow_accuracy_floor(agent)
+            if agent.shadow_accuracy_current < required_accuracy:
                 raise HTTPException(
                     409,
-                    f"Shadow accuracy {agent.shadow_accuracy_current} is below floor {agent.shadow_accuracy_floor}",
+                    f"Shadow accuracy {agent.shadow_accuracy_current} is below floor {required_accuracy}",
                 )
 
         old_status = agent.status

--- a/api/v1/connectors.py
+++ b/api/v1/connectors.py
@@ -20,6 +20,46 @@ from core.schemas.api import ConnectorCreate, ConnectorUpdate
 
 _log = logging.getLogger(__name__)
 
+_ZOHO_IN_BASE = "https://books.zoho.in/api/v3"
+_ZOHO_GLOBAL_BASE = "https://www.zohoapis.com/books/v3"
+
+
+def _normalise_connector_base_url(name: str, base_url: str | None) -> str | None:
+    """Normalize known provider URL footguns before storing or displaying."""
+    value = (base_url or "").strip()
+    if (name or "").strip().lower() != "zoho_books":
+        return value or None
+    lowered = value.lower()
+    if "zohoapis.in" in lowered or "books.zoho.in" in lowered:
+        return _ZOHO_IN_BASE
+    return value or _ZOHO_GLOBAL_BASE
+
+
+def _connector_tool_functions(conn: Connector) -> list[str]:
+    raw_tools = getattr(conn, "tool_functions", None)
+    if isinstance(raw_tools, list) and raw_tools:
+        return [str(tool) for tool in raw_tools]
+    try:
+        import connectors  # noqa: F401, PLC0415
+        from connectors.registry import ConnectorRegistry
+
+        connector_cls = ConnectorRegistry.get(str(conn.name or ""))
+        class_tools = getattr(connector_cls, "tools", None) if connector_cls else None
+        if class_tools:
+            return [
+                tool if isinstance(tool, str) else getattr(tool, "name", str(tool))
+                for tool in class_tools
+            ]
+        if connector_cls and hasattr(connector_cls, "_register_tools"):
+            instance = connector_cls.__new__(connector_cls)
+            instance.config = {}
+            instance._tool_registry = {}
+            instance._register_tools()
+            return sorted(instance._tool_registry.keys())
+    except Exception:
+        _log.debug("connector_tool_discovery_failed", exc_info=True)
+    return []
+
 
 def _assert_public_base_url(base_url: str) -> None:
     """Reject connector base_urls that resolve to private/reserved ranges.
@@ -86,7 +126,6 @@ def _connector_to_dict(conn: Connector) -> dict:
     # Return a boolean flag for whether credentials are configured —
     # NEVER return the actual auth_config (secrets) in the API response.
     auth_config = getattr(conn, "auth_config", None)
-    tool_functions = getattr(conn, "tool_functions", None)
     has_creds = bool(auth_config) or bool(getattr(conn, "secret_ref", None))
     health_check_at = getattr(conn, "health_check_at", None)
     created_at = getattr(conn, "created_at", None)
@@ -96,10 +135,10 @@ def _connector_to_dict(conn: Connector) -> dict:
         "name": str(conn.name or ""),
         "category": str(conn.category or ""),
         "description": conn.description or "",
-        "base_url": conn.base_url or "",
+        "base_url": _normalise_connector_base_url(conn.name, conn.base_url) or "",
         "auth_type": str(conn.auth_type or ""),
         "has_credentials": has_creds,
-        "tool_functions": tool_functions if isinstance(tool_functions, list) else [],
+        "tool_functions": _connector_tool_functions(conn),
         "data_schema_ref": conn.data_schema_ref or "",
         "rate_limit_rpm": int(conn.rate_limit_rpm or 0),
         "timeout_ms": int(conn.timeout_ms or 0),
@@ -293,9 +332,10 @@ async def register_connector(
     tenant_id: str = Depends(get_current_tenant),
 ):
     tid = _uuid.UUID(tenant_id)
+    normalised_base_url = _normalise_connector_base_url(body.name, body.base_url)
 
     # MEDIUM-12: reject SSRF-capable base_urls before persisting.
-    _assert_public_base_url(body.base_url or "")
+    _assert_public_base_url(normalised_base_url or "")
 
     # Separate secret material from non-secret config.
     # auth_config on the Connector model is deprecated for secrets —
@@ -303,7 +343,7 @@ async def register_connector(
     # tenant-aware encryption.
     secret_fields = body.auth_config or {}
     non_secret_config = {
-        "base_url": body.base_url,
+        "base_url": normalised_base_url,
         "auth_type": body.auth_type,
         "data_schema_ref": body.data_schema_ref,
         "rate_limit_rpm": body.rate_limit_rpm,
@@ -314,7 +354,7 @@ async def register_connector(
             tenant_id=tid,
             name=body.name,
             category=body.category,
-            base_url=body.base_url,
+            base_url=normalised_base_url,
             auth_type=body.auth_type,
             auth_config={},  # no longer store secrets here
             secret_ref=body.secret_ref,
@@ -357,7 +397,7 @@ async def register_connector(
             if existing is not None and (existing.status or "").lower() == "deleted":
                 existing.status = "active"
                 existing.category = body.category
-                existing.base_url = body.base_url
+                existing.base_url = normalised_base_url
                 existing.auth_type = body.auth_type
                 existing.auth_config = {}
                 existing.secret_ref = body.secret_ref
@@ -459,6 +499,10 @@ async def update_connector(
         updates = body.model_dump(exclude_none=True)
         # MEDIUM-12: same SSRF guard on update paths.
         if "base_url" in updates:
+            updates["base_url"] = _normalise_connector_base_url(
+                connector.name,
+                updates["base_url"],
+            )
             _assert_public_base_url(updates["base_url"] or "")
         for field, value in updates.items():
             if field in _blocked_fields:
@@ -605,14 +649,35 @@ async def connector_health(
     if not connector:
         raise HTTPException(404, "Connector not found")
 
+    probe = await test_connector(conn_id, tenant_id)
+    health = probe.get("health") if isinstance(probe, dict) else None
+    status = (
+        health.get("status")
+        if isinstance(health, dict)
+        else ("error" if probe.get("error") else connector.status)
+    )
+    healthy = bool(probe.get("tested") and isinstance(health, dict) and status == "healthy")
+
+    async with get_tenant_session(tid) as session:
+        refreshed = (
+            await session.execute(
+                select(Connector).where(Connector.id == conn_id, Connector.tenant_id == tid)
+            )
+        ).scalar_one_or_none()
+        if refreshed is not None:
+            connector = refreshed
+
     return {
         "connector_id": str(connector.id),
         "name": connector.name,
-        "status": connector.status,
+        "status": status,
         "health_check_at": connector.health_check_at.isoformat()
         if connector.health_check_at
         else None,
-        "healthy": connector.status == "active",
+        "healthy": healthy,
+        "tested": bool(probe.get("tested")),
+        "health": health or {},
+        "error": probe.get("error"),
     }
 
 
@@ -648,7 +713,10 @@ async def test_connector(
     # MEDIUM-12: even if the stored base_url was valid when saved, re-check
     # at test time so a stale DNS record flipped to a private IP can't be
     # used as an SSRF primitive.
-    effective_base_url = (connector.base_url or getattr(connector_cls, "base_url", "") or "")
+    effective_base_url = _normalise_connector_base_url(
+        connector.name,
+        connector.base_url or getattr(connector_cls, "base_url", "") or "",
+    )
     _assert_public_base_url(effective_base_url)
 
     # Load credentials from ENCRYPTED connector_configs first,

--- a/connectors/finance/zoho_books.py
+++ b/connectors/finance/zoho_books.py
@@ -15,6 +15,20 @@ logger = structlog.get_logger()
 _ZOHO_GLOBAL_BASE = "https://www.zohoapis.com/books/v3"
 _ZOHO_IN_BASE = "https://books.zoho.in/api/v3"
 _ZOHO_TOKEN_URL = "https://accounts.zoho.com/oauth/v2/token"
+_ZOHO_IN_TOKEN_URL = "https://accounts.zoho.in/oauth/v2/token"
+
+
+def _is_india_config(config: dict[str, Any]) -> bool:
+    region = str(config.get("region") or "").strip().lower()
+    if region in {"in", "india", "in_dc"}:
+        return True
+    base_url = str(config.get("base_url") or "").strip().lower()
+    token_url = str(config.get("token_url") or "").strip().lower()
+    return (
+        "zohoapis.in" in base_url
+        or "books.zoho.in" in base_url
+        or "accounts.zoho.in" in token_url
+    )
 
 
 class ZohoBooksConnector(BaseConnector):
@@ -23,13 +37,35 @@ class ZohoBooksConnector(BaseConnector):
     auth_type = "oauth2"
     base_url = _ZOHO_GLOBAL_BASE
     rate_limit_rpm = 100
+    tools = [
+        "create_invoice",
+        "list_invoices",
+        "list_overdue_invoices",
+        "record_expense",
+        "get_balance_sheet",
+        "get_profit_loss",
+        "get_ledger_balance",
+        "get_trial_balance",
+        "generate_gst_report",
+        "calculate_tds",
+        "list_chartofaccounts",
+        "fetch_bank_statement",
+        "check_account_balance",
+        "get_transaction_list",
+        "reconcile_bank",
+        "reconcile_transaction",
+        "get_organization",
+    ]
 
     def __init__(self, config: dict[str, Any] | None = None):
         super().__init__(config)
-        # India-specific base URL if configured
-        region = self.config.get("region", "global")
-        if region == "in" and "base_url" not in self.config:
+        if _is_india_config(self.config):
             self.base_url = _ZOHO_IN_BASE
+            self.config["region"] = "in"
+            self.config["base_url"] = _ZOHO_IN_BASE
+            self.config.setdefault("token_url", _ZOHO_IN_TOKEN_URL)
+        else:
+            self.base_url = self.config.get("base_url") or _ZOHO_GLOBAL_BASE
         self._org_id: str = self.config.get("organization_id", "")
 
     def _register_tools(self):
@@ -500,24 +536,27 @@ class ZohoBooksConnector(BaseConnector):
         return await self.reconcile_transaction(**params)
 
     async def reconcile_transaction(self, **params) -> dict[str, Any]:
-        """Reconcile an uncategorized bank transaction.
+        """Match a bank transaction to an existing book transaction.
 
-        Required: account_id, amount, date.
-        Optional: reference_number.
+        Required: transaction_id, match_id. Optional: match_type.
         """
-        for required in ("account_id", "amount", "date"):
-            if not params.get(required):
-                return {"error": f"{required} is required"}
+        transaction_id = params.get("transaction_id")
+        match_id = params.get("match_id") or params.get("matched_transaction_id")
+        if not transaction_id:
+            return {"error": "transaction_id is required"}
+        if not match_id:
+            return {"error": "match_id is required"}
 
         body: dict[str, Any] = {
-            "account_id": params["account_id"],
-            "amount": params["amount"],
-            "date": params["date"],
+            "transactions_to_be_matched": [
+                {
+                    "transaction_id": match_id,
+                    "transaction_type": params.get("match_type", "expense"),
+                }
+            ],
         }
-        if params.get("reference_number"):
-            body["reference_number"] = params["reference_number"]
 
-        data = await self._post("/banktransactions/uncategorized", data=body)
+        data = await self._put(f"/banktransactions/{transaction_id}/match", data=body)
         return self._unwrap(data, "bank_transaction")
 
     # ── Internal: override _get/_post to inject organization_id ────────
@@ -536,6 +575,18 @@ class ZohoBooksConnector(BaseConnector):
         if not self._client:
             raise RuntimeError("Connector not connected")
         resp = await self._client.post(
+            path,
+            json=data,
+            params={"organization_id": self._org_id},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def _put(self, path: str, data: dict | None = None) -> dict[str, Any]:
+        """PUT with organization_id injected as query param."""
+        if not self._client:
+            raise RuntimeError("Connector not connected")
+        resp = await self._client.put(
             path,
             json=data,
             params={"organization_id": self._org_id},

--- a/core/agents/base.py
+++ b/core/agents/base.py
@@ -282,9 +282,12 @@ class BaseAgent:
         tools: list[dict[str, Any]] = []
         seen: set[str] = set()
         for tool_ref in self.authorized_tools:
-            # Format: "connector.tool_name" or "tool:connector:perm:resource"
+            # Format: "connector.tool_name", "connector:tool_name", or
+            # "tool:connector:perm:resource"
             if "." in tool_ref:
                 connector_name, tool_name = tool_ref.split(".", 1)
+            elif ":" in tool_ref and not tool_ref.startswith("tool:"):
+                connector_name, tool_name = tool_ref.split(":", 1)
             elif ":" in tool_ref:
                 parts = tool_ref.split(":")
                 connector_name = parts[1] if len(parts) > 1 else ""

--- a/core/agents/packs/installer.py
+++ b/core/agents/packs/installer.py
@@ -52,6 +52,15 @@ _installed: dict[str, set[str]] = {}
 _DEFAULT_LLM_MODEL = "gpt-4o-mini"
 _DEFAULT_FALLBACK_MODEL = "gpt-4o-mini"
 _DEFAULT_TIMEOUT_HOURS = 4
+_MIN_PACK_ACTIVE_ACCURACY = Decimal("0.600")
+
+WORKFLOW_SCHEDULES: dict[str, str] = {
+    "bank_recon_daily": "0 6 * * *",
+    "gstr_filing_monthly": "0 9 1 * *",
+    "tds_quarterly_filing": "0 9 1 */3 *",
+    "month_end_close": "0 9 1 * *",
+    "tax_calendar": "0 8 * * 1",
+}
 
 
 def _slugify(value: str) -> str:
@@ -63,13 +72,7 @@ def _title_case(value: str) -> str:
 
 
 def _normalize_tool_names(tools: list[str]) -> list[str]:
-    normalized: list[str] = []
-    for tool_name in tools:
-        if ":" in tool_name:
-            normalized.append(tool_name.rsplit(":", 1)[-1])
-        else:
-            normalized.append(tool_name)
-    return normalized
+    return list(dict.fromkeys(str(tool_name).strip() for tool_name in tools if str(tool_name).strip()))
 
 
 _CONNECTOR_ALIASES: dict[str, str] = {
@@ -90,7 +93,10 @@ def _tool_connector_map(tools: list[str]) -> dict[str, str]:
             continue
         connector_name, tool_name = tool_ref.split(":", 1)
         connector = _canonical_connector_name(connector_name)
-        if tool_name and tool_name not in mapping:
+        if not tool_name:
+            continue
+        mapping[tool_ref] = connector
+        if tool_name not in mapping:
             mapping[tool_name] = connector
     return mapping
 
@@ -98,6 +104,58 @@ def _tool_connector_map(tools: list[str]) -> dict[str, str]:
 def _connector_ids_for_tools(tools: list[str]) -> list[str]:
     connectors = list(dict.fromkeys(_tool_connector_map(tools).values()))
     return [f"registry-{connector}" for connector in connectors]
+
+
+def _pack_agent_sort_key(agent: Agent) -> tuple[int, int, datetime]:
+    status_rank = 0 if agent.status == "active" else 1
+    sample_rank = -(agent.shadow_sample_count or 0)
+    created_at = agent.created_at or datetime.min.replace(tzinfo=UTC)
+    return (status_rank, sample_rank, created_at)
+
+
+async def _mark_duplicate_pack_agents_deleted(
+    session,
+    tid: UUID,
+    agents: list[Agent],
+) -> Agent | None:
+    """Keep one company pack agent per tenant/company/type and hide the rest."""
+    if not agents:
+        return None
+    ordered = sorted(agents, key=_pack_agent_sort_key)
+    keep = ordered[0]
+    for duplicate in ordered[1:]:
+        if duplicate.status == "deleted":
+            continue
+        old_status = duplicate.status
+        duplicate.status = "deleted"
+        session.add(duplicate)
+        session.add(
+            AgentLifecycleEvent(
+                tenant_id=tid,
+                agent_id=duplicate.id,
+                from_status=old_status,
+                to_status="deleted",
+                triggered_by="pack_installer",
+                reason=(
+                    "Duplicate industry-pack agent suppressed during "
+                    "idempotent pack sync; canonical agent is "
+                    f"{keep.id}"
+                ),
+                shadow_accuracy=duplicate.shadow_accuracy_current,
+                shadow_samples=duplicate.shadow_sample_count,
+            )
+        )
+    return keep
+
+
+def _pack_agent_below_active_floor(agent: Agent) -> bool:
+    if agent.status != "active" or agent.shadow_accuracy_current is None:
+        return False
+    floor = max(
+        Decimal(str(agent.shadow_accuracy_floor or 0)),
+        _MIN_PACK_ACTIVE_ACCURACY,
+    )
+    return Decimal(str(agent.shadow_accuracy_current)) < floor
 
 
 def _resolve_pack_dir(pack_name: str) -> Path | None:
@@ -280,6 +338,7 @@ def _build_workflow_definition(
     if selected_agents:
         review_step = {
             "id": "human_review",
+            "title": "CA partner approval",
             "type": "human_in_loop",
             "assignee_role": "admin",
             "timeout_hours": _DEFAULT_TIMEOUT_HOURS,
@@ -299,16 +358,20 @@ def _build_workflow_definition(
         if scope_name
         else f"{workflow_title} workflow provisioned by {pack_label}."
     )
+    cron = WORKFLOW_SCHEDULES.get(workflow_name)
+    trigger_config = {
+        "source_pack": pack_name,
+        **({"company_id": str(company_id)} if company_id else {}),
+    }
+    if cron:
+        trigger_config["cron"] = cron
     return {
         "name": workflow_display_name,
         "version": "1.0",
         "description": workflow_description,
         "domain": selected_agents[0]["domain"] if selected_agents else "ops",
-        "trigger_type": "manual",
-        "trigger_config": {
-            "source_pack": pack_name,
-            **({"company_id": str(company_id)} if company_id else {}),
-        },
+        "trigger_type": "schedule" if cron else "manual",
+        "trigger_config": trigger_config,
         "timeout_hours": _DEFAULT_TIMEOUT_HOURS,
         "metadata": {
             "source": "industry_pack",
@@ -472,11 +535,14 @@ async def _get_or_create_pack_agents(
                 Agent.tenant_id == tid,
                 Agent.company_id == company_id,
                 Agent.agent_type == agent_type,
-                Agent.employee_name == display_name,
-                Agent.version == "1.0.0",
+                Agent.status != "deleted",
             )
         )
-        agent = existing.scalar_one_or_none()
+        agent = await _mark_duplicate_pack_agents_deleted(
+            session,
+            tid,
+            list(existing.scalars().all()),
+        )
 
         if agent is None:
             agent = Agent(
@@ -591,6 +657,24 @@ async def _get_or_create_pack_agents(
             if isinstance(fixture, dict):
                 cfg["shadow_fixture"] = fixture
             agent.config = cfg
+            if _pack_agent_below_active_floor(agent):
+                old_status = agent.status
+                agent.status = "shadow"
+                session.add(
+                    AgentLifecycleEvent(
+                        tenant_id=tid,
+                        agent_id=agent.id,
+                        from_status=old_status,
+                        to_status="shadow",
+                        triggered_by="pack_installer",
+                        reason=(
+                            "Demoted active industry-pack agent below "
+                            f"production accuracy floor {_MIN_PACK_ACTIVE_ACCURACY}"
+                        ),
+                        shadow_accuracy=agent.shadow_accuracy_current,
+                        shadow_samples=agent.shadow_sample_count,
+                    )
+                )
             session.add(agent)
 
         agent_specs.append(
@@ -658,6 +742,14 @@ async def _get_or_create_pack_workflows(
             )
             session.add(workflow)
             await session.flush()
+        else:
+            workflow.description = str(definition.get("description") or "")
+            workflow.domain = str(definition.get("domain") or "ops")
+            workflow.definition = definition
+            workflow.trigger_type = str(definition.get("trigger_type") or "manual")
+            workflow.trigger_config = definition.get("trigger_config") or {}
+            workflow.is_active = True
+            session.add(workflow)
 
         workflows_created.append(
             {

--- a/core/langgraph/agent_graph.py
+++ b/core/langgraph/agent_graph.py
@@ -27,7 +27,11 @@ from langgraph.types import interrupt
 from core.langgraph.grantex_auth import get_grantex_client
 from core.langgraph.llm_factory import create_chat_model
 from core.langgraph.state import AgentState
-from core.langgraph.tool_adapter import _build_tool_index, build_tools_for_agent
+from core.langgraph.tool_adapter import (
+    _actual_tool_name,
+    _build_tool_index,
+    build_tools_for_agent,
+)
 
 logger = structlog.get_logger()
 
@@ -168,7 +172,7 @@ async def validate_tool_scopes(state: AgentState) -> dict[str, Any]:
 
     # _build_tool_index() returns dict[str, tuple[str, str]]
     # where each value is (connector_name, description)
-    index = _build_tool_index()
+    index = _build_tool_index(include_connector_aliases=True)
 
     for tc in last_ai.tool_calls:
         # tc is normally a dict with 'name'/'args'/'id'; handle legacy
@@ -184,12 +188,13 @@ async def validate_tool_scopes(state: AgentState) -> dict[str, Any]:
         # Resolve connector name from tool index
         match = index.get(tool_name)
         connector_name = match[0] if match else "unknown"
+        actual_tool_name = _actual_tool_name(tool_name)
 
         # One call — Grantex handles JWT verification + manifest lookup + permission check
         result = grantex.enforce(
             grant_token=grant_token,
             connector=connector_name,
-            tool=tool_name,
+            tool=actual_tool_name,
         )
 
         if not result.allowed:
@@ -203,7 +208,7 @@ async def validate_tool_scopes(state: AgentState) -> dict[str, Any]:
             return {
                 "messages": [AIMessage(
                     content=f"Access denied: {result.reason}. "
-                    f"Tool '{tool_name}' on '{connector_name}' is not permitted by your current authorization."
+                    f"Tool '{actual_tool_name}' on '{connector_name}' is not permitted by your current authorization."
                 )],
                 "status": "failed",
                 "error": f"Scope denied: {result.reason}",

--- a/core/langgraph/grantex_auth.py
+++ b/core/langgraph/grantex_auth.py
@@ -265,13 +265,13 @@ def _tools_to_scopes(tools: list[str]) -> list[str]:
 
     "fetch_bank_statement" -> "tool:banking_aa:execute:fetch_bank_statement"
     """
-    from core.langgraph.tool_adapter import _build_tool_index
+    from core.langgraph.tool_adapter import _actual_tool_name, _build_tool_index
 
-    index = _build_tool_index()
+    index = _build_tool_index(include_connector_aliases=True)
     scopes: list[str] = []
     for tool_name in tools:
         match = index.get(tool_name)
         if match:
             connector_name = match[0]
-            scopes.append(f"tool:{connector_name}:execute:{tool_name}")
+            scopes.append(f"tool:{connector_name}:execute:{_actual_tool_name(tool_name)}")
     return scopes

--- a/core/langgraph/tool_adapter.py
+++ b/core/langgraph/tool_adapter.py
@@ -49,6 +49,50 @@ _TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
 )
 
 
+def _canonical_connector_name(connector_name: str) -> str:
+    return connector_name.removeprefix("registry-").strip().lower()
+
+
+def _split_connector_tool_ref(tool_ref: str) -> tuple[str | None, str]:
+    """Return (connector, tool) for connector-qualified tool references.
+
+    CA pack tools intentionally use ``connector:tool`` because bare tool
+    names like ``get_trial_balance`` exist on both Tally and Zoho Books.
+    ``tool:connector:execute:resource`` is a Grantex scope, not an
+    authorized-tool reference, so it is left untouched.
+    """
+    raw = str(tool_ref or "").strip()
+    if raw.startswith("tool:"):
+        return None, raw
+    if ":" not in raw:
+        return None, raw
+    connector_name, tool_name = raw.split(":", 1)
+    connector_name = _canonical_connector_name(connector_name)
+    tool_name = tool_name.strip()
+    if not connector_name or not tool_name or ":" in tool_name:
+        return None, raw
+    return connector_name, tool_name
+
+
+def _llm_safe_tool_name(connector_name: str | None, tool_name: str) -> str:
+    """Map connector-qualified names to provider-safe function names."""
+    if not connector_name:
+        return tool_name
+    return f"{connector_name}__{tool_name}"[:64]
+
+
+def _actual_tool_name(tool_ref: str) -> str:
+    connector_name, tool_name = _split_connector_tool_ref(tool_ref)
+    if connector_name:
+        return tool_name
+    raw = str(tool_ref or "").strip()
+    if "__" in raw:
+        maybe_connector, maybe_tool = raw.split("__", 1)
+        if ConnectorRegistry.get(_canonical_connector_name(maybe_connector)):
+            return maybe_tool
+    return raw
+
+
 def _flatten_structured_tool_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     """Unwrap LangChain's ``**kwargs`` schema artifact for var-kw tools.
 
@@ -207,8 +251,15 @@ def build_tools_for_agent(
     tools: list[StructuredTool] = []
     seen: set[str] = set()
 
-    # Build a reverse index: tool_name -> (connector_name, handler_doc)
-    tool_index = _build_tool_index(connector_config, connector_names)
+    # Build a reverse index. Connector-qualified aliases are included so
+    # CA pack tools can keep ``zoho_books:get_trial_balance`` and
+    # ``tally:get_trial_balance`` separate instead of collapsing into a
+    # bare-name collision.
+    tool_index = _build_tool_index(
+        connector_config,
+        connector_names,
+        include_connector_aliases=True,
+    )
 
     for tool_ref in authorized_tools:
         if tool_ref in seen:
@@ -220,6 +271,13 @@ def build_tools_for_agent(
             continue
 
         connector_name, description = match
+        connector_hint, parsed_tool_name = _split_connector_tool_ref(tool_ref)
+        actual_tool_name = parsed_tool_name if connector_hint else _actual_tool_name(tool_ref)
+        public_tool_name = (
+            _llm_safe_tool_name(connector_name, actual_tool_name)
+            if connector_hint
+            else actual_tool_name
+        )
 
         # Create an async wrapper that calls the connector
         def _make_tool_fn(cn: str, tn: str, desc: str):
@@ -231,9 +289,10 @@ def build_tools_for_agent(
             return _tool_fn
 
         tool = StructuredTool.from_function(
-            coroutine=_make_tool_fn(connector_name, tool_ref, description),
-            name=tool_ref,
-            description=description or f"Execute {tool_ref}",
+            coroutine=_make_tool_fn(connector_name, actual_tool_name, description),
+            name=public_tool_name,
+            description=description
+            or f"Execute {actual_tool_name} on {connector_name}",
         )
         tools.append(tool)
 
@@ -243,12 +302,17 @@ def build_tools_for_agent(
 def _build_tool_index(
     connector_config: dict[str, Any] | None = None,
     connector_names: list[str] | None = None,
+    *,
+    include_connector_aliases: bool = False,
 ) -> dict[str, tuple[str, str]]:
     """Build a reverse index: tool_name -> (connector_name, description).
 
     Scans all registered native connectors and their tool registries,
     then appends Composio tools (with ``composio:`` prefix) from the
-    ConnectorRegistry.  Native tools always take priority.
+    ConnectorRegistry.  Native bare tool names keep their historical
+    first-wins behavior; when ``include_connector_aliases`` is true,
+    connector-qualified aliases are also indexed so duplicate bare
+    tools can be addressed unambiguously.
 
     UR-Bug-2 (Uday/Ramesh 2026-04-21): when ``connector_names`` is
     provided, the index is restricted to tools registered by those
@@ -301,9 +365,15 @@ def _build_tool_index(
             continue  # Skip connectors that fail to register tools
 
         for tool_name, handler in instance._tool_registry.items():
+            doc = (handler.__doc__ or "").strip().split("\n")[0]
             if tool_name not in index:
-                doc = (handler.__doc__ or "").strip().split("\n")[0]
                 index[tool_name] = (connector_name, doc)
+            if include_connector_aliases:
+                index[f"{connector_name}:{tool_name}"] = (connector_name, doc)
+                index[_llm_safe_tool_name(connector_name, tool_name)] = (
+                    connector_name,
+                    doc,
+                )
 
     # 2. Composio tools (already filtered for native priority in registry)
     if allowed is None or "composio" in allowed:

--- a/migrations/versions/v4_9_10_pack_agent_idempotency.py
+++ b/migrations/versions/v4_9_10_pack_agent_idempotency.py
@@ -1,0 +1,74 @@
+"""Industry-pack agent idempotency guard.
+
+Revision ID: v4910_pack_agent_idempotency
+Revises: v499_pool_config_noop
+Create Date: 2026-05-11
+
+Ramesh 2026-05-11: CA/industry pack installs must be idempotent. A
+reinstall created duplicate company-scoped shadow agents because the
+installer lookup included ``employee_name`` and ``version``. This
+migration suppresses pre-existing duplicate pack agents and adds a
+partial unique index so future inserts fail loudly instead of silently
+creating ghosts.
+
+Safety:
+- Filter is tight: only rows with ``company_id IS NOT NULL`` and
+  ``config->pack_install->>source == 'industry_pack'`` are touched.
+  Customer-created agents and tenant-default agents are untouched.
+- Duplicate suppression uses a soft delete (``status='deleted'``); rows
+  remain on disk for auditing.
+- The unique index is partial and uses the same predicate, so it never
+  conflicts with non-pack or deleted rows.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v4910_pack_agent_idempotency"
+down_revision = "v499_pool_config_noop"
+branch_labels = None
+depends_on = None
+
+
+_DEDUPE_SQL = """
+WITH ranked AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY tenant_id, company_id, agent_type
+      ORDER BY
+        CASE WHEN status = 'active' THEN 0 ELSE 1 END,
+        shadow_sample_count DESC,
+        created_at ASC
+    ) AS rn
+  FROM agents
+  WHERE company_id IS NOT NULL
+    AND status <> 'deleted'
+    AND config->'pack_install'->>'source' = 'industry_pack'
+)
+UPDATE agents
+SET status = 'deleted',
+    updated_at = now()
+FROM ranked
+WHERE agents.id = ranked.id
+  AND ranked.rn > 1
+"""
+
+
+_INDEX_SQL = """
+CREATE UNIQUE INDEX IF NOT EXISTS uq_agents_industry_pack_company_type
+ON agents (tenant_id, company_id, agent_type)
+WHERE company_id IS NOT NULL
+  AND status <> 'deleted'
+  AND config->'pack_install'->>'source' = 'industry_pack'
+"""
+
+
+def upgrade() -> None:
+    op.execute(_DEDUPE_SQL)
+    op.execute(_INDEX_SQL)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_agents_industry_pack_company_type")

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -640,7 +640,14 @@ class TestFullPipeline:
 
         health_resp = await client.get(f"/api/v1/connectors/{conn_id}/health", headers=auth_headers)
         assert health_resp.status_code == 200
-        assert health_resp.json()["status"] in ("healthy", "active")
+        # Ramesh 2026-05-11 #9: /health now reflects the live probe result,
+        # not the cached DB status. In the integration env the test connector
+        # has no real Tally backend, so the probe legitimately reports
+        # "error" — the envelope is the contract, not the verdict.
+        body = health_resp.json()
+        assert "tested" in body
+        assert "healthy" in body
+        assert body["status"] in ("healthy", "active", "error", "degraded")
 
     async def test_approval_flow_after_workflow_trigger(
         self, client: AsyncClient, auth_headers: dict

--- a/tests/regression/test_ca_firms_may03_reopens.py
+++ b/tests/regression/test_ca_firms_may03_reopens.py
@@ -61,8 +61,11 @@ def test_ca_pack_has_connector_policy_for_every_authorized_tool() -> None:
     for agent in CA_PACK["agents"]:
         tool_map = _tool_connector_map(agent["tools"])
         connector_ids = _connector_ids_for_tools(agent["tools"])
-        normalized_tools = [tool.rsplit(":", 1)[-1] for tool in agent["tools"]]
-        assert set(tool_map) == set(normalized_tools)
+        normalized_tools = list(agent["tools"])
+        assert set(normalized_tools).issubset(set(tool_map))
+        for tool_ref in normalized_tools:
+            connector, _tool = tool_ref.split(":", 1)
+            assert tool_map[tool_ref] == connector
         assert connector_ids
         assert all(cid.startswith("registry-") for cid in connector_ids)
 
@@ -138,7 +141,7 @@ def test_agent_scopes_tab_has_no_fabricated_security_state() -> None:
     assert "salesforce" not in block
     assert "hubspot" not in block
     assert "No enforcement decisions recorded" in block
-    assert "tool:${connector || \"agenticorg\"}:execute:${tool}" in src
+    assert "tool:${actualConnector || \"agenticorg\"}:execute:${actualTool}" in src
 
 
 def test_each_ca_pack_agent_binds_callable_tools_in_zoho_only_env() -> None:
@@ -780,7 +783,7 @@ def test_api_run_agent_gates_fixture_on_authorized_tools() -> None:
     ).read_text(encoding="utf-8")
     # The gate variable + its in-authorized check
     assert "fixture_tool_authorized" in src
-    assert "in (authorized_tools or [])" in src
+    assert "_is_tool_authorized(authorized_tools or [], fixture_expected)" in src
     # Drift-warning log so operators see the fall-through
     assert "agent_run_shadow_fixture_tool_not_authorized" in src
     # When tool not authorized, fall through to generic hint

--- a/tests/regression/test_ramesh_11may_zoho_ca_reopens.py
+++ b/tests/regression/test_ramesh_11may_zoho_ca_reopens.py
@@ -1,0 +1,162 @@
+"""Regression pins for Ramesh 2026-05-11 CA/Zoho reopen report."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_zoho_books_india_url_overrides_invalid_db_base_url() -> None:
+    from connectors.finance.zoho_books import (
+        _ZOHO_IN_BASE,
+        _ZOHO_IN_TOKEN_URL,
+        ZohoBooksConnector,
+    )
+
+    connector = ZohoBooksConnector(
+        {
+            "base_url": "https://www.zohoapis.in/books/v3",
+            "organization_id": "org-1",
+        }
+    )
+
+    assert connector.base_url == _ZOHO_IN_BASE
+    assert connector.config["base_url"] == _ZOHO_IN_BASE
+    assert connector.config["region"] == "in"
+    assert connector.config["token_url"] == _ZOHO_IN_TOKEN_URL
+
+
+@pytest.mark.asyncio
+async def test_zoho_reconcile_transaction_uses_match_endpoint() -> None:
+    from connectors.finance.zoho_books import ZohoBooksConnector
+
+    connector = ZohoBooksConnector({"region": "in", "organization_id": "org-1"})
+    calls: dict[str, object] = {}
+
+    async def fake_put(path: str, data: dict | None = None) -> dict:
+        calls["path"] = path
+        calls["data"] = data
+        return {"bank_transaction": {"transaction_id": "bank-1", "status": "matched"}}
+
+    connector._put = fake_put  # type: ignore[method-assign]
+
+    result = await connector.reconcile_transaction(
+        transaction_id="bank-1",
+        match_id="book-1",
+        match_type="deposit",
+    )
+
+    assert calls["path"] == "/banktransactions/bank-1/match"
+    assert calls["data"] == {
+        "transactions_to_be_matched": [
+            {"transaction_id": "book-1", "transaction_type": "deposit"}
+        ]
+    }
+    assert result["status"] == "matched"
+
+
+def test_ca_pack_preserves_connector_qualified_tools_and_runtime_aliases() -> None:
+    from core.agents.packs.installer import _normalize_tool_names, _tool_connector_map
+    from core.langgraph.tool_adapter import build_tools_for_agent
+
+    raw = ["tally:get_trial_balance", "zoho_books:get_trial_balance"]
+    normalized = _normalize_tool_names(raw)
+    assert normalized == raw
+
+    mapping = _tool_connector_map(raw)
+    assert mapping["tally:get_trial_balance"] == "tally"
+    assert mapping["zoho_books:get_trial_balance"] == "zoho_books"
+    assert mapping["get_trial_balance"] == "tally"
+
+    tools = build_tools_for_agent(raw, {}, ["tally", "zoho_books"])
+    names = {tool.name for tool in tools}
+    assert "tally__get_trial_balance" in names
+    assert "zoho_books__get_trial_balance" in names
+
+
+def test_ca_workflows_are_scheduled_not_all_manual() -> None:
+    from core.agents.packs.ca import CA_PACK
+    from core.agents.packs.installer import _build_workflow_definition
+
+    agent_specs = [
+        {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "agent_type": "gst_filing_agent",
+            "authorized_tools": ["zoho_books:list_invoices"],
+            "system_prompt_text": "prompt",
+            "llm_model": "gpt-4o",
+            "domain": "finance",
+            "description": "",
+        }
+    ]
+    definition = _build_workflow_definition(
+        "ca-firm",
+        CA_PACK,
+        "bank_recon_daily",
+        agent_specs,
+    )
+    assert definition["trigger_type"] == "schedule"
+    assert definition["trigger_config"]["cron"] == "0 6 * * *"
+    assert any(step["type"] == "human_in_loop" for step in definition["steps"])
+
+
+def test_production_floor_blocks_legacy_twenty_percent_promotions() -> None:
+    from api.v1.agents import (
+        _MIN_PRODUCTION_SHADOW_ACCURACY,
+        _active_agent_below_production_floor,
+        _is_tool_authorized,
+    )
+    from core.models.agent import Agent
+
+    agent = Agent(
+        tenant_id="00000000-0000-0000-0000-000000000001",
+        name="Acme GST",
+        agent_type="gst_filing_agent",
+        domain="finance",
+        system_prompt_ref="industry-pack://ca-firm/gst_filing_agent",
+        hitl_condition="always_before_filing",
+        authorized_tools=["zoho_books:list_invoices"],
+        status="active",
+        version="1.0.0",
+        shadow_accuracy_floor=Decimal("0.200"),
+        shadow_accuracy_current=Decimal("0.240"),
+    )
+
+    assert _MIN_PRODUCTION_SHADOW_ACCURACY == Decimal("0.600")
+    assert _active_agent_below_production_floor(agent) is True
+    assert _is_tool_authorized(["zoho_books:list_invoices"], "list_invoices") is True
+
+
+def test_connector_health_and_detail_use_live_runtime_truth() -> None:
+    src = (ROOT / "api" / "v1" / "connectors.py").read_text(encoding="utf-8")
+    assert "probe = await test_connector(conn_id, tenant_id)" in src
+    assert "_connector_tool_functions(conn)" in src
+    assert "_normalise_connector_base_url(conn.name, conn.base_url)" in src
+
+
+def test_pack_agent_idempotency_migration_guards_company_agent_type() -> None:
+    migration = (
+        ROOT
+        / "migrations"
+        / "versions"
+        / "v4_9_10_pack_agent_idempotency.py"
+    ).read_text(encoding="utf-8")
+    assert "uq_agents_industry_pack_company_type" in migration
+    assert "PARTITION BY tenant_id, company_id, agent_type" in migration
+    assert "config->'pack_install'->>'source' = 'industry_pack'" in migration
+    # Alembic discipline: must chain off the prior head.
+    assert 'revision = "v4910_pack_agent_idempotency"' in migration
+    assert 'down_revision = "v499_pool_config_noop"' in migration
+
+
+def test_zoho_token_placeholder_is_not_google_for_zoho_books() -> None:
+    src = (ROOT / "ui" / "src" / "pages" / "ConnectorDetail.tsx").read_text(
+        encoding="utf-8"
+    )
+    assert "https://accounts.zoho.in/oauth/v2/token" in src
+    assert 'connector?.name === "zoho_books"' in src
+    assert "https://accounts.google.com/o/oauth2/token" not in src

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -580,6 +580,13 @@ class TestConnectorsEndpoints:
 
     @pytest.mark.asyncio
     async def test_connector_health_happy(self, tenant_id, mock_session):
+        """Ramesh 2026-05-11 #9: connector health now runs the live probe path,
+        so this fixture (which doesn't supply credentials or a connector class
+        capable of network I/O) must report ``healthy=False`` with the new
+        ``tested``/``health``/``error`` envelope. The old assertion that
+        ``healthy`` mirrored the stored ``status`` column was the false-healthy
+        bug Ramesh reopened.
+        """
         from api.v1.connectors import connector_health
 
         conn = _make_connector(status="active")
@@ -591,8 +598,10 @@ class TestConnectorsEndpoints:
         finally:
             ctx.stop()
 
-        assert resp["healthy"] is True
-        assert resp["status"] == "active"
+        assert resp["healthy"] is False
+        assert "tested" in resp
+        assert "health" in resp
+        assert "error" in resp
 
     @pytest.mark.asyncio
     async def test_connector_health_not_found(self, tenant_id, mock_session):

--- a/tests/unit/test_connector_real_paths.py
+++ b/tests/unit/test_connector_real_paths.py
@@ -177,13 +177,20 @@ class TestZohoBooksRealPaths:
 
     @pytest.mark.asyncio
     async def test_reconcile_transaction_path(self):
+        """Ramesh 2026-05-11 #5: reconcile_transaction now PUTs to the real
+        Zoho ``/banktransactions/{id}/match`` endpoint with a
+        ``transactions_to_be_matched`` body, instead of POSTing the
+        unrelated /uncategorized create-uncategorized-transaction path.
+        """
         c = self._make_connector()
-        c._client.post = _async_response({"bank_transaction": {"transaction_id": "T1"}})
-        await c.reconcile_transaction(
-            account_id="a1", amount=1000, date="2026-05-01", reference_number="R1"
-        )
-        args = c._client.post.call_args
-        assert args[0][0] == "/banktransactions/uncategorized"
+        c._client.put = _async_response({"bank_transaction": {"transaction_id": "T1"}})
+        await c.reconcile_transaction(transaction_id="T1", match_id="M2", match_type="expense")
+        args = c._client.put.call_args
+        assert args[0][0] == "/banktransactions/T1/match"
+        body = args[1]["json"]
+        assert body["transactions_to_be_matched"] == [
+            {"transaction_id": "M2", "transaction_type": "expense"}
+        ]
 
     @pytest.mark.asyncio
     async def test_get_organization_path(self):
@@ -233,9 +240,14 @@ class TestZohoBooksRealPaths:
 
     @pytest.mark.asyncio
     async def test_reconcile_transaction_validates_required(self):
+        """Ramesh 2026-05-11 #5: required params are now transaction_id +
+        match_id (the legacy account_id/amount/date were for creating an
+        uncategorized transaction, not matching one)."""
         c = self._make_connector()
-        out = await c.reconcile_transaction(amount=100, date="2026-05-01")
-        assert "account_id" in out["error"]
+        missing_txn = await c.reconcile_transaction(match_id="M1")
+        assert "transaction_id" in missing_txn["error"]
+        missing_match = await c.reconcile_transaction(transaction_id="T1")
+        assert "match_id" in missing_match["error"]
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/unit/test_module_4_agent_fleet.py
+++ b/tests/unit/test_module_4_agent_fleet.py
@@ -252,12 +252,15 @@ def test_tc_agt_009_promote_validates_min_samples() -> None:
 
 
 def test_tc_agt_009_promote_validates_accuracy_floor() -> None:
-    """Sample count alone isn't enough — accuracy floor must
-    also be met. Both gates required to flip shadow→active."""
+    """Sample count alone isn't enough — accuracy floor must also be met.
+    Ramesh 2026-05-11 hardened the gate so the comparison runs against
+    ``max(row_floor, 0.60)`` via ``_effective_shadow_accuracy_floor`` —
+    legacy 0.20 rows can no longer authorize live agents.
+    """
     src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
-    assert (
-        "if agent.shadow_accuracy_current < agent.shadow_accuracy_floor:" in src
-    )
+    assert "required_accuracy = _effective_shadow_accuracy_floor(agent)" in src
+    assert "if agent.shadow_accuracy_current < required_accuracy:" in src
+    assert "_MIN_PRODUCTION_SHADOW_ACCURACY = Decimal(\"0.600\")" in src
     assert "is below floor" in src
 
 

--- a/ui/e2e/ramesh-11may2026.spec.ts
+++ b/ui/e2e/ramesh-11may2026.spec.ts
@@ -1,0 +1,153 @@
+import { expect, Page, test } from "@playwright/test";
+
+const zohoTools = [
+  "create_invoice",
+  "list_invoices",
+  "list_overdue_invoices",
+  "record_expense",
+  "get_balance_sheet",
+  "get_profit_loss",
+  "get_ledger_balance",
+  "get_trial_balance",
+  "generate_gst_report",
+  "calculate_tds",
+  "list_chartofaccounts",
+  "fetch_bank_statement",
+  "check_account_balance",
+  "get_transaction_list",
+  "reconcile_bank",
+  "reconcile_transaction",
+  "get_organization",
+];
+
+async function installRoutes(page: Page) {
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+
+    if (path.endsWith("/auth/me")) {
+      await route.fulfill({
+        json: {
+          email: "qa@example.com",
+          name: "QA",
+          role: "admin",
+          domain: "all",
+          tenant_id: "tenant-1",
+          onboarding_complete: true,
+        },
+      });
+      return;
+    }
+
+    if (path.endsWith("/product-facts")) {
+      await route.fulfill({
+        json: { version: "test", connector_count: 1, agent_count: 1, tool_count: 17 },
+      });
+      return;
+    }
+
+    if (path.endsWith("/connectors/zoho-1/health")) {
+      await route.fulfill({
+        json: {
+          connector_id: "zoho-1",
+          name: "zoho_books",
+          status: "healthy",
+          healthy: true,
+          tested: true,
+          health: { status: "healthy", organizations: 1 },
+          health_check_at: "2026-05-11T00:00:00Z",
+        },
+      });
+      return;
+    }
+
+    if (path.endsWith("/connectors/zoho-1/test")) {
+      await route.fulfill({
+        json: {
+          tested: true,
+          name: "zoho_books",
+          health: { status: "healthy", organizations: 1 },
+        },
+      });
+      return;
+    }
+
+    if (path.endsWith("/connectors/zoho-1")) {
+      await route.fulfill({
+        json: {
+          connector_id: "zoho-1",
+          name: "zoho_books",
+          category: "finance",
+          description: "Zoho Books",
+          base_url: "https://books.zoho.in/api/v3",
+          auth_type: "oauth2",
+          tool_functions: zohoTools,
+          data_schema_ref: null,
+          rate_limit_rpm: 100,
+          timeout_ms: 10000,
+          status: "active",
+          health_check_at: "2026-05-11T00:00:00Z",
+          created_at: "2026-05-11T00:00:00Z",
+        },
+      });
+      return;
+    }
+
+    if (path.endsWith("/workflows/templates")) {
+      await route.fulfill({ json: { items: [], total: 0 } });
+      return;
+    }
+
+    if (path.endsWith("/workflows")) {
+      await route.fulfill({
+        json: {
+          items: [
+            {
+              id: "wf-bank-recon",
+              name: "Acme Manufacturing - Bank Recon Daily",
+              version: "1.0",
+              description: "Bank reconciliation",
+              domain: "finance",
+              trigger_type: "schedule",
+              trigger_config: { cron: "0 6 * * *" },
+              is_active: true,
+              created_at: "2026-05-11T00:00:00Z",
+            },
+          ],
+          total: 1,
+        },
+      });
+      return;
+    }
+
+    await route.fulfill({ json: {} });
+  });
+}
+
+test.describe("Ramesh 11 May 2026 CA/Zoho regressions", () => {
+  test("Zoho connector detail shows normalized India URL, real tools, and Zoho token URL", async ({ page, baseURL }) => {
+    await installRoutes(page);
+
+    await page.goto(`${baseURL}/dashboard/connectors/zoho-1`, { waitUntil: "domcontentloaded" });
+    await expect(page.locator("main")).toContainText("https://books.zoho.in/api/v3");
+    await expect(page.locator("main")).toContainText("Registered Tools (17)");
+    await expect(page.locator("main")).toContainText("get_trial_balance");
+    await expect(page.locator("main")).toContainText("reconcile_transaction");
+
+    await page.getByRole("button", { name: "Edit" }).click();
+    await expect(page.getByPlaceholder("https://accounts.zoho.in/oauth/v2/token")).toBeVisible();
+
+    await page.getByRole("button", { name: "Health Check" }).click();
+    await expect(page.locator("main")).toContainText("Health: healthy (healthy)");
+  });
+
+  test("CA workflows surface scheduled triggers instead of all manual", async ({ page, baseURL }) => {
+    await installRoutes(page);
+
+    await page.goto(`${baseURL}/dashboard/workflows`, { waitUntil: "domcontentloaded" });
+    await expect(page.locator("main")).toContainText("Acme Manufacturing - Bank Recon Daily");
+    await expect(page.locator("main")).toContainText("Trigger:");
+    await expect(page.locator("main")).toContainText("schedule");
+  });
+});

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1580,7 +1580,18 @@ function normalizeConnectorId(value: unknown): string {
   return String(value || "").trim().replace(/^registry-/, "");
 }
 
+function splitConnectorTool(tool: string): { connector: string; tool: string } | null {
+  if (!tool.includes(":") || tool.startsWith("tool:")) return null;
+  const [connector, toolName] = tool.split(":", 2);
+  const normalized = normalizeConnectorId(connector);
+  if (!normalized || !toolName) return null;
+  return { connector: normalized, tool: toolName };
+}
+
 function connectorForTool(tool: string, agent: Agent): string {
+  const qualified = splitConnectorTool(tool);
+  if (qualified) return qualified.connector;
+
   const cfg = agent.config || {};
   const configured = normalizeConnectorId(cfg.tool_connectors?.[tool]);
   if (configured) return configured;
@@ -1594,7 +1605,10 @@ function connectorForTool(tool: string, agent: Agent): string {
 }
 
 function buildScopeString(tool: string, connector: string): string {
-  return `tool:${connector || "agenticorg"}:execute:${tool}`;
+  const qualified = splitConnectorTool(tool);
+  const actualTool = qualified?.tool || tool;
+  const actualConnector = qualified?.connector || connector;
+  return `tool:${actualConnector || "agenticorg"}:execute:${actualTool}`;
 }
 
 function grantexConfigured(agent: Agent): boolean {

--- a/ui/src/pages/ConnectorDetail.tsx
+++ b/ui/src/pages/ConnectorDetail.tsx
@@ -61,6 +61,13 @@ export default function ConnectorDetailPage() {
     return /^https?:\/\/.+/.test(url.trim());
   }
 
+  function oauthTokenUrlPlaceholder(): string {
+    if (connector?.name === "zoho_books") {
+      return "https://accounts.zoho.in/oauth/v2/token";
+    }
+    return "https://oauth2.googleapis.com/token";
+  }
+
   useEffect(() => {
     fetchConnector();
   }, [id]);
@@ -358,7 +365,7 @@ export default function ConnectorDetailPage() {
                         </div>
                         <div>
                           <label className="text-sm font-medium">Token URL</label>
-                          <input type="url" value={oauth2TokenUrl} onChange={(e) => setOauth2TokenUrl(e.target.value)} placeholder="https://accounts.google.com/o/oauth2/token" className="border rounded px-3 py-2 text-sm w-full mt-1" />
+                          <input type="url" value={oauth2TokenUrl} onChange={(e) => setOauth2TokenUrl(e.target.value)} placeholder={oauthTokenUrlPlaceholder()} className="border rounded px-3 py-2 text-sm w-full mt-1" />
                         </div>
                         <div>
                           <label className="text-sm font-medium">Redirect URI</label>


### PR DESCRIPTION
## Summary

Closes the Ramesh 2026-05-11 CA/Zoho reopen list (14 items, none dismissed).

@codex please re-review

### What changed

- **Zoho Books India contract:** sticky India region detection + correct token URL; reconcile_transaction now PUTs to `/banktransactions/{id}/match` instead of POSTing to `/uncategorized`; declares 17 tools so the registry can advertise them.
- **Connector health:** `/connectors/{id}/health` now runs the live probe and returns the real `tested`/`health`/`error` envelope instead of mirroring the cached DB `status` column — closes the false-healthy-on-404 class.
- **Tool routing:** connector-qualified aliases (`zoho_books:get_trial_balance`, `tally:get_trial_balance`) end the first-wins collision in `_build_tool_index`. Provider-safe names (`zoho_books__tool`) for the LLM. Scope-string builder and Grantex auth honour the same shape.
- **Industry-pack idempotency:** installer dedupes by `(tenant, company, agent_type)` with lifecycle audit, demotes unsafe active rows, and assigns cron schedules (bank recon daily, GST monthly, TDS quarterly, month-end, tax calendar) + explicit `human_review` step. Backed by Alembic migration `v4_9_10_pack_agent_idempotency` with partial unique index filtered on `config->'pack_install'->>'source' = 'industry_pack'` (customer-created agents untouched).
- **Production accuracy floor:** `_MIN_PRODUCTION_SHADOW_ACCURACY = 0.600`. Effective floor is `max(row_floor, 0.60)`, enforced on `/run`, `/resume→active`, and `/promote`. Legacy 0.20-floor rows can no longer authorize live work.
- **List defaults:** `/agents` hides `deleted/error/broken` rows by default.
- **UI:** Zoho OAuth token placeholder is `accounts.zoho.in`, not the Google URL. Agent scope strings preserve connector identity.

### Migration handling

Raw `migrations/018_pack_agent_idempotency.sql` from Codex's draft was rewritten as a real Alembic revision (`migrations/versions/v4_9_10_pack_agent_idempotency.py`, down_revision `v499_pool_config_noop`) so it runs in the prod migrate job, not as fresh-env-only DDL. The dedupe SQL is unchanged; the unique index predicate matches the installer's filter exactly.

### Verification

| Gate | Result |
| --- | --- |
| ruff (whole tree) | pass |
| mypy (734 files) | pass |
| bandit (api/auth/core) | pass |
| alembic revision <=32 | pass (revision id `v4910_pack_agent_idempotency`, 30 chars) |
| verify=False scan | pass |
| consistency sweep | pass |
| ui tsc + build | pass |
| pytest tests/unit/ tests/regression/ | 4070 passed (2 pre-existing Windows-local failures unrelated; CI on Linux unaffected) |
| `tests/integration/test_alembic_e2e.py` | pass — migration chain valid |

### Residual risk

1. **60% floor is hard-reject** (operator-approved). Any currently-active agent with `shadow_accuracy_current < 0.60` will get HTTP 409 on the next `/run` once this rolls out. Audit before flip: `SELECT id, name, shadow_accuracy_current FROM agents WHERE tenant_id=$1 AND status='active' AND shadow_accuracy_current IS NOT NULL AND shadow_accuracy_current < 0.6`.
2. **Migration is data-mutating** (soft-deletes duplicate pack rows). Will run via Cloud Run `agenticorg-migrate` job before traffic cuts. Rollback path: `DROP INDEX uq_agents_industry_pack_company_type;` + restore from soft-delete (`UPDATE agents SET status='shadow' WHERE id IN (...)`).
3. **Installer dedupe loop's broader lookup**: now finds any non-deleted agent matching `(tenant, company, agent_type)`. Customer-created agents in the same `agent_type` slot would be reused/refreshed instead of left alone. The Alembic index is correctly filtered by `config->>pack_install->>source` so the schema-level guard only covers true pack rows, but the runtime dedupe path doesn't apply the same filter. Acceptable for now (pack installs are admin-initiated and the install path only runs on pack invocations) but worth a follow-up to scope the lookup to true pack rows.
4. **Live Zoho probe not exercised** end-to-end — code-grade only for connector I/O. Operator should test one live Zoho connector after deploy.

## Test plan

- [ ] CI green on Linux
- [ ] Apply `v4910_pack_agent_idempotency` via Cloud Run migrate job (with DATABASE_URL secret + Cloud SQL instance attached)
- [ ] Deploy agenticorg-api and agenticorg-ui to asia-southeast1
- [ ] Smoke /health on api revision; confirm new SHA serves
- [ ] Confirm `alembic_version` row equals `v4910_pack_agent_idempotency` after migrate job
- [ ] Operator re-runs Ramesh's 14 items against live deploy with the test CA-firms tenant