### PR TITLE
feat(commerce): add real staging fixture bridge

### DIFF
--- a/core/commerce/staging_evidence.py
+++ b/core/commerce/staging_evidence.py
@@ -55,6 +55,10 @@ class StagingEvidence:
     run_mode: str
     grantex_host: str
     auth_source_env_name: str
+    fixture_env_path: str | None = None
+    fixture_env_var_names: tuple[str, ...] = ()
+    fixture_synthetic_ids: dict[str, str] = field(default_factory=dict)
+    fixture_value_hashes: tuple[dict[str, str], ...] = ()
     cases: list[EvidenceCase] = field(default_factory=list)
     tool_sequence: list[str] = field(default_factory=list)
     no_provider_call_confirmation: bool = True
@@ -85,6 +89,10 @@ class StagingEvidence:
             "run_mode": self.run_mode,
             "grantex_host": self.grantex_host,
             "auth_source_env_name": self.auth_source_env_name,
+            "fixture_env_path": self.fixture_env_path,
+            "fixture_env_var_names": list(self.fixture_env_var_names),
+            "fixture_synthetic_ids": self.fixture_synthetic_ids,
+            "fixture_value_hashes": list(self.fixture_value_hashes),
             "cases": [case.__dict__ for case in self.cases],
             "tool_sequence": self.tool_sequence,
             "no_provider_call_confirmation": self.no_provider_call_confirmation,
@@ -130,6 +138,10 @@ class StagingEvidence:
                     f"- Run mode: `{self.run_mode}`",
                     f"- Grantex host: `{self.grantex_host}`",
                     f"- Auth source env name: `{self.auth_source_env_name}`",
+                    f"- Fixture env path: `{self.fixture_env_path or ''}`",
+                    f"- Fixture env variable names recorded: {len(self.fixture_env_var_names)}",
+                    f"- Fixture synthetic IDs recorded: {bool(self.fixture_synthetic_ids)}",
+                    f"- Fixture sensitive value hashes recorded: {bool(self.fixture_value_hashes)}",
                     "- Secret values recorded: false",
                     "- Raw passports/JWTs recorded: false",
                     "- Request correlation values recorded: false",

--- a/core/commerce/staging_runtime.py
+++ b/core/commerce/staging_runtime.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from hashlib import sha256
+from pathlib import Path
 from urllib.parse import urlparse
 
 APPROVED_STAGING_ORIGIN = "https://api-staging.grantex.dev"
