### PR TITLE
fix: persist CDC webhook events and dedupe records

### DIFF
--- a/api/v1/cdc_webhooks.py
+++ b/api/v1/cdc_webhooks.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
 
-from api.deps import get_current_tenant
-from core.cdc.receiver import get_stored_events, handle_cdc_webhook
+from api.deps import get_current_tenant, get_current_user, require_tenant_admin
+from core.cdc.receiver import handle_cdc_webhook, list_stored_events, replay_cdc_event
 
 router = APIRouter()
 
@@ -17,7 +19,7 @@ async def cdc_webhook(
     tenant_id: str,
     connector: str,
     request: Request,
-) -> dict[str, Any]:
+) -> JSONResponse:
     """Receive a CDC webhook for a specific tenant.
 
     The URL carries the tenant_id so cross-tenant routing is explicit
@@ -29,10 +31,34 @@ async def cdc_webhook(
     Producers must update their webhook URL to include the tenant.
     The legacy unscoped path returns 410 Gone below.
     """
-    payload: dict[str, Any] = await request.json()
+    raw_body = await request.body()
+    try:
+        payload = json.loads(raw_body.decode("utf-8") or "{}")
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={"status": "rejected", "reason": "invalid_json"},
+        ) from exc
+    if not isinstance(payload, dict):
+        raise HTTPException(
+            status_code=422,
+            detail={"status": "rejected", "reason": "invalid_payload"},
+        )
+
     signature = request.headers.get("X-CDC-Signature", "")
-    result = await handle_cdc_webhook(tenant_id, connector, payload, signature)
-    return result
+    result = await handle_cdc_webhook(
+        tenant_id,
+        connector,
+        payload,
+        signature,
+        raw_body=raw_body,
+    )
+    http_status = int(result.pop("http_status", 202))
+    if result.get("status") == "rejected":
+        raise HTTPException(status_code=http_status, detail=result)
+    if result.get("status") == "error":
+        raise HTTPException(status_code=http_status, detail=result)
+    return JSONResponse(status_code=http_status, content=result)
 
 
 @router.post("/webhooks/cdc/{connector}", status_code=410)
