### PR TITLE
fix: authenticate and broker websocket live feed

### DIFF
--- a/api/websocket/feed.py
+++ b/api/websocket/feed.py
@@ -1,76 +1,288 @@
-"""Real-time agent activity feed + HITL notifications via WebSocket."""
+"""Authenticated, durable live feed WebSocket."""
 
 from __future__ import annotations
 
 import asyncio
 import json
+from contextlib import suppress
+from datetime import UTC, datetime
+from typing import Any
 
+import bcrypt
 import structlog
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, Query, WebSocket, WebSocketDisconnect
+from sqlalchemy import select, update
 
-logger = structlog.get_logger()
+from api.deps import get_current_tenant
+from auth.grantex_middleware import _is_grantex_token
+from auth.jwt import extract_scopes, extract_tenant_id, validate_token
+from core.database import async_session_factory
+from core.live_feed import (
+    BrokerSubscription,
+    get_feed_event_broker,
+    get_feed_event_repository,
+)
+from core.models.api_key import APIKey
 
 router = APIRouter()
+logger = structlog.get_logger()
 
-# Active WebSocket connections per tenant
-_connections: dict[str, list[WebSocket]] = {}
+_connections: dict[str, set[WebSocket]] = {}
+_subscriptions: dict[str, BrokerSubscription] = {}
+_connections_lock = asyncio.Lock()
 
 
-async def broadcast_to_tenant(tenant_id: str, data: dict) -> int:
-    """Broadcast a message to all WebSocket connections for a tenant.
+class WebSocketAuthError(Exception):
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
 
-    Used by the approval system to push real-time HITL notifications.
-    Returns the number of clients that received the message.
-    """
-    connections = _connections.get(tenant_id, [])
-    sent = 0
-    stale = []
-    for ws in connections:
+
+def _extract_token(websocket: WebSocket) -> str:
+    cookie_token = websocket.cookies.get("agenticorg_session") or ""
+    if cookie_token:
+        return cookie_token
+
+    authorization = websocket.headers.get("authorization", "")
+    if authorization.startswith("Bearer "):
+        return authorization[7:]
+
+    return (
+        websocket.query_params.get("token")
+        or websocket.query_params.get("access_token")
+        or websocket.query_params.get("ws_ticket")
+        or ""
+    )
+
+
+async def _claims_from_api_key(token: str) -> dict[str, Any]:
+    prefix = f"ao_sk_{token[6:12]}"
+    async with async_session_factory() as session:
+        result = await session.execute(
+            select(APIKey).where(
+                APIKey.prefix == prefix,
+                APIKey.status == "active",
+            )
+        )
+        candidates = result.scalars().all()
+
+    matched_key = None
+    for candidate in candidates:
+        if bcrypt.checkpw(token.encode(), candidate.key_hash.encode()):
+            matched_key = candidate
+            break
+
+    if matched_key is None:
+        raise WebSocketAuthError("invalid_api_key", "Invalid API key")
+    if matched_key.expires_at and matched_key.expires_at < datetime.now(UTC):
+        raise WebSocketAuthError("expired_api_key", "API key expired")
+
+    async with async_session_factory() as session:
+        await session.execute(
+            update(APIKey)
+            .where(APIKey.id == matched_key.id)
+            .values(last_used_at=datetime.now(UTC))
+        )
+        await session.commit()
+
+    return {
+        "sub": f"apikey:{matched_key.prefix}",
+        "agenticorg:tenant_id": str(matched_key.tenant_id),
+        "grantex:scopes": matched_key.scopes or [],
+    }
+
+
+async def _claims_from_grantex_token(token: str) -> dict[str, Any]:
+    try:
+        import os
+
+        from grantex._verify import VerifyGrantTokenOptions, verify_grant_token
+
+        grantex_url = os.getenv("GRANTEX_BASE_URL", "https://api.grantex.dev")
+        verified = verify_grant_token(
+            token,
+            VerifyGrantTokenOptions(jwks_uri=f"{grantex_url}/.well-known/jwks.json"),
+        )
+    except Exception as exc:  # noqa: BLE001 - auth failure maps to policy violation.
+        raise WebSocketAuthError("invalid_grant_token", "Invalid or expired grant token") from exc
+
+    return {
+        "sub": getattr(verified, "principal_id", ""),
+        "agenticorg:tenant_id": getattr(verified, "developer_id", ""),
+        "grantex:scopes": getattr(verified, "scopes", []),
+        "agenticorg:agent_id": getattr(verified, "agent_did", ""),
+        "grantex:grant_id": getattr(verified, "grant_id", ""),
+        "grantex:delegation_depth": getattr(verified, "delegation_depth", 0),
+    }
+
+
+async def authenticate_websocket(websocket: WebSocket, path_tenant_id: str) -> dict[str, Any]:
+    token = _extract_token(websocket)
+    if not token:
+        raise WebSocketAuthError("missing_auth", "Missing session cookie or bearer token")
+
+    if token.startswith("ao_sk_"):
+        claims = await _claims_from_api_key(token)
+    elif _is_grantex_token(token):
+        claims = await _claims_from_grantex_token(token)
+    else:
         try:
-            await ws.send_text(json.dumps(data))
+            claims = await validate_token(token)
+        except ValueError as exc:
+            raise WebSocketAuthError("invalid_token", "Invalid or expired token") from exc
+
+    tenant_id = extract_tenant_id(claims)
+    if not tenant_id:
+        raise WebSocketAuthError("missing_tenant", "Token is missing tenant claim")
+    if str(tenant_id) != str(path_tenant_id):
+        raise WebSocketAuthError("tenant_mismatch", "Tenant mismatch")
+
+    return {
+        "claims": claims,
+        "tenant_id": tenant_id,
+        "scopes": extract_scopes(claims),
+    }
+
+
+async def _fanout_local(message: dict[str, Any]) -> int:
+    tenant_id = str(message.get("tenant_id") or "")
+    async with _connections_lock:
+        sockets = list(_connections.get(tenant_id, set()))
+
+    failed: list[WebSocket] = []
+    sent = 0
+    for socket in sockets:
+        try:
+            await socket.send_json(message)
             sent += 1
