### PR TITLE
[codex] Fix Zoho connector registration readiness

### DIFF
--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -811,6 +811,104 @@ async def _load_connector_configs_for_agent(
 
 
 # ── GET /agents/default-tools/{agent_type} ───────────────────────────────────
+async def _assert_connectors_ready_for_activation(
+    session: Any,
+    tenant_id: _uuid.UUID,
+    connector_ids: list[str] | None,
+) -> None:
+    """Block active status unless every linked connector is truly ready."""
+    if not connector_ids:
+        return
+
+    import json as _json
+
+    from core.crypto import decrypt_for_tenant
+    from core.models.connector import Connector
+    from core.models.connector_config import ConnectorConfig
+
+    not_ready: list[dict[str, str]] = []
+    for raw_id in connector_ids:
+        if not isinstance(raw_id, str) or not raw_id.strip():
+            continue
+        raw = raw_id.strip()
+        connector_name = raw.removeprefix("registry-")
+
+        cc = (
+            await session.execute(
+                select(ConnectorConfig).where(
+                    ConnectorConfig.tenant_id == tenant_id,
+                    ConnectorConfig.connector_name == connector_name,
+                )
+            )
+        ).scalar_one_or_none()
+        if cc is None:
+            try:
+                cc_uuid = _uuid.UUID(connector_name)
+            except (TypeError, ValueError):
+                cc_uuid = None
+            if cc_uuid is not None:
+                cc = (
+                    await session.execute(
+                        select(ConnectorConfig).where(
+                            ConnectorConfig.tenant_id == tenant_id,
+                            ConnectorConfig.id == cc_uuid,
+                        )
+                    )
+                ).scalar_one_or_none()
+
+        if cc is None:
+            not_ready.append({"connector": connector_name, "reason": "missing_connector_config"})
+            continue
+
+        connector_name = str(cc.connector_name)
+        connector = (
+            await session.execute(
+                select(Connector).where(
+                    Connector.tenant_id == tenant_id,
+                    Connector.name == connector_name,
+                )
+            )
+        ).scalar_one_or_none()
+        if connector is None or str(connector.status or "").lower() != "active":
+            not_ready.append({"connector": connector_name, "reason": "connector_not_active"})
+            continue
+        if str(cc.status or "").lower() != "configured":
+            not_ready.append({"connector": connector_name, "reason": "connector_config_not_configured"})
+            continue
+        if str(cc.health_status or "").lower() != "healthy":
+            not_ready.append({"connector": connector_name, "reason": "connector_health_not_healthy"})
+            continue
+
+        creds = cc.credentials_encrypted or {}
+        if isinstance(creds, str):
+            creds = _json.loads(creds)
+        encrypted = creds.get("_encrypted") if isinstance(creds, dict) else None
+        if not encrypted:
+            not_ready.append({"connector": connector_name, "reason": "missing_encrypted_credentials"})
+            continue
+        try:
+            decrypted = _json.loads(decrypt_for_tenant(encrypted))
+        except Exception:
+            not_ready.append({"connector": connector_name, "reason": "credentials_not_decryptable"})
+            continue
+        if (
+            connector_name == "zoho_books"
+            and str(cc.auth_type or "").lower() == "oauth2"
+            and not decrypted.get("refresh_token")
+        ):
+            not_ready.append({"connector": connector_name, "reason": "missing_refresh_token"})
+
+    if not_ready:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "connector_not_ready_for_activation",
+                "message": "Agents can become active only when all linked connectors are healthy and refreshable.",
+                "connectors": not_ready,
+            },
+        )
+
+
 @router.get("/agents/default-tools/{agent_type}")
 async def get_default_tools(
     agent_type: str,
@@ -903,6 +1001,12 @@ async def create_agent(body: AgentCreate, tenant_id: str = Depends(get_current_t
             )
             if company_exists.scalar_one_or_none() is None:
                 raise HTTPException(404, "Company not found")
+        if initial_status == "active":
+            await _assert_connectors_ready_for_activation(
+                session,
+                tid,
+                connector_ids,
+            )
         # ── SET-008: Enforce shadow agent limit ────────────────────────
         #
         # Codex 2026-04-22 audit gap #7 — fail-closed on safety errors.
@@ -2596,6 +2700,12 @@ async def resume_agent(agent_id: UUID, tenant_id: str = Depends(get_current_tena
                 ),
             )
 
+        if resume_to == "active":
+            await _assert_connectors_ready_for_activation(
+                session,
+                tid,
+                list(agent.connector_ids or []),
+            )
         agent.status = resume_to
 
         event = AgentLifecycleEvent(
@@ -2655,6 +2765,11 @@ async def promote_agent(agent_id: UUID, tenant_id: str = Depends(get_current_ten
                     f"Shadow accuracy {agent.shadow_accuracy_current} is below floor {required_accuracy}",
                 )
 
+        await _assert_connectors_ready_for_activation(
+            session,
+            tid,
+            list(agent.connector_ids or []),
+        )
         old_status = agent.status
         old_version = agent.version or "1.0.0"
         new_version = _next_agent_version(old_version)

--- a/api/v1/connectors.py
+++ b/api/v1/connectors.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import ipaddress
+import json
 import logging
 import socket
 import uuid as _uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -22,6 +25,51 @@ _log = logging.getLogger(__name__)
 
 _ZOHO_IN_BASE = "https://books.zoho.in/api/v3"
 _ZOHO_GLOBAL_BASE = "https://www.zohoapis.com/books/v3"
+_ZOHO_API_BASE_URLS = {
+    "in": _ZOHO_IN_BASE,
+    "us": _ZOHO_GLOBAL_BASE,
+    "eu": "https://www.zohoapis.eu/books/v3",
+    "au": "https://www.zohoapis.com.au/books/v3",
+    "jp": "https://www.zohoapis.jp/books/v3",
+}
+_ZOHO_TOKEN_URLS = {
+    "in": "https://accounts.zoho.in/oauth/v2/token",
+    "us": "https://accounts.zoho.com/oauth/v2/token",
+    "eu": "https://accounts.zoho.eu/oauth/v2/token",
+    "au": "https://accounts.zoho.com.au/oauth/v2/token",
+    "jp": "https://accounts.zoho.jp/oauth/v2/token",
+}
+_ZOHO_REGION_HOSTS = {
+    "in": ("zohoapis.in", "books.zoho.in", "accounts.zoho.in"),
+    "eu": ("zohoapis.eu", "accounts.zoho.eu"),
+    "au": ("zohoapis.com.au", "accounts.zoho.com.au"),
+    "jp": ("zohoapis.jp", "accounts.zoho.jp"),
+    "us": ("zohoapis.com", "accounts.zoho.com"),
+}
+
+
+def _host_from_urlish(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    candidate = text if "://" in text else f"https://{text}"
+    parsed = urlparse(candidate)
+    return (parsed.hostname or "").rstrip(".").lower()
+
+
+def _host_matches(host: str, domain: str) -> bool:
+    return host == domain or host.endswith(f".{domain}")
+
+
+def _zoho_region_from_urls(values: tuple[Any, ...]) -> str | None:
+    for value in values:
+        host = _host_from_urlish(value)
+        if not host:
+            continue
+        for region, domains in _ZOHO_REGION_HOSTS.items():
+            if any(_host_matches(host, domain) for domain in domains):
+                return region
+    return None
 
 
 def _normalise_connector_base_url(name: str, base_url: str | None) -> str | None:
@@ -29,10 +77,217 @@ def _normalise_connector_base_url(name: str, base_url: str | None) -> str | None
     value = (base_url or "").strip()
     if (name or "").strip().lower() != "zoho_books":
         return value or None
-    lowered = value.lower()
-    if "zohoapis.in" in lowered or "books.zoho.in" in lowered:
-        return _ZOHO_IN_BASE
-    return value or _ZOHO_GLOBAL_BASE
+    region = _zoho_region_from_urls((value,))
+    if region:
+        return _ZOHO_API_BASE_URLS[region]
+    return _ZOHO_GLOBAL_BASE
+
+
+def _infer_zoho_region(base_url: str | None, auth_config: dict[str, Any] | None) -> str:
+    """Infer Zoho data center from explicit config or provider URLs."""
+    config = auth_config or {}
+    raw = config.get("region") or config.get("data_center") or config.get("zoho_region")
+    if raw:
+        normalized = str(raw).strip().lower().replace(".", "")
+        aliases = {
+            "india": "in",
+            "in_dc": "in",
+            "global": "us",
+            "us_dc": "us",
+            "europe": "eu",
+            "eu_dc": "eu",
+            "australia": "au",
+            "au_dc": "au",
+            "japan": "jp",
+            "jp_dc": "jp",
+        }
+        normalized = aliases.get(normalized, normalized)
+        if normalized in _ZOHO_TOKEN_URLS:
+            return normalized
+
+    return _zoho_region_from_urls(
+        (
+            base_url,
+            config.get("base_url"),
+            config.get("api_base_url"),
+            config.get("token_url"),
+            config.get("authorize_url"),
+        )
+    ) or "in"
+
+
+def _clean_auth_config(auth_config: dict[str, Any] | None) -> dict[str, Any]:
+    cleaned: dict[str, Any] = {}
+    for key, value in (auth_config or {}).items():
+        if value is None:
+            continue
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                continue
+            cleaned[str(key)] = stripped
+        else:
+            cleaned[str(key)] = value
+    return cleaned
+
+
+def _prepare_zoho_books_registration(
+    body: ConnectorCreate,
+    normalised_base_url: str | None,
+) -> tuple[str | None, dict[str, Any], dict[str, Any]]:
+    """Normalize and validate no-redirect Zoho Books registration.
+
+    Client ID + client secret identify the OAuth app, but they are not
+    usable Zoho API credentials by themselves. No-redirect registration
+    must therefore include refresh token material (or a one-time grant
+    code that the backend can exchange) before the connector can be
+    marked ready for agent execution.
+    """
+    secret_fields = _clean_auth_config(body.auth_config)
+    region = _infer_zoho_region(normalised_base_url or body.base_url, secret_fields)
+    token_url = _ZOHO_TOKEN_URLS[region]
+    secret_fields["region"] = region
+    secret_fields["token_url"] = token_url
+
+    missing = [
+        label
+        for key, label in (
+            ("client_id", "Client ID"),
+            ("client_secret", "Client Secret"),
+            ("organization_id", "organization_id"),
+        )
+        if not str(secret_fields.get(key) or "").strip()
+    ]
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "connector_validation_failed",
+                "connector": "zoho_books",
+                "message": "Missing required fields for Zoho Books: " + ", ".join(missing),
+                "missing": missing,
+            },
+        )
+
+    if not any(secret_fields.get(key) for key in ("refresh_token", "authorization_code", "grant_token", "code")):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "zoho_token_material_required",
+                "connector": "zoho_books",
+                "message": (
+                    "Zoho Books no-redirect registration needs a refresh_token "
+                    "or one-time authorization_code/grant_token in Extra config. "
+                    "Client ID and Client Secret alone cannot call Zoho Books "
+                    "or prove token refresh capability."
+                ),
+            },
+        )
+
+    non_secret_config = {
+        "base_url": normalised_base_url,
+        "auth_type": body.auth_type,
+        "data_schema_ref": body.data_schema_ref,
+        "rate_limit_rpm": body.rate_limit_rpm,
+        "region": region,
+        "token_url": token_url,
+        "oauth_refresh_token_present": bool(secret_fields.get("refresh_token")),
+    }
+    return normalised_base_url, secret_fields, non_secret_config
+
+
+async def _exchange_zoho_one_time_code(secret_fields: dict[str, Any], region: str) -> None:
+    code = (
+        secret_fields.pop("authorization_code", None)
+        or secret_fields.pop("grant_token", None)
+        or secret_fields.pop("code", None)
+    )
+    if not code:
+        return
+    import httpx
+
+    token_url = _ZOHO_TOKEN_URLS[region]
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        resp = await client.post(
+            token_url,
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "client_id": secret_fields["client_id"],
+                "client_secret": secret_fields["client_secret"],
+                "redirect_uri": secret_fields.get("redirect_uri", "https://agenticorg.ai"),
+            },
+            headers={"Accept": "application/json"},
+        )
+    if resp.status_code >= 400:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "zoho_authorization_code_rejected",
+                "connector": "zoho_books",
+                "message": "Zoho rejected the supplied one-time authorization code.",
+                "status_code": resp.status_code,
+            },
+        )
+    token_data = resp.json()
+    if token_data.get("refresh_token"):
+        secret_fields["refresh_token"] = token_data["refresh_token"]
+    if token_data.get("access_token"):
+        secret_fields["access_token"] = token_data["access_token"]
+    if token_data.get("expires_in"):
+        expires_in = int(token_data.get("expires_in") or 3600)
+        secret_fields["expires_in"] = expires_in
+        secret_fields["expires_at"] = (datetime.now(UTC) + timedelta(seconds=expires_in)).isoformat()
+    if not secret_fields.get("refresh_token") and not secret_fields.get("access_token"):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "zoho_token_exchange_missing_token",
+                "connector": "zoho_books",
+                "message": "Zoho accepted the code but did not return usable token material.",
+            },
+        )
+
+
+async def _validate_zoho_books_readiness(secret_fields: dict[str, Any]) -> None:
+    """Run the same connector path agents will use before persisting."""
+    region = _infer_zoho_region(secret_fields.get("base_url"), secret_fields)
+    secret_fields["region"] = region
+    secret_fields["token_url"] = _ZOHO_TOKEN_URLS[region]
+    await _exchange_zoho_one_time_code(secret_fields, region)
+    if not secret_fields.get("refresh_token"):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "zoho_refresh_token_required",
+                "connector": "zoho_books",
+                "message": (
+                    "Zoho Books registration requires refresh_token for production "
+                    "readiness. Access tokens expire and are not sufficient for "
+                    "agent activation."
+                ),
+            },
+        )
+
+    from connectors.finance.zoho_books import ZohoBooksConnector
+
+    connector = ZohoBooksConnector(dict(secret_fields))
+    try:
+        await connector.connect()
+        health = await connector.health_check()
+    finally:
+        await connector.disconnect()
+
+    if health.get("status") != "healthy":
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "zoho_readiness_check_failed",
+                "connector": "zoho_books",
+                "message": "Zoho Books credentials could not be validated against the Books API.",
+                "health_status": health.get("status", "unknown"),
+            },
+        )
 
 
 def _connector_tool_functions(conn: Connector) -> list[str]:
