### PR TITLE
docs(commerce): record agent contract completeness gaps

### DIFF
--- a/docs/commerce-agent-contract-gap-report.md
+++ b/docs/commerce-agent-contract-gap-report.md
@@ -1,0 +1,123 @@
+# Commerce Sales Agent Contract Gap Report
+
+Status: M12 gap analysis and safe regression coverage only. This pass did not deploy, merge, create cloud resources, change production config, enable live payments, enable live Plural, touch production secrets, or commit local-only artifacts.
+
+## Classification Key
+
+- `done`: implemented and covered enough for the internal mock-provider sandbox contract.
+- `partial`: a meaningful slice exists, but the V1 contract is not complete.
+- `blocked`: implementation depends on missing hosted staging, external contract, or safety design.
+- `deferred`: intentionally later than the current V1 Sales Agent slice.
+- `not-started`: no concrete AgenticOrg runtime/eval path exists yet.
+
+## Brutal Summary
+
+| Area | Status | Assessment |
+| --- | --- | --- |
+| Grantex-only commerce connector | `done` | `GrantexCommerceConnector` exposes `grantex_commerce:*` aliases and does not import Stripe, Plural, Pine, or provider credential connectors. |
+| Safe tool aliases | `done` | Aliases map to Grantex MCP tools plus Grantex passport REST endpoints: catalog, inventory, cart, consent, passport exchange, payment intent, checkout, and status. |
+| Consent/passport guardrails | `partial` | Local guardrails refuse missing, denied, revoked, or expired passport inputs; final cryptographic verification remains Grantex-owned and hosted staging is not yet exercised. |
+| Amount cap guardrails | `done` | Local guardrails refuse requested amounts above passport cap before calling Grantex. |
+| Disabled merchant/agent guardrails | `partial` | Local status/error handling exists; real staging disabled merchant and untrusted agent cases are not yet executed. |
+| Stale inventory behavior | `done` | Local guardrails require cautious responses for stale or unknown inventory. |
+| Unsupported EMI/discount/warranty behavior | `done` | Claim grounding refuses unbacked EMI, discount, offer, return, tax, and warranty claims. |
+| No direct Stripe/Plural/Pine/provider credential path | `done` | Regression tests statically block provider imports and default Commerce Sales Agent tools are Grantex-only. |
+| Mocked eval/demo status | `partial` | Local demo and evals cover the safety path, but they use mocked Grantex responses. |
+| Real hosted staging eval gap | `blocked` | M11 documents commands only; non-mocked hosted staging connector/demo/eval mode and hosted services do not exist yet. |
+| Broader PRD Commerce Agent Pack | `deferred` | Only the Sales Agent slice exists; catalog enrichment, offer, support, reconciliation, and store operations agent pack work remains roadmap. |
+
+## Contract Surface Inventory
+
+| Contract item | Status | Current evidence | Gap |
+| --- | --- | --- | --- |
+| Grantex-only connector | `done` | `connectors/commerce/grantex_commerce.py` uses `/mcp` and Grantex passport REST endpoints. | Hosted staging evidence pending. |
+| `merchant_get_profile` alias | `done` | Maps to `merchant.get_profile`. | None for local contract. |
+| `catalog_search` alias | `done` | Maps to `catalog.search`. | Depends on Grantex product data completeness. |
+| `catalog_get_item` alias | `done` | Maps to `catalog.get_item`. | Depends on Grantex product data completeness. |
+| `inventory_check` alias | `done` | Maps to `inventory.check`. | Hosted stale inventory negative case pending. |
+| `cart_create` alias | `done` | Requires idempotency key and maps to `cart.create`. | Hosted staging evidence pending. |
+| `consent_request` alias | `done` | Calls `/v1/commerce/passports/consent-requests`. | Hosted staging consent UX and delivery pending. |
+| `consent_exchange` alias | `done` | Calls `/v1/commerce/passports/exchange`. | Hosted staging approval flow pending. |
+| `payment_create_intent` alias | `done` | Requires idempotency key, local guardrail pass, then maps to `payment.create_intent`. | Hosted staging evidence pending. |
+| `checkout_create` alias | `done` | Requires idempotency key, local guardrail pass, then maps to `checkout.create`. | Hosted staging evidence pending. |
+| `payment_get_status` alias | `done` | Maps to `payment.get_status`. | Hosted staging evidence pending. |
+| Production default base URL | `partial` | Connector default is production-shaped when env is absent. | Staging must set `GRANTEX_COMMERCE_BASE_URL=https://api-staging.grantex.dev`; future hosted mode should fail closed when staging env is absent. |
+| Mocked demo | `partial` | `demos/commerce_sales_agent_demo.py` proves ordered Grantex aliases and no provider credential handling. | It is not hosted evidence and must not be reported as such. |
+| Mocked evals | `partial` | `tests/evals/test_commerce_sales_agent_evals.py` covers 14 local mocked cases. | A real-staging eval mode is still blocked. |
+| Direct provider calls | `done` | `tests/regression/test_commerce_sales_agent_no_provider_calls.py` blocks provider imports/calls in commerce code. | Keep this static guard whenever adding agent pack features. |
+
+## Guardrail Coverage
+
+| Guardrail | Status | Evidence | Remaining gap |
+| --- | --- | --- | --- |
+| Missing consent | `done` | Local guardrail refuses payment/checkout without passport material. | Hosted staging negative case pending. |
+| Denied consent | `done` | Local guardrail refuses denied/rejected/revoked/withdrawn/failed consent statuses. | Hosted staging negative case pending. |
+| Revoked passport | `done` | Local guardrail refuses `passport_status=revoked`. | Hosted staging negative case pending. |
+| Expired passport | `done` | Local guardrail refuses `passport_status=expired`. | Hosted staging negative case pending. |
+| Amount cap breach | `done` | Local guardrail compares requested amount to passport cap. | Hosted staging negative case pending. |
+| Disabled merchant | `partial` | Local explicit status/error refusal exists. | Hosted staging disabled merchant case pending. |
+| Untrusted agent | `partial` | Local explicit status refusal exists. | Hosted staging untrusted agent case pending. |
+| Stale inventory | `done` | `inventory_caution` refuses to guarantee stale or unknown stock. | Hosted staging negative case pending. |
+| Unsupported EMI | `done` | Claim grounding refuses unbacked EMI claims. | Hosted staging negative case pending. |
+| Unsupported discount | `done` | Claim grounding refuses unbacked discount claims. | Hosted staging negative case pending. |
+| Unsupported warranty | `done` | Claim grounding refuses unbacked warranty claims. | Hosted staging negative case pending. |
+
+## No-Provider-Call Boundary
+
+No direct Stripe/Plural/Pine/provider credential commerce path is allowed.
+
+AgenticOrg Commerce Sales Agent must not:
+
+- call Stripe, Plural, Pine, or payment provider connectors for commerce;
+- read provider credentials for commerce;
+- create checkout links outside Grantex;
+- poll provider status directly;
+- retry a refused Grantex payment through another provider path.
+
+The only commerce execution path is Grantex:
+
+- `GRANTEX_COMMERCE_BASE_URL=https://api-staging.grantex.dev` for hosted staging;
+- `GRANTEX_BASE_URL=https://api-staging.grantex.dev` for hosted staging fallback;
+- one staging-only connector auth material source by name: `GRANTEX_COMMERCE_BEARER_TOKEN`, `GRANTEX_AGENT_ASSERTION`, or `GRANTEX_API_KEY`.
+
+Do not record values for those names.
+
+## Real Hosted Staging Gap
+
+The real-staging gap is still blocked because:
+
+- Grantex hosted staging infrastructure does not exist yet.
+- AgenticOrg hosted staging services do not exist yet.
+- `demos/commerce_sales_agent_demo.py --mode=hosted-staging` is only a documented command plan.
+- `python -m pytest tests/evals/test_commerce_sales_agent_evals.py -q --hosted-staging` is only a documented command plan.
+- The current local demo/eval path uses mocked Grantex responses.
+- No redacted hosted staging evidence exists yet.
+
+## Broader PRD Commerce Agent Pack Gap
+
+The PRD calls for AgenticOrg commerce agents beyond the current Sales Agent. Current status:
+
+| Agent pack item | Status | Reason |
+| --- | --- | --- |
+| Commerce Sales Agent | `partial` | Local mock/eval path exists; hosted staging proof is blocked. |
+| Catalog enrichment agent | `deferred` | Requires Grantex catalog list/bulk/CSV completion first. |
+| Offer agent | `deferred` | Requires Grantex offers/discount/EMI data contract. |
+| Support agent | `deferred` | Requires order/support/refund capability contract. |
+| Reconciliation agent | `deferred` | Requires provider reconciliation and audit export contract. |
+| Store operations agent | `deferred` | Requires inventory/location/POS contract. |
+
+## Safe Fixes Made In M12
+
+- Added this gap report.
+- Added regression coverage that pins no-provider-call language, real-staging gap language, staging URL usage, status classifications, and no secret values.
+- Did not implement real hosted staging mode, provider integration, broad agent pack features, or production config changes.
+
+## Exact Future Implementation Prompts
+
+### AgenticOrg Real Hosted Staging Eval Mode
+
+`Task: M12A-Agent only - implement AgenticOrg real hosted staging eval mode for the Commerce Sales Agent after Grantex staging exists. Do not deploy, merge, create cloud resources, change production config, enable live payments, or enable live Plural. Add an explicit hosted-staging mode that refuses production URLs, requires GRANTEX_COMMERCE_BASE_URL=https://api-staging.grantex.dev, uses only grantex_commerce:* tools, redacts auth/passport/idempotency material, and produces a redacted evidence report. Add focused tests for production URL refusal, missing staging env refusal, no direct provider calls, and no mocked results being reported as hosted evidence.`
+
+### Broader Commerce Agent Pack Planning
+
+`Task: Commerce Agent Pack planning only - map the broader AgenticOrg Commerce Agent Pack against Grantex-owned source-of-truth APIs. Do not implement provider calls. Define catalog enrichment, offer, support, reconciliation, and store operations agent requirements, and mark each as blocked until corresponding Grantex catalog/offers/order/reconciliation/POS contracts exist. Add regression tests that keep all commerce payment-affecting work on Grantex tools only.`