-        except Exception:
-            stale.append(ws)
-    # Clean up stale connections
-    for ws in stale:
-        connections.remove(ws)
+        except Exception as exc:  # noqa: BLE001 - stale sockets are removed below.
+            logger.debug("live_feed_socket_send_failed", tenant_id=tenant_id, error=str(exc))
+            failed.append(socket)
+
+    if failed:
+        async with _connections_lock:
+            bucket = _connections.get(tenant_id)
+            if bucket is not None:
+                for socket in failed:
+                    bucket.discard(socket)
     return sent
 
 
-@router.websocket("/ws/feed/{tenant_id}")
-async def live_feed(websocket: WebSocket, tenant_id: str):
-    await websocket.accept()
+async def _ensure_subscription_locked(tenant_id: str) -> None:
+    if tenant_id in _subscriptions:
+        return
+    _subscriptions[tenant_id] = await get_feed_event_broker().subscribe(tenant_id, _fanout_local)
 
-    # Register connection
-    if tenant_id not in _connections:
-        _connections[tenant_id] = []
-    _connections[tenant_id].append(websocket)
 
-    logger.info("ws_connected", tenant_id=tenant_id, total=len(_connections[tenant_id]))
+async def _add_connection(tenant_id: str, websocket: WebSocket) -> None:
+    async with _connections_lock:
+        _connections.setdefault(tenant_id, set()).add(websocket)
+        await _ensure_subscription_locked(tenant_id)
 
+
+async def _remove_connection(tenant_id: str, websocket: WebSocket) -> None:
+    subscription: BrokerSubscription | None = None
+    async with _connections_lock:
+        bucket = _connections.get(tenant_id)
+        if bucket is not None:
+            bucket.discard(websocket)
+            if not bucket:
+                _connections.pop(tenant_id, None)
+                subscription = _subscriptions.pop(tenant_id, None)
+    if subscription is not None:
+        await subscription.close()
+
+
+async def broadcast_to_tenant(tenant_id: str, data: dict) -> int:
+    """Persist and broker a tenant feed event.
+
+    The return value is the number of currently connected local sockets; cross-pod
+    delivery is asynchronous through the broker.
+    """
+
+    event_type = str(data.get("type") or data.get("event_type") or "message")
+    event = await get_feed_event_repository().append(
+        tenant_id=str(tenant_id),
+        event_type=event_type,
+        payload=data,
+        source=data.get("source") if isinstance(data.get("source"), str) else None,
+        correlation_id=(
+            data.get("correlation_id") if isinstance(data.get("correlation_id"), str) else None
+        ),
+    )
+    message = event.to_message()
     try:
+        await get_feed_event_broker().publish(event)
+    except Exception as exc:  # noqa: BLE001 - persisted feed event remains replayable.
+        logger.warning("live_feed_broker_publish_failed", tenant_id=tenant_id, error=str(exc))
+        await _fanout_local(message)
+
+    async with _connections_lock:
+        return len(_connections.get(str(tenant_id), set()))
+
+
+@router.get("/feed/events")
+async def list_feed_events(
+    after: int = Query(default=0, ge=0),
+    limit: int = Query(default=100, ge=1, le=500),
+    tenant_id: str = Depends(get_current_tenant),
+) -> dict[str, Any]:
+    events = await get_feed_event_repository().list_after(
+        tenant_id=tenant_id,
+        after=after,
+        limit=limit,
+    )
+    return {
+        "tenant_id": tenant_id,
+        "after": after,
+        "items": [event.to_message() for event in events],
+    }
+
+
+@router.websocket("/ws/feed/{tenant_id}")
+async def live_feed(websocket: WebSocket, tenant_id: str) -> None:
+    try:
+        await authenticate_websocket(websocket, tenant_id)
+    except WebSocketAuthError as exc:
+        logger.warning("live_feed_auth_rejected", tenant_id=tenant_id, code=exc.code)
+        await websocket.close(code=1008, reason=exc.message[:123])
+        return
+
+    await websocket.accept()
+    try:
+        await _add_connection(tenant_id, websocket)
+        await websocket.send_json({"type": "heartbeat", "tenant_id": tenant_id, "sequence": None})
         while True:
-            # Send heartbeat every 15 seconds
-            data = {"type": "heartbeat", "tenant_id": tenant_id}
-            await websocket.send_text(json.dumps(data))
-            # Also listen for client messages (ping/pong, etc.)
             try:
-                msg = await asyncio.wait_for(websocket.receive_text(), timeout=15)
-                # Client sent something — could be a ping
-                client_data = json.loads(msg)
-                if client_data.get("type") == "ping":
-                    await websocket.send_text(json.dumps({"type": "pong"}))
+                raw_message = await asyncio.wait_for(websocket.receive_text(), timeout=15)
             except TimeoutError:
-                pass  # Normal — just send next heartbeat
+                await websocket.send_json(
+                    {"type": "heartbeat", "tenant_id": tenant_id, "sequence": None}
+                )
+                continue
+            except WebSocketDisconnect:
+                break
+
+            try:
+                inbound = json.loads(raw_message)
+            except json.JSONDecodeError:
+                await websocket.send_json(
+                    {
+                        "type": "error",
+                        "code": "invalid_json",
+                        "tenant_id": tenant_id,
+                        "sequence": None,
+                    }
+                )
+                continue
+            if isinstance(inbound, dict) and inbound.get("type") == "ping":
+                await websocket.send_json({"type": "pong", "tenant_id": tenant_id, "sequence": None})
     except WebSocketDisconnect:
         pass