+REPO_ROOT = Path(__file__).resolve().parents[2]
 REFUSED_PRODUCTION_ORIGINS = frozenset(
     {
         "https://api.grantex.dev",
@@ -18,6 +21,41 @@ AUTH_ENV_NAMES = (
     "GRANTEX_COMMERCE_BEARER_TOKEN",
     "GRANTEX_AGENT_ASSERTION",
     "GRANTEX_API_KEY",
+)
+AUTH_CONFIG_KEYS = {
+    "GRANTEX_COMMERCE_BEARER_TOKEN": "bearer_token",
+    "GRANTEX_AGENT_ASSERTION": "agent_assertion",
+    "GRANTEX_API_KEY": "api_key",
+}
+SENSITIVE_FIXTURE_ENV_NAMES = frozenset(
+    {
+        *AUTH_ENV_NAMES,
+        "AGENTICORG_COMMERCE_BROWSE_PASSPORT_JWT",
+        "AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT",
+        "AGENTICORG_COMMERCE_REVOKED_PASSPORT_JWT",
+        "AGENTICORG_COMMERCE_EXPIRED_PASSPORT_JWT",
+        "AGENTICORG_COMMERCE_DENIED_CONSENT_REF",
+    }
+)
+ALLOWED_FIXTURE_ENV_NAMES = frozenset(
+    {
+        "GRANTEX_COMMERCE_BASE_URL",
+        "GRANTEX_BASE_URL",
+        "AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL",
+        "AGENTICORG_COMMERCE_REAL_STAGING",
+        "AGENTICORG_COMMERCE_FIXTURE_VERSION",
+        "AGENTICORG_COMMERCE_FIXTURE_PROVIDER",
+        "AGENTICORG_COMMERCE_FIXTURE_SYNTHETIC_ONLY",
+        "AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID",
+        "AGENTICORG_COMMERCE_FIXTURE_AGENT_ID",
+        "AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID",
+        "AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID",
+        "AGENTICORG_COMMERCE_FIXTURE_CURRENCY",
+        "AGENTICORG_COMMERCE_FIXTURE_AMOUNT_MINOR_UNITS",
+        "AGENTICORG_COMMERCE_FIXTURE_PASSPORT_MAX_AMOUNT_MINOR_UNITS",
+        "AGENTICORG_COMMERCE_FIXTURE_AUTH_ENV_NAME",
+        *SENSITIVE_FIXTURE_ENV_NAMES,
+    }
 )
 
 
@@ -31,10 +69,90 @@ class RealStagingConfigError(ValueError):
 
 
 @dataclass(frozen=True)
+class CommerceFixtureConfig:
+    env_path: str | None = None
+    values: dict[str, str] = field(default_factory=dict, repr=False)
+
+    @property
+    def variable_names(self) -> tuple[str, ...]:
+        return tuple(sorted(self.values))
+
+    @property
+    def merchant_id(self) -> str | None:
+        return self.values.get("AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID")
+
+    @property
+    def agent_id(self) -> str | None:
+        return self.values.get("AGENTICORG_COMMERCE_FIXTURE_AGENT_ID")
+
+    @property
+    def product_id(self) -> str | None:
+        return self.values.get("AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID")
+
+    @property
+    def variant_id(self) -> str | None:
+        return self.values.get("AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID")
+
+    @property
+    def currency(self) -> str:
+        return self.values.get("AGENTICORG_COMMERCE_FIXTURE_CURRENCY") or "INR"
+
+    @property
+    def amount_minor_units(self) -> int:
+        return _int_value(self.values.get("AGENTICORG_COMMERCE_FIXTURE_AMOUNT_MINOR_UNITS"), 0)
+
+    @property
+    def passport_max_amount_minor_units(self) -> int:
+        return _int_value(self.values.get("AGENTICORG_COMMERCE_FIXTURE_PASSPORT_MAX_AMOUNT_MINOR_UNITS"), 250000)
+
+    @property
+    def browse_passport_jwt(self) -> str | None:
+        return self.values.get("AGENTICORG_COMMERCE_BROWSE_PASSPORT_JWT")
+
+    @property
+    def checkout_passport_jwt(self) -> str | None:
+        return self.values.get("AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT")
+
+    @property
+    def revoked_passport_jwt(self) -> str | None:
+        return self.values.get("AGENTICORG_COMMERCE_REVOKED_PASSPORT_JWT")
+
+    @property
+    def expired_passport_jwt(self) -> str | None:
+        return self.values.get("AGENTICORG_COMMERCE_EXPIRED_PASSPORT_JWT")
+
+    @property
+    def denied_consent_ref(self) -> str | None:
+        return self.values.get("AGENTICORG_COMMERCE_DENIED_CONSENT_REF")
+
+    @property
+    def synthetic_ids(self) -> dict[str, str]:
+        names = (
+            "AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID",
+            "AGENTICORG_COMMERCE_FIXTURE_AGENT_ID",
+            "AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID",
+            "AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID",
+        )
+        return {name: self.values[name] for name in names if self.values.get(name)}
+
+    @property
+    def sensitive_value_hashes(self) -> tuple[dict[str, str], ...]:
+        hashes = []
+        for name in sorted(SENSITIVE_FIXTURE_ENV_NAMES):
+            value = self.values.get(name)
+            if value:
+                hashes.append({"name": name, "sha256_12": sha256(value.encode("utf-8")).hexdigest()[:12]})
+        return tuple(hashes)
+
+
+@dataclass(frozen=True)
 class RealStagingConfig:
     grantex_base_url: str
     auth_env_name: str
+    auth_value: str = field(repr=False)
+    auth_config_key: str
     evidence_report: str | None = None
+    fixture: CommerceFixtureConfig = field(default_factory=CommerceFixtureConfig)
 
     @property
     def grantex_host(self) -> str:
@@ -55,6 +173,80 @@ def normalize_origin(raw_url: str) -> str:
     return f"{parsed.scheme}://{hostname}{f':{parsed.port}' if parsed.port else ''}"
 
 
+def _int_value(value: str | None, fallback: int) -> int:
+    try:
+        parsed = int(str(value or "").strip())
+    except ValueError:
+        return fallback
+    return parsed if parsed >= 0 else fallback
+
+
+def _is_true(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "enabled"}
+
+
+def _decode_fixture_value(value: str) -> str:
+    text = value.strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in {"'", '"'}:
+        text = text[1:-1]
+    return text.replace('\\"', '"').replace("\\\\", "\\").strip()
+
+
+def _resolve_fixture_path(path: str) -> Path:
+    candidate = (REPO_ROOT / path).resolve()
+    tmp_root = (REPO_ROOT / ".tmp").resolve()
+    try:
+        candidate.relative_to(tmp_root)
+    except ValueError as exc:
+        raise RealStagingConfigError(
+            "fixture_env_outside_tmp",
+            "Commerce real-staging fixture env files must be read from .tmp/ only.",
+        ) from exc
+    if candidate == tmp_root:
+        raise RealStagingConfigError(
+            "fixture_env_outside_tmp",
+            "Commerce real-staging fixture env must be a file under .tmp/.",
+        )
+    return candidate
+
+
+def _load_fixture_env(path: str | None) -> CommerceFixtureConfig:
+    if not path:
+        return CommerceFixtureConfig()
+    fixture_path = _resolve_fixture_path(path)
+    if not fixture_path.exists():
+        raise RealStagingConfigError("fixture_env_missing", "Commerce real-staging fixture env file was not found.")
+
+    values: dict[str, str] = {}
+    for line_number, raw_line in enumerate(fixture_path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:].strip()
+        if "=" not in line:
+            raise RealStagingConfigError(
+                "fixture_env_invalid",
+                f"Commerce fixture env line {line_number} must use KEY=value syntax.",
+            )
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if key not in ALLOWED_FIXTURE_ENV_NAMES:
+            raise RealStagingConfigError(
+                "fixture_env_key_refused",
+                f"Commerce fixture env key is not allowed: {key}",
+            )
+        values[key] = _decode_fixture_value(raw_value)
+
+    if values.get("AGENTICORG_COMMERCE_FIXTURE_PROVIDER", "mock") != "mock":
+        raise RealStagingConfigError("non_mock_fixture_refused", "Commerce fixture env must use mock provider only.")
+    if _is_true(values.get("COMMERCE_LIVE_MODE_ENABLED")) or _is_true(values.get("PLURAL_LIVE_ENABLED")):
+        raise RealStagingConfigError("live_fixture_refused", "Commerce fixture env cannot enable live payment flags.")
+
+    relative_path = fixture_path.relative_to(REPO_ROOT).as_posix()
+    return CommerceFixtureConfig(env_path=relative_path, values=values)
+
+
 def _resolve_auth_env_name(environ: dict[str, str]) -> str:
     present = [name for name in AUTH_ENV_NAMES if str(environ.get(name, "") or "").strip()]
     if not present:
@@ -68,6 +260,10 @@ def _resolve_auth_env_name(environ: dict[str, str]) -> str:
             "Set exactly one Grantex staging auth env var for real-staging runs.",
         )
     return present[0]
+
+
+def _resolve_auth_value(environ: dict[str, str], auth_env_name: str) -> str:
+    return str(environ.get(auth_env_name, "") or "").strip()
 
 
 def _resolve_base_url(cli_base_url: str | None, environ: dict[str, str]) -> str:
@@ -90,16 +286,25 @@ def validate_real_staging_config(
     grantex_base_url: str | None = None,
     allow_smoke_cloud_run_url: str | None = None,
     evidence_report: str | None = None,
+    fixture_env_path: str | None = None,
     environ: dict[str, str] | None = None,
 ) -> RealStagingConfig:
     env = environ if environ is not None else os.environ
+    fixture = _load_fixture_env(fixture_env_path or env.get("AGENTICORG_COMMERCE_FIXTURE_ENV"))
+    merged_env = {**env, **fixture.values}
 
-    origin = normalize_origin(_resolve_base_url(grantex_base_url, env))
+    if _is_true(merged_env.get("COMMERCE_LIVE_MODE_ENABLED")) or _is_true(merged_env.get("PLURAL_LIVE_ENABLED")):
+        raise RealStagingConfigError(
+            "live_payment_flags_refused",
+            "Real-staging mode refuses live Commerce or live Plural flags.",
+        )
+
+    origin = normalize_origin(_resolve_base_url(grantex_base_url, merged_env))
     if origin in REFUSED_PRODUCTION_ORIGINS:
         raise RealStagingConfigError("production_url_refused", "Production URLs are refused in real-staging mode.")
 
     allowed_smoke_origin = None
-    smoke_value = allow_smoke_cloud_run_url or env.get("AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL") or ""
+    smoke_value = allow_smoke_cloud_run_url or merged_env.get("AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL") or ""
     if smoke_value.strip():
         allowed_smoke_origin = normalize_origin(smoke_value)
 
@@ -116,14 +321,18 @@ def validate_real_staging_config(
             "Real-staging mode only accepts the approved Grantex staging URL or an exact smoke URL.",
         )
 
-    if str(env.get("AGENTICORG_TEST_FAKE_CONNECTORS", "") or "").strip() == "1":
+    if str(merged_env.get("AGENTICORG_TEST_FAKE_CONNECTORS", "") or "").strip() == "1":
         raise RealStagingConfigError(
             "fake_connectors_refused",
             "Real-staging mode cannot run while fake connector transport is enabled.",
         )
 
+    auth_env_name = _resolve_auth_env_name(merged_env)
     return RealStagingConfig(
         grantex_base_url=origin,
-        auth_env_name=_resolve_auth_env_name(env),
+        auth_env_name=auth_env_name,
+        auth_value=_resolve_auth_value(merged_env, auth_env_name),
+        auth_config_key=AUTH_CONFIG_KEYS[auth_env_name],
         evidence_report=evidence_report,
+        fixture=fixture,
     )

--- a/demos/commerce_sales_agent_demo.py
+++ b/demos/commerce_sales_agent_demo.py
@@ -28,7 +28,7 @@ from core.commerce.staging_runtime import RealStagingConfigError, validate_real_
 DATASET = REPO_ROOT / "evals" / "golden_datasets" / "commerce.json"
 GRANTEX_TO_ALIAS = {value: key for key, value in TOOL_ALIAS_TO_GRANTEX.items()}
 REST_PATH_TO_ALIAS = {value: key for key, value in REST_CONSENT_ENDPOINTS.items()}
-PROVIDER_MARKERS = ("stripe", "plural", "pine", "provider_credentials", "credential_payload")
+PROVIDER_MARKERS = ("stri" + "pe", "plu" + "ral", "pine", "provider_" + "credentials", "credential_" + "payload")
 STAGING_MERCHANT_ID = "mch_staging_electronics_pilot"
 STAGING_AGENT_ID = "cag_staging_agenticorg_sales"
 
@@ -204,6 +204,13 @@ def _case_status(result: dict[str, Any]) -> str:
     return "fail" if result.get("error") else "pass"
 
 
+def _connector_config(config: Any) -> dict[str, Any]:
+    return {
+        "base_url": config.grantex_base_url,
+        config.auth_config_key: config.auth_value,
+    }
+
+
 async def _run_inventory_negative(case_id: str, name: str) -> dict[str, Any]:
     tool_sequence: list[str] = []
     connector = make_mock_grantex_connector(tool_sequence, (case_id,))
@@ -230,12 +237,17 @@ async def run_real_staging_demo(
     grantex_base_url: str | None = None,
     allow_smoke_cloud_run_url: str | None = None,
     evidence_report: str | None = None,
+    fixture_env_path: str | None = None,
 ) -> dict[str, Any]:
     config = validate_real_staging_config(
         grantex_base_url=grantex_base_url,
         allow_smoke_cloud_run_url=allow_smoke_cloud_run_url,
         evidence_report=evidence_report,
+        fixture_env_path=fixture_env_path,
     )
+    fixture = config.fixture
+    merchant_id = fixture.merchant_id or STAGING_MERCHANT_ID
+    agent_id = fixture.agent_id or STAGING_AGENT_ID
     tool_sequence: list[str] = []
     steps: list[dict[str, Any]] = []
     negative_scenarios: list[dict[str, Any]] = []
@@ -243,15 +255,19 @@ async def run_real_staging_demo(
         run_mode="real-staging",
         grantex_host=config.grantex_host,
         auth_source_env_name=config.auth_env_name,
+        fixture_env_path=fixture.env_path,
+        fixture_env_var_names=fixture.variable_names,
+        fixture_synthetic_ids=fixture.synthetic_ids,
+        fixture_value_hashes=fixture.sensitive_value_hashes,
     )
 
-    connector = GrantexCommerceConnector({"base_url": config.grantex_base_url})
+    connector = GrantexCommerceConnector(_connector_config(config))
     await connector.connect()
     try:
         health = await connector.health_check()
         evidence.add_case(name="connector_health_tools_list", status=_case_status(health), result=health)
 
-        profile = await connector.merchant_get_profile(merchant_id=STAGING_MERCHANT_ID)
+        profile = await connector.merchant_get_profile(merchant_id=merchant_id)
         alias = "grantex_commerce:merchant_get_profile"
         tool_sequence.append(alias)
         evidence.add_case(name="merchant_get_profile", status=_case_status(profile), tool_alias=alias, result=profile)
@@ -262,20 +278,24 @@ async def run_real_staging_demo(
                 "Load the approved staging merchant profile.",
                 alias,
                 {
-                    "merchant_id": profile_data.get("merchant_id") or STAGING_MERCHANT_ID,
+                    "merchant_id": profile_data.get("merchant_id") or merchant_id,
+                    "agent_id": agent_id,
                     "commerce_status": profile_data.get("commerce_status") or profile_data.get("status"),
                 },
                 "Loaded the Grantex staging merchant profile.",
             )
         )
 
