### PR TITLE
fix: fail workflow steps instead of reporting false success

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ os.environ.setdefault("AGENTICORG_TEST_FAKE_MAIL", "1")
 os.environ.setdefault("AGENTICORG_TEST_FAKE_STORAGE", "1")
 os.environ.setdefault("AGENTICORG_TEST_FAKE_CONNECTORS", "1")
 os.environ.setdefault("AGENTICORG_TEST_FAKE_CELERY", "1")
+os.environ.setdefault("AGENTICORG_WORKFLOW_ALLOW_STUB_STEPS", "1")
 
 # SEC-2026-05-P1-007 (docs/BRUTAL_SECURITY_SCAN_2026-05-01.md): the
 # webhook unsigned-bypass guard refuses to start in any non-local

--- a/tests/unit/test_finance_functional.py
+++ b/tests/unit/test_finance_functional.py
@@ -159,7 +159,8 @@ class TestFinanceFunctional:
         assert "post_gl" in step_results
         assert step_results["post_gl"]["status"] == "completed"
         assert "send_remittance" in step_results
-        assert step_results["send_remittance"]["output"]["status"] == "sent"
+        assert step_results["send_remittance"]["status"] == "stubbed"
+        assert step_results["send_remittance"]["code"] == "notify_side_effect_not_configured"
 
     # -----------------------------------------------------------------------
     # FT-FIN-003: 3-way match — mismatch triggers HITL
@@ -259,7 +260,8 @@ class TestFinanceFunctional:
         state = {"context": {"gstin_valid": False}, "step_results": {}}
         result = await execute_step(step, state)
 
-        assert result["status"] == "sent"
+        assert result["status"] == "stubbed"
+        assert result["stubbed"] is True
         assert result["connector"] == "slack"
         assert result["type"] == "notify"
 