+    except Exception as exc:  # noqa: BLE001 - connection-level failure should not crash the app.
+        logger.warning("live_feed_connection_failed", tenant_id=tenant_id, error=str(exc))
+        with suppress(RuntimeError):
+            await websocket.close(code=1011, reason="Feed connection failed")
     finally:
-        # Unregister connection
-        if tenant_id in _connections:
-            try:
-                _connections[tenant_id].remove(websocket)
-            except ValueError:
-                pass
-            if not _connections[tenant_id]:
-                del _connections[tenant_id]
-        logger.info("ws_disconnected", tenant_id=tenant_id)
+        await _remove_connection(tenant_id, websocket)

--- a/core/live_feed.py
+++ b/core/live_feed.py
@@ -1,0 +1,388 @@
+"""Durable, brokered live feed events."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import inspect
+import json
+import uuid
+from collections.abc import Awaitable, Callable
+from contextlib import suppress
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+import redis.asyncio as aioredis
+import structlog
+from sqlalchemy import func, select, text
+
+from core.config import redis_socket_timeout_kwargs, settings
+
+logger = structlog.get_logger()
+
+FeedHandler = Callable[[dict[str, Any]], Awaitable[None]]
+
+
+def _json_safe(value: Any) -> Any:
+    return json.loads(json.dumps(value, default=str))
+
+
+def _coerce_uuid(value: str) -> uuid.UUID:
+    return uuid.UUID(str(value))
+
+
+@dataclass(slots=True)
+class FeedEventRecord:
+    tenant_id: str
+    sequence: int
+    event_type: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    source: str | None = None
+    correlation_id: str | None = None
+    id: str | None = None
+    created_at: datetime | None = None
+
+    def to_message(self) -> dict[str, Any]:
+        message = copy.deepcopy(_json_safe(self.payload or {}))
+        message["id"] = self.id
+        message["tenant_id"] = self.tenant_id
+        message["sequence"] = self.sequence
+        message["type"] = self.event_type
+        message["source"] = self.source
+        message["correlation_id"] = self.correlation_id
+        message["created_at"] = self.created_at.isoformat() if self.created_at else None
+        return message
+
+
+class FeedEventRepository(Protocol):
+    async def append(
+        self,
+        *,
+        tenant_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        source: str | None = None,
+        correlation_id: str | None = None,
+    ) -> FeedEventRecord:
+        ...
+
+    async def list_after(
+        self,
+        *,
+        tenant_id: str,
+        after: int = 0,
+        limit: int = 100,
+    ) -> list[FeedEventRecord]:
+        ...
+
+
+class BrokerSubscription(Protocol):
+    async def close(self) -> None:
+        ...
+
+
+class FeedEventBroker(Protocol):
+    async def publish(self, event: FeedEventRecord) -> None:
+        ...
+
+    async def subscribe(self, tenant_id: str, handler: FeedHandler) -> BrokerSubscription:
+        ...
+
+
+class InMemoryFeedEventRepository:
+    """Durable feed event test double."""
+
+    def __init__(self) -> None:
+        self.events: dict[str, list[FeedEventRecord]] = {}
+
+    async def append(
+        self,
+        *,
+        tenant_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        source: str | None = None,
+        correlation_id: str | None = None,
+    ) -> FeedEventRecord:
+        rows = self.events.setdefault(str(tenant_id), [])
+        record = FeedEventRecord(
+            id=str(uuid.uuid4()),
+            tenant_id=str(tenant_id),
+            sequence=len(rows) + 1,
+            event_type=str(event_type),
+            payload=copy.deepcopy(_json_safe(payload)),
+            source=source,
+            correlation_id=correlation_id,
+            created_at=datetime.now(UTC),
+        )
+        rows.append(record)
+        return copy.deepcopy(record)
+
+    async def list_after(
+        self,
+        *,
+        tenant_id: str,
+        after: int = 0,
+        limit: int = 100,
+    ) -> list[FeedEventRecord]:
+        capped_limit = min(max(int(limit), 1), 500)
+        return [
+            copy.deepcopy(event)
+            for event in self.events.get(str(tenant_id), [])
+            if event.sequence > int(after)
+        ][:capped_limit]
+
+
+class SqlAlchemyFeedEventRepository:
+    """PostgreSQL-backed feed event repository."""
+
+    def __init__(self, session_factory: Any) -> None:
+        self._session_factory = session_factory
+
+    async def append(
+        self,
+        *,
+        tenant_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        source: str | None = None,
+        correlation_id: str | None = None,
+    ) -> FeedEventRecord:
+        from core.models.feed import FeedEvent
+
+        tenant_uuid = _coerce_uuid(tenant_id)
+        safe_payload = _json_safe(payload)
+        async with self._session_factory() as session:
+            async with session.begin():
+                await session.execute(
+                    text("SELECT set_config('agenticorg.tenant_id', :tenant_id, true)"),
+                    {"tenant_id": str(tenant_uuid)},
+                )
+                await session.execute(
+                    text("SELECT pg_advisory_xact_lock(hashtext(:tenant_id)::bigint)"),
+                    {"tenant_id": str(tenant_uuid)},
+                )
+                next_sequence = (
+                    await session.execute(
+                        select(func.coalesce(func.max(FeedEvent.sequence), 0) + 1).where(
+                            FeedEvent.tenant_id == tenant_uuid
+                        )
+                    )
+                ).scalar_one()
+                row = FeedEvent(
+                    tenant_id=tenant_uuid,
+                    sequence=int(next_sequence),
+                    event_type=str(event_type),
+                    payload=safe_payload,
+                    source=source,
+                    correlation_id=correlation_id,
+                )
+                session.add(row)
+                await session.flush()
+                return self._from_model(row)
+
+    async def list_after(
+        self,
+        *,
+        tenant_id: str,
+        after: int = 0,
+        limit: int = 100,
+    ) -> list[FeedEventRecord]:
+        from core.models.feed import FeedEvent
+
+        tenant_uuid = _coerce_uuid(tenant_id)
+        capped_limit = min(max(int(limit), 1), 500)
+        async with self._session_factory() as session:
+            async with session.begin():
+                await session.execute(
+                    text("SELECT set_config('agenticorg.tenant_id', :tenant_id, true)"),
+                    {"tenant_id": str(tenant_uuid)},
+                )
+                rows = (
+                    await session.execute(
+                        select(FeedEvent)
+                        .where(
+                            FeedEvent.tenant_id == tenant_uuid,
+                            FeedEvent.sequence > int(after),
+                        )
+                        .order_by(FeedEvent.sequence.asc())
+                        .limit(capped_limit)
+                    )
+                ).scalars().all()
+                return [self._from_model(row) for row in rows]
+
+    @staticmethod
+    def _from_model(row: Any) -> FeedEventRecord:
+        return FeedEventRecord(
+            id=str(row.id),
+            tenant_id=str(row.tenant_id),
+            sequence=int(row.sequence),
+            event_type=row.event_type,
+            payload=copy.deepcopy(row.payload or {}),
+            source=row.source,
+            correlation_id=row.correlation_id,
+            created_at=row.created_at,
+        )
+
+
+class _InMemorySubscription:
+    def __init__(self, broker: InMemoryFeedEventBroker, tenant_id: str, handler: FeedHandler) -> None:
+        self._broker = broker
+        self._tenant_id = tenant_id
+        self._handler = handler
+
+    async def close(self) -> None:
+        self._broker._handlers.get(self._tenant_id, set()).discard(self._handler)
+
+
+class InMemoryFeedEventBroker:
+    """Broker test double that fanouts to local subscribers."""
+
+    def __init__(self) -> None:
+        self._handlers: dict[str, set[FeedHandler]] = {}
+        self.published: list[dict[str, Any]] = []
+
+    async def publish(self, event: FeedEventRecord) -> None:
+        message = event.to_message()
+        self.published.append(copy.deepcopy(message))
+        for handler in list(self._handlers.get(event.tenant_id, set())):
+            await handler(copy.deepcopy(message))
+
+    async def subscribe(self, tenant_id: str, handler: FeedHandler) -> BrokerSubscription:
+        self._handlers.setdefault(str(tenant_id), set()).add(handler)
+        return _InMemorySubscription(self, str(tenant_id), handler)
+
+
+class _RedisFeedSubscription:
+    def __init__(self, redis_url: str, tenant_id: str, handler: FeedHandler) -> None:
+        self._redis_url = redis_url
+        self._tenant_id = str(tenant_id)
+        self._handler = handler
+        self._redis: aioredis.Redis | None = None
+        self._pubsub: Any = None
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        self._redis = aioredis.from_url(
+            self._redis_url,
+            decode_responses=True,
+            **redis_socket_timeout_kwargs(),
+        )
+        self._pubsub = self._redis.pubsub()
+        await self._pubsub.subscribe(_channel(self._tenant_id))
+        self._task = asyncio.create_task(self._run())
+
+    async def _run(self) -> None:
+        assert self._pubsub is not None
+        try:
+            async for message in self._pubsub.listen():
+                if message.get("type") != "message":
+                    continue
+                try:
+                    payload = json.loads(message.get("data") or "{}")
+                except json.JSONDecodeError:
+                    logger.warning("live_feed_broker_invalid_json", tenant_id=self._tenant_id)
+                    continue
+                await self._handler(payload)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - subscription failure should not crash the app.
+            logger.warning(
+                "live_feed_broker_subscription_failed",
+                tenant_id=self._tenant_id,
+                error=str(exc),
+            )
+
+    async def close(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        if self._pubsub is not None:
+            with suppress(Exception):
+                await self._pubsub.unsubscribe(_channel(self._tenant_id))
+                await self._pubsub.close()
+        if self._redis is not None:
+            await _close_redis(self._redis)
+
+
+class RedisFeedEventBroker:
+    """Redis Pub/Sub broker for cross-pod live feed fanout."""
+
+    def __init__(self, redis_url: str | None = None) -> None:
+        self._redis_url = redis_url or settings.redis_url
+        self._redis: aioredis.Redis | None = None
+
+    async def publish(self, event: FeedEventRecord) -> None:
+        redis = await self._publisher()
+        await redis.publish(_channel(event.tenant_id), json.dumps(event.to_message()))
+
+    async def subscribe(self, tenant_id: str, handler: FeedHandler) -> BrokerSubscription:
+        subscription = _RedisFeedSubscription(self._redis_url, str(tenant_id), handler)
+        await subscription.start()
+        return subscription
+
+    async def _publisher(self) -> aioredis.Redis:
+        if self._redis is None:
+            self._redis = aioredis.from_url(
+                self._redis_url,
+                decode_responses=True,
+                **redis_socket_timeout_kwargs(),
+            )
+        return self._redis
+
+
+async def _close_redis(redis: aioredis.Redis) -> None:
+    close_fn = getattr(redis, "aclose", None) or getattr(redis, "close", None)
+    if close_fn is None:
+        return
+    result = close_fn()
+    if inspect.isawaitable(result):
+        await result
+
+
+def _channel(tenant_id: str) -> str:
+    return f"feed:{tenant_id}"
+
+
+_repository_override: FeedEventRepository | None = None
+_broker_override: FeedEventBroker | None = None
+_default_repository: FeedEventRepository | None = None
+_default_broker: FeedEventBroker | None = None
+
+
+def get_feed_event_repository() -> FeedEventRepository:
+    global _default_repository
+    if _repository_override is not None:
+        return _repository_override
+    if _default_repository is None:
+        from core.database import async_session_factory
+
+        _default_repository = SqlAlchemyFeedEventRepository(async_session_factory)
+    return _default_repository
+
+
+def get_feed_event_broker() -> FeedEventBroker:
+    global _default_broker
+    if _broker_override is not None:
+        return _broker_override
+    if _default_broker is None:
+        _default_broker = RedisFeedEventBroker()
+    return _default_broker
+
+
+def configure_live_feed_for_tests(
+    *,
+    repository: FeedEventRepository | None = None,
+    broker: FeedEventBroker | None = None,
+) -> None:
+    global _broker_override, _repository_override
+    _repository_override = repository
+    _broker_override = broker
+
+
+def reset_live_feed_for_tests() -> None:
+    configure_live_feed_for_tests(repository=None, broker=None)

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -36,6 +36,7 @@ from core.models.connector_config import ConnectorConfig as ConnectorConfig
 from core.models.delegation import UserDelegation as UserDelegation
 from core.models.document import Document as Document
 from core.models.feature_flag import FeatureFlag as FeatureFlag
+from core.models.feed import FeedEvent as FeedEvent
 from core.models.filing_approval import FilingApproval as FilingApproval
 from core.models.governance_config import GovernanceConfig as GovernanceConfig
 from core.models.gstn_credential import GSTNCredential as GSTNCredential

--- a/core/models/feed.py
+++ b/core/models/feed.py
@@ -1,0 +1,34 @@
+"""Live feed ORM models."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, BigInteger, ForeignKey, Index, String, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.models.base import BaseModel
+
+
+class FeedEvent(BaseModel):
+    __tablename__ = "feed_events"
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "sequence", name="uq_feed_events_tenant_sequence"),
+        Index("ix_feed_events_tenant_sequence", "tenant_id", "sequence"),
+        Index("ix_feed_events_tenant_created", "tenant_id", "created_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    sequence: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    event_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    source: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    correlation_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/migrations/versions/v4_9_13_feed_events.py
+++ b/migrations/versions/v4_9_13_feed_events.py
@@ -1,0 +1,57 @@
+"""Durable live feed events.
+
+Revision ID: v4913_feed_events
+Revises: v4912_workflow_event_waits
+Create Date: 2026-05-16
+
+Live feed WebSocket delivery is now backed by a tenant-scoped append-only
+event log so missed socket events can be replayed after reconnect.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v4913_feed_events"
+down_revision = "v4912_workflow_event_waits"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS feed_events (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+            sequence BIGINT NOT NULL,
+            event_type VARCHAR(100) NOT NULL,
+            payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+            source VARCHAR(100),
+            correlation_id VARCHAR(255),
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT uq_feed_events_tenant_sequence UNIQUE (tenant_id, sequence)
+        )
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_feed_events_tenant_sequence "
+        "ON feed_events (tenant_id, sequence)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_feed_events_tenant_created "
+        "ON feed_events (tenant_id, created_at)"
+    )
+    op.execute("ALTER TABLE feed_events ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE feed_events FORCE ROW LEVEL SECURITY")
+    op.execute("DROP POLICY IF EXISTS feed_events_tenant_isolation ON feed_events")
+    op.execute("""
+        CREATE POLICY feed_events_tenant_isolation ON feed_events
+        USING (tenant_id::text = current_setting('agenticorg.tenant_id', true))
+        WITH CHECK (tenant_id::text = current_setting('agenticorg.tenant_id', true))
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS feed_events_tenant_isolation ON feed_events")
+    op.drop_index("ix_feed_events_tenant_created", table_name="feed_events")
+    op.drop_index("ix_feed_events_tenant_sequence", table_name="feed_events")
+    op.drop_table("feed_events")

--- a/tests/unit/test_websocket_feed_resilience.py
+++ b/tests/unit/test_websocket_feed_resilience.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from api.deps import get_current_tenant
+from api.websocket import feed
+from core.live_feed import (
+    InMemoryFeedEventBroker,
+    InMemoryFeedEventRepository,
+    configure_live_feed_for_tests,
+    reset_live_feed_for_tests,
+)
+
+
+@pytest.fixture
+def feed_runtime() -> Generator[tuple[InMemoryFeedEventRepository, InMemoryFeedEventBroker]]:
+    repository = InMemoryFeedEventRepository()
+    broker = InMemoryFeedEventBroker()
+    configure_live_feed_for_tests(repository=repository, broker=broker)
+    feed._connections.clear()
+    feed._subscriptions.clear()
+    try:
+        yield repository, broker
+    finally:
+        feed._connections.clear()
+        feed._subscriptions.clear()
+        reset_live_feed_for_tests()
+
+
+def _test_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(feed.router, prefix="/api/v1")
+    return app
+
+
+def test_unauthenticated_websocket_handshake_is_rejected(feed_runtime) -> None:
+    tenant_id = str(uuid.uuid4())
+    client = TestClient(_test_app())
+
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect(f"/api/v1/ws/feed/{tenant_id}"):
+            pass
+
+    assert exc.value.code == 1008
+
+
+def test_authenticated_matching_tenant_connects(feed_runtime) -> None:
+    tenant_id = str(uuid.uuid4())
+    claims = {"sub": "user-1", "agenticorg:tenant_id": tenant_id, "grantex:scopes": []}
+    client = TestClient(_test_app())
+
+    with patch("api.websocket.feed.validate_token", new_callable=AsyncMock, return_value=claims):
+        with client.websocket_connect(f"/api/v1/ws/feed/{tenant_id}?token=valid") as websocket:
+            message = websocket.receive_json()
+
+    assert message == {"type": "heartbeat", "tenant_id": tenant_id, "sequence": None}
+
+
+def test_authenticated_tenant_mismatch_is_rejected(feed_runtime) -> None:
+    path_tenant_id = str(uuid.uuid4())
+    token_tenant_id = str(uuid.uuid4())
+    claims = {"sub": "user-1", "agenticorg:tenant_id": token_tenant_id, "grantex:scopes": []}
+    client = TestClient(_test_app())
+
+    with patch("api.websocket.feed.validate_token", new_callable=AsyncMock, return_value=claims):
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with client.websocket_connect(f"/api/v1/ws/feed/{path_tenant_id}?token=valid"):
+                pass
+
+    assert exc.value.code == 1008
+
+
+@pytest.mark.asyncio
+async def test_broadcast_to_tenant_persists_sequence_and_brokers_to_subscribers(feed_runtime) -> None:
+    repository, broker = feed_runtime
+    tenant_id = str(uuid.uuid4())
+    delivered: list[dict] = []
+
+    async def _handler(message: dict) -> None:
+        delivered.append(message)
+
+    await broker.subscribe(tenant_id, _handler)
+
+    connected_count = await feed.broadcast_to_tenant(
+        tenant_id,
+        {
+            "type": "hitl.approval.created",
+            "payload": {"approval_id": "hitl-1"},
+            "source": "approvals",
+            "correlation_id": "corr-1",
+        },
+    )
+
+    stored = await repository.list_after(tenant_id=tenant_id, after=0)
+    assert connected_count == 0
+    assert len(stored) == 1
+    assert stored[0].sequence == 1
+    assert stored[0].event_type == "hitl.approval.created"
+    assert broker.published[0]["sequence"] == 1
+    assert delivered[0]["sequence"] == 1
+    assert delivered[0]["type"] == "hitl.approval.created"
+
+
+def test_catch_up_endpoint_returns_only_caller_tenant_events_after_sequence(feed_runtime) -> None:
+    repository, _broker = feed_runtime
+    tenant_a = str(uuid.uuid4())
+    tenant_b = str(uuid.uuid4())
+
+    async def _seed() -> None:
+        await repository.append(tenant_id=tenant_a, event_type="first", payload={"type": "first"})
+        await repository.append(tenant_id=tenant_a, event_type="second", payload={"type": "second"})
+        await repository.append(tenant_id=tenant_b, event_type="other", payload={"type": "other"})
+
+    import anyio
+
+    anyio.run(_seed)
+
+    app = _test_app()
+    app.dependency_overrides[get_current_tenant] = lambda: tenant_a
+    client = TestClient(app)
+
+    response = client.get("/api/v1/feed/events?after=1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["tenant_id"] == tenant_a
+    assert [item["type"] for item in body["items"]] == ["second"]
+    assert [item["tenant_id"] for item in body["items"]] == [tenant_a]
+
+
+def test_bad_json_socket_message_is_isolated(feed_runtime) -> None:
+    tenant_id = str(uuid.uuid4())
+    claims = {"sub": "user-1", "agenticorg:tenant_id": tenant_id, "grantex:scopes": []}
+    client = TestClient(_test_app())
+
+    with patch("api.websocket.feed.validate_token", new_callable=AsyncMock, return_value=claims):
+        with client.websocket_connect(f"/api/v1/ws/feed/{tenant_id}?token=valid") as websocket:
+            assert websocket.receive_json()["type"] == "heartbeat"
+            websocket.send_text("{bad-json")
+            assert websocket.receive_json()["code"] == "invalid_json"
+            websocket.send_json({"type": "ping"})
+            assert websocket.receive_json()["type"] == "pong"

--- a/ui/src/__tests__/LiveFeed.test.tsx
+++ b/ui/src/__tests__/LiveFeed.test.tsx
@@ -1,0 +1,47 @@
+import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const wsMock = vi.hoisted(() => ({
+  subscribers: [] as Array<(data: Record<string, unknown>) => void>,
+}));
+
+vi.mock("@/lib/websocket", () => ({
+  AgenticOrgWS: class {
+    connect = vi.fn();
+    disconnect = vi.fn();
+    subscribe = vi.fn((fn: (data: Record<string, unknown>) => void) => {
+      wsMock.subscribers.push(fn);
+      return () => undefined;
+    });
+  },
+}));
+
+import LiveFeed from "@/components/LiveFeed";
+
+describe("LiveFeed", () => {
+  beforeEach(() => {
+    wsMock.subscribers = [];
+  });
+
+  it("does not render heartbeat messages as activity", () => {
+    render(<LiveFeed tenantId="tenant-a" />);
+    expect(screen.getByText("Waiting for events...")).toBeInTheDocument();
+
+    act(() => {
+      wsMock.subscribers[0]({ type: "heartbeat", sequence: null });
+    });
+
+    expect(screen.getByText("Waiting for events...")).toBeInTheDocument();
+
+    act(() => {
+      wsMock.subscribers[0]({
+        type: "approval.created",
+        sequence: 7,
+        payload: { title: "Approval needed" },
+      });
+    });
+
+    expect(screen.getByText(/approval.created:/)).toBeInTheDocument();
+    expect(screen.getByText(/Approval needed/)).toBeInTheDocument();
+  });
+});

--- a/ui/src/__tests__/websocket.test.ts
+++ b/ui/src/__tests__/websocket.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgenticOrgWS } from "@/lib/websocket";
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readonly url: string;
+  readyState = MockWebSocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code: 1000 } as CloseEvent);
+  });
+
+  emitOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.(new Event("open"));
+  }
+
+  emitMessage(data: string) {
+    this.onmessage?.({ data } as MessageEvent<string>);
+  }
+
+  emitClose(code: number) {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code } as CloseEvent);
+  }
+}
+
+describe("AgenticOrgWS", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockWebSocket);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not reconnect after explicit disconnect", () => {
+    const client = new AgenticOrgWS({ baseDelayMs: 10, jitterRatio: 0, maxRetries: 3 });
+    client.connect("tenant-a");
+    const socket = MockWebSocket.instances[0];
+    socket.emitOpen();
+
+    client.disconnect();
+    vi.advanceTimersByTime(1000);
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("treats auth failure as terminal", () => {
+    const client = new AgenticOrgWS({ baseDelayMs: 10, jitterRatio: 0, maxRetries: 3 });
+    client.connect("tenant-a");
+    MockWebSocket.instances[0].emitClose(1008);
+
+    vi.advanceTimersByTime(1000);
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("isolates bad JSON socket messages", () => {
+    const listener = vi.fn();
+    const client = new AgenticOrgWS({ baseDelayMs: 10, jitterRatio: 0 });
+    client.subscribe(listener);
+    client.connect("tenant-a");
+    const socket = MockWebSocket.instances[0];
+
+    socket.emitMessage("{bad-json");
+    socket.emitMessage(JSON.stringify({ type: "activity", sequence: 1 }));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ type: "activity", sequence: 1 });
+  });
+
+  it("fetches missed events after reconnect using the last seen sequence", async () => {
+    const listener = vi.fn();
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [{ type: "missed", sequence: 2 }] }),
+    } as Response);
+    const client = new AgenticOrgWS({
+      baseDelayMs: 10,
+      jitterRatio: 0,
+      fetchImpl,
+    });
+    client.subscribe(listener);
+    client.connect("tenant-a");
+    const firstSocket = MockWebSocket.instances[0];
+    firstSocket.emitMessage(JSON.stringify({ type: "seen", sequence: 1 }));
+    firstSocket.emitClose(1006);
+
+    vi.advanceTimersByTime(10);
+    const reconnectSocket = MockWebSocket.instances[1];
+    reconnectSocket.emitOpen();
+    await vi.runAllTicks();
+
+    expect(fetchImpl).toHaveBeenCalledWith("/api/v1/feed/events?after=1&limit=100", {
+      credentials: "include",
+    });
+    await vi.waitFor(() => {
+      expect(listener).toHaveBeenCalledWith({ type: "missed", sequence: 2 });
+    });
+  });
+});