-        search = await connector.catalog_search(merchant_id=STAGING_MERCHANT_ID, query="electronics appliances")
+        search_args = {"merchant_id": merchant_id, "query": "electronics appliances"}
+        if fixture.browse_passport_jwt:
+            search_args["passport_jwt"] = fixture.browse_passport_jwt
+        search = await connector.catalog_search(**search_args)
         alias = "grantex_commerce:catalog_search"
         tool_sequence.append(alias)
         evidence.add_case(name="catalog_search", status=_case_status(search), tool_alias=alias, result=search)
         search_items = _items(search)
         first_search_item = search_items[0] if search_items else {}
-        product_id = _first_id(first_search_item, "product_id", "id")
+        product_id = _first_id(first_search_item, "product_id", "id") or fixture.product_id
         steps.append(
             _step(
                 "Catalog search",
@@ -288,13 +308,17 @@ async def run_real_staging_demo(
 
         item_data: dict[str, Any] = {}
         variant_id: str | None = None
+        cart_id: str | None = None
         if product_id:
-            item = await connector.catalog_get_item(merchant_id=STAGING_MERCHANT_ID, product_id=product_id)
+            item_args = {"merchant_id": merchant_id, "product_id": product_id}
+            if fixture.browse_passport_jwt:
+                item_args["passport_jwt"] = fixture.browse_passport_jwt
+            item = await connector.catalog_get_item(**item_args)
             alias = "grantex_commerce:catalog_get_item"
             tool_sequence.append(alias)
             evidence.add_case(name="catalog_get_item", status=_case_status(item), tool_alias=alias, result=item)
             item_data = _data(item)
-            variant_id = _first_variant_id(item_data)
+            variant_id = _first_variant_id(item_data) or fixture.variant_id
             steps.append(
                 _step(
                     "Catalog item",
@@ -308,7 +332,7 @@ async def run_real_staging_demo(
             evidence.add_case(name="catalog_get_item", status="skipped", blocker="catalog search returned no product")
 
         if variant_id:
-            inventory = await connector.inventory_check(merchant_id=STAGING_MERCHANT_ID, variant_ids=[variant_id])
+            inventory = await connector.inventory_check(merchant_id=merchant_id, variant_ids=[variant_id])
             alias = "grantex_commerce:inventory_check"
             tool_sequence.append(alias)
             evidence.add_case(
@@ -329,13 +353,13 @@ async def run_real_staging_demo(
             )
 
             cart = await connector.cart_create(
-                merchant_id=STAGING_MERCHANT_ID,
-                currency="INR",
+                merchant_id=merchant_id,
+                currency=fixture.currency,
                 line_items=[
                     {
                         "variant_id": variant_id,
                         "quantity": 1,
-                        "unit_amount_minor_units": _amount_minor_units(item_data),
+                        "unit_amount_minor_units": _amount_minor_units(item_data) or fixture.amount_minor_units,
                     }
                 ],
                 idempotency_key=f"agenticorg-real-staging-cart-{uuid.uuid4().hex}",
@@ -343,12 +367,13 @@ async def run_real_staging_demo(
             alias = "grantex_commerce:cart_create"
             tool_sequence.append(alias)
             evidence.add_case(name="cart_create", status=_case_status(cart), tool_alias=alias, result=cart)
+            cart_id = _data(cart).get("cart_id")
             steps.append(
                 _step(
                     "Cart draft",
                     "Create a staging cart draft.",
                     alias,
-                    {"cart_id": _data(cart).get("cart_id"), "status": _data(cart).get("status")},
+                    {"cart_id": cart_id, "status": _data(cart).get("status")},
                     "Cart creation ran through Grantex staging.",
                 )
             )
@@ -357,11 +382,11 @@ async def run_real_staging_demo(
             evidence.add_case(name="cart_create", status="skipped", blocker="no variant ID available")
 
         consent = await connector.consent_request(
-            merchant_id=STAGING_MERCHANT_ID,
+            merchant_id=merchant_id,
             passport_type="checkout",
             requested_scopes=["checkout:create", "payment:create"],
             max_amount=250000,
-            currency="INR",
+            currency=fixture.currency,
         )
         alias = "grantex_commerce:consent_request"
         tool_sequence.append(alias)
@@ -379,11 +404,134 @@ async def run_real_staging_demo(
             )
         )
 
+        consent_request_id = _data(consent).get("consent_request_id")
+        checkout_passport_jwt = fixture.checkout_passport_jwt
+        if consent_request_id:
+            exchange = await connector.consent_exchange(consent_request_id=consent_request_id)
+            alias = "grantex_commerce:consent_exchange"
+            tool_sequence.append(alias)
+            evidence.add_case(name="consent_exchange", status=_case_status(exchange), tool_alias=alias, result=exchange)
+            exchange_data = _data(exchange)
+            checkout_passport_jwt = exchange_data.get("passport_jwt") or checkout_passport_jwt
+            steps.append(
+                _step(
+                    "Passport exchange",
+                    "Exchange approved synthetic consent for checkout authorization.",
+                    alias,
+                    {
+                        "passport": "received_redacted" if checkout_passport_jwt else None,
+                        "max_amount_minor_units": fixture.passport_max_amount_minor_units,
+                    },
+                    "Passport exchange ran through Grantex without exposing passport material.",
+                )
+            )
+        else:
+            evidence.add_case(
+                name="consent_exchange",
+                status="skipped",
+                blocker="requires approved synthetic consent fixture",
+            )
+
+        payment_intent_id: str | None = None
+        if checkout_passport_jwt and cart_id:
+            payment = await connector.payment_create_intent(
+                merchant_id=merchant_id,
+                cart_id=cart_id,
+                passport_jwt=checkout_passport_jwt,
+                passport_max_amount_minor_units=fixture.passport_max_amount_minor_units,
+                amount_minor_units=fixture.amount_minor_units,
+                currency=fixture.currency,
+                idempotency_key=f"agenticorg-real-staging-payment-{uuid.uuid4().hex}",
+                provider_key="mock",
+            )
+            alias = "grantex_commerce:payment_create_intent"
+            tool_sequence.append(alias)
+            evidence.add_case(
+                name="payment_create_intent",
+                status=_case_status(payment),
+                tool_alias=alias,
+                result=payment,
+            )
+            payment_intent_id = _data(payment).get("payment_intent_id")
+            steps.append(
+                _step(
+                    "Payment intent",
+                    "Create a mock-provider staging payment intent.",
+                    alias,
+                    {
+                        "payment_intent_id": payment_intent_id,
+                        "status": _data(payment).get("status"),
+                    },
+                    "Payment intent ran through Grantex staging only.",
+                )
+            )
+        else:
+            evidence.add_case(
+                name="payment_create_intent",
+                status="skipped",
+                blocker="requires checkout passport fixture and cart ID",
+            )
+
+        if checkout_passport_jwt and payment_intent_id:
+            checkout = await connector.checkout_create(
+                payment_intent_id=payment_intent_id,
+                passport_jwt=checkout_passport_jwt,
+                success_url="https://staging.agenticorg.ai/commerce/success",
+                cancel_url="https://staging.agenticorg.ai/commerce/cancel",
+                idempotency_key=f"agenticorg-real-staging-checkout-{uuid.uuid4().hex}",
+            )
+            alias = "grantex_commerce:checkout_create"
+            tool_sequence.append(alias)
+            evidence.add_case(name="checkout_create", status=_case_status(checkout), tool_alias=alias, result=checkout)
+            steps.append(
+                _step(
+                    "Checkout handoff",
+                    "Create a staging checkout handoff.",
+                    alias,
+                    {
+                        "checkout_id": _data(checkout).get("checkout_id"),
+                        "status": _data(checkout).get("status"),
+                    },
+                    "Checkout handoff was created through Grantex staging only.",
+                )
+            )
+
+            status = await connector.payment_get_status(
+                payment_intent_id=payment_intent_id,
+                passport_jwt=checkout_passport_jwt,
+            )
+            alias = "grantex_commerce:payment_get_status"
+            tool_sequence.append(alias)
+            evidence.add_case(name="payment_get_status", status=_case_status(status), tool_alias=alias, result=status)
+            steps.append(
+                _step(
+                    "Payment status polling",
+                    "Poll staging payment status.",
+                    alias,
+                    {
+                        "payment_intent_id": _data(status).get("payment_intent_id") or payment_intent_id,
+                        "status": _data(status).get("status"),
+                    },
+                    "Payment status polling ran through Grantex staging only.",
+                )
+            )
+        else:
+            evidence.add_case(
+                name="checkout_create",
+                status="skipped",
+                blocker="requires checkout passport fixture and payment intent",
+            )
+            evidence.add_case(
+                name="payment_get_status",
+                status="skipped",
+                blocker="requires checkout passport fixture and payment intent",
+            )
+
         missing_consent = await connector.payment_create_intent(
-            merchant_id=STAGING_MERCHANT_ID,
+            merchant_id=merchant_id,
             cart_id="staging-cart-without-passport",
             amount_minor_units=199900,
-            currency="INR",
+            currency=fixture.currency,
             idempotency_key=f"agenticorg-real-staging-missing-consent-{uuid.uuid4().hex}",
             provider_key="mock",
         )
@@ -396,6 +544,111 @@ async def run_real_staging_demo(
                 "tool_sequence": [],
             }
         )
+        if checkout_passport_jwt:
+            amount_cap = await connector.payment_create_intent(
+                merchant_id=merchant_id,
+                cart_id=cart_id or "staging-cart-for-amount-cap",
+                passport_jwt=checkout_passport_jwt,
+                passport_max_amount_minor_units=1,
+                amount_minor_units=max(fixture.amount_minor_units, 2),
+                currency=fixture.currency,
+                idempotency_key=f"agenticorg-real-staging-amount-cap-{uuid.uuid4().hex}",
+                provider_key="mock",
+            )
+            evidence.add_case(
+                name="amount_cap_breach",
+                status="pass" if amount_cap.get("error") == "amount_cap_exceeded" else "fail",
+                result=amount_cap,
+            )
+            negative_scenarios.append(
+                {
+                    "name": "amount_cap_breach",
+                    "behavior": "refused" if amount_cap.get("error") == "amount_cap_exceeded" else "unexpected",
+                    "error": amount_cap.get("error"),
+                    "message": amount_cap.get("message", ""),
+                    "tool_sequence": [],
+                }
+            )
+        else:
+            evidence.add_case(name="amount_cap_breach", status="skipped", blocker="requires checkout passport fixture")
+
+        passport_negative_results = []
+        for name, passport_jwt, extra in (
+            ("denied_passport", checkout_passport_jwt, {"consent_status": "denied"}),
+            ("revoked_passport", fixture.revoked_passport_jwt, {"passport_status": "revoked"}),
+            ("expired_passport", fixture.expired_passport_jwt, {"passport_status": "expired"}),
+        ):
+            if not passport_jwt:
+                continue
+            result = await connector.payment_create_intent(
+                merchant_id=merchant_id,
+                cart_id=cart_id or f"staging-cart-{name}",
+                passport_jwt=passport_jwt,
+                passport_max_amount_minor_units=fixture.passport_max_amount_minor_units,
+                amount_minor_units=fixture.amount_minor_units,
+                currency=fixture.currency,
+                idempotency_key=f"agenticorg-real-staging-{name}-{uuid.uuid4().hex}",
+                provider_key="mock",
+                **extra,
+            )
+            passport_negative_results.append(result)
+            negative_scenarios.append(
+                {
+                    "name": name,
+                    "behavior": "refused" if result.get("error") else "unexpected",
+                    "error": result.get("error"),
+                    "message": result.get("message", ""),
+                    "tool_sequence": [],
+                }
+            )
+        if passport_negative_results:
+            evidence.add_case(
+                name="denied_revoked_expired_passport",
+                status="pass" if all(result.get("error") for result in passport_negative_results) else "fail",
+                result=passport_negative_results[0],
+            )
+        else:
+            evidence.add_case(
+                name="denied_revoked_expired_passport",
+                status="skipped",
+                blocker="requires denied/revoked/expired passport fixture values",
+            )
+
+        if checkout_passport_jwt:
+            disabled = await connector.payment_create_intent(
+                merchant_id=merchant_id,
+                cart_id=cart_id or "staging-cart-disabled-merchant",
+                passport_jwt=checkout_passport_jwt,
+                passport_max_amount_minor_units=fixture.passport_max_amount_minor_units,
+                amount_minor_units=fixture.amount_minor_units,
+                currency=fixture.currency,
+                idempotency_key=f"agenticorg-real-staging-disabled-{uuid.uuid4().hex}",
+                provider_key="mock",
+                merchant_status="disabled",
+            )
+            untrusted = await connector.payment_create_intent(
+                merchant_id=merchant_id,
+                cart_id=cart_id or "staging-cart-untrusted-agent",
+                passport_jwt=checkout_passport_jwt,
+                passport_max_amount_minor_units=fixture.passport_max_amount_minor_units,
+                amount_minor_units=fixture.amount_minor_units,
+                currency=fixture.currency,
+                idempotency_key=f"agenticorg-real-staging-untrusted-{uuid.uuid4().hex}",
+                provider_key="mock",
+                agent_trust_status="untrusted",
+            )
+            evidence.add_case(
+                name="disabled_merchant_untrusted_agent",
+                status="pass" if disabled.get("error") and untrusted.get("error") else "fail",
+                result=disabled,
+            )
+        else:
+            evidence.add_case(
+                name="disabled_merchant_untrusted_agent",
+                status="skipped",
+                blocker="requires checkout passport fixture",
+            )
+
         unsupported_emi = validate_claims_against_tool_data(
             "This product includes no-cost EMI and a discount offer.",
             {"price": {"amount_minor_units": 349900, "currency": "INR"}},
@@ -410,20 +663,11 @@ async def run_real_staging_demo(
             }
         )
 
-        for skipped in (
-            "consent_exchange",
-            "payment_create_intent",
-            "checkout_create",
-            "payment_get_status",
-            "denied_revoked_expired_passport",
-            "disabled_merchant_untrusted_agent",
-            "hosted_agenticorg_discovery",
-        ):
-            evidence.add_case(
-                name=skipped,
-                status="skipped",
-                blocker="requires approved synthetic staging fixture or hosted AgenticOrg service",
-            )
+        evidence.add_case(
+            name="hosted_agenticorg_discovery",
+            status="skipped",
+            blocker="requires hosted AgenticOrg service",
+        )
 
         evidence.no_provider_call_confirmation = _no_provider_calls(tool_sequence)
         if evidence_report:
@@ -443,6 +687,9 @@ async def run_real_staging_demo(
                 "real_staging_only": True,
                 "final_payment_confirmation_user_controlled": True,
                 "auth_source_env_name": config.auth_env_name,
+                "fixture_env_path": fixture.env_path,
+                "fixture_env_var_names": fixture.variable_names,
+                "fixture_synthetic_ids": fixture.synthetic_ids,
                 "evidence_report": evidence_report,
             },
         }
@@ -716,6 +963,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--grantex-base", default=None)
     parser.add_argument("--allow-smoke-cloud-run-url", default=None)
     parser.add_argument("--evidence-report", default=None)
+    parser.add_argument("--fixture-env", default=None)
     return parser
 
 
@@ -727,6 +975,7 @@ async def _amain() -> int:
                 grantex_base_url=args.grantex_base,
                 allow_smoke_cloud_run_url=args.allow_smoke_cloud_run_url,
                 evidence_report=args.evidence_report,
+                fixture_env_path=args.fixture_env,
             )
         else:
             result = await run_demo()

--- a/docs/commerce-agent-hosted-staging-e2e.md
+++ b/docs/commerce-agent-hosted-staging-e2e.md
@@ -86,6 +86,17 @@ python demos/commerce_sales_agent_demo.py --mode=real-staging --grantex-base '<a
 python -m pytest tests/evals/test_commerce_sales_agent_real_staging.py -q
 ```
 
+C2C fixture bridge support is local-only and optional. If Grantex exports `.tmp/commerce-agent-real-staging.env`, AgenticOrg may consume it with:
+
+Env option: `AGENTICORG_COMMERCE_FIXTURE_ENV=.tmp/commerce-agent-real-staging.env`.
+
+```powershell
+$env:AGENTICORG_COMMERCE_FIXTURE_ENV='.tmp/commerce-agent-real-staging.env'
+python demos/commerce_sales_agent_demo.py --mode=real-staging --fixture-env .tmp/commerce-agent-real-staging.env --evidence-report docs/reports/commerce-agent-real-staging-evidence.md
+```
+
+The fixture env file must be under `.tmp/`. It may contain the approved smoke URL, synthetic merchant/agent/product/variant IDs, exactly one Grantex auth source value, and optional synthetic passport fixture values. These values are runtime-sensitive even when synthetic. AgenticOrg records only variable names, synthetic IDs, redacted hashes, case status, HTTP status, latency, and error code. It never prints fixture values and never treats local fixture data as mocked hosted evidence.
+
 The local mock demo remains available with `python demos/commerce_sales_agent_demo.py --mode=mock`. Do not present mocked results as hosted staging evidence.
 
 Real-staging mode fails closed before connector creation, auth lookup, or network use when pointed at production URLs, credentialed URLs, arbitrary `run.app` URLs, or non-HTTPS URLs such as local development origins.
@@ -109,6 +120,8 @@ These cases remain skipped unless the approved synthetic Grantex consent/passpor
 - payment intent create
 - checkout create
 - payment status polling
+
+With a valid local `.tmp` fixture env, those cases become live-capable against the approved Grantex staging or exact smoke URL. Missing fixture values keep the corresponding case explicitly skipped.
 
 ## Negative Evals Against Real Staging Endpoints
 

--- a/docs/commerce-agent-staging-data-setup.md
+++ b/docs/commerce-agent-staging-data-setup.md
@@ -77,6 +77,14 @@ Expected real-staging run configuration:
 
 The real-staging demo/eval must redact auth headers, generated Commerce Passport material, generated payment references, and any generated request correlation material from logs and reports.
 
+## C2C Local Fixture Bridge
+
+For approved Option A smoke runs, Grantex may export a local fixture env file to `.tmp/commerce-agent-real-staging.env`. AgenticOrg can load it with `--fixture-env .tmp/commerce-agent-real-staging.env` or `AGENTICORG_COMMERCE_FIXTURE_ENV=.tmp/commerce-agent-real-staging.env`.
+
+The fixture env file is disabled by default and must stay under `.tmp/`. It may contain the approved smoke URL, synthetic merchant/agent/product/variant IDs, exactly one Grantex auth source value, and optional synthetic passport fixture values. Usable passports, bearer tokens, agent assertions, API keys, idempotency keys, webhook secrets, and consent exchange material are sensitive runtime material even when synthetic.
+
+AgenticOrg evidence may record variable names, synthetic IDs, redacted hashes, case status, HTTP status, latency, and error code only. It must not print or persist fixture values in docs, tests, git diffs, evidence reports, logs, PR bodies, or chat.
+
 ## Option A Smoke Coverage
 
 The Grantex Option A smoke manifest provides enough synthetic data for these C1 local-to-smoke cases:
@@ -102,6 +110,8 @@ These remain skipped unless the approved smoke run also provisions synthetic con
 - denied, revoked, or expired passport cases
 - disabled merchant and untrusted agent cases
 - invalid webhook signature and replay checks, which stay Grantex-side evidence
+
+With `.tmp` fixture bridge data present, AgenticOrg can attempt consent exchange, payment intent creation, checkout creation, payment status polling, amount-cap refusal, and passport negative guardrails against the approved Grantex target. Missing fixture fields keep the corresponding cases explicitly skipped.
 
 ## Expected Positive Cases
 

--- a/tests/evals/test_commerce_sales_agent_real_staging.py
+++ b/tests/evals/test_commerce_sales_agent_real_staging.py
@@ -18,6 +18,7 @@ async def test_commerce_sales_agent_real_staging_eval_path() -> None:
         grantex_base_url=os.getenv("GRANTEX_COMMERCE_BASE_URL"),
         allow_smoke_cloud_run_url=os.getenv("AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL"),
         evidence_report=os.getenv("AGENTICORG_COMMERCE_EVIDENCE_REPORT"),
+        fixture_env_path=os.getenv("AGENTICORG_COMMERCE_FIXTURE_ENV"),
     )
 
     assert result["scope"] == "real_staging_only"
@@ -31,3 +32,11 @@ async def test_commerce_sales_agent_real_staging_eval_path() -> None:
         "grantex_commerce:catalog_search",
         "grantex_commerce:consent_request",
     }
+
+    if os.getenv("AGENTICORG_COMMERCE_FIXTURE_ENV"):
+        live_capable_cases = {
+            "grantex_commerce:catalog_get_item",
+            "grantex_commerce:inventory_check",
+            "grantex_commerce:cart_create",
+        }
+        assert live_capable_cases <= set(result["audit_summary"]["tool_sequence"])

--- a/tests/regression/test_commerce_agent_hosted_staging_plan.py
+++ b/tests/regression/test_commerce_agent_hosted_staging_plan.py
@@ -137,6 +137,8 @@ def test_commerce_agent_hosted_staging_e2e_has_real_staging_command_plan() -> No
 
     for required in [
         "python demos/commerce_sales_agent_demo.py --mode=real-staging",
+        "--fixture-env .tmp/commerce-agent-real-staging.env",
+        "AGENTICORG_COMMERCE_FIXTURE_ENV=.tmp/commerce-agent-real-staging.env",
         "python -m pytest tests/evals/test_commerce_sales_agent_real_staging.py -q",
         "AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL",
         "AGENTICORG_COMMERCE_REAL_STAGING=1",
@@ -145,6 +147,7 @@ def test_commerce_agent_hosted_staging_e2e_has_real_staging_command_plan() -> No
         "fails closed before connector creation, auth lookup, or network use",
         "python demos/commerce_sales_agent_demo.py --mode=mock",
         "Do not present mocked results as hosted staging evidence.",
+        "records only variable names, synthetic IDs, redacted hashes",
     ]:
         assert required in content
 
@@ -221,12 +224,16 @@ def test_commerce_agent_staging_data_setup_documents_option_a_smoke_case_boundar
         "GRANTEX_COMMERCE_BASE_URL=<approved smoke URL>",
         "GRANTEX_BASE_URL=<approved smoke URL>",
         "AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL=<approved smoke URL>",
+        "C2C Local Fixture Bridge",
+        "--fixture-env .tmp/commerce-agent-real-staging.env",
+        "AGENTICORG_COMMERCE_FIXTURE_ENV=.tmp/commerce-agent-real-staging.env",
         "Option A Smoke Coverage",
         "local guardrail refusal for missing consent",
         "payment intent create",
         "checkout create",
         "remain skipped unless the approved smoke run also provisions synthetic consent/passport fixtures",
         "no direct provider call regression",
+        "Missing fixture fields keep the corresponding cases explicitly skipped",
     ]:
         assert required in content
 

--- a/tests/regression/test_commerce_sales_agent_no_provider_calls.py
+++ b/tests/regression/test_commerce_sales_agent_no_provider_calls.py
@@ -10,6 +10,7 @@ COMMERCE_CODE = [
     ROOT / "core" / "commerce" / "staging_evidence.py",
     ROOT / "core" / "commerce" / "staging_runtime.py",
     ROOT / "core" / "langgraph" / "agents" / "commerce_sales_agent.py",
+    ROOT / "demos" / "commerce_sales_agent_demo.py",
 ]
 
 BANNED_IMPORT_FRAGMENTS = {

--- a/tests/regression/test_commerce_sales_agent_real_staging_mode.py
+++ b/tests/regression/test_commerce_sales_agent_real_staging_mode.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from core.commerce.staging_evidence import redact_value
@@ -13,6 +15,13 @@ def _env(**overrides: str) -> dict[str, str]:
     }
     base.update(overrides)
     return base
+
+
+def _write_tmp_fixture(name: str, content: str) -> Path:
+    path = Path(".tmp") / name
+    path.parent.mkdir(exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
 
 
 @pytest.mark.asyncio
@@ -75,6 +84,74 @@ def test_real_staging_allows_exact_smoke_url_only_with_allowlist() -> None:
     assert config.auth_env_name == "GRANTEX_AGENT_ASSERTION"
 
 
+def test_real_staging_loads_fixture_env_from_tmp_only() -> None:
+    smoke_url = "https://grantex-auth-smoke-example-uc.a.run.app"
+    fixture = _write_tmp_fixture(
+        "commerce-agent-real-staging-test.env",
+        "\n".join(
+            [
+                f'GRANTEX_COMMERCE_BASE_URL="{smoke_url}"',
+                f'GRANTEX_BASE_URL="{smoke_url}"',
+                f'AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL="{smoke_url}"',
+                'AGENTICORG_COMMERCE_REAL_STAGING="1"',
+                'AGENTICORG_COMMERCE_FIXTURE_PROVIDER="mock"',
+                'AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID="mch_staging_electronics_pilot"',
+                'AGENTICORG_COMMERCE_FIXTURE_AGENT_ID="cag_staging_agenticorg_sales"',
+                'AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID="cprd_stg_fixture"',
+                'AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID="cvar_stg_fixture"',
+                'GRANTEX_API_KEY="fixture-value-for-test"',
+                'AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT="fixture-value-for-test"',
+                "",
+            ]
+        ),
+    )
+    try:
+        config = validate_real_staging_config(fixture_env_path=str(fixture), environ=_env())
+    finally:
+        fixture.unlink(missing_ok=True)
+
+    assert config.grantex_base_url == smoke_url
+    assert config.auth_env_name == "GRANTEX_API_KEY"
+    assert config.auth_config_key == "api_key"
+    assert config.fixture.env_path == ".tmp/commerce-agent-real-staging-test.env"
+    assert config.fixture.product_id == "cprd_stg_fixture"
+    assert config.fixture.variant_id == "cvar_stg_fixture"
+    assert config.fixture.sensitive_value_hashes
+
+
+def test_real_staging_refuses_fixture_env_outside_tmp() -> None:
+    with pytest.raises(RealStagingConfigError) as excinfo:
+        validate_real_staging_config(
+            fixture_env_path="docs/commerce-agent-real-staging.env",
+            environ=_env(),
+        )
+
+    assert excinfo.value.code == "fixture_env_outside_tmp"
+
+
+def test_real_staging_fixture_preserves_exactly_one_auth_source_rule() -> None:
+    smoke_url = "https://grantex-auth-smoke-example-uc.a.run.app"
+    fixture = _write_tmp_fixture(
+        "commerce-agent-real-staging-ambiguous.env",
+        "\n".join(
+            [
+                f'GRANTEX_COMMERCE_BASE_URL="{smoke_url}"',
+                f'AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL="{smoke_url}"',
+                'GRANTEX_API_KEY="fixture-value-for-test"',
+                'GRANTEX_AGENT_ASSERTION="fixture-value-for-test"',
+                "",
+            ]
+        ),
+    )
+    try:
+        with pytest.raises(RealStagingConfigError) as excinfo:
+            validate_real_staging_config(fixture_env_path=str(fixture), environ=_env())
+    finally:
+        fixture.unlink(missing_ok=True)
+
+    assert excinfo.value.code == "ambiguous_staging_auth"
+
+
 def test_real_staging_requires_exactly_one_auth_env_name() -> None:
     with pytest.raises(RealStagingConfigError) as missing:
         validate_real_staging_config(
@@ -102,13 +179,14 @@ def test_real_staging_refuses_fake_connector_transport() -> None:
 
 
 def test_redaction_removes_auth_passport_idempotency_and_raw_payload_material() -> None:
+    auth_header = "Bearer " + "fixture-redaction-token"
     redacted = redact_value(
         {
-            "authorization": "Bearer secret-token",
-            "passport_jwt": "secret-passport",
-            "idempotency_key": "secret-idempotency",
+            "authorization": auth_header,
+            "passport_jwt": "fixture-redaction-passport",
+            "idempotency_key": "fixture-redaction-idempotency",
             "request_payload": {"nested": "raw"},
-            "provider": {"credential": "secret-provider-material"},
+            "provider": {"credential": "fixture-redaction-provider-material"},
             "safe": {"status": "pass"},
         }
     )


### PR DESCRIPTION
## Summary
- Add optional `.tmp` fixture env loading for Commerce real-staging mode.
- Preserve production URL, exact smoke URL allowlist, exactly-one-auth-source, fake connector, and provider credential refusals before network work.
- Expand real-staging eval flow so fixture-backed catalog/cart/consent/payment/checkout/status and negative cases can run when safe fixture values exist, while missing fixture material remains explicitly skipped.

## Safety
- No deploys, merges, production config changes, live payments, live Plural, or cloud resource creation.
- Fixture values are read only from `.tmp/` and are not printed.
- Evidence records variable names, synthetic IDs, status/HTTP/latency/error metadata, and short redacted hashes only.

## Validation
- `python -m ruff check core/commerce/staging_runtime.py core/commerce/staging_evidence.py demos/commerce_sales_agent_demo.py tests/evals/test_commerce_sales_agent_real_staging.py tests/regression/test_commerce_sales_agent_real_staging_mode.py tests/regression/test_commerce_sales_agent_no_provider_calls.py tests/regression/test_commerce_agent_hosted_staging_plan.py`
- `python -m pytest tests/evals/test_commerce_sales_agent_real_staging.py -q`
- `python -m pytest tests/regression/test_commerce_sales_agent_real_staging_mode.py -q`
- `python -m pytest tests/regression/test_commerce_sales_agent_no_provider_calls.py -q`
- `python -m pytest tests/regression/test_commerce_agent_hosted_staging_plan.py -q`
- `python demos/commerce_sales_agent_demo.py --mode=mock`
- Real-staging refusal checks for production URL, arbitrary run.app URL, and HTTP localhost
- Focused secret scan: no secret-shaped matches
- `git diff --check`