--- a/tests/regression/test_commerce_agent_hosted_staging_plan.py
+++ b/tests/regression/test_commerce_agent_hosted_staging_plan.py
@@ -5,6 +5,7 @@ from pathlib import Path
 PLAN = Path("docs/commerce-agent-hosted-staging-plan.md")
 DATA_SETUP = Path("docs/commerce-agent-staging-data-setup.md")
 E2E = Path("docs/commerce-agent-hosted-staging-e2e.md")
+CONTRACT_GAP = Path("docs/commerce-agent-contract-gap-report.md")
 
 
 def test_commerce_agent_hosted_staging_plan_pins_staging_topology() -> None:
@@ -188,3 +189,64 @@ def test_commerce_agent_hosted_staging_e2e_lists_negative_evals_and_no_secrets()
     assert not any(ord(char) > 127 for char in content)
     assert "does not deploy" in content
     assert "create cloud resources" in content
+
+
+def test_commerce_agent_contract_gap_report_classifies_required_items() -> None:
+    content = CONTRACT_GAP.read_text(encoding="utf-8")
+
+    for status in ["`done`", "`partial`", "`blocked`", "`deferred`", "`not-started`"]:
+        assert status in content
+
+    for required in [
+        "Grantex-only commerce connector",
+        "Safe tool aliases",
+        "Consent/passport guardrails",
+        "Amount cap guardrails",
+        "Disabled merchant/agent guardrails",
+        "Stale inventory behavior",
+        "Unsupported EMI/discount/warranty behavior",
+        "No direct Stripe/Plural/Pine/provider credential path",
+        "Mocked eval/demo status",
+        "Real hosted staging eval gap",
+        "Broader PRD Commerce Agent Pack",
+    ]:
+        assert required in content
+
+
+def test_commerce_agent_contract_gap_report_preserves_no_provider_boundary() -> None:
+    content = CONTRACT_GAP.read_text(encoding="utf-8")
+
+    assert "No direct Stripe/Plural/Pine/provider credential commerce path is allowed." in content
+    assert "The only commerce execution path is Grantex" in content
+    assert "GRANTEX_COMMERCE_BASE_URL=https://api-staging.grantex.dev" in content
+    assert "GRANTEX_BASE_URL=https://api-staging.grantex.dev" in content
+    assert "GRANTEX_COMMERCE_BASE_URL=https://api.grantex.dev" not in content
+    assert "GRANTEX_BASE_URL=https://api.grantex.dev" not in content
+    assert "retry a refused Grantex payment through another provider path" in content
+
+
+def test_commerce_agent_contract_gap_report_preserves_real_staging_gap_and_no_secrets() -> None:
+    content = CONTRACT_GAP.read_text(encoding="utf-8")
+
+    for required in [
+        "The real-staging gap is still blocked",
+        "current local demo/eval path uses mocked Grantex responses",
+        "No redacted hosted staging evidence exists yet",
+        "demos/commerce_sales_agent_demo.py --mode=hosted-staging",
+        "python -m pytest tests/evals/test_commerce_sales_agent_evals.py -q --hosted-staging",
+    ]:
+        assert required in content
+
+    forbidden_values = [
+        "sk_live_",
+        "pk_live_",
+        "-----BEGIN",
+        "Bearer ",
+        "passport.jwt",
+        "idempotency-key:",
+        "mock-webhook-secret",
+    ]
+    for forbidden in forbidden_values:
+        assert forbidden not in content
+
+    assert not any(ord(char) > 127 for char in content)