--- a/ui/src/components/LiveFeed.tsx
+++ b/ui/src/components/LiveFeed.tsx
@@ -1,15 +1,23 @@
 import { useEffect, useState } from "react";
-import { AgenticOrgWS } from "@/lib/websocket";
+import { AgenticOrgWS, type FeedMessage } from "@/lib/websocket";
 
 interface Props { tenantId: string; maxItems?: number; }
 
 export default function LiveFeed({ tenantId, maxItems = 7 }: Props) {
-  const [events, setEvents] = useState<any[]>([]);
+  const [events, setEvents] = useState<FeedMessage[]>([]);
   useEffect(() => {
     const ws = new AgenticOrgWS();
     ws.connect(tenantId);
-    ws.subscribe((data) => setEvents((prev) => [data, ...prev].slice(0, maxItems)));
-    return () => ws.disconnect();
+    const unsubscribe = ws.subscribe((data) => {
+      if (data.type === "heartbeat") {
+        return;
+      }
+      setEvents((prev) => [data, ...prev].slice(0, maxItems));
+    });
+    return () => {
+      unsubscribe();
+      ws.disconnect();
+    };
   }, [tenantId, maxItems]);
 
   return (
@@ -17,7 +25,12 @@ export default function LiveFeed({ tenantId, maxItems = 7 }: Props) {
       <h3 className="font-semibold">Live Activity</h3>
       {events.length === 0 ? <p className="text-sm text-muted-foreground">Waiting for events...</p> :
         events.map((e, i) => (
-          <div key={i} className="text-sm p-2 rounded bg-muted">{e.type}: {JSON.stringify(e).slice(0, 80)}...</div>
+          <div
+            key={typeof e.sequence === "number" ? `${tenantId}-${e.sequence}` : String(e.id ?? e.created_at ?? i)}
+            className="text-sm p-2 rounded bg-muted"
+          >
+            {String(e.type ?? "event")}: {JSON.stringify(e.payload ?? e).slice(0, 80)}...
+          </div>
         ))
       }
     </div>

--- a/ui/src/lib/websocket.ts
+++ b/ui/src/lib/websocket.ts
@@ -1,17 +1,187 @@
+export interface FeedMessage {
+  type?: string;
+  sequence?: number | null;
+  [key: string]: unknown;
+}
+
+type Listener = (data: FeedMessage) => void;
+
+interface AgenticOrgWSOptions {
+  maxRetries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  jitterRatio?: number;
+  catchUpLimit?: number;
+  fetchImpl?: typeof fetch;
+}
+
+const TERMINAL_CLOSE_CODES = new Set([1008, 4401, 4403]);
+
 export class AgenticOrgWS {
   private ws: WebSocket | null = null;
-  private listeners: ((data: any) => void)[] = [];
+  private readonly listeners = new Set<Listener>();
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private tenantId: string | null = null;
+  private intentionalClose = false;
+  private terminal = false;
+  private retryCount = 0;
+  private lastSequence = 0;
+  private readonly maxRetries: number;
+  private readonly baseDelayMs: number;
+  private readonly maxDelayMs: number;
+  private readonly jitterRatio: number;
+  private readonly catchUpLimit: number;
+  private readonly fetchImpl: typeof fetch;
 
-  connect(tenantId: string) {
-    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    this.ws = new WebSocket(`${protocol}//${window.location.host}/ws/feed/${tenantId}`);
-    this.ws.onmessage = (event) => {
-      const data = JSON.parse(event.data);
-      this.listeners.forEach((fn) => fn(data));
-    };
-    this.ws.onclose = () => setTimeout(() => this.connect(tenantId), 3000);
+  constructor(options: AgenticOrgWSOptions = {}) {
+    this.maxRetries = options.maxRetries ?? 8;
+    this.baseDelayMs = options.baseDelayMs ?? 1000;
+    this.maxDelayMs = options.maxDelayMs ?? 30000;
+    this.jitterRatio = options.jitterRatio ?? 0.25;
+    this.catchUpLimit = options.catchUpLimit ?? 100;
+    this.fetchImpl = options.fetchImpl ?? fetch.bind(window);
   }
 
-  subscribe(fn: (data: any) => void) { this.listeners.push(fn); }
-  disconnect() { this.ws?.close(); }
+  connect(tenantId: string) {
+    if (this.isSocketActive() && this.tenantId === tenantId) {
+      return;
+    }
+    this.clearReconnectTimer();
+    if (this.ws && this.tenantId !== tenantId) {
+      this.ws.onclose = null;
+      this.ws.close();
+      this.ws = null;
+    }
+    this.tenantId = tenantId;
+    this.intentionalClose = false;
+    this.terminal = false;
+    this.openSocket();
+  }
+
+  subscribe(fn: Listener) {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  }
+
+  disconnect() {
+    this.intentionalClose = true;
+    this.terminal = true;
+    this.clearReconnectTimer();
+    if (this.ws) {
+      this.ws.onclose = null;
+    }
+    this.ws?.close();
+    this.ws = null;
+  }
+
+  private openSocket() {
+    if (!this.tenantId || this.terminal) {
+      return;
+    }
+    if (this.isSocketActive()) {
+      return;
+    }
+
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const url = new URL(`/api/v1/ws/feed/${encodeURIComponent(this.tenantId)}`, window.location.origin);
+    url.protocol = protocol;
+
+    this.ws = new WebSocket(url.toString());
+    this.ws.onopen = () => {
+      this.retryCount = 0;
+      void this.catchUp();
+    };
+    this.ws.onmessage = (event) => this.handleMessage(event.data);
+    this.ws.onerror = () => {
+      // The close event carries the actionable policy decision.
+    };
+    this.ws.onclose = (event) => {
+      this.ws = null;
+      if (this.intentionalClose || this.terminal) {
+        return;
+      }
+      if (TERMINAL_CLOSE_CODES.has(event.code)) {
+        this.terminal = true;
+        return;
+      }
+      this.scheduleReconnect();
+    };
+  }
+
+  private handleMessage(rawData: unknown) {
+    if (typeof rawData !== "string") {
+      return;
+    }
+    let data: FeedMessage;
+    try {
+      data = JSON.parse(rawData) as FeedMessage;
+    } catch {
+      return;
+    }
+    this.emit(data);
+  }
+
+  private emit(data: FeedMessage) {
+    const sequence = typeof data.sequence === "number" ? data.sequence : null;
+    if (sequence !== null) {
+      if (sequence <= this.lastSequence) {
+        return;
+      }
+      this.lastSequence = sequence;
+    }
+    this.listeners.forEach((fn) => fn(data));
+  }
+
+  private scheduleReconnect() {
+    if (this.retryCount >= this.maxRetries) {
+      this.terminal = true;
+      return;
+    }
+    const delay = Math.min(this.maxDelayMs, this.baseDelayMs * 2 ** this.retryCount);
+    const jitter = delay * this.jitterRatio * Math.random();
+    this.retryCount += 1;
+    this.reconnectTimer = window.setTimeout(() => {
+      this.reconnectTimer = null;
+      this.openSocket();
+    }, delay + jitter);
+  }
+
+  private async catchUp() {
+    if (!this.tenantId || this.lastSequence <= 0) {
+      return;
+    }
+    const params = new URLSearchParams({
+      after: String(this.lastSequence),
+      limit: String(this.catchUpLimit),
+    });
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`/api/v1/feed/events?${params.toString()}`, {
+        credentials: "include",
+      });
+    } catch {
+      return;
+    }
+    if (response.status === 401 || response.status === 403) {
+      this.terminal = true;
+      this.ws?.close();
+      return;
+    }
+    if (!response.ok) {
+      return;
+    }
+    const body = (await response.json()) as { items?: FeedMessage[] };
+    (body.items ?? []).forEach((item) => this.emit(item));
+  }
+
+  private clearReconnectTimer() {
+    if (this.reconnectTimer !== null) {
+      window.clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private isSocketActive() {
+    return this.ws?.readyState === WebSocket.OPEN || this.ws?.readyState === WebSocket.CONNECTING;
+  }
 }


### PR DESCRIPTION
## Summary
- authenticate `/ws/feed/{tenant_id}` before accepting and reject tenant mismatches
- persist tenant-scoped feed events with per-tenant sequences and expose catch-up at `/feed/events`
- route broadcasts through a broker abstraction with Redis Pub/Sub production support and test fakes
- harden the browser WebSocket client with bounded backoff, terminal auth failure handling, explicit disconnect behavior, JSON guards, catch-up, and LiveFeed heartbeat filtering

## Validation
- `python -m ruff check api/websocket/feed.py core/live_feed.py core/models/feed.py tests/unit/test_websocket_feed_resilience.py migrations/versions/v4_9_13_feed_events.py`
- `python -m compileall api/websocket/feed.py core/live_feed.py core/models/feed.py tests/unit/test_websocket_feed_resilience.py`
- `python -m pytest tests/unit/test_websocket_feed_resilience.py -q`
- `python -m pytest tests/regression/test_pr_fixes_april2026.py tests/regression/test_security_pr_b_csrf.py tests/unit/test_workflow_event_wait_durability.py -q`
- `npm test -- --run src/__tests__/websocket.test.ts src/__tests__/LiveFeed.test.tsx`
- `npm run typecheck`
- `npx eslint src/lib/websocket.ts src/components/LiveFeed.tsx src/__tests__/websocket.test.ts src/__tests__/LiveFeed.test.tsx`
- `python -m alembic heads`
- `python -m alembic upgrade v4912_workflow_event_waits:v4913_feed_events --sql`

## Notes
- Full `npm run lint` still fails on pre-existing unrelated `no-useless-assignment` errors in `ui/src/lib/api.ts:106` and `ui/src/pages/Playground.tsx:412`; touched-file eslint passes.