@@ -367,6 +369,12 @@ class TestFinanceFunctional:
         step = {
             "id": "currency_convert",
             "type": "transform",
+            "operation": "currency_convert",
+            "config": {
+                "amount_field": "invoice_amount_usd",
+                "rate_field": "exchange_rate",
+                "output_field": "invoice_amount_inr",
+            },
         }
         state = {
             "context": {
@@ -382,6 +390,7 @@ class TestFinanceFunctional:
 
         assert result["status"] == "completed"
         assert result["type"] == "transform"
+        assert result["output"]["invoice_amount_inr"] == pytest.approx(99900.0, rel=1e-2)
 
         # Validate the conversion arithmetic in context
         ctx = state["context"]
@@ -499,7 +508,8 @@ class TestFinanceFunctional:
         assert result["status"] == "completed"
         step_results = result["step_results"]
         assert "flag_breaks" in step_results
-        assert step_results["flag_breaks"]["output"]["status"] == "sent"
+        assert step_results["flag_breaks"]["status"] == "stubbed"
+        assert step_results["flag_breaks"]["code"] == "notify_side_effect_not_configured"
 
     # -----------------------------------------------------------------------
     # FT-FIN-012: Break threshold escalation (₹75K > ₹50K)
@@ -684,7 +694,11 @@ class TestFinanceFunctional:
                 assert step_results[step_id]["status"] == "completed"
             assert step_results["validate_close"]["output"]["result"] is True
             assert "notify_stakeholders" in step_results
-            assert step_results["notify_stakeholders"]["output"]["status"] == "sent"
+            assert step_results["notify_stakeholders"]["status"] == "stubbed"
+            assert (
+                step_results["notify_stakeholders"]["code"]
+                == "notify_side_effect_not_configured"
+            )
 
     # -----------------------------------------------------------------------
     # FT-FIN-015: TDS computation accuracy

--- a/tests/unit/test_hr_functional.py
+++ b/tests/unit/test_hr_functional.py
@@ -175,7 +175,8 @@ class TestHRFunctional:
         assert len(parallel_output["results"]) == 5
         # Common slot found and invites sent
         assert step_results["find_common_slot"]["status"] == "completed"
-        assert step_results["send_invites"]["output"]["status"] == "sent"
+        assert step_results["send_invites"]["status"] == "stubbed"
+        assert step_results["send_invites"]["code"] == "notify_side_effect_not_configured"
 
     # -----------------------------------------------------------------------
     # FT-HR-004: Rescheduling automation
@@ -229,7 +230,8 @@ class TestHRFunctional:
         assert step_results["detect_cancellation"]["status"] == "completed"
         assert step_results["find_new_slot"]["status"] == "completed"
         assert step_results["update_calendar"]["status"] == "completed"
-        assert step_results["notify_all"]["output"]["status"] == "sent"
+        assert step_results["notify_all"]["status"] == "stubbed"
+        assert step_results["notify_all"]["code"] == "notify_side_effect_not_configured"
 
     # -----------------------------------------------------------------------
     # FT-HR-005: Offer letter generation (DocuSign to HR Head)
@@ -276,8 +278,8 @@ class TestHRFunctional:
         step_results = result["step_results"]
         assert step_results["generate_offer"]["status"] == "completed"
         assert step_results["send_docusign"]["status"] == "completed"
-        assert step_results["notify_hr_head"]["output"]["status"] == "sent"
-        assert step_results["notify_hr_head"]["output"]["connector"] == "email"
+        assert step_results["notify_hr_head"]["status"] == "stubbed"
+        assert step_results["notify_hr_head"]["connector"] == "email"
 
     # -----------------------------------------------------------------------
     # FT-HR-006: Day-0 provisioning completeness (all systems within 10 min)
@@ -335,7 +337,8 @@ class TestHRFunctional:
         # Verification passed
         assert step_results["verify_provision"]["status"] == "completed"
         # Welcome sent
-        assert step_results["welcome_notification"]["output"]["status"] == "sent"
+        assert step_results["welcome_notification"]["status"] == "stubbed"
+        assert step_results["welcome_notification"]["code"] == "notify_side_effect_not_configured"
 
     # -----------------------------------------------------------------------
     # FT-HR-007: Provisioning idempotency (trigger twice, no duplicates)
@@ -589,8 +592,8 @@ class TestHRFunctional:
         # Verification passed
         assert step_results["verify_revocation"]["status"] == "completed"
         # IT security notified
-        assert step_results["notify_it_security"]["output"]["status"] == "sent"
-        assert step_results["notify_it_security"]["output"]["connector"] == "slack"
+        assert step_results["notify_it_security"]["status"] == "stubbed"
+        assert step_results["notify_it_security"]["connector"] == "slack"
 
     # -----------------------------------------------------------------------
     # FT-HR-012: Attrition risk detection (3 signals, HRBP notified)
@@ -652,5 +655,5 @@ class TestHRFunctional:
         assert evaluate_condition("risk_signal_count >= 3", {"risk_signal_count": 3}) is True
         # HRBP notified via Slack
         assert "notify_hrbp" in step_results
-        assert step_results["notify_hrbp"]["output"]["status"] == "sent"
-        assert step_results["notify_hrbp"]["output"]["connector"] == "slack"
+        assert step_results["notify_hrbp"]["status"] == "stubbed"
+        assert step_results["notify_hrbp"]["connector"] == "slack"

--- a/tests/unit/test_ops_marketing_functional.py
+++ b/tests/unit/test_ops_marketing_functional.py
@@ -124,7 +124,8 @@ class TestOpsFunctional:
         assert step_results["sanctions_check"]["status"] == "completed"
         assert "create_erp_record" in step_results
         assert step_results["create_erp_record"]["status"] == "completed"
-        assert step_results["notify_procurement"]["output"]["status"] == "sent"
+        assert step_results["notify_procurement"]["status"] == "stubbed"
+        assert step_results["notify_procurement"]["code"] == "notify_side_effect_not_configured"
 
     # -----------------------------------------------------------------------
     # FT-OPS-002: Vendor onboarding — sanctions hit (blocked, no ERP record)
@@ -178,9 +179,10 @@ class TestOpsFunctional:
         step_results = result["step_results"]
         # Sanctions condition evaluated to true
         assert step_results["check_sanctions"]["output"]["result"] is True
-        # Block notification sent
+        # Block notification is explicit test stub, not a production send.
         assert "block_vendor" in step_results
-        assert step_results["block_vendor"]["output"]["status"] == "sent"
+        assert step_results["block_vendor"]["status"] == "stubbed"
+        assert step_results["block_vendor"]["code"] == "notify_side_effect_not_configured"
         # No ERP record step exists in workflow for sanctioned vendor
         assert "create_erp_record" not in step_results
 
@@ -371,7 +373,8 @@ class TestOpsFunctional:
         assert result["status"] == "completed"
         step_results = result["step_results"]
         assert step_results["compute_penalty"]["status"] == "completed"
-        assert step_results["notify_vendor"]["output"]["status"] == "sent"
+        assert step_results["notify_vendor"]["status"] == "stubbed"
+        assert step_results["notify_vendor"]["code"] == "notify_side_effect_not_configured"
         # Validate penalty arithmetic
         payload = base_state["trigger_payload"]
         penalty = (
@@ -718,8 +721,8 @@ class TestMarketingFunctional:
         assert step_results["score_lead"]["status"] == "completed"
         # High score (85 >= 70) -> assigned to sales
         assert "assign_to_sales" in step_results
-        assert step_results["assign_to_sales"]["output"]["status"] == "sent"
-        assert step_results["assign_to_sales"]["output"]["connector"] == "slack"
+        assert step_results["assign_to_sales"]["status"] == "stubbed"
+        assert step_results["assign_to_sales"]["connector"] == "slack"
 
     # -----------------------------------------------------------------------
     # FT-MKT-002: Campaign budget reallocation (>₹50K → HITL)

--- a/tests/unit/test_remaining_coverage.py
+++ b/tests/unit/test_remaining_coverage.py
@@ -1774,7 +1774,8 @@ class TestParallelExecutor:
             return "b"
 
         results = await execute_parallel([task_a, task_b], wait_for="all")
-        assert sorted(results) == ["a", "b"]
+        assert [r["status"] for r in results] == ["completed", "completed"]
+        assert sorted(r["output"] for r in results) == ["a", "b"]
 
     @pytest.mark.asyncio
     async def test_execute_any(self):
@@ -1789,7 +1790,7 @@ class TestParallelExecutor:
 
         results = await execute_parallel([fast, slow], wait_for="any")
         assert len(results) >= 1
-        assert "fast" in results
+        assert any(r["output"] == "fast" and r["status"] == "completed" for r in results)
 
     @pytest.mark.asyncio
     async def test_execute_n(self):
@@ -1819,7 +1820,8 @@ class TestParallelExecutor:
             raise ValueError("boom")
 
         results = await execute_parallel([ok, fail], wait_for="all")
-        assert any(isinstance(r, ValueError) for r in results)
+        assert any(r["status"] == "failed" for r in results)
+        assert all(not isinstance(r, BaseException) for r in results)
 
 
 # =============================================================================
@@ -1911,7 +1913,8 @@ class TestStepTypes:
         from workflows.step_types import execute_step
 
         result = await execute_step({"id": "s1", "type": "transform"}, {})
-        assert result["status"] == "completed"
+        assert result["status"] == "stubbed"
+        assert result["stubbed"] is True
 
     @pytest.mark.asyncio
     async def test_execute_notify_step(self):
@@ -1921,7 +1924,8 @@ class TestStepTypes:
             {"id": "s1", "type": "notify", "connector": "slack"},
             {},
         )
-        assert result["status"] == "sent"
+        assert result["status"] == "stubbed"
+        assert result["stubbed"] is True
         assert result["connector"] == "slack"
 
     @pytest.mark.asyncio
@@ -1966,11 +1970,12 @@ class TestStepTypes:
         """
         from workflows.step_types import execute_step
 
-        with pytest.raises(TypeError, match="coroutines is forbidden"):
-            await execute_step(
-                {"id": "s1", "type": "parallel", "steps": ["a", "b"], "wait_for": "any"},
-                {},
-            )
+        result = await execute_step(
+            {"id": "s1", "type": "parallel", "steps": ["a", "b"], "wait_for": "any"},
+            {},
+        )
+        assert result["status"] == "completed"
+        assert result["results"][0]["status"] == "completed"
 
 
 # =============================================================================

--- a/tests/unit/test_workflow_no_false_success.py
+++ b/tests/unit/test_workflow_no_false_success.py
@@ -1,0 +1,213 @@
+"""Regression tests for workflow no-false-success step execution."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _strict_workflow_runtime(monkeypatch):
+    from workflows import step_types
+
+    monkeypatch.setattr(step_types.settings, "env", "production")
+    monkeypatch.delenv("AGENTICORG_TEST_FAKE_LLM", raising=False)
+    monkeypatch.delenv("AGENTICORG_WORKFLOW_ALLOW_STUB_STEPS", raising=False)
+    monkeypatch.setattr(step_types.external_keys, "google_gemini_api_key", "")
+    monkeypatch.setattr(step_types.external_keys, "anthropic_api_key", "")
+    monkeypatch.setattr(step_types.external_keys, "openai_api_key", "")
+
+
+def _relaxed_stub_runtime(monkeypatch):
+    from workflows import step_types
+
+    monkeypatch.setattr(step_types.settings, "env", "test")
+    monkeypatch.delenv("AGENTICORG_TEST_FAKE_LLM", raising=False)
+    monkeypatch.setenv("AGENTICORG_WORKFLOW_ALLOW_STUB_STEPS", "1")
+    monkeypatch.setattr(step_types.external_keys, "google_gemini_api_key", "")
+    monkeypatch.setattr(step_types.external_keys, "anthropic_api_key", "")
+    monkeypatch.setattr(step_types.external_keys, "openai_api_key", "")
+
+
+@pytest.mark.asyncio
+async def test_no_false_success_missing_agent_config_fails_in_strict_mode(monkeypatch):
+    _strict_workflow_runtime(monkeypatch)
+    from workflows.step_types import execute_step
+
+    result = await execute_step({"id": "agent_step", "type": "agent"}, {})
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "missing_agent_config"
+
+
+@pytest.mark.asyncio
+async def test_no_false_success_missing_llm_provider_config_fails_in_strict_mode(monkeypatch):
+    _strict_workflow_runtime(monkeypatch)
+    from workflows.step_types import execute_step
+
+    result = await execute_step(
+        {"id": "agent_step", "type": "agent", "agent": "ap_processor"},
+        {},
+    )
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "missing_llm_provider_config"
+
+
+@pytest.mark.asyncio
+async def test_no_false_success_agent_execution_exception_fails_in_strict_mode(monkeypatch):
+    _strict_workflow_runtime(monkeypatch)
+    from core.agents.registry import AgentRegistry
+    from workflows import step_types
+
+    monkeypatch.setattr(step_types.external_keys, "google_gemini_api_key", "test-key")
+
+    class BrokenAgent:
+        async def execute(self, task):
+            raise RuntimeError("agent exploded")
+
+    monkeypatch.setattr(
+        AgentRegistry,
+        "create_from_config",
+        staticmethod(lambda config: BrokenAgent()),
+    )
+
+    result = await step_types.execute_step(
+        {"id": "agent_step", "type": "agent", "agent": "ap_processor"},
+        {},
+    )
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "agent_execution_failed"
+    assert result["error"]["details"]["exception_type"] == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_no_false_success_relaxed_stub_is_marked_stubbed_not_completed(monkeypatch):
+    _relaxed_stub_runtime(monkeypatch)
+    from workflows.step_types import execute_step
+
+    result = await execute_step(
+        {"id": "agent_step", "type": "agent", "agent": "ap_processor"},
+        {},
+    )
+
+    assert result["status"] == "stubbed"
+    assert result["stubbed"] is True
+    assert result["status"] != "completed"
+    assert result["code"] == "missing_llm_provider_config"
+
+
+@pytest.mark.asyncio
+async def test_no_false_success_notify_without_side_effect_fails_in_strict_mode(monkeypatch):
+    _strict_workflow_runtime(monkeypatch)
+    from workflows.step_types import execute_step
+
+    result = await execute_step(
+        {"id": "notify_step", "type": "notify", "connector": "slack"},
+        {},
+    )
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "notify_side_effect_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_no_false_success_transform_without_config_fails_in_strict_mode(monkeypatch):
+    _strict_workflow_runtime(monkeypatch)
+    from workflows.step_types import execute_step
+
+    result = await execute_step({"id": "transform_step", "type": "transform"}, {})
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "unsupported_transform_configuration"
+
+
+@pytest.mark.asyncio
+async def test_no_false_success_parallel_all_fails_when_any_child_fails(monkeypatch):
+    _strict_workflow_runtime(monkeypatch)
+    from workflows.step_types import execute_step
+
+    result = await execute_step(
+        {
+            "id": "parallel_step",
+            "type": "parallel",
+            "wait_for": "all",
+            "steps": [
+                {"id": "ok", "type": "transform", "operation": "identity"},
+                {"id": "bad", "type": "transform"},
+            ],
+        },
+        {"context": {"value": 1}},
+    )
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "parallel_child_failed"
+    assert result["output"]["failed_children"][0]["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_no_false_success_parallel_any_fails_when_only_child_fails(monkeypatch):
+    _strict_workflow_runtime(monkeypatch)
+    from workflows.step_types import execute_step
+
+    result = await execute_step(
+        {
+            "id": "parallel_step",
+            "type": "parallel",
+            "wait_for": "any",
+            "steps": [{"id": "bad", "type": "transform"}],
+        },
+        {},
+    )
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "parallel_child_failed"
+
+
+@pytest.mark.asyncio
+async def test_no_false_success_parallel_exceptions_are_normalized():
+    from workflows.parallel_executor import execute_parallel
+
+    async def raises():
+        raise ValueError("boom")
+
+    results = await execute_parallel([raises], wait_for="all")
+
+    assert results[0]["status"] == "failed"
+    assert results[0]["error"]["code"] == "parallel_child_exception"
+    assert not isinstance(results[0], BaseException)
+
+
+@pytest.mark.asyncio
+async def test_no_false_success_failed_step_fails_workflow_in_engine(monkeypatch):
+    _strict_workflow_runtime(monkeypatch)
+    from workflows.engine import WorkflowEngine
+    from workflows.state_store import WorkflowStateStore
+
+    state = {
+        "id": "wfr_no_false_success",
+        "status": "running",
+        "definition": {
+            "name": "no_false_success",
+            "steps": [{"id": "notify_step", "type": "notify", "connector": "slack"}],
+        },
+        "trigger_payload": {},
+        "steps_total": 1,
+        "steps_completed": 0,
+        "step_results": {},
+        "started_at": datetime.now(UTC).isoformat(),
+    }
+    store = AsyncMock(spec=WorkflowStateStore)
+    store.load = AsyncMock(return_value=state)
+    store.save = AsyncMock()
+
+    result = await WorkflowEngine(state_store=store).execute("wfr_no_false_success")
+
+    assert result["status"] == "failed"
+    assert result["step_results"]["notify_step"]["status"] == "failed"
+    assert (
+        result["step_results"]["notify_step"]["error"]["code"]
+        == "notify_side_effect_not_configured"
+    )

--- a/workflows/engine.py
+++ b/workflows/engine.py
@@ -13,6 +13,11 @@ import structlog
 from workflows.parser import WorkflowParser
 from workflows.retry import retry_with_backoff
 from workflows.state_store import WorkflowStateStore
+from workflows.step_results import (
+    ALLOWED_STEP_STATUSES,
+    UnknownStepStatusError,
+    failure_result,
+)
 from workflows.step_types import execute_step
 
 try:
@@ -177,12 +182,25 @@ class WorkflowEngine:
                 return {"status": "failed", "step_results": state["step_results"]}
 
             # ---- record result ----
-            state["step_results"][step_id] = {
-                "output": result.get("output", result),
-                "status": result.get("status", "completed"),
-                "confidence": result.get("confidence"),
-            }
+            result = self._normalize_step_result(step, result)
+            state["step_results"][step_id] = self._state_result_from_step_result(result)
             state["steps_completed"] = len(state["step_results"])
+
+            if result.get("status") == "failed" and not self._step_allows_failure(step):
+                state["status"] = "failed"
+                await self.state_store.save(
+                    state,
+                    actor="workflow_engine",
+                    step_id=step_id,
+                    metadata={"event": "step_failed", "error": result.get("error")},
+                )
+                logger.error(
+                    "workflow_step_failed",
+                    run_id=run_id,
+                    step_id=step_id,
+                    error=result.get("error"),
+                )
+                return {"status": "failed", "step_results": state["step_results"]}
 
             # ---- handle condition branching ----
             if step.get("type") == "condition":
@@ -326,12 +344,19 @@ class WorkflowEngine:
                 )
                 return {"status": "failed", "step_id": step_id, "error": str(exc)}
 
-            state["step_results"][step_id] = {
-                "output": result.get("output", result),
-                "status": result.get("status", "completed"),
-                "confidence": result.get("confidence"),
-            }
+            result = self._normalize_step_result(step, result)
+            state["step_results"][step_id] = self._state_result_from_step_result(result)
             state["steps_completed"] = len(state["step_results"])
+
+            if result.get("status") == "failed" and not self._step_allows_failure(step):
+                state["status"] = "failed"
+                await self.state_store.save(
+                    state,
+                    actor="workflow_engine",
+                    step_id=step_id,
+                    metadata={"event": "step_failed", "error": result.get("error")},
+                )
+                return {"status": "failed", "step_id": step_id, "error": result.get("error")}
 
             if step.get("type") == "condition":
                 branch_target = self._resolve_condition_branch(step, result, context)
@@ -348,6 +373,28 @@ class WorkflowEngine:
                     metadata={"event": "waiting_hitl"},
                 )
                 return {"status": "waiting_hitl", "step_id": step_id}
+
+            if result.get("status") == "waiting_delay":
+                state["status"] = "waiting_delay"
+                state["waiting_step_id"] = step_id
+                await self.state_store.save(
+                    state,
+                    actor="workflow_engine",
+                    step_id=step_id,
+                    metadata={"event": "waiting_delay", "resume_at": result.get("resume_at")},
+                )
+                return {"status": "waiting_delay", "step_id": step_id}
+
+            if result.get("status") == "waiting_event":
+                state["status"] = "waiting_event"
+                state["waiting_step_id"] = step_id
+                await self.state_store.save(
+                    state,
+                    actor="workflow_engine",
+                    step_id=step_id,
+                    metadata={"event": "waiting_event", "event_type": result.get("event_type")},
+                )
+                return {"status": "waiting_event", "step_id": step_id}
 
             await self.state_store.save(
                 state,
@@ -583,6 +630,59 @@ class WorkflowEngine:
     # ------------------------------------------------------------------
     # Dependency graph helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalize_step_result(step: dict, result: dict[str, Any]) -> dict[str, Any]:
+        if not isinstance(result, dict):
+            return failure_result(
+                step_id=step["id"],
+                step_type=step.get("type", "agent"),
+                failure=UnknownStepStatusError(step_id=step["id"], status=None),
+                output=result,
+            )
+
+        status = result.get("status")
+        if status not in ALLOWED_STEP_STATUSES:
+            return failure_result(
+                step_id=step["id"],
+                step_type=step.get("type", "agent"),
+                failure=UnknownStepStatusError(
+                    step_id=step["id"],
+                    status=str(status) if status is not None else None,
+                ),
+                output=result,
+            )
+        return result
+
+    @staticmethod
+    def _state_result_from_step_result(result: dict[str, Any]) -> dict[str, Any]:
+        state_result = {
+            "output": result.get("output", result),
+            "status": result["status"],
+            "confidence": result.get("confidence"),
+        }
+        if result.get("error"):
+            state_result["error"] = result["error"]
+        if result.get("stubbed"):
+            state_result["stubbed"] = True
+            state_result["reason"] = result.get("reason")
+            state_result["code"] = result.get("code")
+            if result.get("connector"):
+                state_result["connector"] = result.get("connector")
+            if result.get("agent"):
+                state_result["agent"] = result.get("agent")
+            if result.get("action"):
+                state_result["action"] = result.get("action")
+        return state_result
+
+    @staticmethod
+    def _step_allows_failure(step: dict) -> bool:
+        on_failure = str(step.get("on_failure", "")).strip().lower()
+        return bool(
+            step.get("optional") is True
+            or step.get("allow_failure") is True
+            or on_failure in {"continue", "ignore", "optional"}
+        )
 
     @staticmethod
     def _build_step_index(steps: list[dict]) -> dict[str, dict]:

--- a/workflows/parallel_executor.py
+++ b/workflows/parallel_executor.py
@@ -6,30 +6,63 @@ import asyncio
 from collections.abc import Callable, Coroutine
 from typing import Any
 
+from workflows.step_results import normalize_child_result
+
 
 async def execute_parallel(
     tasks: list[Callable[[], Coroutine]],
     wait_for: str = "all",
     n: int = 1,
-) -> list[Any]:
+) -> list[dict[str, Any]]:
+    async def _run_one(index: int, task_factory: Callable[[], Coroutine]) -> dict[str, Any]:
+        try:
+            value = await task_factory()
+        except Exception as exc:
+            return normalize_child_result(exc, child_id=str(index))
+        return normalize_child_result(value, child_id=str(index))
+
     if wait_for == "all":
-        return await asyncio.gather(*[t() for t in tasks], return_exceptions=True)
-    elif wait_for == "any":
-        done, pending = await asyncio.wait(
-            [asyncio.create_task(t()) for t in tasks],
-            return_when=asyncio.FIRST_COMPLETED,
+        return await asyncio.gather(
+            *[_run_one(index, task) for index, task in enumerate(tasks)],
+            return_exceptions=False,
         )
-        for p in pending:
-            p.cancel()
-        return [d.result() for d in done]
+    elif wait_for == "any":
+        running = [
+            asyncio.create_task(_run_one(index, task))
+            for index, task in enumerate(tasks)
+        ]
+        results: list[dict[str, Any]] = []
+        pending = set(running)
+        while pending:
+            done, pending = await asyncio.wait(
+                pending,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in done:
+                result = task.result()
+                results.append(result)
+                if result.get("status") == "completed":
+                    for p in pending:
+                        p.cancel()
+                    await asyncio.gather(*pending, return_exceptions=True)
+                    return results
+        return results
     else:
         count = int(wait_for) if wait_for.isdigit() else n
-        results = []
-        coros = [asyncio.create_task(t()) for t in tasks]
+        results: list[dict[str, Any]] = []
+        coros = [
+            asyncio.create_task(_run_one(index, task))
+            for index, task in enumerate(tasks)
+        ]
+        successes = 0
         for coro in asyncio.as_completed(coros):
-            results.append(await coro)
-            if len(results) >= count:
+            result = await coro
+            results.append(result)
+            if result.get("status") == "completed":
+                successes += 1
+            if successes >= count:
                 for c in coros:
                     c.cancel()
+                await asyncio.gather(*coros, return_exceptions=True)
                 break
         return results

--- a/workflows/parallel_executor.py
+++ b/workflows/parallel_executor.py
@@ -49,7 +49,7 @@ async def execute_parallel(
         return results
     else:
         count = int(wait_for) if wait_for.isdigit() else n
-        results: list[dict[str, Any]] = []
+        collected_results: list[dict[str, Any]] = []
         coros = [
             asyncio.create_task(_run_one(index, task))
             for index, task in enumerate(tasks)
@@ -57,7 +57,7 @@ async def execute_parallel(
         successes = 0
         for coro in asyncio.as_completed(coros):
             result = await coro
-            results.append(result)
+            collected_results.append(result)
             if result.get("status") == "completed":
                 successes += 1
             if successes >= count:
@@ -65,4 +65,4 @@ async def execute_parallel(
                     c.cancel()
                 await asyncio.gather(*coros, return_exceptions=True)
                 break
-        return results
+        return collected_results

--- a/workflows/step_results.py
+++ b/workflows/step_results.py
@@ -1,0 +1,200 @@
+"""Shared workflow step result contracts and failure helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+ALLOWED_STEP_STATUSES = frozenset(
+    {
+        "completed",
+        "failed",
+        "skipped",
+        "stubbed",
+        "waiting_hitl",
+        "waiting_delay",
+        "waiting_event",
+        "timed_out",
+        "cancelled",
+        "compensated",
+    }
+)
+
+SUCCESSFUL_STEP_STATUSES = frozenset({"completed"})
+PAUSED_STEP_STATUSES = frozenset({"waiting_hitl", "waiting_delay", "waiting_event"})
+FAILED_STEP_STATUSES = frozenset({"failed", "cancelled"})
+
+
+@dataclass(slots=True)
+class WorkflowStepError(Exception):
+    """Typed workflow step failure with a stable machine-readable code."""
+
+    code: str
+    message: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        Exception.__init__(self, self.message)
+
+    def to_error(self) -> dict[str, Any]:
+        error: dict[str, Any] = {"code": self.code, "message": self.message}
+        if self.details:
+            error["details"] = self.details
+        return error
+
+
+class MissingAgentConfigError(WorkflowStepError):
+    def __init__(self, *, step_id: str) -> None:
+        super().__init__(
+            "missing_agent_config",
+            "Agent step is missing an agent or agent_id configuration.",
+            {"step_id": step_id},
+        )
+
+
+class MissingLLMProviderConfigError(WorkflowStepError):
+    def __init__(self, *, agent: str, step_id: str) -> None:
+        super().__init__(
+            "missing_llm_provider_config",
+            "Agent step cannot run because no usable LLM/provider configuration is available.",
+            {"agent": agent, "step_id": step_id},
+        )
+
+
+class AgentExecutionError(WorkflowStepError):
+    def __init__(self, *, agent: str, step_id: str, cause: str, exception_type: str | None = None) -> None:
+        details: dict[str, Any] = {"agent": agent, "step_id": step_id, "cause": cause}
+        if exception_type:
+            details["exception_type"] = exception_type
+        super().__init__(
+            "agent_execution_failed",
+            "Agent execution failed.",
+            details,
+        )
+
+
+class UnsupportedTransformConfigError(WorkflowStepError):
+    def __init__(self, *, step_id: str, operation: str | None = None) -> None:
+        details: dict[str, Any] = {"step_id": step_id}
+        if operation:
+            details["operation"] = operation
+        super().__init__(
+            "unsupported_transform_configuration",
+            "Transform step is missing a supported transform configuration.",
+            details,
+        )
+
+
+class NotifySideEffectNotConfiguredError(WorkflowStepError):
+    def __init__(self, *, step_id: str, connector: str) -> None:
+        super().__init__(
+            "notify_side_effect_not_configured",
+            "Notify step is missing a configured delivery path.",
+            {"step_id": step_id, "connector": connector},
+        )
+
+
+class ParallelChildError(WorkflowStepError):
+    def __init__(self, *, step_id: str, failed_children: list[dict[str, Any]]) -> None:
+        super().__init__(
+            "parallel_child_failed",
+            "One or more parallel child steps failed.",
+            {"step_id": step_id, "failed_children": failed_children},
+        )
+
+
+class UnknownStepStatusError(WorkflowStepError):
+    def __init__(self, *, step_id: str, status: str | None) -> None:
+        super().__init__(
+            "unknown_step_status",
+            "Workflow step returned an unsupported status.",
+            {"step_id": step_id, "status": status},
+        )
+
+
+def failure_result(
+    *,
+    step_id: str,
+    step_type: str,
+    failure: WorkflowStepError,
+    output: Any | None = None,
+) -> dict[str, Any]:
+    return {
+        "step_id": step_id,
+        "type": step_type,
+        "status": "failed",
+        "output": output,
+        "error": failure.to_error(),
+    }
+
+
+def stubbed_result(
+    *,
+    step_id: str,
+    step_type: str,
+    code: str,
+    message: str,
+    output: Any | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    result = {
+        "step_id": step_id,
+        "type": step_type,
+        "status": "stubbed",
+        "stubbed": True,
+        "code": code,
+        "reason": message,
+        "output": output if output is not None else {},
+    }
+    result.update(extra)
+    return result
+
+
+def exception_child_result(exc: BaseException, *, child_id: str | None = None) -> dict[str, Any]:
+    return {
+        "step_id": child_id or "",
+        "status": "failed",
+        "output": None,
+        "error": {
+            "code": "parallel_child_exception",
+            "message": "Parallel child raised an exception.",
+            "details": {
+                "exception_type": type(exc).__name__,
+                "cause": str(exc),
+            },
+        },
+    }
+
+
+def normalize_child_result(value: Any, *, child_id: str | None = None) -> dict[str, Any]:
+    if isinstance(value, BaseException):
+        return exception_child_result(value, child_id=child_id)
+    if isinstance(value, dict):
+        normalized = dict(value)
+        normalized.setdefault("step_id", child_id or normalized.get("step_id", ""))
+        status = normalized.get("status")
+        if status not in ALLOWED_STEP_STATUSES:
+            return failure_result(
+                step_id=str(normalized.get("step_id") or child_id or ""),
+                step_type=str(normalized.get("type") or "parallel_child"),
+                failure=UnknownStepStatusError(
+                    step_id=str(normalized.get("step_id") or child_id or ""),
+                    status=str(status) if status is not None else None,
+                ),
+                output=normalized,
+            )
+        normalized.setdefault("output", {})
+        return normalized
+    return {
+        "step_id": child_id or "",
+        "status": "completed",
+        "output": value,
+    }
+
+
+def is_success_status(status: str | None) -> bool:
+    return status in SUCCESSFUL_STEP_STATUSES
+
+
+def is_failure_status(status: str | None) -> bool:
+    return status in FAILED_STEP_STATUSES

--- a/workflows/step_types.py
+++ b/workflows/step_types.py
@@ -310,7 +310,7 @@ async def _execute_parallel(step: dict, state: dict) -> dict[str, Any]:
 
 async def _execute_loop(step: dict, state: dict) -> dict[str, Any]:
     items = step.get("items", [])
-    results = []
+    results: list[dict[str, Any]] = []
     for item in items:
         child_step = step.get(
             "step",

--- a/workflows/step_types.py
+++ b/workflows/step_types.py
@@ -1,13 +1,96 @@
-"""All 15 workflow step type implementations."""
+"""Workflow step type implementations."""
 
 from __future__ import annotations
 
-import asyncio
+import os
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from core.config import external_keys, is_relaxed_env, is_strict_runtime_env, settings
 from workflows.condition_evaluator import evaluate_condition
 from workflows.event_waits import WorkflowEventWaitStore
+from workflows.parallel_executor import execute_parallel
+from workflows.step_results import (
+    ALLOWED_STEP_STATUSES,
+    AgentExecutionError,
+    MissingAgentConfigError,
+    MissingLLMProviderConfigError,
+    NotifySideEffectNotConfiguredError,
+    ParallelChildError,
+    UnknownStepStatusError,
+    UnsupportedTransformConfigError,
+    failure_result,
+    is_success_status,
+    stubbed_result,
+)
+
+TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def _env_flag(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in TRUTHY_ENV_VALUES
+
+
+def _stub_steps_allowed() -> bool:
+    return _env_flag("AGENTICORG_WORKFLOW_ALLOW_STUB_STEPS") and is_relaxed_env(settings.env)
+
+
+def _fake_llm_allowed() -> bool:
+    return _env_flag("AGENTICORG_TEST_FAKE_LLM") and is_relaxed_env(settings.env)
+
+
+def _real_llm_provider_configured() -> bool:
+    return bool(
+        external_keys.google_gemini_api_key
+        or external_keys.anthropic_api_key
+        or external_keys.openai_api_key
+    )
+
+
+def _llm_available_for_workflow() -> bool:
+    if _env_flag("AGENTICORG_TEST_FAKE_LLM") and is_strict_runtime_env(settings.env):
+        return False
+    if _real_llm_provider_configured():
+        return True
+    if settings.llm_mode.lower().strip() == "local":
+        return bool(os.getenv("OLLAMA_HOST") or os.getenv("VLLM_BASE_URL"))
+    return _fake_llm_allowed()
+
+
+def _missing_agent_result(step: dict, action: str) -> dict[str, Any]:
+    step_id = step.get("id", "")
+    if _stub_steps_allowed():
+        return stubbed_result(
+            step_id=step_id,
+            step_type="agent",
+            code="missing_agent_config",
+            message="Agent execution was stubbed because no agent config was provided.",
+            agent="",
+            action=action,
+        )
+    return failure_result(
+        step_id=step_id,
+        step_type="agent",
+        failure=MissingAgentConfigError(step_id=step_id),
+    )
+
+
+def _missing_llm_result(step: dict, agent_type: str, action: str) -> dict[str, Any]:
+    step_id = step.get("id", "")
+    if _stub_steps_allowed():
+        return stubbed_result(
+            step_id=step_id,
+            step_type="agent",
+            code="missing_llm_provider_config",
+            message="Agent execution was stubbed because no LLM/provider config is available.",
+            agent=agent_type,
+            action=action,
+        )
+    return failure_result(
+        step_id=step_id,
+        step_type="agent",
+        failure=MissingLLMProviderConfigError(agent=agent_type, step_id=step_id),
+    )
 
 
 async def execute_step(step: dict, state: dict) -> dict[str, Any]:
@@ -30,49 +113,28 @@ async def execute_step(step: dict, state: dict) -> dict[str, Any]:
 
 
 async def _execute_collaboration(step: dict, state: dict) -> dict[str, Any]:
-    """Delegate to the collaboration step handler for parallel multi-agent execution."""
     from workflows.collaboration import execute_collaboration_step
 
     return await execute_collaboration_step(step, state)
 
 
-async def _execute_agent(step, state):
-    """Execute an agent step by instantiating and running the real agent."""
+async def _execute_agent(step: dict, state: dict) -> dict[str, Any]:
+    """Execute an agent step by instantiating and running the configured agent."""
     agent_type = step.get("agent", step.get("agent_type", ""))
     agent_id = step.get("agent_id", "")
     action = step.get("action", "process")
     inputs = step.get("inputs", state.get("trigger_payload", {}))
 
-    # If no agent_id or agent_type, return stub (backward compat)
     if not agent_type and not agent_id:
-        return {
-            "step_id": step["id"],
-            "type": "agent",
-            "status": "completed",
-            "agent": "",
-            "action": action,
-        }
+        return _missing_agent_result(step, action)
 
-    # Check if LLM is available — if not, return stub (CI/test environments)
-    try:
-        from core.config import external_keys
-
-        has_llm = bool(external_keys.google_gemini_api_key)
-    except Exception:
-        has_llm = False
-
-    if not has_llm:
-        return {
-            "step_id": step["id"],
-            "type": "agent",
-            "status": "completed",
-            "output": {},
-            "agent": agent_type,
-            "action": action,
-        }
+    if not _llm_available_for_workflow():
+        return _missing_llm_result(step, agent_type, action)
 
     try:
-        import core.agents  # noqa: F401 — triggers registration
+        import uuid
+
+        import core.agents  # noqa: F401 - triggers registration
         from core.agents.registry import AgentRegistry
         from core.schemas.messages import (
             HITLPolicy,
@@ -82,10 +144,7 @@ async def _execute_agent(step, state):
             TaskMetadata,
         )
 
-        # Resolve tenant_id from state
         tenant_id = state.get("tenant_id", "")
-
-        # Build agent config
         config = {
             "id": agent_id or f"wf_agent_{step['id']}",
             "tenant_id": tenant_id,
@@ -95,9 +154,18 @@ async def _execute_agent(step, state):
             "llm_model": step.get("llm_model"),
         }
 
-        agent_instance = AgentRegistry.create_from_config(config)
+        if _fake_llm_allowed() and not _real_llm_provider_configured():
+            from core.agents.base import BaseAgent
 
-        import uuid
+            agent_instance = BaseAgent(
+                agent_id=config["id"],
+                tenant_id=config["tenant_id"],
+                authorized_tools=config.get("authorized_tools", []),
+                llm_model=config.get("llm_model"),
+            )
+            agent_instance.confidence_floor = 0.0
+        else:
+            agent_instance = AgentRegistry.create_from_config(config)
 
         task = TaskAssignment(
             message_id=f"msg_{uuid.uuid4().hex[:12]}",
@@ -118,42 +186,77 @@ async def _execute_agent(step, state):
         )
 
         result = await agent_instance.execute(task)
+        result_status = result.status
+        if result_status == "hitl_triggered":
+            result_status = "waiting_hitl"
+        if result_status not in ALLOWED_STEP_STATUSES:
+            return failure_result(
+                step_id=step["id"],
+                step_type="agent",
+                failure=UnknownStepStatusError(step_id=step["id"], status=result_status),
+                output=result.output,
+            )
+
+        if result_status == "failed":
+            error = result.error
+            cause = (
+                str(error.get("message"))
+                if isinstance(error, dict) and error.get("message")
+                else "Agent returned failed status."
+            )
+            failure = AgentExecutionError(
+                agent=agent_type,
+                step_id=step["id"],
+                cause=cause,
+            )
+            if isinstance(error, dict) and error.get("code"):
+                failure.code = str(error["code"])
+            return failure_result(
+                step_id=step["id"],
+                step_type="agent",
+                failure=failure,
+                output=result.output,
+            )
 
         return {
             "step_id": step["id"],
             "type": "agent",
-            "status": result.status,
+            "status": result_status,
             "output": result.output,
             "confidence": result.confidence,
             "reasoning_trace": result.reasoning_trace,
             "tool_calls": [tc.model_dump() for tc in result.tool_calls],
-        }
-    except Exception:
-        # Fallback to stub when agent execution fails (e.g., no LLM key in CI)
-        return {
-            "step_id": step["id"],
-            "type": "agent",
-            "status": "completed",
-            "output": {},
             "agent": agent_type,
             "action": action,
         }
+    except Exception as exc:
+        return failure_result(
+            step_id=step["id"],
+            step_type="agent",
+            failure=AgentExecutionError(
+                agent=agent_type,
+                step_id=step["id"],
+                cause=str(exc),
+                exception_type=type(exc).__name__,
+            ),
+        )
 
 
-async def _execute_condition(step, state):
-    condition = step.get("condition", "true")
+async def _execute_condition(step: dict, state: dict) -> dict[str, Any]:
+    condition = step.get("condition", step.get("expression", "true"))
     context = state.get("context", {})
     result = evaluate_condition(condition, context)
     path = step.get("true_path") if result else step.get("false_path")
     return {
         "step_id": step["id"],
         "type": "condition",
+        "status": "completed",
         "result": result,
         "next_path": path,
     }
 
 
-async def _execute_hitl(step, state):
+async def _execute_hitl(step: dict, state: dict) -> dict[str, Any]:
     return {
         "step_id": step["id"],
         "type": "human_in_loop",
@@ -163,61 +266,179 @@ async def _execute_hitl(step, state):
     }
 
 
-async def _execute_parallel(step, state):
+def _parallel_child_step(child: Any) -> dict[str, Any]:
+    if isinstance(child, dict):
+        child_step = dict(child)
+        child_step.setdefault("type", "agent")
+        return child_step
+    child_id = str(child)
+    return {"id": child_id, "type": "agent", "agent": child_id}
+
+
+def _parallel_failures(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [result for result in results if not is_success_status(result.get("status"))]
+
+
+async def _execute_parallel(step: dict, state: dict) -> dict[str, Any]:
     sub_steps = step.get("steps", [])
-    wait_for = step.get("wait_for", "all")
-    tasks = [execute_step({"id": s, "type": "agent"}, state) for s in sub_steps]
-    if wait_for == "any":
-        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-        for p in pending:
-            p.cancel()
-        results = [d.result() for d in done]
-    else:
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-    return {"step_id": step["id"], "type": "parallel", "results": results}
+    wait_for = str(step.get("wait_for", "all"))
+    task_factories = [
+        (lambda child=child: execute_step(_parallel_child_step(child), state))
+        for child in sub_steps
+    ]
+    results = await execute_parallel(task_factories, wait_for=wait_for)
+    failures = _parallel_failures(results)
 
+    should_fail = bool(failures) if wait_for != "any" else not any(
+        is_success_status(result.get("status")) for result in results
+    )
+    if should_fail:
+        return failure_result(
+            step_id=step["id"],
+            step_type="parallel",
+            failure=ParallelChildError(step_id=step["id"], failed_children=failures),
+            output={"results": results, "failed_children": failures},
+        )
 
-async def _execute_loop(step, state):
-    items = step.get("items", [])
-    results = []
-    for _item in items:
-        r = await execute_step({"id": f"{step['id']}_item", "type": "agent"}, state)
-        results.append(r)
-    return {"step_id": step["id"], "type": "loop", "results": results}
-
-
-async def _execute_transform(step, state):
-    return {"step_id": step["id"], "type": "transform", "status": "completed"}
-
-
-async def _execute_notify(step, state):
     return {
         "step_id": step["id"],
-        "type": "notify",
-        "status": "sent",
-        "connector": step.get("connector", ""),
+        "type": "parallel",
+        "status": "completed",
+        "results": results,
     }
 
 
+async def _execute_loop(step: dict, state: dict) -> dict[str, Any]:
+    items = step.get("items", [])
+    results = []
+    for item in items:
+        child_step = step.get(
+            "step",
+            {
+                "id": f"{step['id']}_item",
+                "type": "agent",
+                "agent": f"{step['id']}_item",
+            },
+        )
+        child_step = {**child_step, "id": f"{step['id']}_{len(results)}"}
+        child_state = {**state, "loop_item": item}
+        results.append(await execute_step(child_step, child_state))
+
+    failures = _parallel_failures(results)
+    if failures:
+        return failure_result(
+            step_id=step["id"],
+            step_type="loop",
+            failure=ParallelChildError(step_id=step["id"], failed_children=failures),
+            output={"results": results, "failed_children": failures},
+        )
+    return {"step_id": step["id"], "type": "loop", "status": "completed", "results": results}
+
+
+def _context_value(state: dict, key: str, default: Any = None) -> Any:
+    context = state.get("context", {})
+    if key in context:
+        return context[key]
+    trigger_payload = state.get("trigger_payload", {})
+    if isinstance(trigger_payload, dict) and key in trigger_payload:
+        return trigger_payload[key]
+    return default
+
+
+async def _execute_transform(step: dict, state: dict) -> dict[str, Any]:
+    config = step.get("transform") or step.get("config") or {}
+    operation = step.get("operation") or config.get("operation") or step.get("action")
+    operation = str(operation or "").strip().lower()
+
+    if operation in {"identity", "copy", "passthrough"}:
+        return {
+            "step_id": step["id"],
+            "type": "transform",
+            "status": "completed",
+            "output": step.get("inputs", state.get("context", {})),
+        }
+
+    if operation == "pick":
+        fields = config.get("fields") or step.get("fields") or []
+        output = {field: _context_value(state, field) for field in fields}
+        return {"step_id": step["id"], "type": "transform", "status": "completed", "output": output}
+
+    if operation == "currency_convert":
+        amount_field = config.get("amount_field", "invoice_amount_usd")
+        rate_field = config.get("rate_field", "exchange_rate")
+        output_field = config.get("output_field", "converted_amount")
+        amount = float(_context_value(state, amount_field, 0))
+        rate = float(_context_value(state, rate_field, 0))
+        output = {
+            output_field: amount * rate,
+            "amount_field": amount_field,
+            "rate_field": rate_field,
+        }
+        return {"step_id": step["id"], "type": "transform", "status": "completed", "output": output}
+
+    if _stub_steps_allowed():
+        return stubbed_result(
+            step_id=step["id"],
+            step_type="transform",
+            code="unsupported_transform_configuration",
+            message="Transform execution was stubbed because no supported transform is configured.",
+            operation=operation or None,
+        )
+
+    return failure_result(
+        step_id=step["id"],
+        step_type="transform",
+        failure=UnsupportedTransformConfigError(
+            step_id=step["id"],
+            operation=operation or None,
+        ),
+    )
+
+
+async def _execute_notify(step: dict, state: dict) -> dict[str, Any]:
+    connector = str(step.get("connector", step.get("channel", ""))).lower()
+    to = step.get("to") or step.get("target")
+    subject = step.get("subject") or "AgenticOrg workflow notification"
+    html = step.get("html") or step.get("message") or step.get("body") or ""
+
+    if connector in {"email", "sendgrid", "smtp"} and to and html:
+        from core.email import send_email
+
+        if send_email(str(to), str(subject), str(html)):
+            return {
+                "step_id": step["id"],
+                "type": "notify",
+                "status": "completed",
+                "output": {
+                    "status": "sent",
+                    "connector": connector,
+                    "target": to,
+                    "side_effect": "email_send",
+                },
+            }
+
+    if _stub_steps_allowed():
+        return stubbed_result(
+            step_id=step["id"],
+            step_type="notify",
+            code="notify_side_effect_not_configured",
+            message="Notify execution was stubbed because no delivery path is configured.",
+            connector=connector,
+        )
+
+    return failure_result(
+        step_id=step["id"],
+        step_type="notify",
+        failure=NotifySideEffectNotConfiguredError(step_id=step["id"], connector=connector),
+    )
+
+
 async def _execute_sub_workflow(step: dict, state: dict) -> dict[str, Any]:
-    """Execute a nested sub-workflow to completion.
-
-    The step must provide either:
-      - ``definition``: an inline workflow definition dict/YAML, or
-      - ``workflow_definition_id``: an identifier that the engine resolves
-        (falls back to looking in ``state["workflow_registry"]``).
-
-    A new :class:`WorkflowEngine` instance is created so the sub-workflow has
-    its own run lifecycle, state, and checkpoint trail.  The parent workflow
-    blocks until the child completes (or fails).
-    """
-    # Lazy import to avoid circular dependency (engine imports step_types).
-    from workflows.engine import WorkflowEngine  # noqa: F811
+    from workflows.engine import WorkflowEngine
 
     sub_definition = step.get("definition")
 
     if sub_definition is None:
-        # Try to resolve from a registry attached to state.
         definition_id = step.get("workflow_definition_id")
         registry = state.get("workflow_registry", {})
         if definition_id and definition_id in registry:
@@ -237,8 +458,6 @@ async def _execute_sub_workflow(step: dict, state: dict) -> dict[str, Any]:
                 "error": "No 'definition' or 'workflow_definition_id' provided for sub_workflow step",
             }
 
-    # Reuse the same state store from the parent.  If `state_store` is not
-    # attached (e.g. in tests), fall back to creating a fresh in-memory store.
     state_store = state.get("_state_store")
     if state_store is None:
         from workflows.state_store import WorkflowStateStore
@@ -246,32 +465,26 @@ async def _execute_sub_workflow(step: dict, state: dict) -> dict[str, Any]:
         state_store = WorkflowStateStore()
 
     sub_engine = WorkflowEngine(state_store=state_store)
-
-    # Build trigger payload from the parent step's input config.
-    trigger_payload = step.get("input", {})
-
-    sub_run_id = await sub_engine.start_run(sub_definition, trigger_payload=trigger_payload)
+    sub_run_id = await sub_engine.start_run(
+        sub_definition,
+        trigger_payload=step.get("input", {}),
+        tenant_id=state.get("tenant_id"),
+    )
     result = await sub_engine.execute(sub_run_id)
+    status = result.get("status", "failed")
+    if status not in ALLOWED_STEP_STATUSES:
+        status = "failed"
 
     return {
         "step_id": step["id"],
         "type": "sub_workflow",
-        "status": result.get("status", "completed"),
+        "status": status,
         "sub_run_id": sub_run_id,
         "output": result.get("step_results", {}),
     }
 
 
-async def _execute_wait(step, state):
-    """Wait/delay step — pauses workflow for a specified duration.
-
-    Config options:
-        duration_hours, duration_minutes, duration_seconds — relative delay
-        until — ISO8601 datetime to wait until (absolute)
-
-    The workflow engine detects ``waiting_delay`` status and schedules
-    a Celery task to resume after the delay.
-    """
+async def _execute_wait(step: dict, state: dict) -> dict[str, Any]:
     now = datetime.now(UTC)
     resume_at = None
 
@@ -286,10 +499,8 @@ async def _execute_wait(step, state):
             resume_at = now + timedelta(seconds=total_seconds)
 
     if resume_at is None or resume_at <= now:
-        # No delay or already past — complete immediately
         return {"step_id": step["id"], "type": "wait", "status": "completed"}
 
-    # Schedule Celery task to resume after delay
     try:
         from core.tasks.workflow_tasks import resume_workflow_wait
 
@@ -299,7 +510,7 @@ async def _execute_wait(step, state):
             eta=resume_at,
         )
     except Exception:  # noqa: S110
-        pass  # Celery unavailable — step completes on next poll
+        pass
 
     return {
         "step_id": step["id"],
@@ -309,18 +520,7 @@ async def _execute_wait(step, state):
     }
 
 
-async def _execute_wait_for_event(step, state):
-    """Wait for an external event (email open, click, webhook, etc.).
-
-    Config:
-        event_type — e.g. "email.opened", "email.clicked", "webhook.received"
-        timeout_hours — how long to wait before giving up (default 48)
-        match — dict of fields to match against incoming events
-
-    The workflow engine detects ``waiting_event`` status. When a matching
-    event arrives via the webhook listener, it resumes the workflow.
-    If timeout expires, the step completes with status "timed_out".
-    """
+async def _execute_wait_for_event(step: dict, state: dict) -> dict[str, Any]:
     event_type = step.get("event_type", "")
     timeout_hours = step.get("timeout_hours", 48)
     match_criteria = step.get("match", {})
@@ -361,7 +561,6 @@ async def _execute_wait_for_event(step, state):
         if created_store:
             await event_wait_store.close()
 
-    # Schedule timeout
     try:
         from core.tasks.workflow_tasks import timeout_workflow_event
 
@@ -370,7 +569,7 @@ async def _execute_wait_for_event(step, state):
             eta=timeout_at,
         )
     except Exception:  # noqa: S110
-        pass  # Celery unavailable — event will not auto-timeout
+        pass
 
     return {
         "step_id": step["id"],


### PR DESCRIPTION
## Summary
- add a typed workflow step result/error contract and strict-vs-relaxed stub guard
- make agent, transform, notify, and parallel execution fail closed in strict runtimes instead of reporting false success
- normalize engine step statuses and fail workflows on failed steps unless explicitly tolerated
- update workflow functional coverage and add no-false-success regression tests

## Validation
- `python -m pytest tests/unit/test_workflow_no_false_success.py tests/unit/test_remaining_coverage.py::TestStepTypes tests/unit/test_remaining_coverage.py::TestParallelExecutor tests/unit/test_finance_functional.py tests/unit/test_hr_functional.py tests/unit/test_ops_marketing_functional.py tests/unit/test_workflow_state_durability.py tests/unit/test_reliability.py -q`
- `python -m pytest tests/integration/test_workflow_state_store_postgres.py -q -rs` (skipped: requires `AGENTICORG_DB_URL`)
- `python -m ruff check workflows/step_results.py workflows/step_types.py workflows/parallel_executor.py workflows/engine.py tests/conftest.py tests/unit/test_remaining_coverage.py tests/unit/test_finance_functional.py tests/unit/test_hr_functional.py tests/unit/test_ops_marketing_functional.py tests/unit/test_workflow_no_false_success.py`
- `python -m compileall workflows/step_results.py workflows/step_types.py workflows/parallel_executor.py workflows/engine.py tests/unit/test_workflow_no_false_success.py`

## Notes
- Based on `codex/p0-workflow-state-durability` because PR #550 is still unmerged.