### PR TITLE
Fix Stripe billing checkout production packaging

### DIFF
--- a/api/v1/billing.py
+++ b/api/v1/billing.py
@@ -14,6 +14,7 @@ Plural flow:
 
 from __future__ import annotations
 
+import importlib.util
 import os
 from typing import Any
 from urllib.parse import urlparse
@@ -28,6 +29,10 @@ from api.deps import get_current_tenant
 logger = structlog.get_logger()
 
 router = APIRouter(prefix="/billing", tags=["Billing"])
+
+
+def _is_module_installed(module_name: str) -> bool:
+    return importlib.util.find_spec(module_name) is not None
 
 
 def _allowed_redirect_hosts() -> set[str]:
@@ -191,14 +196,20 @@ async def get_usage_endpoint(tenant_id: str = Depends(get_current_tenant)) -> di
 async def billing_health() -> dict[str, Any]:
     """Report which payment gateway(s) are configured on this deploy.
 
-    Does NOT validate creds — just reports whether env vars are
-    populated, which is the necessary (not sufficient) precondition
-    for a working checkout. A true validation needs a test charge,
-    which must be run manually by ops.
+    Does NOT validate creds or create a charge. It reports local runtime
+    prerequisites: env vars plus the gateway SDKs needed by request-path
+    code. A true validation still needs a manual gateway test transaction.
     """
     import os as _os
 
-    stripe_configured = bool(_os.getenv("STRIPE_SECRET_KEY"))
+    stripe_secret_configured = bool(_os.getenv("STRIPE_SECRET_KEY"))
+    stripe_prices_configured = bool(
+        _os.getenv("STRIPE_PRICE_PRO") and _os.getenv("STRIPE_PRICE_ENTERPRISE")
+    )
+    stripe_sdk_installed = _is_module_installed("stripe")
+    stripe_configured = (
+        stripe_secret_configured and stripe_prices_configured and stripe_sdk_installed
+    )
     pinelabs_configured = bool(
         _os.getenv("PINELABS_API_KEY") or _os.getenv("PLURAL_API_KEY")
     )
@@ -207,6 +218,17 @@ async def billing_health() -> dict[str, Any]:
         recommended = "both — Stripe for USD, Pine Labs for INR"
     elif stripe_configured:
         recommended = "Stripe — INR callers need Pine Labs config"
+    elif stripe_secret_configured and not stripe_sdk_installed:
+        recommended = (
+            "Stripe is configured but the server image is missing the "
+            "stripe Python package. Add stripe to production dependencies "
+            "and redeploy before enabling checkout."
+        )
+    elif stripe_secret_configured and not stripe_prices_configured:
+        recommended = (
+            "Stripe secret is configured but STRIPE_PRICE_PRO and/or "
+            "STRIPE_PRICE_ENTERPRISE are missing."
+        )
     elif pinelabs_configured:
         recommended = "Pine Labs — USD callers need Stripe config"
     else:
@@ -219,6 +241,9 @@ async def billing_health() -> dict[str, Any]:
 
     return {
         "stripe_configured": stripe_configured,
+        "stripe_secret_configured": stripe_secret_configured,
+        "stripe_prices_configured": stripe_prices_configured,
+        "stripe_sdk_installed": stripe_sdk_installed,
         "pinelabs_configured": pinelabs_configured,
         "recommended_checkout_flow": recommended,
         "ready_for_release": stripe_configured or pinelabs_configured,
@@ -262,6 +287,22 @@ async def subscribe_stripe(
                 "(/billing/subscribe/india) if you're in INR."
             ),
         )
