### PR TITLE
chore(mcp-server): bump to 4.0.4 for security republish

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -1,5 +1,24 @@
 # agenticorg-mcp-server changelog
 
+## 4.0.4 — 2026-05-12
+
+Security republish — same runtime as 4.0.3, with patched transitive
+dependencies.
+
+### Security
+- Bumped overrides for transitive deps inside `@modelcontextprotocol/sdk`
+  to close 8 GitHub Dependabot advisories (PR #504):
+  - `hono` `>=4.12.18` (was `>=4.12.14`) — closes 4 medium + 1 low
+    (CSS Declaration Injection, cache `Vary` leakage, JSX HTML injection,
+    `bodyLimit` bypass, JWT NumericDate validation).
+  - `fast-uri` `>=3.1.2` (new) — closes 2 high (host confusion via
+    percent-encoded authority delimiters; path traversal via percent-encoded
+    dot segments).
+  - `ip-address` `>=10.1.1` (new) — closes 1 medium (XSS in `Address6`
+    HTML-emitting methods).
+
+`npm audit --omit=dev` returns 0 vulnerabilities after this release.
+
 ## 4.0.3 — 2026-04-19
 
 Republish to pick up the runtime fixes that landed on main after 4.0.2

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenticorg-mcp-server",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenticorg-mcp-server",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticorg-mcp-server",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "mcpName": "io.github.mishrasanjeev/agenticorg",
   "description": "MCP server for AgenticOrg — expose every AgenticOrg AI agent and native tool to ChatGPT, Claude, and any MCP client",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/mishrasanjeev/agentic-org",
     "source": "github"
   },
-  "version": "4.0.3",
+  "version": "4.0.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "agenticorg-mcp-server",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

Patch-bump `agenticorg-mcp-server` 4.0.3 → 4.0.4 so we can republish to npm + the MCP registry and ship the security fix from #504 to actual users.

Without this republish, `npx agenticorg-mcp-server` and the MCP registry both still serve 4.0.3 — which still bundles the vulnerable hono / fast-uri / ip-address versions. GitHub-side Dependabot alerts are closed; user-shipped versions are not.

## Changes

| File | Change |
|---|---|
| `package.json` | `version` 4.0.3 → 4.0.4 |
| `package-lock.json` | top-level + nested project version 4.0.3 → 4.0.4 |
| `server.json` | top-level `version` and `packages[0].version` 4.0.3 → 4.0.4 |
| `CHANGELOG.md` | new 4.0.4 entry summarising the 8 closed CVEs |

No source code changes. Same runtime as 4.0.3.

## Verification

- `npm install` resolves `hono@4.12.18`, `fast-uri@3.1.2`, `ip-address@10.2.0`
- `npm audit --omit=dev` → **0 vulnerabilities**
- `npm run build` (tsc) → green
- Local preflight: ruff / mypy / bandit / ui tsc / ui build / consistency / coverage / critical-path all pass
- Pytest gate: bypassed via `SKIP_PYTEST=1` (documented in `scripts/preflight.sh`); pytest fails locally on the known Windows + Py 3.13 timeout in `test_self_visible_to_pytest`. CI runs pytest in Linux.

## Manual publish steps after merge (owner-only)

```bash
cd mcp-server
npm publish                    # requires `npm whoami`
./mcp-publisher.exe publish    # requires MCP registry auth
```

Per `feedback_publish_gotchas.md`: the MCP registry can flake with 504s — retry until it accepts and `isLatest: true` shows for 4.0.4.

## Test plan

- [ ] CI green
- [ ] After merge + manual `npm publish`: `npm view agenticorg-mcp-server version` returns `4.0.4`
- [ ] After `mcp-publisher publish`: registry search `?search=agenticorg` shows 4.0.4 with `isLatest: true`
- [ ] Smoke `npx agenticorg-mcp-server@4.0.4 --help` runs without error

cc @codex please review.