### PR TITLE
fix(agent): close Aishwarya May 13 regressions

### DIFF
--- a/api/v1/_tds_routing.py
+++ b/api/v1/_tds_routing.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 
 import math
 import re
-from datetime import date
+from datetime import date, timedelta
 from typing import Any
 
 # ----------------------------------------------------------------------
@@ -323,24 +323,23 @@ def _build_challan_281_response(
     pan: str | None,
     deductee_type: str | None,
 ) -> dict[str, Any]:
-    missing: list[str] = []
+    critical_missing: list[str] = []
     if not section:
-        missing.append("TDS section for the payment, e.g. 194C / 194J")
-    if not pan:
-        missing.append("PAN of the deductee")
-    if not deductee_type:
-        missing.append("deductee type (individual / HUF / company / firm)")
-    missing.extend(
+        critical_missing.append("TDS section / nature-of-payment code, e.g. 194C / 194J")
+    critical_missing.extend(
         [
             "TAN of the deductor",
-            "assessment year and minor head (200 or 400)",
-            "bank / BSR details after the Challan 281 payment is made",
+            "assessment year and minor head confirmation (200 or 400)",
             "explicit partner-review approval before payment submission",
         ]
     )
+    deferred_fields = [
+        "deductee PAN and deductee type for the later TDS return mapping",
+        "bank BSR code, challan serial, and deposit date after payment",
+    ]
 
     parts = [
-        "Challan 281 preparation started from the values already present in the prompt:",
+        "Challan 281 draft prepared from the values already present in the prompt:",
         f"  • TDS amount to pay: INR {amount:,.2f}",
     ]
     if period:
@@ -348,10 +347,13 @@ def _build_challan_281_response(
     if section:
         parts.append(f"  • Section: {section}")
     parts.append(
-        "\nNo amount clarification is needed. The actual Challan 281 payment is blocked "
-        "fail-closed until these genuinely missing fields/approvals are supplied:"
+        "\nNo amount clarification is needed. The draft can proceed; actual Challan 281 "
+        "payment submission is blocked fail-closed until these payment-critical fields "
+        "and approvals are supplied:"
     )
-    parts.extend(f"  ✗ {item}" for item in missing)
+    parts.extend(f"  - {item}" for item in critical_missing)
+    parts.append("\nDeferred for later compliance evidence; not blocking this draft:")
+    parts.extend(f"  - {item}" for item in deferred_fields)
     parts.append("\nNo payment call was made.")
 
     return {
@@ -366,7 +368,8 @@ def _build_challan_281_response(
             "tds_amount": amount,
             "period": period,
             "section": section,
-            "missing_fields": missing,
+            "missing_fields": critical_missing,
+            "deferred_fields": deferred_fields,
         },
     }
 
@@ -381,11 +384,18 @@ def _build_late_filing_response(
     delay_days = _extract_delay_days(query)
     due_date = _tds_return_due_date(period, form_name)
 
-    missing: list[str] = []
+    assumptions: list[str] = []
     if tds_amount is None:
-        missing.append("TDS amount payable for the quarter")
+        tds_amount = 100_000.0
+        assumptions.append(
+            "TDS amount payable was not supplied; used INR 1,00,000 as a working assumption."
+        )
     if delay_days is None:
-        missing.append("actual delay in days or the actual filing/deposit date")
+        delay_days = 30
+        assumed_date = (due_date + timedelta(days=delay_days)).isoformat() if due_date else "30 days after due date"
+        assumptions.append(
+            f"Actual filing/deposit date was not supplied; assumed {delay_days} days late ({assumed_date})."
+        )
 
     parts = [
         f"Section 234E / 201(1A) computation route selected for Form {form_name or '26Q/24Q'}.",
@@ -394,37 +404,31 @@ def _build_late_filing_response(
         parts.append(f"  • Period extracted: {period}")
     if due_date:
         parts.append(f"  • Statutory filing due date: {due_date.isoformat()}")
+    if assumptions:
+        parts.append("  • Assumptions used for this provisional computation:")
+        parts.extend(f"    - {item}" for item in assumptions)
 
-    if tds_amount is not None and delay_days is not None:
-        late_fee = min(tds_amount, 200.0 * delay_days)
-        months_for_interest = max(1, math.ceil(delay_days / 30))
-        late_deposit_interest = round(tds_amount * 0.015 * months_for_interest, 2)
-        parts.extend(
-            [
-                f"  • Section 234E late fee: INR {late_fee:,.2f} "
-                f"(INR 200/day × {delay_days} days, capped at TDS amount)",
-                f"  • Section 201(1A) late-deposit interest estimate: INR {late_deposit_interest:,.2f} "
-                f"(1.5% per month or part month × {months_for_interest} month(s))",
-                "  • Final 201(1A) split still needs deduction date vs deposit date "
-                "if late deduction and late deposit both apply.",
-            ]
-        )
-    else:
-        parts.extend(
-            [
-                "The statutory rules are configured and available:",
-                "  • Section 234E: INR 200 per day, capped at the TDS amount payable.",
-                "  • Section 201(1A): 1% per month or part month for late deduction "
-                "and 1.5% per month or part month for late deposit.",
-                "Exact rupee computation needs only the missing inputs below:",
-            ]
-        )
-        parts.extend(f"  ✗ {item}" for item in missing)
+    late_fee = min(tds_amount, 200.0 * delay_days)
+    months_for_interest = max(1, math.ceil(delay_days / 30))
+    late_deduction_interest = round(tds_amount * 0.01 * months_for_interest, 2)
+    late_deposit_interest = round(tds_amount * 0.015 * months_for_interest, 2)
+    parts.extend(
+        [
+            f"  • Section 234E late fee: INR {late_fee:,.2f} "
+            f"(INR 200/day × {delay_days} days, capped at TDS amount)",
+            f"  • Section 201(1A) late-deduction interest scenario: INR {late_deduction_interest:,.2f} "
+            f"(1% per month or part month × {months_for_interest} month(s))",
+            f"  • Section 201(1A) late-deposit interest scenario: INR {late_deposit_interest:,.2f} "
+            f"(1.5% per month or part month × {months_for_interest} month(s))",
+            "  • Replace assumptions with actual TDS payable, deduction date, deposit date, "
+            "and filing date before filing or payment. No filing/payment call was made.",
+        ]
+    )
 
     return {
         "answer": "\n".join(parts),
         "tool_calls": [],
-        "confidence": 0.80 if missing else 0.90,
+        "confidence": 0.82 if assumptions else 0.90,
         "tools_used": False,
         "hitl_trigger": "tds_late_fee_or_interest_requires_partner_review",
         "hitl_context": {
@@ -434,7 +438,7 @@ def _build_late_filing_response(
             "due_date": due_date.isoformat() if due_date else None,
             "tds_amount": tds_amount,
             "delay_days": delay_days,
-            "missing_fields": missing,
+            "assumptions": assumptions,
         },
     }
 

--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -2858,31 +2858,36 @@ async def rollback_agent(agent_id: UUID, tenant_id: str = Depends(get_current_te
                         .limit(1)
                     )
                 ).scalar_one_or_none()
-                if transition is not None:
-                    old_status = agent.status
-                    agent.status = "shadow"
-                    event = AgentLifecycleEvent(
-                        tenant_id=tid,
-                        agent_id=agent.id,
-                        from_status=old_status,
-                        to_status="shadow",
-                        triggered_by="api",
-                        reason=(
-                            "Rolled back active agent to shadow using lifecycle "
-                            "checkpoint; no prior version snapshot existed"
-                        ),
-                        shadow_accuracy=agent.shadow_accuracy_current,
-                        shadow_samples=agent.shadow_sample_count,
-                    )
-                    session.add(event)
-                    return {
-                        "id": str(agent_id),
-                        "rolled_back": True,
-                        "from_version": agent.version,
-                        "to_version": agent.version,
-                        "from_status": old_status,
-                        "to_status": "shadow",
-                    }
+                old_status = agent.status
+                agent.status = "shadow"
+                checkpoint_note = (
+                    "using lifecycle checkpoint; no prior version snapshot existed"
+                    if transition is not None
+                    else "without a prior checkpoint; restoring shadow state for re-evaluation"
+                )
+                event = AgentLifecycleEvent(
+                    tenant_id=tid,
+                    agent_id=agent.id,
+                    from_status=old_status,
+                    to_status="shadow",
+                    triggered_by="api",
+                    reason=(
+                        "Rolled back active agent to shadow "
+                        f"{checkpoint_note}"
+                    ),
+                    shadow_accuracy=agent.shadow_accuracy_current,
+                    shadow_samples=agent.shadow_sample_count,
+                )
+                session.add(event)
+                return {
+                    "id": str(agent_id),
+                    "rolled_back": True,
+                    "from_version": agent.version,
+                    "to_version": agent.version,
+                    "from_status": old_status,
+                    "to_status": "shadow",
+                    "checkpoint_available": transition is not None,
+                }
             raise HTTPException(409, "No previous version to rollback to")
 
         old_status = agent.status

--- a/auth/grantex_middleware.py
+++ b/auth/grantex_middleware.py
@@ -58,6 +58,7 @@ class GrantexAuthMiddleware(BaseHTTPMiddleware):
         "/api/v1/push/vapid-key",  # VAPID public key (browser needs before login)
         "/api/v1/billing/callback",  # Plural redirect callback (browser returning from gateway)
         "/api/v1/billing/callback/stripe",  # Stripe redirect callback
+        "/api/v1/oauth/callback",  # Native connector OAuth callback (pre-session; state-validated)
         "/api/v1/billing/plans",  # Public pricing — no tenant data
         # Codex 2026-04-23 prod re-verification: /billing/health +
         # /knowledge/health are declared auth-free in their route

--- a/auth/middleware.py
+++ b/auth/middleware.py
@@ -21,6 +21,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         "/api/v1/demo-request",
         "/api/v1/billing/callback",  # Plural redirect callback
         "/api/v1/billing/callback/stripe",  # Stripe redirect callback
+        "/api/v1/oauth/callback",  # Native connector OAuth callback (pre-session; state-validated)
         "/api/v1/billing/plans",  # Public pricing page
         # Codex 2026-04-23 prod re-verification: the billing + knowledge
         # health probes were declared auth-free in their route files but

--- a/core/agents/packs/ca/__init__.py
+++ b/core/agents/packs/ca/__init__.py
@@ -179,10 +179,15 @@ CA_PACK: dict[str, Any] = {
                 "if those are genuinely missing — do NOT re-ask for amount/"
                 "section.\n\n"
                 "For Challan 281 generation, extract any provided TDS payment "
-                "amount and period first. Ask only for missing section, TAN, "
-                "PAN/deductee data, challan evidence, and partner-review "
-                "approval; never ask the user to repeat an amount already "
-                "present in the prompt."
+                "amount and period first and prepare a draft. Do not block the "
+                "draft on deductee PAN/type or post-payment BSR/challan evidence; "
+                "defer those to return mapping/evidence. Before actual payment "
+                "submission, require only payment-critical section/nature code, "
+                "TAN, assessment-year/minor-head confirmation, and partner-review "
+                "approval. For Section 234E / 201(1A) late filing questions, "
+                "compute a provisional result with explicit assumptions when "
+                "TDS amount or delay dates are missing; never stop at route "
+                "selection only."
             ),
         },
         {

--- a/core/agents/packs/ca/config.yaml
+++ b/core/agents/packs/ca/config.yaml
@@ -62,9 +62,14 @@ agents:
         4. For the Form 26Q step, ask only for PAN + deductee_type if
            those are genuinely missing — do NOT re-ask for amount/section.
       For Challan 281 generation, extract any provided TDS payment amount
-      and period first. Ask only for missing section, TAN, PAN/deductee
-      data, challan evidence, and partner-review approval; never ask the
-      user to repeat an amount already present in the prompt.
+      and period first and prepare a draft. Do not block the draft on
+      deductee PAN/type or post-payment BSR/challan evidence; defer those
+      to return mapping/evidence. Before actual payment submission, require
+      only payment-critical section/nature code, TAN, assessment-year/minor-head
+      confirmation, and partner-review approval. For Section 234E / 201(1A)
+      late filing questions, compute a provisional result with explicit
+      assumptions when TDS amount or delay dates are missing; never stop at
+      route selection only.
   - type: bank_reconciliation
     domain: finance
     prompt_file: prompts/bank_reconciliation.prompt.txt

--- a/core/agents/packs/ca/prompts/tds_compliance.prompt.txt
+++ b/core/agents/packs/ca/prompts/tds_compliance.prompt.txt
@@ -31,6 +31,17 @@ Use the procedural sequence below (EXTRACT → VALIDATE_DEDUCTEES → ...) only 
 the user has not yet provided enough information for a direct calculate_tds call.
 For ad-hoc calculation queries with all fields present, the direct path above is
 the right behavior.
+
+For Challan 281 requests, prepare a draft from any amount and period already
+present. Do not block the draft on deductee PAN/type or post-payment BSR/challan
+evidence; defer those to return mapping/evidence. Actual payment submission still
+requires payment-critical section/nature code, TAN, assessment-year/minor-head
+confirmation, and partner-review approval.
+
+For Section 234E / 201(1A) late filing questions, compute a provisional result
+using explicit assumptions when the TDS amount or actual delay dates are missing.
+Show the assumptions, Section 234E fee, 1% late-deduction interest scenario, and
+1.5% late-deposit interest scenario. Never stop at "route selected" only.
 </interactive_extraction>
 
 <processing_sequence>

--- a/tests/regression/test_aishwarya_12may2026_agent_runtime.py
+++ b/tests/regression/test_aishwarya_12may2026_agent_runtime.py
@@ -57,15 +57,21 @@ def test_challan_281_extracts_amount_and_does_not_reask_it() -> None:
     lower = answer.lower()
     assert "125,000" in answer or "125000" in answer
     assert "april 2026" in lower
+    assert "draft prepared" in lower
     assert "section" in lower
     assert "tan" in lower
-    assert "pan" in lower
+    assert "payment-critical" in lower
+    assert "deferred" in lower
+    assert "deductee pan" not in lower.split("payment-critical", 1)[1].split("deferred", 1)[0]
     for forbidden in (
         "amount of tds to be paid",
         "please provide the amount",
         "what is the amount",
+        "PAN of the deductee",
+        "deductee type (individual / HUF / company / firm)",
+        "bank / BSR details after the Challan 281 payment is made",
     ):
-        assert forbidden not in lower
+        assert forbidden.lower() not in lower
 
 
 def test_tds_late_filing_route_uses_234e_and_201_1a_logic() -> None:
@@ -88,8 +94,15 @@ def test_tds_late_filing_route_uses_234e_and_201_1a_logic() -> None:
     assert "201(1a)" in lower
     assert "q4 fy 2025-26" in lower
     assert "2026-05-31" in lower
-    assert "tds amount payable" in lower
-    assert "actual delay" in lower
+    assert "assumptions used" in lower
+    assert "1,00,000" in answer
+    assert "30 days late" in lower
+    assert "6,000.00" in answer
+    assert "1,000.00" in answer
+    assert "1,500.00" in answer
+    assert result["hitl_context"]["tds_amount"] == 100_000.0
+    assert result["hitl_context"]["delay_days"] == 30
+    assert result["hitl_context"]["assumptions"]
     assert "cannot directly compute" not in lower
 
 

--- a/tests/regression/test_aishwarya_13may2026_reopens.py
+++ b/tests/regression/test_aishwarya_13may2026_reopens.py
@@ -1,0 +1,79 @@
+"""Aishwarya 13 May 2026 reopen regressions.
+
+These tests pin the bugs to completed outcomes, not just route selection.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_session_ctx(mock_session: AsyncMock) -> AsyncMock:
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+def test_oauth_connector_callback_is_pre_session_auth_exempt() -> None:
+    from auth.grantex_middleware import GrantexAuthMiddleware
+    from auth.middleware import AuthMiddleware
+
+    assert "/api/v1/oauth/callback" in GrantexAuthMiddleware.EXEMPT_PATHS
+    assert "/api/v1/oauth/callback" in AuthMiddleware.EXEMPT_PATHS
+
+
+@pytest.mark.asyncio
+async def test_active_agent_rollback_returns_to_shadow_without_snapshot() -> None:
+    from api.v1.agents import rollback_agent
+    from tests.unit.test_agents_and_sales import make_mock_agent
+
+    tenant_id = "00000000-0000-0000-0000-000000000001"
+    agent_id = uuid.uuid4()
+    agent = make_mock_agent(
+        id=agent_id,
+        status="active",
+        version="1.0.1",
+        shadow_sample_count=12,
+        shadow_accuracy_current=Decimal("0.910"),
+    )
+
+    agent_result = MagicMock()
+    agent_result.scalar_one_or_none.return_value = agent
+    version_result = MagicMock()
+    version_result.scalar_one_or_none.return_value = None
+    transition_result = MagicMock()
+    transition_result.scalar_one_or_none.return_value = None
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[agent_result, version_result, transition_result])
+    session.add = MagicMock()
+
+    with patch("api.v1.agents.get_tenant_session") as get_tenant_session:
+        get_tenant_session.return_value = _make_session_ctx(session)
+        result = await rollback_agent(agent_id=agent_id, tenant_id=tenant_id)
+
+    assert result["rolled_back"] is True
+    assert result["from_status"] == "active"
+    assert result["to_status"] == "shadow"
+    assert result["checkpoint_available"] is False
+    assert agent.status == "shadow"
+    event = session.add.call_args.args[0]
+    assert event.from_status == "active"
+    assert event.to_status == "shadow"
+
+
+def test_agent_detail_refreshes_shadow_metrics_after_sample_generation() -> None:
+    from pathlib import Path
+
+    src = (Path(__file__).resolve().parents[2] / "ui" / "src" / "pages" / "AgentDetail.tsx").read_text(
+        encoding="utf-8"
+    )
+    assert "<ShadowTab agent={agent} onUpdated={() => fetchAgent(true)} />" in src
+    assert "await onUpdated();" in src
+    assert "Refresh to see updated count and accuracy" not in src
+    assert "Refresh to see updated results" not in src

--- a/ui/e2e/aishwarya-12may2026.spec.ts
+++ b/ui/e2e/aishwarya-12may2026.spec.ts
@@ -17,8 +17,17 @@ const tdsAgent = {
   created_at: "2026-05-12T00:00:00Z",
 };
 
-async function installRoutes(page: Page) {
-  let detailAgent = { ...tdsAgent };
+const shadowTdsAgent = {
+  ...tdsAgent,
+  status: "shadow",
+  shadow_sample_count: 0,
+  shadow_accuracy_current: null,
+  shadow_min_samples: 2,
+  shadow_accuracy_floor: 0.8,
+};
+
+async function installRoutes(page: Page, initialAgent: any = tdsAgent) {
+  let detailAgent: any = { ...initialAgent };
 
   await page.route("**/api/v1/**", async (route) => {
     const request = route.request();
@@ -52,6 +61,30 @@ async function installRoutes(page: Page) {
     }
 
     if (path.endsWith("/agents/agent-tds/run") && request.method() === "POST") {
+      const body = request.postDataJSON() as { action?: string };
+      if (body.action === "shadow_sample") {
+        detailAgent = {
+          ...detailAgent,
+          shadow_sample_count: (detailAgent.shadow_sample_count ?? 0) + 1,
+          shadow_accuracy_current: 0.91,
+        };
+        await route.fulfill({
+          json: {
+            run_id: "run-shadow-sample",
+            task_id: "run-shadow-sample",
+            agent_id: "agent-tds",
+            status: "completed",
+            confidence: 0.91,
+            output: { answer: "Shadow sample completed with calculate_tds." },
+            reasoning_trace: ["shadow sample scored"],
+            tool_calls: [{ tool: "calculate_tds", status: "success" }],
+            performance: { total_latency_ms: 10, llm_tokens_used: 0, llm_cost_usd: 0 },
+            hitl_trigger: null,
+            error: null,
+          },
+        });
+        return;
+      }
       await route.fulfill({
         json: {
           run_id: "run-tool-failure",
@@ -110,7 +143,7 @@ async function installRoutes(page: Page) {
         await route.fulfill({
           json: {
             answer:
-              "Challan 281 preparation started. TDS amount to pay: INR 125,000.00. Missing: section, TAN, PAN, partner-review approval. No payment call was made.",
+              "Challan 281 draft prepared. TDS amount to pay: INR 125,000.00. Period: April 2026. Payment-critical missing fields: section, TAN, assessment year, partner-review approval. Deferred for later compliance evidence: deductee PAN and BSR after payment. No payment call was made.",
             agent: "TDS Compliance Agent",
             confidence: 0.82,
             domain: "finance",
@@ -122,7 +155,7 @@ async function installRoutes(page: Page) {
       await route.fulfill({
         json: {
           answer:
-            "Section 234E / 201(1A) computation route selected for Form 26Q. Period extracted: Q4 FY 2025-26. Statutory filing due date: 2026-05-31. Missing: TDS amount payable and actual delay.",
+            "Section 234E / 201(1A) computation route selected for Form 26Q. Period extracted: Q4 FY 2025-26. Statutory filing due date: 2026-05-31. Assumptions used: TDS amount INR 1,00,000 and 30 days late. Section 234E late fee: INR 6,000.00. Section 201(1A) late-deduction interest scenario: INR 1,000.00. Section 201(1A) late-deposit interest scenario: INR 1,500.00. No filing/payment call was made.",
           agent: "TDS Compliance Agent",
           confidence: 0.8,
           domain: "finance",
@@ -188,11 +221,37 @@ test.describe("Aishwarya 12 May 2026 TDS regressions", () => {
     await input.fill("Generate Challan 281 for April 2026 TDS payment of INR 1,25,000.");
     await input.press("Enter");
     await expect(page.locator("body")).toContainText("TDS amount to pay: INR 125,000.00");
+    await expect(page.locator("body")).toContainText("draft prepared");
+    await expect(page.locator("body")).toContainText("Deferred for later compliance evidence");
+    await expect(page.locator("body")).not.toContainText("Missing: section, TAN, PAN");
     await expect(page.locator("body")).not.toContainText("Amount of TDS to be paid");
 
     await input.fill("Compute late filing interest and penalty for delayed Form 26Q filing for Q4 FY 2025-26.");
     await input.press("Enter");
     await expect(page.locator("body")).toContainText("Section 234E / 201(1A)");
     await expect(page.locator("body")).toContainText("2026-05-31");
+    await expect(page.locator("body")).toContainText("Assumptions used");
+    await expect(page.locator("body")).toContainText("INR 6,000.00");
+    await expect(page.locator("body")).toContainText("INR 1,000.00");
+    await expect(page.locator("body")).toContainText("INR 1,500.00");
+  });
+
+  test("shadow sample generation refreshes persisted sample count and accuracy", async ({
+    page,
+    baseURL,
+  }) => {
+    await installRoutes(page, shadowTdsAgent);
+
+    await page.goto(`${baseURL}/dashboard/agents/agent-tds`, { waitUntil: "domcontentloaded" });
+    await page.getByRole("button", { name: "shadow" }).click();
+    await expect(page.locator("main")).toContainText("Samples generated");
+    await expect(page.locator("main")).toContainText("Sample count (0/2)");
+
+    await page.getByRole("button", { name: "Generate Test Sample" }).click();
+
+    await expect(page.locator("main")).toContainText("Generated 1 shadow sample");
+    await expect(page.locator("main")).toContainText("Sample count (1/2)");
+    await expect(page.locator("main")).toContainText("Accuracy (91.0% / 80.0%)");
+    await expect(page.locator("main")).not.toContainText("Refresh to see updated");
   });
 });

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -45,8 +45,8 @@ export default function AgentDetail() {
     if (id) fetchAgent();
   }, [id]);
 
-  async function fetchAgent() {
-    setLoading(true);
+  async function fetchAgent(silent = false) {
+    if (!silent) setLoading(true);
     try {
       const resp = await api.get(`/agents/${id}`);
       const data = resp.data;
@@ -54,7 +54,7 @@ export default function AgentDetail() {
     } catch {
       setAgent(null);
     } finally {
-      setLoading(false);
+      if (!silent) setLoading(false);
     }
   }
 
@@ -73,7 +73,7 @@ export default function AgentDetail() {
     setActionError(null);
     try {
       await api.post(`/agents/${id}/promote`);
-      fetchAgent();
+      void fetchAgent(true);
     } catch (err: any) {
       setActionError(err.response?.data?.detail || "Promote failed");
     } finally {
@@ -86,13 +86,13 @@ export default function AgentDetail() {
     setActionError(null);
     try {
       await api.post(`/agents/${id}/rollback`);
-      fetchAgent();
+      void fetchAgent(true);
     } catch (err: any) {
       const detail = err.response?.data?.detail || "Rollback failed";
       if (detail.toLowerCase().includes("no previous") || detail.toLowerCase().includes("version")) {
-        setActionError("No previous version available. Switch to Shadow mode first to create a version checkpoint.");
+        setActionError("No previous version checkpoint is available for this agent.");
       } else {
-        setActionError(`${detail} — Switch to Shadow mode first to create a version checkpoint.`);
+        setActionError(detail);
       }
     } finally {
       setActionLoading(null);
@@ -104,7 +104,7 @@ export default function AgentDetail() {
     setActionError(null);
     try {
       await agentsApi.resume(id || "");
-      fetchAgent();
+      void fetchAgent(true);
     } catch (err: any) {
       setActionError(err.response?.data?.detail || "Resume failed");
     } finally {
@@ -152,7 +152,7 @@ export default function AgentDetail() {
       });
       setRunResult(data);
       setActionNotice(`Agent run ${data?.status || "completed"}.`);
-      fetchAgent();
+      void fetchAgent(true);
     } catch (err: any) {
       setActionError(err.response?.data?.detail || "Run failed");
     } finally {
@@ -320,7 +320,7 @@ export default function AgentDetail() {
       {activeTab === "overview" && <OverviewTab agent={agent} onUpdated={fetchAgent} />}
       {activeTab === "config" && <ConfigTab agent={agent} />}
       {activeTab === "prompt" && <PromptTab agent={agent} />}
-      {activeTab === "shadow" && <ShadowTab agent={agent} />}
+      {activeTab === "shadow" && <ShadowTab agent={agent} onUpdated={() => fetchAgent(true)} />}
       {activeTab === "cost" && <CostTab agent={agent} />}
       {activeTab === "scopes" && <ScopesTab agent={agent} />}
       {activeTab === "learning" && <LearningTab agent={agent} />}
@@ -1174,7 +1174,7 @@ function PromptTab({ agent }: { agent: Agent }) {
 }
 
 /* ─── Shadow Tab ─── */
-function ShadowTab({ agent }: { agent: Agent }) {
+function ShadowTab({ agent, onUpdated }: { agent: Agent; onUpdated: () => Promise<void> }) {
   const [generating, setGenerating] = useState(false);
   const [retesting, setRetesting] = useState(false);
   const [genResult, setGenResult] = useState<{ type: "success" | "error"; msg: string } | null>(null);
@@ -1242,7 +1242,7 @@ function ShadowTab({ agent }: { agent: Agent }) {
             type: "success",
             msg:
               `Stopped after ${successes} sample${successes === 1 ? "" : "s"} ` +
-              `(of ${plannedRuns} planned). Refresh to see updated count and accuracy.`,
+              `(of ${plannedRuns} planned). Updated count and accuracy.`,
           });
           return;
         }
@@ -1263,6 +1263,7 @@ function ShadowTab({ agent }: { agent: Agent }) {
           );
           successes += 1;
           consecutiveFailures = 0;
+          await onUpdated();
         } catch (err: any) {
           // Treat axios CanceledError as a clean stop, not a failure.
           if (err?.name === "CanceledError" || err?.code === "ERR_CANCELED") {
@@ -1270,7 +1271,7 @@ function ShadowTab({ agent }: { agent: Agent }) {
               type: "success",
               msg:
                 `Stopped after ${successes} sample${successes === 1 ? "" : "s"} ` +
-                `(of ${plannedRuns} planned). Refresh to see updated count and accuracy.`,
+                `(of ${plannedRuns} planned). Updated count and accuracy.`,
             });
             return;
           }
@@ -1284,7 +1285,7 @@ function ShadowTab({ agent }: { agent: Agent }) {
         type: "success",
         msg:
           `Generated ${successes} shadow sample${successes === 1 ? "" : "s"} (of ${plannedRuns} attempted). ` +
-          "Refresh to see updated count and accuracy.",
+          "Updated count and accuracy.",
       });
     } catch (err: any) {
       setGenResult({ type: "error", msg: err.response?.data?.detail || "Failed to generate sample. The agent may need to be configured first." });
@@ -1300,7 +1301,8 @@ function ShadowTab({ agent }: { agent: Agent }) {
     setGenResult(null);
     try {
       await api.post(`/agents/${agent.id}/retest`);
-      setGenResult({ type: "success", msg: "Shadow retest completed. Refresh to see updated results." });
+      await onUpdated();
+      setGenResult({ type: "success", msg: "Shadow retest completed. Updated results." });
     } catch (err: any) {
       const detail =
         err?.response?.data?.detail ||


### PR DESCRIPTION
## Summary
- Fixes all five items from `AgenticOrgAishwarya13May2026.xlsx` as valid bug/enhancement regressions.
- Completes TDS Section 234E / 201(1A) provisional computation with explicit assumptions instead of stopping at route selection.
- Makes Challan 281 draft generation less brittle by deferring non-payment-critical evidence fields while keeping actual payment submission blocked behind critical fields and partner review.
- Restores active agents to Shadow for safe re-evaluation when rollback lacks an ideal version snapshot.
- Exempts the native OAuth callback in both auth middleware paths so Zoho Books browser redirects reach state validation.
- Refreshes Shadow Mode sample count/accuracy immediately after sample generation and retest.

## Regression Coverage
- `tests/regression/test_aishwarya_12may2026_agent_runtime.py`
- `tests/regression/test_aishwarya_13may2026_reopens.py`
- `ui/e2e/aishwarya-12may2026.spec.ts`

## Local Validation
- `python -m ruff check api/v1/_tds_routing.py api/v1/agents.py auth/grantex_middleware.py auth/middleware.py tests/regression/test_aishwarya_12may2026_agent_runtime.py tests/regression/test_aishwarya_13may2026_reopens.py` - passed
- `python -m pytest tests/regression/test_aishwarya_12may2026_agent_runtime.py tests/regression/test_aishwarya_13may2026_reopens.py -q --no-cov` - passed, 9 tests
- `python -m compileall api/v1/_tds_routing.py api/v1/agents.py auth/grantex_middleware.py auth/middleware.py tests/regression/test_aishwarya_13may2026_reopens.py` - passed
- `npm run typecheck` from `ui` - passed
- `BASE_URL=http://127.0.0.1:4177 npm run test:e2e -- aishwarya-12may2026.spec.ts` from `ui` - passed, 3 Playwright tests

## Notes
- Summary workbook created locally at `C:\Users\mishr\Downloads\AgenticOrgAishwarya13May2026_BugFixSummary.xlsx`.
- No production config, secrets, live payment, or provider credential changes are included.