@@ -67,21 +93,14 @@ async def list_cdc_events(
     Enforces tenant isolation at the read layer so a global in-memory
     store never leaks cross-tenant events (CRITICAL-03 fix).
     """
-    events = get_stored_events(tenant_id=tenant_id)
-
-    # Apply optional filters
-    if connector:
-        events = [e for e in events if e.get("connector") == connector]
-    if event_type:
-        events = [e for e in events if e.get("event_type") == event_type]
-
-    total = len(events)
-
-    # Paginate (newest first)
-    events = list(reversed(events))
     start = (page - 1) * page_size
-    end = start + page_size
-    page_events = events[start:end]
+    page_events, total = await list_stored_events(
+        tenant_id=tenant_id,
+        connector=connector,
+        event_type=event_type,
+        limit=page_size,
+        offset=start,
+    )
 
     return {
         "items": page_events,
@@ -90,3 +109,21 @@ async def list_cdc_events(
         "page_size": page_size,
         "pages": (total + page_size - 1) // page_size if total > 0 else 0,
     }
+
+
+@router.post("/cdc/events/{event_id}/replay")
+async def replay_cdc_event_endpoint(
+    event_id: str,
+    tenant_id: str = Depends(get_current_tenant),
+    user: dict[str, Any] = Depends(get_current_user),
+    _admin_check=require_tenant_admin,
+) -> JSONResponse:
+    """Replay one failed CDC event for the caller's tenant."""
+    actor = str(user.get("sub") or user.get("email") or "admin")
+    result = await replay_cdc_event(tenant_id=tenant_id, event_id=event_id, actor=actor)
+    http_status = int(result.pop("http_status", 202))
+    if result.get("status") == "not_found":
+        raise HTTPException(status_code=http_status, detail=result)
+    if result.get("status") == "failed":
+        raise HTTPException(status_code=http_status, detail=result)
+    return JSONResponse(status_code=http_status, content=result)

--- a/core/cdc/receiver.py
+++ b/core/cdc/receiver.py
@@ -1,51 +1,630 @@
-"""CDC webhook receiver — validates, normalizes, and stores change-data-capture events."""
+"""Durable CDC webhook receiver.
+
+The production source of truth is PostgreSQL. Redis/process memory must never
+own CDC event history or deduplication; the in-memory store below exists only
+as an explicit test seam.
+"""
 
 from __future__ import annotations
 
+import asyncio
+import copy
 import hashlib
 import hmac
+import json
 import os
-import time
-from typing import Any
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Protocol
 
-# In-memory event store.  Replace with DB-backed store once migration exists.
-# Each entry is `{tenant_id, connector, ...}` — callers that read this
-# store MUST filter by tenant_id before returning to users. See
-# get_stored_events(tenant_id=...) below. The audit in 2026-04-19
-# (CRITICAL-03) flagged that a single shared list without tenant tags
-# leaked events across tenants through the read API.
-_event_store: list[dict[str, Any]] = []
-# Dedup set scoped by (tenant_id, connector, resource_type, resource_id,
-# event_type) — a different tenant can legitimately emit the same
-# fingerprint and we must still accept it.
-_seen_ids: set[tuple[str, str]] = set()
+import structlog
+from sqlalchemy import func, or_, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from core.config import is_relaxed_env, settings
+
+logger = structlog.get_logger()
 
 
-def _compute_event_id(connector: str, payload: dict[str, Any]) -> str:
-    """Deterministic event fingerprint for deduplication."""
-    parts = [connector, payload.get("resource_type", ""), payload.get("resource_id", ""), payload.get("event_type", "")]
-    raw = ":".join(parts)
-    return hashlib.sha256(raw.encode()).hexdigest()
+def _json_safe(value: Any) -> Any:
+    return json.loads(json.dumps(value, default=str))
 
 
-def _validate_signature(payload_bytes: bytes, signature: str, connector: str) -> bool:
+def _canonical_payload_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True).encode("utf-8")
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _coerce_uuid(value: str) -> uuid.UUID:
+    return uuid.UUID(str(value))
+
+
+def _public_event(record: dict[str, Any]) -> dict[str, Any]:
+    safe = _json_safe(record)
+    safe["event_id"] = str(safe.get("id") or safe.get("event_id") or "")
+    safe.setdefault("tenant_id", str(record.get("tenant_id", "")))
+    return safe
+
+
+def _provider_event_id(payload: dict[str, Any]) -> str | None:
+    for key in ("provider_event_id", "event_id", "webhook_event_id", "delivery_id"):
+        value = payload.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return None
+
+
+def _payload_field(payload: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = payload.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return ""
+
+
+def _validate_payload_shape(payload: Any) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    if not isinstance(payload, dict):
+        return None, {"status": "rejected", "reason": "invalid_payload", "http_status": 422}
+
+    event_type = _payload_field(payload, "event_type", "type")
+    resource_type = _payload_field(payload, "resource_type", "object")
+    resource_id = _payload_field(payload, "resource_id", "object_id", "id")
+    if not event_type or not resource_type or not resource_id:
+        return None, {
+            "status": "rejected",
+            "reason": "invalid_payload",
+            "message": "event_type, resource_type, and resource_id are required",
+            "http_status": 422,
+        }
+    return {
+        "event_type": event_type,
+        "resource_type": resource_type,
+        "resource_id": resource_id,
+    }, None
+
+
+def _compute_fingerprint(
+    *,
+    connector: str,
+    event_type: str,
+    resource_type: str,
+    resource_id: str,
+    payload_hash: str,
+) -> str:
+    raw = json.dumps(
+        {
+            "connector": connector,
+            "event_type": event_type,
+            "resource_type": resource_type,
+            "resource_id": resource_id,
+            "payload_hash": payload_hash,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _validate_signature(
+    payload_bytes: bytes,
+    signature: str,
+    connector: str,
+    *,
+    alternate_payload_bytes: bytes | None = None,
+) -> bool:
     """Validate HMAC-SHA256 signature using per-connector secret.
 
-    Fails closed — rejects all events when no secret is configured.
+    Fails closed when no connector secret is configured.
     """
-    import structlog
-
-    _log = structlog.get_logger()
     secret = os.getenv(f"CDC_WEBHOOK_SECRET_{connector.upper()}", "")
     if not secret:
-        _log.warning(
+        logger.warning(
             "cdc_webhook_secret_missing",
             connector=connector,
             hint="Set CDC_WEBHOOK_SECRET_<CONNECTOR> env var",
         )
-        return False  # fail closed — no secret configured
-    expected = hmac.new(secret.encode(), payload_bytes, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(expected, signature)
+        return False
+    candidates = [payload_bytes]
+    if alternate_payload_bytes is not None and alternate_payload_bytes != payload_bytes:
+        candidates.append(alternate_payload_bytes)
+    for candidate in candidates:
+        expected = hmac.new(secret.encode(), candidate, hashlib.sha256).hexdigest()
+        if hmac.compare_digest(expected, signature or ""):
+            return True
+    return False
+
+
+class CDCEventStore(Protocol):
+    async def insert_event(self, event: dict[str, Any]) -> dict[str, Any]:
+        ...
+
+    async def mark_processed(
+        self,
+        event_id: str,
+        *,
+        outcome: dict[str, Any],
+        replay_status: str | None = None,
+    ) -> None:
+        ...
+
+    async def mark_failed(
+        self,
+        event_id: str,
+        *,
+        failure_stage: str,
+        error_code: str,
+        error_message: str,
+        error_details: dict[str, Any] | None = None,
+        replay_status: str | None = None,
+    ) -> None:
+        ...
+
+    async def list_events(
+        self,
+        *,
+        tenant_id: str | None,
+        connector: str | None = None,
+        event_type: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], int]:
+        ...
+
+    async def claim_replay(self, *, tenant_id: str, event_id: str, actor: str) -> dict[str, Any]:
+        ...
+
+    async def clear(self) -> None:
+        ...
+
+
+@dataclass
+class InMemoryCDCEventRepository:
+    records: dict[str, dict[str, Any]] = field(default_factory=dict)
+    fingerprint_index: dict[tuple[str, str, str], str] = field(default_factory=dict)
+    provider_index: dict[tuple[str, str, str], str] = field(default_factory=dict)
+    dead_letters: list[dict[str, Any]] = field(default_factory=list)
+
+
+class InMemoryCDCEventStore:
+    """Explicit durable-store test double.
+
+    Separate store instances can share the same repository to prove idempotency
+    does not depend on receiver instance state.
+    """
+
+    def __init__(self, repository: InMemoryCDCEventRepository | None = None) -> None:
+        self.repository = repository or InMemoryCDCEventRepository()
+
+    async def insert_event(self, event: dict[str, Any]) -> dict[str, Any]:
+        event = copy.deepcopy(_json_safe(event))
+        provider_event_id = event.get("provider_event_id")
+        if provider_event_id:
+            provider_key = (event["tenant_id"], event["connector"], str(provider_event_id))
+            existing_id = self.repository.provider_index.get(provider_key)
+            if existing_id:
+                return {
+                    "inserted": False,
+                    "event": copy.deepcopy(self.repository.records[existing_id]),
+                }
+
+        fingerprint_key = (event["tenant_id"], event["connector"], event["fingerprint"])
+        existing_id = self.repository.fingerprint_index.get(fingerprint_key)
+        if existing_id:
+            return {
+                "inserted": False,
+                "event": copy.deepcopy(self.repository.records[existing_id]),
+            }
+
+        event.setdefault("id", str(uuid.uuid4()))
+        event.setdefault("processing_status", "received")
+        event.setdefault("processing_outcome", {})
+        event.setdefault("replay_status", "not_replayed")
+        event.setdefault("processed", False)
+        event.setdefault("replay_attempts", 0)
+        now = datetime.now(UTC).isoformat()
+        event.setdefault("created_at", now)
+        event.setdefault("received_at", now)
+        self.repository.records[event["id"]] = event
+        self.repository.fingerprint_index[fingerprint_key] = event["id"]
+        if provider_event_id:
+            self.repository.provider_index[provider_key] = event["id"]
+        return {"inserted": True, "event": copy.deepcopy(event)}
+
+    async def mark_processed(
+        self,
+        event_id: str,
+        *,
+        outcome: dict[str, Any],
+        replay_status: str | None = None,
+    ) -> None:
+        event = self.repository.records[str(event_id)]
+        now = datetime.now(UTC).isoformat()
+        event["processed"] = True
+        event["processing_status"] = "processed"
+        event["processing_outcome"] = copy.deepcopy(_json_safe(outcome))
+        event["processed_at"] = now
+        event["updated_at"] = now
+        event["error_details"] = None
+        if replay_status:
+            event["replay_status"] = replay_status
+
+    async def mark_failed(
+        self,
+        event_id: str,
+        *,
+        failure_stage: str,
+        error_code: str,
+        error_message: str,
+        error_details: dict[str, Any] | None = None,
+        replay_status: str | None = None,
+    ) -> None:
+        event = self.repository.records[str(event_id)]
+        now = datetime.now(UTC).isoformat()
+        details = copy.deepcopy(_json_safe(error_details or {}))
+        event["processed"] = False
+        event["processing_status"] = "dead_lettered"
+        event["processing_outcome"] = {
+            "failure_stage": failure_stage,
+            "error_code": error_code,
+            "error_message": error_message,
+        }
+        event["error_details"] = details
+        event["updated_at"] = now
+        if replay_status:
+            event["replay_status"] = replay_status
+        self.repository.dead_letters.append(
+            {
+                "id": str(uuid.uuid4()),
+                "cdc_event_id": event_id,
+                "tenant_id": event["tenant_id"],
+                "connector": event["connector"],
+                "event_hash": event["event_hash"],
+                "failure_stage": failure_stage,
+                "error_code": error_code,
+                "error_message": error_message,
+                "error_details": details,
+                "created_at": now,
+            }
+        )
+
+    async def list_events(
+        self,
+        *,
+        tenant_id: str | None,
+        connector: str | None = None,
+        event_type: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], int]:
+        events = list(self.repository.records.values())
+        if tenant_id is not None:
+            events = [event for event in events if event.get("tenant_id") == tenant_id]
+        if connector:
+            events = [event for event in events if event.get("connector") == connector]
+        if event_type:
+            events = [event for event in events if event.get("event_type") == event_type]
+        events.sort(key=lambda event: event.get("received_at") or event.get("created_at") or "", reverse=True)
+        total = len(events)
+        if limit is not None:
+            events = events[offset : offset + limit]
+        elif offset:
+            events = events[offset:]
+        return [copy.deepcopy(event) for event in events], total
+
+    async def claim_replay(self, *, tenant_id: str, event_id: str, actor: str) -> dict[str, Any]:
+        event = self.repository.records.get(str(event_id))
+        if not event or event.get("tenant_id") != tenant_id:
+            return {"status": "not_found"}
+        if event.get("processing_status") == "processed" or event.get("replay_status") in {
+            "replay_pending",
+            "replayed",
+            "failed",
+        }:
+            return {"status": "duplicate", "event": copy.deepcopy(event)}
+        now = datetime.now(UTC).isoformat()
+        event["replay_status"] = "replay_pending"
+        event["replay_attempts"] = int(event.get("replay_attempts") or 0) + 1
+        event["last_replayed_at"] = now
+        event["last_replayed_by"] = actor
+        event["updated_at"] = now
+        return {"status": "claimed", "event": copy.deepcopy(event)}
+
+    async def clear(self) -> None:
+        self.repository.records.clear()
+        self.repository.fingerprint_index.clear()
+        self.repository.provider_index.clear()
+        self.repository.dead_letters.clear()
+
+    def list_events_sync(self, tenant_id: str | None = None) -> list[dict[str, Any]]:
+        events = list(self.repository.records.values())
+        if tenant_id is not None:
+            events = [event for event in events if event.get("tenant_id") == tenant_id]
+        return [copy.deepcopy(event) for event in events]
+
+    def clear_sync(self) -> None:
+        self.repository.records.clear()
+        self.repository.fingerprint_index.clear()
+        self.repository.provider_index.clear()
+        self.repository.dead_letters.clear()
+
+
+class SqlAlchemyCDCEventStore:
+    """PostgreSQL implementation of CDC event ingestion and replay."""
+
+    def __init__(self, session_factory: Any) -> None:
+        self._session_factory = session_factory
+
+    async def insert_event(self, event: dict[str, Any]) -> dict[str, Any]:
+        from core.models.cdc import CDCEvent
+
+        tenant_uuid = _coerce_uuid(event["tenant_id"])
+        event_id = uuid.uuid4()
+        values = {
+            "id": event_id,
+            "tenant_id": tenant_uuid,
+            "connector": event["connector"],
+            "provider_event_id": event.get("provider_event_id"),
+            "fingerprint": event["fingerprint"],
+            "event_hash": event["event_hash"],
+            "event_type": event["event_type"],
+            "resource_type": event["resource_type"],
+            "resource_id": event["resource_id"],
+            "payload": _json_safe(event["payload"]),
+            "raw_body_hash": event.get("raw_body_hash"),
+            "signature_verification_status": event.get("signature_verification_status", "valid"),
+            "processing_status": "received",
+            "processing_outcome": {},
+            "replay_status": "not_replayed",
+            "processed": False,
+            "received_at": event.get("received_at") or datetime.now(UTC),
+        }
+        async with self._session_factory() as session:
+            async with session.begin():
+                result = await session.execute(
+                    pg_insert(CDCEvent).values(**values).on_conflict_do_nothing()
+                )
+                if result.rowcount:
+                    row = (
+                        await session.execute(select(CDCEvent).where(CDCEvent.id == event_id))
+                    ).scalar_one()
+                    return {"inserted": True, "event": _cdc_model_to_dict(row)}
+
+                row = await self._find_duplicate_row(
+                    session,
+                    tenant_uuid=tenant_uuid,
+                    connector=event["connector"],
+                    provider_event_id=event.get("provider_event_id"),
+                    fingerprint=event["fingerprint"],
+                )
+                if row is None:
+                    raise RuntimeError("cdc duplicate insert conflict was not queryable")
+                return {"inserted": False, "event": _cdc_model_to_dict(row)}
+
+    async def _find_duplicate_row(
+        self,
+        session: Any,
+        *,
+        tenant_uuid: uuid.UUID,
+        connector: str,
+        provider_event_id: str | None,
+        fingerprint: str,
+    ) -> Any:
+        from core.models.cdc import CDCEvent
+
+        clauses = [CDCEvent.fingerprint == fingerprint]
+        if provider_event_id:
+            clauses.append(CDCEvent.provider_event_id == provider_event_id)
+        return (
+            await session.execute(
+                select(CDCEvent).where(
+                    CDCEvent.tenant_id == tenant_uuid,
+                    CDCEvent.connector == connector,
+                    or_(*clauses),
+                )
+            )
+        ).scalar_one_or_none()
+
+    async def mark_processed(
+        self,
+        event_id: str,
+        *,
+        outcome: dict[str, Any],
+        replay_status: str | None = None,
+    ) -> None:
+        from core.models.cdc import CDCEvent
+
+        values: dict[str, Any] = {
+            "processed": True,
+            "processing_status": "processed",
+            "processing_outcome": _json_safe(outcome),
+            "processed_at": datetime.now(UTC),
+            "updated_at": datetime.now(UTC),
+            "error_details": None,
+        }
+        if replay_status:
+            values["replay_status"] = replay_status
+        async with self._session_factory() as session:
+            async with session.begin():
+                await session.execute(
+                    update(CDCEvent).where(CDCEvent.id == uuid.UUID(str(event_id))).values(**values)
+                )
+
+    async def mark_failed(
+        self,
+        event_id: str,
+        *,
+        failure_stage: str,
+        error_code: str,
+        error_message: str,
+        error_details: dict[str, Any] | None = None,
+        replay_status: str | None = None,
+    ) -> None:
+        from core.models.cdc import CDCEvent, CDCEventDeadLetter
+
+        event_uuid = uuid.UUID(str(event_id))
+        now = datetime.now(UTC)
+        details = _json_safe(error_details or {})
+        async with self._session_factory() as session:
+            async with session.begin():
+                row = (
+                    await session.execute(
+                        select(CDCEvent).where(CDCEvent.id == event_uuid).with_for_update()
+                    )
+                ).scalar_one()
+                row.processed = False
+                row.processing_status = "dead_lettered"
+                row.processing_outcome = {
+                    "failure_stage": failure_stage,
+                    "error_code": error_code,
+                    "error_message": error_message,
+                }
+                row.error_details = details
+                row.updated_at = now
+                if replay_status:
+                    row.replay_status = replay_status
+                session.add(
+                    CDCEventDeadLetter(
+                        cdc_event_id=row.id,
+                        tenant_id=row.tenant_id,
+                        connector=row.connector,
+                        event_hash=row.event_hash,
+                        failure_stage=failure_stage,
+                        error_code=error_code,
+                        error_message=error_message,
+                        error_details=details,
+                    )
+                )
+
+    async def list_events(
+        self,
+        *,
+        tenant_id: str | None,
+        connector: str | None = None,
+        event_type: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], int]:
+        from core.models.cdc import CDCEvent
+
+        async with self._session_factory() as session:
+            query = select(CDCEvent)
+            count_query = select(func.count()).select_from(CDCEvent)
+            if tenant_id is not None:
+                tenant_uuid = _coerce_uuid(tenant_id)
+                query = query.where(CDCEvent.tenant_id == tenant_uuid)
+                count_query = count_query.where(CDCEvent.tenant_id == tenant_uuid)
+            if connector:
+                query = query.where(CDCEvent.connector == connector)
+                count_query = count_query.where(CDCEvent.connector == connector)
+            if event_type:
+                query = query.where(CDCEvent.event_type == event_type)
+                count_query = count_query.where(CDCEvent.event_type == event_type)
+
+            total = int((await session.execute(count_query)).scalar_one())
+            query = query.order_by(CDCEvent.received_at.desc(), CDCEvent.created_at.desc()).offset(offset)
+            if limit is not None:
+                query = query.limit(limit)
+            rows = (await session.execute(query)).scalars().all()
+        return [_cdc_model_to_dict(row) for row in rows], total
+
+    async def claim_replay(self, *, tenant_id: str, event_id: str, actor: str) -> dict[str, Any]:
+        from core.models.cdc import CDCEvent
+
+        tenant_uuid = _coerce_uuid(tenant_id)
+        event_uuid = uuid.UUID(str(event_id))
+        async with self._session_factory() as session:
+            async with session.begin():
+                row = (
+                    await session.execute(
+                        select(CDCEvent)
+                        .where(CDCEvent.id == event_uuid, CDCEvent.tenant_id == tenant_uuid)
+                        .with_for_update()
+                    )
+                ).scalar_one_or_none()
+                if row is None:
+                    return {"status": "not_found"}
+                if row.processing_status == "processed" or row.replay_status in {
+                    "replay_pending",
+                    "replayed",
+                    "failed",
+                }:
+                    return {"status": "duplicate", "event": _cdc_model_to_dict(row)}
+                now = datetime.now(UTC)
+                row.replay_status = "replay_pending"
+                row.replay_attempts = int(row.replay_attempts or 0) + 1
+                row.last_replayed_at = now
+                row.last_replayed_by = actor
+                row.updated_at = now
+                return {"status": "claimed", "event": _cdc_model_to_dict(row)}
+
+    async def clear(self) -> None:
+        raise RuntimeError("clear_store is test-only and unavailable for PostgreSQL CDC store")
+
+
+def _cdc_model_to_dict(row: Any) -> dict[str, Any]:
+    return {
+        "id": str(row.id),
+        "event_id": str(row.id),
+        "tenant_id": str(row.tenant_id),
+        "connector": row.connector,
+        "provider_event_id": row.provider_event_id,
+        "fingerprint": row.fingerprint,
+        "event_hash": row.event_hash,
+        "event_type": row.event_type,
+        "resource_type": row.resource_type,
+        "resource_id": row.resource_id,
+        "payload": copy.deepcopy(row.payload),
+        "raw_body_hash": row.raw_body_hash,
+        "signature_verification_status": row.signature_verification_status,
+        "processing_status": row.processing_status,
+        "processing_outcome": copy.deepcopy(row.processing_outcome or {}),
+        "replay_status": row.replay_status,
+        "processed": bool(row.processed),
+        "replay_attempts": int(row.replay_attempts or 0),
+        "received_at": row.received_at,
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+        "processed_at": row.processed_at,
+        "last_replayed_at": row.last_replayed_at,
+        "last_replayed_by": row.last_replayed_by,
+        "error_details": copy.deepcopy(row.error_details),
+    }
+
+
+_default_store: CDCEventStore | None = None
+
+
+def get_cdc_event_store() -> CDCEventStore:
+    global _default_store
+    if _default_store is not None:
+        return _default_store
+
+    if is_relaxed_env(settings.env):
+        _default_store = InMemoryCDCEventStore()
+        return _default_store
+
+    from core.database import async_session_factory
+
+    _default_store = SqlAlchemyCDCEventStore(async_session_factory)
+    return _default_store
+
+
+def set_cdc_event_store_for_tests(store: CDCEventStore | None) -> None:
+    """Install an explicit CDC store test seam."""
+    global _default_store
+    _default_store = store
+
+
+def _run_sync(coro: Any) -> Any:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    raise RuntimeError("Use the async CDC store APIs from an active event loop")
 
 
 async def handle_cdc_webhook(
@@ -53,73 +632,228 @@ async def handle_cdc_webhook(
     connector: str,
     payload: dict[str, Any],
     signature: str,
+    *,
+    raw_body: bytes | None = None,
+    store: CDCEventStore | None = None,
 ) -> dict[str, Any]:
-    """Process an incoming CDC webhook for a specific tenant.
+    """Process an incoming CDC webhook for a tenant."""
+    if not tenant_id or not str(tenant_id).strip():
+        return {"status": "rejected", "reason": "missing_tenant", "http_status": 400}
+    if not connector or not str(connector).strip():
+        return {"status": "rejected", "reason": "missing_connector", "http_status": 422}
 
-    1. Validate signature (HMAC-SHA256 or provider-specific).
-    2. Normalize payload to CDC event format + tag with tenant_id.
-    3. Deduplicate within the tenant (skip if already seen).
-    4. Store event and trigger workflow evaluation asynchronously.
+    shape, shape_error = _validate_payload_shape(payload)
+    if shape_error:
+        return shape_error
+    assert shape is not None
 
-    Reject the webhook (400) if no tenant_id is provided — a CDC
-    event without tenant ownership cannot be routed safely.
-    """
-    import json as _json
+    canonical_bytes = _canonical_payload_bytes(payload)
+    if not _validate_signature(
+        canonical_bytes,
+        signature,
+        connector,
+        alternate_payload_bytes=raw_body,
+    ):
+        return {"status": "rejected", "reason": "invalid_signature", "http_status": 403}
 
-    if not tenant_id:
-        return {"status": "rejected", "reason": "missing_tenant"}
-
-    payload_bytes = _json.dumps(payload, sort_keys=True).encode()
-
-    if not _validate_signature(payload_bytes, signature, connector):
-        return {"status": "rejected", "reason": "invalid_signature"}
-
-    # Normalize to standard CDC event format. tenant_id is the first
-    # field so any downstream consumer MUST see the ownership tag.
-    event: dict[str, Any] = {
-        "tenant_id": tenant_id,
+    payload_hash = _sha256_bytes(canonical_bytes)
+    raw_body_hash = _sha256_bytes(raw_body if raw_body is not None else canonical_bytes)
+    fingerprint = _compute_fingerprint(
+        connector=connector,
+        event_type=shape["event_type"],
+        resource_type=shape["resource_type"],
+        resource_id=shape["resource_id"],
+        payload_hash=payload_hash,
+    )
+    received_at = datetime.now(UTC)
+    event = {
+        "tenant_id": str(tenant_id),
         "connector": connector,
-        "event_type": payload.get("event_type", payload.get("type", "unknown")),
-        "resource_type": payload.get("resource_type", payload.get("object", "unknown")),
-        "resource_id": str(payload.get("resource_id", payload.get("id", ""))),
-        "payload": payload,
-        "received_at": time.time(),
+        "provider_event_id": _provider_event_id(payload),
+        "fingerprint": fingerprint,
+        "event_hash": fingerprint,
+        "event_type": shape["event_type"],
+        "resource_type": shape["resource_type"],
+        "resource_id": shape["resource_id"],
+        "payload": copy.deepcopy(_json_safe(payload)),
+        "raw_body_hash": raw_body_hash,
+        "signature_verification_status": "valid",
+        "processing_status": "received",
+        "processing_outcome": {},
+        "replay_status": "not_replayed",
+        "processed": False,
+        "received_at": received_at,
     }
 
-    fingerprint = _compute_event_id(connector, event)
-    dedup_key = (tenant_id, fingerprint)
+    event_store = store or get_cdc_event_store()
+    try:
+        stored = await event_store.insert_event(event)
+    except ValueError as exc:
+        logger.warning("cdc_webhook_invalid_tenant", tenant_id=tenant_id, error=str(exc))
+        return {"status": "rejected", "reason": "invalid_tenant", "http_status": 422}
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("cdc_webhook_store_failed", connector=connector, error=str(exc))
+        return {"status": "error", "reason": "store_unavailable", "http_status": 503}
 
-    if dedup_key in _seen_ids:
-        return {"status": "duplicate", "event_id": fingerprint}
+    stored_event = stored["event"]
+    if not stored["inserted"]:
+        return {
+            "status": "duplicate",
+            "event_id": str(stored_event["id"]),
+            "fingerprint": stored_event["fingerprint"],
+            "processing_status": stored_event.get("processing_status", "received"),
+            "http_status": 200,
+        }
 
-    _seen_ids.add(dedup_key)
-    _event_store.append(event)
-
-    # Trigger workflow evaluation asynchronously (best-effort) with
-    # the real tenant so downstream routing respects tenancy.
     try:
         from core.cdc.triggers import evaluate_triggers
 
-        evaluate_triggers(event, tenant_id=tenant_id)
-    except Exception:  # noqa: S110
-        pass  # best-effort trigger evaluation
+        matched_workflows = evaluate_triggers(stored_event, tenant_id=str(tenant_id))
+        await event_store.mark_processed(
+            str(stored_event["id"]),
+            outcome={"matched_workflows": matched_workflows, "workflow_count": len(matched_workflows)},
+        )
+        stored_event["processed"] = True
+        stored_event["processing_status"] = "processed"
+        stored_event["processing_outcome"] = {
+            "matched_workflows": matched_workflows,
+            "workflow_count": len(matched_workflows),
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "cdc_trigger_evaluation_failed",
+            event_id=str(stored_event["id"]),
+            tenant_id=tenant_id,
+            connector=connector,
+            error=str(exc),
+        )
+        await event_store.mark_failed(
+            str(stored_event["id"]),
+            failure_stage="trigger_evaluation",
+            error_code="trigger_evaluation_failed",
+            error_message=str(exc),
+            error_details={"exception_type": type(exc).__name__},
+        )
+        stored_event["processing_status"] = "dead_lettered"
+        stored_event["processing_outcome"] = {
+            "failure_stage": "trigger_evaluation",
+            "error_code": "trigger_evaluation_failed",
+            "error_message": str(exc),
+        }
 
-    return {"status": "accepted", "event_id": fingerprint, "event": event}
+    return {
+        "status": "accepted",
+        "event_id": str(stored_event["id"]),
+        "fingerprint": fingerprint,
+        "processing_status": stored_event.get("processing_status", "processed"),
+        "event": _public_event(stored_event),
+        "http_status": 202,
+    }
+
+
+async def list_stored_events(
+    *,
+    tenant_id: str | None = None,
+    connector: str | None = None,
+    event_type: str | None = None,
+    limit: int | None = None,
+    offset: int = 0,
+    store: CDCEventStore | None = None,
+) -> tuple[list[dict[str, Any]], int]:
+    event_store = store or get_cdc_event_store()
+    events, total = await event_store.list_events(
+        tenant_id=tenant_id,
+        connector=connector,
+        event_type=event_type,
+        limit=limit,
+        offset=offset,
+    )
+    return [_public_event(event) for event in events], total
 
 
 def get_stored_events(tenant_id: str | None = None) -> list[dict[str, Any]]:
-    """Return stored CDC events, optionally filtered by tenant.
+    """Return stored CDC events for tests/diagnostics.
 
-    Callers that serve user requests MUST pass a tenant_id. The
-    no-argument form (tenant_id=None) is only for tests and internal
-    diagnostics — it returns the full store.
+    Production API paths use ``list_stored_events`` so they can read
+    PostgreSQL asynchronously. The sync wrapper remains for legacy tests and
+    refuses to run inside an active event loop for SQL-backed stores.
     """
-    if tenant_id is None:
-        return list(_event_store)
-    return [e for e in _event_store if e.get("tenant_id") == tenant_id]
+    store = get_cdc_event_store()
+    if isinstance(store, InMemoryCDCEventStore):
+        return [_public_event(event) for event in store.list_events_sync(tenant_id=tenant_id)]
+    events, _total = _run_sync(list_stored_events(tenant_id=tenant_id, store=store))
+    return events
 
 
 def clear_store() -> None:
-    """Clear the in-memory event store and dedup set."""
-    _event_store.clear()
-    _seen_ids.clear()
+    """Clear the configured CDC test store."""
+    store = get_cdc_event_store()
+    if isinstance(store, InMemoryCDCEventStore):
+        store.clear_sync()
+        return
+    _run_sync(store.clear())
+
+
+async def replay_cdc_event(
+    *,
+    tenant_id: str,
+    event_id: str,
+    actor: str = "admin",
+    store: CDCEventStore | None = None,
+) -> dict[str, Any]:
+    """Replay a failed CDC event once, scoped to a tenant."""
+    event_store = store or get_cdc_event_store()
+    claim = await event_store.claim_replay(tenant_id=tenant_id, event_id=event_id, actor=actor)
+    if claim["status"] == "not_found":
+        return {"status": "not_found", "http_status": 404}
+    if claim["status"] == "duplicate":
+        return {
+            "status": "duplicate",
+            "reason": "already_replayed_or_processed",
+            "event_id": event_id,
+            "http_status": 200,
+        }
+
+    event = claim["event"]
+    try:
+        from core.cdc.triggers import evaluate_triggers
+
+        matched_workflows = evaluate_triggers(event, tenant_id=tenant_id)
+        await event_store.mark_processed(
+            event_id,
+            outcome={
+                "matched_workflows": matched_workflows,
+                "workflow_count": len(matched_workflows),
+                "replayed_by": actor,
+            },
+            replay_status="replayed",
+        )
+        logger.info("cdc_event_replayed", tenant_id=tenant_id, event_id=event_id, actor=actor)
+        return {
+            "status": "replayed",
+            "event_id": event_id,
+            "matched_workflows": matched_workflows,
+            "http_status": 202,
+        }
+    except Exception as exc:  # noqa: BLE001
+        await event_store.mark_failed(
+            event_id,
+            failure_stage="replay_trigger_evaluation",
+            error_code="replay_trigger_evaluation_failed",
+            error_message=str(exc),
+            error_details={"exception_type": type(exc).__name__, "replayed_by": actor},
+            replay_status="failed",
+        )
+        logger.exception(
+            "cdc_event_replay_failed",
+            tenant_id=tenant_id,
+            event_id=event_id,
+            actor=actor,
+            error=str(exc),
+        )
+        return {
+            "status": "failed",
+            "event_id": event_id,
+            "reason": "replay_trigger_evaluation_failed",
+            "http_status": 500,
+        }

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -29,6 +29,8 @@ from core.models.branding import TenantBranding as TenantBranding
 from core.models.bridge import BridgeRegistration as BridgeRegistration
 from core.models.budget_alert import BudgetAlert as BudgetAlert
 from core.models.ca_subscription import CASubscription as CASubscription
+from core.models.cdc import CDCEvent as CDCEvent
+from core.models.cdc import CDCEventDeadLetter as CDCEventDeadLetter
 from core.models.company import Company as Company
 from core.models.compliance_deadline import ComplianceDeadline as ComplianceDeadline
 from core.models.connector import Connector as Connector

--- a/core/models/cdc.py
+++ b/core/models/cdc.py
@@ -1,0 +1,132 @@
+"""CDC webhook ingestion ORM models."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    TIMESTAMP,
+    Boolean,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.models.base import BaseModel
+
+
+class CDCEvent(BaseModel):
+    """Durable, tenant-scoped CDC webhook event record."""
+
+    __tablename__ = "cdc_events"
+    __table_args__ = (
+        Index(
+            "uq_cdc_events_tenant_connector_fingerprint",
+            "tenant_id",
+            "connector",
+            "fingerprint",
+            unique=True,
+        ),
+        Index("ix_cdc_events_tenant_id", "tenant_id"),
+        Index("ix_cdc_events_connector", "connector"),
+        Index("ix_cdc_events_event_hash", "event_hash"),
+        Index("ix_cdc_events_tenant_connector_status", "tenant_id", "connector", "processing_status"),
+        Index("ix_cdc_events_tenant_event_received", "tenant_id", "event_type", "received_at"),
+        Index(
+            "uq_cdc_events_tenant_connector_provider_event",
+            "tenant_id",
+            "connector",
+            "provider_event_id",
+            unique=True,
+            postgresql_where=text("provider_event_id IS NOT NULL"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False
+    )
+    connector: Mapped[str] = mapped_column(String(100), nullable=False)
+    provider_event_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    fingerprint: Mapped[str] = mapped_column(String(64), nullable=False)
+    event_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    event_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    resource_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    resource_id: Mapped[str] = mapped_column(String(200), nullable=False)
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    raw_body_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    signature_verification_status: Mapped[str] = mapped_column(
+        String(30), nullable=False, default="valid", server_default="valid"
+    )
+    processing_status: Mapped[str] = mapped_column(
+        String(30), nullable=False, default="received", server_default="received"
+    )
+    processing_outcome: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'::jsonb")
+    )
+    replay_status: Mapped[str] = mapped_column(
+        String(30), nullable=False, default="not_replayed", server_default="not_replayed"
+    )
+    processed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("FALSE")
+    )
+    replay_attempts: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    received_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=True,
+    )
+    processed_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+    last_replayed_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    last_replayed_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    error_details: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+
+class CDCEventDeadLetter(BaseModel):
+    """Append-only record for CDC events that failed downstream processing."""
+
+    __tablename__ = "cdc_event_dead_letters"
+    __table_args__ = (
+        Index("ix_cdc_event_dead_letters_tenant_created", "tenant_id", "created_at"),
+        Index("ix_cdc_event_dead_letters_event", "cdc_event_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    cdc_event_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("cdc_events.id", ondelete="CASCADE"), nullable=False
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False
+    )
+    connector: Mapped[str] = mapped_column(String(100), nullable=False)
+    event_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    failure_stage: Mapped[str] = mapped_column(String(100), nullable=False)
+    error_code: Mapped[str] = mapped_column(String(100), nullable=False)
+    error_message: Mapped[str] = mapped_column(Text, nullable=False)
+    error_details: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'::jsonb")
+    )
+    replayable: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=text("TRUE")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/migrations/versions/v4_9_13_cdc_webhook_durability.py
+++ b/migrations/versions/v4_9_13_cdc_webhook_durability.py
@@ -1,0 +1,132 @@
+"""Durable CDC webhook ingestion.
+
+Revision ID: v4913_cdc_webhook_durability
+Revises: v4912_workflow_event_waits
+Create Date: 2026-05-16
+
+CDC webhook ingestion previously depended on process-local lists and sets for
+event history and deduplication. This migration extends the existing
+``cdc_events`` table into the source of truth and adds a dead-letter table for
+auditable processing failures.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v4913_cdc_webhook_durability"
+down_revision = "v4912_workflow_event_waits"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS provider_event_id VARCHAR(255)")
+    op.execute("ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS fingerprint VARCHAR(64)")
+    op.execute(
+        "UPDATE cdc_events SET fingerprint = left(event_hash, 32) || replace(id::text, '-', '') "
+        "WHERE fingerprint IS NULL"
+    )
+    op.execute("ALTER TABLE cdc_events ALTER COLUMN fingerprint SET NOT NULL")
+    op.execute("ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS raw_body_hash VARCHAR(64)")
+    op.execute(
+        "ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS "
+        "signature_verification_status VARCHAR(30) NOT NULL DEFAULT 'valid'"
+    )
+    op.execute(
+        "ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS "
+        "processing_status VARCHAR(30) NOT NULL DEFAULT 'received'"
+    )
+    op.execute(
+        "UPDATE cdc_events SET processing_status = 'processed' "
+        "WHERE processed IS TRUE AND processing_status = 'received'"
+    )
+    op.execute(
+        "ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS "
+        "processing_outcome JSONB NOT NULL DEFAULT '{}'::jsonb"
+    )
+    op.execute(
+        "ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS "
+        "replay_status VARCHAR(30) NOT NULL DEFAULT 'not_replayed'"
+    )
+    op.execute(
+        "ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS "
+        "replay_attempts INTEGER NOT NULL DEFAULT 0"
+    )
+    op.execute(
+        "ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS received_at "
+        "TIMESTAMPTZ NOT NULL DEFAULT now()"
+    )
+    op.execute("ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS processed_at TIMESTAMPTZ")
+    op.execute("ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT now()")
+    op.execute("ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS last_replayed_at TIMESTAMPTZ")
+    op.execute("ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS last_replayed_by VARCHAR(255)")
+    op.execute("ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS error_details JSONB")
+
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_cdc_events_tenant_connector_fingerprint "
+        "ON cdc_events (tenant_id, connector, fingerprint)"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_cdc_events_tenant_connector_provider_event "
+        "ON cdc_events (tenant_id, connector, provider_event_id) "
+        "WHERE provider_event_id IS NOT NULL"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_cdc_events_tenant_connector_status "
+        "ON cdc_events (tenant_id, connector, processing_status)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_cdc_events_tenant_event_received "
+        "ON cdc_events (tenant_id, event_type, received_at)"
+    )
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS cdc_event_dead_letters (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            cdc_event_id UUID NOT NULL REFERENCES cdc_events(id) ON DELETE CASCADE,
+            tenant_id UUID NOT NULL REFERENCES tenants(id),
+            connector VARCHAR(100) NOT NULL,
+            event_hash VARCHAR(64) NOT NULL,
+            failure_stage VARCHAR(100) NOT NULL,
+            error_code VARCHAR(100) NOT NULL,
+            error_message TEXT NOT NULL,
+            error_details JSONB NOT NULL DEFAULT '{}'::jsonb,
+            replayable BOOLEAN NOT NULL DEFAULT TRUE,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_cdc_event_dead_letters_tenant_created "
+        "ON cdc_event_dead_letters (tenant_id, created_at)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_cdc_event_dead_letters_event "
+        "ON cdc_event_dead_letters (cdc_event_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_cdc_event_dead_letters_event")
+    op.execute("DROP INDEX IF EXISTS ix_cdc_event_dead_letters_tenant_created")
+    op.execute("DROP TABLE IF EXISTS cdc_event_dead_letters")
+
+    op.execute("DROP INDEX IF EXISTS ix_cdc_events_tenant_event_received")
+    op.execute("DROP INDEX IF EXISTS ix_cdc_events_tenant_connector_status")
+    op.execute("DROP INDEX IF EXISTS uq_cdc_events_tenant_connector_provider_event")
+    op.execute("DROP INDEX IF EXISTS uq_cdc_events_tenant_connector_fingerprint")
+
+    op.execute("ALTER TABLE cdc_events DROP COLUMN IF EXISTS error_details")
+    op.execute("ALTER TABLE cdc_events DROP COLUMN IF EXISTS last_replayed_by")
+    op.execute("ALTER TABLE cdc_events DROP COLUMN IF EXISTS last_replayed_at")
+    op.execute("ALTER TABLE cdc_events DROP COLUMN IF EXISTS updated_at")
+    op.execute("ALTER TABLE cdc_events DROP COLUMN IF EXISTS processed_at")
+    op.execute("ALTER TABLE cdc_events DROP COLUMN IF EXISTS received_at")
+    op.execute("ALTER TABLE cdc_events DROP COLUMN IF EXISTS replay_attempts")
+    op.execute("ALTER TABLE cdc_events DROP COLUMN IF EXISTS replay_status")
+    op.execute("ALTER TABLE cdc_events DROP COLUMN IF EXISTS processing_outcome")
+    op.execute("ALTER TABLE cdc_events DROP COLUMN IF EXISTS processing_status")
+    op.execute("ALTER TABLE cdc_events DROP COLUMN IF EXISTS signature_verification_status")
+    op.execute("ALTER TABLE cdc_events DROP COLUMN IF EXISTS raw_body_hash")
+    op.execute("ALTER TABLE cdc_events DROP COLUMN IF EXISTS fingerprint")
+    op.execute("ALTER TABLE cdc_events DROP COLUMN IF EXISTS provider_event_id")

--- a/tests/integration/test_cdc_event_store_postgres.py
+++ b/tests/integration/test_cdc_event_store_postgres.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import uuid
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import NullPool
+
+from core.cdc.receiver import SqlAlchemyCDCEventStore, handle_cdc_webhook, replay_cdc_event
+from core.models.cdc import CDCEvent, CDCEventDeadLetter
+
+
+async def _isolated_session_factory(db_engine: AsyncEngine):
+    import core.models  # noqa: F401 - registers all ORM models
+    from core.models.base import BaseModel as ORMBase
+
+    engine = create_async_engine(
+        db_engine.url.render_as_string(hide_password=False),
+        echo=False,
+        poolclass=NullPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(ORMBase.metadata.create_all)
+    return engine, async_sessionmaker(
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+
+
+def _sign(payload: dict, secret: str = "test-secret") -> str:  # noqa: S107
+    return hmac.new(
+        secret.encode(),
+        json.dumps(payload, sort_keys=True).encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_cdc_event_store_persists_and_dedupes_in_postgres(
+    db_engine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CDC_WEBHOOK_SECRET_XERO", "test-secret")
+    engine, session_factory = await _isolated_session_factory(db_engine)
+    tenant_id = uuid.uuid4()
+    payload = {
+        "event_id": "evt-pg-1",
+        "event_type": "invoice.created",
+        "resource_type": "invoice",
+        "resource_id": "inv-pg-1",
+    }
+    store_a = SqlAlchemyCDCEventStore(session_factory)
+    store_b = SqlAlchemyCDCEventStore(session_factory)
+
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO tenants (id, name, slug, plan, data_region, settings) "
+                    "VALUES (:id, 'cdc tenant', :slug, 'enterprise', 'IN', '{}'::jsonb) "
+                    "ON CONFLICT (id) DO NOTHING"
+                ),
+                {"id": tenant_id, "slug": f"cdc-{tenant_id.hex[:8]}"},
+            )
+
+        first = await handle_cdc_webhook(
+            str(tenant_id),
+            "xero",
+            payload,
+            _sign(payload),
+            store=store_a,
+        )
+        second = await handle_cdc_webhook(
+            str(tenant_id),
+            "xero",
+            payload,
+            _sign(payload),
+            store=store_b,
+        )
+
+        async with session_factory() as session:
+            rows = (
+                await session.execute(
+                    select(CDCEvent).where(CDCEvent.tenant_id == tenant_id)
+                )
+            ).scalars().all()
+
+        assert first["status"] == "accepted"
+        assert second["status"] == "duplicate"
+        assert len(rows) == 1
+        assert rows[0].provider_event_id == "evt-pg-1"
+        assert rows[0].processing_status == "processed"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_cdc_replay_failure_writes_postgres_dead_letter(
+    db_engine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CDC_WEBHOOK_SECRET_XERO", "test-secret")
+    engine, session_factory = await _isolated_session_factory(db_engine)
+    tenant_id = uuid.uuid4()
+    payload = {
+        "event_id": "evt-pg-fail",
+        "event_type": "invoice.created",
+        "resource_type": "invoice",
+        "resource_id": "inv-pg-fail",
+    }
+    store = SqlAlchemyCDCEventStore(session_factory)
+
+    def _boom(event: dict, tenant_id: str) -> list[str]:
+        raise RuntimeError("trigger failure")
+
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO tenants (id, name, slug, plan, data_region, settings) "
+                    "VALUES (:id, 'cdc tenant', :slug, 'enterprise', 'IN', '{}'::jsonb) "
+                    "ON CONFLICT (id) DO NOTHING"
+                ),
+                {"id": tenant_id, "slug": f"cdc-{tenant_id.hex[:8]}"},
+            )
+
+        monkeypatch.setattr("core.cdc.triggers.evaluate_triggers", _boom)
+        accepted = await handle_cdc_webhook(
+            str(tenant_id),
+            "xero",
+            payload,
+            _sign(payload),
+            store=store,
+        )
+        event_id = accepted["event_id"]
+
+        replay = await replay_cdc_event(
+            tenant_id=str(tenant_id),
+            event_id=event_id,
+            actor="admin",
+            store=store,
+        )
+
+        async with session_factory() as session:
+            event = (
+                await session.execute(
+                    select(CDCEvent).where(CDCEvent.id == uuid.UUID(event_id))
+                )
+            ).scalar_one()
+            dead_letters = (
+                await session.execute(
+                    select(CDCEventDeadLetter).where(
+                        CDCEventDeadLetter.cdc_event_id == uuid.UUID(event_id)
+                    )
+                )
+            ).scalars().all()
+
+        assert accepted["processing_status"] == "dead_lettered"
+        assert replay["status"] == "failed"
+        assert event.processing_status == "dead_lettered"
+        assert event.replay_status == "failed"
+        assert len(dead_letters) == 2
+    finally:
+        await engine.dispose()

--- a/tests/unit/test_cdc_webhook_durability.py
+++ b/tests/unit/test_cdc_webhook_durability.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.v1.cdc_webhooks import router as cdc_router
+from core.cdc.receiver import (
+    InMemoryCDCEventRepository,
+    InMemoryCDCEventStore,
+    clear_store,
+    handle_cdc_webhook,
+    list_stored_events,
+    replay_cdc_event,
+    set_cdc_event_store_for_tests,
+)
+
+
+def _sign(payload: dict, secret: str = "test-secret") -> str:  # noqa: S107
+    return hmac.new(
+        secret.encode(),
+        json.dumps(payload, sort_keys=True).encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+@pytest.fixture
+def cdc_store(monkeypatch: pytest.MonkeyPatch) -> InMemoryCDCEventStore:
+    monkeypatch.setenv("CDC_WEBHOOK_SECRET_XERO", "test-secret")
+    monkeypatch.setenv("CDC_WEBHOOK_SECRET_TESTCONN", "test-secret")
+    store = InMemoryCDCEventStore()
+    set_cdc_event_store_for_tests(store)
+    yield store
+    clear_store()
+    set_cdc_event_store_for_tests(None)
+
+
+@pytest.mark.asyncio
+async def test_cdc_event_persists_to_durable_store(cdc_store: InMemoryCDCEventStore) -> None:
+    payload = {
+        "event_id": "evt-1",
+        "event_type": "invoice.created",
+        "resource_type": "invoice",
+        "resource_id": "inv-1",
+    }
+
+    result = await handle_cdc_webhook("tenant-a", "xero", payload, _sign(payload))
+
+    assert result["status"] == "accepted"
+    events, total = await list_stored_events(tenant_id="tenant-a", store=cdc_store)
+    assert total == 1
+    assert events[0]["provider_event_id"] == "evt-1"
+    assert events[0]["processing_status"] == "processed"
+    assert events[0]["signature_verification_status"] == "valid"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_delivery_dedupes_across_separate_store_instances(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CDC_WEBHOOK_SECRET_XERO", "test-secret")
+    repo = InMemoryCDCEventRepository()
+    pod_a = InMemoryCDCEventStore(repo)
+    pod_b = InMemoryCDCEventStore(repo)
+    payload = {
+        "event_id": "evt-same",
+        "event_type": "invoice.updated",
+        "resource_type": "invoice",
+        "resource_id": "inv-2",
+    }
+
+    first = await handle_cdc_webhook("tenant-a", "xero", payload, _sign(payload), store=pod_a)
+    second = await handle_cdc_webhook("tenant-a", "xero", payload, _sign(payload), store=pod_b)
+
+    assert first["status"] == "accepted"
+    assert second["status"] == "duplicate"
+    assert len(repo.records) == 1
+
+
+@pytest.mark.asyncio
+async def test_invalid_signature_rejects_without_accepted_event(
+    cdc_store: InMemoryCDCEventStore,
+) -> None:
+    payload = {
+        "event_type": "invoice.created",
+        "resource_type": "invoice",
+        "resource_id": "inv-bad",
+    }
+
+    result = await handle_cdc_webhook("tenant-a", "xero", payload, "bad-signature")
+
+    assert result == {"status": "rejected", "reason": "invalid_signature", "http_status": 403}
+    events, total = await list_stored_events(tenant_id="tenant-a", store=cdc_store)
+    assert events == []
+    assert total == 0
+
+
+@pytest.mark.asyncio
+async def test_missing_tenant_returns_400(cdc_store: InMemoryCDCEventStore) -> None:
+    payload = {
+        "event_type": "invoice.created",
+        "resource_type": "invoice",
+        "resource_id": "inv-3",
+    }
+
+    result = await handle_cdc_webhook("", "xero", payload, _sign(payload))
+
+    assert result["status"] == "rejected"
+    assert result["reason"] == "missing_tenant"
+    assert result["http_status"] == 400
+
+
+@pytest.mark.asyncio
+async def test_get_cdc_events_reads_durable_tenant_scoped_store(
+    cdc_store: InMemoryCDCEventStore,
+) -> None:
+    payload_a = {
+        "event_id": "evt-a",
+        "event_type": "invoice.created",
+        "resource_type": "invoice",
+        "resource_id": "inv-a",
+    }
+    payload_b = {
+        "event_id": "evt-b",
+        "event_type": "invoice.created",
+        "resource_type": "invoice",
+        "resource_id": "inv-b",
+    }
+    await handle_cdc_webhook("tenant-a", "xero", payload_a, _sign(payload_a), store=cdc_store)
+    await handle_cdc_webhook("tenant-b", "xero", payload_b, _sign(payload_b), store=cdc_store)
+
+    events, total = await list_stored_events(tenant_id="tenant-a", store=cdc_store)
+
+    assert total == 1
+    assert events[0]["tenant_id"] == "tenant-a"
+    assert events[0]["resource_id"] == "inv-a"
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_duplicate_fingerprints_are_allowed(
+    cdc_store: InMemoryCDCEventStore,
+) -> None:
+    payload = {
+        "event_type": "invoice.created",
+        "resource_type": "invoice",
+        "resource_id": "inv-cross",
+    }
+
+    first = await handle_cdc_webhook("tenant-a", "xero", payload, _sign(payload), store=cdc_store)
+    second = await handle_cdc_webhook("tenant-b", "xero", payload, _sign(payload), store=cdc_store)
+
+    assert first["status"] == "accepted"
+    assert second["status"] == "accepted"
+    events_a, total_a = await list_stored_events(tenant_id="tenant-a", store=cdc_store)
+    events_b, total_b = await list_stored_events(tenant_id="tenant-b", store=cdc_store)
+    assert total_a == 1
+    assert total_b == 1
+    assert events_a[0]["fingerprint"] == events_b[0]["fingerprint"]
+
+
+@pytest.mark.asyncio
+async def test_trigger_evaluation_failure_records_dead_letter(
+    cdc_store: InMemoryCDCEventStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(event: dict, tenant_id: str) -> list[str]:
+        raise RuntimeError("trigger db unavailable")
+
+    monkeypatch.setattr("core.cdc.triggers.evaluate_triggers", _boom)
+    payload = {
+        "event_id": "evt-fail",
+        "event_type": "invoice.created",
+        "resource_type": "invoice",
+        "resource_id": "inv-fail",
+    }
+
+    result = await handle_cdc_webhook("tenant-a", "xero", payload, _sign(payload), store=cdc_store)
+
+    assert result["status"] == "accepted"
+    assert result["processing_status"] == "dead_lettered"
+    events, _total = await list_stored_events(tenant_id="tenant-a", store=cdc_store)
+    assert events[0]["processing_status"] == "dead_lettered"
+    assert events[0]["processing_outcome"]["error_code"] == "trigger_evaluation_failed"
+    assert cdc_store.repository.dead_letters[0]["failure_stage"] == "trigger_evaluation"
+
+
+@pytest.mark.asyncio
+async def test_replay_path_is_tenant_scoped_and_idempotent(
+    cdc_store: InMemoryCDCEventStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(event: dict, tenant_id: str) -> list[str]:
+        raise RuntimeError("first pass failed")
+
+    monkeypatch.setattr("core.cdc.triggers.evaluate_triggers", _boom)
+    payload = {
+        "event_id": "evt-replay",
+        "event_type": "invoice.created",
+        "resource_type": "invoice",
+        "resource_id": "inv-replay",
+    }
+    accepted = await handle_cdc_webhook("tenant-a", "xero", payload, _sign(payload), store=cdc_store)
+    event_id = accepted["event_id"]
+
+    wrong_tenant = await replay_cdc_event(
+        tenant_id="tenant-b",
+        event_id=event_id,
+        actor="admin-a",
+        store=cdc_store,
+    )
+    assert wrong_tenant["status"] == "not_found"
+
+    monkeypatch.setattr("core.cdc.triggers.evaluate_triggers", lambda event, tenant_id: ["wf-1"])
+    replayed = await replay_cdc_event(
+        tenant_id="tenant-a",
+        event_id=event_id,
+        actor="admin-a",
+        store=cdc_store,
+    )
+    duplicate = await replay_cdc_event(
+        tenant_id="tenant-a",
+        event_id=event_id,
+        actor="admin-a",
+        store=cdc_store,
+    )
+
+    assert replayed["status"] == "replayed"
+    assert replayed["matched_workflows"] == ["wf-1"]
+    assert duplicate["status"] == "duplicate"
+    events, _total = await list_stored_events(tenant_id="tenant-a", store=cdc_store)
+    assert events[0]["replay_status"] == "replayed"
+    assert events[0]["replay_attempts"] == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_replay_is_idempotent(
+    cdc_store: InMemoryCDCEventStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(event: dict, tenant_id: str) -> list[str]:
+        raise RuntimeError("still failing")
+
+    monkeypatch.setattr("core.cdc.triggers.evaluate_triggers", _boom)
+    payload = {
+        "event_id": "evt-replay-fail",
+        "event_type": "invoice.created",
+        "resource_type": "invoice",
+        "resource_id": "inv-replay-fail",
+    }
+    accepted = await handle_cdc_webhook("tenant-a", "xero", payload, _sign(payload), store=cdc_store)
+    event_id = accepted["event_id"]
+
+    first = await replay_cdc_event(
+        tenant_id="tenant-a",
+        event_id=event_id,
+        actor="admin-a",
+        store=cdc_store,
+    )
+    second = await replay_cdc_event(
+        tenant_id="tenant-a",
+        event_id=event_id,
+        actor="admin-a",
+        store=cdc_store,
+    )
+
+    assert first["status"] == "failed"
+    assert second["status"] == "duplicate"
+    assert len(cdc_store.repository.dead_letters) == 2
+
+
+def test_cdc_webhook_api_invalid_signature_returns_403(
+    cdc_store: InMemoryCDCEventStore,
+) -> None:
+    app = FastAPI()
+    app.include_router(cdc_router)
+    client = TestClient(app)
+    payload = {
+        "event_type": "invoice.created",
+        "resource_type": "invoice",
+        "resource_id": "inv-http",
+    }
+
+    response = client.post(
+        "/webhooks/cdc/tenant-a/xero",
+        json=payload,
+        headers={"X-CDC-Signature": "bad-signature"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["reason"] == "invalid_signature"
+
+
+def test_cdc_webhook_api_duplicate_returns_200(cdc_store: InMemoryCDCEventStore) -> None:
+    app = FastAPI()
+    app.include_router(cdc_router)
+    client = TestClient(app)
+    payload = {
+        "event_type": "invoice.created",
+        "resource_type": "invoice",
+        "resource_id": "inv-http-dup",
+    }
+    signature = _sign(payload)
+
+    first = client.post(
+        "/webhooks/cdc/tenant-a/xero",
+        json=payload,
+        headers={"X-CDC-Signature": signature},
+    )
+    second = client.post(
+        "/webhooks/cdc/tenant-a/xero",
+        json=payload,
+        headers={"X-CDC-Signature": signature},
+    )
+
+    assert first.status_code == 202
+    assert first.json()["status"] == "accepted"
+    assert second.status_code == 200
+    assert second.json()["status"] == "duplicate"
+
+
+def test_cdc_webhook_api_accepts_raw_body_signature(cdc_store: InMemoryCDCEventStore) -> None:
+    app = FastAPI()
+    app.include_router(cdc_router)
+    client = TestClient(app)
+    raw_body = b'{"resource_id":"inv-raw","resource_type":"invoice","event_type":"invoice.created"}'
+    signature = hmac.new(b"test-secret", raw_body, hashlib.sha256).hexdigest()
+
+    response = client.post(
+        "/webhooks/cdc/tenant-a/xero",
+        content=raw_body,
+        headers={"X-CDC-Signature": signature, "Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 202
+    assert response.json()["status"] == "accepted"
+
+
+def test_cdc_webhook_api_invalid_json_returns_400(cdc_store: InMemoryCDCEventStore) -> None:
+    app = FastAPI()
+    app.include_router(cdc_router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/webhooks/cdc/tenant-a/xero",
+        content=b"not-json",
+        headers={"X-CDC-Signature": "irrelevant"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["reason"] == "invalid_json"
+
+
+def test_cdc_webhook_api_invalid_shape_returns_422(cdc_store: InMemoryCDCEventStore) -> None:
+    app = FastAPI()
+    app.include_router(cdc_router)
+    client = TestClient(app)
+    payload = {"event_type": "invoice.created"}
+
+    response = client.post(
+        "/webhooks/cdc/tenant-a/xero",
+        json=payload,
+        headers={"X-CDC-Signature": _sign(payload)},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["reason"] == "invalid_payload"


### PR DESCRIPTION
## Summary
- replace CDC receiver process-local event/dedup state with a store abstraction backed by PostgreSQL in strict runtimes
- add CDC ORM models, a v4.9.13 Alembic migration extending `cdc_events`, and a `cdc_event_dead_letters` table
- enforce tenant-scoped idempotency using provider event IDs or deterministic fingerprints
- map CDC webhook outcomes to explicit HTTP semantics for invalid JSON, invalid shape, invalid signatures, duplicates, and DB failures
- add tenant-scoped durable listing plus admin replay support with replay audit fields

## Validation
- `python -m pytest tests/unit/test_cdc.py tests/unit/test_cdc_webhook_durability.py tests/regression/test_security_audit_20260419.py -q`
- `python -m pytest tests/unit/test_tier1_features.py -q`
- `python -m pytest tests/unit/test_workflow_state_durability.py tests/unit/test_reliability.py -q`
- `python -m pytest tests/integration/test_cdc_event_store_postgres.py -q -rs` (skipped locally: requires `AGENTICORG_DB_URL`)
- `python -m ruff check core/cdc/receiver.py core/models/cdc.py core/models/__init__.py api/v1/cdc_webhooks.py migrations/versions/v4_9_13_cdc_webhook_durability.py tests/unit/test_cdc.py tests/unit/test_cdc_webhook_durability.py tests/regression/test_security_audit_20260419.py tests/integration/test_cdc_event_store_postgres.py`
- `python -m compileall core/cdc/receiver.py core/models/cdc.py core/models/__init__.py api/v1/cdc_webhooks.py migrations/versions/v4_9_13_cdc_webhook_durability.py tests/unit/test_cdc_webhook_durability.py tests/integration/test_cdc_event_store_postgres.py`
- `python -m alembic heads`
- `python -m alembic upgrade v4912_workflow_event_waits:v4913_cdc_webhook_durability --sql`

## Notes
- Based on `codex/p0-workflow-state-durability` because PR #550 is still open.
- This intentionally does not make the in-memory CDC trigger registry durable; event ingestion/dedup/history/replay is the scoped P0-3 fix.