+    if not _is_module_installed("stripe"):
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Stripe SDK is not installed in this server image. Add "
+                "the stripe Python package to production dependencies and "
+                "redeploy before enabling checkout."
+            ),
+        )
+    if body.plan in {"pro", "enterprise"}:
+        price_env = "STRIPE_PRICE_PRO" if body.plan == "pro" else "STRIPE_PRICE_ENTERPRISE"
+        if not _os.getenv(price_env):
+            raise HTTPException(
+                status_code=503,
+                detail=f"{price_env} is not configured in this environment.",
+            )
     # Codex 2026-04-23 blocker F: Stripe SDK is synchronous. Run in
     # threadpool so the event loop is not parked for the whole round-trip.
     import asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,10 @@ dependencies = [
     "python-jose[cryptography]>=3.3.0",
     "passlib[bcrypt]>=1.7.4",
     "httpx>=0.28.0",
+    # Billing checkout is a production request path. Keep the Stripe SDK in
+    # base deps so Docker's `pip install .[v4]` image can create Checkout
+    # Sessions when STRIPE_SECRET_KEY and price IDs are configured.
+    "stripe>=15.1.0",
     "google-genai>=1.75.0",
     "anthropic>=0.102.0",
     "openai>=2.36.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,9 @@ grantex==0.3.9
 # ─── HTTP Client & DNS ───────────────────────────────────────────────────────
 httpx==0.28.1
 dnspython==2.8.0
+# Billing checkout SDK. Required in the production API image whenever
+# STRIPE_SECRET_KEY and Stripe price IDs are configured.
+stripe==15.1.0
 
 # ─── LLM Providers ──────────────────────────────────────────────────────────
 google-genai==1.75.0

--- a/tests/regression/test_billing_stripe_runtime_prereqs.py
+++ b/tests/regression/test_billing_stripe_runtime_prereqs.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pathlib
+import tomllib
+
+import pytest
+
+
+def test_stripe_sdk_is_a_production_dependency() -> None:
+    pyproject = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
+    dependencies = pyproject["project"]["dependencies"]
+
+    assert any(dep.lower().startswith("stripe>=") for dep in dependencies)
+
+
+@pytest.mark.asyncio
+async def test_billing_health_refuses_ready_when_stripe_sdk_missing(monkeypatch) -> None:
+    from api.v1 import billing
+
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_configured")
+    monkeypatch.setenv("STRIPE_PRICE_PRO", "price_pro")
+    monkeypatch.setenv("STRIPE_PRICE_ENTERPRISE", "price_enterprise")
+    monkeypatch.delenv("PINELABS_API_KEY", raising=False)
+    monkeypatch.delenv("PLURAL_API_KEY", raising=False)
+    monkeypatch.setattr(billing, "_is_module_installed", lambda name: False)
+
+    result = await billing.billing_health()
+
+    assert result["stripe_secret_configured"] is True
+    assert result["stripe_prices_configured"] is True
+    assert result["stripe_sdk_installed"] is False
+    assert result["stripe_configured"] is False
+    assert result["ready_for_release"] is False
+    assert "missing the stripe Python package" in result["recommended_checkout_flow"]
+
+
+@pytest.mark.asyncio
+async def test_billing_health_requires_stripe_price_ids(monkeypatch) -> None:
+    from api.v1 import billing
+
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_configured")
+    monkeypatch.delenv("STRIPE_PRICE_PRO", raising=False)
+    monkeypatch.setenv("STRIPE_PRICE_ENTERPRISE", "price_enterprise")
+    monkeypatch.delenv("PINELABS_API_KEY", raising=False)
+    monkeypatch.delenv("PLURAL_API_KEY", raising=False)
+    monkeypatch.setattr(billing, "_is_module_installed", lambda name: True)
+
+    result = await billing.billing_health()
+
+    assert result["stripe_sdk_installed"] is True
+    assert result["stripe_prices_configured"] is False
+    assert result["stripe_configured"] is False
+    assert result["ready_for_release"] is False


### PR DESCRIPTION
## Summary
- add the Stripe Python SDK to production dependencies so the API image can create Checkout Sessions
- harden `/billing/health` to report SDK and price-ID prerequisites instead of treating secrets alone as ready
- add regression coverage for Stripe runtime prerequisites

## Root Cause
Production Cloud Run had Stripe secrets and price IDs configured, but the API image did not include the `stripe` Python package. Checkout crashed in `core.billing.stripe_client._get_stripe()` with `RuntimeError: stripe package is not installed`, which surfaced in the UI as `Payment gateway error`.

## Verification
- `python -m pytest tests/regression/test_billing_stripe_runtime_prereqs.py -q --no-cov`
- `python -m pytest tests/unit/test_signoff_remaining_blockers.py::TestBillingHealthEndpoint tests/unit/test_bug_sweep_22apr_pm.py::TestBillingConfigurationMessage -q --no-cov`
- `python -m pytest tests/unit/test_billing.py::TestStripeCheckoutSession tests/unit/test_billing.py::TestStripeE2ECheckoutFlow -q`
- `python -m ruff check api/v1/billing.py tests/regression/test_billing_stripe_runtime_prereqs.py`
- `python -m pip install --dry-run stripe==15.1.0`
- Deployed API image `asia-south1-docker.pkg.dev/perfect-period-305406/agenticorg/agenticorg:cc26072867db1855c25d72bdf23985f8220c5e1e` to production Cloud Run revision `agenticorg-api-00057-ql8`
- Production `/api/v1/health` reports commit `cc26072867db1855c25d72bdf23985f8220c5e1e`
- Production `/api/v1/billing/health` reports `stripe_configured: true`, `stripe_sdk_installed: true`, and `ready_for_release: true`