@@ -122,11 +377,15 @@ def _assert_public_base_url(base_url: str) -> None:
 router = APIRouter(dependencies=[require_tenant_admin])
 
 
-def _connector_to_dict(conn: Connector) -> dict:
+def _connector_to_dict(conn: Connector, has_encrypted_credentials: bool | None = None) -> dict:
     # Return a boolean flag for whether credentials are configured —
     # NEVER return the actual auth_config (secrets) in the API response.
     auth_config = getattr(conn, "auth_config", None)
-    has_creds = bool(auth_config) or bool(getattr(conn, "secret_ref", None))
+    has_creds = (
+        bool(auth_config)
+        or bool(getattr(conn, "secret_ref", None))
+        or bool(has_encrypted_credentials)
+    )
     health_check_at = getattr(conn, "health_check_at", None)
     created_at = getattr(conn, "created_at", None)
     return {
@@ -317,8 +576,21 @@ async def list_connectors(
         query = query.offset((page - 1) * per_page).limit(per_page)
         result = await session.execute(query)
         connectors = result.scalars().all()
+        encrypted_names: set[str] = set()
+        if connectors:
+            from core.models.connector_config import ConnectorConfig
+
+            names = [str(c.name) for c in connectors if c.name]
+            cc_result = await session.execute(
+                select(ConnectorConfig.connector_name).where(
+                    ConnectorConfig.tenant_id == tid,
+                    ConnectorConfig.connector_name.in_(names),
+                    ConnectorConfig.credentials_encrypted != {},
+                )
+            )
+            encrypted_names = {str(name) for name in cc_result.scalars().all()}
     return {
-        "items": [_connector_to_dict(c) for c in connectors],
+        "items": [_connector_to_dict(c, c.name in encrypted_names) for c in connectors],
         "total": total,
         "page": page,
         "per_page": per_page,
@@ -341,13 +613,23 @@ async def register_connector(
     # auth_config on the Connector model is deprecated for secrets —
     # new writes go to connector_configs.credentials_encrypted via
     # tenant-aware encryption.
-    secret_fields = body.auth_config or {}
+    secret_fields = _clean_auth_config(body.auth_config)
     non_secret_config = {
         "base_url": normalised_base_url,
         "auth_type": body.auth_type,
         "data_schema_ref": body.data_schema_ref,
         "rate_limit_rpm": body.rate_limit_rpm,
     }
+    if (body.name or "").strip().lower() == "zoho_books":
+        normalised_base_url, secret_fields, non_secret_config = _prepare_zoho_books_registration(
+            body,
+            normalised_base_url,
+        )
+        await _validate_zoho_books_readiness(secret_fields)
+        _log.info(
+            "connector_registration_validated",
+            extra={"connector": "zoho_books"},
+        )
 
     async with get_tenant_session(tid) as session:
         connector = Connector(
@@ -416,9 +698,7 @@ async def register_connector(
             from core.crypto import encrypt_for_tenant
             from core.models.connector_config import ConnectorConfig
 
-            encrypted_creds = await encrypt_for_tenant(
-                __import__("json").dumps(secret_fields), tid
-            )
+            encrypted_creds = await encrypt_for_tenant(json.dumps(secret_fields), tid)
             # Uday 2026-04-26 (BUG 1): connector_configs has its own
             # UniqueConstraint(tenant_id, connector_name). When the
             # Connector was reactivated above, an old ConnectorConfig
@@ -439,6 +719,11 @@ async def register_connector(
                 cc_existing.config = non_secret_config
                 cc_existing.auth_type = body.auth_type or "api_key"
                 cc_existing.status = "configured"
+                cc_existing.health_status = (
+                    "healthy"
+                    if (body.name or "").strip().lower() == "zoho_books"
+                    else cc_existing.health_status
+                )
             else:
                 cc = ConnectorConfig(
                     tenant_id=tid,
@@ -448,11 +733,16 @@ async def register_connector(
                     credentials_encrypted={"_encrypted": encrypted_creds},
                     config=non_secret_config,
                     status="configured",
+                    health_status=(
+                        "healthy"
+                        if (body.name or "").strip().lower() == "zoho_books"
+                        else "unknown"
+                    ),
                 )
                 session.add(cc)
             await session.flush()
 
-    return _connector_to_dict(connector)
+    return _connector_to_dict(connector, bool(secret_fields))
 
 
 # ── GET /connectors/{conn_id} ────────────────────────────────────────────────
@@ -469,9 +759,21 @@ async def get_connector(
             )
         )
         connector = result.scalar_one_or_none()
+        has_encrypted_credentials = False
+        if connector is not None:
+            from core.models.connector_config import ConnectorConfig
+
+            cc_result = await session.execute(
+                select(ConnectorConfig.id).where(
+                    ConnectorConfig.tenant_id == tid,
+                    ConnectorConfig.connector_name == connector.name,
+                    ConnectorConfig.credentials_encrypted != {},
+                )
+            )
+            has_encrypted_credentials = cc_result.scalar_one_or_none() is not None
     if not connector:
         raise HTTPException(404, "Connector not found")
-    return _connector_to_dict(connector)
+    return _connector_to_dict(connector, has_encrypted_credentials)
 
 
 # ── PUT /connectors/{conn_id} ──────────────────────────────────────────────
@@ -525,6 +827,9 @@ async def update_connector(
         # want to replace all creds still can — they just have to send
         # every key they intend to keep.
         new_secrets = body.model_dump(exclude_none=True).get("auth_config")
+        credential_surface_changed = bool(new_secrets) or any(
+            field in updates for field in ("base_url", "auth_type")
+        )
         if new_secrets:
             from core.crypto import encrypt_for_tenant
             from core.crypto.tenant_secrets import decrypt_for_tenant
@@ -576,12 +881,52 @@ async def update_connector(
                         ) from exc
             # New keys win on collision so admins can rotate creds.
             merged_secrets.update(new_secrets)
+            zoho_non_secret_config: dict[str, Any] | None = None
+            if (connector.name or "").strip().lower() == "zoho_books":
+                zoho_body = ConnectorCreate(
+                    name=connector.name,
+                    category=connector.category,
+                    base_url=connector.base_url,
+                    auth_type=connector.auth_type,
+                    auth_config=merged_secrets,
+                    data_schema_ref=connector.data_schema_ref,
+                    rate_limit_rpm=connector.rate_limit_rpm,
+                )
+                (
+                    connector.base_url,
+                    merged_secrets,
+                    zoho_non_secret_config,
+                ) = _prepare_zoho_books_registration(
+                    zoho_body,
+                    _normalise_connector_base_url(
+                        connector.name,
+                        connector.base_url,
+                    ),
+                )
+                await _validate_zoho_books_readiness(merged_secrets)
 
             encrypted = await encrypt_for_tenant(
                 __import__("json").dumps(merged_secrets), tid
             )
             if cc:
                 cc.credentials_encrypted = {"_encrypted": encrypted}
+                cc.auth_type = connector.auth_type or cc.auth_type
+                cc.config = (
+                    zoho_non_secret_config
+                    if zoho_non_secret_config is not None
+                    else {
+                        **(cc.config or {}),
+                        "base_url": connector.base_url,
+                        "auth_type": connector.auth_type,
+                    }
+                )
+                cc.status = "configured"
+                cc.health_status = (
+                    "healthy"
+                    if zoho_non_secret_config is not None
+                    else "unknown"
+                )
+                cc.sync_error = None
             else:
                 new_cc = ConnectorConfig(
                     tenant_id=tid,
@@ -589,10 +934,39 @@ async def update_connector(
                     display_name=connector.name,
                     auth_type=connector.auth_type or "api_key",
                     credentials_encrypted={"_encrypted": encrypted},
-                    config={},
+                    config=zoho_non_secret_config or {},
                     status="configured",
+                    health_status=(
+                        "healthy"
+                        if zoho_non_secret_config is not None
+                        else "unknown"
+                    ),
                 )
                 session.add(new_cc)
+        elif credential_surface_changed:
+            from core.models.connector_config import ConnectorConfig
+
+            cc_result = await session.execute(
+                select(ConnectorConfig).where(
+                    ConnectorConfig.tenant_id == tid,
+                    ConnectorConfig.connector_name == connector.name,
+                )
+            )
+            cc = cc_result.scalar_one_or_none()
+            if cc:
+                next_config = {
+                    **(cc.config or {}),
+                    "base_url": connector.base_url,
+                    "auth_type": connector.auth_type,
+                }
+                if (connector.name or "").strip().lower() == "zoho_books":
+                    region = _infer_zoho_region(connector.base_url, next_config)
+                    next_config["region"] = region
+                    next_config["token_url"] = _ZOHO_TOKEN_URLS[region]
+                cc.config = next_config
+                cc.auth_type = connector.auth_type or cc.auth_type
+                cc.health_status = "unknown"
+                cc.sync_error = "credential_surface_changed"
 
         await session.commit()
         await session.refresh(connector)
@@ -806,6 +1180,22 @@ async def test_connector(
                 "credential is marked Active — the connector test "
                 "automatically uses the most recent active vault entry."
             )
+        from datetime import UTC, datetime
+
+        from core.models.connector_config import ConnectorConfig
+
+        async with get_tenant_session(tid) as session:
+            cc_result = await session.execute(
+                select(ConnectorConfig).where(
+                    ConnectorConfig.tenant_id == tid,
+                    ConnectorConfig.connector_name == connector.name,
+                )
+            )
+            cc = cc_result.scalar_one_or_none()
+            if cc:
+                cc.last_health_check = datetime.now(UTC)
+                cc.health_status = "unhealthy"
+                cc.sync_error = "missing_encrypted_credentials"
         return {
             "tested": False,
             "name": connector.name,
@@ -828,6 +1218,23 @@ async def test_connector(
             if db_conn:
                 db_conn.health_check_at = datetime.now(UTC)
                 db_conn.status = "active" if health.get("status") == "healthy" else "error"
+            from core.models.connector_config import ConnectorConfig
+
+            cc_result = await session.execute(
+                select(ConnectorConfig).where(
+                    ConnectorConfig.tenant_id == tid,
+                    ConnectorConfig.connector_name == connector.name,
+                )
+            )
+            cc = cc_result.scalar_one_or_none()
+            if cc:
+                cc.last_health_check = datetime.now(UTC)
+                cc.health_status = str(health.get("status") or "unknown")
+                cc.sync_error = (
+                    None
+                    if health.get("status") == "healthy"
+                    else str(health.get("error") or "health_check_failed")
+                )
 
         return {
             "tested": True,
@@ -835,6 +1242,22 @@ async def test_connector(
             "health": health,
         }
     except TimeoutError:
+        from datetime import UTC, datetime
+
+        from core.models.connector_config import ConnectorConfig
+
+        async with get_tenant_session(tid) as session:
+            cc_result = await session.execute(
+                select(ConnectorConfig).where(
+                    ConnectorConfig.tenant_id == tid,
+                    ConnectorConfig.connector_name == connector.name,
+                )
+            )
+            cc = cc_result.scalar_one_or_none()
+            if cc:
+                cc.last_health_check = datetime.now(UTC)
+                cc.health_status = "unhealthy"
+                cc.sync_error = "TimeoutError"
         # TC_007 (Aishwarya 2026-04-23): "Connection timed out (10s)" is
         # specific; return a hint about what to check.
         return {
@@ -848,6 +1271,22 @@ async def test_connector(
             ),
         }
     except Exception as exc:
+        from datetime import UTC, datetime
+
+        from core.models.connector_config import ConnectorConfig
+
+        async with get_tenant_session(tid) as session:
+            cc_result = await session.execute(
+                select(ConnectorConfig).where(
+                    ConnectorConfig.tenant_id == tid,
+                    ConnectorConfig.connector_name == connector.name,
+                )
+            )
+            cc = cc_result.scalar_one_or_none()
+            if cc:
+                cc.last_health_check = datetime.now(UTC)
+                cc.health_status = "unhealthy"
+                cc.sync_error = type(exc).__name__
         # TC_007 (Aishwarya 2026-04-23): the route used to always return
         # "Connector test failed" regardless of the actual cause (401,
         # SSL, DNS, auth token expired, etc.). Surface a specific,

--- a/api/v1/oauth_connector.py
+++ b/api/v1/oauth_connector.py
@@ -1,6 +1,6 @@
 """OAuth connector authorization-code automation.
 
-Powers the "Authorize Connector" button in the UI. Each request flows
+Powers provider OAuth handoffs for legacy and re-connect flows. Each request flows
 through a provider-isolated ``ProviderSpec`` (see
 ``core/connectors/provider_registry.py``):
 
@@ -188,6 +188,8 @@ def _coerce_user_fields(
     # Legacy ``extra_config`` blob — preserve, but let user_fields win.
     for k, v in (body.extra_config or {}).items():
         coerced.setdefault(k, v)
+    if body.base_url:
+        coerced.setdefault("base_url", body.base_url.strip())
 
     missing = []
     for field_spec in spec.user_fields:
@@ -644,6 +646,8 @@ async def initiate_connector_oauth(
         )
 
     extra_config: dict[str, Any] = dict(body.extra_config or {})
+    if body.base_url:
+        extra_config.setdefault("base_url", body.base_url.strip())
     # Surface region from user_fields into extra_config so the connector
     # row stores it for downstream tools.
     if "region" in user_fields:
@@ -704,7 +708,7 @@ async def revoke_and_retry(
             status_code=400,
             detail=(
                 "No prior authorization attempt found for this connector. "
-                "Start a fresh Authorize Connector flow instead."
+                "Start a fresh connector authorization flow instead."
             ),
         )
     # Best-effort revoke using whatever token material we have.

--- a/connectors/finance/zoho_books.py
+++ b/connectors/finance/zoho_books.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 import structlog
@@ -16,19 +17,72 @@ _ZOHO_GLOBAL_BASE = "https://www.zohoapis.com/books/v3"
 _ZOHO_IN_BASE = "https://books.zoho.in/api/v3"
 _ZOHO_TOKEN_URL = "https://accounts.zoho.com/oauth/v2/token"
 _ZOHO_IN_TOKEN_URL = "https://accounts.zoho.in/oauth/v2/token"
+_ZOHO_BASE_URLS = {
+    "in": _ZOHO_IN_BASE,
+    "us": _ZOHO_GLOBAL_BASE,
+    "eu": "https://www.zohoapis.eu/books/v3",
+    "au": "https://www.zohoapis.com.au/books/v3",
+    "jp": "https://www.zohoapis.jp/books/v3",
+}
+_ZOHO_TOKEN_URLS = {
+    "in": _ZOHO_IN_TOKEN_URL,
+    "us": _ZOHO_TOKEN_URL,
+    "eu": "https://accounts.zoho.eu/oauth/v2/token",
+    "au": "https://accounts.zoho.com.au/oauth/v2/token",
+    "jp": "https://accounts.zoho.jp/oauth/v2/token",
+}
+_ZOHO_REGION_HOSTS = {
+    "in": ("zohoapis.in", "books.zoho.in", "accounts.zoho.in"),
+    "eu": ("zohoapis.eu", "accounts.zoho.eu"),
+    "au": ("zohoapis.com.au", "accounts.zoho.com.au"),
+    "jp": ("zohoapis.jp", "accounts.zoho.jp"),
+    "us": ("zohoapis.com", "accounts.zoho.com"),
+}
+
+
+def _host_from_urlish(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    candidate = text if "://" in text else f"https://{text}"
+    parsed = urlparse(candidate)
+    return (parsed.hostname or "").rstrip(".").lower()
+
+
+def _host_matches(host: str, domain: str) -> bool:
+    return host == domain or host.endswith(f".{domain}")
+
+
+def _region_from_config(config: dict[str, Any]) -> str:
+    region = str(config.get("region") or "").strip().lower().replace(".", "")
+    aliases = {
+        "india": "in",
+        "in_dc": "in",
+        "global": "us",
+        "us_dc": "us",
+        "europe": "eu",
+        "eu_dc": "eu",
+        "australia": "au",
+        "au_dc": "au",
+        "japan": "jp",
+        "jp_dc": "jp",
+    }
+    region = aliases.get(region, region)
+    if region in _ZOHO_BASE_URLS:
+        return region
+
+    for value in (config.get("base_url"), config.get("api_base_url"), config.get("token_url")):
+        host = _host_from_urlish(value)
+        if not host:
+            continue
+        for candidate_region, domains in _ZOHO_REGION_HOSTS.items():
+            if any(_host_matches(host, domain) for domain in domains):
+                return candidate_region
+    return "us"
 
 
 def _is_india_config(config: dict[str, Any]) -> bool:
-    region = str(config.get("region") or "").strip().lower()
-    if region in {"in", "india", "in_dc"}:
-        return True
-    base_url = str(config.get("base_url") or "").strip().lower()
-    token_url = str(config.get("token_url") or "").strip().lower()
-    return (
-        "zohoapis.in" in base_url
-        or "books.zoho.in" in base_url
-        or "accounts.zoho.in" in token_url
-    )
+    return _region_from_config(config) == "in"
 
 
 class ZohoBooksConnector(BaseConnector):
@@ -59,13 +113,11 @@ class ZohoBooksConnector(BaseConnector):
 
     def __init__(self, config: dict[str, Any] | None = None):
         super().__init__(config)
-        if _is_india_config(self.config):
-            self.base_url = _ZOHO_IN_BASE
-            self.config["region"] = "in"
-            self.config["base_url"] = _ZOHO_IN_BASE
-            self.config.setdefault("token_url", _ZOHO_IN_TOKEN_URL)
-        else:
-            self.base_url = self.config.get("base_url") or _ZOHO_GLOBAL_BASE
+        region = _region_from_config(self.config)
+        self.base_url = _ZOHO_BASE_URLS[region]
+        self.config["region"] = region
+        self.config["base_url"] = self.base_url
+        self.config["token_url"] = _ZOHO_TOKEN_URLS[region]
         self._org_id: str = self.config.get("organization_id", "")
 
     def _register_tools(self):
@@ -114,7 +166,7 @@ class ZohoBooksConnector(BaseConnector):
         self, client_id: str, client_secret: str, refresh_token: str
     ) -> str | None:
         """Exchange refresh_token for a fresh access_token via Zoho OAuth2."""
-        token_url = self.config.get("token_url", _ZOHO_TOKEN_URL)
+        token_url = _ZOHO_TOKEN_URLS.get(str(self.config.get("region") or "us"), _ZOHO_TOKEN_URL)
         try:
             async with httpx.AsyncClient() as client:
                 resp = await client.post(
@@ -131,7 +183,7 @@ class ZohoBooksConnector(BaseConnector):
                 logger.info("zoho_books_token_refreshed", expires_in=data.get("expires_in"))
                 return data["access_token"]
         except Exception as exc:
-            logger.warning("zoho_books_token_refresh_failed", error=str(exc))
+            logger.warning("zoho_books_token_refresh_failed", error_type=type(exc).__name__)
             return None
 
     async def connect(self) -> None:
@@ -168,7 +220,7 @@ class ZohoBooksConnector(BaseConnector):
                     org_name=orgs[0].get("name", ""),
                 )
         except Exception as exc:  # noqa: BLE001 — best-effort fallback
-            logger.warning("zoho_books_org_id_auto_fetch_failed", error=str(exc))
+            logger.warning("zoho_books_org_id_auto_fetch_failed", error_type=type(exc).__name__)
 
     async def _ensure_org_id(self) -> None:
         """Lazy-fetch org_id immediately before tool dispatch.
@@ -232,7 +284,7 @@ class ZohoBooksConnector(BaseConnector):
             orgs = data.get("organizations", [])
             return {"status": "healthy", "organizations": len(orgs)}
         except Exception as e:
-            return {"status": "unhealthy", "error": str(e)}
+            return {"status": "unhealthy", "error": type(e).__name__}
 
     # ── Invoices ───────────────────────────────────────────────────────
 

--- a/core/connectors/provider_registry.py
+++ b/core/connectors/provider_registry.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
+from urllib.parse import urlparse
 
 # ── Region helpers ────────────────────────────────────────────────────────────
 
@@ -60,33 +61,73 @@ ZOHO_REGIONS: dict[str, dict[str, str]] = {
         "api_base_url": "https://www.zohoapis.jp/books/v3",
     },
 }
+ZOHO_REGION_HOSTS: dict[str, tuple[str, ...]] = {
+    "in": ("zohoapis.in", "books.zoho.in", "accounts.zoho.in"),
+    "eu": ("zohoapis.eu", "accounts.zoho.eu"),
+    "au": ("zohoapis.com.au", "accounts.zoho.com.au"),
+    "jp": ("zohoapis.jp", "accounts.zoho.jp"),
+    "us": ("zohoapis.com", "accounts.zoho.com"),
+}
+
+
+def _host_from_urlish(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    candidate = text if "://" in text else f"https://{text}"
+    parsed = urlparse(candidate)
+    return (parsed.hostname or "").rstrip(".").lower()
+
+
+def _host_matches(host: str, domain: str) -> bool:
+    return host == domain or host.endswith(f".{domain}")
+
+
+def _zoho_region_from_urls(values: tuple[Any, ...]) -> str | None:
+    for value in values:
+        host = _host_from_urlish(value)
+        if not host:
+            continue
+        for region, domains in ZOHO_REGION_HOSTS.items():
+            if any(_host_matches(host, domain) for domain in domains):
+                return region
+    return None
 
 
 def _zoho_region(extra: dict[str, Any]) -> str:
     """Pick the Zoho data-center suffix from user-supplied config.
 
     Accepts any of ``region``, ``data_center``, or ``zoho_region`` and
-    falls back to ``in`` for India (the default region for AgenticOrg's
-    primary CA-firms market).
+    falls back to the Zoho API/account host when no explicit region is
+    provided. India remains the default for AgenticOrg's primary CA-firms
+    market.
     """
     raw = (
         extra.get("region")
         or extra.get("data_center")
         or extra.get("zoho_region")
-        or "in"
     )
-    normalized = str(raw).strip().lower().replace(".", "")
-    aliases = {
-        "india": "in",
-        "in_dc": "in",
-        "us_dc": "us",
-        "global": "us",
-        "eu_dc": "eu",
-        "au_dc": "au",
-        "jp_dc": "jp",
-    }
-    normalized = aliases.get(normalized, normalized)
-    return normalized if normalized in ZOHO_REGIONS else "in"
+    if raw:
+        normalized = str(raw).strip().lower().replace(".", "")
+        aliases = {
+            "india": "in",
+            "in_dc": "in",
+            "us_dc": "us",
+            "global": "us",
+            "eu_dc": "eu",
+            "europe": "eu",
+            "au_dc": "au",
+            "australia": "au",
+            "jp_dc": "jp",
+            "japan": "jp",
+        }
+        normalized = aliases.get(normalized, normalized)
+        if normalized in ZOHO_REGIONS:
+            return normalized
+
+    return _zoho_region_from_urls(
+        tuple(extra.get(key) for key in ("base_url", "api_base_url", "token_url", "authorize_url"))
+    ) or "in"
 
 
 # ── Spec dataclass ────────────────────────────────────────────────────────────
@@ -369,12 +410,12 @@ def _bootstrap() -> None:
                 ),
                 ProviderField(
                     key="region",
-                    label="Data Center",
+                    label="Zoho Region",
                     help_text=(
-                        "Pick the Zoho region your account belongs to. "
-                        "Defaults to India."
+                        "Optional override. When omitted, AgenticOrg "
+                        "infers the region from the Zoho API base URL."
                     ),
-                    required=True,
+                    required=False,
                     options=(
                         ("in", "India (zoho.in)"),
                         ("us", "United States / Global (zoho.com)"),

--- a/core/tasks/token_refresh.py
+++ b/core/tasks/token_refresh.py
@@ -64,6 +64,8 @@ async def _refresh_all() -> dict:
                 except Exception:
                     skipped += 1
                     continue
+            if isinstance(creds, dict):
+                creds = {**(cc.config or {}), **creds}
 
             refresh_token = creds.get("refresh_token", "")
             token_url = creds.get("token_url", "")
@@ -129,6 +131,7 @@ async def _refresh_all() -> dict:
                 fresh = row.scalar_one_or_none()
                 if fresh:
                     fresh.credentials_encrypted = {"_encrypted": encrypted}
+                    fresh.health_status = "healthy"
                     await write_session.commit()
 
             refreshed += 1
@@ -140,11 +143,29 @@ async def _refresh_all() -> dict:
             )
         except Exception as exc:
             failed += 1
+            try:
+                async with async_session_factory() as write_session:
+                    from sqlalchemy import select as _sel
+
+                    row = await write_session.execute(
+                        _sel(ConnectorConfig).where(ConnectorConfig.id == cc.id)
+                    )
+                    fresh = row.scalar_one_or_none()
+                    if fresh:
+                        fresh.health_status = "unhealthy"
+                        fresh.sync_error = type(exc).__name__
+                        await write_session.commit()
+            except Exception:
+                logger.warning(
+                    "token_refresh_health_status_update_failed",
+                    connector=cc.connector_name,
+                    tenant_id=str(cc.tenant_id),
+                )
             logger.warning(
                 "token_refresh_failed",
                 connector=cc.connector_name,
                 tenant_id=str(cc.tenant_id),
-                error=str(exc)[:200],
+                error_type=type(exc).__name__,
             )
 
     summary = {"refreshed": refreshed, "failed": failed, "skipped": skipped}

--- a/docs/bug_triage_skill.md
+++ b/docs/bug_triage_skill.md
@@ -199,6 +199,38 @@ Reference: `tests/regression/test_bugs_uday_14may2026.py`,
 
 ---
 
+## Rule 11 - Connector registration must not produce false healthy state
+
+Added 2026-05-15 after the Zoho Books registration reopen on Uday's
+CA-Firms sweep. The failure pattern was not just a button label. It was
+contract drift between the UI, provider registry, encrypted credential
+store, connector health checks, and agent activation.
+
+1. **Do not mark a connector healthy from static fields alone.** Client ID,
+   client secret, organization_id, or base URL formatting are not evidence
+   that runtime tool execution can call the provider. A connector is healthy
+   only after the same encrypted credential path used by runtime execution
+   passes the connector's health check.
+2. **No-redirect registration must require refreshable token material.**
+   If the UI is not opening a provider consent screen, the registration
+   payload must include refresh_token or an exchangeable one-time code.
+   Otherwise the correct verdict is "not ready", not "registered".
+3. **Agent activation is downstream of connector health.** Creating,
+   resuming, or promoting an active agent must fail closed when any linked
+   connector has missing encrypted credentials, non-configured status,
+   unhealthy/unknown health, or a missing refresh_token for refresh-token
+   providers such as Zoho Books.
+4. **When changing connector onboarding, update old tests that assert the
+   previous UI contract.** A stale Playwright test looking for an old
+   "Authorize Connector" button is a regression source, not harmless
+   historical coverage.
+
+Reference: `tests/regression/test_uday_15may_connector_registration.py`,
+`ui/e2e/qa-uday-15may2026.spec.ts`, `api/v1/connectors.py`,
+`api/v1/agents.py`, `core/tasks/token_refresh.py`.
+
+---
+
 ## Why this file lives in the repo, not my memory
 
 Memory files live under `~/.claude/` and don't ship with the product. This skill lives in `docs/` so:

--- a/docs/post_deploy_checklist_uday_2026-05-14.md
+++ b/docs/post_deploy_checklist_uday_2026-05-14.md
@@ -31,21 +31,23 @@ Run this AFTER `deploy-production` lands the new commit on
 ## 1) OAuth — Zoho Books India authorize URL
 
 - Open `https://agenticorg.ai/dashboard/connectors/new`.
-- Pick **Zoho Books** from the provider dropdown.
-- **Region** = `India (zoho.in)`.
-- Fill Client ID / Client Secret / Organization ID from the bug report.
-- Click **Authorize Connector**.
+- Confirm the provider dropdown contains only **Custom / Generic Connector**.
+- Set connector name to `zoho_books`.
+- Set Base URL to `https://www.zohoapis.in/books/v3`.
+- Set Auth Type to `OAuth2`.
+- Fill Client ID / Client Secret.
+- Add `organization_id` and `refresh_token` in Extra config JSON.
+- Click **Register Connector**.
 
 Expected:
-- Browser navigates to `https://accounts.zoho.in/oauth/v2/auth?...`
-  (NOT `accounts.zoho.com`).
-- The `redirect_uri` query param starts with `https://`.
-- `access_type=offline` and `prompt=consent` are present.
-- Zoho prompts you to consent (no "Invalid Redirect Uri" error page).
+- Browser stays inside AgenticOrg; no Zoho OAuth page is opened.
+- The connector is saved with encrypted credentials.
+- The region is inferred as India from the base URL.
+- Agent activation is blocked unless the connector health status is `healthy`.
 
-If "Invalid Redirect Uri" appears: the env var hasn't rolled out OR the
-Zoho Developer Console is missing the https value. Re-run step 1 of
-pre-requisites and confirm step 2.
+If registration returns `zoho_token_material_required`, the payload is
+missing refreshable token material. Do not mark the connector fixed or
+healthy from Client ID / Client Secret alone.
 
 ## 2) OAuth — refresh_token issuance
 

--- a/tests/regression/test_bugs_uday_14may2026.py
+++ b/tests/regression/test_bugs_uday_14may2026.py
@@ -372,6 +372,17 @@ def test_zoho_books_lists_all_supported_regions() -> None:
     region_field = next(
         f for f in schema["user_fields"] if f["key"] == "region"
     )
-    assert region_field["required"] is True
+    assert region_field["required"] is False
     option_keys = {opt["value"] for opt in region_field["options"]}
     assert {"us", "in", "eu", "au", "jp"} <= option_keys
+
+
+def test_zoho_region_is_inferred_from_base_url_without_data_center() -> None:
+    from core.connectors.provider_registry import get_provider
+
+    spec = get_provider("zoho_books")
+    assert spec is not None
+
+    assert spec.resolve_region({"base_url": "https://www.zohoapis.in/books/v3"}) == "in"
+    assert spec.resolve_region({"base_url": "https://www.zohoapis.com/books/v3"}) == "us"
+    assert spec.resolve_region({"base_url": "https://www.zohoapis.eu/books/v3"}) == "eu"

--- a/tests/regression/test_uday_15may_connector_registration.py
+++ b/tests/regression/test_uday_15may_connector_registration.py
@@ -1,0 +1,196 @@
+"""Regression pins for Uday CA Firms 2026-05-15 connector reopening."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_zoho_region_infers_from_base_url_without_data_center() -> None:
+    from api.v1.connectors import _infer_zoho_region
+
+    assert _infer_zoho_region("https://www.zohoapis.in/books/v3", {}) == "in"
+    assert _infer_zoho_region("https://www.zohoapis.com/books/v3", {}) == "us"
+    assert _infer_zoho_region("https://www.zohoapis.eu/books/v3", {}) == "eu"
+    assert _infer_zoho_region("https://www.zohoapis.com.attacker.test/books/v3", {}) == "in"
+
+
+def test_zoho_registration_ignores_user_supplied_token_endpoint() -> None:
+    from api.v1.connectors import _normalise_connector_base_url, _prepare_zoho_books_registration
+    from core.schemas.api import ConnectorCreate
+
+    body = ConnectorCreate(
+        name="zoho_books",
+        category="finance",
+        base_url="https://www.zohoapis.in/books/v3",
+        auth_type="oauth2",
+        auth_config={
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "organization_id": "60069102279",
+            "refresh_token": "refresh-token",
+            "token_url": "https://accounts.zoho.com.attacker.test/oauth/v2/token",
+        },
+    )
+
+    _, secret_fields, non_secret_config = _prepare_zoho_books_registration(
+        body,
+        _normalise_connector_base_url(body.name, body.base_url),
+    )
+
+    assert secret_fields["token_url"] == "https://accounts.zoho.in/oauth/v2/token"
+    assert non_secret_config["token_url"] == "https://accounts.zoho.in/oauth/v2/token"
+
+
+def test_zoho_normalisation_rejects_lookalike_hosts() -> None:
+    from api.v1.connectors import _normalise_connector_base_url
+
+    assert (
+        _normalise_connector_base_url(
+            "zoho_books",
+            "https://www.zohoapis.com.attacker.test/books/v3",
+        )
+        == "https://www.zohoapis.com/books/v3"
+    )
+
+
+def test_zoho_runtime_uses_fixed_region_endpoints_not_user_token_url() -> None:
+    from connectors.finance.zoho_books import ZohoBooksConnector
+
+    connector = ZohoBooksConnector(
+        {
+            "base_url": "https://www.zohoapis.in/books/v3",
+            "token_url": "https://accounts.zoho.com.attacker.test/oauth/v2/token",
+        }
+    )
+
+    assert connector.base_url == "https://books.zoho.in/api/v3"
+    assert connector.config["token_url"] == "https://accounts.zoho.in/oauth/v2/token"
+
+
+def test_zoho_registration_does_not_require_data_center_field() -> None:
+    from api.v1.connectors import _normalise_connector_base_url, _prepare_zoho_books_registration
+    from core.schemas.api import ConnectorCreate
+
+    body = ConnectorCreate(
+        name="zoho_books",
+        category="finance",
+        base_url="https://www.zohoapis.in/books/v3",
+        auth_type="oauth2",
+        auth_config={
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "organization_id": "60069102279",
+            "refresh_token": "refresh-token",
+        },
+    )
+
+    _, secret_fields, non_secret_config = _prepare_zoho_books_registration(
+        body,
+        _normalise_connector_base_url(body.name, body.base_url),
+    )
+
+    assert secret_fields["region"] == "in"
+    assert secret_fields["token_url"] == "https://accounts.zoho.in/oauth/v2/token"
+    assert non_secret_config["oauth_refresh_token_present"] is True
+
+
+def test_zoho_registration_refuses_false_healthy_without_token_material() -> None:
+    from api.v1.connectors import _normalise_connector_base_url, _prepare_zoho_books_registration
+    from core.schemas.api import ConnectorCreate
+
+    body = ConnectorCreate(
+        name="zoho_books",
+        category="finance",
+        base_url="https://www.zohoapis.in/books/v3",
+        auth_type="oauth2",
+        auth_config={
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "organization_id": "60069102279",
+        },
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        _prepare_zoho_books_registration(
+            body,
+            _normalise_connector_base_url(body.name, body.base_url),
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["error"] == "zoho_token_material_required"
+    assert "Data Center" not in exc.value.detail["message"]
+
+
+def test_connector_list_reports_encrypted_vault_credentials() -> None:
+    from api.v1.connectors import _connector_to_dict
+    from core.models.connector import Connector
+
+    connector = Connector(
+        tenant_id="11111111-1111-1111-1111-111111111111",
+        name="zoho_books",
+        category="finance",
+        base_url="https://www.zohoapis.in/books/v3",
+        auth_type="oauth2",
+        auth_config={},
+        status="active",
+    )
+
+    assert _connector_to_dict(connector, has_encrypted_credentials=True)["has_credentials"] is True
+
+
+def test_connector_create_ui_has_no_managed_provider_or_authorize_button() -> None:
+    src = (ROOT / "ui" / "src" / "pages" / "ConnectorCreate.tsx").read_text(encoding="utf-8")
+
+    assert "Custom / Generic Connector" in src
+    assert "Authorize Connector" not in src
+    assert "/connectors/oauth/initiate" not in src
+    assert "Register Connector" in src
+
+
+def test_connector_detail_does_not_offer_zoho_oauth_redirect() -> None:
+    src = (ROOT / "ui" / "src" / "pages" / "ConnectorDetail.tsx").read_text(encoding="utf-8")
+
+    assert 'const isZohoBooks = connector?.name === "zoho_books"' in src
+    assert 'connector.auth_type === "oauth2" && !isZohoBooks' in src
+    assert "without opening Zoho OAuth" in src
+
+
+def test_provider_registry_zoho_region_is_optional_not_data_center() -> None:
+    from core.connectors.provider_registry import get_provider
+
+    provider = get_provider("zoho_books")
+    assert provider is not None
+    region_field = next(field for field in provider.user_fields if field.key == "region")
+    assert region_field.required is False
+    assert region_field.label == "Zoho Region"
+    assert provider.resolve_region({"base_url": "https://www.zohoapis.com.attacker.test/books/v3"}) == "in"
+
+
+def test_health_checks_update_connector_config_health_gate_source() -> None:
+    src = (ROOT / "api" / "v1" / "connectors.py").read_text(encoding="utf-8")
+
+    assert "cc.health_status = str(health.get(\"status\") or \"unknown\")" in src
+    assert 'cc.health_status = "unhealthy"' in src
+    assert 'cc.sync_error = "missing_encrypted_credentials"' in src
+
+
+def test_zoho_update_revalidates_before_healthy_status() -> None:
+    src = (ROOT / "api" / "v1" / "connectors.py").read_text(encoding="utf-8")
+
+    assert "_validate_zoho_books_readiness(merged_secrets)" in src
+    assert 'cc.health_status = (\n                    "healthy"' in src
+    assert 'cc.sync_error = "credential_surface_changed"' in src
+
+
+def test_agent_activation_uses_connector_readiness_gate() -> None:
+    src = (ROOT / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+
+    assert "async def _assert_connectors_ready_for_activation" in src
+    assert src.count("_assert_connectors_ready_for_activation(") >= 4
+    assert "connector_health_not_healthy" in src
+    assert "missing_refresh_token" in src

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -425,6 +425,8 @@ def _make_connector(**overrides):
     conn.description = overrides.get("description", "Slack connector")
     conn.base_url = overrides.get("base_url", "https://slack.com/api")
     conn.auth_type = overrides.get("auth_type", "oauth2")
+    conn.auth_config = overrides.get("auth_config", None)
+    conn.secret_ref = overrides.get("secret_ref", None)
     conn.tool_functions = overrides.get("tool_functions", [])
     conn.data_schema_ref = overrides.get("data_schema_ref", None)
     conn.rate_limit_rpm = overrides.get("rate_limit_rpm", 60)
@@ -470,10 +472,11 @@ class TestConnectorsEndpoints:
         from api.v1.connectors import list_connectors
 
         connectors = [_make_connector(name="Slack"), _make_connector(name="Jira")]
-        # First execute returns count, second returns list
+        # Count, connector page, then encrypted credential names.
         mock_session.execute.side_effect = [
             _make_result(scalar_value=2),
             _make_result(scalars_list=connectors),
+            _make_result(scalars_list=["Slack"]),
         ]
 
         ctx = _patch_tenant_session("connectors", mock_session)
@@ -485,6 +488,8 @@ class TestConnectorsEndpoints:
         assert resp["total"] == 2
         assert len(resp["items"]) == 2
         assert resp["page"] == 1
+        assert resp["items"][0]["has_credentials"] is True
+        assert resp["items"][1]["has_credentials"] is False
 
     @pytest.mark.asyncio
     async def test_list_connectors_empty(self, tenant_id, mock_session):
@@ -512,6 +517,7 @@ class TestConnectorsEndpoints:
         mock_session.execute.side_effect = [
             _make_result(scalar_value=1),
             _make_result(scalars_list=connectors),
+            _make_result(scalars_list=[]),
         ]
 
         ctx = _patch_tenant_session("connectors", mock_session)
@@ -529,6 +535,7 @@ class TestConnectorsEndpoints:
         mock_session.execute.side_effect = [
             _make_result(scalar_value=100),
             _make_result(scalars_list=[_make_connector()]),
+            _make_result(scalars_list=[]),
         ]
 
         ctx = _patch_tenant_session("connectors", mock_session)

--- a/ui/e2e/qa-ramesh-aishwarya-may04.spec.ts
+++ b/ui/e2e/qa-ramesh-aishwarya-may04.spec.ts
@@ -65,7 +65,7 @@ test("Partner dashboard labels overdue values as filings and reflects inactive c
   await expect(page.getByText("Overdue Filings").first()).toBeVisible();
   await expect(page.getByText("3 filings")).toBeVisible();
   await expect(page.getByText("Archived CA Client")).toBeVisible();
-  await expect(page.getByText("Inactive")).toBeVisible();
+  await expect(page.getByText("Inactive", { exact: true }).first()).toBeVisible();
   await expect(page.getByText("Avg Health Score")).toBeVisible();
   await expect(page.getByText("75%").first()).toBeVisible();
   await expect(page.getByText("Overdue (score < 50)")).toHaveCount(0);
@@ -80,44 +80,47 @@ test("Hindi language switch reaches partner dashboard metric labels", async ({ p
 
   await expect(page.getByRole("heading", { name: "पार्टनर डैशबोर्ड" })).toBeVisible();
   await expect(page.getByText("अतिदेय फाइलिंग").first()).toBeVisible();
-  await expect(page.getByText("निष्क्रिय")).toBeVisible();
+  await expect(page.getByText("निष्क्रिय", { exact: true }).first()).toBeVisible();
 });
 
-test("OAuth2 connector setup starts backend authorization and never asks for refresh-token paste", async ({ page }) => {
+test("OAuth2 connector setup registers internally without external authorization", async ({ page }) => {
   await mockAuthenticatedApp(page);
-  await page.route("https://accounts.google.com/**", async (route) => {
-    await route.fulfill({ status: 200, contentType: "text/html", body: "<h1>Google OAuth</h1>" });
-  });
-  let initiateBody: any = null;
-  await page.route("**/api/v1/connectors/oauth/initiate", async (route) => {
-    initiateBody = route.request().postDataJSON();
+  let createBody: any = null;
+  await page.route("**/api/v1/connectors", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+    createBody = route.request().postDataJSON();
     await route.fulfill({
-      status: 200,
+      status: 201,
       contentType: "application/json",
       body: JSON.stringify({
-        authorization_url: "https://accounts.google.com/o/oauth2/v2/auth?state=opaque-state",
-        state: "opaque-state",
-        redirect_uri: "http://localhost:4173/api/v1/oauth/callback",
-        expires_in: 600,
+        id: "connector-1",
+        connector_id: "connector-1",
+        name: "gmail",
+        status: "active",
       }),
     });
   });
 
   await page.goto("/dashboard/connectors/new");
   await page.locator("select").filter({ has: page.locator('option[value="oauth2"]') }).selectOption("oauth2");
-  await page.getByPlaceholder("e.g. Slack, SAP S/4HANA").fill("gmail");
+  await page.getByPlaceholder(/zoho_books/).fill("gmail");
   await page.getByPlaceholder("Enter client ID").fill("client-id");
   await page.getByPlaceholder("Enter client secret").fill("client-secret");
 
   await expect(page.getByPlaceholder(/refresh token/i)).toHaveCount(0);
-  await page.getByRole("button", { name: "Authorize Connector" }).click();
-  await expect(page.getByRole("heading", { name: "Google OAuth" })).toBeVisible();
+  await page.getByRole("button", { name: "Register Connector" }).click();
 
-  expect(initiateBody).toMatchObject({
-    connector_name: "gmail",
-    client_id: "client-id",
-    client_secret: "client-secret",
+  expect(createBody).toMatchObject({
+    name: "gmail",
+    auth_type: "oauth2",
     category: "finance",
+    auth_config: {
+      client_id: "client-id",
+      client_secret: "client-secret",
+    },
   });
 });
 

--- a/ui/e2e/qa-uday-14may2026.spec.ts
+++ b/ui/e2e/qa-uday-14may2026.spec.ts
@@ -265,7 +265,7 @@ test.describe("Uday CA Firms 2026-05-14 — Zoho Books OAuth onboarding", () => 
     // main bug-1+2 test above is what gates the verdict.
   });
 
-  test("Connector wizard renders provider-specific fields, not the raw JSON blob", async ({
+  test("Connector wizard exposes only generic provider registration", async ({
     page,
     request,
   }) => {
@@ -279,18 +279,15 @@ test.describe("Uday CA Firms 2026-05-14 — Zoho Books OAuth onboarding", () => 
       waitUntil: "domcontentloaded",
     });
 
-    // Provider dropdown must list Zoho Books.
+    // May-15 reopening: the create page must not list managed providers
+    // or send admins through OAuth redirects. Backend provider support
+    // stays available via API, but the UI exposes only generic setup.
     const providerSelect = page.getByTestId("provider-select");
     await expect(providerSelect).toBeVisible({ timeout: 10_000 });
-    await providerSelect.selectOption("zoho_books");
-
-    // The new dynamic form must render:
-    //   region picker (with India option), organization_id field,
-    //   client_id + client_secret. The old JSON-blob form should be gone.
-    await expect(page.getByTestId("field-region")).toBeVisible();
-    await expect(page.getByTestId("field-organization_id")).toBeVisible();
-    await expect(page.getByTestId("field-client_id")).toBeVisible();
-    await expect(page.getByTestId("field-client_secret")).toBeVisible();
-    await expect(page.locator("text=Extra config")).toHaveCount(0);
+    await expect(providerSelect.locator("option")).toHaveCount(1);
+    await expect(providerSelect.locator("option")).toHaveText("Custom / Generic Connector");
+    await expect(page.getByText("Extra config")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Register Connector" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Authorize Connector" })).toHaveCount(0);
   });
 });

--- a/ui/e2e/qa-uday-15may2026.spec.ts
+++ b/ui/e2e/qa-uday-15may2026.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "@playwright/test";
+
+const user = {
+  email: "uday.chauhan@edumatica.io",
+  name: "Uday Chauhan",
+  role: "admin",
+  domain: "finance",
+  tenant_id: "11111111-1111-1111-1111-111111111111",
+  onboarding_complete: true,
+};
+
+test("Uday 2026-05-15: Zoho Books registers through generic form without OAuth redirect", async ({
+  page,
+}) => {
+  let createBody: any = null;
+  let oauthInitiateCalled = false;
+  let externalZohoOpened = false;
+
+  await page.route("**/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(user),
+    });
+  });
+  await page.route("**/api/v1/connectors/oauth/initiate", async (route) => {
+    oauthInitiateCalled = true;
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "oauth/initiate must not be called" }),
+    });
+  });
+  await page.route("**accounts.zoho**", async (route) => {
+    externalZohoOpened = true;
+    await route.abort();
+  });
+  await page.route("**/api/v1/connectors", async (route) => {
+    if (route.request().method() === "POST") {
+      createBody = route.request().postDataJSON();
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "connector-zoho",
+          connector_id: "connector-zoho",
+          name: "zoho_books",
+          category: "finance",
+          auth_type: "oauth2",
+          status: "active",
+          has_credentials: true,
+        }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ items: [], total: 0, page: 1, per_page: 20 }),
+    });
+  });
+
+  await page.goto("/dashboard/connectors/new");
+
+  const providerSelect = page.getByTestId("provider-select");
+  await expect(providerSelect).toBeVisible();
+  await expect(providerSelect.locator("option")).toHaveCount(1);
+  await expect(providerSelect.locator("option")).toHaveText(
+    "Custom / Generic Connector",
+  );
+
+  await page.getByPlaceholder(/zoho_books/).fill("zoho_books");
+  await page.getByPlaceholder("https://api.example.com").fill(
+    "https://www.zohoapis.in/books/v3",
+  );
+  await page
+    .locator("select")
+    .filter({ has: page.locator('option[value="oauth2"]') })
+    .selectOption("oauth2");
+  await page.getByPlaceholder("Enter client ID").fill("client-id");
+  await page.getByPlaceholder("Enter client secret").fill("client-secret");
+  await page.locator("textarea").fill(
+    JSON.stringify(
+      {
+        organization_id: "60069102279",
+        refresh_token: "refresh-token",
+      },
+      null,
+      2,
+    ),
+  );
+
+  await expect(
+    page.getByRole("button", { name: "Authorize Connector" }),
+  ).toHaveCount(0);
+  await page.getByRole("button", { name: "Register Connector" }).click();
+
+  await expect(page).toHaveURL(/\/dashboard\/connectors$/);
+  expect(oauthInitiateCalled).toBe(false);
+  expect(externalZohoOpened).toBe(false);
+  expect(createBody).toMatchObject({
+    name: "zoho_books",
+    category: "finance",
+    base_url: "https://www.zohoapis.in/books/v3",
+    auth_type: "oauth2",
+    auth_config: {
+      client_id: "client-id",
+      client_secret: "client-secret",
+      organization_id: "60069102279",
+      refresh_token: "refresh-token",
+    },
+  });
+  expect(createBody.auth_config).not.toHaveProperty("region");
+  expect(createBody.auth_config).not.toHaveProperty("data_center");
+});

--- a/ui/src/pages/ConnectorCreate.tsx
+++ b/ui/src/pages/ConnectorCreate.tsx
@@ -1,45 +1,12 @@
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import api, { extractApiError } from "@/lib/api";
 import { AUTH_TYPES, AUTH_FIELD_HINTS } from "@/lib/connector-constants";
 
-// Uday 2026-05-14 — connector creation is now driven by the backend
-// provider registry (``GET /connectors/oauth/providers``). The UI no
-// longer hardcodes OAuth field lists per provider: the registry tells us
-// which fields each provider needs (region for Zoho, FIU ID for Banking
-// AA, GSTIN for GSTN, etc.). Generic ad-hoc connectors still use the
-// fallback ``api_key`` / ``basic`` flows from the AUTH_TYPES list.
-
 const CATEGORIES = ["finance", "hr", "marketing", "ops", "comms"];
 
-type ProviderFieldOption = { value: string; label: string };
-
-interface ProviderField {
-  key: string;
-  label: string;
-  placeholder: string;
-  help_text: string;
-  secret: boolean;
-  required: boolean;
-  options: ProviderFieldOption[];
-}
-
-interface ProviderSchema {
-  connector_name: string;
-  display_name: string;
-  category: string;
-  auth_flow: string;
-  scopes: string[];
-  requires_organization_id: boolean;
-  supports_refresh_token: boolean;
-  documentation_url: string;
-  regions: string[];
-  user_fields: ProviderField[];
-}
-
-/** Fallback field lists for connectors NOT in the provider registry. */
 const FALLBACK_AUTH_FIELDS: Record<string, { key: string; label: string; placeholder: string }[]> = {
   api_key: [{ key: "api_key", label: "API Key", placeholder: "Enter API key" }],
   oauth2: [
@@ -73,53 +40,12 @@ export default function ConnectorCreate() {
   const [extraConfigError, setExtraConfigError] = useState("");
   const [rateLimitRpm, setRateLimitRpm] = useState(100);
   const [submitting, setSubmitting] = useState(false);
-  const [oauthStarting, setOauthStarting] = useState(false);
   const [error, setError] = useState("");
-
-  // Provider registry catalog.
-  const [providers, setProviders] = useState<ProviderSchema[]>([]);
-  const [providerKey, setProviderKey] = useState<string>("custom");
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const { data } = await api.get<ProviderSchema[]>("/connectors/oauth/providers");
-        if (!cancelled) setProviders(Array.isArray(data) ? data : []);
-      } catch {
-        // Non-fatal — UI gracefully falls back to the manual flow.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const selectedProvider: ProviderSchema | null = useMemo(() => {
-    if (providerKey === "custom") return null;
-    return providers.find((p) => p.connector_name === providerKey) ?? null;
-  }, [providerKey, providers]);
-
-  function handleProviderSelect(key: string) {
-    setProviderKey(key);
-    setAuthFields({});
-    setError("");
-    if (key === "custom") return;
-    const spec = providers.find((p) => p.connector_name === key);
-    if (!spec) return;
-    setName(spec.connector_name);
-    setCategory(spec.category);
-    // Pre-select the right auth_type so the eventual /connectors POST
-    // (for manual flows) is consistent.
-    if (spec.auth_flow === "oauth2_authorization_code") setAuthType("oauth2");
-    else if (spec.auth_flow === "api_key") setAuthType("api_key");
-    else if (spec.auth_flow === "client_credentials") setAuthType("oauth2");
-    else setAuthType("none");
-  }
 
   function handleAuthTypeChange(newType: string) {
     setAuthType(newType);
     setAuthFields({});
+    setError("");
   }
 
   function setAuthField(key: string, value: string) {
@@ -136,108 +62,37 @@ export default function ConnectorCreate() {
 
   function parseExtraConfig(): Record<string, unknown> | null {
     setExtraConfigError("");
-    if (extraConfig.trim()) {
-      try {
-        const parsed = JSON.parse(extraConfig);
-        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-          setExtraConfigError("Extra config must be a JSON object.");
-          return null;
-        }
-        return parsed as Record<string, unknown>;
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : "Invalid JSON";
-        setExtraConfigError(`Invalid JSON: ${msg}`);
+    if (!extraConfig.trim()) return {};
+    try {
+      const parsed = JSON.parse(extraConfig);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        setExtraConfigError("Extra config must be a JSON object.");
         return null;
       }
-    }
-    return {};
-  }
-
-  function validateProviderFields(spec: ProviderSchema): string | null {
-    for (const f of spec.user_fields) {
-      if (!f.required) continue;
-      const v = (authFields[f.key] || "").trim();
-      if (!v) return `${f.label} is required.`;
-    }
-    return null;
-  }
-
-  async function startOAuthAuthorization() {
-    if (selectedProvider) {
-      const validationError = validateProviderFields(selectedProvider);
-      if (validationError) {
-        setError(validationError);
-        return;
-      }
-    } else {
-      if (!name.trim()) {
-        setError("Connector name is required");
-        return;
-      }
-    }
-    const extraParsed = parseExtraConfig();
-    if (extraParsed === null) return;
-
-    const userFields: Record<string, string> = {};
-    if (selectedProvider) {
-      for (const f of selectedProvider.user_fields) {
-        const value = (authFields[f.key] || "").trim();
-        if (value) userFields[f.key] = value;
-      }
-    } else {
-      // Legacy path — generic OAuth2 form.
-      const clientId = (authFields.client_id || "").trim();
-      const clientSecret = (authFields.client_secret || "").trim();
-      if (!clientId || !clientSecret) {
-        setError("Client ID and Client Secret are required before authorization.");
-        return;
-      }
-      userFields.client_id = clientId;
-      userFields.client_secret = clientSecret;
-    }
-
-    setOauthStarting(true);
-    setError("");
-    try {
-      const { data } = await api.post("/connectors/oauth/initiate", {
-        connector_name: (selectedProvider?.connector_name || name).trim(),
-        user_fields: userFields,
-        // Legacy shape — backend still accepts these for older callers.
-        client_id: userFields.client_id,
-        client_secret: userFields.client_secret,
-        base_url: baseUrl.trim() || undefined,
-        category: selectedProvider?.category || category,
-        extra_config: extraParsed,
-      });
-      if (!data?.authorization_url) throw new Error("Missing authorization URL");
-      window.location.assign(String(data.authorization_url));
-    } catch (e: unknown) {
-      setError(extractApiError(e, "Failed to start OAuth authorization."));
-    } finally {
-      setOauthStarting(false);
+      return parsed as Record<string, unknown>;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Invalid JSON";
+      setExtraConfigError(`Invalid JSON: ${msg}`);
+      return null;
     }
   }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (selectedProvider?.auth_flow === "oauth2_authorization_code" || (!selectedProvider && authType === "oauth2")) {
-      await startOAuthAuthorization();
-      return;
-    }
     if (!name.trim()) {
       setError("Connector name is required");
       return;
     }
     const extraParsed = parseExtraConfig();
     if (extraParsed === null) return;
+
     setSubmitting(true);
     setError("");
     try {
-      // Non-OAuth providers persist directly via /connectors.
       const authConfig = { ...buildMultiAuthConfig(), ...extraParsed } as Record<string, unknown>;
       await api.post("/connectors", {
         name: name.trim(),
-        category: selectedProvider?.category || category,
+        category,
         base_url: baseUrl.trim() || undefined,
         auth_type: authType,
         auth_config: Object.keys(authConfig).length > 0 ? authConfig : undefined,
@@ -252,55 +107,43 @@ export default function ConnectorCreate() {
     }
   }
 
-  const renderFallbackFields = !selectedProvider;
-  const provider = selectedProvider;
-
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <h2 className="text-2xl font-bold">Register Connector</h2>
-        <Button variant="outline" onClick={() => navigate("/dashboard/connectors")}>Back to Connectors</Button>
+        <Button variant="outline" onClick={() => navigate("/dashboard/connectors")}>
+          Back to Connectors
+        </Button>
       </div>
 
       <Card>
-        <CardHeader><CardTitle>Connector Configuration</CardTitle></CardHeader>
+        <CardHeader>
+          <CardTitle>Connector Configuration</CardTitle>
+        </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-4">
-            {providers.length > 0 && (
-              <div>
-                <label className="text-sm font-medium">Provider</label>
-                <select
-                  value={providerKey}
-                  onChange={(e) => handleProviderSelect(e.target.value)}
-                  className="border rounded px-3 py-2 text-sm w-full mt-1"
-                  data-testid="provider-select"
-                >
-                  <option value="custom">Custom / generic connector</option>
-                  {providers.map((p) => (
-                    <option key={p.connector_name} value={p.connector_name}>
-                      {p.display_name} ({p.auth_flow.replace(/_/g, " ")})
-                    </option>
-                  ))}
-                </select>
-                <p className="text-xs text-muted-foreground mt-1">
-                  Pick a managed provider to use AgenticOrg's automated OAuth flow and
-                  provider-specific fields. Pick "Custom" for a generic API connector.
-                </p>
-              </div>
-            )}
+            <div>
+              <label className="text-sm font-medium">Provider</label>
+              <select
+                value="custom"
+                disabled
+                className="border rounded px-3 py-2 text-sm w-full mt-1 bg-muted"
+                data-testid="provider-select"
+              >
+                <option value="custom">Custom / Generic Connector</option>
+              </select>
+            </div>
 
-            {renderFallbackFields && (
-              <div>
-                <label className="text-sm font-medium">Connector Name *</label>
-                <input
-                  type="text"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  placeholder="e.g. Slack, SAP S/4HANA"
-                  className="border rounded px-3 py-2 text-sm w-full mt-1"
-                />
-              </div>
-            )}
+            <div>
+              <label className="text-sm font-medium">Connector Name *</label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. zoho_books, Slack, SAP S/4HANA"
+                className="border rounded px-3 py-2 text-sm w-full mt-1"
+              />
+            </div>
 
             <div>
               <label className="text-sm font-medium">Base URL</label>
@@ -308,13 +151,11 @@ export default function ConnectorCreate() {
                 type="url"
                 value={baseUrl}
                 onChange={(e) => setBaseUrl(e.target.value)}
-                placeholder={provider ? "Defaults to the provider's region API base" : "https://api.example.com"}
+                placeholder="https://api.example.com"
                 className="border rounded px-3 py-2 text-sm w-full mt-1"
               />
               <p className="text-xs text-muted-foreground mt-1">
-                {provider
-                  ? "Optional — the provider registry already knows the right base URL for the selected region."
-                  : "The API endpoint for this connector (e.g., https://slack.com/api)"}
+                The API endpoint for this connector. Zoho Books regions are inferred from this URL.
               </p>
             </div>
 
@@ -322,22 +163,31 @@ export default function ConnectorCreate() {
               <div>
                 <label className="text-sm font-medium">Category</label>
                 <select
-                  value={provider?.category || category}
+                  value={category}
                   onChange={(e) => setCategory(e.target.value)}
-                  disabled={Boolean(provider)}
                   className="border rounded px-3 py-2 text-sm w-full mt-1"
                 >
-                  {CATEGORIES.map((c) => <option key={c} value={c}>{c.charAt(0).toUpperCase() + c.slice(1)}</option>)}
+                  {CATEGORIES.map((c) => (
+                    <option key={c} value={c}>
+                      {c.charAt(0).toUpperCase() + c.slice(1)}
+                    </option>
+                  ))}
                 </select>
               </div>
-              {renderFallbackFields && (
-                <div>
-                  <label className="text-sm font-medium">Auth Type</label>
-                  <select value={authType} onChange={(e) => handleAuthTypeChange(e.target.value)} className="border rounded px-3 py-2 text-sm w-full mt-1">
-                    {AUTH_TYPES.map((a) => <option key={a} value={a}>{a.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}</option>)}
-                  </select>
-                </div>
-              )}
+              <div>
+                <label className="text-sm font-medium">Auth Type</label>
+                <select
+                  value={authType}
+                  onChange={(e) => handleAuthTypeChange(e.target.value)}
+                  className="border rounded px-3 py-2 text-sm w-full mt-1"
+                >
+                  {AUTH_TYPES.map((a) => (
+                    <option key={a} value={a}>
+                      {a.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
+                    </option>
+                  ))}
+                </select>
+              </div>
               <div>
                 <label className="text-sm font-medium">Rate Limit (RPM)</label>
                 <input
@@ -353,128 +203,66 @@ export default function ConnectorCreate() {
 
             <div className="border rounded-lg p-4 space-y-3 bg-muted/30">
               <p className="text-sm font-medium">Authentication</p>
-              {provider ? (
+              <p className="text-xs text-muted-foreground">
+                {AUTH_FIELD_HINTS[authType] || "Configure authentication credentials"}
+              </p>
+              {authType === "oauth2" && (
+                <p className="text-xs text-muted-foreground">
+                  OAuth2 connectors are registered server-side. For Zoho Books, include organization_id and
+                  refresh_token in Extra config so the backend can validate readiness without a browser redirect.
+                </p>
+              )}
+              {authType !== "none" && (
                 <>
-                  <p className="text-xs text-muted-foreground">
-                    {provider.display_name} uses{" "}
-                    <code>{provider.auth_flow.replace(/_/g, " ")}</code>.
-                    {provider.documentation_url && (
-                      <>
-                        {" "}
-                        <a
-                          href={provider.documentation_url}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="underline"
-                        >
-                          Provider docs
-                        </a>
-                      </>
-                    )}
-                    .
-                  </p>
-                  {provider.user_fields.map((f) => (
-                    <div key={f.key}>
-                      <label className="text-sm font-medium" htmlFor={`pf-${f.key}`}>
-                        {f.label}
-                        {f.required ? " *" : ""}
-                      </label>
-                      {f.options.length > 0 ? (
-                        <select
-                          id={`pf-${f.key}`}
-                          value={authFields[f.key] || ""}
-                          onChange={(e) => setAuthField(f.key, e.target.value)}
-                          className="border rounded px-3 py-2 text-sm w-full mt-1"
-                          data-testid={`field-${f.key}`}
-                        >
-                          <option value="">{f.placeholder || "Select…"}</option>
-                          {f.options.map((opt) => (
-                            <option key={opt.value} value={opt.value}>
-                              {opt.label}
-                            </option>
-                          ))}
-                        </select>
-                      ) : (
-                        <input
-                          id={`pf-${f.key}`}
-                          type={f.secret ? "password" : "text"}
-                          value={authFields[f.key] || ""}
-                          onChange={(e) => setAuthField(f.key, e.target.value)}
-                          placeholder={f.placeholder}
-                          className="border rounded px-3 py-2 text-sm w-full mt-1"
-                          data-testid={`field-${f.key}`}
-                          autoComplete="off"
-                        />
-                      )}
-                      {f.help_text && (
-                        <p className="text-xs text-muted-foreground mt-1">{f.help_text}</p>
-                      )}
+                  {(FALLBACK_AUTH_FIELDS[authType] || []).map((field) => (
+                    <div key={field.key}>
+                      <label className="text-sm font-medium">{field.label}</label>
+                      <input
+                        type="password"
+                        value={authFields[field.key] || ""}
+                        onChange={(e) => setAuthField(field.key, e.target.value)}
+                        placeholder={field.placeholder}
+                        className="border rounded px-3 py-2 text-sm w-full mt-1"
+                      />
                     </div>
                   ))}
-                </>
-              ) : (
-                <>
-                  <p className="text-xs text-muted-foreground">{AUTH_FIELD_HINTS[authType] || "Configure authentication credentials"}</p>
-                  {authType === "oauth2" && (
-                    <p className="text-xs text-muted-foreground">
-                      Enter the OAuth app credentials, then authorize in the provider consent screen.
-                      AgenticOrg will exchange the code server-side and store the refresh token encrypted.
-                    </p>
-                  )}
-                  {authType !== "none" && (
-                    <>
-                      {(FALLBACK_AUTH_FIELDS[authType] || []).map((field) => (
-                        <div key={field.key}>
-                          <label className="text-sm font-medium">{field.label}</label>
-                          <input
-                            type="password"
-                            value={authFields[field.key] || ""}
-                            onChange={(e) => setAuthField(field.key, e.target.value)}
-                            placeholder={field.placeholder}
-                            className="border rounded px-3 py-2 text-sm w-full mt-1"
-                          />
-                        </div>
-                      ))}
-                      <div>
-                        <label className="text-sm font-medium">Secret Reference (optional)</label>
-                        <input
-                          type="text"
-                          value={secretRef}
-                          onChange={(e) => setSecretRef(e.target.value)}
-                          placeholder="e.g. gcp://projects/my-project/secrets/my-secret/versions/latest"
-                          className="border rounded px-3 py-2 text-sm w-full mt-1"
-                        />
-                        <p className="text-xs text-muted-foreground mt-1">GCP Secret Manager URI. Used at runtime instead of inline credentials.</p>
-                      </div>
-                    </>
-                  )}
                   <div>
-                    <label className="text-sm font-medium">Extra config (optional, JSON)</label>
-                    <textarea
-                      value={extraConfig}
-                      onChange={(e) => setExtraConfig(e.target.value)}
-                      placeholder={'{\n  "organization_id": "12345678"\n}'}
-                      rows={3}
-                      className="border rounded px-3 py-2 text-sm w-full mt-1 font-mono"
+                    <label className="text-sm font-medium">Secret Reference (optional)</label>
+                    <input
+                      type="text"
+                      value={secretRef}
+                      onChange={(e) => setSecretRef(e.target.value)}
+                      placeholder="e.g. gcp://projects/my-project/secrets/my-secret/versions/latest"
+                      className="border rounded px-3 py-2 text-sm w-full mt-1"
                     />
-                    <p className="text-xs text-muted-foreground mt-1">Connector-specific parameters (e.g. Zoho Books <code>organization_id</code>, NetSuite <code>account</code>, Shopify <code>shop</code>).</p>
-                    {extraConfigError && <p className="text-xs text-red-600 mt-1">{extraConfigError}</p>}
                   </div>
                 </>
               )}
+              <div>
+                <label className="text-sm font-medium">Extra config (optional, JSON)</label>
+                <textarea
+                  value={extraConfig}
+                  onChange={(e) => setExtraConfig(e.target.value)}
+                  placeholder={'{\n  "organization_id": "12345678",\n  "refresh_token": "1000.xxxxx"\n}'}
+                  rows={4}
+                  className="border rounded px-3 py-2 text-sm w-full mt-1 font-mono"
+                />
+                <p className="text-xs text-muted-foreground mt-1">
+                  Connector-specific parameters, such as Zoho Books organization_id.
+                </p>
+                {extraConfigError && <p className="text-xs text-red-600 mt-1">{extraConfigError}</p>}
+              </div>
             </div>
 
             {error && <p className="text-sm text-destructive">{error}</p>}
 
             <div className="flex gap-3">
-              <Button type="submit" disabled={submitting || oauthStarting}>
-                {provider?.auth_flow === "oauth2_authorization_code"
-                  ? (oauthStarting ? "Starting authorization..." : "Authorize Connector")
-                  : authType === "oauth2"
-                    ? (oauthStarting ? "Starting authorization..." : "Authorize Connector")
-                    : (submitting ? "Registering..." : "Register Connector")}
+              <Button type="submit" disabled={submitting}>
+                {submitting ? "Registering..." : "Register Connector"}
               </Button>
-              <Button type="button" variant="outline" onClick={() => navigate("/dashboard/connectors")}>Cancel</Button>
+              <Button type="button" variant="outline" onClick={() => navigate("/dashboard/connectors")}>
+                Cancel
+              </Button>
             </div>
           </form>
         </CardContent>

--- a/ui/src/pages/ConnectorDetail.tsx
+++ b/ui/src/pages/ConnectorDetail.tsx
@@ -39,8 +39,8 @@ export default function ConnectorDetailPage() {
   const [baseUrl, setBaseUrl] = useState("");
   const [baseUrlError, setBaseUrlError] = useState("");
   const [rateLimitRpm, setRateLimitRpm] = useState(60);
-  // OAuth2-specific fields. Refresh tokens are intentionally not pasted
-  // into the UI anymore; re-auth uses /connectors/oauth/initiate.
+  // OAuth2-specific fields. Zoho Books is registered without a browser
+  // redirect; other OAuth providers can still use the consent handoff.
   const [oauth2ClientId, setOauth2ClientId] = useState("");
   const [oauth2ClientSecret, setOauth2ClientSecret] = useState("");
   const [oauth2TokenUrl, setOauth2TokenUrl] = useState("");
@@ -67,6 +67,8 @@ export default function ConnectorDetailPage() {
     }
     return "https://oauth2.googleapis.com/token";
   }
+
+  const isZohoBooks = connector?.name === "zoho_books";
 
   useEffect(() => {
     fetchConnector();
@@ -125,8 +127,8 @@ export default function ConnectorDetailPage() {
         authType === "basic"
           ? buildBasicAuthConfig(basicUsername, authToken)
           : buildAuthConfig(authType, authToken);
-      // Add editable OAuth2 metadata. The refresh_token itself is minted
-      // through the provider authorization flow and stored server-side.
+      // Add editable OAuth2 metadata. Zoho refresh tokens are pasted in
+      // Extra config; other providers can still mint tokens server-side.
       if (authType === "oauth2") {
         if (oauth2ClientId.trim()) authConfig.client_id = oauth2ClientId.trim();
         if (oauth2ClientSecret.trim()) authConfig.client_secret = oauth2ClientSecret.trim();
@@ -186,7 +188,7 @@ export default function ConnectorDetailPage() {
     if (!clientId || !clientSecret) {
       setFeedback({
         type: "error",
-        msg: "Client ID and Client Secret are required before authorization.",
+        msg: "Client ID and Client Secret are required before provider connection.",
       });
       return;
     }
@@ -204,7 +206,7 @@ export default function ConnectorDetailPage() {
       if (!data?.authorization_url) throw new Error("Missing authorization URL");
       window.location.assign(String(data.authorization_url));
     } catch (e: unknown) {
-      setFeedback({ type: "error", msg: extractApiError(e, "Failed to start OAuth authorization") });
+      setFeedback({ type: "error", msg: extractApiError(e, "Failed to start provider connection") });
     } finally {
       setOauthStarting(false);
     }
@@ -223,7 +225,7 @@ export default function ConnectorDetailPage() {
     } catch (e: unknown) {
       setFeedback({
         type: "error",
-        msg: extractApiError(e, "Reconnect failed — start a new Authorize flow from the connector list."),
+        msg: extractApiError(e, "Reconnect failed — start a fresh provider connection from the connector list."),
       });
     } finally {
       setOauthStarting(false);
@@ -297,7 +299,7 @@ export default function ConnectorDetailPage() {
         <div className="flex gap-2">
           <Button variant="outline" onClick={handleTestConnection} disabled={testing}>{testing ? "Testing..." : "Test Connection"}</Button>
           <Button variant="outline" onClick={handleHealthCheck}>Health Check</Button>
-          {connector.auth_type === "oauth2" && (
+          {connector.auth_type === "oauth2" && !isZohoBooks && (
             <Button
               variant="outline"
               onClick={handleReconnect}
@@ -384,15 +386,24 @@ export default function ConnectorDetailPage() {
                           <label className="text-sm font-medium">Client Secret</label>
                           <input type="password" value={oauth2ClientSecret} onChange={(e) => setOauth2ClientSecret(e.target.value)} placeholder="Enter new client secret (leave blank to keep existing)" autoComplete="new-password" className="border rounded px-3 py-2 text-sm w-full mt-1" />
                         </div>
-                        <div className="rounded-md border bg-muted/40 p-3 space-y-2">
-                          <p className="text-sm font-medium">OAuth Refresh Token</p>
-                          <p className="text-xs text-muted-foreground">
-                            Refresh tokens are no longer pasted manually. Authorize in the provider consent screen and the backend will exchange the code and store the token encrypted.
-                          </p>
-                          <Button size="sm" variant="outline" onClick={handleOAuthReauthorize} disabled={oauthStarting}>
-                            {oauthStarting ? "Starting authorization..." : "Authorize with provider"}
-                          </Button>
-                        </div>
+                        {isZohoBooks ? (
+                          <div className="rounded-md border bg-muted/40 p-3 space-y-2">
+                            <p className="text-sm font-medium">Zoho Refresh Token</p>
+                            <p className="text-xs text-muted-foreground">
+                              Add refresh_token and organization_id in Extra config, then Save. This path registers credentials server-side without opening Zoho OAuth.
+                            </p>
+                          </div>
+                        ) : (
+                          <div className="rounded-md border bg-muted/40 p-3 space-y-2">
+                            <p className="text-sm font-medium">OAuth Refresh Token</p>
+                            <p className="text-xs text-muted-foreground">
+                              Refresh tokens are stored encrypted after the provider consent screen returns a code.
+                            </p>
+                            <Button size="sm" variant="outline" onClick={handleOAuthReauthorize} disabled={oauthStarting}>
+                              {oauthStarting ? "Starting connection..." : "Connect with provider"}
+                            </Button>
+                          </div>
+                        )}
                         <div>
                           <label className="text-sm font-medium">Token URL</label>
                           <input type="url" value={oauth2TokenUrl} onChange={(e) => setOauth2TokenUrl(e.target.value)} placeholder={oauthTokenUrlPlaceholder()} className="border rounded px-3 py-2 text-sm w-full mt-1" />

--- a/ui/tests/e2e-feature-flows.spec.ts
+++ b/ui/tests/e2e-feature-flows.spec.ts
@@ -244,14 +244,14 @@ test.describe("Flow 2: Connector Registration E2E", () => {
     }
   });
 
-  test("OAuth2 auth type shows client credentials and authorization button", async ({ page }) => {
+  test("OAuth2 auth type shows client credentials and registration button", async ({ page }) => {
     const authTypeSelect = page.locator("select").filter({ has: page.locator('option[value="oauth2"]') });
     await authTypeSelect.selectOption("oauth2");
 
     // Wait for auth fields to render
     await page.waitForTimeout(500);
 
-    // Verify client credential fields appear, but refresh token paste is gone.
+    // Verify client credential fields appear, but external authorization is gone.
     const clientIdField = page.locator('input[placeholder="Enter client ID"]');
     const clientSecretField = page.locator('input[placeholder="Enter client secret"]');
     const refreshTokenField = page.locator('input[placeholder*="refresh token"]');
@@ -259,7 +259,8 @@ test.describe("Flow 2: Connector Registration E2E", () => {
     await expect(clientIdField).toBeVisible();
     await expect(clientSecretField).toBeVisible();
     await expect(refreshTokenField).not.toBeVisible();
-    await expect(page.getByRole("button", { name: "Authorize Connector" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Register Connector" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Authorize Connector" })).toHaveCount(0);
   });
 
   test("API Key auth type shows 1 credential field", async ({ page }) => {
@@ -296,13 +297,14 @@ test.describe("Flow 2: Connector Registration E2E", () => {
   test("Switching auth types updates fields correctly", async ({ page }) => {
     const authTypeSelect = page.locator("select").filter({ has: page.locator('option[value="oauth2"]') });
 
-    // Start with oauth2: client credentials plus provider authorization.
+    // Start with oauth2: client credentials plus server-side registration.
     await authTypeSelect.selectOption("oauth2");
     await page.waitForTimeout(300);
     await expect(page.locator('input[placeholder="Enter client ID"]')).toBeVisible();
     await expect(page.locator('input[placeholder="Enter client secret"]')).toBeVisible();
     await expect(page.locator('input[placeholder*="refresh token"]')).not.toBeVisible();
-    await expect(page.getByRole("button", { name: "Authorize Connector" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Register Connector" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Authorize Connector" })).toHaveCount(0);
 
     // Switch to api_key — 1 field
     await authTypeSelect.selectOption("api_key");

--- a/ui/tests/regression-bugs-march2026.spec.ts
+++ b/ui/tests/regression-bugs-march2026.spec.ts
@@ -714,11 +714,11 @@ test.describe("INT-CONN-012: Gmail connector in registry", () => {
 });
 
 // =============================================================================
-//  INT-CONN-014: Connector creation UI starts automated OAuth2 authorization
+//  INT-CONN-014: Connector creation UI registers OAuth2 without browser redirects
 // =============================================================================
 
-test.describe("INT-CONN-014: Connector creation automated OAuth2 setup", () => {
-  test("Selecting oauth2 auth type shows client credentials and no refresh-token paste field", async ({ page }) => {
+test.describe("INT-CONN-014: Connector creation OAuth2 registration", () => {
+  test("Selecting oauth2 auth type shows client credentials and no external authorization button", async ({ page }) => {
     await loginAsCeo(page);
 
     await page.goto(`${APP}/dashboard/connectors/new`);
@@ -734,7 +734,8 @@ test.describe("INT-CONN-014: Connector creation automated OAuth2 setup", () => {
     const bodyText = await page.textContent("body");
     expect(bodyText).toContain("Client ID");
     expect(bodyText).toContain("Client Secret");
-    expect(bodyText).toContain("Authorize Connector");
+    expect(bodyText).toContain("Register Connector");
+    expect(bodyText).not.toContain("Authorize Connector");
     expect(bodyText).not.toContain("Paste refresh token");
   });
 


### PR DESCRIPTION
## Summary
- Replaces managed-provider connector creation with generic server-side registration for the May 15 CA Firms Zoho reopen.
- Infers Zoho region from base URL, refuses false healthy state without refreshable token material, stores secrets encrypted, and updates connector health/token refresh behavior.
- Blocks active agent create/promote/resume unless linked connectors are configured, healthy, decryptable, and refreshable.
- Adds May 15 backend and Playwright regressions plus permanent bug-triage learning.

## Validation
- `python -m ruff check api/v1/connectors.py api/v1/agents.py core/connectors/provider_registry.py core/tasks/token_refresh.py connectors/finance/zoho_books.py tests/regression/test_uday_15may_connector_registration.py tests/regression/test_bugs_uday_14may2026.py`
- `python -m pytest tests/regression/test_uday_15may_connector_registration.py tests/regression/test_bugs_uday_14may2026.py -q`
- `npm run typecheck`
- `npm run build`
- `BASE_URL=http://127.0.0.1:4177 npm run test:e2e -- qa-uday-15may2026.spec.ts qa-ramesh-aishwarya-may04.spec.ts --project=chromium --workers=1`

## Deploy note
Fixed in commit `f555236`; production deploy is pending CI green and main merge.