### PR TITLE
fix(mcp-server): patch hono / fast-uri / ip-address (8 Dependabot alerts)

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -450,9 +450,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -587,9 +587,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -638,9 +638,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -40,6 +40,8 @@
     "typescript": "^5.7.0"
   },
   "overrides": {
-    "hono": ">=4.12.14"
+    "hono": ">=4.12.18",
+    "fast-uri": ">=3.1.2",
+    "ip-address": ">=10.1.1"
   }
 }


### PR DESCRIPTION
## Summary

Closes 8 open Dependabot alerts on `mcp-server/package-lock.json`. All three vulnerable packages are transitive deps of `@modelcontextprotocol/sdk`; bumping via `overrides` in `mcp-server/package.json`.

| Pkg | Before | After | Severity | Advisories |
|---|---|---|---|---|
| `hono` | `>=4.12.14` (override) → resolved 4.12.17 | `>=4.12.18` → resolved 4.12.18 | medium ×4 + low ×1 | GHSA-qp7p-654g-cw7p (CSS injection), GHSA-p77w-8qqv-26rm (cache Vary leakage), GHSA-69xw-7hcm-h432 (JSX HTML injection), GHSA-9vqf-7f2p-gf9v (bodyLimit bypass), GHSA-hm8q-7f3q-5f36 (JWT NumericDate) |
| `fast-uri` | none → resolved 3.1.0 | `>=3.1.2` → resolved 3.1.2 | high ×2 | GHSA-v39h-62p7-jpjc (host confusion), GHSA-q3j6-qgpj-74h6 (path traversal) |
| `ip-address` | none → resolved 10.1.0 | `>=10.1.1` → resolved 10.2.0 | medium | GHSA-v2v4-37r5-5v8g (XSS in Address6) |

The existing `hono >=4.12.14` override was insufficient — patches landed in 4.12.16 and 4.12.18, so we still resolved 4.12.17 and were exposed to all five advisories.

## Verification

- `npm audit --omit=dev` → **`found 0 vulnerabilities`** (was 8)
- `npm ls hono fast-uri ip-address` → all at patched versions
- `npm run build` (tsc) → green
- Local preflight: ruff / mypy / bandit / ui-tsc / ui-build / consistency / coverage / critical-path → all pass
- Pytest gate: bypassed via `SKIP_PYTEST=1` (documented in `scripts/preflight.sh`); pytest fails locally on a known Windows + Py 3.13 timeout in `test_self_visible_to_pytest` unrelated to this npm-only change. CI will run pytest in Linux.

## Risk / blast radius

- mcp-server only. No backend, no UI, no migrations.
- `hono`, `fast-uri`, `ip-address` are all internal to `@modelcontextprotocol/sdk`'s HTTP transport layer; not directly imported by our code.
- Override is a minor-version pin — semver-compatible with what `@modelcontextprotocol/sdk` already expects.

## Test plan

- [ ] CI green (lint, codeql, unit-tests, security-scan)
- [ ] Dependabot alerts page shows 0 open after merge
- [ ] mcp-server published to npm continues to function (verify via `npx @agenticorg/agenticorg-mcp` smoke after publish)

cc @codex please review.