### PR TITLE
[codex] fix aishwarya tds runtime regressions

### DIFF
--- a/api/v1/_tds_routing.py
+++ b/api/v1/_tds_routing.py
@@ -33,7 +33,9 @@ no global runtime change, no impact on any other agent.
 
 from __future__ import annotations
 
+import math
 import re
+from datetime import date
 from typing import Any
 
 # ----------------------------------------------------------------------
@@ -61,7 +63,24 @@ _TDS_SECTION_RE = re.compile(
 
 # Action verbs that signal computation/filing intent.
 _TDS_ACTION_RE = re.compile(
-    r"\b(calculate|compute|compute\s+tds|file|filing|submit|prepare|deduct|withhold)\b",
+    r"\b(calculate|compute|compute\s+tds|file|filing|submit|prepare|generate|deduct|withhold|pay)\b",
+    re.IGNORECASE,
+)
+
+HIGH_VALUE_TDS_TRANSACTION_THRESHOLD = 500_000.0
+
+_CHALLAN_281_RE = re.compile(
+    r"\b(?:challan\s*281|281\s+challan|tds\s+payment)\b",
+    re.IGNORECASE,
+)
+
+_LATE_FILING_RE = re.compile(
+    r"\b(?:late\s+fil(?:e|ing)|delayed\s+fil(?:e|ing)|234E|201\s*\(?1A\)?|penalt(?:y|ies)|interest)\b",
+    re.IGNORECASE,
+)
+
+_DELAY_DAYS_RE = re.compile(
+    r"\b(?:delayed\s+by|delay\s+of|late\s+by)\s+(?P<days>\d{1,4})\s+days?\b",
     re.IGNORECASE,
 )
 
@@ -154,6 +173,26 @@ def _extract_amount(query: str) -> float | None:
         return None
 
 
+def _extract_tds_amount(query: str) -> float | None:
+    for pattern in (
+        re.compile(
+            r"\bTDS\s+(?:amount|payable|due)\s+(?:of\s+)?(?:INR|Rs\.?|₹)?\s*(?P<num>\d[\d,]*(?:\.\d+)?)",
+            re.IGNORECASE,
+        ),
+        re.compile(
+            r"\b(?:INR|Rs\.?|₹)\s*(?P<num>\d[\d,]*(?:\.\d+)?)\s+(?:TDS|tax\s+deducted)\b",
+            re.IGNORECASE,
+        ),
+    ):
+        match = pattern.search(query)
+        if match:
+            try:
+                return float(match.group("num").replace(",", ""))
+            except ValueError:
+                return None
+    return None
+
+
 def _extract_section(query: str) -> str | None:
     match = _TDS_SECTION_RE.search(query)
     if not match:
@@ -232,6 +271,174 @@ def _filing_requested(query: str) -> str | None:
     return (match.group(1) or match.group(2) or "").upper() or None
 
 
+def _challan_281_requested(query: str) -> bool:
+    return bool(_CHALLAN_281_RE.search(query))
+
+
+def _late_filing_requested(query: str) -> bool:
+    return bool(_LATE_FILING_RE.search(query) and _FILING_FORM_RE.search(query))
+
+
+def _extract_delay_days(query: str) -> int | None:
+    match = _DELAY_DAYS_RE.search(query)
+    if not match:
+        return None
+    try:
+        return int(match.group("days"))
+    except ValueError:
+        return None
+
+
+def _tds_return_due_date(period: str | None, form_name: str | None) -> date | None:
+    if not period or not form_name:
+        return None
+    # TDS quarterly returns: Q1 Jul 31, Q2 Oct 31, Q3 Jan 31, Q4 May 31.
+    # For an FY token "2025-26", the FY starts in 2025 and ends in 2026.
+    match = re.search(r"\bQ(?P<quarter>[1-4])\b.*?\bFY\s*(?P<start>\d{4})(?:-(?P<end>\d{2,4}))?", period, re.IGNORECASE)
+    if not match:
+        return None
+    quarter = int(match.group("quarter"))
+    start_year = int(match.group("start"))
+    end_token = match.group("end")
+    if end_token:
+        end_year = int(end_token)
+        if end_year < 100:
+            end_year = (start_year // 100) * 100 + end_year
+    else:
+        end_year = start_year + 1
+    if quarter == 1:
+        return date(start_year, 7, 31)
+    if quarter == 2:
+        return date(start_year, 10, 31)
+    if quarter == 3:
+        return date(end_year, 1, 31)
+    return date(end_year, 5, 31)
+
+
+def _build_challan_281_response(
+    *,
+    amount: float,
+    period: str | None,
+    section: str | None,
+    pan: str | None,
+    deductee_type: str | None,
+) -> dict[str, Any]:
+    missing: list[str] = []
+    if not section:
+        missing.append("TDS section for the payment, e.g. 194C / 194J")
+    if not pan:
+        missing.append("PAN of the deductee")
+    if not deductee_type:
+        missing.append("deductee type (individual / HUF / company / firm)")
+    missing.extend(
+        [
+            "TAN of the deductor",
+            "assessment year and minor head (200 or 400)",
+            "bank / BSR details after the Challan 281 payment is made",
+            "explicit partner-review approval before payment submission",
+        ]
+    )
+
+    parts = [
+        "Challan 281 preparation started from the values already present in the prompt:",
+        f"  • TDS amount to pay: INR {amount:,.2f}",
+    ]
+    if period:
+        parts.append(f"  • Period: {period}")
+    if section:
+        parts.append(f"  • Section: {section}")
+    parts.append(
+        "\nNo amount clarification is needed. The actual Challan 281 payment is blocked "
+        "fail-closed until these genuinely missing fields/approvals are supplied:"
+    )
+    parts.extend(f"  ✗ {item}" for item in missing)
+    parts.append("\nNo payment call was made.")
+
+    return {
+        "answer": "\n".join(parts),
+        "tool_calls": [],
+        "confidence": 0.82,
+        "tools_used": False,
+        "hitl_trigger": "challan_281_payment_requires_partner_review",
+        "hitl_context": {
+            "workflow": "challan_281",
+            "transaction_amount": amount,
+            "tds_amount": amount,
+            "period": period,
+            "section": section,
+            "missing_fields": missing,
+        },
+    }
+
+
+def _build_late_filing_response(
+    *,
+    query: str,
+    period: str | None,
+    form_name: str | None,
+) -> dict[str, Any]:
+    tds_amount = _extract_tds_amount(query)
+    delay_days = _extract_delay_days(query)
+    due_date = _tds_return_due_date(period, form_name)
+
+    missing: list[str] = []
+    if tds_amount is None:
+        missing.append("TDS amount payable for the quarter")
+    if delay_days is None:
+        missing.append("actual delay in days or the actual filing/deposit date")
+
+    parts = [
+        f"Section 234E / 201(1A) computation route selected for Form {form_name or '26Q/24Q'}.",
+    ]
+    if period:
+        parts.append(f"  • Period extracted: {period}")
+    if due_date:
+        parts.append(f"  • Statutory filing due date: {due_date.isoformat()}")
+
+    if tds_amount is not None and delay_days is not None:
+        late_fee = min(tds_amount, 200.0 * delay_days)
+        months_for_interest = max(1, math.ceil(delay_days / 30))
+        late_deposit_interest = round(tds_amount * 0.015 * months_for_interest, 2)
+        parts.extend(
+            [
+                f"  • Section 234E late fee: INR {late_fee:,.2f} "
+                f"(INR 200/day × {delay_days} days, capped at TDS amount)",
+                f"  • Section 201(1A) late-deposit interest estimate: INR {late_deposit_interest:,.2f} "
+                f"(1.5% per month or part month × {months_for_interest} month(s))",
+                "  • Final 201(1A) split still needs deduction date vs deposit date "
+                "if late deduction and late deposit both apply.",
+            ]
+        )
+    else:
+        parts.extend(
+            [
+                "The statutory rules are configured and available:",
+                "  • Section 234E: INR 200 per day, capped at the TDS amount payable.",
+                "  • Section 201(1A): 1% per month or part month for late deduction "
+                "and 1.5% per month or part month for late deposit.",
+                "Exact rupee computation needs only the missing inputs below:",
+            ]
+        )
+        parts.extend(f"  ✗ {item}" for item in missing)
+
+    return {
+        "answer": "\n".join(parts),
+        "tool_calls": [],
+        "confidence": 0.80 if missing else 0.90,
+        "tools_used": False,
+        "hitl_trigger": "tds_late_fee_or_interest_requires_partner_review",
+        "hitl_context": {
+            "workflow": "tds_late_filing",
+            "period": period,
+            "form": form_name,
+            "due_date": due_date.isoformat() if due_date else None,
+            "tds_amount": tds_amount,
+            "delay_days": delay_days,
+            "missing_fields": missing,
+        },
+    }
+
+
 # ----------------------------------------------------------------------
 # Public entrypoint
 # ----------------------------------------------------------------------
@@ -269,15 +476,31 @@ async def try_tds_deterministic_route(
     if not query or not _TDS_ACTION_RE.search(query):
         return None
 
+    period = _extract_period(query)
+    requested_form = _filing_requested(query)
+    if _late_filing_requested(query):
+        return _build_late_filing_response(
+            query=query,
+            period=period,
+            form_name=requested_form,
+        )
+
     amount = _extract_amount(query)
     section = _extract_section(query)
+    pan = _extract_pan(query)
+    deductee_type = _extract_deductee_type(query)
+    if _challan_281_requested(query) and amount is not None:
+        return _build_challan_281_response(
+            amount=amount,
+            period=period,
+            section=section,
+            pan=pan,
+            deductee_type=deductee_type,
+        )
     if amount is None or section is None:
         return None
 
-    period = _extract_period(query)
     deductee_type = _extract_deductee_type(query) or "individual"
-    pan = _extract_pan(query)
-    requested_form = _filing_requested(query)
 
     # PAN handling: only treat PAN as unavailable when the user
     # *explicitly* says so. A query like "calculate TDS for INR 50,000
@@ -331,6 +554,11 @@ async def try_tds_deterministic_route(
         "result": calc,
         "deterministic_route": True,
         "route_reason": "issue_440_tds_runtime_routing",
+        "governance": {
+            "transaction_amount": amount,
+            "tds_amount": calc["tds_amount"],
+            "high_value_threshold": HIGH_VALUE_TDS_TRANSACTION_THRESHOLD,
+        },
     }
 
     parts: list[str] = []
@@ -399,9 +627,33 @@ async def try_tds_deterministic_route(
     else:
         confidence = 0.92  # Pure calculation, no follow-up gate needed
 
+    high_value_trigger = ""
+    if amount > HIGH_VALUE_TDS_TRANSACTION_THRESHOLD:
+        high_value_trigger = (
+            "transaction_amount "
+            f"{amount:.2f} > {HIGH_VALUE_TDS_TRANSACTION_THRESHOLD:.2f}"
+        )
+        parts.append(
+            "\nHITL triggered: gross transaction amount "
+            f"INR {amount:,.2f} exceeds the INR "
+            f"{HIGH_VALUE_TDS_TRANSACTION_THRESHOLD:,.0f} threshold. "
+            "The calculation above is prepared for partner review; no filing, "
+            "challan payment, voucher posting, or other processing step was "
+            "auto-submitted."
+        )
+
     return {
         "answer": "\n".join(parts),
         "tool_calls": [tool_call],
         "confidence": confidence,
         "tools_used": True,
+        "hitl_trigger": high_value_trigger or None,
+        "hitl_context": {
+            "workflow": "tds_calculation",
+            "transaction_amount": amount,
+            "tds_amount": calc["tds_amount"],
+            "section": section,
+            "period": period,
+            "requested_form": requested_form,
+        },
     }

--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -418,6 +418,44 @@ def _agent_version_snapshot(
     )
 
 
+def _tool_calls_contain_failure(tool_calls: Any) -> bool:
+    if not isinstance(tool_calls, list):
+        return False
+    for call in tool_calls:
+        if not isinstance(call, dict):
+            continue
+        status = str(call.get("status") or "").strip().lower()
+        if status in {"error", "failed", "failure"}:
+            return True
+        error = call.get("error")
+        if error:
+            return True
+        result = call.get("result")
+        if isinstance(result, dict) and result.get("error"):
+            return True
+    return False
+
+
+def _is_shadow_accuracy_measurable(
+    *,
+    task_status: str,
+    task_confidence: float | None,
+    tool_calls: Any,
+) -> bool:
+    """Decide whether a run should move shadow accuracy.
+
+    Shadow accuracy measures model/task correctness. Tool infrastructure,
+    connector, and invocation failures are tracked separately through tool
+    error metrics and must not be averaged into model accuracy.
+    """
+    return (
+        task_status in ("completed", "hitl_triggered")
+        and task_confidence is not None
+        and float(task_confidence) >= 0.10
+        and not _tool_calls_contain_failure(tool_calls)
+    )
+
+
 def _user_uuid_from_claims(user: dict | None) -> _uuid.UUID | None:
     """Extract a user UUID from JWT claims for audit-log ``edited_by``.
 
@@ -2363,10 +2401,11 @@ async def run_agent(
     # skip them entirely. Also bump the sample count only when we're
     # actually scoring. The min-samples gate still prevents promotion
     # until enough real samples have accumulated.
-    is_measurable = (
-        task_status in ("completed", "hitl_triggered")
-        and task_confidence is not None
-        and float(task_confidence) >= 0.10
+    task_tool_calls = lg_result.get("tool_calls") or lg_result.get("tool_calls_log") or []
+    is_measurable = _is_shadow_accuracy_measurable(
+        task_status=task_status,
+        task_confidence=task_confidence,
+        tool_calls=task_tool_calls,
     )
     if (
         agent_config.get("status") in ("shadow", "active")

--- a/api/v1/chat.py
+++ b/api/v1/chat.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json as _json
 import re
 import uuid as _uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import structlog
@@ -18,6 +18,7 @@ from api.v1.agents import _AGENT_TYPE_DEFAULT_TOOLS, _DOMAIN_DEFAULT_TOOLS
 from core.config import redis_socket_timeout_kwargs, redis_url_from_env
 from core.database import get_tenant_session
 from core.models.agent import Agent
+from core.models.hitl import HITLQueue
 
 router = APIRouter()
 _log = structlog.get_logger()
@@ -369,12 +370,74 @@ class ChatQueryResponse(BaseModel):
     agent: str
     confidence: float
     domain: str
+    hitl_trigger: str | None = None
     # Issue #440 (TDS deterministic route): when the chat handler bypasses
     # the LLM and invokes a tool deterministically, the tool_calls trace
     # is surfaced here so audit/regression/UI can verify a real tool
     # invocation happened. ``None`` means "LLM path was used" — that
     # path persists tool_calls in the langgraph_run result instead.
     tool_calls: list[dict] | None = None
+
+
+async def _record_chat_hitl(
+    *,
+    tenant_id: str,
+    agent_id: str | None,
+    agent_type: str | None,
+    agent_name: str,
+    domain: str,
+    query: str,
+    hitl_trigger: str | None,
+    confidence: float,
+    hitl_context: dict[str, Any] | None = None,
+) -> None:
+    """Persist chat-triggered HITL so the approval queue is not bypassed.
+
+    The /agents/{id}/run endpoint creates HITLQueue rows after LangGraph
+    execution. Chat previously only surfaced text, so deterministic policy
+    gates such as high-value TDS calculations had no approval artifact.
+    """
+    if not hitl_trigger or not agent_id:
+        return
+    try:
+        tid = _uuid.UUID(tenant_id)
+        aid = _uuid.UUID(agent_id)
+    except (TypeError, ValueError):
+        return
+
+    context = {
+        "source": "chat",
+        "query": query[:2000],
+        "agent_type": agent_type,
+        "agent_name": agent_name,
+        "domain": domain,
+        "confidence": confidence,
+        "trigger": hitl_trigger,
+    }
+    if hitl_context:
+        context.update(hitl_context)
+
+    try:
+        async with get_tenant_session(tid) as session:
+            session.add(
+                HITLQueue(
+                    tenant_id=tid,
+                    agent_id=aid,
+                    workflow_run_id=None,
+                    title=f"HITL: {agent_type or agent_name} — {hitl_trigger}",
+                    trigger_type="chat_policy",
+                    priority="high",
+                    assignee_role=domain or "admin",
+                    decision_options={
+                        "options": ["approve", "reject", "override"],
+                        "context": context,
+                    },
+                    context=context,
+                    expires_at=datetime.now(UTC) + timedelta(hours=4),
+                )
+            )
+    except Exception:  # noqa: BLE001
+        _log.warning("chat_hitl_queue_create_failed", agent_id=agent_id, exc_info=True)
 
 
 class ChatMessage(BaseModel):
@@ -443,6 +506,7 @@ async def chat_query(
     # still showed 60% even when the LLM had high-quality reasoning.
     tools_used = False
     confidence: float | None = None
+    hitl_trigger: str | None = None
 
     # Resolve agent_type: prefer DB value, fall back to domain keyword (BUG #3)
     resolved_agent_type = agent_type or domain
@@ -475,11 +539,25 @@ async def chat_query(
         _log.warning("chat_tds_route_helper_raised", exc_info=True)
         det = None
     if det is not None:
+        hitl_trigger = det.get("hitl_trigger") or None
+        det_confidence = float(det["confidence"])
+        await _record_chat_hitl(
+            tenant_id=tenant_id,
+            agent_id=agent_id,
+            agent_type=resolved_agent_type,
+            agent_name=agent_name,
+            domain=domain,
+            query=body.query,
+            hitl_trigger=hitl_trigger,
+            confidence=det_confidence,
+            hitl_context=det.get("hitl_context") or None,
+        )
         return ChatQueryResponse(
             answer=det["answer"],
             agent=agent_name,
-            confidence=float(det["confidence"]),
+            confidence=det_confidence,
             domain=domain,
+            hitl_trigger=hitl_trigger,
             tool_calls=det.get("tool_calls") or None,
         )
 
@@ -561,7 +639,8 @@ async def chat_query(
                 connector_config=connector_config,
                 connector_names=connector_names,
             )
-            if lg_result.get("status") == "completed" and lg_result.get("output"):
+            hitl_trigger = lg_result.get("hitl_trigger") or None
+            if lg_result.get("status") in ("completed", "hitl_triggered") and lg_result.get("output"):
                 output = lg_result["output"]
                 answer = _format_agent_output(output)
                 # Extract real confidence from LLM response (BUG #21).
@@ -573,6 +652,29 @@ async def chat_query(
                 tools_used = bool(
                     lg_result.get("tool_calls") or lg_result.get("tool_calls_log")
                 )
+            if hitl_trigger:
+                confidence_for_hitl = (
+                    float(confidence)
+                    if isinstance(confidence, (int, float))
+                    else float(lg_result.get("confidence") or 0.0)
+                )
+                await _record_chat_hitl(
+                    tenant_id=tenant_id,
+                    agent_id=agent_id,
+                    agent_type=resolved_agent_type,
+                    agent_name=agent_name,
+                    domain=domain,
+                    query=body.query,
+                    hitl_trigger=hitl_trigger,
+                    confidence=confidence_for_hitl,
+                    hitl_context={
+                        "output": lg_result.get("output", {}),
+                        "tool_calls": lg_result.get("tool_calls") or lg_result.get("tool_calls_log") or [],
+                    },
+                )
+                if not answer:
+                    answer = f"HITL triggered: {hitl_trigger}. The agent stopped and queued this for human review."
+                    confidence = confidence_for_hitl
         except Exception:
             _log.warning("chat_langgraph_fallback", domain=domain, agent_id=agent_id)
 
@@ -647,6 +749,7 @@ async def chat_query(
         agent=agent_name,
         confidence=confidence,
         domain=domain,
+        hitl_trigger=hitl_trigger,
     )
 
 

--- a/core/agents/packs/ca/__init__.py
+++ b/core/agents/packs/ca/__init__.py
@@ -166,6 +166,9 @@ CA_PACK: dict[str, Any] = {
                 "genuinely needed for the filing step. Never ask the user to "
                 "repeat the amount, section, or period when they are already "
                 "in the prompt — that is the BUG-17 failure pattern.\n\n"
+                "HIGH-VALUE HITL: Escalate when the gross transaction/"
+                "payment amount exceeds INR 5,00,000. This gate must use "
+                "the original payment amount, not the computed TDS amount.\n\n"
                 "Worked example for the canonical tester prompt 'Calculate "
                 "TDS for vendor payment of INR 50,000 under Section 194C for "
                 "April 2026 and file Form 26Q':\n"
@@ -174,7 +177,12 @@ CA_PACK: dict[str, Any] = {
                 "  3. Report the computed tds_amount, rate, net_payable\n"
                 "  4. For the Form 26Q step, ask only for PAN + deductee_type "
                 "if those are genuinely missing — do NOT re-ask for amount/"
-                "section."
+                "section.\n\n"
+                "For Challan 281 generation, extract any provided TDS payment "
+                "amount and period first. Ask only for missing section, TAN, "
+                "PAN/deductee data, challan evidence, and partner-review "
+                "approval; never ask the user to repeat an amount already "
+                "present in the prompt."
             ),
         },
         {

--- a/core/agents/packs/ca/config.yaml
+++ b/core/agents/packs/ca/config.yaml
@@ -40,6 +40,7 @@ agents:
     system_prompt_suffix: >
       You compute TDS per applicable sections, file Form 26Q/24Q, generate Form 16A, and reconcile 26AS.
       ALWAYS trigger human-in-the-loop before filing returns or paying challans.
+      ALWAYS trigger human-in-the-loop when the gross transaction/payment amount exceeds INR 5,00,000; do not evaluate this gate against the computed TDS amount.
       Validate PAN and section applicability for every deductee before computing TDS.
       Never proceed if 26AS credit does not reconcile with books within 1% tolerance.
 
@@ -60,6 +61,10 @@ agents:
         3. Report the computed tds_amount, rate, and net_payable
         4. For the Form 26Q step, ask only for PAN + deductee_type if
            those are genuinely missing — do NOT re-ask for amount/section.
+      For Challan 281 generation, extract any provided TDS payment amount
+      and period first. Ask only for missing section, TAN, PAN/deductee
+      data, challan evidence, and partner-review approval; never ask the
+      user to repeat an amount already present in the prompt.
   - type: bank_reconciliation
     domain: finance
     prompt_file: prompts/bank_reconciliation.prompt.txt

--- a/core/agents/packs/ca/prompts/tds_compliance.prompt.txt
+++ b/core/agents/packs/ca/prompts/tds_compliance.prompt.txt
@@ -83,7 +83,7 @@ Trigger HITL (never auto-proceed) if ANY condition is true:
   26AS mismatch > 1% of total TDS for any deductee
   Late filing attracting penalty under Section 234E (INR 200/day)
   Interest computation under Section 201(1A) exceeds INR 10,000
-  TDS on single transaction > INR 5,00,000
+  Gross transaction/payment amount > INR 5,00,000 (evaluate the original transaction amount, not the computed TDS amount)
   Confidence < 0.92 for any computation step
 Include in HITL context: full trace, all computed values, trigger condition, recommendation.
 </escalation_rules>

--- a/tests/regression/test_aishwarya_12may2026_agent_runtime.py
+++ b/tests/regression/test_aishwarya_12may2026_agent_runtime.py
@@ -1,0 +1,158 @@
+"""Aishwarya 12 May 2026 agent-runtime reopen regressions."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def test_tds_high_value_hitl_uses_transaction_amount_not_tds_amount() -> None:
+    from api.v1._tds_routing import try_tds_deterministic_route
+
+    result = asyncio.run(
+        try_tds_deterministic_route(
+            agent_type="tds_compliance_agent",
+            query=(
+                "Calculate TDS for contractor payment of INR 12,50,000 "
+                "under Section 194C for Q2 FY 2026-27."
+            ),
+        )
+    )
+
+    assert result is not None
+    assert result["hitl_trigger"]
+    assert "transaction_amount" in result["hitl_trigger"]
+    assert "500000" in result["hitl_trigger"]
+
+    tool_call = result["tool_calls"][0]
+    assert tool_call["arguments"]["amount"] == 1_250_000.0
+    assert tool_call["result"]["tds_amount"] == 12_500.0
+    assert tool_call["governance"]["transaction_amount"] == 1_250_000.0
+
+    answer = result["answer"].lower()
+    assert "hitl triggered" in answer
+    assert "gross transaction amount" in answer
+    assert "no filing" in answer
+    assert "auto-submitted" in answer
+
+
+def test_challan_281_extracts_amount_and_does_not_reask_it() -> None:
+    from api.v1._tds_routing import try_tds_deterministic_route
+
+    result = asyncio.run(
+        try_tds_deterministic_route(
+            agent_type="tds_compliance_agent",
+            query="Generate Challan 281 for April 2026 TDS payment of INR 1,25,000.",
+        )
+    )
+
+    assert result is not None
+    assert result["tool_calls"] == []
+    assert result["hitl_trigger"] == "challan_281_payment_requires_partner_review"
+    assert result["hitl_context"]["tds_amount"] == 125_000.0
+
+    answer = result["answer"]
+    lower = answer.lower()
+    assert "125,000" in answer or "125000" in answer
+    assert "april 2026" in lower
+    assert "section" in lower
+    assert "tan" in lower
+    assert "pan" in lower
+    for forbidden in (
+        "amount of tds to be paid",
+        "please provide the amount",
+        "what is the amount",
+    ):
+        assert forbidden not in lower
+
+
+def test_tds_late_filing_route_uses_234e_and_201_1a_logic() -> None:
+    from api.v1._tds_routing import try_tds_deterministic_route
+
+    result = asyncio.run(
+        try_tds_deterministic_route(
+            agent_type="tds_compliance_agent",
+            query=(
+                "Compute late filing interest and penalty for delayed Form 26Q "
+                "filing for Q4 FY 2025-26."
+            ),
+        )
+    )
+
+    assert result is not None
+    answer = result["answer"]
+    lower = answer.lower()
+    assert "234e" in lower
+    assert "201(1a)" in lower
+    assert "q4 fy 2025-26" in lower
+    assert "2026-05-31" in lower
+    assert "tds amount payable" in lower
+    assert "actual delay" in lower
+    assert "cannot directly compute" not in lower
+
+
+def test_tds_late_filing_computes_when_amount_and_delay_are_present() -> None:
+    from api.v1._tds_routing import try_tds_deterministic_route
+
+    result = asyncio.run(
+        try_tds_deterministic_route(
+            agent_type="tds_compliance_agent",
+            query=(
+                "Compute Section 234E and 201(1A) for delayed Form 26Q "
+                "filing for Q4 FY 2025-26 with TDS amount INR 1,00,000 "
+                "delayed by 10 days."
+            ),
+        )
+    )
+
+    assert result is not None
+    answer = result["answer"]
+    assert "2,000.00" in answer
+    assert "1,500.00" in answer
+    assert result["hitl_context"]["tds_amount"] == 100_000.0
+    assert result["hitl_context"]["delay_days"] == 10
+
+
+def test_shadow_accuracy_excludes_tool_failure_samples() -> None:
+    from api.v1.agents import _is_shadow_accuracy_measurable
+
+    assert (
+        _is_shadow_accuracy_measurable(
+            task_status="completed",
+            task_confidence=0.92,
+            tool_calls=[{"tool": "get_ledger_balance", "status": "success"}],
+        )
+        is True
+    )
+    assert (
+        _is_shadow_accuracy_measurable(
+            task_status="completed",
+            task_confidence=0.50,
+            tool_calls=[{"tool": "get_ledger_balance", "status": "error"}],
+        )
+        is False
+    )
+    assert (
+        _is_shadow_accuracy_measurable(
+            task_status="completed",
+            task_confidence=0.92,
+            tool_calls=[{"tool": "get_ledger_balance", "result": {"error": "timeout"}}],
+        )
+        is False
+    )
+
+
+def test_tds_prompt_pins_high_value_gate_to_gross_transaction_amount() -> None:
+    prompt = (REPO / "core" / "agents" / "packs" / "ca" / "prompts" / "tds_compliance.prompt.txt").read_text(
+        encoding="utf-8"
+    )
+    assert "Gross transaction/payment amount > INR 5,00,000" in prompt
+    assert "not the computed TDS amount" in prompt
+
+    pack = (REPO / "core" / "agents" / "packs" / "ca" / "__init__.py").read_text(
+        encoding="utf-8"
+    )
+    assert "HIGH-VALUE HITL" in pack
+    assert "not the computed TDS amount" in pack

--- a/ui/e2e/aishwarya-12may2026.spec.ts
+++ b/ui/e2e/aishwarya-12may2026.spec.ts
@@ -1,0 +1,198 @@
+import { expect, Page, test } from "@playwright/test";
+
+const tdsAgent = {
+  id: "agent-tds",
+  name: "TDS Compliance Agent",
+  employee_name: "TDS Compliance Agent",
+  agent_type: "tds_compliance_agent",
+  domain: "finance",
+  status: "active",
+  version: "1.0.1",
+  confidence_floor: 0.92,
+  shadow_sample_count: 22,
+  shadow_accuracy_current: 0.87,
+  shadow_accuracy_floor: 0.8,
+  shadow_min_samples: 10,
+  authorized_tools: ["calculate_tds", "pay_tax_challan"],
+  created_at: "2026-05-12T00:00:00Z",
+};
+
+async function installRoutes(page: Page) {
+  let detailAgent = { ...tdsAgent };
+
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+
+    if (path.endsWith("/auth/me")) {
+      await route.fulfill({
+        json: {
+          email: "qa@example.com",
+          name: "QA",
+          role: "admin",
+          domain: "all",
+          tenant_id: "tenant-1",
+          onboarding_complete: true,
+        },
+      });
+      return;
+    }
+
+    if (path.endsWith("/product-facts")) {
+      await route.fulfill({
+        json: { version: "test", connector_count: 10, agent_count: 1, tool_count: 20 },
+      });
+      return;
+    }
+
+    if (path.endsWith("/agents/agent-tds") && request.method() === "GET") {
+      await route.fulfill({ json: detailAgent });
+      return;
+    }
+
+    if (path.endsWith("/agents/agent-tds/run") && request.method() === "POST") {
+      await route.fulfill({
+        json: {
+          run_id: "run-tool-failure",
+          task_id: "run-tool-failure",
+          agent_id: "agent-tds",
+          status: "completed",
+          confidence: 0.5,
+          output: { answer: "Ledger fetch failed; retry after connector access is restored." },
+          reasoning_trace: ["tool infrastructure failure handled without hallucination"],
+          tool_calls: [{ tool: "get_ledger_balance", status: "error", result: "connector timeout" }],
+          performance: { total_latency_ms: 10, llm_tokens_used: 0, llm_cost_usd: 0 },
+          hitl_trigger: null,
+          error: null,
+        },
+      });
+      return;
+    }
+
+    if (path.endsWith("/agents/agent-tds/rollback") && request.method() === "POST") {
+      detailAgent = { ...detailAgent, status: "shadow", version: "1.0.0" };
+      await route.fulfill({
+        json: {
+          id: "agent-tds",
+          rolled_back: true,
+          from_status: "active",
+          to_status: "shadow",
+          from_version: "1.0.1",
+          to_version: "1.0.0",
+        },
+      });
+      return;
+    }
+
+    if (path.endsWith("/chat/history")) {
+      await route.fulfill({ json: [] });
+      return;
+    }
+
+    if (path.endsWith("/chat/query") && request.method() === "POST") {
+      const body = request.postDataJSON() as { query?: string };
+      const query = body.query || "";
+      if (query.includes("12,50,000")) {
+        await route.fulfill({
+          json: {
+            answer:
+              "Calculated TDS amount: INR 12,500. HITL triggered: gross transaction amount INR 12,50,000 exceeds INR 5,00,000. No filing or payment was auto-submitted.",
+            agent: "TDS Compliance Agent",
+            confidence: 0.9,
+            domain: "finance",
+            hitl_trigger: "transaction_amount 1250000.00 > 500000.00",
+          },
+        });
+        return;
+      }
+      if (query.includes("Challan 281")) {
+        await route.fulfill({
+          json: {
+            answer:
+              "Challan 281 preparation started. TDS amount to pay: INR 125,000.00. Missing: section, TAN, PAN, partner-review approval. No payment call was made.",
+            agent: "TDS Compliance Agent",
+            confidence: 0.82,
+            domain: "finance",
+            hitl_trigger: "challan_281_payment_requires_partner_review",
+          },
+        });
+        return;
+      }
+      await route.fulfill({
+        json: {
+          answer:
+            "Section 234E / 201(1A) computation route selected for Form 26Q. Period extracted: Q4 FY 2025-26. Statutory filing due date: 2026-05-31. Missing: TDS amount payable and actual delay.",
+          agent: "TDS Compliance Agent",
+          confidence: 0.8,
+          domain: "finance",
+          hitl_trigger: "tds_late_fee_or_interest_requires_partner_review",
+        },
+      });
+      return;
+    }
+
+    if (path.endsWith("/agents/agent-tds/feedback")) {
+      await route.fulfill({ json: { feedback: [], count: 0 } });
+      return;
+    }
+
+    if (path.endsWith("/agents/agent-tds/explanation/latest")) {
+      await route.fulfill({ json: { has_run: false, bullets: [], tools_cited: [] } });
+      return;
+    }
+
+    await route.fulfill({ json: {} });
+  });
+}
+
+test.describe("Aishwarya 12 May 2026 TDS regressions", () => {
+  test("tool failure run keeps shadow metrics visible and rollback returns active to shadow", async ({
+    page,
+    baseURL,
+  }) => {
+    await installRoutes(page);
+
+    await page.goto(`${baseURL}/dashboard/agents/agent-tds`, { waitUntil: "domcontentloaded" });
+    await expect(page.locator("main")).toContainText("87.0%");
+
+    await page.getByRole("button", { name: "Run Agent" }).click();
+    await page
+      .getByPlaceholder("What should the agent do?")
+      .fill("Calculate TDS for contractor payments and fetch ledger balances.");
+    await page.getByRole("button", { name: /^Run$/ }).click();
+    await expect(page.getByTestId("agent-run-result")).toContainText("Ledger fetch failed");
+    await expect(page.locator("main")).toContainText("87.0%");
+
+    await page.getByRole("button", { name: "Rollback" }).click();
+    await expect(page.locator("main")).toContainText("shadow");
+  });
+
+  test("TDS chat surfaces HITL, Challan 281 extraction, and late-fee logic", async ({
+    page,
+    baseURL,
+  }) => {
+    await installRoutes(page);
+
+    await page.goto(`${baseURL}/dashboard/agents/agent-tds`, { waitUntil: "domcontentloaded" });
+    await page.getByRole("button", { name: "Chat with Agent" }).click();
+
+    const input = page.getByPlaceholder("Type a message...").last();
+    await input.fill(
+      "Calculate TDS for contractor payment of INR 12,50,000 under Section 194C for Q2 FY 2026-27.",
+    );
+    await input.press("Enter");
+    await expect(page.locator("body")).toContainText("gross transaction amount");
+    await expect(page.locator("body")).toContainText("HITL");
+
+    await input.fill("Generate Challan 281 for April 2026 TDS payment of INR 1,25,000.");
+    await input.press("Enter");
+    await expect(page.locator("body")).toContainText("TDS amount to pay: INR 125,000.00");
+    await expect(page.locator("body")).not.toContainText("Amount of TDS to be paid");
+
+    await input.fill("Compute late filing interest and penalty for delayed Form 26Q filing for Q4 FY 2025-26.");
+    await input.press("Enter");
+    await expect(page.locator("body")).toContainText("Section 234E / 201(1A)");
+    await expect(page.locator("body")).toContainText("2026-05-31");
+  });
+});

--- a/ui/src/components/ChatPanel.tsx
+++ b/ui/src/components/ChatPanel.tsx
@@ -8,6 +8,7 @@ interface Message {
   agent?: string;
   confidence?: number;
   domain?: string;
+  hitlTrigger?: string;
   timestamp: Date;
 }
 
@@ -16,6 +17,7 @@ interface ChatQueryResponse {
   agent: string;
   confidence: number;
   domain: string;
+  hitl_trigger?: string | null;
 }
 
 // Some LangGraph agents return a JSON-shaped answer (e.g.
@@ -146,6 +148,7 @@ export default function ChatPanel({
         agent: m.agent,
         confidence: m.confidence,
         domain: m.domain,
+        hitlTrigger: m.hitl_trigger || undefined,
         timestamp: new Date(m.timestamp || m.created_at || Date.now()),
       }));
       if (loaded.length > 0) setMessages(loaded);
@@ -189,6 +192,7 @@ export default function ChatPanel({
         agent: res.data.agent,
         confidence: res.data.confidence,
         domain: res.data.domain,
+        hitlTrigger: res.data.hitl_trigger || undefined,
         timestamp: new Date(),
       };
       setMessages((prev) => [...prev, agentMsg]);
@@ -289,6 +293,11 @@ export default function ChatPanel({
                       {msg.confidence != null && (
                         <span className="text-[10px] text-slate-500">
                           {Math.round(msg.confidence * 100)}%
+                        </span>
+                      )}
+                      {msg.hitlTrigger && (
+                        <span className="inline-flex items-center rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-300">
+                          HITL
                         </span>
                       )}
                     </div>


### PR DESCRIPTION
## Summary

Fixes the Aishwarya 12 May 2026 workbook findings by enforcing the runtime invariants behind the reported issues instead of relying on prompt/UI wording.

## Changes

- Exclude failed tool executions from shadow accuracy while preserving tool failure metrics.
- Make high-value TDS HITL use the gross transaction/payment amount, not computed TDS.
- Add deterministic TDS late-filing handling for Section 234E and 201(1A), including missing-input guidance and exact computation when enough inputs are present.
- Add Challan 281 extraction that preserves supplied amount/period and asks only for missing fields.
- Queue and surface chat-triggered HITL events, with a HITL badge in chat responses.
- Add backend and Playwright regressions for the workbook cases.

## Validation

- `uv run pytest tests/regression/test_aishwarya_12may2026_agent_runtime.py tests/unit/test_shadow_confidence_noise_floor.py tests/unit/test_module_6_agent_execution.py -q` -> 41 passed
- `uv run ruff check api/v1/_tds_routing.py api/v1/chat.py api/v1/agents.py tests/regression/test_aishwarya_12may2026_agent_runtime.py` -> passed
- `cd ui; npm run typecheck` -> passed
- `BASE_URL=http://127.0.0.1:4179 npx playwright test e2e/aishwarya-12may2026.spec.ts --project=chromium` -> 2 passed