### PR TITLE
fix: harden connector auth endpoints against SSRF

### DIFF
--- a/connectors/comms/gmail.py
+++ b/connectors/comms/gmail.py
@@ -10,6 +10,8 @@ import httpx
 
 from connectors.framework.base_connector import BaseConnector
 
+GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
+
 
 class GmailConnector(BaseConnector):
     name = "gmail"
@@ -29,15 +31,12 @@ class GmailConnector(BaseConnector):
         refresh_token = self._get_secret("refresh_token")
         client_id = self._get_secret("client_id")
         client_secret = self._get_secret("client_secret")
-        token_url = self.config.get(
-            "token_url", "https://oauth2.googleapis.com/token"
-        )
 
         if refresh_token and client_id and client_secret:
             # Exchange refresh token for access token
             async with httpx.AsyncClient() as client:
                 resp = await client.post(
-                    token_url,
+                    GOOGLE_OAUTH_TOKEN_URL,
                     data={
                         "grant_type": "refresh_token",
                         "refresh_token": refresh_token,

--- a/connectors/comms/youtube.py
+++ b/connectors/comms/youtube.py
@@ -10,6 +10,7 @@ import structlog
 from connectors.framework.base_connector import BaseConnector
 
 logger = structlog.get_logger()
+GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
 
 
 class YouTubeConnector(BaseConnector):
@@ -38,15 +39,12 @@ class YouTubeConnector(BaseConnector):
         refresh_token = self._get_secret("refresh_token")
         client_id = self._get_secret("client_id")
         client_secret = self._get_secret("client_secret")
-        token_url = self.config.get(
-            "token_url", "https://oauth2.googleapis.com/token"
-        )
 
         if refresh_token and client_id and client_secret:
             # Exchange refresh token for a fresh access token
             async with httpx.AsyncClient() as client:
                 resp = await client.post(
-                    token_url,
+                    GOOGLE_OAUTH_TOKEN_URL,
                     data={
                         "grant_type": "refresh_token",
                         "refresh_token": refresh_token,

--- a/connectors/finance/banking_aa.py
+++ b/connectors/finance/banking_aa.py
@@ -20,16 +20,21 @@ import httpx
 
 from connectors.framework.base_connector import BaseConnector
 
+FINVU_API_BASE_URL = "https://aa.finvu.in/api/v1"
+FINVU_TOKEN_URL = f"{FINVU_API_BASE_URL}/oauth2/token"
+
 
 class BankingAaConnector(BaseConnector):
     name = "banking_aa"
     category = "finance"
     auth_type = "aa_oauth2"
-    base_url = "https://aa.finvu.in/api/v1"
+    base_url = FINVU_API_BASE_URL
     rate_limit_rpm = 100
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        safe_config = dict(config or {})
+        safe_config["base_url"] = FINVU_API_BASE_URL
+        super().__init__(safe_config)
         self._consent_manager = None
 
         # Initialize consent manager if callback_url is configured
@@ -38,7 +43,7 @@ class BankingAaConnector(BaseConnector):
             from connectors.finance.aa_consent import AAConsentManager
 
             self._consent_manager = AAConsentManager(
-                base_url=self.base_url,
+                base_url=FINVU_API_BASE_URL,
                 client_id=self.config.get("client_id", ""),
                 client_secret=self.config.get("client_secret", ""),
                 callback_url=callback_url,
@@ -55,10 +60,9 @@ class BankingAaConnector(BaseConnector):
     async def _authenticate(self):
         client_id = self._get_secret("client_id")
         client_secret = self._get_secret("client_secret")
-        token_url = self.config.get("token_url", f"{self.base_url}/oauth2/token")
         async with httpx.AsyncClient() as client:
             resp = await client.post(
-                token_url,
+                FINVU_TOKEN_URL,
                 data={
                     "grant_type": "client_credentials",
                     "client_id": client_id,

--- a/connectors/finance/gstn.py
+++ b/connectors/finance/gstn.py
@@ -21,16 +21,31 @@ from connectors.framework.base_connector import BaseConnector
 
 logger = structlog.get_logger()
 
+GSTN_API_BASE_URL = "https://gsp.adaequare.com/gsp"
+GSTN_SANDBOX_API_BASE_URL = "https://gsp.adaequare.com/test/enriched/gsp"
+GSTN_ALLOWED_BASE_URLS = {GSTN_API_BASE_URL, GSTN_SANDBOX_API_BASE_URL}
+
+
+def _provider_base_url(connector_cls: type[GstnConnector]) -> str:
+    base_url = getattr(connector_cls, "base_url", GSTN_API_BASE_URL)
+    if base_url not in GSTN_ALLOWED_BASE_URLS:
+        raise ValueError("GSTN base URL must be an Adaequare provider endpoint")
+    return base_url
+
 
 class GstnConnector(BaseConnector):
     name = "gstn"
     category = "finance"
     auth_type = "gsp_dsc"
-    base_url = "https://gsp.adaequare.com/gsp"
+    base_url = GSTN_API_BASE_URL
     rate_limit_rpm = 50
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        provider_base_url = _provider_base_url(type(self))
+        safe_config = dict(config or {})
+        safe_config["base_url"] = provider_base_url
+        super().__init__(safe_config)
+        self._provider_base_url = provider_base_url
         self._dsc_adapter = None
 
         dsc_path = self.config.get("dsc_path", "")
@@ -61,7 +76,7 @@ class GstnConnector(BaseConnector):
 
         async with httpx.AsyncClient() as client:
             resp = await client.post(
-                f"{self.base_url}/authenticate",
+                f"{self._provider_base_url}/authenticate",
                 json={
                     "action": "ACCESSTOKEN",
                     "username": username,

--- a/connectors/finance/gstn_sandbox.py
+++ b/connectors/finance/gstn_sandbox.py
@@ -15,10 +15,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from connectors.finance.gstn import GstnConnector
+from connectors.finance.gstn import GSTN_SANDBOX_API_BASE_URL, GstnConnector
 
 # Adaequare sandbox environment
-SANDBOX_BASE_URL = "https://gsp.adaequare.com/test/enriched/gsp"
+SANDBOX_BASE_URL = GSTN_SANDBOX_API_BASE_URL
 
 # Test GSTINs available in Adaequare sandbox
 SANDBOX_GSTINS = [

--- a/connectors/finance/sap.py
+++ b/connectors/finance/sap.py
@@ -8,6 +8,7 @@ import httpx
 import structlog
 
 from connectors.framework.base_connector import BaseConnector
+from connectors.framework.url_security import require_dns_label, require_sap_region
 
 logger = structlog.get_logger()
 
@@ -20,14 +21,16 @@ class SapConnector(BaseConnector):
     rate_limit_rpm = 300
 
     def __init__(self, config: dict[str, Any] | None = None):
-        config = config or {}
-        # Build the real base_url from the host config key
+        config = dict(config or {})
         host = config.get("host", "")
         if host:
-            config.setdefault(
-                "base_url",
-                f"https://{host}.s4hana.cloud.sap/sap/opu/odata/sap",
+            safe_host = require_dns_label(host, "SAP host")
+            config["host"] = safe_host
+            config["base_url"] = (
+                f"https://{safe_host}.s4hana.cloud.sap/sap/opu/odata/sap"
             )
+        else:
+            config.pop("base_url", None)
         super().__init__(config)
 
     def _register_tools(self):
@@ -43,25 +46,20 @@ class SapConnector(BaseConnector):
         """OAuth2 client_credentials flow via SAP XSUAA."""
         client_id = self._get_secret("client_id")
         client_secret = self._get_secret("client_secret")
-        subdomain = self.config.get("subdomain", "")
-        region = self.config.get("region", "eu10")
+        subdomain = self.config.get("subdomain") or self.config.get("host", "")
+        region = require_sap_region(self.config.get("region", "eu10"))
 
         if not subdomain:
-            # Fallback: allow explicit token_url in config
-            token_url = self.config.get("token_url", "")
-            if not token_url:
-                raise ValueError(
-                    "SAP connector requires config['subdomain'] or config['token_url']"
-                )
+            raise ValueError("SAP connector requires config['subdomain'] or config['host']")
         else:
-            token_url = (
-                f"https://{subdomain}.authentication.{region}.hana.ondemand.com"
-                "/oauth/token"
+            safe_subdomain = require_dns_label(subdomain, "SAP subdomain")
+            token_origin = (
+                f"https://{safe_subdomain}.authentication.{region}.hana.ondemand.com"
             )
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(base_url=token_origin) as client:
             resp = await client.post(
-                token_url,
+                "/oauth/token",
                 data={
                     "grant_type": "client_credentials",
                     "client_id": client_id,

--- a/connectors/framework/url_security.py
+++ b/connectors/framework/url_security.py
@@ -1,0 +1,48 @@
+"""URL helpers for connector-owned outbound endpoints."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from urllib.parse import urlparse
+
+_DNS_LABEL_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+_SAP_REGION_RE = re.compile(r"^[a-z][a-z0-9-]{1,18}[a-z0-9]$")
+
+
+def require_dns_label(value: object, field: str) -> str:
+    """Return a lower-case DNS label or raise when it can alter the host."""
+    label = str(value or "").strip().lower()
+    if not _DNS_LABEL_RE.fullmatch(label):
+        raise ValueError(f"{field} must be a single DNS label")
+    return label
+
+
+def require_sap_region(value: object) -> str:
+    region = str(value or "eu10").strip().lower()
+    if not _SAP_REGION_RE.fullmatch(region) or "." in region:
+        raise ValueError("SAP region must be a single provider region label")
+    return region
+
+
+def require_https_origin(
+    value: object,
+    *,
+    field: str,
+    allowed_exact_hosts: Iterable[str] = (),
+    allowed_host_suffixes: Iterable[str] = (),
+) -> str:
+    """Validate a provider-returned HTTPS origin against exact/suffix host rules."""
+    raw = str(value or "").strip()
+    parsed = urlparse(raw)
+    host = (parsed.hostname or "").rstrip(".").lower()
+    exact_hosts = {item.lower() for item in allowed_exact_hosts}
+    suffixes = tuple(item.lower() for item in allowed_host_suffixes)
+
+    if parsed.scheme != "https" or not host or parsed.username or parsed.password:
+        raise ValueError(f"{field} must be a HTTPS origin")
+    if parsed.path not in ("", "/") or parsed.params or parsed.query or parsed.fragment:
+        raise ValueError(f"{field} must not include path, query, or fragment")
+    if host not in exact_hosts and not any(host.endswith(suffix) for suffix in suffixes):
+        raise ValueError(f"{field} host is not an allowed provider host")
+    return f"https://{host}"

--- a/connectors/marketing/brandwatch.py
+++ b/connectors/marketing/brandwatch.py
@@ -12,16 +12,20 @@ import httpx
 
 from connectors.framework.base_connector import BaseConnector
 
+BRANDWATCH_API_BASE_URL = "https://api.brandwatch.com"
+
 
 class BrandwatchConnector(BaseConnector):
     name = "brandwatch"
     category = "marketing"
     auth_type = "oauth2"
-    base_url = "https://api.brandwatch.com"
+    base_url = BRANDWATCH_API_BASE_URL
     rate_limit_rpm = 60
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        safe_config = dict(config or {})
+        safe_config["base_url"] = BRANDWATCH_API_BASE_URL
+        super().__init__(safe_config)
         self._project_id = self.config.get("project_id", "")
 
     def _register_tools(self):
@@ -37,7 +41,7 @@ class BrandwatchConnector(BaseConnector):
 
         async with httpx.AsyncClient() as client:
             resp = await client.post(
-                f"{self.base_url}/oauth/token",
+                f"{BRANDWATCH_API_BASE_URL}/oauth/token",
                 data={
                     "grant_type": "api-password",
                     "username": username,

--- a/connectors/marketing/salesforce.py
+++ b/connectors/marketing/salesforce.py
@@ -13,6 +13,14 @@ from typing import Any
 import httpx
 
 from connectors.framework.base_connector import BaseConnector
+from connectors.framework.url_security import require_https_origin
+
+SALESFORCE_LOGIN_URLS = {
+    "production": "https://login.salesforce.com/services/oauth2/token",
+    "login": "https://login.salesforce.com/services/oauth2/token",
+    "sandbox": "https://test.salesforce.com/services/oauth2/token",
+    "test": "https://test.salesforce.com/services/oauth2/token",
+}
 
 
 class SalesforceConnector(BaseConnector):
@@ -39,9 +47,7 @@ class SalesforceConnector(BaseConnector):
         client_secret = self._get_secret("client_secret")
         username = self.config.get("username", "")
         password = self.config.get("password", "")
-        login_url = self.config.get(
-            "login_url", "https://login.salesforce.com/services/oauth2/token"
-        )
+        login_url = self._login_url()
 
         data: dict[str, str] = {
             "client_id": client_id,
@@ -58,12 +64,23 @@ class SalesforceConnector(BaseConnector):
             resp = await client.post(login_url, data=data)
             resp.raise_for_status()
             body = resp.json()
-            self._instance_url = body["instance_url"]
+            self._instance_url = require_https_origin(
+                body["instance_url"],
+                field="Salesforce instance_url",
+                allowed_exact_hosts=("login.salesforce.com", "test.salesforce.com"),
+                allowed_host_suffixes=(".salesforce.com", ".force.com"),
+            )
             token = body["access_token"]
 
         # Update base_url to use the instance URL from auth response
         self.base_url = f"{self._instance_url}/services/data/v60.0"
         self._auth_headers = {"Authorization": f"Bearer {token}"}
+
+    def _login_url(self) -> str:
+        environment = str(
+            self.config.get("environment") or self.config.get("login_domain") or "production"
+        ).strip().lower()
+        return SALESFORCE_LOGIN_URLS.get(environment, SALESFORCE_LOGIN_URLS["production"])
 
     async def health_check(self) -> dict[str, Any]:
         try:

--- a/connectors/ops/servicenow.py
+++ b/connectors/ops/servicenow.py
@@ -11,6 +11,7 @@ from typing import Any
 import httpx
 
 from connectors.framework.base_connector import BaseConnector
+from connectors.framework.url_security import require_dns_label
 
 
 class ServicenowConnector(BaseConnector):
@@ -19,6 +20,13 @@ class ServicenowConnector(BaseConnector):
     auth_type = "rest_oauth2"
     base_url = "https://org.service-now.com/api/now"
     rate_limit_rpm = 100
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        safe_config = dict(config or {})
+        instance = require_dns_label(safe_config.get("instance", "org"), "ServiceNow instance")
+        safe_config["instance"] = instance
+        safe_config["base_url"] = f"https://{instance}.service-now.com/api/now"
+        super().__init__(safe_config)
 
     def _register_tools(self):
         self._tool_registry["create_incident"] = self.create_incident
@@ -34,12 +42,12 @@ class ServicenowConnector(BaseConnector):
         username = self.config.get("username", "")
         password = self.config.get("password", "")
 
-        instance = self.config.get("instance", "org")
-        token_url = f"https://{instance}.service-now.com/oauth_token.do"
+        instance = require_dns_label(self.config.get("instance", "org"), "ServiceNow instance")
+        token_origin = f"https://{instance}.service-now.com"
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(base_url=token_origin) as client:
             resp = await client.post(
-                token_url,
+                "/oauth_token.do",
                 data={
                     "grant_type": "password",
                     "client_id": client_id,

--- a/tests/regression/test_codeql_connector_ssrf_hardening.py
+++ b/tests/regression/test_codeql_connector_ssrf_hardening.py
@@ -1,0 +1,244 @@
+"""Regression pins for provider connector SSRF hardening."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class _FakeResponse:
+    def __init__(self, body: dict[str, object]):
+        self._body = body
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, object]:
+        return self._body
+
+
+class _RecordingAsyncClient:
+    def __init__(self, response_body: dict[str, object]):
+        self.response_body = response_body
+        self.base_url = ""
+        self.posts: list[tuple[str, dict[str, object]]] = []
+
+    async def __aenter__(self) -> _RecordingAsyncClient:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+    async def post(self, url: str, **kwargs: object) -> _FakeResponse:
+        self.posts.append((url, kwargs))
+        return _FakeResponse(self.response_body)
+
+
+def _client_factory(client: _RecordingAsyncClient):
+    def _factory(*_args: object, **kwargs: object) -> _RecordingAsyncClient:
+        client.base_url = str(kwargs.get("base_url", ""))
+        return client
+
+    return _factory
+
+
+@pytest.mark.asyncio
+async def test_google_connectors_ignore_configured_token_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    import connectors.comms.gmail as gmail_module
+    import connectors.comms.youtube as youtube_module
+    from connectors.comms.gmail import GmailConnector
+    from connectors.comms.youtube import YouTubeConnector
+
+    gmail_client = _RecordingAsyncClient({"access_token": "gmail-token"})
+    monkeypatch.setattr(gmail_module.httpx, "AsyncClient", _client_factory(gmail_client))
+
+    gmail = GmailConnector(
+        {
+            "refresh_token": "refresh",
+            "client_id": "client",
+            "client_secret": "secret",
+            "token_url": "https://169.254.169.254/latest/meta-data",
+        }
+    )
+    await gmail._authenticate()
+    assert gmail_client.posts[0][0] == gmail_module.GOOGLE_OAUTH_TOKEN_URL
+
+    youtube_client = _RecordingAsyncClient({"access_token": "youtube-token"})
+    monkeypatch.setattr(
+        youtube_module.httpx, "AsyncClient", _client_factory(youtube_client)
+    )
+
+    youtube = YouTubeConnector(
+        {
+            "refresh_token": "refresh",
+            "client_id": "client",
+            "client_secret": "secret",
+            "token_url": "https://attacker.test/oauth/token",
+        }
+    )
+    await youtube._authenticate()
+    assert youtube_client.posts[0][0] == youtube_module.GOOGLE_OAUTH_TOKEN_URL
+
+
+@pytest.mark.asyncio
+async def test_banking_aa_uses_fixed_finvu_token_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    import connectors.finance.banking_aa as banking_module
+    from connectors.finance.banking_aa import BankingAaConnector
+
+    client = _RecordingAsyncClient({"access_token": "aa-token"})
+    monkeypatch.setattr(banking_module.httpx, "AsyncClient", _client_factory(client))
+
+    connector = BankingAaConnector(
+        {
+            "client_id": "client",
+            "client_secret": "secret",
+            "base_url": "https://metadata.google.internal",
+            "token_url": "https://attacker.test/oauth/token",
+        }
+    )
+    assert connector.base_url == banking_module.FINVU_API_BASE_URL
+
+    await connector._authenticate()
+    assert client.posts[0][0] == banking_module.FINVU_TOKEN_URL
+
+
+@pytest.mark.asyncio
+async def test_servicenow_requires_instance_label_and_derives_provider_urls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import connectors.ops.servicenow as servicenow_module
+    from connectors.ops.servicenow import ServicenowConnector
+
+    with pytest.raises(ValueError, match="single DNS label"):
+        ServicenowConnector({"instance": "tenant.service-now.com#@169.254.169.254"})
+
+    client = _RecordingAsyncClient({"access_token": "servicenow-token"})
+    monkeypatch.setattr(
+        servicenow_module.httpx, "AsyncClient", _client_factory(client)
+    )
+
+    connector = ServicenowConnector(
+        {
+            "instance": "tenant-1",
+            "client_id": "client",
+            "client_secret": "secret",
+            "username": "user",
+            "password": "pass",
+        }
+    )
+    assert connector.base_url == "https://tenant-1.service-now.com/api/now"
+
+    await connector._authenticate()
+    assert client.base_url == "https://tenant-1.service-now.com"
+    assert client.posts[0][0] == "/oauth_token.do"
+
+
+@pytest.mark.asyncio
+async def test_sap_requires_safe_subdomain_and_ignores_token_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import connectors.finance.sap as sap_module
+    from connectors.finance.sap import SapConnector
+
+    with pytest.raises(ValueError, match="single DNS label"):
+        SapConnector({"host": "tenant.s4hana.cloud.sap#evil"})
+
+    connector = SapConnector(
+        {
+            "host": "tenant-1",
+            "subdomain": "tenant-1",
+            "region": "eu10",
+            "client_id": "client",
+            "client_secret": "secret",
+            "token_url": "https://attacker.test/oauth/token",
+        }
+    )
+    assert connector.base_url == "https://tenant-1.s4hana.cloud.sap/sap/opu/odata/sap"
+
+    client = _RecordingAsyncClient({"access_token": "sap-token"})
+    monkeypatch.setattr(sap_module.httpx, "AsyncClient", _client_factory(client))
+
+    await connector._authenticate()
+    assert client.base_url == "https://tenant-1.authentication.eu10.hana.ondemand.com"
+    assert client.posts[0][0] == "/oauth/token"
+
+
+@pytest.mark.asyncio
+async def test_salesforce_uses_known_login_hosts_and_validates_instance_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import connectors.marketing.salesforce as salesforce_module
+    from connectors.marketing.salesforce import SalesforceConnector
+
+    client = _RecordingAsyncClient(
+        {"instance_url": "https://acme.my.salesforce.com", "access_token": "sf-token"}
+    )
+    monkeypatch.setattr(
+        salesforce_module.httpx, "AsyncClient", _client_factory(client)
+    )
+
+    connector = SalesforceConnector(
+        {
+            "client_id": "client",
+            "client_secret": "secret",
+            "login_url": "https://attacker.test/services/oauth2/token",
+        }
+    )
+    await connector._authenticate()
+    assert client.posts[0][0] == salesforce_module.SALESFORCE_LOGIN_URLS["production"]
+    assert connector.base_url == "https://acme.my.salesforce.com/services/data/v60.0"
+
+    blocked_client = _RecordingAsyncClient(
+        {"instance_url": "https://169.254.169.254", "access_token": "sf-token"}
+    )
+    monkeypatch.setattr(
+        salesforce_module.httpx, "AsyncClient", _client_factory(blocked_client)
+    )
+
+    blocked = SalesforceConnector({"client_id": "client", "client_secret": "secret"})
+    with pytest.raises(ValueError, match="allowed provider host"):
+        await blocked._authenticate()
+
+
+@pytest.mark.asyncio
+async def test_fixed_provider_connectors_ignore_base_url_in_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import connectors.finance.gstn as gstn_module
+    import connectors.marketing.brandwatch as brandwatch_module
+    from connectors.finance.gstn import GstnConnector
+    from connectors.marketing.brandwatch import BrandwatchConnector
+
+    gstn_client = _RecordingAsyncClient({"auth-token": "gstn-token"})
+    monkeypatch.setattr(gstn_module.httpx, "AsyncClient", _client_factory(gstn_client))
+    gstn = GstnConnector(
+        {
+            "api_key": "api",
+            "gstin": "29ABCDE1234F1Z5",
+            "username": "user",
+            "password": "pass",
+            "base_url": "https://169.254.169.254",
+        }
+    )
+    assert gstn.base_url == gstn_module.GSTN_API_BASE_URL
+
+    await gstn._authenticate()
+    assert gstn_client.posts[0][0] == f"{gstn_module.GSTN_API_BASE_URL}/authenticate"
+
+    brandwatch_client = _RecordingAsyncClient({"access_token": "brandwatch-token"})
+    monkeypatch.setattr(
+        brandwatch_module.httpx, "AsyncClient", _client_factory(brandwatch_client)
+    )
+    brandwatch = BrandwatchConnector(
+        {
+            "username": "user",
+            "password": "pass",
+            "base_url": "https://attacker.test",
+        }
+    )
+    assert brandwatch.base_url == brandwatch_module.BRANDWATCH_API_BASE_URL
+
+    await brandwatch._authenticate()
+    assert (
+        brandwatch_client.posts[0][0]
+        == f"{brandwatch_module.BRANDWATCH_API_BASE_URL}/oauth/token"
+    )


### PR DESCRIPTION
## Summary
- lock Google, Finvu, GSTN, Brandwatch, and Salesforce auth endpoints to provider-owned URLs
- validate ServiceNow/SAP tenant labels before deriving provider subdomains
- add regression coverage for the open CodeQL SSRF alert patterns and adjacent fixed-provider auth URLs

## Verification
- python -m ruff check connectors/framework/url_security.py connectors/comms/gmail.py connectors/comms/youtube.py connectors/finance/banking_aa.py connectors/finance/gstn.py connectors/finance/sap.py connectors/marketing/brandwatch.py connectors/marketing/salesforce.py connectors/ops/servicenow.py tests/regression/test_codeql_connector_ssrf_hardening.py
- python -m pytest tests/regression/test_codeql_connector_ssrf_hardening.py tests/regression/test_bugs_march2026.py::TestIntConn012GmailConnectorTools tests/unit/test_production_components.py::TestBankingAAConnectorConsent tests/unit/test_connector_real_paths.py::TestSalesforceRealPaths tests/e2e/test_ca_firm_workflow.py::TestCAFirmWorkflowE2E::test_step3_gstn_base_url_correct --no-cov -q