### PR TITLE
feat(commerce): add real staging eval mode

### DIFF
--- a/core/commerce/staging_evidence.py
+++ b/core/commerce/staging_evidence.py
@@ -1,0 +1,152 @@
+"""Redacted evidence helpers for Commerce Sales Agent real-staging runs."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+SENSITIVE_KEY_PARTS = (
+    "authorization",
+    "token",
+    "jwt",
+    "passport",
+    "idempotency",
+    "credential",
+    "secret",
+    "payload",
+)
+
+
+def redact_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, child in value.items():
+            key_text = str(key).lower()
+            if any(part in key_text for part in SENSITIVE_KEY_PARTS):
+                redacted[key] = "[redacted]"
+            else:
+                redacted[key] = redact_value(child)
+        return redacted
+    if isinstance(value, list):
+        return [redact_value(item) for item in value]
+    return value
+
+
+def safe_error_code(result: dict[str, Any]) -> str | None:
+    code = result.get("error") or result.get("code")
+    return str(code) if code else None
+
+
+@dataclass
+class EvidenceCase:
+    name: str
+    status: str
+    tool_alias: str | None = None
+    http_status: int | None = None
+    latency_ms: int | None = None
+    error_code: str | None = None
+    blocker: str | None = None
+
+
+@dataclass
+class StagingEvidence:
+    run_mode: str
+    grantex_host: str
+    auth_source_env_name: str
+    cases: list[EvidenceCase] = field(default_factory=list)
+    tool_sequence: list[str] = field(default_factory=list)
+    no_provider_call_confirmation: bool = True
+
+    def add_case(
+        self,
+        *,
+        name: str,
+        status: str,
+        tool_alias: str | None = None,
+        result: dict[str, Any] | None = None,
+        blocker: str | None = None,
+    ) -> None:
+        self.cases.append(
+            EvidenceCase(
+                name=name,
+                status=status,
+                tool_alias=tool_alias,
+                error_code=safe_error_code(result or {}),
+                blocker=blocker,
+            )
+        )
+        if tool_alias:
+            self.tool_sequence.append(tool_alias)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "run_mode": self.run_mode,
+            "grantex_host": self.grantex_host,
+            "auth_source_env_name": self.auth_source_env_name,
+            "cases": [case.__dict__ for case in self.cases],
+            "tool_sequence": self.tool_sequence,
+            "no_provider_call_confirmation": self.no_provider_call_confirmation,
+            "redaction": {
+                "auth_values_recorded": False,
+                "passport_values_recorded": False,
+                "idempotency_values_recorded": False,
+                "provider_material_recorded": False,
+                "raw_payloads_recorded": False,
+            },
+        }
+
+    def write_markdown(self, path: str | Path) -> None:
+        report_path = Path(path)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        data = redact_value(self.as_dict())
+        rows = [
+            "| Case | Status | Tool | HTTP | Latency ms | Error | Blocker |",
+            "| --- | --- | --- | --- | --- | --- | --- |",
+        ]
+        for case in self.cases:
+            rows.append(
+                "| "
+                + " | ".join(
+                    [
+                        case.name,
+                        case.status,
+                        case.tool_alias or "",
+                        "" if case.http_status is None else str(case.http_status),
+                        "" if case.latency_ms is None else str(case.latency_ms),
+                        case.error_code or "",
+                        case.blocker or "",
+                    ]
+                )
+                + " |"
+            )
+
+        report_path.write_text(
+            "\n".join(
+                [
+                    "# Commerce Sales Agent Real-Staging Evidence",
+                    "",
+                    f"- Run mode: `{self.run_mode}`",
+                    f"- Grantex host: `{self.grantex_host}`",
+                    f"- Auth source env name: `{self.auth_source_env_name}`",
+                    "- Secret values recorded: false",
+                    "- Raw passports/JWTs recorded: false",
+                    "- Request correlation values recorded: false",
+                    "- Provider material recorded: false",
+                    "- Raw request/response bodies recorded: false",
+                    "",
+                    "## Case Results",
+                    "",
+                    *rows,
+                    "",
+                    "## Redacted Summary",
+                    "",
+                    "```json",
+                    json.dumps(data, indent=2, sort_keys=True),
+                    "```",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )

--- a/core/commerce/staging_runtime.py
+++ b/core/commerce/staging_runtime.py
@@ -1,0 +1,129 @@
+"""Real-staging runtime guards for Grantex Commerce evals."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+APPROVED_STAGING_ORIGIN = "https://api-staging.grantex.dev"
+REFUSED_PRODUCTION_ORIGINS = frozenset(
+    {
+        "https://api.grantex.dev",
+        "https://grantex.dev",
+        "https://app.agenticorg.ai",
+    }
+)
+AUTH_ENV_NAMES = (
+    "GRANTEX_COMMERCE_BEARER_TOKEN",
+    "GRANTEX_AGENT_ASSERTION",
+    "GRANTEX_API_KEY",
+)
+
+
+class RealStagingConfigError(ValueError):
+    """Raised before auth lookup, connector creation, or network use."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class RealStagingConfig:
+    grantex_base_url: str
+    auth_env_name: str
+    evidence_report: str | None = None
+
+    @property
+    def grantex_host(self) -> str:
+        return urlparse(self.grantex_base_url).hostname or ""
+
+
+def normalize_origin(raw_url: str) -> str:
+    parsed = urlparse(raw_url.strip())
+    if not parsed.scheme or not parsed.netloc:
+        raise RealStagingConfigError("invalid_staging_url", "A complete Grantex staging URL is required.")
+    if parsed.username or parsed.password:
+        raise RealStagingConfigError("credentialed_url_refused", "Credentialed URLs are not allowed.")
+    if parsed.scheme != "https":
+        raise RealStagingConfigError("non_https_url_refused", "Real-staging mode requires HTTPS.")
+    if parsed.path not in ("", "/") or parsed.params or parsed.query or parsed.fragment:
+        raise RealStagingConfigError("non_origin_url_refused", "Use only the Grantex staging URL origin.")
+    hostname = parsed.hostname or ""
+    return f"{parsed.scheme}://{hostname}{f':{parsed.port}' if parsed.port else ''}"
+
+
+def _resolve_auth_env_name(environ: dict[str, str]) -> str:
+    present = [name for name in AUTH_ENV_NAMES if str(environ.get(name, "") or "").strip()]
+    if not present:
+        raise RealStagingConfigError(
+            "staging_auth_required",
+            "Set exactly one Grantex staging auth env var by name before real-staging runs.",
+        )
+    if len(present) > 1:
+        raise RealStagingConfigError(
+            "ambiguous_staging_auth",
+            "Set exactly one Grantex staging auth env var for real-staging runs.",
+        )
+    return present[0]
+
+
+def _resolve_base_url(cli_base_url: str | None, environ: dict[str, str]) -> str:
+    value = (
+        cli_base_url
+        or environ.get("GRANTEX_COMMERCE_BASE_URL")
+        or environ.get("GRANTEX_BASE_URL")
+        or ""
+    ).strip()
+    if not value:
+        raise RealStagingConfigError(
+            "staging_url_required",
+            "Set GRANTEX_COMMERCE_BASE_URL or pass --grantex-base for real-staging mode.",
+        )
+    return value
+
+
+def validate_real_staging_config(
+    *,
+    grantex_base_url: str | None = None,
+    allow_smoke_cloud_run_url: str | None = None,
+    evidence_report: str | None = None,
+    environ: dict[str, str] | None = None,
+) -> RealStagingConfig:
+    env = environ if environ is not None else os.environ
+
+    origin = normalize_origin(_resolve_base_url(grantex_base_url, env))
+    if origin in REFUSED_PRODUCTION_ORIGINS:
+        raise RealStagingConfigError("production_url_refused", "Production URLs are refused in real-staging mode.")
+
+    allowed_smoke_origin = None
+    smoke_value = allow_smoke_cloud_run_url or env.get("AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL") or ""
+    if smoke_value.strip():
+        allowed_smoke_origin = normalize_origin(smoke_value)
+
+    host = urlparse(origin).hostname or ""
+    if host.endswith(".run.app"):
+        if origin != allowed_smoke_origin:
+            raise RealStagingConfigError(
+                "smoke_url_not_allowlisted",
+                "Cloud Run smoke URLs must be exactly allowlisted before real-staging runs.",
+            )
+    elif origin != APPROVED_STAGING_ORIGIN:
+        raise RealStagingConfigError(
+            "staging_url_not_approved",
+            "Real-staging mode only accepts the approved Grantex staging URL or an exact smoke URL.",
+        )
+
+    if str(env.get("AGENTICORG_TEST_FAKE_CONNECTORS", "") or "").strip() == "1":
+        raise RealStagingConfigError(
+            "fake_connectors_refused",
+            "Real-staging mode cannot run while fake connector transport is enabled.",
+        )
+
+    return RealStagingConfig(
+        grantex_base_url=origin,
+        auth_env_name=_resolve_auth_env_name(env),
+        evidence_report=evidence_report,
+    )

--- a/demos/commerce_sales_agent_demo.py
+++ b/demos/commerce_sales_agent_demo.py
@@ -1,10 +1,12 @@
-"""Local mocked Commerce Sales Agent demo for Grantex Commerce V1 internal sandbox."""
+"""Commerce Sales Agent demo for mocked and approved real-staging Grantex runs."""
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import json
 import sys
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -20,11 +22,15 @@ from connectors.commerce.grantex_commerce import (  # noqa: E402
     GrantexCommerceConnector,
 )
 from core.commerce.sales_guardrails import inventory_caution, validate_claims_against_tool_data  # noqa: E402
+from core.commerce.staging_evidence import StagingEvidence  # noqa: E402
+from core.commerce.staging_runtime import RealStagingConfigError, validate_real_staging_config  # noqa: E402
 
 DATASET = REPO_ROOT / "evals" / "golden_datasets" / "commerce.json"
 GRANTEX_TO_ALIAS = {value: key for key, value in TOOL_ALIAS_TO_GRANTEX.items()}
 REST_PATH_TO_ALIAS = {value: key for key, value in REST_CONSENT_ENDPOINTS.items()}
 PROVIDER_MARKERS = ("stripe", "plural", "pine", "provider_credentials", "credential_payload")
+STAGING_MERCHANT_ID = "mch_staging_electronics_pilot"
+STAGING_AGENT_ID = "cag_staging_agenticorg_sales"
 
 DEMO_MCP_RESPONSES: dict[str, dict[str, Any]] = {
     "merchant_get_profile": {
@@ -113,11 +119,8 @@ def make_mock_grantex_connector(
 
         return httpx.Response(404, json={"error": {"code": "not_found", "message": "Unknown mocked path"}})
 
-    connector = GrantexCommerceConnector(
-        {"base_url": "https://grantex.mock", "bearer_token": "demo_agent_assertion"}
-    )
+    connector = GrantexCommerceConnector({"base_url": "https://grantex.mock"})
     connector._auth_headers = {
-        "Authorization": "Bearer demo_agent_assertion",
         "Accept": "application/json",
     }
     connector._client = httpx.AsyncClient(
@@ -151,6 +154,56 @@ def _no_provider_calls(tool_sequence: list[str]) -> bool:
     )
 
 
+def _data(payload: dict[str, Any]) -> dict[str, Any]:
+    value = payload.get("data", payload)
+    return value if isinstance(value, dict) else {}
+
+
+def _items(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = _data(payload)
+    raw_items = data.get("items") or data.get("products") or []
+    return [item for item in raw_items if isinstance(item, dict)]
+
+
+def _first_id(record: dict[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def _first_variant_id(item: dict[str, Any]) -> str | None:
+    raw_variants = item.get("variants") or item.get("items") or []
+    if not isinstance(raw_variants, list):
+        return None
+    for variant in raw_variants:
+        if isinstance(variant, dict):
+            variant_id = _first_id(variant, "variant_id", "id")
+            if variant_id:
+                return variant_id
+    return _first_id(item, "variant_id")
+
+
+def _amount_minor_units(item: dict[str, Any]) -> int:
+    for container in (item, item.get("price") if isinstance(item.get("price"), dict) else {}):
+        value = container.get("amount_minor_units") if isinstance(container, dict) else None
+        if isinstance(value, int) and value >= 0:
+            return value
+    raw_variants = item.get("variants") or []
+    if isinstance(raw_variants, list):
+        for variant in raw_variants:
+            if isinstance(variant, dict):
+                value = variant.get("price_amount") or variant.get("amount_minor_units")
+                if isinstance(value, int) and value >= 0:
+                    return value
+    return 0
+
+
+def _case_status(result: dict[str, Any]) -> str:
+    return "fail" if result.get("error") else "pass"
+
+
 async def _run_inventory_negative(case_id: str, name: str) -> dict[str, Any]:
     tool_sequence: list[str] = []
     connector = make_mock_grantex_connector(tool_sequence, (case_id,))
@@ -167,6 +220,231 @@ async def _run_inventory_negative(case_id: str, name: str) -> dict[str, Any]:
             "behavior": "cautious" if caution["caution_required"] else "allowed",
             "message": caution["message"],
             "tool_sequence": tool_sequence,
+        }
+    finally:
+        await connector.disconnect()
+
+
+async def run_real_staging_demo(
+    *,
+    grantex_base_url: str | None = None,
+    allow_smoke_cloud_run_url: str | None = None,
+    evidence_report: str | None = None,
+) -> dict[str, Any]:
+    config = validate_real_staging_config(
+        grantex_base_url=grantex_base_url,
+        allow_smoke_cloud_run_url=allow_smoke_cloud_run_url,
+        evidence_report=evidence_report,
+    )
+    tool_sequence: list[str] = []
+    steps: list[dict[str, Any]] = []
+    negative_scenarios: list[dict[str, Any]] = []
+    evidence = StagingEvidence(
+        run_mode="real-staging",
+        grantex_host=config.grantex_host,
+        auth_source_env_name=config.auth_env_name,
+    )
+
+    connector = GrantexCommerceConnector({"base_url": config.grantex_base_url})
+    await connector.connect()
+    try:
+        health = await connector.health_check()
+        evidence.add_case(name="connector_health_tools_list", status=_case_status(health), result=health)
+
+        profile = await connector.merchant_get_profile(merchant_id=STAGING_MERCHANT_ID)
+        alias = "grantex_commerce:merchant_get_profile"
+        tool_sequence.append(alias)
+        evidence.add_case(name="merchant_get_profile", status=_case_status(profile), tool_alias=alias, result=profile)
+        profile_data = _data(profile)
+        steps.append(
+            _step(
+                "Merchant profile",
+                "Load the approved staging merchant profile.",
+                alias,
+                {
+                    "merchant_id": profile_data.get("merchant_id") or STAGING_MERCHANT_ID,
+                    "commerce_status": profile_data.get("commerce_status") or profile_data.get("status"),
+                },
+                "Loaded the Grantex staging merchant profile.",
+            )
+        )
+
+        search = await connector.catalog_search(merchant_id=STAGING_MERCHANT_ID, query="electronics appliances")
+        alias = "grantex_commerce:catalog_search"
+        tool_sequence.append(alias)
+        evidence.add_case(name="catalog_search", status=_case_status(search), tool_alias=alias, result=search)
+        search_items = _items(search)
+        first_search_item = search_items[0] if search_items else {}
+        product_id = _first_id(first_search_item, "product_id", "id")
+        steps.append(
+            _step(
+                "Catalog search",
+                "Search the approved staging catalog.",
+                alias,
+                {"items_returned": len(search_items), "product_id": product_id},
+                "Catalog search ran through Grantex staging.",
+            )
+        )
+
+        item_data: dict[str, Any] = {}
+        variant_id: str | None = None
+        if product_id:
+            item = await connector.catalog_get_item(merchant_id=STAGING_MERCHANT_ID, product_id=product_id)
+            alias = "grantex_commerce:catalog_get_item"
+            tool_sequence.append(alias)
+            evidence.add_case(name="catalog_get_item", status=_case_status(item), tool_alias=alias, result=item)
+            item_data = _data(item)
+            variant_id = _first_variant_id(item_data)
+            steps.append(
+                _step(
+                    "Catalog item",
+                    "Get the first staging catalog item.",
+                    alias,
+                    {"product_id": product_id, "variant_id": variant_id},
+                    "Catalog item details came from Grantex staging.",
+                )
+            )
+        else:
+            evidence.add_case(name="catalog_get_item", status="skipped", blocker="catalog search returned no product")
+
+        if variant_id:
+            inventory = await connector.inventory_check(merchant_id=STAGING_MERCHANT_ID, variant_ids=[variant_id])
+            alias = "grantex_commerce:inventory_check"
+            tool_sequence.append(alias)
+            evidence.add_case(
+                name="inventory_check",
+                status=_case_status(inventory),
+                tool_alias=alias,
+                result=inventory,
+            )
+            caution = inventory_caution(inventory.get("data", inventory))
+            steps.append(
+                _step(
+                    "Inventory check",
+                    "Check staging inventory for the first variant.",
+                    alias,
+                    {"variant_id": variant_id, "caution_required": caution["caution_required"]},
+                    "Inventory was checked through Grantex staging.",
+                )
+            )
+
+            cart = await connector.cart_create(
+                merchant_id=STAGING_MERCHANT_ID,
+                currency="INR",
+                line_items=[
+                    {
+                        "variant_id": variant_id,
+                        "quantity": 1,
+                        "unit_amount_minor_units": _amount_minor_units(item_data),
+                    }
+                ],
+                idempotency_key=f"agenticorg-real-staging-cart-{uuid.uuid4().hex}",
+            )
+            alias = "grantex_commerce:cart_create"
+            tool_sequence.append(alias)
+            evidence.add_case(name="cart_create", status=_case_status(cart), tool_alias=alias, result=cart)
+            steps.append(
+                _step(
+                    "Cart draft",
+                    "Create a staging cart draft.",
+                    alias,
+                    {"cart_id": _data(cart).get("cart_id"), "status": _data(cart).get("status")},
+                    "Cart creation ran through Grantex staging.",
+                )
+            )
+        else:
+            evidence.add_case(name="inventory_check", status="skipped", blocker="no variant ID available")
+            evidence.add_case(name="cart_create", status="skipped", blocker="no variant ID available")
+
+        consent = await connector.consent_request(
+            merchant_id=STAGING_MERCHANT_ID,
+            passport_type="checkout",
+            requested_scopes=["checkout:create", "payment:create"],
+            max_amount=250000,
+            currency="INR",
+        )
+        alias = "grantex_commerce:consent_request"
+        tool_sequence.append(alias)
+        evidence.add_case(name="consent_request", status=_case_status(consent), tool_alias=alias, result=consent)
+        steps.append(
+            _step(
+                "Consent request",
+                "Create a staging checkout consent request.",
+                alias,
+                {
+                    "consent_request_id": _data(consent).get("consent_request_id"),
+                    "passport_type": _data(consent).get("passport_type"),
+                },
+                "Consent request was created without exposing auth or passport material.",
+            )
+        )
+
+        missing_consent = await connector.payment_create_intent(
+            merchant_id=STAGING_MERCHANT_ID,
+            cart_id="staging-cart-without-passport",
+            amount_minor_units=199900,
+            currency="INR",
+            idempotency_key=f"agenticorg-real-staging-missing-consent-{uuid.uuid4().hex}",
+            provider_key="mock",
+        )
+        negative_scenarios.append(
+            {
+                "name": "missing_consent_checkout",
+                "behavior": "refused" if missing_consent.get("error") == "consent_required" else "unexpected",
+                "error": missing_consent.get("error"),
+                "message": missing_consent.get("message", ""),
+                "tool_sequence": [],
+            }
+        )
+        unsupported_emi = validate_claims_against_tool_data(
+            "This product includes no-cost EMI and a discount offer.",
+            {"price": {"amount_minor_units": 349900, "currency": "INR"}},
+        )
+        negative_scenarios.append(
+            {
+                "name": "unsupported_emi_discount",
+                "behavior": "refused" if not unsupported_emi.get("allowed") else "unexpected",
+                "error": unsupported_emi.get("error"),
+                "message": unsupported_emi.get("message", ""),
+                "tool_sequence": [],
+            }
+        )
+
+        for skipped in (
+            "consent_exchange",
+            "payment_create_intent",
+            "checkout_create",
+            "payment_get_status",
+            "denied_revoked_expired_passport",
+            "disabled_merchant_untrusted_agent",
+            "hosted_agenticorg_discovery",
+        ):
+            evidence.add_case(
+                name=skipped,
+                status="skipped",
+                blocker="requires approved synthetic staging fixture or hosted AgenticOrg service",
+            )
+
+        evidence.no_provider_call_confirmation = _no_provider_calls(tool_sequence)
+        if evidence_report:
+            evidence.write_markdown(evidence_report)
+
+        return {
+            "title": "AgenticOrg Commerce Sales Agent Real-Staging Demo",
+            "scope": "real_staging_only",
+            "grantex_dependency": config.grantex_host,
+            "steps": steps,
+            "negative_scenarios": negative_scenarios,
+            "audit_summary": {
+                "tool_sequence": tool_sequence,
+                "no_direct_provider_calls": _no_provider_calls(tool_sequence),
+                "no_provider_credential_handling": True,
+                "internal_sandbox_only": False,
+                "real_staging_only": True,
+                "final_payment_confirmation_user_controlled": True,
+                "auth_source_env_name": config.auth_env_name,
+                "evidence_report": evidence_report,
+            },
         }
     finally:
         await connector.disconnect()
@@ -432,9 +710,33 @@ def format_demo_output(result: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-async def _amain() -> None:
-    print(format_demo_output(await run_demo()))
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the Commerce Sales Agent demo.")
+    parser.add_argument("--mode", choices=("mock", "real-staging"), default="mock")
+    parser.add_argument("--grantex-base", default=None)
+    parser.add_argument("--allow-smoke-cloud-run-url", default=None)
+    parser.add_argument("--evidence-report", default=None)
+    return parser
+
+
+async def _amain() -> int:
+    args = _parser().parse_args()
+    try:
+        if args.mode == "real-staging":
+            result = await run_real_staging_demo(
+                grantex_base_url=args.grantex_base,
+                allow_smoke_cloud_run_url=args.allow_smoke_cloud_run_url,
+                evidence_report=args.evidence_report,
+            )
+        else:
+            result = await run_demo()
+    except RealStagingConfigError as exc:
+        print(f"{exc.code}: {exc.message}", file=sys.stderr)
+        return 2
+
+    print(format_demo_output(result))
+    return 0
 
 
 if __name__ == "__main__":
-    asyncio.run(_amain())
+    raise SystemExit(asyncio.run(_amain()))

--- a/docs/commerce-agent-contract-gap-report.md
+++ b/docs/commerce-agent-contract-gap-report.md
@@ -23,7 +23,7 @@ Status: M12 gap analysis and safe regression coverage only. This pass did not de
 | Unsupported EMI/discount/warranty behavior | `done` | Claim grounding refuses unbacked EMI, discount, offer, return, tax, and warranty claims. |
 | No direct Stripe/Plural/Pine/provider credential path | `done` | Regression tests statically block provider imports and default Commerce Sales Agent tools are Grantex-only. |
 | Mocked eval/demo status | `partial` | Local demo and evals cover the safety path, but they use mocked Grantex responses. |
-| Real hosted staging eval gap | `blocked` | M11 documents commands only; non-mocked hosted staging connector/demo/eval mode and hosted services do not exist yet. |
+| Real hosted staging eval gap | `partial` | C1 adds explicit local AgenticOrg real-staging mode against approved Grantex staging or exact smoke URLs; hosted AgenticOrg services and full negative fixture coverage remain pending. |
 | Broader PRD Commerce Agent Pack | `deferred` | Only the Sales Agent slice exists; catalog enrichment, offer, support, reconciliation, and store operations agent pack work remains roadmap. |
 
 ## Contract Surface Inventory
@@ -41,9 +41,10 @@ Status: M12 gap analysis and safe regression coverage only. This pass did not de
 | `payment_create_intent` alias | `done` | Requires idempotency key, local guardrail pass, then maps to `payment.create_intent`. | Hosted staging evidence pending. |
 | `checkout_create` alias | `done` | Requires idempotency key, local guardrail pass, then maps to `checkout.create`. | Hosted staging evidence pending. |
 | `payment_get_status` alias | `done` | Maps to `payment.get_status`. | Hosted staging evidence pending. |
-| Production default base URL | `partial` | Connector default is production-shaped when env is absent. | Staging must set `GRANTEX_COMMERCE_BASE_URL=https://api-staging.grantex.dev`; future hosted mode should fail closed when staging env is absent. |
-| Mocked demo | `partial` | `demos/commerce_sales_agent_demo.py` proves ordered Grantex aliases and no provider credential handling. | It is not hosted evidence and must not be reported as such. |
-| Mocked evals | `partial` | `tests/evals/test_commerce_sales_agent_evals.py` covers 14 local mocked cases. | A real-staging eval mode is still blocked. |
+| Production default base URL | `partial` | Connector default is production-shaped when env is absent for existing runtime compatibility. | C1 real-staging entry points fail closed unless an approved Grantex staging or exact smoke URL is supplied. |
+| Mocked demo | `partial` | `demos/commerce_sales_agent_demo.py --mode=mock` proves ordered Grantex aliases and no provider credential handling. | It is not hosted evidence and must not be reported as such. |
+| Mocked evals | `partial` | `tests/evals/test_commerce_sales_agent_evals.py` covers 14 local mocked cases. | Real-staging eval coverage is separate and gated behind explicit approval env. |
+| Real-staging demo/eval mode | `partial` | `demos/commerce_sales_agent_demo.py --mode=real-staging` and `tests/evals/test_commerce_sales_agent_real_staging.py` run only against approved Grantex staging or exact smoke URLs. | Passport exchange, checkout, disabled merchant, and untrusted agent cases need approved synthetic staging fixtures. |
 | Direct provider calls | `done` | `tests/regression/test_commerce_sales_agent_no_provider_calls.py` blocks provider imports/calls in commerce code. | Keep this static guard whenever adding agent pack features. |
 
 ## Guardrail Coverage
@@ -84,14 +85,14 @@ Do not record values for those names.
 
 ## Real Hosted Staging Gap
 
-The real-staging gap is still blocked because:
+The real-staging gap is now partial because:
 
-- Grantex hosted staging infrastructure does not exist yet.
-- AgenticOrg hosted staging services do not exist yet.
-- `demos/commerce_sales_agent_demo.py --mode=hosted-staging` is only a documented command plan.
-- `python -m pytest tests/evals/test_commerce_sales_agent_evals.py -q --hosted-staging` is only a documented command plan.
-- The current local demo/eval path uses mocked Grantex responses.
-- No redacted hosted staging evidence exists yet.
+- C1 real-staging mode refuses production URLs, arbitrary `run.app` URLs, credentialed URLs, and non-HTTPS URLs before connector creation, auth lookup, or network use.
+- `demos/commerce_sales_agent_demo.py --mode=real-staging` can run local AgenticOrg against an approved Grantex staging or exact smoke URL.
+- `python -m pytest tests/evals/test_commerce_sales_agent_real_staging.py -q` is gated behind explicit approval env and remains skipped by default.
+- Full hosted AgenticOrg services do not exist yet.
+- Passport exchange, checkout, disabled merchant, and untrusted agent real-staging cases still require approved synthetic fixtures.
+- No redacted hosted AgenticOrg evidence exists yet.
 
 ## Broader PRD Commerce Agent Pack Gap
 
@@ -110,13 +111,13 @@ The PRD calls for AgenticOrg commerce agents beyond the current Sales Agent. Cur
 
 - Added this gap report.
 - Added regression coverage that pins no-provider-call language, real-staging gap language, staging URL usage, status classifications, and no secret values.
-- Did not implement real hosted staging mode, provider integration, broad agent pack features, or production config changes.
+- Implemented explicit local AgenticOrg real-staging mode and kept provider integration, broad agent pack features, hosted AgenticOrg services, and production config unchanged.
 
 ## Exact Future Implementation Prompts
 
 ### AgenticOrg Real Hosted Staging Eval Mode
 
-`Task: M12A-Agent only - implement AgenticOrg real hosted staging eval mode for the Commerce Sales Agent after Grantex staging exists. Do not deploy, merge, create cloud resources, change production config, enable live payments, or enable live Plural. Add an explicit hosted-staging mode that refuses production URLs, requires GRANTEX_COMMERCE_BASE_URL=https://api-staging.grantex.dev, uses only grantex_commerce:* tools, redacts auth/passport/idempotency material, and produces a redacted evidence report. Add focused tests for production URL refusal, missing staging env refusal, no direct provider calls, and no mocked results being reported as hosted evidence.`
+`Task: C1-run only - run AgenticOrg Commerce Sales Agent real-staging demo/eval against an approved Grantex staging or exact smoke URL. Do not deploy, merge, create cloud resources, change production config, enable live payments, or enable live Plural. Set GRANTEX_COMMERCE_BASE_URL and GRANTEX_BASE_URL to the approved URL, set exactly one Grantex auth env var securely outside logs, set AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL only for an exact run.app smoke origin, run demos/commerce_sales_agent_demo.py --mode=real-staging with a redacted evidence report path, and run python -m pytest tests/evals/test_commerce_sales_agent_real_staging.py -q. Do not print bearer tokens, passports, idempotency keys, provider material, or raw payloads.`
 
 ### Broader Commerce Agent Pack Planning
 

--- a/docs/commerce-agent-hosted-staging-e2e.md
+++ b/docs/commerce-agent-hosted-staging-e2e.md
@@ -52,17 +52,30 @@ Plural sandbox may remain available only for unrelated non-commerce app areas if
 
 ## Real Staging Demo And Eval Command Plan
 
-These commands are for later hosted staging execution after non-mocked staging connector support is explicitly implemented and reviewed:
+The C1 real-staging mode runs local AgenticOrg demo/evals against an approved Grantex staging or smoke URL. Mock mode remains the default and must not be reported as hosted evidence.
 
 ```powershell
 $env:AGENTICORG_BASE_URL='https://staging.agenticorg.ai'
+$env:AGENTICORG_COMMERCE_EVAL_MODE='real-staging'
 $env:GRANTEX_COMMERCE_BASE_URL='https://api-staging.grantex.dev'
 $env:GRANTEX_BASE_URL='https://api-staging.grantex.dev'
-python demos/commerce_sales_agent_demo.py --mode=hosted-staging
-python -m pytest tests/evals/test_commerce_sales_agent_evals.py -q --hosted-staging
+# Set exactly one Grantex auth env var securely outside logs.
+python demos/commerce_sales_agent_demo.py --mode=real-staging --evidence-report docs/reports/commerce-agent-real-staging-evidence.md
+python -m pytest tests/evals/test_commerce_sales_agent_real_staging.py -q
 ```
 
-The current local demo/eval path is mocked. Do not present mocked results as hosted staging evidence.
+For a temporary approved Grantex Cloud Run smoke URL, add an exact allowlist. Arbitrary `run.app` URLs are refused:
+
+```powershell
+$env:GRANTEX_COMMERCE_BASE_URL='<approved-smoke-run-app-origin>'
+$env:GRANTEX_BASE_URL='<approved-smoke-run-app-origin>'
+$env:AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL='<same-approved-smoke-run-app-origin>'
+python demos/commerce_sales_agent_demo.py --mode=real-staging --grantex-base '<approved-smoke-run-app-origin>' --allow-smoke-cloud-run-url '<same-approved-smoke-run-app-origin>'
+```
+
+The local mock demo remains available with `python demos/commerce_sales_agent_demo.py --mode=mock`. Do not present mocked results as hosted staging evidence.
+
+Real-staging mode fails closed before connector creation, auth lookup, or network use when pointed at production URLs, credentialed URLs, arbitrary `run.app` URLs, or non-HTTPS URLs such as local development origins.
 
 ## Positive Hosted Checks
 
@@ -99,21 +112,25 @@ The later hosted staging evidence should include only redacted metadata:
 
 ```json
 {
-  "report_type": "agenticorg-commerce-hosted-staging-e2e",
-  "agenticorg_base": "https://staging.agenticorg.ai",
-  "grantex_commerce_base": "https://api-staging.grantex.dev",
+  "report_type": "agenticorg-commerce-real-staging-e2e",
+  "run_mode": "real-staging",
+  "grantex_host": "api-staging.grantex.dev",
+  "auth_source_env_name": "GRANTEX_AGENT_ASSERTION",
   "merchant_id": "mch_staging_electronics_pilot",
   "agent_id": "cag_staging_agenticorg_sales",
   "provider": "mock",
-  "mcp_discovery": "pass|fail|blocked",
-  "a2a_discovery": "pass|fail|blocked",
-  "positive_evals": [],
-  "negative_evals": [],
+  "case_table": [
+    {"case": "catalog_search", "status": "pass|fail|skipped", "http_status": 200, "latency_ms": 0, "error_code": null}
+  ],
+  "tool_sequence": ["grantex_commerce:catalog_search"],
+  "no_provider_call_confirmation": true,
   "redaction": {
     "secret_values_recorded": false,
     "bearer_tokens_recorded": false,
     "passports_recorded": false,
-    "provider_credentials_recorded": false
+    "request_correlation_values_recorded": false,
+    "provider_material_recorded": false,
+    "raw_payloads_recorded": false
   }
 }
 ```

--- a/docs/commerce-agent-staging-data-setup.md
+++ b/docs/commerce-agent-staging-data-setup.md
@@ -47,24 +47,30 @@ Do not place values for those names in docs, logs, fixtures, local env files, or
 
 ## Staging Demo And Eval Command Plan For Later
 
-After Grantex and AgenticOrg hosted staging are both deployed, M11 should add or run a staging-safe command plan like:
+For C1, AgenticOrg can run locally against an approved Grantex staging or smoke URL. This proves the connector/demo/eval path against real Grantex endpoints without deploying AgenticOrg hosting.
 
 ```bash
-python demos/commerce_sales_agent_demo.py
-python -m pytest tests/evals/test_commerce_sales_agent_demo.py -q
-python -m pytest tests/evals/test_commerce_sales_agent_evals.py -q
+AGENTICORG_COMMERCE_EVAL_MODE=real-staging
+GRANTEX_COMMERCE_BASE_URL=https://api-staging.grantex.dev
+GRANTEX_BASE_URL=https://api-staging.grantex.dev
+AGENTICORG_COMMERCE_EVIDENCE_REPORT=docs/reports/commerce-agent-real-staging-evidence.md
+python demos/commerce_sales_agent_demo.py --mode=real-staging --evidence-report docs/reports/commerce-agent-real-staging-evidence.md
+python -m pytest tests/evals/test_commerce_sales_agent_real_staging.py -q
 ```
 
-Expected staging run configuration:
+If the approved target is a temporary Cloud Run smoke URL, set `AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL` to that exact origin. Arbitrary `run.app` origins are refused.
+
+Expected real-staging run configuration:
 
 - `AGENTICORG_BASE_URL=https://staging.agenticorg.ai`
 - `GRANTEX_COMMERCE_BASE_URL=https://api-staging.grantex.dev`
 - `GRANTEX_BASE_URL=https://api-staging.grantex.dev`
+- `AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL=<exact approved smoke origin>` only for temporary smoke runs
 - Merchant ID `mch_staging_electronics_pilot`
 - Agent ID `cag_staging_agenticorg_sales`
 - Provider `mock`
 
-The future hosted staging demo/eval must redact auth headers, generated Commerce Passport material, generated payment references, and any generated request correlation material from logs and reports.
+The real-staging demo/eval must redact auth headers, generated Commerce Passport material, generated payment references, and any generated request correlation material from logs and reports.
 
 ## Expected Positive Cases
 

--- a/tests/evals/test_commerce_sales_agent_real_staging.py
+++ b/tests/evals/test_commerce_sales_agent_real_staging.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from demos.commerce_sales_agent_demo import run_real_staging_demo
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.skipif(
+    os.getenv("AGENTICORG_COMMERCE_REAL_STAGING") != "1",
+    reason="Set AGENTICORG_COMMERCE_REAL_STAGING=1 only for approved Grantex staging or smoke runs.",
+)
+async def test_commerce_sales_agent_real_staging_eval_path() -> None:
+    result = await run_real_staging_demo(
+        grantex_base_url=os.getenv("GRANTEX_COMMERCE_BASE_URL"),
+        allow_smoke_cloud_run_url=os.getenv("AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL"),
+        evidence_report=os.getenv("AGENTICORG_COMMERCE_EVIDENCE_REPORT"),
+    )
+
+    assert result["scope"] == "real_staging_only"
+    assert result["audit_summary"]["no_direct_provider_calls"] is True
+    assert all(
+        tool.startswith("grantex_commerce:")
+        for tool in result["audit_summary"]["tool_sequence"]
+    )
+    assert {step["tool_alias"] for step in result["steps"]} >= {
+        "grantex_commerce:merchant_get_profile",
+        "grantex_commerce:catalog_search",
+        "grantex_commerce:consent_request",
+    }

--- a/tests/regression/test_commerce_agent_hosted_staging_plan.py
+++ b/tests/regression/test_commerce_agent_hosted_staging_plan.py
@@ -136,9 +136,11 @@ def test_commerce_agent_hosted_staging_e2e_has_real_staging_command_plan() -> No
     content = E2E.read_text(encoding="utf-8")
 
     for required in [
-        "python demos/commerce_sales_agent_demo.py --mode=hosted-staging",
-        "python -m pytest tests/evals/test_commerce_sales_agent_evals.py -q --hosted-staging",
-        "The current local demo/eval path is mocked.",
+        "python demos/commerce_sales_agent_demo.py --mode=real-staging",
+        "python -m pytest tests/evals/test_commerce_sales_agent_real_staging.py -q",
+        "AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL",
+        "fails closed before connector creation, auth lookup, or network use",
+        "python demos/commerce_sales_agent_demo.py --mode=mock",
         "Do not present mocked results as hosted staging evidence.",
     ]:
         assert required in content
@@ -229,11 +231,11 @@ def test_commerce_agent_contract_gap_report_preserves_real_staging_gap_and_no_se
     content = CONTRACT_GAP.read_text(encoding="utf-8")
 
     for required in [
-        "The real-staging gap is still blocked",
-        "current local demo/eval path uses mocked Grantex responses",
-        "No redacted hosted staging evidence exists yet",
-        "demos/commerce_sales_agent_demo.py --mode=hosted-staging",
-        "python -m pytest tests/evals/test_commerce_sales_agent_evals.py -q --hosted-staging",
+        "The real-staging gap is now partial",
+        "refuses production URLs, arbitrary `run.app` URLs, credentialed URLs, and non-HTTPS URLs",
+        "No redacted hosted AgenticOrg evidence exists yet",
+        "demos/commerce_sales_agent_demo.py --mode=real-staging",
+        "python -m pytest tests/evals/test_commerce_sales_agent_real_staging.py -q",
     ]:
         assert required in content
 

--- a/tests/regression/test_commerce_sales_agent_no_provider_calls.py
+++ b/tests/regression/test_commerce_sales_agent_no_provider_calls.py
@@ -7,6 +7,8 @@ ROOT = Path(__file__).resolve().parents[2]
 COMMERCE_CODE = [
     ROOT / "connectors" / "commerce" / "grantex_commerce.py",
     ROOT / "core" / "commerce" / "sales_guardrails.py",
+    ROOT / "core" / "commerce" / "staging_evidence.py",
+    ROOT / "core" / "commerce" / "staging_runtime.py",
     ROOT / "core" / "langgraph" / "agents" / "commerce_sales_agent.py",
 ]
 

--- a/tests/regression/test_commerce_sales_agent_real_staging_mode.py
+++ b/tests/regression/test_commerce_sales_agent_real_staging_mode.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import pytest
+
+from core.commerce.staging_evidence import redact_value
+from core.commerce.staging_runtime import RealStagingConfigError, validate_real_staging_config
+from demos import commerce_sales_agent_demo
+
+
+def _env(**overrides: str) -> dict[str, str]:
+    base = {
+        "AGENTICORG_TEST_FAKE_CONNECTORS": "0",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_real_staging_refuses_production_before_connector_auth_or_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_connector(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("connector should not be created")
+
+    monkeypatch.setattr(commerce_sales_agent_demo, "GrantexCommerceConnector", fail_connector)
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_CONNECTORS", "0")
+
+    with pytest.raises(RealStagingConfigError) as excinfo:
+        await commerce_sales_agent_demo.run_real_staging_demo(grantex_base_url="https://api.grantex.dev")
+
+    assert excinfo.value.code == "production_url_refused"
+
+
+@pytest.mark.asyncio
+async def test_real_staging_refuses_arbitrary_run_app_before_connector_auth_or_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_connector(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("connector should not be created")
+
+    monkeypatch.setattr(commerce_sales_agent_demo, "GrantexCommerceConnector", fail_connector)
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_CONNECTORS", "0")
+
+    with pytest.raises(RealStagingConfigError) as excinfo:
+        await commerce_sales_agent_demo.run_real_staging_demo(grantex_base_url="https://example.run.app")
+
+    assert excinfo.value.code == "smoke_url_not_allowlisted"
+
+
+@pytest.mark.asyncio
+async def test_real_staging_refuses_localhost_http_before_connector_auth_or_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_connector(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("connector should not be created")
+
+    monkeypatch.setattr(commerce_sales_agent_demo, "GrantexCommerceConnector", fail_connector)
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_CONNECTORS", "0")
+
+    with pytest.raises(RealStagingConfigError) as excinfo:
+        await commerce_sales_agent_demo.run_real_staging_demo(grantex_base_url="http://localhost:3001")
+
+    assert excinfo.value.code == "non_https_url_refused"
+
+
+def test_real_staging_allows_exact_smoke_url_only_with_allowlist() -> None:
+    smoke_url = "https://grantex-auth-smoke-example-uc.a.run.app"
+    config = validate_real_staging_config(
+        grantex_base_url=smoke_url,
+        allow_smoke_cloud_run_url=smoke_url,
+        environ=_env(GRANTEX_AGENT_ASSERTION="present-but-not-printed"),
+    )
+
+    assert config.grantex_base_url == smoke_url
+    assert config.auth_env_name == "GRANTEX_AGENT_ASSERTION"
+
+
+def test_real_staging_requires_exactly_one_auth_env_name() -> None:
+    with pytest.raises(RealStagingConfigError) as missing:
+        validate_real_staging_config(
+            grantex_base_url="https://api-staging.grantex.dev",
+            environ=_env(),
+        )
+    assert missing.value.code == "staging_auth_required"
+
+    with pytest.raises(RealStagingConfigError) as ambiguous:
+        validate_real_staging_config(
+            grantex_base_url="https://api-staging.grantex.dev",
+            environ=_env(GRANTEX_AGENT_ASSERTION="one", GRANTEX_API_KEY="two"),
+        )
+    assert ambiguous.value.code == "ambiguous_staging_auth"
+
+
+def test_real_staging_refuses_fake_connector_transport() -> None:
+    with pytest.raises(RealStagingConfigError) as excinfo:
+        validate_real_staging_config(
+            grantex_base_url="https://api-staging.grantex.dev",
+            environ=_env(AGENTICORG_TEST_FAKE_CONNECTORS="1", GRANTEX_AGENT_ASSERTION="present"),
+        )
+
+    assert excinfo.value.code == "fake_connectors_refused"
+
+
+def test_redaction_removes_auth_passport_idempotency_and_raw_payload_material() -> None:
+    redacted = redact_value(
+        {
+            "authorization": "Bearer secret-token",
+            "passport_jwt": "secret-passport",
+            "idempotency_key": "secret-idempotency",
+            "request_payload": {"nested": "raw"},
+            "provider": {"credential": "secret-provider-material"},
+            "safe": {"status": "pass"},
+        }
+    )
+
+    assert redacted["authorization"] == "[redacted]"
+    assert redacted["passport_jwt"] == "[redacted]"
+    assert redacted["idempotency_key"] == "[redacted]"
+    assert redacted["request_payload"] == "[redacted]"
+    assert redacted["provider"]["credential"] == "[redacted]"
+    assert redacted["safe"]["status"] == "pass"


### PR DESCRIPTION
## Scope

Adds an explicit AgenticOrg Commerce Sales Agent real-staging mode for approved Grantex staging/smoke endpoints while keeping the existing mocked demo/eval path as the default.

## What changed

- Added real-staging runtime validation for approved Grantex staging origin and exact smoke run.app allowlisting.
- Added redacted evidence helpers for future real-staging reports.
- Added `--mode=real-staging` to the commerce demo and kept `--mode=mock` as default.
- Added an env-gated real-staging eval test that skips unless explicitly enabled.
- Added regression coverage for production URL refusal, arbitrary run.app refusal, non-HTTPS refusal, fake connector refusal, auth-source checks, and redaction.
- Updated staging docs and the contract gap report to describe C1 partial real-staging coverage.

## Safety

- No deploy, cloud resources, production config, live payment path, or live Plural path.
- Real-staging mode refuses `https://api.grantex.dev`, `https://grantex.dev`, and `https://app.agenticorg.ai` before connector creation, auth lookup, or network use.
- Arbitrary `*.run.app` URLs are refused unless the exact origin is allowlisted.
- Non-HTTPS URLs, including localhost, are refused in real-staging mode.
- Commerce remains Grantex-only; no direct Stripe/Plural/Pine/provider credential path was added.
- Evidence records auth env names only and redacts auth/passport/idempotency/provider/raw payload material.

## Validation

- `python -m ruff check connectors/commerce/grantex_commerce.py core/commerce/staging_runtime.py core/commerce/staging_evidence.py demos/commerce_sales_agent_demo.py tests/evals/test_commerce_sales_agent_real_staging.py tests/regression/test_commerce_sales_agent_real_staging_mode.py tests/regression/test_commerce_sales_agent_no_provider_calls.py`
- `python -m pytest tests/regression/test_commerce_sales_agent_real_staging_mode.py -q`
- `python -m pytest tests/regression/test_commerce_sales_agent_no_provider_calls.py -q`
- `python -m pytest tests/evals/test_commerce_sales_agent_evals.py -q`
- `python -m pytest tests/evals/test_commerce_sales_agent_demo.py -q`
- `python -m pytest tests/evals/test_commerce_sales_agent_real_staging.py -q` (skips by default)
- `python -m pytest tests/regression/test_commerce_agent_hosted_staging_plan.py -q`
- `python demos/commerce_sales_agent_demo.py --mode=mock`
- Refusal checks for production URL, arbitrary run.app URL, and HTTP localhost all failed closed with expected codes.
- `git diff --check`