### PR TITLE
Fix lxml CVE pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,10 @@ dependencies = [
     # deps (Tesseract binary + ffmpeg) so they can't land until the
     # deploy image updates.
     "python-docx>=1.2.0",
+    # SEC-2026-05-15: python-docx pulls lxml transitively. Pin the
+    # patched floor for CVE-2026-41066 so resolver drift cannot
+    # reinstall vulnerable lxml 6.0.x in CI or production images.
+    "lxml>=6.1.0",
     "pyyaml>=6.0.2",
     "jinja2>=3.1.4",
     "python-multipart>=0.0.28",

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,6 +82,8 @@ prometheus-client==0.25.0
 
 # ─── Document Processing & Reporting ─────────────────────────────────────────
 pypdf==6.11.0
+# CVE-2026-41066: keep python-docx/transitive XML parsing on patched lxml.
+lxml==6.1.0
 pyyaml==6.0.3
 jinja2==3.1.6
 defusedxml==0.7.1

--- a/tests/regression/test_dependency_vulnerability_pins.py
+++ b/tests/regression/test_dependency_vulnerability_pins.py
@@ -1,0 +1,33 @@
+"""Regression pins for dependency CVE remediations."""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
+def test_lxml_cve_2026_41066_floor_is_permanent() -> None:
+    """python-docx can pull vulnerable lxml 6.0.x unless we pin the floor."""
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    dependencies = pyproject["project"]["dependencies"]
+
+    lxml_specs = [dep for dep in dependencies if dep.startswith("lxml>=")]
+    assert lxml_specs, "CVE-2026-41066 requires lxml>=6.1.0 in project deps"
+
+    floor = lxml_specs[0].split(">=", 1)[1]
+    assert _version_tuple(floor) >= (6, 1, 0)
+
+
+def test_requirements_pin_uses_patched_lxml() -> None:
+    requirements = (ROOT / "requirements.txt").read_text(encoding="utf-8")
+    match = re.search(r"^lxml==(?P<version>\d+\.\d+\.\d+)$", requirements, re.MULTILINE)
+
+    assert match, "requirements.txt must pin patched lxml for audits"
+    assert _version_tuple(match.group("version")) >= (6, 1, 0)


### PR DESCRIPTION
## Summary
- pin lxml to the patched 6.1.0 floor for CVE-2026-41066
- add the same requirements.txt pin used by requirements-based audits
- add regression tests so the vulnerability pin cannot be removed silently

## Verification
- pip-audit -r requirements.txt --desc: No known vulnerabilities found
- python -m pytest tests\\security tests\\regression\\test_codeql_connector_ssrf_hardening.py --no-cov -q: 92 passed
- python -m pytest tests\\regression\\test_dependency_vulnerability_pins.py tests\\regression\\test_codeql_connector_ssrf_hardening.py --no-cov -q: 8 passed