### PR TITLE
fix: make workflow state durable in postgres

### DIFF
--- a/api/v1/webhooks.py
+++ b/api/v1/webhooks.py
@@ -17,6 +17,8 @@ from typing import Any
 import structlog
 from fastapi import APIRouter, HTTPException, Request
 
+from workflows.event_waits import WorkflowEventWaitStore
+
 logger = structlog.get_logger()
 
 router = APIRouter()
@@ -89,6 +91,60 @@ def _get_redis():
     return aioredis.from_url(url, decode_responses=True)
 
 
+def _workflow_event_wait_store() -> WorkflowEventWaitStore:
+    return WorkflowEventWaitStore()
+
+
+def _email_event_type_candidates(event_type: str) -> tuple[str, ...]:
+    aliases = {
+        "open": ("email.open", "email.opened"),
+        "opened": ("email.opened", "email.open"),
+        "click": ("email.click", "email.clicked"),
+        "clicked": ("email.clicked", "email.click"),
+        "bounce": ("email.bounce", "email.bounced"),
+        "bounced": ("email.bounced", "email.bounce"),
+    }
+    candidates = aliases.get(event_type.lower(), (f"email.{event_type}",))
+    return tuple(dict.fromkeys(candidates))
+
+
+def _extract_event_tenant_id(event_fields: dict[str, Any]) -> str | None:
+    for key in ("tenant_id", "agenticorg:tenant_id", "agenticorg_tenant_id"):
+        value = event_fields.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _event_delivery_id(event_fields: dict[str, Any]) -> str:
+    payload = json.dumps(event_fields, sort_keys=True, default=str, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _listener_match_criteria(listener_payload: dict[str, Any]) -> dict[str, Any]:
+    raw = listener_payload.get("match", listener_payload.get("match_criteria", {}))
+    return raw if isinstance(raw, dict) else {}
+
+
+def _sendgrid_category_metadata(categories: Any) -> tuple[str, dict[str, str]]:
+    category_list = categories if isinstance(categories, list) else [categories]
+    campaign_id = ""
+    extra: dict[str, str] = {}
+    for raw_category in category_list:
+        if not raw_category:
+            continue
+        category = str(raw_category)
+        if ":" in category:
+            key, value = category.split(":", 1)
+            normalized = key.strip().lower().replace("-", "_")
+            if normalized in {"tenant", "tenant_id", "agenticorg_tenant_id"}:
+                extra["tenant_id"] = value.strip()
+                continue
+        if not campaign_id:
+            campaign_id = category
+    return campaign_id, extra
+
+
 def _event_matches_criteria(
     event_fields: dict[str, Any],
     match_criteria: dict[str, Any],
@@ -107,6 +163,7 @@ def _event_matches_criteria(
     older workflows are declared without a match and should still resume
     on the first event of the right type).
     """
+    match_criteria = _listener_match_criteria({"match": match_criteria})
     if not match_criteria:
         return True
     for k, expected in match_criteria.items():
@@ -125,18 +182,61 @@ async def _store_email_event(
     timestamp: str | int,
     extra: dict[str, Any] | None = None,
 ) -> None:
-    """Store event in Redis and check for waiting workflows.
+    """Store the email event and check durable workflow event waits.
 
     Codex 2026-04-23 re-verification blocker B: resume now honours
     the ``match`` criteria the listener stored — a click event on
     campaign A must not resume a workflow that was waiting for a
     click on campaign B.
     """
-    import json as _json
+    event_fields: dict[str, Any] = {
+        "campaign_id": campaign_id,
+        "email": email,
+        "event_type": event_type,
+        "timestamp": timestamp,
+        **(extra or {}),
+    }
+    event_types = _email_event_type_candidates(event_type)
+    event_fields["workflow_event_types"] = list(event_types)
+    tenant_id = _extract_event_tenant_id(event_fields)
+    delivery_id = _event_delivery_id(event_fields)
 
-    r = _get_redis()
+    store = _workflow_event_wait_store()
+    await store.init()
     try:
-        # Store in hash: email_events:{campaign_id}:{email}
+        matched_waits = await store.claim_matching_waits(
+            event_types=event_types,
+            event_fields=event_fields,
+            tenant_id=tenant_id,
+            matched_event_id=delivery_id,
+        )
+    finally:
+        await store.close()
+
+    from core.tasks.workflow_tasks import _resume_workflow_wait_async, resume_workflow_wait
+
+    for wait in matched_waits:
+        logger.info(
+            "workflow_event_match",
+            event_type=event_type,
+            email=email,
+            run_id=wait.engine_run_id,
+            step_id=wait.step_id,
+        )
+        try:
+            resume_workflow_wait.delay(wait.engine_run_id, wait.step_id)
+        except Exception as exc:  # noqa: BLE001 - fall back to direct durable resume.
+            logger.warning(
+                "workflow_event_resume_enqueue_failed",
+                run_id=wait.engine_run_id,
+                step_id=wait.step_id,
+                error=str(exc),
+            )
+            await _resume_workflow_wait_async(wait.engine_run_id, wait.step_id)
+
+    r = None
+    try:
+        r = _get_redis()
         key = f"email_events:{campaign_id}:{email}"
         mapping: dict[str, str] = {
             event_type: "true",
@@ -146,76 +246,17 @@ async def _store_email_event(
             for k, v in extra.items():
                 mapping[k] = str(v)
         await r.hset(key, mapping=mapping)
-
-        event_fields: dict[str, Any] = {
-            "campaign_id": campaign_id,
-            "email": email,
-            "event_type": event_type,
-            "timestamp": timestamp,
-            **(extra or {}),
-        }
-
-        # Check for workflow event waits.
-        # Keys look like: wfwait_event:email.{event}:{run_id}:{step_id}
-        pattern = f"wfwait_event:email.{event_type}:*"
-        cursor = 0
-        while True:
-            cursor, keys = await r.scan(cursor=cursor, match=pattern, count=100)
-            for wait_key in keys:
-                parts = wait_key.split(":")
-                if len(parts) < 4:
-                    continue
-                run_id = parts[2]
-                step_id = parts[3]
-
-                # Load the listener payload and honour the stored
-                # match criteria before firing. The criteria were
-                # stored by workflows/step_types.py::_execute_wait_for_event.
-                match_criteria: dict[str, Any] = {}
-                try:
-                    raw_payload = await r.get(wait_key)
-                    if raw_payload:
-                        payload = _json.loads(raw_payload)
-                        match_criteria = payload.get("match", {}) or {}
-                except Exception as exc:
-                    logger.warning(
-                        "workflow_event_listener_payload_unreadable",
-                        wait_key=wait_key,
-                        error=str(exc),
-                    )
-                    # Unreadable payload: do NOT fire — refusing to
-                    # resume a workflow we can't prove matches is the
-                    # safer side of the fail-closed line.
-                    continue
-
-                if not _event_matches_criteria(event_fields, match_criteria):
-                    logger.debug(
-                        "workflow_event_criteria_mismatch",
-                        event_type=event_type,
-                        match=match_criteria,
-                        email=email,
-                        run_id=run_id,
-                        step_id=step_id,
-                    )
-                    continue
-
-                logger.info(
-                    "workflow_event_match",
-                    event_type=event_type,
-                    email=email,
-                    run_id=run_id,
-                    step_id=step_id,
-                )
-                # Trigger workflow resumption via Celery
-                from core.tasks.workflow_tasks import resume_workflow_wait
-
-                resume_workflow_wait.delay(run_id, step_id)
-                # Remove the wait key so it only fires once
-                await r.delete(wait_key)
-            if cursor == 0:
-                break
+    except Exception as exc:  # noqa: BLE001 - Redis event history is best-effort.
+        logger.warning(
+            "email_event_redis_store_failed",
+            campaign_id=campaign_id,
+            email=email,
+            event_type=event_type,
+            error=str(exc),
+        )
     finally:
-        await r.aclose()
+        if r is not None:
+            await r.aclose()
 
 
 def _verify_sendgrid_signature(
@@ -367,22 +408,29 @@ async def sendgrid_webhook(request: Request) -> dict[str, Any]:
         if not email or not event_type:
             continue
 
-        # Use sg_message_id as campaign_id proxy, or extract from categories
-        campaign_id = ""
+        # Use sg_message_id as campaign_id proxy, or extract from categories.
         categories = event.get("category", [])
-        if isinstance(categories, list) and categories:
-            campaign_id = categories[0]
-        elif isinstance(categories, str):
-            campaign_id = categories
+        campaign_id, category_extra = _sendgrid_category_metadata(categories)
         if not campaign_id:
             campaign_id = sg_message_id or "unknown"
+        extra: dict[str, Any] = dict(category_extra)
+        custom_args = event.get("custom_args")
+        if isinstance(custom_args, dict):
+            tenant_id = custom_args.get("tenant_id") or custom_args.get("agenticorg:tenant_id")
+            if tenant_id:
+                extra["tenant_id"] = tenant_id
+        explicit_tenant_id = event.get("tenant_id") or event.get("agenticorg:tenant_id")
+        if explicit_tenant_id:
+            extra["tenant_id"] = explicit_tenant_id
+        if url:
+            extra["url"] = url
 
         await _store_email_event(
             campaign_id=campaign_id,
             email=email,
             event_type=event_type,
             timestamp=ts,
-            extra={"url": url} if url else None,
+            extra=extra or None,
         )
         processed += 1
 
@@ -426,11 +474,20 @@ async def mailchimp_webhook(request: Request) -> dict[str, Any]:
     campaign_id = str(form.get("data[id]", "") or form.get("data[list_id]", "unknown"))
 
     if data_email:
+        extra: dict[str, Any] = {}
+        tenant_id = (
+            form.get("tenant_id")
+            or form.get("agenticorg:tenant_id")
+            or form.get("data[tenant_id]")
+        )
+        if tenant_id:
+            extra["tenant_id"] = tenant_id
         await _store_email_event(
             campaign_id=campaign_id,
             email=str(data_email),
             event_type=event_type,
             timestamp=str(fired_at),
+            extra=extra or None,
         )
 
     logger.info("mailchimp_webhook_processed", type=webhook_type, email=data_email)
@@ -480,13 +537,19 @@ async def moengage_webhook(request: Request) -> dict[str, Any]:
     normalized_event = moengage_event_map.get(event_type, event_type.lower())
 
     url = payload.get("url", payload.get("click_url", ""))
+    extra: dict[str, Any] = {}
+    tenant_id = payload.get("tenant_id") or payload.get("agenticorg:tenant_id")
+    if tenant_id:
+        extra["tenant_id"] = tenant_id
+    if url:
+        extra["url"] = url
 
     await _store_email_event(
         campaign_id=campaign_id,
         email=email,
         event_type=normalized_event,
         timestamp=timestamp,
-        extra={"url": url} if url else None,
+        extra=extra or None,
     )
 
     logger.info(

--- a/api/v1/workflows.py
+++ b/api/v1/workflows.py
@@ -366,7 +366,12 @@ async def _execute_workflow_bg(
     engine = WorkflowEngine(state_store)
 
     try:
-        engine_run_id = await engine.start_run(definition, trigger_payload)
+        engine_run_id = await engine.start_run(
+            definition,
+            trigger_payload,
+            tenant_id=str(tenant_id),
+            workflow_run_id=str(run_id),
+        )
 
         # Persist engine_run_id so HITL resume can find it later
         async with get_tenant_session(tenant_id) as session:

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -62,4 +62,6 @@ from core.models.user import User as User
 from core.models.workflow import StepExecution as StepExecution
 from core.models.workflow import WorkflowDefinition as WorkflowDefinition
 from core.models.workflow import WorkflowRun as WorkflowRun
+from core.models.workflow import WorkflowRunState as WorkflowRunState
+from core.models.workflow import WorkflowStateTransition as WorkflowStateTransition
 from core.models.workflow_variant import WorkflowVariant as WorkflowVariant

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -61,6 +61,7 @@ from core.models.tool_call import ToolCall as ToolCall
 from core.models.user import User as User
 from core.models.workflow import StepExecution as StepExecution
 from core.models.workflow import WorkflowDefinition as WorkflowDefinition
+from core.models.workflow import WorkflowEventWait as WorkflowEventWait
 from core.models.workflow import WorkflowRun as WorkflowRun
 from core.models.workflow import WorkflowRunState as WorkflowRunState
 from core.models.workflow import WorkflowStateTransition as WorkflowStateTransition

--- a/core/models/workflow.py
+++ b/core/models/workflow.py
@@ -162,6 +162,61 @@ class WorkflowStateTransition(BaseModel):
     )
 
 
+class WorkflowEventWait(BaseModel):
+    __tablename__ = "workflow_event_waits"
+    __table_args__ = (
+        Index(
+            "ix_workflow_event_waits_tenant_event_status",
+            "tenant_id",
+            "event_type",
+            "status",
+        ),
+        Index("ix_workflow_event_waits_run_step", "engine_run_id", "step_id"),
+        Index(
+            "ix_workflow_event_waits_waiting_timeout",
+            "timeout_at",
+            postgresql_where=text("status = 'waiting'"),
+        ),
+        Index(
+            "uq_workflow_event_waits_active_run_step",
+            "engine_run_id",
+            "step_id",
+            unique=True,
+            postgresql_where=text("status = 'waiting'"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="SET NULL"), nullable=True
+    )
+    engine_run_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    workflow_run_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("workflow_runs.id", ondelete="SET NULL"), nullable=True
+    )
+    step_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    event_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    connector: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    provider: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    match_criteria: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'::jsonb")
+    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="waiting")
+    timeout_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+    matched_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+    matched_event_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    matched_event: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=True,
+    )
+
+
 class StepExecution(BaseModel):
     __tablename__ = "step_executions"
     __table_args__ = (Index("idx_step_exec_run", "workflow_run_id"),)

--- a/core/models/workflow.py
+++ b/core/models/workflow.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -91,6 +92,74 @@ class WorkflowRun(BaseModel):
 
     workflow_def = relationship("WorkflowDefinition", back_populates="runs")
     steps = relationship("StepExecution", back_populates="workflow_run")
+
+
+class WorkflowRunState(BaseModel):
+    __tablename__ = "workflow_run_states"
+    __table_args__ = (
+        UniqueConstraint("run_id", name="uq_workflow_run_states_run_id"),
+        Index("ix_workflow_run_states_tenant_status", "tenant_id", "status"),
+        Index("ix_workflow_run_states_workflow_run_id", "workflow_run_id"),
+        Index("ix_workflow_run_states_updated_at", "updated_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    run_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    tenant_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="SET NULL"), nullable=True
+    )
+    workflow_run_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("workflow_runs.id", ondelete="SET NULL"), nullable=True
+    )
+    status: Mapped[str] = mapped_column(String(30), nullable=False)
+    waiting_step_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    state: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    state_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    version: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default=text("1")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=True,
+    )
+
+
+class WorkflowStateTransition(BaseModel):
+    __tablename__ = "workflow_state_transitions"
+    __table_args__ = (
+        Index("ix_workflow_state_transitions_run_created", "run_id", "created_at"),
+        Index("ix_workflow_state_transitions_step", "run_id", "step_id"),
+        Index(
+            "uq_workflow_state_transitions_idempotency",
+            "run_id",
+            "idempotency_key",
+            unique=True,
+            postgresql_where=text("idempotency_key IS NOT NULL"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    run_id: Mapped[str] = mapped_column(
+        String(100),
+        ForeignKey("workflow_run_states.run_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    step_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    previous_state_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    new_state_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    actor: Mapped[str] = mapped_column(String(100), nullable=False, default="workflow_engine")
+    idempotency_key: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    transition_metadata: Mapped[dict] = mapped_column(
+        "metadata", JSONB, nullable=False, default=dict
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
 
 
 class StepExecution(BaseModel):

--- a/core/tasks/workflow_tasks.py
+++ b/core/tasks/workflow_tasks.py
@@ -1,35 +1,29 @@
 """Celery tasks for workflow wait step and event-based resumption.
 
-Codex 2026-04-23 re-verification blocker A: these tasks were reading
-``state["steps"]`` / writing ``state["current_step"]``, but the
-async engine (``workflows/engine.py``) writes
-``state["step_results"]`` / ``state["waiting_step_id"]`` /
-``state["status"]`` to the same Redis key. Scheduled timeouts and
-external-event resumes silently did nothing because the keys didn't
-match — the workflow sat in ``waiting_*`` forever.
-
-The fix aligns this module to the engine's canonical schema. We
-re-implement the engine's ``resume_from_wait`` / ``timeout_event_wait``
-semantics in sync Redis so scheduled Celery workers can drive the
-same state transitions the async engine uses. The delegate functions
-keep the behaviour in lockstep: any subsequent engine schema change
-must update both this file and ``workflows/engine.py`` together.
+Workflow run state is durable in PostgreSQL via ``WorkflowStateStore``.
+Redis is still used for event-listener discovery and cleanup, but these tasks
+must not mutate ``wfstate:{run_id}`` directly.
 """
 
 from __future__ import annotations
 
-import json
+import asyncio
 from typing import Any
 
 import structlog
 
 from core.tasks.celery_app import app
+from workflows.state_store import WorkflowStateStore
 
 logger = structlog.get_logger()
 
 
+def _state_store() -> WorkflowStateStore:
+    return WorkflowStateStore()
+
+
 def _get_redis():
-    """Return a synchronous Redis client for workflow state."""
+    """Return a synchronous Redis client for event-listener cleanup."""
     import os
 
     import redis
@@ -50,45 +44,37 @@ def _clean_event_wait_keys(r: Any, run_id: str, step_id: str) -> None:
             break
 
 
-@app.task(name="resume_workflow_wait")
-def resume_workflow_wait(run_id: str, step_id: str) -> dict:
-    """Resume a workflow paused at a wait_delay or wait_for_event step.
-
-    Called when:
-    - A scheduled wait duration expires (via Celery ETA / countdown).
-    - An external event matches a ``wait_for_event`` step (triggered
-      by webhook).
-
-    Writes to the same ``wfstate:{run_id}`` key the async engine uses
-    and with the same schema the engine's ``resume_from_wait`` writes:
-
-      - ``state["step_results"][step_id] = {output, status="completed"}``
-      - ``state["status"]`` transitions ``waiting_* → running``
-      - ``state["waiting_step_id"]`` is cleared
-      - ``state["steps_completed"]`` is recomputed
-
-    This lets the web process (async engine) and the Celery worker
-    both drive the same state machine without diverging.
-    """
-    log = logger.bind(run_id=run_id, step_id=step_id)
+def _best_effort_clean_event_wait_keys(run_id: str, step_id: str) -> None:
     try:
         r = _get_redis()
-        state_key = f"wfstate:{run_id}"
-        raw = r.get(state_key)
-        if not raw:
+        try:
+            _clean_event_wait_keys(r, run_id, step_id)
+        finally:
+            close = getattr(r, "close", None)
+            if close is not None:
+                close()
+    except Exception as exc:  # noqa: BLE001 - cleanup cache must not block state progress.
+        logger.warning(
+            "workflow_event_wait_cleanup_failed",
+            run_id=run_id,
+            step_id=step_id,
+            error=str(exc),
+        )
+
+
+async def _resume_workflow_wait_async(run_id: str, step_id: str) -> dict:
+    log = logger.bind(run_id=run_id, step_id=step_id)
+    store = _state_store()
+    await store.init()
+    try:
+        state = await store.load(run_id)
+        if not state:
             log.warning("workflow_state_not_found")
             return {"status": "error", "reason": "workflow_state_not_found"}
 
-        state = json.loads(raw)
         current_status = state.get("status")
-
         if current_status not in ("waiting_delay", "waiting_event"):
-            log.info(
-                "workflow_not_waiting",
-                status=current_status,
-            )
-            # Idempotent: the state already advanced (maybe by the
-            # async resume path or the other worker). Don't overwrite.
+            log.info("workflow_not_waiting", status=current_status)
             return {"status": "noop", "reason": f"current status is {current_status}"}
 
         waiting_step_id = state.get("waiting_step_id")
@@ -103,7 +89,6 @@ def resume_workflow_wait(run_id: str, step_id: str) -> dict:
                 "reason": "waiting_step_id does not match",
             }
 
-        # Record completion — same schema the engine uses.
         step_results = state.setdefault("step_results", {})
         step_results[step_id] = {
             "output": {},
@@ -114,8 +99,13 @@ def resume_workflow_wait(run_id: str, step_id: str) -> dict:
         state["status"] = "running"
         state.pop("waiting_step_id", None)
 
-        r.set(state_key, json.dumps(state), ex=172800)
-        _clean_event_wait_keys(r, run_id, step_id)
+        await store.save(
+            state,
+            actor="celery.resume_workflow_wait",
+            step_id=step_id,
+            idempotency_key=f"resume_workflow_wait:{run_id}:{step_id}",
+            metadata={"task": "resume_workflow_wait"},
+        )
 
         log.info("workflow_wait_resumed")
         return {
@@ -123,44 +113,47 @@ def resume_workflow_wait(run_id: str, step_id: str) -> dict:
             "run_id": run_id,
             "step_id": step_id,
         }
+    finally:
+        await store.close()
 
-    except Exception as exc:
-        log.error("resume_workflow_wait_failed", error=str(exc))
+
+@app.task(name="resume_workflow_wait")
+def resume_workflow_wait(run_id: str, step_id: str) -> dict:
+    """Resume a workflow paused at a wait_delay or wait_for_event step."""
+    try:
+        result = asyncio.run(_resume_workflow_wait_async(run_id, step_id))
+        if result.get("status") in {"resumed", "noop"}:
+            _best_effort_clean_event_wait_keys(run_id, step_id)
+        return result
+    except Exception as exc:  # noqa: BLE001 - Celery task returns structured errors.
+        logger.error(
+            "resume_workflow_wait_failed",
+            run_id=run_id,
+            step_id=step_id,
+            error=str(exc),
+        )
         return {"status": "error", "reason": str(exc)}
 
 
-@app.task(name="timeout_workflow_event")
-def timeout_workflow_event(run_id: str, step_id: str) -> dict:
-    """Mark an event wait as timed_out and resume to the fallback path.
-
-    Scheduled with a countdown equal to the step's ``timeout_hours``.
-    Idempotent: if the event already arrived (step already in
-    ``step_results``), this is a no-op.
-    """
+async def _timeout_workflow_event_async(run_id: str, step_id: str) -> dict:
     log = logger.bind(run_id=run_id, step_id=step_id)
+    store = _state_store()
+    await store.init()
     try:
-        r = _get_redis()
-        state_key = f"wfstate:{run_id}"
-        raw = r.get(state_key)
-        if not raw:
+        state = await store.load(run_id)
+        if not state:
             log.warning("workflow_state_not_found")
             return {"status": "error", "reason": "workflow_state_not_found"}
 
-        state = json.loads(raw)
-
-        # Idempotency: step already completed (event arrived first).
         step_results = state.get("step_results", {})
         if step_id in step_results:
             log.info("event_already_received_before_timeout")
             return {"status": "already_completed"}
 
-        # Not waiting for this step any more (manual cancel / concurrent
-        # resume). Don't touch.
         if state.get("waiting_step_id") != step_id:
             log.info("step_no_longer_waiting")
             return {"status": "noop"}
 
-        # Mark as timed out — same schema as engine.timeout_event_wait.
         step_results[step_id] = {
             "status": "timed_out",
             "output": {},
@@ -171,8 +164,13 @@ def timeout_workflow_event(run_id: str, step_id: str) -> dict:
         state["status"] = "running"
         state.pop("waiting_step_id", None)
 
-        r.set(state_key, json.dumps(state), ex=172800)
-        _clean_event_wait_keys(r, run_id, step_id)
+        await store.save(
+            state,
+            actor="celery.timeout_workflow_event",
+            step_id=step_id,
+            idempotency_key=f"timeout_workflow_event:{run_id}:{step_id}",
+            metadata={"task": "timeout_workflow_event"},
+        )
 
         log.info("workflow_event_timed_out")
         return {
@@ -180,7 +178,23 @@ def timeout_workflow_event(run_id: str, step_id: str) -> dict:
             "run_id": run_id,
             "step_id": step_id,
         }
+    finally:
+        await store.close()
 
-    except Exception as exc:
-        log.error("timeout_workflow_event_failed", error=str(exc))
+
+@app.task(name="timeout_workflow_event")
+def timeout_workflow_event(run_id: str, step_id: str) -> dict:
+    """Mark an event wait as timed_out and let the engine continue later."""
+    try:
+        result = asyncio.run(_timeout_workflow_event_async(run_id, step_id))
+        if result.get("status") in {"timed_out", "already_completed", "noop"}:
+            _best_effort_clean_event_wait_keys(run_id, step_id)
+        return result
+    except Exception as exc:  # noqa: BLE001 - Celery task returns structured errors.
+        logger.error(
+            "timeout_workflow_event_failed",
+            run_id=run_id,
+            step_id=step_id,
+            error=str(exc),
+        )
         return {"status": "error", "reason": str(exc)}

--- a/core/tasks/workflow_tasks.py
+++ b/core/tasks/workflow_tasks.py
@@ -1,8 +1,9 @@
 """Celery tasks for workflow wait step and event-based resumption.
 
 Workflow run state is durable in PostgreSQL via ``WorkflowStateStore``.
-Redis is still used for event-listener discovery and cleanup, but these tasks
-must not mutate ``wfstate:{run_id}`` directly.
+Redis is still used for best-effort event-listener cache cleanup, but these
+tasks must not mutate ``wfstate:{run_id}`` directly or treat Redis listener
+keys as authoritative.
 """
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ from typing import Any
 import structlog
 
 from core.tasks.celery_app import app
+from workflows.event_waits import WorkflowEventWaitStore
 from workflows.state_store import WorkflowStateStore
 
 logger = structlog.get_logger()
@@ -20,6 +22,10 @@ logger = structlog.get_logger()
 
 def _state_store() -> WorkflowStateStore:
     return WorkflowStateStore()
+
+
+def _event_wait_store() -> WorkflowEventWaitStore:
+    return WorkflowEventWaitStore()
 
 
 def _get_redis():
@@ -137,10 +143,25 @@ def resume_workflow_wait(run_id: str, step_id: str) -> dict:
 
 async def _timeout_workflow_event_async(run_id: str, step_id: str) -> dict:
     log = logger.bind(run_id=run_id, step_id=step_id)
-    store = _state_store()
-    await store.init()
+    event_wait_store = _event_wait_store()
+    await event_wait_store.init()
+    event_wait_record = None
     try:
-        state = await store.load(run_id)
+        event_wait_record = await event_wait_store.mark_timed_out(
+            engine_run_id=run_id,
+            step_id=step_id,
+        )
+    finally:
+        await event_wait_store.close()
+
+    if event_wait_record and event_wait_record.status in {"matched", "cancelled", "expired"}:
+        log.info("event_wait_no_longer_waiting", listener_status=event_wait_record.status)
+        return {"status": "noop", "reason": f"listener is {event_wait_record.status}"}
+
+    state_store = _state_store()
+    await state_store.init()
+    try:
+        state = await state_store.load(run_id)
         if not state:
             log.warning("workflow_state_not_found")
             return {"status": "error", "reason": "workflow_state_not_found"}
@@ -164,7 +185,7 @@ async def _timeout_workflow_event_async(run_id: str, step_id: str) -> dict:
         state["status"] = "running"
         state.pop("waiting_step_id", None)
 
-        await store.save(
+        await state_store.save(
             state,
             actor="celery.timeout_workflow_event",
             step_id=step_id,
@@ -179,7 +200,7 @@ async def _timeout_workflow_event_async(run_id: str, step_id: str) -> dict:
             "step_id": step_id,
         }
     finally:
-        await store.close()
+        await state_store.close()
 
 
 @app.task(name="timeout_workflow_event")

--- a/migrations/versions/v4_9_11_workflow_state_durability.py
+++ b/migrations/versions/v4_9_11_workflow_state_durability.py
@@ -1,0 +1,103 @@
+"""Durable workflow engine state.
+
+Revision ID: v4911_workflow_state_pg
+Revises: v4910_pack_agent_idempotency
+Create Date: 2026-05-16
+
+Workflow engine state was previously Redis-only. This migration adds a
+PostgreSQL source-of-truth row per engine run plus append-only transition
+audit rows. Redis may still cache these records, but correctness now depends
+on these tables.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v4911_workflow_state_pg"
+down_revision = "v4910_pack_agent_idempotency"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS workflow_run_states (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            run_id VARCHAR(100) NOT NULL,
+            tenant_id UUID NULL REFERENCES tenants(id) ON DELETE SET NULL,
+            workflow_run_id UUID NULL REFERENCES workflow_runs(id) ON DELETE SET NULL,
+            status VARCHAR(30) NOT NULL,
+            waiting_step_id VARCHAR(100),
+            state JSONB NOT NULL,
+            state_hash VARCHAR(64) NOT NULL,
+            version INTEGER NOT NULL DEFAULT 1,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ DEFAULT now(),
+            CONSTRAINT uq_workflow_run_states_run_id UNIQUE (run_id)
+        )
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_workflow_run_states_tenant_status "
+        "ON workflow_run_states (tenant_id, status)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_workflow_run_states_workflow_run_id "
+        "ON workflow_run_states (workflow_run_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_workflow_run_states_updated_at "
+        "ON workflow_run_states (updated_at)"
+    )
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS workflow_state_transitions (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            run_id VARCHAR(100) NOT NULL
+                REFERENCES workflow_run_states(run_id) ON DELETE CASCADE,
+            step_id VARCHAR(100),
+            previous_state_hash VARCHAR(64),
+            new_state_hash VARCHAR(64) NOT NULL,
+            actor VARCHAR(100) NOT NULL DEFAULT 'workflow_engine',
+            idempotency_key VARCHAR(255),
+            metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_workflow_state_transitions_run_created "
+        "ON workflow_state_transitions (run_id, created_at)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_workflow_state_transitions_step "
+        "ON workflow_state_transitions (run_id, step_id)"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_workflow_state_transitions_idempotency "
+        "ON workflow_state_transitions (run_id, idempotency_key) "
+        "WHERE idempotency_key IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_workflow_state_transitions_idempotency",
+        table_name="workflow_state_transitions",
+    )
+    op.drop_index(
+        "ix_workflow_state_transitions_step",
+        table_name="workflow_state_transitions",
+    )
+    op.drop_index(
+        "ix_workflow_state_transitions_run_created",
+        table_name="workflow_state_transitions",
+    )
+    op.drop_table("workflow_state_transitions")
+
+    op.drop_index("ix_workflow_run_states_updated_at", table_name="workflow_run_states")
+    op.drop_index(
+        "ix_workflow_run_states_workflow_run_id",
+        table_name="workflow_run_states",
+    )
+    op.drop_index("ix_workflow_run_states_tenant_status", table_name="workflow_run_states")
+    op.drop_table("workflow_run_states")

--- a/migrations/versions/v4_9_12_workflow_event_waits.py
+++ b/migrations/versions/v4_9_12_workflow_event_waits.py
@@ -1,0 +1,75 @@
+"""Durable workflow event-wait listeners.
+
+Revision ID: v4912_workflow_event_waits
+Revises: v4911_workflow_state_pg
+Create Date: 2026-05-16
+
+wait_for_event listener discovery was previously Redis-only. This migration
+adds PostgreSQL-backed listener rows so Redis loss cannot make a waiting
+workflow miss future matching events.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v4912_workflow_event_waits"
+down_revision = "v4911_workflow_state_pg"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS workflow_event_waits (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id UUID NULL REFERENCES tenants(id) ON DELETE SET NULL,
+            engine_run_id VARCHAR(100) NOT NULL,
+            workflow_run_id UUID NULL REFERENCES workflow_runs(id) ON DELETE SET NULL,
+            step_id VARCHAR(100) NOT NULL,
+            event_type VARCHAR(100) NOT NULL,
+            connector VARCHAR(100),
+            provider VARCHAR(100),
+            match_criteria JSONB NOT NULL DEFAULT '{}'::jsonb,
+            status VARCHAR(20) NOT NULL DEFAULT 'waiting',
+            timeout_at TIMESTAMPTZ,
+            matched_at TIMESTAMPTZ,
+            matched_event_id VARCHAR(255),
+            matched_event JSONB,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ DEFAULT now()
+        )
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_workflow_event_waits_tenant_event_status "
+        "ON workflow_event_waits (tenant_id, event_type, status)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_workflow_event_waits_run_step "
+        "ON workflow_event_waits (engine_run_id, step_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_workflow_event_waits_waiting_timeout "
+        "ON workflow_event_waits (timeout_at) WHERE status = 'waiting'"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_workflow_event_waits_active_run_step "
+        "ON workflow_event_waits (engine_run_id, step_id) WHERE status = 'waiting'"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_workflow_event_waits_active_run_step",
+        table_name="workflow_event_waits",
+    )
+    op.drop_index(
+        "ix_workflow_event_waits_waiting_timeout",
+        table_name="workflow_event_waits",
+    )
+    op.drop_index("ix_workflow_event_waits_run_step", table_name="workflow_event_waits")
+    op.drop_index(
+        "ix_workflow_event_waits_tenant_event_status",
+        table_name="workflow_event_waits",
+    )
+    op.drop_table("workflow_event_waits")

--- a/tests/integration/test_workflow_event_wait_store_postgres.py
+++ b/tests/integration/test_workflow_event_wait_store_postgres.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import NullPool
+
+from core.models.workflow import WorkflowEventWait
+from workflows.event_waits import (
+    SqlAlchemyWorkflowEventWaitRepository,
+    WorkflowEventWaitStore,
+)
+
+
+async def _isolated_session_factory(db_engine: AsyncEngine):
+    import core.models  # noqa: F401 - registers all ORM models
+    from core.models.base import BaseModel as ORMBase
+
+    engine = create_async_engine(
+        db_engine.url.render_as_string(hide_password=False),
+        echo=False,
+        poolclass=NullPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(ORMBase.metadata.create_all)
+    return engine, async_sessionmaker(
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_workflow_event_wait_store_writes_and_claims_postgres_source_of_truth(
+    db_engine,
+) -> None:
+    engine, session_factory = await _isolated_session_factory(db_engine)
+    repo = SqlAlchemyWorkflowEventWaitRepository(session_factory)
+    redis = AsyncMock()
+    redis.set.side_effect = ConnectionError("redis unavailable")
+    store = WorkflowEventWaitStore(repository=repo, redis=redis)
+    run_id = f"wfr_evt_{uuid.uuid4().hex[:12]}"
+
+    try:
+        await store.register(
+            engine_run_id=run_id,
+            step_id="wait-1",
+            event_type="email.opened",
+            match_criteria={"campaign_id": "camp-pg"},
+            timeout_at=datetime.now(UTC) + timedelta(hours=1),
+        )
+
+        async with session_factory() as session:
+            row = (
+                await session.execute(
+                    select(WorkflowEventWait).where(
+                        WorkflowEventWait.engine_run_id == run_id
+                    )
+                )
+            ).scalar_one()
+        assert row.status == "waiting"
+        assert row.match_criteria == {"campaign_id": "camp-pg"}
+
+        store.redis = None
+        matched = await store.claim_matching_waits(
+            event_types=["email.opened"],
+            event_fields={"campaign_id": "camp-pg"},
+            matched_event_id="evt-pg",
+        )
+        duplicate = await store.claim_matching_waits(
+            event_types=["email.opened"],
+            event_fields={"campaign_id": "camp-pg"},
+            matched_event_id="evt-pg",
+        )
+
+        assert [(m.engine_run_id, m.step_id) for m in matched] == [(run_id, "wait-1")]
+        assert duplicate == []
+        async with session_factory() as session:
+            row = (
+                await session.execute(
+                    select(WorkflowEventWait).where(
+                        WorkflowEventWait.engine_run_id == run_id
+                    )
+                )
+            ).scalar_one()
+        assert row.status == "matched"
+        assert row.matched_event_id == "evt-pg"
+    finally:
+        async with session_factory() as session:
+            async with session.begin():
+                await session.execute(
+                    delete(WorkflowEventWait).where(
+                        WorkflowEventWait.engine_run_id == run_id
+                    )
+                )
+        await engine.dispose()

--- a/tests/integration/test_workflow_state_store_postgres.py
+++ b/tests/integration/test_workflow_state_store_postgres.py
@@ -5,19 +5,39 @@ from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import NullPool
 
 from core.models.workflow import WorkflowRunState, WorkflowStateTransition
 from workflows.state_store import SqlAlchemyWorkflowStateRepository, WorkflowStateStore
 
 
-@pytest.mark.asyncio
-async def test_workflow_state_store_writes_and_reads_postgres_source_of_truth(db_engine) -> None:
-    session_factory = async_sessionmaker(
-        db_engine,
+async def _isolated_session_factory(db_engine: AsyncEngine):
+    import core.models  # noqa: F401 - registers all ORM models
+    from core.models.base import BaseModel as ORMBase
+
+    engine = create_async_engine(
+        db_engine.url.render_as_string(hide_password=False),
+        echo=False,
+        poolclass=NullPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(ORMBase.metadata.create_all)
+    return engine, async_sessionmaker(
+        engine,
         class_=AsyncSession,
         expire_on_commit=False,
     )
+
+
+@pytest.mark.asyncio
+async def test_workflow_state_store_writes_and_reads_postgres_source_of_truth(db_engine) -> None:
+    engine, session_factory = await _isolated_session_factory(db_engine)
     repo = SqlAlchemyWorkflowStateRepository(session_factory)
     redis = AsyncMock()
     redis.set.side_effect = ConnectionError("redis unavailable")
@@ -66,3 +86,4 @@ async def test_workflow_state_store_writes_and_reads_postgres_source_of_truth(db
                 ).scalar_one_or_none()
                 if row is not None:
                     await session.delete(row)
+        await engine.dispose()

--- a/tests/integration/test_workflow_state_store_postgres.py
+++ b/tests/integration/test_workflow_state_store_postgres.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from core.models.workflow import WorkflowRunState, WorkflowStateTransition
+from workflows.state_store import SqlAlchemyWorkflowStateRepository, WorkflowStateStore
+
+
+@pytest.mark.asyncio
+async def test_workflow_state_store_writes_and_reads_postgres_source_of_truth(db_engine) -> None:
+    session_factory = async_sessionmaker(
+        db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    repo = SqlAlchemyWorkflowStateRepository(session_factory)
+    redis = AsyncMock()
+    redis.set.side_effect = ConnectionError("redis unavailable")
+    store = WorkflowStateStore(repository=repo, redis=redis)
+    run_id = f"wfr_test_{uuid.uuid4().hex[:12]}"
+    state = {
+        "id": run_id,
+        "status": "waiting_event",
+        "waiting_step_id": "wait-1",
+        "definition": {"steps": []},
+        "step_results": {},
+    }
+
+    try:
+        await store.save(state, actor="test", step_id="wait-1")
+
+        async with session_factory() as session:
+            row = (
+                await session.execute(
+                    select(WorkflowRunState).where(WorkflowRunState.run_id == run_id)
+                )
+            ).scalar_one()
+            transition = (
+                await session.execute(
+                    select(WorkflowStateTransition).where(
+                        WorkflowStateTransition.run_id == run_id
+                    )
+                )
+            ).scalar_one()
+
+        assert row.status == "waiting_event"
+        assert row.waiting_step_id == "wait-1"
+        assert row.state["id"] == run_id
+        assert transition.actor == "test"
+        assert transition.step_id == "wait-1"
+
+        loaded = await store.load(run_id)
+        assert loaded == state
+    finally:
+        async with session_factory() as session:
+            async with session.begin():
+                row = (
+                    await session.execute(
+                        select(WorkflowRunState).where(WorkflowRunState.run_id == run_id)
+                    )
+                ).scalar_one_or_none()
+                if row is not None:
+                    await session.delete(row)

--- a/tests/unit/test_performance.py
+++ b/tests/unit/test_performance.py
@@ -28,7 +28,7 @@ def _make_state_store() -> WorkflowStateStore:
     store = WorkflowStateStore()
     _data: dict[str, dict] = {}
 
-    async def _save(state):
+    async def _save(state, **_kwargs):
         import copy
 
         _data[state["id"]] = copy.deepcopy(state)

--- a/tests/unit/test_reliability.py
+++ b/tests/unit/test_reliability.py
@@ -32,7 +32,7 @@ def _in_memory_state_store() -> WorkflowStateStore:
     store = WorkflowStateStore()
     _data: dict[str, dict] = {}
 
-    async def _save(state):
+    async def _save(state, **_kwargs):
         _data[state["id"]] = copy.deepcopy(state)
 
     async def _load(run_id):

--- a/tests/unit/test_tier1_features.py
+++ b/tests/unit/test_tier1_features.py
@@ -91,26 +91,34 @@ class TestWaitForEvent:
 
     @pytest.fixture(autouse=True)
     def _patch_deps(self):
-        mock_redis_cls = MagicMock()
         mock_redis_inst = AsyncMock()
         mock_redis_inst.set = AsyncMock()
         mock_redis_inst.aclose = AsyncMock()
-        mock_redis_cls.from_url.return_value = mock_redis_inst
         self._mock_redis = mock_redis_inst
+        from workflows.event_waits import (
+            InMemoryWorkflowEventWaitRepository,
+            WorkflowEventWaitStore,
+        )
 
-        with patch("workflows.step_types.aioredis", mock_redis_cls, create=True):
-            with patch(
-                "core.tasks.workflow_tasks.timeout_workflow_event",
-                new=MagicMock(apply_async=MagicMock()),
-            ):
-                with patch("core.config.settings", new=MagicMock(redis_url="redis://mock:6379/0")):
-                    yield
+        self._event_wait_repo = InMemoryWorkflowEventWaitRepository()
+        self._event_wait_store = WorkflowEventWaitStore(
+            repository=self._event_wait_repo,
+            redis=mock_redis_inst,
+        )
+
+        with patch(
+            "core.tasks.workflow_tasks.timeout_workflow_event",
+            new=MagicMock(apply_async=MagicMock()),
+        ):
+            yield
 
     def _run(self, step: dict, state: dict | None = None) -> dict:
         from workflows.step_types import execute_step
 
+        state = state or {"id": "run-42"}
+        state["_event_wait_store"] = self._event_wait_store
         return asyncio.run(
-            execute_step(step, state or {"id": "run-42"})
+            execute_step(step, state)
         )
 
     def test_returns_waiting_event_with_correct_type(self):
@@ -341,7 +349,19 @@ class TestWebhookParsing:
         mock_redis.hset = AsyncMock()
         mock_redis.scan = AsyncMock(return_value=(0, []))
         mock_redis.aclose = AsyncMock()
-        with patch("api.v1.webhooks._get_redis", return_value=mock_redis):
+        from workflows.event_waits import (
+            InMemoryWorkflowEventWaitRepository,
+            WorkflowEventWaitStore,
+        )
+
+        event_wait_store = WorkflowEventWaitStore(
+            repository=InMemoryWorkflowEventWaitRepository(),
+            redis=mock_redis,
+        )
+        with patch("api.v1.webhooks._get_redis", return_value=mock_redis), patch(
+            "api.v1.webhooks._workflow_event_wait_store",
+            return_value=event_wait_store,
+        ):
             self._redis = mock_redis
             yield
 

--- a/tests/unit/test_workflow_event_wait_durability.py
+++ b/tests/unit/test_workflow_event_wait_durability.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from workflows.event_waits import (
+    InMemoryWorkflowEventWaitRepository,
+    WorkflowEventWaitStore,
+)
+
+
+def _store(redis: AsyncMock | None = None) -> tuple[
+    WorkflowEventWaitStore,
+    InMemoryWorkflowEventWaitRepository,
+]:
+    repo = InMemoryWorkflowEventWaitRepository()
+    return WorkflowEventWaitStore(repository=repo, redis=redis), repo
+
+
+@pytest.mark.asyncio
+async def test_event_wait_registration_persists_to_durable_repository() -> None:
+    redis = AsyncMock()
+    redis.set.side_effect = ConnectionError("redis unavailable")
+    store, repo = _store(redis)
+
+    await store.register(
+        engine_run_id="run-1",
+        step_id="wait-1",
+        event_type="email.opened",
+        match_criteria={"campaign_id": "camp-1", "email": "u@example.com"},
+        timeout_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+
+    record = repo.records[("run-1", "wait-1")]
+    assert record.status == "waiting"
+    assert record.event_type == "email.opened"
+    assert record.match_criteria["campaign_id"] == "camp-1"
+
+
+@pytest.mark.asyncio
+async def test_redis_flush_after_registration_does_not_prevent_event_matching() -> None:
+    redis = AsyncMock()
+    store, _repo = _store(redis)
+    await store.register(
+        engine_run_id="run-2",
+        step_id="wait-1",
+        event_type="email.opened",
+        match_criteria={"campaign_id": "camp-2"},
+        timeout_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+    store.redis = None
+
+    matched = await store.claim_matching_waits(
+        event_types=["email.opened"],
+        event_fields={"campaign_id": "camp-2", "email": "u@example.com"},
+        matched_event_id="evt-1",
+    )
+
+    assert [(m.engine_run_id, m.step_id) for m in matched] == [("run-2", "wait-1")]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_event_delivery_claims_workflow_once() -> None:
+    store, _repo = _store()
+    await store.register(
+        engine_run_id="run-dup",
+        step_id="wait-1",
+        event_type="email.clicked",
+        match_criteria={"campaign_id": "camp-dup"},
+        timeout_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+
+    first = await store.claim_matching_waits(
+        event_types=["email.clicked"],
+        event_fields={"campaign_id": "camp-dup"},
+        matched_event_id="evt-dup",
+    )
+    second = await store.claim_matching_waits(
+        event_types=["email.clicked"],
+        event_fields={"campaign_id": "camp-dup"},
+        matched_event_id="evt-dup",
+    )
+
+    assert len(first) == 1
+    assert second == []
+
+
+@pytest.mark.asyncio
+async def test_event_timeout_marks_listener_timed_out_without_clobbering_matched() -> None:
+    store, repo = _store()
+    await store.register(
+        engine_run_id="run-timeout",
+        step_id="wait-timeout",
+        event_type="email.opened",
+    )
+    timed_out = await store.mark_timed_out(
+        engine_run_id="run-timeout",
+        step_id="wait-timeout",
+    )
+
+    await store.register(
+        engine_run_id="run-matched",
+        step_id="wait-matched",
+        event_type="email.opened",
+    )
+    await store.claim_matching_waits(
+        event_types=["email.opened"],
+        event_fields={},
+        matched_event_id="evt-matched",
+    )
+    matched_after_timeout = await store.mark_timed_out(
+        engine_run_id="run-matched",
+        step_id="wait-matched",
+    )
+
+    assert timed_out is not None
+    assert timed_out.status == "timed_out"
+    assert repo.records[("run-timeout", "wait-timeout")].status == "timed_out"
+    assert matched_after_timeout is not None
+    assert matched_after_timeout.status == "matched"
+    assert repo.records[("run-matched", "wait-matched")].status == "matched"
+
+
+@pytest.mark.asyncio
+async def test_tenant_mismatch_does_not_resume_other_tenant_workflow() -> None:
+    store, _repo = _store()
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+    await store.register(
+        engine_run_id="run-tenant-a",
+        step_id="wait-1",
+        event_type="email.opened",
+        tenant_id=tenant_a,
+    )
+
+    matched = await store.claim_matching_waits(
+        event_types=["email.opened"],
+        event_fields={"tenant_id": str(tenant_b)},
+        tenant_id=tenant_b,
+        matched_event_id="evt-tenant",
+    )
+
+    assert matched == []
+
+
+@pytest.mark.asyncio
+async def test_webhook_event_matching_uses_durable_store_when_redis_unavailable() -> None:
+    from api.v1 import webhooks
+
+    redis = AsyncMock()
+    redis.hset.side_effect = ConnectionError("redis unavailable")
+    redis.aclose = AsyncMock()
+    store, _repo = _store()
+    tenant_id = uuid.uuid4()
+    await store.register(
+        engine_run_id="run-webhook",
+        step_id="wait-1",
+        event_type="email.opened",
+        tenant_id=tenant_id,
+        match_criteria={"campaign_id": "camp-web", "email": "u@example.com"},
+        timeout_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+
+    with patch("api.v1.webhooks._get_redis", return_value=redis), patch(
+        "api.v1.webhooks._workflow_event_wait_store",
+        return_value=store,
+    ), patch("core.tasks.workflow_tasks.resume_workflow_wait.delay") as delay:
+        await webhooks._store_email_event(
+            campaign_id="camp-web",
+            email="u@example.com",
+            event_type="open",
+            timestamp=1,
+            extra={"tenant_id": str(tenant_id)},
+        )
+        await webhooks._store_email_event(
+            campaign_id="camp-web",
+            email="u@example.com",
+            event_type="open",
+            timestamp=1,
+            extra={"tenant_id": str(tenant_id)},
+        )
+
+    delay.assert_called_once_with("run-webhook", "wait-1")
+
+
+@pytest.mark.asyncio
+async def test_celery_event_timeout_marks_durable_listener_timed_out() -> None:
+    from core.tasks import workflow_tasks
+    from workflows.state_store import InMemoryWorkflowStateRepository, WorkflowStateStore
+
+    state_repo = InMemoryWorkflowStateRepository()
+    state_store = WorkflowStateStore(repository=state_repo, redis=AsyncMock())
+    state_store.init = AsyncMock()
+    state_store.close = AsyncMock()
+    waiting_state = {
+        "id": "run-timeout-task",
+        "status": "waiting_event",
+        "waiting_step_id": "wait-1",
+        "definition": {"steps": []},
+        "step_results": {},
+        "steps_completed": 0,
+    }
+    await state_store.save(waiting_state)
+
+    event_store, event_repo = _store(AsyncMock())
+    await event_store.register(
+        engine_run_id="run-timeout-task",
+        step_id="wait-1",
+        event_type="email.opened",
+    )
+
+    with patch.object(workflow_tasks, "_state_store", return_value=state_store), patch.object(
+        workflow_tasks,
+        "_event_wait_store",
+        return_value=event_store,
+    ):
+        result = await workflow_tasks._timeout_workflow_event_async(
+            "run-timeout-task",
+            "wait-1",
+        )
+
+    assert result["status"] == "timed_out"
+    assert event_repo.records[("run-timeout-task", "wait-1")].status == "timed_out"
+    durable_state = state_repo.states["run-timeout-task"]["state"]
+    assert durable_state["status"] == "running"
+    assert durable_state["step_results"]["wait-1"]["status"] == "timed_out"

--- a/tests/unit/test_workflow_state_durability.py
+++ b/tests/unit/test_workflow_state_durability.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from workflows.state_store import InMemoryWorkflowStateRepository, WorkflowStateStore
+
+
+def _state(run_id: str = "run-1", status: str = "running") -> dict:
+    return {
+        "id": run_id,
+        "status": status,
+        "definition": {"steps": []},
+        "step_results": {},
+        "steps_completed": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_save_writes_durable_store_before_redis_cache() -> None:
+    repo = InMemoryWorkflowStateRepository()
+    redis = AsyncMock()
+
+    async def _redis_set(*_args, **_kwargs):
+        assert "run-1" in repo.states
+
+    redis.set.side_effect = _redis_set
+    store = WorkflowStateStore(repository=repo, redis=redis)
+
+    await store.save(_state())
+
+    assert repo.states["run-1"]["state"]["status"] == "running"
+    assert repo.states["run-1"]["version"] == 1
+    assert repo.transitions[-1]["new_state_hash"] == repo.states["run-1"]["state_hash"]
+    redis.set.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_load_prefers_durable_store_over_redis_cache() -> None:
+    repo = InMemoryWorkflowStateRepository()
+    redis = AsyncMock()
+    redis.get.return_value = json.dumps(_state(status="failed"))
+    store = WorkflowStateStore(repository=repo, redis=redis)
+
+    await store.save(_state(status="completed"))
+    loaded = await store.load("run-1")
+
+    assert loaded is not None
+    assert loaded["status"] == "completed"
+    redis.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_load_survives_redis_flush_or_unavailable_cache() -> None:
+    repo = InMemoryWorkflowStateRepository()
+    redis = AsyncMock()
+    redis.set.side_effect = ConnectionError("redis down")
+    redis.get.side_effect = ConnectionError("redis down")
+    store = WorkflowStateStore(repository=repo, redis=redis)
+
+    await store.save(_state(status="waiting_event"))
+    redis.get.reset_mock()
+
+    loaded = await store.load("run-1")
+
+    assert loaded is not None
+    assert loaded["status"] == "waiting_event"
+    redis.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_redis_legacy_fallback_backfills_durable_store() -> None:
+    repo = InMemoryWorkflowStateRepository()
+    redis = AsyncMock()
+    redis.get.return_value = json.dumps(_state(status="waiting_delay"))
+    store = WorkflowStateStore(repository=repo, redis=redis)
+
+    loaded = await store.load("run-1")
+
+    assert loaded is not None
+    assert loaded["status"] == "waiting_delay"
+    assert repo.states["run-1"]["state"]["status"] == "waiting_delay"
+    assert repo.transitions[-1]["actor"] == "redis_legacy_backfill"
+
+
+@pytest.mark.asyncio
+async def test_celery_wait_resume_updates_durable_state_not_redis_only() -> None:
+    from core.tasks import workflow_tasks
+
+    repo = InMemoryWorkflowStateRepository()
+    redis = AsyncMock()
+    store = WorkflowStateStore(repository=repo, redis=redis)
+    store.init = AsyncMock()
+    store.close = AsyncMock()
+
+    waiting = _state("run-wait", "waiting_event")
+    waiting["waiting_step_id"] = "wait-1"
+    await store.save(waiting)
+
+    with patch.object(workflow_tasks, "_state_store", return_value=store):
+        result = await workflow_tasks._resume_workflow_wait_async("run-wait", "wait-1")
+
+    assert result["status"] == "resumed"
+    durable_state = repo.states["run-wait"]["state"]
+    assert durable_state["status"] == "running"
+    assert durable_state["step_results"]["wait-1"]["status"] == "completed"
+    assert "waiting_step_id" not in durable_state
+    assert repo.transitions[-1]["actor"] == "celery.resume_workflow_wait"
+    assert repo.transitions[-1]["step_id"] == "wait-1"

--- a/workflows/engine.py
+++ b/workflows/engine.py
@@ -45,7 +45,14 @@ class WorkflowEngine:
     # Public API
     # ------------------------------------------------------------------
 
-    async def start_run(self, definition: dict, trigger_payload: dict | None = None) -> str:
+    async def start_run(
+        self,
+        definition: dict,
+        trigger_payload: dict | None = None,
+        *,
+        tenant_id: str | None = None,
+        workflow_run_id: str | None = None,
+    ) -> str:
         """Parse a workflow definition, persist initial state, and return the run_id."""
         run_id = f"wfr_{uuid.uuid4().hex[:12]}"
         parsed = self.parser.parse(definition)
@@ -61,7 +68,15 @@ class WorkflowEngine:
             "replan_count": 0,
             "replan_history": [],
         }
-        await self.state_store.save(state)
+        if tenant_id:
+            state["tenant_id"] = tenant_id
+        if workflow_run_id:
+            state["workflow_run_id"] = workflow_run_id
+        await self.state_store.save(
+            state,
+            actor="workflow_engine",
+            metadata={"event": "run_started"},
+        )
         logger.info("workflow_run_started", run_id=run_id)
         return run_id
 
@@ -94,7 +109,12 @@ class WorkflowEngine:
                     self._check_timeout(state, timeout_hours)
                 except WorkflowTimeoutError:
                     state["status"] = "timed_out"
-                    await self.state_store.save(state)
+                    await self.state_store.save(
+                        state,
+                        actor="workflow_engine",
+                        step_id=step_id,
+                        metadata={"event": "workflow_timed_out"},
+                    )
                     logger.warning("workflow_timed_out", run_id=run_id, step_id=step_id)
                     return {"status": "timed_out", "step_results": state["step_results"]}
 
@@ -110,7 +130,12 @@ class WorkflowEngine:
                     "reason": dep_failure,
                 }
                 state["steps_completed"] = len(state["step_results"])
-                await self.state_store.save(state)
+                await self.state_store.save(
+                    state,
+                    actor="workflow_engine",
+                    step_id=step_id,
+                    metadata={"event": "step_skipped", "reason": dep_failure},
+                )
                 continue
 
             # ---- build context from prior step outputs for condition resolution ----
@@ -142,7 +167,12 @@ class WorkflowEngine:
                 }
                 state["status"] = "failed"
                 state["steps_completed"] = len(state["step_results"])
-                await self.state_store.save(state)
+                await self.state_store.save(
+                    state,
+                    actor="workflow_engine",
+                    step_id=step_id,
+                    metadata={"event": "step_failed", "error": str(exc)},
+                )
                 logger.error("workflow_step_failed", run_id=run_id, step_id=step_id, error=str(exc))
                 return {"status": "failed", "step_results": state["step_results"]}
 
@@ -167,7 +197,12 @@ class WorkflowEngine:
             if step.get("type") == "human_in_loop" or result.get("status") == "waiting_hitl":
                 state["status"] = "waiting_hitl"
                 state["waiting_step_id"] = step_id
-                await self.state_store.save(state)
+                await self.state_store.save(
+                    state,
+                    actor="workflow_engine",
+                    step_id=step_id,
+                    metadata={"event": "waiting_hitl"},
+                )
                 logger.info("workflow_waiting_hitl", run_id=run_id, step_id=step_id)
                 return {"status": "waiting_hitl", "step_results": state["step_results"]}
 
@@ -175,7 +210,12 @@ class WorkflowEngine:
             if result.get("status") == "waiting_delay":
                 state["status"] = "waiting_delay"
                 state["waiting_step_id"] = step_id
-                await self.state_store.save(state)
+                await self.state_store.save(
+                    state,
+                    actor="workflow_engine",
+                    step_id=step_id,
+                    metadata={"event": "waiting_delay", "resume_at": result.get("resume_at")},
+                )
                 logger.info("workflow_waiting_delay", run_id=run_id, step_id=step_id, resume_at=result.get("resume_at"))
                 return {"status": "waiting_delay", "step_results": state["step_results"]}
 
@@ -183,19 +223,33 @@ class WorkflowEngine:
             if result.get("status") == "waiting_event":
                 state["status"] = "waiting_event"
                 state["waiting_step_id"] = step_id
-                await self.state_store.save(state)
+                await self.state_store.save(
+                    state,
+                    actor="workflow_engine",
+                    step_id=step_id,
+                    metadata={"event": "waiting_event", "event_type": result.get("event_type")},
+                )
                 evt = result.get("event_type")
                 logger.info("workflow_waiting_event", run_id=run_id, step_id=step_id, event_type=evt)
                 return {"status": "waiting_event", "step_results": state["step_results"]}
 
             # ---- checkpoint ----
-            await self.state_store.save(state)
+            await self.state_store.save(
+                state,
+                actor="workflow_engine",
+                step_id=step_id,
+                metadata={"event": "step_checkpointed"},
+            )
             logger.debug("step_checkpointed", run_id=run_id, step_id=step_id)
 
         # All steps done.
         state["status"] = "completed"
         state["completed_at"] = datetime.now(UTC).isoformat()
-        await self.state_store.save(state)
+        await self.state_store.save(
+            state,
+            actor="workflow_engine",
+            metadata={"event": "workflow_completed"},
+        )
         logger.info("workflow_completed", run_id=run_id)
         return {"status": "completed", "step_results": state["step_results"]}
 
@@ -225,7 +279,12 @@ class WorkflowEngine:
                     self._check_timeout(state, timeout_hours)
                 except WorkflowTimeoutError:
                     state["status"] = "timed_out"
-                    await self.state_store.save(state)
+                    await self.state_store.save(
+                        state,
+                        actor="workflow_engine",
+                        step_id=step_id,
+                        metadata={"event": "workflow_timed_out"},
+                    )
                     return {"status": "timed_out"}
 
             step = step_index[step_id]
@@ -238,7 +297,12 @@ class WorkflowEngine:
                     "reason": dep_failure,
                 }
                 state["steps_completed"] = len(state["step_results"])
-                await self.state_store.save(state)
+                await self.state_store.save(
+                    state,
+                    actor="workflow_engine",
+                    step_id=step_id,
+                    metadata={"event": "step_skipped", "reason": dep_failure},
+                )
                 continue
 
             context = self._build_context(state)
@@ -254,7 +318,12 @@ class WorkflowEngine:
                 }
                 state["status"] = "failed"
                 state["steps_completed"] = len(state["step_results"])
-                await self.state_store.save(state)
+                await self.state_store.save(
+                    state,
+                    actor="workflow_engine",
+                    step_id=step_id,
+                    metadata={"event": "step_failed", "error": str(exc)},
+                )
                 return {"status": "failed", "step_id": step_id, "error": str(exc)}
 
             state["step_results"][step_id] = {
@@ -272,16 +341,30 @@ class WorkflowEngine:
             if step.get("type") == "human_in_loop" or result.get("status") == "waiting_hitl":
                 state["status"] = "waiting_hitl"
                 state["waiting_step_id"] = step_id
-                await self.state_store.save(state)
+                await self.state_store.save(
+                    state,
+                    actor="workflow_engine",
+                    step_id=step_id,
+                    metadata={"event": "waiting_hitl"},
+                )
                 return {"status": "waiting_hitl", "step_id": step_id}
 
-            await self.state_store.save(state)
+            await self.state_store.save(
+                state,
+                actor="workflow_engine",
+                step_id=step_id,
+                metadata={"event": "step_checkpointed"},
+            )
             return result
 
         # All steps executed.
         state["status"] = "completed"
         state["completed_at"] = datetime.now(UTC).isoformat()
-        await self.state_store.save(state)
+        await self.state_store.save(
+            state,
+            actor="workflow_engine",
+            metadata={"event": "workflow_completed"},
+        )
         return {"status": "completed", "step_results": state["step_results"]}
 
     async def resume_from_hitl(self, run_id: str, decision: dict[str, Any]) -> dict[str, Any]:
@@ -308,7 +391,12 @@ class WorkflowEngine:
         state["steps_completed"] = len(state["step_results"])
         state["status"] = "running"
         state.pop("waiting_step_id", None)
-        await self.state_store.save(state)
+        await self.state_store.save(
+            state,
+            actor="workflow_engine.hitl_resume",
+            step_id=waiting_step_id,
+            metadata={"event": "hitl_resumed"},
+        )
 
         logger.info("workflow_hitl_resumed", run_id=run_id, step_id=waiting_step_id)
 
@@ -334,7 +422,12 @@ class WorkflowEngine:
         state["steps_completed"] = len(state["step_results"])
         state["status"] = "running"
         state.pop("waiting_step_id", None)
-        await self.state_store.save(state)
+        await self.state_store.save(
+            state,
+            actor="workflow_engine.wait_resume",
+            step_id=waiting_step_id,
+            metadata={"event": "wait_resumed"},
+        )
 
         logger.info("workflow_wait_resumed", run_id=run_id, step_id=waiting_step_id)
         return await self.execute(run_id)
@@ -355,7 +448,12 @@ class WorkflowEngine:
         state["steps_completed"] = len(state["step_results"])
         state["status"] = "running"
         state.pop("waiting_step_id", None)
-        await self.state_store.save(state)
+        await self.state_store.save(
+            state,
+            actor="workflow_engine.event_timeout",
+            step_id=step_id,
+            metadata={"event": "event_wait_timed_out"},
+        )
 
         logger.info("workflow_event_timed_out", run_id=run_id, step_id=step_id)
         return await self.execute(run_id)
@@ -366,7 +464,11 @@ class WorkflowEngine:
         if state:
             state["status"] = "cancelled"
             state["cancelled_at"] = datetime.now(UTC).isoformat()
-            await self.state_store.save(state)
+            await self.state_store.save(
+                state,
+                actor="workflow_engine.cancel",
+                metadata={"event": "workflow_cancelled"},
+            )
             logger.info("workflow_cancelled", run_id=run_id)
 
     # ------------------------------------------------------------------
@@ -461,7 +563,12 @@ class WorkflowEngine:
         state["definition"]["steps"] = completed_step_defs + new_steps
         state["steps_total"] = len(state["definition"]["steps"])
 
-        await self.state_store.save(state)
+        await self.state_store.save(
+            state,
+            actor="workflow_engine.replan",
+            step_id=failed_step_id,
+            metadata={"event": "workflow_replanned", "error": error_msg},
+        )
 
         logger.info(
             "workflow_replanned_successfully",
@@ -593,7 +700,7 @@ class WorkflowEngine:
         max_retries = self._parse_retry_count(on_failure)
 
         # Inject the built context into state so step handlers can use it.
-        state_with_context = {**state, "context": context}
+        state_with_context = {**state, "context": context, "_state_store": self.state_store}
 
         if max_retries > 0:
             return await retry_with_backoff(

--- a/workflows/event_waits.py
+++ b/workflows/event_waits.py
@@ -1,0 +1,523 @@
+"""Durable workflow event-wait listener store.
+
+PostgreSQL is authoritative for wait_for_event listener registration and
+matching. Redis is used only as a rebuildable cache/index for older paths.
+"""
+
+from __future__ import annotations
+
+import copy
+import inspect
+import json
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+import redis.asyncio as aioredis
+import structlog
+from sqlalchemy import select
+
+from core.config import settings
+
+logger = structlog.get_logger()
+
+ACTIVE_STATUS = "waiting"
+TERMINAL_STATUSES = {"matched", "timed_out", "cancelled", "expired"}
+
+
+def _json_safe(value: Any) -> Any:
+    return json.loads(json.dumps(value, default=str))
+
+
+def _coerce_uuid(value: Any) -> uuid.UUID | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, uuid.UUID):
+        return value
+    try:
+        return uuid.UUID(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _event_matches_criteria(
+    event_fields: dict[str, Any],
+    match_criteria: dict[str, Any],
+) -> bool:
+    if not match_criteria:
+        return True
+    for key, expected in match_criteria.items():
+        actual = event_fields.get(key)
+        if actual is None:
+            return False
+        if str(actual).strip().lower() != str(expected).strip().lower():
+            return False
+    return True
+
+
+@dataclass(slots=True)
+class EventWaitRecord:
+    engine_run_id: str
+    step_id: str
+    event_type: str
+    match_criteria: dict[str, Any] = field(default_factory=dict)
+    tenant_id: uuid.UUID | None = None
+    workflow_run_id: uuid.UUID | None = None
+    connector: str | None = None
+    provider: str | None = None
+    status: str = ACTIVE_STATUS
+    timeout_at: datetime | None = None
+    id: uuid.UUID | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    matched_at: datetime | None = None
+    matched_event_id: str | None = None
+    matched_event: dict[str, Any] | None = None
+
+
+class WorkflowEventWaitRepository(Protocol):
+    async def register(self, record: EventWaitRecord) -> EventWaitRecord:
+        ...
+
+    async def list_waiting(
+        self,
+        *,
+        event_types: Sequence[str] | None = None,
+        tenant_id: uuid.UUID | None = None,
+    ) -> list[EventWaitRecord]:
+        ...
+
+    async def claim_matched(
+        self,
+        *,
+        engine_run_id: str,
+        step_id: str,
+        matched_event_id: str | None,
+        event_data: dict[str, Any],
+    ) -> EventWaitRecord | None:
+        ...
+
+    async def mark_timed_out(
+        self,
+        *,
+        engine_run_id: str,
+        step_id: str,
+    ) -> EventWaitRecord | None:
+        ...
+
+
+class InMemoryWorkflowEventWaitRepository:
+    """Durable event-wait test double."""
+
+    def __init__(self) -> None:
+        self.records: dict[tuple[str, str], EventWaitRecord] = {}
+
+    async def register(self, record: EventWaitRecord) -> EventWaitRecord:
+        now = datetime.now(UTC)
+        key = (record.engine_run_id, record.step_id)
+        existing = self.records.get(key)
+        if existing and existing.status == ACTIVE_STATUS:
+            existing.tenant_id = record.tenant_id
+            existing.workflow_run_id = record.workflow_run_id
+            existing.event_type = record.event_type
+            existing.connector = record.connector
+            existing.provider = record.provider
+            existing.match_criteria = copy.deepcopy(_json_safe(record.match_criteria))
+            existing.timeout_at = record.timeout_at
+            existing.updated_at = now
+            return copy.deepcopy(existing)
+
+        stored = copy.deepcopy(record)
+        stored.id = stored.id or uuid.uuid4()
+        stored.match_criteria = copy.deepcopy(_json_safe(stored.match_criteria))
+        stored.status = ACTIVE_STATUS
+        stored.created_at = now
+        stored.updated_at = now
+        self.records[key] = stored
+        return copy.deepcopy(stored)
+
+    async def list_waiting(
+        self,
+        *,
+        event_types: Sequence[str] | None = None,
+        tenant_id: uuid.UUID | None = None,
+    ) -> list[EventWaitRecord]:
+        event_type_set = set(event_types or [])
+        now = datetime.now(UTC)
+        records: list[EventWaitRecord] = []
+        for record in self.records.values():
+            if record.status != ACTIVE_STATUS:
+                continue
+            if event_type_set and record.event_type not in event_type_set:
+                continue
+            if record.tenant_id != tenant_id:
+                continue
+            if record.timeout_at and record.timeout_at <= now:
+                continue
+            records.append(copy.deepcopy(record))
+        return records
+
+    async def claim_matched(
+        self,
+        *,
+        engine_run_id: str,
+        step_id: str,
+        matched_event_id: str | None,
+        event_data: dict[str, Any],
+    ) -> EventWaitRecord | None:
+        record = self.records.get((engine_run_id, step_id))
+        if not record or record.status != ACTIVE_STATUS:
+            return None
+        now = datetime.now(UTC)
+        record.status = "matched"
+        record.matched_at = now
+        record.updated_at = now
+        record.matched_event_id = matched_event_id
+        record.matched_event = copy.deepcopy(_json_safe(event_data))
+        return copy.deepcopy(record)
+
+    async def mark_timed_out(
+        self,
+        *,
+        engine_run_id: str,
+        step_id: str,
+    ) -> EventWaitRecord | None:
+        record = self.records.get((engine_run_id, step_id))
+        if not record:
+            return None
+        if record.status == ACTIVE_STATUS:
+            now = datetime.now(UTC)
+            record.status = "timed_out"
+            record.updated_at = now
+        return copy.deepcopy(record)
+
+
+class SqlAlchemyWorkflowEventWaitRepository:
+    """PostgreSQL implementation using the app async SQLAlchemy session factory."""
+
+    def __init__(self, session_factory: Any) -> None:
+        self._session_factory = session_factory
+
+    async def register(self, record: EventWaitRecord) -> EventWaitRecord:
+        from core.models.workflow import WorkflowEventWait
+
+        async with self._session_factory() as session:
+            async with session.begin():
+                row = (
+                    await session.execute(
+                        select(WorkflowEventWait)
+                        .where(
+                            WorkflowEventWait.engine_run_id == record.engine_run_id,
+                            WorkflowEventWait.step_id == record.step_id,
+                            WorkflowEventWait.status == ACTIVE_STATUS,
+                        )
+                        .with_for_update()
+                    )
+                ).scalar_one_or_none()
+
+                if row is None:
+                    row = WorkflowEventWait(
+                        tenant_id=record.tenant_id,
+                        engine_run_id=record.engine_run_id,
+                        workflow_run_id=record.workflow_run_id,
+                        step_id=record.step_id,
+                        event_type=record.event_type,
+                        connector=record.connector,
+                        provider=record.provider,
+                        match_criteria=_json_safe(record.match_criteria or {}),
+                        status=ACTIVE_STATUS,
+                        timeout_at=record.timeout_at,
+                    )
+                    session.add(row)
+                    await session.flush()
+                else:
+                    row.tenant_id = record.tenant_id or row.tenant_id
+                    row.workflow_run_id = record.workflow_run_id or row.workflow_run_id
+                    row.event_type = record.event_type
+                    row.connector = record.connector
+                    row.provider = record.provider
+                    row.match_criteria = _json_safe(record.match_criteria or {})
+                    row.timeout_at = record.timeout_at
+                    row.updated_at = datetime.now(UTC)
+
+                return self._from_model(row)
+
+    async def list_waiting(
+        self,
+        *,
+        event_types: Sequence[str] | None = None,
+        tenant_id: uuid.UUID | None = None,
+    ) -> list[EventWaitRecord]:
+        from core.models.workflow import WorkflowEventWait
+
+        conditions = [
+            WorkflowEventWait.status == ACTIVE_STATUS,
+            (WorkflowEventWait.timeout_at.is_(None))
+            | (WorkflowEventWait.timeout_at > datetime.now(UTC)),
+        ]
+        if event_types:
+            conditions.append(WorkflowEventWait.event_type.in_(list(event_types)))
+        if tenant_id is None:
+            conditions.append(WorkflowEventWait.tenant_id.is_(None))
+        else:
+            conditions.append(WorkflowEventWait.tenant_id == tenant_id)
+
+        async with self._session_factory() as session:
+            rows = (
+                await session.execute(select(WorkflowEventWait).where(*conditions))
+            ).scalars().all()
+            return [self._from_model(row) for row in rows]
+
+    async def claim_matched(
+        self,
+        *,
+        engine_run_id: str,
+        step_id: str,
+        matched_event_id: str | None,
+        event_data: dict[str, Any],
+    ) -> EventWaitRecord | None:
+        from core.models.workflow import WorkflowEventWait
+
+        async with self._session_factory() as session:
+            async with session.begin():
+                row = (
+                    await session.execute(
+                        select(WorkflowEventWait)
+                        .where(
+                            WorkflowEventWait.engine_run_id == engine_run_id,
+                            WorkflowEventWait.step_id == step_id,
+                            WorkflowEventWait.status == ACTIVE_STATUS,
+                        )
+                        .with_for_update()
+                    )
+                ).scalar_one_or_none()
+                if row is None or row.status != ACTIVE_STATUS:
+                    return None
+
+                now = datetime.now(UTC)
+                row.status = "matched"
+                row.matched_at = now
+                row.updated_at = now
+                row.matched_event_id = matched_event_id
+                row.matched_event = _json_safe(event_data)
+                return self._from_model(row)
+
+    async def mark_timed_out(
+        self,
+        *,
+        engine_run_id: str,
+        step_id: str,
+    ) -> EventWaitRecord | None:
+        from core.models.workflow import WorkflowEventWait
+
+        async with self._session_factory() as session:
+            async with session.begin():
+                row = (
+                    await session.execute(
+                        select(WorkflowEventWait)
+                        .where(
+                            WorkflowEventWait.engine_run_id == engine_run_id,
+                            WorkflowEventWait.step_id == step_id,
+                        )
+                        .order_by(WorkflowEventWait.updated_at.desc().nullslast())
+                        .limit(1)
+                        .with_for_update()
+                    )
+                ).scalar_one_or_none()
+                if row is None:
+                    return None
+                if row.status == ACTIVE_STATUS:
+                    row.status = "timed_out"
+                    row.updated_at = datetime.now(UTC)
+                return self._from_model(row)
+
+    @staticmethod
+    def _from_model(row: Any) -> EventWaitRecord:
+        return EventWaitRecord(
+            id=row.id,
+            tenant_id=row.tenant_id,
+            engine_run_id=row.engine_run_id,
+            workflow_run_id=row.workflow_run_id,
+            step_id=row.step_id,
+            event_type=row.event_type,
+            connector=row.connector,
+            provider=row.provider,
+            match_criteria=copy.deepcopy(row.match_criteria or {}),
+            status=row.status,
+            timeout_at=row.timeout_at,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+            matched_at=row.matched_at,
+            matched_event_id=row.matched_event_id,
+            matched_event=copy.deepcopy(row.matched_event),
+        )
+
+
+class WorkflowEventWaitStore:
+    def __init__(
+        self,
+        repository: WorkflowEventWaitRepository | None = None,
+        redis: aioredis.Redis | None = None,
+    ) -> None:
+        self.repository: WorkflowEventWaitRepository = (
+            repository or InMemoryWorkflowEventWaitRepository()
+        )
+        self._repository_explicit = repository is not None
+        self.redis = redis
+        self._redis_explicit = redis is not None
+
+    async def init(self) -> None:
+        if not self._redis_explicit:
+            self.redis = aioredis.from_url(settings.redis_url, decode_responses=True)
+        if not self._repository_explicit:
+            from core.database import async_session_factory
+
+            self.repository = SqlAlchemyWorkflowEventWaitRepository(async_session_factory)
+
+    async def close(self) -> None:
+        if not self.redis or self._redis_explicit:
+            return
+        close_fn = getattr(self.redis, "aclose", None) or getattr(self.redis, "close", None)
+        if close_fn is None:
+            return
+        result = close_fn()
+        if inspect.isawaitable(result):
+            await result
+
+    async def register(
+        self,
+        *,
+        engine_run_id: str,
+        step_id: str,
+        event_type: str,
+        match_criteria: dict[str, Any] | None = None,
+        timeout_at: datetime | None = None,
+        tenant_id: uuid.UUID | str | None = None,
+        workflow_run_id: uuid.UUID | str | None = None,
+        connector: str | None = None,
+        provider: str | None = None,
+    ) -> EventWaitRecord:
+        record = EventWaitRecord(
+            tenant_id=_coerce_uuid(tenant_id),
+            engine_run_id=str(engine_run_id),
+            workflow_run_id=_coerce_uuid(workflow_run_id),
+            step_id=str(step_id),
+            event_type=str(event_type),
+            connector=connector,
+            provider=provider,
+            match_criteria=copy.deepcopy(_json_safe(match_criteria or {})),
+            timeout_at=timeout_at,
+        )
+        stored = await self.repository.register(record)
+        await self._write_redis_index(stored)
+        return stored
+
+    async def claim_matching_waits(
+        self,
+        *,
+        event_types: Sequence[str],
+        event_fields: dict[str, Any],
+        tenant_id: uuid.UUID | str | None = None,
+        matched_event_id: str | None = None,
+    ) -> list[EventWaitRecord]:
+        effective_tenant_id = _coerce_uuid(tenant_id)
+        waiting = await self.repository.list_waiting(
+            event_types=event_types,
+            tenant_id=effective_tenant_id,
+        )
+        await self._write_redis_indexes(waiting)
+
+        claimed: list[EventWaitRecord] = []
+        for record in waiting:
+            if not _event_matches_criteria(event_fields, record.match_criteria):
+                logger.debug(
+                    "workflow_event_criteria_mismatch",
+                    event_types=list(event_types),
+                    match=record.match_criteria,
+                    run_id=record.engine_run_id,
+                    step_id=record.step_id,
+                )
+                continue
+            matched = await self.repository.claim_matched(
+                engine_run_id=record.engine_run_id,
+                step_id=record.step_id,
+                matched_event_id=matched_event_id,
+                event_data=event_fields,
+            )
+            if matched is not None:
+                claimed.append(matched)
+                await self._delete_redis_index(matched)
+        return claimed
+
+    async def mark_timed_out(self, *, engine_run_id: str, step_id: str) -> EventWaitRecord | None:
+        record = await self.repository.mark_timed_out(
+            engine_run_id=str(engine_run_id),
+            step_id=str(step_id),
+        )
+        if record and record.status in TERMINAL_STATUSES:
+            await self._delete_redis_index(record)
+        return record
+
+    async def rebuild_redis_indexes(
+        self,
+        *,
+        event_types: Sequence[str] | None = None,
+        tenant_id: uuid.UUID | str | None = None,
+    ) -> int:
+        waiting = await self.repository.list_waiting(
+            event_types=event_types,
+            tenant_id=_coerce_uuid(tenant_id),
+        )
+        await self._write_redis_indexes(waiting)
+        return len(waiting)
+
+    async def _write_redis_indexes(self, records: Sequence[EventWaitRecord]) -> None:
+        for record in records:
+            await self._write_redis_index(record)
+
+    async def _write_redis_index(self, record: EventWaitRecord) -> None:
+        if not self.redis:
+            return
+        payload = {
+            "run_id": record.engine_run_id,
+            "step_id": record.step_id,
+            "tenant_id": str(record.tenant_id) if record.tenant_id else None,
+            "workflow_run_id": str(record.workflow_run_id) if record.workflow_run_id else None,
+            "event_type": record.event_type,
+            "connector": record.connector,
+            "provider": record.provider,
+            "match": record.match_criteria,
+            "timeout_at": record.timeout_at.isoformat() if record.timeout_at else None,
+        }
+        ttl_seconds: int | None = None
+        if record.timeout_at:
+            ttl_seconds = max(int((record.timeout_at - datetime.now(UTC)).total_seconds()) + 60, 60)
+        try:
+            kwargs = {"ex": ttl_seconds} if ttl_seconds else {}
+            await self.redis.set(self._redis_key(record), json.dumps(_json_safe(payload)), **kwargs)
+        except Exception as exc:  # noqa: BLE001 - Redis index is best-effort only.
+            logger.warning(
+                "workflow_event_wait_cache_write_failed",
+                run_id=record.engine_run_id,
+                step_id=record.step_id,
+                error=str(exc),
+            )
+
+    async def _delete_redis_index(self, record: EventWaitRecord) -> None:
+        if not self.redis:
+            return
+        try:
+            await self.redis.delete(self._redis_key(record))
+        except Exception as exc:  # noqa: BLE001 - Redis cleanup is best-effort only.
+            logger.warning(
+                "workflow_event_wait_cache_delete_failed",
+                run_id=record.engine_run_id,
+                step_id=record.step_id,
+                error=str(exc),
+            )
+
+    @staticmethod
+    def _redis_key(record: EventWaitRecord) -> str:
+        return f"wfwait_event:{record.event_type}:{record.engine_run_id}:{record.step_id}"

--- a/workflows/state_store.py
+++ b/workflows/state_store.py
@@ -1,34 +1,348 @@
-"""Persist workflow state to Redis (and PostgreSQL)."""
+"""Durable workflow state store.
+
+PostgreSQL is the source of truth for workflow run state. Redis is only a
+best-effort cache plus a legacy fallback for pre-durability rows.
+"""
 
 from __future__ import annotations
 
+import copy
+import hashlib
+import inspect
 import json
-from typing import Any
+import uuid
+from datetime import UTC, datetime
+from typing import Any, Protocol
 
 import redis.asyncio as aioredis
+import structlog
+from sqlalchemy import select
 
 from core.config import settings
 
+logger = structlog.get_logger()
 
-class WorkflowStateStore:
-    def __init__(self):
-        self.redis: aioredis.Redis | None = None
 
-    async def init(self):
-        self.redis = aioredis.from_url(settings.redis_url, decode_responses=True)
+def _json_safe(value: Any) -> Any:
+    """Return a JSON-compatible deep copy."""
+    return json.loads(json.dumps(value, default=str))
 
-    async def save(self, state: dict[str, Any]) -> None:
-        if self.redis:
-            await self.redis.set(
-                f"wfstate:{state['id']}", json.dumps(state, default=str), ex=172800
-            )
+
+def _state_hash(state: dict[str, Any]) -> str:
+    payload = json.dumps(
+        _json_safe(state),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _coerce_uuid(value: Any) -> uuid.UUID | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, uuid.UUID):
+        return value
+    try:
+        return uuid.UUID(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_tenant_id(state: dict[str, Any], override: Any = None) -> uuid.UUID | None:
+    if override:
+        return _coerce_uuid(override)
+    trigger_payload = state.get("trigger_payload")
+    if not isinstance(trigger_payload, dict):
+        trigger_payload = {}
+    return _coerce_uuid(
+        state.get("tenant_id")
+        or trigger_payload.get("tenant_id")
+        or trigger_payload.get("agenticorg:tenant_id")
+    )
+
+
+def _extract_workflow_run_id(state: dict[str, Any], override: Any = None) -> uuid.UUID | None:
+    if override:
+        return _coerce_uuid(override)
+    return _coerce_uuid(
+        state.get("workflow_run_id")
+        or state.get("db_workflow_run_id")
+        or state.get("database_workflow_run_id")
+    )
+
+
+class WorkflowStateRepository(Protocol):
+    """Persistence boundary for workflow state.
+
+    Unit tests can inject an in-memory implementation. Production ``init()``
+    swaps the default in-memory repository for the SQLAlchemy-backed one.
+    """
+
+    async def save(
+        self,
+        state: dict[str, Any],
+        *,
+        state_hash: str,
+        tenant_id: uuid.UUID | None = None,
+        workflow_run_id: uuid.UUID | None = None,
+        actor: str,
+        step_id: str | None = None,
+        idempotency_key: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        ...
 
     async def load(self, run_id: str) -> dict[str, Any] | None:
+        ...
+
+
+class InMemoryWorkflowStateRepository:
+    """Durable-store test double with transition capture."""
+
+    def __init__(self) -> None:
+        self.states: dict[str, dict[str, Any]] = {}
+        self.transitions: list[dict[str, Any]] = []
+
+    async def save(
+        self,
+        state: dict[str, Any],
+        *,
+        state_hash: str,
+        tenant_id: uuid.UUID | None = None,
+        workflow_run_id: uuid.UUID | None = None,
+        actor: str,
+        step_id: str | None = None,
+        idempotency_key: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        run_id = str(state["id"])
+        if idempotency_key and any(
+            t["run_id"] == run_id and t.get("idempotency_key") == idempotency_key
+            for t in self.transitions
+        ):
+            return
+
+        previous = self.states.get(run_id)
+        previous_hash = previous["state_hash"] if previous else None
+        version = int(previous["version"]) + 1 if previous else 1
+        now = datetime.now(UTC).isoformat()
+
+        self.states[run_id] = {
+            "run_id": run_id,
+            "tenant_id": str(tenant_id) if tenant_id else None,
+            "workflow_run_id": str(workflow_run_id) if workflow_run_id else None,
+            "status": state.get("status", "unknown"),
+            "waiting_step_id": state.get("waiting_step_id"),
+            "state": copy.deepcopy(_json_safe(state)),
+            "state_hash": state_hash,
+            "version": version,
+            "updated_at": now,
+        }
+        self.transitions.append(
+            {
+                "run_id": run_id,
+                "step_id": step_id,
+                "previous_state_hash": previous_hash,
+                "new_state_hash": state_hash,
+                "actor": actor,
+                "idempotency_key": idempotency_key,
+                "metadata": copy.deepcopy(metadata or {}),
+                "created_at": now,
+            }
+        )
+
+    async def load(self, run_id: str) -> dict[str, Any] | None:
+        record = self.states.get(str(run_id))
+        if not record:
+            return None
+        return copy.deepcopy(record["state"])
+
+
+class SqlAlchemyWorkflowStateRepository:
+    """PostgreSQL implementation using the app's async SQLAlchemy session factory."""
+
+    def __init__(self, session_factory: Any) -> None:
+        self._session_factory = session_factory
+
+    async def save(
+        self,
+        state: dict[str, Any],
+        *,
+        state_hash: str,
+        tenant_id: uuid.UUID | None = None,
+        workflow_run_id: uuid.UUID | None = None,
+        actor: str,
+        step_id: str | None = None,
+        idempotency_key: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        from core.models.workflow import WorkflowRunState, WorkflowStateTransition
+
+        run_id = str(state["id"])
+        safe_state = _json_safe(state)
+        async with self._session_factory() as session:
+            async with session.begin():
+                if idempotency_key:
+                    existing_transition = (
+                        await session.execute(
+                            select(WorkflowStateTransition.id).where(
+                                WorkflowStateTransition.run_id == run_id,
+                                WorkflowStateTransition.idempotency_key == idempotency_key,
+                            )
+                        )
+                    ).scalar_one_or_none()
+                    if existing_transition:
+                        return
+
+                row = (
+                    await session.execute(
+                        select(WorkflowRunState)
+                        .where(WorkflowRunState.run_id == run_id)
+                        .with_for_update()
+                    )
+                ).scalar_one_or_none()
+
+                previous_hash = row.state_hash if row else None
+                if row is None:
+                    row = WorkflowRunState(
+                        run_id=run_id,
+                        tenant_id=tenant_id,
+                        workflow_run_id=workflow_run_id,
+                        status=safe_state.get("status", "unknown"),
+                        waiting_step_id=safe_state.get("waiting_step_id"),
+                        state=safe_state,
+                        state_hash=state_hash,
+                        version=1,
+                    )
+                    session.add(row)
+                else:
+                    row.tenant_id = tenant_id or row.tenant_id
+                    row.workflow_run_id = workflow_run_id or row.workflow_run_id
+                    row.status = safe_state.get("status", "unknown")
+                    row.waiting_step_id = safe_state.get("waiting_step_id")
+                    row.state = safe_state
+                    row.state_hash = state_hash
+                    row.version = int(row.version or 0) + 1
+                    row.updated_at = datetime.now(UTC)
+
+                session.add(
+                    WorkflowStateTransition(
+                        run_id=run_id,
+                        step_id=step_id,
+                        previous_state_hash=previous_hash,
+                        new_state_hash=state_hash,
+                        actor=actor,
+                        idempotency_key=idempotency_key,
+                        transition_metadata=_json_safe(metadata or {}),
+                    )
+                )
+
+    async def load(self, run_id: str) -> dict[str, Any] | None:
+        from core.models.workflow import WorkflowRunState
+
+        async with self._session_factory() as session:
+            row = (
+                await session.execute(
+                    select(WorkflowRunState).where(WorkflowRunState.run_id == str(run_id))
+                )
+            ).scalar_one_or_none()
+            if row is None:
+                return None
+            return copy.deepcopy(row.state)
+
+
+class WorkflowStateStore:
+    def __init__(
+        self,
+        repository: WorkflowStateRepository | None = None,
+        redis: aioredis.Redis | None = None,
+    ) -> None:
+        self.repository: WorkflowStateRepository = repository or InMemoryWorkflowStateRepository()
+        self._repository_explicit = repository is not None
+        self.redis = redis
+
+    async def init(self) -> None:
+        self.redis = aioredis.from_url(settings.redis_url, decode_responses=True)
+        if not self._repository_explicit:
+            from core.database import async_session_factory
+
+            self.repository = SqlAlchemyWorkflowStateRepository(async_session_factory)
+
+    async def save(
+        self,
+        state: dict[str, Any],
+        *,
+        actor: str = "workflow_engine",
+        step_id: str | None = None,
+        idempotency_key: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        tenant_id: uuid.UUID | str | None = None,
+        workflow_run_id: uuid.UUID | str | None = None,
+    ) -> None:
+        run_id = state.get("id")
+        if not run_id:
+            raise ValueError("workflow state must include an 'id'")
+
+        safe_hash = _state_hash(state)
+        effective_tenant_id = _extract_tenant_id(state, tenant_id)
+        effective_workflow_run_id = _extract_workflow_run_id(state, workflow_run_id)
+
+        await self.repository.save(
+            state,
+            state_hash=safe_hash,
+            tenant_id=effective_tenant_id,
+            workflow_run_id=effective_workflow_run_id,
+            actor=actor,
+            step_id=step_id,
+            idempotency_key=idempotency_key,
+            metadata=metadata,
+        )
+        await self._write_redis_cache(state)
+
+    async def load(self, run_id: str) -> dict[str, Any] | None:
+        state = await self.repository.load(run_id)
+        if state is not None:
+            return state
+
+        legacy_state = await self._load_redis_legacy(run_id)
+        if legacy_state is None:
+            return None
+
+        await self.save(
+            legacy_state,
+            actor="redis_legacy_backfill",
+            metadata={"source": "redis_fallback"},
+        )
+        return legacy_state
+
+    async def close(self) -> None:
+        if not self.redis:
+            return
+        close_fn = getattr(self.redis, "close", None) or getattr(self.redis, "aclose", None)
+        if close_fn is None:
+            return
+        result = close_fn()
+        if inspect.isawaitable(result):
+            await result
+
+    async def _write_redis_cache(self, state: dict[str, Any]) -> None:
+        if not self.redis:
+            return
+        try:
+            await self.redis.set(f"wfstate:{state['id']}", json.dumps(_json_safe(state)))
+        except Exception as exc:  # noqa: BLE001 - Redis cache must not gate correctness.
+            logger.warning(
+                "workflow_state_cache_write_failed",
+                run_id=state.get("id"),
+                error=str(exc),
+            )
+
+    async def _load_redis_legacy(self, run_id: str) -> dict[str, Any] | None:
         if not self.redis:
             return None
-        data = await self.redis.get(f"wfstate:{run_id}")
+        try:
+            data = await self.redis.get(f"wfstate:{run_id}")
+        except Exception as exc:  # noqa: BLE001 - Redis fallback is best effort.
+            logger.warning("workflow_state_cache_read_failed", run_id=run_id, error=str(exc))
+            return None
         return json.loads(data) if data else None
-
-    async def close(self):
-        if self.redis:
-            await self.redis.close()

--- a/workflows/step_types.py
+++ b/workflows/step_types.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from workflows.condition_evaluator import evaluate_condition
+from workflows.event_waits import WorkflowEventWaitStore
 
 
 async def execute_step(step: dict, state: dict) -> dict[str, Any]:
@@ -325,30 +326,40 @@ async def _execute_wait_for_event(step, state):
     match_criteria = step.get("match", {})
     run_id = state.get("id", "")
     timeout_at = datetime.now(UTC) + timedelta(hours=timeout_hours)
+    trigger_payload = state.get("trigger_payload")
+    if not isinstance(trigger_payload, dict):
+        trigger_payload = {}
+    tenant_id = (
+        state.get("tenant_id")
+        or trigger_payload.get("tenant_id")
+        or trigger_payload.get("agenticorg:tenant_id")
+    )
+    workflow_run_id = (
+        state.get("workflow_run_id")
+        or state.get("db_workflow_run_id")
+        or state.get("database_workflow_run_id")
+    )
 
-    # Register event listener in Redis (if available)
+    event_wait_store = state.get("_event_wait_store")
+    created_store = event_wait_store is None
+    if event_wait_store is None:
+        event_wait_store = WorkflowEventWaitStore()
+        await event_wait_store.init()
     try:
-        import json as _json
-
-        import redis.asyncio as aioredis
-
-        from core.config import settings
-
-        r = aioredis.from_url(settings.redis_url, decode_responses=True)
-        listener_key = f"wfwait_event:{event_type}:{run_id}:{step['id']}"
-        await r.set(
-            listener_key,
-            _json.dumps({
-                "run_id": run_id,
-                "step_id": step["id"],
-                "match": match_criteria,
-                "timeout_at": timeout_at.isoformat(),
-            }),
-            ex=int(timeout_hours * 3600) + 60,
+        await event_wait_store.register(
+            engine_run_id=run_id,
+            step_id=step["id"],
+            event_type=event_type,
+            match_criteria=match_criteria,
+            timeout_at=timeout_at,
+            tenant_id=tenant_id,
+            workflow_run_id=workflow_run_id,
+            connector=step.get("connector"),
+            provider=step.get("provider"),
         )
-        await r.aclose()
-    except Exception:  # noqa: S110
-        pass  # Redis unavailable — event will time out
+    finally:
+        if created_store:
+            await event_wait_store.close()
 
     # Schedule timeout
     try:


### PR DESCRIPTION
## Summary
- add PostgreSQL workflow state and transition audit models/migration
- make WorkflowStateStore write PostgreSQL first and read PostgreSQL before Redis legacy fallback/cache
- route Celery wait/event resume mutations through the durable store instead of direct Redis state writes
- link background engine state to tenant/workflow_run IDs and add durability tests
- add durable PostgreSQL workflow event-wait listener registrations and migration
- make wait_for_event registration DB-first with Redis as best-effort/rebuildable cache only
- make webhook event matching query and transactionally claim durable listeners before enqueueing resume
- make event timeout mark durable listeners timed_out and keep duplicate/mismatched tenant events idempotent/no-op
- keep the legacy webhook `"match"` listener-payload contract explicit while matching from durable rows
- use isolated `NullPool` engines in the new durability integration tests to avoid asyncpg cross-loop pool reuse in CI

## Validation
- `python -m pytest tests/unit/test_workflow_event_wait_durability.py tests/unit/test_workflow_state_durability.py tests/unit/test_tier1_features.py::TestWaitForEvent tests/unit/test_tier1_features.py::TestWebhookParsing`
- `python -m pytest tests/regression/test_codex_round4_blockers.py::test_k_b_webhooks_match_criteria_helper_exists tests/regression/test_codex_round4_blockers.py::test_k_b_matches_criteria_logic tests/unit/test_workflow_event_wait_durability.py tests/unit/test_workflow_state_durability.py tests/unit/test_tier1_features.py::TestWaitForEvent tests/unit/test_tier1_features.py::TestWebhookParsing`
- `python -m pytest tests/integration/test_workflow_state_store_postgres.py tests/integration/test_workflow_event_wait_store_postgres.py -rs` (skips locally without `AGENTICORG_DB_URL`)
- `python -m pytest tests/integration/test_alembic_e2e.py -q` (skips locally without reachable Postgres)
- `python -m ruff check workflows/event_waits.py workflows/step_types.py core/tasks/workflow_tasks.py api/v1/webhooks.py core/models/workflow.py tests/unit/test_workflow_event_wait_durability.py tests/unit/test_tier1_features.py tests/integration/test_workflow_state_store_postgres.py tests/integration/test_workflow_event_wait_store_postgres.py tests/regression/test_codex_round4_blockers.py`
- `python -m compileall workflows/event_waits.py workflows/step_types.py workflows/engine.py core/tasks/workflow_tasks.py api/v1/webhooks.py core/models/workflow.py tests/unit/test_workflow_event_wait_durability.py tests/integration/test_workflow_state_store_postgres.py tests/integration/test_workflow_event_wait_store_postgres.py`
- `python -m alembic heads`
- `python -m alembic upgrade v4911_workflow_state_pg:v4912_workflow_event_waits --sql`