### PR DESCRIPTION
## Scope

M12 AgenticOrg gap analysis and safe regression coverage only, stacked on `codex/commerce-agent-m11-staging-e2e`.

Files changed:
- `docs/commerce-agent-contract-gap-report.md`
- `tests/regression/test_commerce_agent_hosted_staging_plan.py`

## Gap summary

- Grantex-only connector and safe tool aliases are recorded as done.
- Consent/passport and disabled merchant/agent guardrails are recorded as partial because real hosted staging is not yet exercised.
- Amount cap, stale inventory, unsupported EMI/discount/warranty, and no direct provider path are recorded as covered locally.
- Mocked demo/evals are recorded as partial.
- Real hosted staging evals are recorded as blocked.
- Broader PRD Commerce Agent Pack work is recorded as deferred beyond the current Sales Agent slice.

## Safe fixes

- Added the AgenticOrg commerce agent contract gap report.
- Extended focused regression coverage to assert no-provider-call language, real-staging gap language, staging Grantex URLs, required classifications, and no secret values.

## Safety confirmations

- AgenticOrg commerce remains Grantex-only.
- No direct Stripe/Plural/Pine/provider credential commerce path is prescribed.
- No deploy was performed.
- No merge was performed.
- No cloud resources were created.
- No production config was changed.
- Live payments were not enabled.
- Live Plural was not enabled.
- Production secrets were not touched.
- No bearer tokens, passports, idempotency keys, provider credentials, secrets, or local-only reports were committed.

## Validation

- `python -m pytest tests/regression/test_commerce_agent_hosted_staging_plan.py -q` - pass, 13 passed with existing pytest cache warning
- `git diff --check` - pass
- `git diff --cached --check` - pass

## Blockers before implementation

- Real hosted staging AgenticOrg eval mode should wait until Grantex staging exists.
- Hosted mode must refuse production URLs and avoid reporting mocked responses as hosted evidence.
- Broader Commerce Agent Pack work should remain blocked until Grantex source-of-truth APIs exist.