### PR TITLE
fix: persist bridge sessions and request lifecycle

### DIFF
--- a/api/v1/bridge.py
+++ b/api/v1/bridge.py
@@ -41,9 +41,14 @@ class BridgeStatus(BaseModel):
     bridge_id: str
     connector_type: str
     registered_at: str
+    status: str = "disconnected"
     connected: bool
+    local_connected: bool = False
     tally_healthy: bool
     last_heartbeat: str | None
+    disconnected_at: str | None = None
+    connection_owner: str | None = None
+    reconnect_count: int = 0
 
 
 @router.post("/register", response_model=BridgeRegisterResponse)
@@ -111,15 +116,20 @@ async def bridge_status(
     if not reg:
         raise HTTPException(status_code=404, detail="Bridge not found")
 
-    live = get_bridge_status(bridge_id)
+    live = await get_bridge_status(bridge_id, tenant_id=tenant_id)
 
     return BridgeStatus(
         bridge_id=bridge_id,
         connector_type=reg.bridge_type,
         registered_at=reg.created_at.isoformat(),
+        status=live.get("status", "disconnected"),
         connected=live.get("connected", False),
+        local_connected=live.get("local_connected", False),
         tally_healthy=live.get("tally_healthy", False),
         last_heartbeat=live.get("last_heartbeat"),
+        disconnected_at=live.get("disconnected_at"),
+        connection_owner=live.get("connection_owner"),
+        reconnect_count=int(live.get("reconnect_count") or 0),
     )
 
 
@@ -143,7 +153,7 @@ async def list_bridges(
     bridges = []
     for reg in rows:
         meta = reg.metadata_ or {}
-        live = get_bridge_status(reg.bridge_id)
+        live = await get_bridge_status(reg.bridge_id, tenant_id=tenant_id)
         bridges.append({
             "bridge_id": reg.bridge_id,
             "tenant_id": str(reg.tenant_id),
@@ -151,9 +161,14 @@ async def list_bridges(
             "tally_port": meta.get("tally_port", 9000),
             "label": meta.get("label", ""),
             "registered_at": reg.created_at.isoformat(),
+            "status": live.get("status", "disconnected"),
             "connected": live.get("connected", False),
+            "local_connected": live.get("local_connected", False),
             "tally_healthy": live.get("tally_healthy", False),
             "last_heartbeat": live.get("last_heartbeat"),
+            "disconnected_at": live.get("disconnected_at"),
+            "connection_owner": live.get("connection_owner"),
+            "reconnect_count": int(live.get("reconnect_count") or 0),
         })
     return bridges
 
@@ -193,6 +208,7 @@ async def route_through_bridge(
     WebSocket tunnel to the CA's local Tally instance.
     """
     from bridge.server_handler import route_to_bridge
+    from bridge.state import BridgeRouteError
 
     bridge_id = payload.get("bridge_id", "")
     if not bridge_id:
@@ -216,7 +232,24 @@ async def route_through_bridge(
             bridge_id=bridge_id,
             xml_body=payload.get("xml_body", ""),
             timeout=30.0,
+            tenant_id=tenant_id,
+            connector_type=connector_type,
+            request_id=payload.get("request_id"),
+            idempotency_key=payload.get("idempotency_key") or payload.get("request_id"),
         )
         return result
-    except RuntimeError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    except BridgeRouteError as exc:
+        status_by_code = {
+            "bridge_not_registered": 404,
+            "tenant_mismatch": 403,
+            "bridge_disconnected": 503,
+            "bridge_broker_unavailable": 503,
+            "bridge_publish_failed": 503,
+            "request_timed_out": 504,
+            "malformed_response": 502,
+            "bridge_error": 502,
+        }
+        raise HTTPException(
+            status_code=status_by_code.get(exc.code, 502),
+            detail=exc.to_detail(),
+        ) from exc

--- a/bridge/server_handler.py
+++ b/bridge/server_handler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import secrets
 import uuid
 from datetime import UTC, datetime
@@ -13,6 +14,15 @@ import structlog
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from sqlalchemy import select
 
+from bridge.state import (
+    BridgeRouteError,
+    BridgeSessionRecord,
+    BrokerSubscription,
+    connection_owner,
+    get_bridge_broker,
+    get_bridge_state_repository,
+    payload_hash,
+)
 from core.database import async_session_factory
 from core.models.bridge import BridgeRegistration
 
@@ -20,19 +30,30 @@ logger = structlog.get_logger()
 
 router = APIRouter()
 
-# Active bridge connections: bridge_id -> BridgeConnection
+# Local socket registry only. PostgreSQL is authoritative for status.
 _active_bridges: dict[str, BridgeConnection] = {}
 
-# Pending request futures: request_id -> (bridge_id, asyncio.Future)
-_pending_requests: dict[str, tuple[str, asyncio.Future]] = {}
+# Local waiter futures only. PostgreSQL is authoritative for request state.
+_pending_requests: dict[str, asyncio.Future] = {}
 
 
 class BridgeConnection:
-    """Represents an active bridge agent connection."""
+    """Represents an active bridge agent connection on this process."""
 
-    def __init__(self, bridge_id: str, websocket: WebSocket):
+    def __init__(
+        self,
+        *,
+        bridge_id: str,
+        tenant_id: str,
+        connector_type: str,
+        websocket: WebSocket,
+        request_subscription: BrokerSubscription,
+    ) -> None:
         self.bridge_id = bridge_id
+        self.tenant_id = tenant_id
+        self.connector_type = connector_type
         self.websocket = websocket
+        self.request_subscription = request_subscription
         self.connected_at = datetime.now(UTC)
         self.last_heartbeat = datetime.now(UTC)
         self.tally_healthy = False
@@ -41,7 +62,10 @@ class BridgeConnection:
     def status(self) -> dict[str, Any]:
         return {
             "bridge_id": self.bridge_id,
+            "tenant_id": self.tenant_id,
+            "connector_type": self.connector_type,
             "connected": True,
+            "local_connected": True,
             "connected_at": self.connected_at.isoformat(),
             "last_heartbeat": self.last_heartbeat.isoformat(),
             "tally_healthy": self.tally_healthy,
@@ -49,12 +73,46 @@ class BridgeConnection:
 
 
 async def _get_bridge_registration(bridge_id: str) -> BridgeRegistration | None:
-    """Load the bridge registration row used for auth."""
+    """Load the bridge registration row used for bridge-token auth."""
     async with async_session_factory() as session:
         result = await session.execute(
             select(BridgeRegistration).where(BridgeRegistration.bridge_id == bridge_id)
         )
         return result.scalar_one_or_none()
+
+
+async def _register_local_connection(
+    *,
+    bridge_id: str,
+    tenant_id: str,
+    connector_type: str,
+    websocket: WebSocket,
+) -> BridgeConnection:
+    async def _broker_handler(message: dict[str, Any]) -> None:
+        await _send_brokered_request_to_bridge(bridge_id, message)
+
+    request_subscription = await get_bridge_broker().subscribe_requests(
+        bridge_id,
+        _broker_handler,
+    )
+    conn = BridgeConnection(
+        bridge_id=bridge_id,
+        tenant_id=tenant_id,
+        connector_type=connector_type,
+        websocket=websocket,
+        request_subscription=request_subscription,
+    )
+    _active_bridges[bridge_id] = conn
+    await get_bridge_state_repository().connect_session(
+        bridge_id=bridge_id,
+        tenant_id=tenant_id,
+        connector_type=connector_type,
+        tally_healthy=False,
+        owner=connection_owner(),
+        process_id=os.getpid(),
+        metadata={"source": "websocket_connect"},
+    )
+    return conn
 
 
 @router.websocket("/ws/bridge/{bridge_id}")
@@ -102,27 +160,37 @@ async def bridge_ws(websocket: WebSocket, bridge_id: str) -> None:
 
     await websocket.send_text(json.dumps({"type": "auth_ok"}))
 
-    conn = BridgeConnection(bridge_id, websocket)
-    _active_bridges[bridge_id] = conn
-    logger.info("bridge_connected", bridge_id=bridge_id)
-
+    conn: BridgeConnection | None = None
     try:
+        conn = await _register_local_connection(
+            bridge_id=bridge_id,
+            tenant_id=str(registration.tenant_id),
+            connector_type=registration.bridge_type,
+            websocket=websocket,
+        )
+        logger.info("bridge_connected", bridge_id=bridge_id, tenant_id=str(registration.tenant_id))
+
         async for raw in websocket.iter_text():
-            msg = json.loads(raw)
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                logger.warning("bridge_socket_malformed_json", bridge_id=bridge_id, error=str(exc))
+                continue
+
             msg_type = msg.get("type", "")
 
             if msg_type == "heartbeat":
+                await handle_bridge_heartbeat(
+                    bridge_id=bridge_id,
+                    tenant_id=conn.tenant_id,
+                    tally_healthy=bool(msg.get("tally_healthy", False)),
+                )
                 conn.last_heartbeat = datetime.now(UTC)
-                conn.tally_healthy = msg.get("tally_healthy", False)
+                conn.tally_healthy = bool(msg.get("tally_healthy", False))
                 await websocket.send_text(json.dumps({"type": "heartbeat_ack"}))
 
             elif msg_type == "response":
-                request_id = msg.get("request_id")
-                pending = _pending_requests.pop(request_id, None)
-                if pending:
-                    _, future = pending
-                    if not future.done():
-                        future.set_result(msg)
+                await handle_bridge_response(msg, tenant_id=conn.tenant_id)
 
             elif msg_type == "pong":
                 pass
@@ -133,54 +201,379 @@ async def bridge_ws(websocket: WebSocket, bridge_id: str) -> None:
     except WebSocketDisconnect:
         logger.info("bridge_disconnected", bridge_id=bridge_id)
     finally:
-        _active_bridges.pop(bridge_id, None)
-        for request_id, (pending_bridge_id, future) in list(_pending_requests.items()):
-            if pending_bridge_id != bridge_id:
-                continue
-            _pending_requests.pop(request_id, None)
-            if not future.done():
-                future.set_exception(RuntimeError("Bridge disconnected"))
+        if conn is not None:
+            await handle_bridge_disconnect(
+                bridge_id=bridge_id,
+                tenant_id=conn.tenant_id,
+                reason="Bridge disconnected",
+            )
+
+
+async def handle_bridge_heartbeat(
+    *,
+    bridge_id: str,
+    tenant_id: str,
+    tally_healthy: bool,
+) -> BridgeSessionRecord:
+    """Persist bridge heartbeat state."""
+    return await get_bridge_state_repository().heartbeat(
+        bridge_id=bridge_id,
+        tenant_id=tenant_id,
+        tally_healthy=tally_healthy,
+    )
+
+
+async def handle_bridge_disconnect(*, bridge_id: str, tenant_id: str, reason: str) -> None:
+    """Mark session disconnected and active requests orphaned."""
+    conn = _active_bridges.pop(bridge_id, None)
+    if conn is not None:
+        await conn.request_subscription.close()
+
+    await get_bridge_state_repository().disconnect_session(
+        bridge_id=bridge_id,
+        tenant_id=tenant_id,
+        reason=reason,
+    )
+    orphaned = await get_bridge_state_repository().mark_bridge_requests_orphaned(
+        bridge_id=bridge_id,
+        tenant_id=tenant_id,
+        reason=reason,
+    )
+    for request in orphaned:
+        future = _pending_requests.pop(request.request_id, None)
+        if future and not future.done():
+            future.set_exception(
+                BridgeRouteError(
+                    reason,
+                    code="bridge_disconnected",
+                    request_id=request.request_id,
+                    bridge_id=bridge_id,
+                )
+            )
+
+
+async def _send_brokered_request_to_bridge(bridge_id: str, message: dict[str, Any]) -> None:
+    conn = _active_bridges.get(bridge_id)
+    request_id = str(message.get("request_id") or "")
+    tenant_id = str(message.get("tenant_id") or (conn.tenant_id if conn else ""))
+    if not conn:
+        if request_id:
+            await get_bridge_state_repository().mark_failed(
+                request_id=request_id,
+                tenant_id=tenant_id or None,
+                code="bridge_not_local",
+                message="Bridge is not connected to this process",
+            )
+            await get_bridge_broker().publish_response(
+                request_id,
+                {
+                    "type": "response",
+                    "request_id": request_id,
+                    "status": "error",
+                    "error_category": "bridge_disconnected",
+                    "error": "Bridge is not connected to this process",
+                },
+            )
+        return
+
+    sent_record = await get_bridge_state_repository().mark_sent(
+        request_id,
+        tenant_id=tenant_id or None,
+    )
+    if sent_record is None:
+        await get_bridge_broker().publish_response(
+            request_id,
+            {
+                "type": "response",
+                "request_id": request_id,
+                "status": "error",
+                "error_category": "bridge_request_not_found",
+                "error": "Bridge request was not durably registered",
+            },
+        )
+        return
+
+    try:
+        await conn.websocket.send_text(json.dumps({
+            "type": "post_xml",
+            "request_id": request_id,
+            "method": message.get("method", "post_xml"),
+            "xml_body": message.get("xml_body", ""),
+        }))
+    except Exception as exc:
+        await get_bridge_state_repository().mark_failed(
+            request_id=request_id,
+            tenant_id=tenant_id or None,
+            code="bridge_send_failed",
+            message=str(exc),
+        )
+        await get_bridge_broker().publish_response(
+            request_id,
+            {
+                "type": "response",
+                "request_id": request_id,
+                "status": "error",
+                "error_category": "bridge_send_failed",
+                "error": "Failed to send request to bridge socket",
+            },
+        )
+        return
+    logger.info("bridge_request_sent", bridge_id=bridge_id, request_id=request_id)
+
+
+async def handle_bridge_response(
+    msg: dict[str, Any],
+    *,
+    tenant_id: str | None = None,
+) -> None:
+    """Persist a bridge response and fan it back to the waiting API pod."""
+    request_id = str(msg.get("request_id") or "")
+    if not request_id:
+        logger.warning("bridge_response_missing_request_id")
+        return
+
+    status = msg.get("status")
+    metadata = {
+        "bridge_status": status,
+        "received_at": datetime.now(UTC).isoformat(),
+    }
+    if status == "ok" and isinstance(msg.get("xml_response"), str):
+        result = {
+            "type": "response",
+            "request_id": request_id,
+            "status": "ok",
+            "xml_response": msg["xml_response"],
+        }
+        _record, transitioned = await get_bridge_state_repository().mark_responded(
+            request_id=request_id,
+            tenant_id=tenant_id,
+            result=result,
+            response_metadata=metadata,
+        )
+        if transitioned:
+            await get_bridge_broker().publish_response(request_id, result)
+            _complete_local_waiter(request_id, result)
+        elif _record is None:
+            logger.warning("bridge_response_without_request", request_id=request_id)
+        return
+
+    if status == "error" and isinstance(msg.get("error"), str):
+        error_message = str(msg.get("error"))
+        result = {
+            "type": "response",
+            "request_id": request_id,
+            "status": "error",
+            "error_category": "bridge_error",
+            "error": error_message,
+        }
+        _record, transitioned = await get_bridge_state_repository().mark_failed(
+            request_id=request_id,
+            tenant_id=tenant_id,
+            code="bridge_error",
+            message=error_message,
+            response_metadata=metadata,
+        )
+        if transitioned:
+            await get_bridge_broker().publish_response(request_id, result)
+            _complete_local_waiter(request_id, result)
+        elif _record is None:
+            logger.warning("bridge_response_without_request", request_id=request_id)
+        return
+
+    error_result = {
+        "type": "response",
+        "request_id": request_id,
+        "status": "error",
+        "error_category": "malformed_response",
+        "error": "Bridge returned a malformed response",
+    }
+    _record, transitioned = await get_bridge_state_repository().mark_failed(
+        request_id=request_id,
+        tenant_id=tenant_id,
+        code="malformed_response",
+        message="Bridge returned a malformed response",
+        response_metadata={**metadata, "raw_keys": sorted(msg.keys())},
+    )
+    if transitioned:
+        await get_bridge_broker().publish_response(request_id, error_result)
+        _complete_local_waiter(request_id, error_result)
+    elif _record is None:
+        logger.warning("bridge_response_without_request", request_id=request_id)
+
+
+def _complete_local_waiter(request_id: str, message: dict[str, Any]) -> None:
+    future = _pending_requests.pop(request_id, None)
+    if future and not future.done():
+        future.set_result(message)
 
 
 async def route_to_bridge(
     bridge_id: str,
     xml_body: str,
     timeout: float = 30.0,
+    *,
+    tenant_id: str | None = None,
+    connector_type: str = "tally",
+    request_id: str | None = None,
+    idempotency_key: str | None = None,
 ) -> dict[str, Any]:
-    """Route an XML request through a bridge to the CA's local Tally."""
-    conn = _active_bridges.get(bridge_id)
-    if not conn:
-        raise RuntimeError(f"Bridge {bridge_id} is not connected")
+    """Route an XML request through a durable bridge request lifecycle."""
+    session = await get_bridge_state_repository().get_session(
+        bridge_id=bridge_id,
+        tenant_id=tenant_id,
+    )
+    if not session:
+        if tenant_id is not None:
+            visible_session = await get_bridge_state_repository().get_session(
+                bridge_id=bridge_id,
+                tenant_id=None,
+            )
+            if visible_session is not None and visible_session.tenant_id != tenant_id:
+                raise BridgeRouteError(
+                    "Tenant mismatch for bridge route",
+                    code="tenant_mismatch",
+                    bridge_id=bridge_id,
+                )
+        raise BridgeRouteError(
+            f"Bridge {bridge_id} is not registered or not visible to this tenant",
+            code="bridge_not_registered",
+            bridge_id=bridge_id,
+        )
+    if tenant_id is not None and session.tenant_id != tenant_id:
+        raise BridgeRouteError(
+            "Tenant mismatch for bridge route",
+            code="tenant_mismatch",
+            bridge_id=bridge_id,
+        )
 
-    request_id = str(uuid.uuid4())
+    effective_request_id = request_id or str(uuid.uuid4())
+    record = await get_bridge_state_repository().create_request(
+        request_id=effective_request_id,
+        bridge_id=bridge_id,
+        tenant_id=session.tenant_id,
+        connector_type=connector_type or session.connector_type,
+        method="post_xml",
+        payload_hash_value=payload_hash(xml_body),
+        timeout_seconds=timeout,
+        idempotency_key=idempotency_key,
+    )
+    effective_request_id = record.request_id
+
+    if not session.connected:
+        await get_bridge_state_repository().mark_failed(
+            request_id=effective_request_id,
+            tenant_id=session.tenant_id,
+            code="bridge_disconnected",
+            message=f"Bridge {bridge_id} is disconnected",
+        )
+        raise BridgeRouteError(
+            f"Bridge {bridge_id} is disconnected",
+            code="bridge_disconnected",
+            request_id=effective_request_id,
+            bridge_id=bridge_id,
+        )
+
     future: asyncio.Future = asyncio.get_running_loop().create_future()
-    _pending_requests[request_id] = (bridge_id, future)
+    _pending_requests[effective_request_id] = future
 
-    await conn.websocket.send_text(json.dumps({
-        "type": "post_xml",
-        "request_id": request_id,
-        "method": "post_xml",
-        "xml_body": xml_body,
-    }))
+    async def _response_handler(message: dict[str, Any]) -> None:
+        _complete_local_waiter(effective_request_id, message)
 
-    logger.info("bridge_request_sent", bridge_id=bridge_id, request_id=request_id)
+    try:
+        response_subscription = await get_bridge_broker().subscribe_response(
+            effective_request_id,
+            _response_handler,
+        )
+    except Exception as exc:
+        _pending_requests.pop(effective_request_id, None)
+        await get_bridge_state_repository().mark_failed(
+            request_id=effective_request_id,
+            tenant_id=session.tenant_id,
+            code="bridge_broker_unavailable",
+            message=str(exc),
+        )
+        raise BridgeRouteError(
+            "Bridge broker unavailable",
+            code="bridge_broker_unavailable",
+            request_id=effective_request_id,
+            bridge_id=bridge_id,
+        ) from exc
+
+    try:
+        await get_bridge_broker().publish_request(
+            bridge_id,
+            {
+                "type": "post_xml",
+                "request_id": effective_request_id,
+                "bridge_id": bridge_id,
+                "tenant_id": session.tenant_id,
+                "method": "post_xml",
+                "xml_body": xml_body,
+            },
+        )
+    except Exception as exc:
+        _pending_requests.pop(effective_request_id, None)
+        await response_subscription.close()
+        await get_bridge_state_repository().mark_failed(
+            request_id=effective_request_id,
+            tenant_id=session.tenant_id,
+            code="bridge_publish_failed",
+            message=str(exc),
+        )
+        raise BridgeRouteError(
+            "Bridge broker publish failed",
+            code="bridge_publish_failed",
+            request_id=effective_request_id,
+            bridge_id=bridge_id,
+        ) from exc
 
     try:
         result = await asyncio.wait_for(future, timeout=timeout)
         return result
     except TimeoutError as exc:
-        _pending_requests.pop(request_id, None)
-        raise RuntimeError(f"Bridge request timed out after {timeout}s") from exc
+        _pending_requests.pop(effective_request_id, None)
+        await get_bridge_state_repository().mark_timed_out(
+            effective_request_id,
+            tenant_id=session.tenant_id,
+        )
+        raise BridgeRouteError(
+            f"Bridge request timed out after {timeout}s",
+            code="request_timed_out",
+            request_id=effective_request_id,
+            bridge_id=bridge_id,
+        ) from exc
+    finally:
+        _pending_requests.pop(effective_request_id, None)
+        await response_subscription.close()
 
 
-def get_bridge_status(bridge_id: str) -> dict[str, Any]:
-    """Get the status of a bridge connection."""
-    conn = _active_bridges.get(bridge_id)
-    if conn:
-        return conn.status
-    return {"bridge_id": bridge_id, "connected": False}
+async def get_bridge_status(
+    bridge_id: str,
+    *,
+    tenant_id: str | None = None,
+) -> dict[str, Any]:
+    """Get durable bridge connection status, enriched with local socket state."""
+    session = await get_bridge_state_repository().get_session(
+        bridge_id=bridge_id,
+        tenant_id=tenant_id,
+    )
+    local_connected = bridge_id in _active_bridges
+    if session:
+        return session.to_status(local_connected=local_connected)
+    return {
+        "bridge_id": bridge_id,
+        "connected": False,
+        "local_connected": local_connected,
+        "status": "unknown",
+    }
 
 
-def list_active_bridges() -> list[dict[str, Any]]:
-    """List all active bridge connections."""
-    return [conn.status for conn in _active_bridges.values()]
+async def list_active_bridges(*, tenant_id: str | None = None) -> list[dict[str, Any]]:
+    """List durable bridge sessions. Without tenant_id, list local sockets only."""
+    if tenant_id is None:
+        return [conn.status for conn in _active_bridges.values()]
+    sessions = await get_bridge_state_repository().list_sessions(tenant_id=tenant_id)
+    return [
+        session.to_status(local_connected=session.bridge_id in _active_bridges)
+        for session in sessions
+    ]

--- a/bridge/state.py
+++ b/bridge/state.py
@@ -1,0 +1,1170 @@
+"""Durable bridge session/request state and cross-pod routing broker."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import hashlib
+import inspect
+import json
+import os
+import uuid
+from collections.abc import Awaitable, Callable
+from contextlib import suppress
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+
+import redis.asyncio as aioredis
+import structlog
+from sqlalchemy import select, text
+
+from core.config import redis_socket_timeout_kwargs, settings
+
+logger = structlog.get_logger()
+
+BridgeRequestHandler = Callable[[dict[str, Any]], Awaitable[None]]
+BridgeResponseHandler = Callable[[dict[str, Any]], Awaitable[None]]
+
+ACTIVE_REQUEST_STATUSES = {"pending", "sent"}
+TERMINAL_REQUEST_STATUSES = {
+    "responded",
+    "timed_out",
+    "failed",
+    "cancelled",
+    "orphaned",
+}
+BRIDGE_HEARTBEAT_STALE_SECONDS = 120
+
+
+def _json_safe(value: Any) -> Any:
+    return json.loads(json.dumps(value, default=str))
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def payload_hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def connection_owner() -> str:
+    pod = os.getenv("K_REVISION") or os.getenv("HOSTNAME") or "local"
+    return f"{pod}:{os.getpid()}"
+
+
+@dataclass(slots=True)
+class BridgeSessionRecord:
+    bridge_id: str
+    tenant_id: str
+    connector_type: str = "tally"
+    status: str = "connected"
+    connected_at: datetime | None = None
+    disconnected_at: datetime | None = None
+    last_heartbeat: datetime | None = None
+    tally_healthy: bool = False
+    connection_owner: str | None = None
+    process_id: int | None = None
+    reconnect_count: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+    id: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    @property
+    def stale(self) -> bool:
+        if not self.last_heartbeat:
+            return False
+        return (_now() - self.last_heartbeat) > timedelta(seconds=BRIDGE_HEARTBEAT_STALE_SECONDS)
+
+    @property
+    def connected(self) -> bool:
+        return self.status in {"active", "connected"} and not self.stale
+
+    def to_status(self, *, local_connected: bool = False) -> dict[str, Any]:
+        status = "unhealthy" if self.status in {"active", "connected"} and self.stale else self.status
+        return {
+            "bridge_id": self.bridge_id,
+            "tenant_id": self.tenant_id,
+            "connector_type": self.connector_type,
+            "status": status,
+            "connected": self.connected,
+            "local_connected": local_connected,
+            "connected_at": self.connected_at.isoformat() if self.connected_at else None,
+            "disconnected_at": (
+                self.disconnected_at.isoformat() if self.disconnected_at else None
+            ),
+            "last_heartbeat": self.last_heartbeat.isoformat() if self.last_heartbeat else None,
+            "tally_healthy": self.tally_healthy,
+            "connection_owner": self.connection_owner,
+            "reconnect_count": self.reconnect_count,
+            "metadata": copy.deepcopy(self.metadata),
+        }
+
+
+@dataclass(slots=True)
+class BridgeRequestRecord:
+    request_id: str
+    bridge_id: str
+    tenant_id: str
+    connector_type: str
+    method: str
+    payload_hash: str
+    status: str = "pending"
+    idempotency_key: str | None = None
+    response_metadata: dict[str, Any] = field(default_factory=dict)
+    result: dict[str, Any] | None = None
+    error: dict[str, Any] | None = None
+    created_at: datetime | None = None
+    sent_at: datetime | None = None
+    responded_at: datetime | None = None
+    expires_at: datetime | None = None
+    id: str | None = None
+    updated_at: datetime | None = None
+
+
+class BridgeRouteError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        request_id: str | None = None,
+        bridge_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.request_id = request_id
+        self.bridge_id = bridge_id
+
+    def to_detail(self) -> dict[str, Any]:
+        return {
+            "message": str(self),
+            "error_category": self.code,
+            "request_id": self.request_id,
+            "bridge_id": self.bridge_id,
+        }
+
+
+class BridgeStateRepository(Protocol):
+    async def connect_session(
+        self,
+        *,
+        bridge_id: str,
+        tenant_id: str,
+        connector_type: str,
+        tally_healthy: bool,
+        owner: str,
+        process_id: int,
+        metadata: dict[str, Any] | None = None,
+    ) -> BridgeSessionRecord:
+        ...
+
+    async def heartbeat(
+        self,
+        *,
+        bridge_id: str,
+        tenant_id: str,
+        tally_healthy: bool,
+    ) -> BridgeSessionRecord:
+        ...
+
+    async def disconnect_session(
+        self,
+        *,
+        bridge_id: str,
+        tenant_id: str,
+        reason: str,
+    ) -> BridgeSessionRecord | None:
+        ...
+
+    async def get_session(
+        self,
+        *,
+        bridge_id: str,
+        tenant_id: str | None = None,
+    ) -> BridgeSessionRecord | None:
+        ...
+
+    async def list_sessions(self, *, tenant_id: str) -> list[BridgeSessionRecord]:
+        ...
+
+    async def create_request(
+        self,
+        *,
+        request_id: str,
+        bridge_id: str,
+        tenant_id: str,
+        connector_type: str,
+        method: str,
+        payload_hash_value: str,
+        timeout_seconds: float,
+        idempotency_key: str | None = None,
+    ) -> BridgeRequestRecord:
+        ...
+
+    async def get_request(
+        self,
+        request_id: str,
+        *,
+        tenant_id: str | None = None,
+    ) -> BridgeRequestRecord | None:
+        ...
+
+    async def mark_sent(
+        self,
+        request_id: str,
+        *,
+        tenant_id: str | None = None,
+    ) -> BridgeRequestRecord | None:
+        ...
+
+    async def mark_responded(
+        self,
+        *,
+        request_id: str,
+        tenant_id: str | None = None,
+        result: dict[str, Any],
+        response_metadata: dict[str, Any] | None = None,
+    ) -> tuple[BridgeRequestRecord | None, bool]:
+        ...
+
+    async def mark_failed(
+        self,
+        *,
+        request_id: str,
+        tenant_id: str | None = None,
+        code: str,
+        message: str,
+        response_metadata: dict[str, Any] | None = None,
+    ) -> tuple[BridgeRequestRecord | None, bool]:
+        ...
+
+    async def mark_timed_out(
+        self,
+        request_id: str,
+        *,
+        tenant_id: str | None = None,
+    ) -> BridgeRequestRecord | None:
+        ...
+
+    async def mark_bridge_requests_orphaned(
+        self,
+        *,
+        bridge_id: str,
+        tenant_id: str,
+        reason: str,
+    ) -> list[BridgeRequestRecord]:
+        ...
+
+
+class InMemoryBridgeStateRepository:
+    def __init__(self) -> None:
+        self.sessions: dict[str, BridgeSessionRecord] = {}
+        self.requests: dict[str, BridgeRequestRecord] = {}
+
+    async def connect_session(
+        self,
+        *,
+        bridge_id: str,
+        tenant_id: str,
+        connector_type: str,
+        tally_healthy: bool,
+        owner: str,
+        process_id: int,
+        metadata: dict[str, Any] | None = None,
+    ) -> BridgeSessionRecord:
+        now = _now()
+        existing = self.sessions.get(bridge_id)
+        reconnect_count = (existing.reconnect_count + 1) if existing else 0
+        created_at = existing.created_at if existing else now
+        record = BridgeSessionRecord(
+            id=existing.id if existing else str(uuid.uuid4()),
+            bridge_id=bridge_id,
+            tenant_id=tenant_id,
+            connector_type=connector_type,
+            status="connected",
+            connected_at=now,
+            disconnected_at=None,
+            last_heartbeat=now,
+            tally_healthy=tally_healthy,
+            connection_owner=owner,
+            process_id=process_id,
+            reconnect_count=reconnect_count,
+            metadata=copy.deepcopy(_json_safe(metadata or (existing.metadata if existing else {}))),
+            created_at=created_at,
+            updated_at=now,
+        )
+        self.sessions[bridge_id] = record
+        return copy.deepcopy(record)
+
+    async def heartbeat(
+        self,
+        *,
+        bridge_id: str,
+        tenant_id: str,
+        tally_healthy: bool,
+    ) -> BridgeSessionRecord:
+        record = self.sessions[bridge_id]
+        if record.tenant_id != tenant_id:
+            raise BridgeRouteError(
+                "Tenant mismatch for bridge heartbeat",
+                code="tenant_mismatch",
+                bridge_id=bridge_id,
+            )
+        record.status = "connected"
+        record.last_heartbeat = _now()
+        record.tally_healthy = tally_healthy
+        record.updated_at = record.last_heartbeat
+        return copy.deepcopy(record)
+
+    async def disconnect_session(
+        self,
+        *,
+        bridge_id: str,
+        tenant_id: str,
+        reason: str,
+    ) -> BridgeSessionRecord | None:
+        record = self.sessions.get(bridge_id)
+        if not record or record.tenant_id != tenant_id:
+            return None
+        now = _now()
+        record.status = "disconnected"
+        record.disconnected_at = now
+        record.updated_at = now
+        record.metadata = {**copy.deepcopy(record.metadata), "disconnect_reason": reason}
+        return copy.deepcopy(record)
+
+    async def get_session(
+        self,
+        *,
+        bridge_id: str,
+        tenant_id: str | None = None,
+    ) -> BridgeSessionRecord | None:
+        record = self.sessions.get(bridge_id)
+        if record is None:
+            return None
+        if tenant_id is not None and record.tenant_id != tenant_id:
+            return None
+        return copy.deepcopy(record)
+
+    async def list_sessions(self, *, tenant_id: str) -> list[BridgeSessionRecord]:
+        return [
+            copy.deepcopy(record)
+            for record in self.sessions.values()
+            if record.tenant_id == tenant_id
+        ]
+
+    async def create_request(
+        self,
+        *,
+        request_id: str,
+        bridge_id: str,
+        tenant_id: str,
+        connector_type: str,
+        method: str,
+        payload_hash_value: str,
+        timeout_seconds: float,
+        idempotency_key: str | None = None,
+    ) -> BridgeRequestRecord:
+        if idempotency_key:
+            for existing in self.requests.values():
+                if (
+                    existing.tenant_id == tenant_id
+                    and existing.bridge_id == bridge_id
+                    and existing.idempotency_key == idempotency_key
+                ):
+                    return copy.deepcopy(existing)
+        now = _now()
+        record = BridgeRequestRecord(
+            id=str(uuid.uuid4()),
+            request_id=request_id,
+            bridge_id=bridge_id,
+            tenant_id=tenant_id,
+            connector_type=connector_type,
+            method=method,
+            payload_hash=payload_hash_value,
+            status="pending",
+            idempotency_key=idempotency_key,
+            created_at=now,
+            expires_at=now + timedelta(seconds=timeout_seconds),
+            updated_at=now,
+        )
+        self.requests[request_id] = record
+        return copy.deepcopy(record)
+
+    async def get_request(
+        self,
+        request_id: str,
+        *,
+        tenant_id: str | None = None,
+    ) -> BridgeRequestRecord | None:
+        record = self.requests.get(request_id)
+        if record is not None and tenant_id is not None and record.tenant_id != tenant_id:
+            return None
+        return copy.deepcopy(record) if record else None
+
+    async def mark_sent(
+        self,
+        request_id: str,
+        *,
+        tenant_id: str | None = None,
+    ) -> BridgeRequestRecord | None:
+        record = self.requests.get(request_id)
+        if not record:
+            return None
+        if tenant_id is not None and record.tenant_id != tenant_id:
+            return None
+        if record.status == "pending":
+            now = _now()
+            record.status = "sent"
+            record.sent_at = now
+            record.updated_at = now
+        return copy.deepcopy(record)
+
+    async def mark_responded(
+        self,
+        *,
+        request_id: str,
+        tenant_id: str | None = None,
+        result: dict[str, Any],
+        response_metadata: dict[str, Any] | None = None,
+    ) -> tuple[BridgeRequestRecord | None, bool]:
+        record = self.requests.get(request_id)
+        if not record:
+            return None, False
+        if tenant_id is not None and record.tenant_id != tenant_id:
+            return None, False
+        if record.status in TERMINAL_REQUEST_STATUSES:
+            self._record_duplicate(record, response_metadata)
+            return copy.deepcopy(record), False
+        now = _now()
+        record.status = "responded"
+        record.responded_at = now
+        record.updated_at = now
+        record.result = copy.deepcopy(_json_safe(result))
+        record.response_metadata = copy.deepcopy(_json_safe(response_metadata or {}))
+        return copy.deepcopy(record), True
+
+    async def mark_failed(
+        self,
+        *,
+        request_id: str,
+        tenant_id: str | None = None,
+        code: str,
+        message: str,
+        response_metadata: dict[str, Any] | None = None,
+    ) -> tuple[BridgeRequestRecord | None, bool]:
+        record = self.requests.get(request_id)
+        if not record:
+            return None, False
+        if tenant_id is not None and record.tenant_id != tenant_id:
+            return None, False
+        if record.status in TERMINAL_REQUEST_STATUSES:
+            self._record_duplicate(record, response_metadata)
+            return copy.deepcopy(record), False
+        now = _now()
+        record.status = "failed"
+        record.responded_at = now
+        record.updated_at = now
+        record.error = {"code": code, "message": message}
+        record.response_metadata = copy.deepcopy(_json_safe(response_metadata or {}))
+        return copy.deepcopy(record), True
+
+    async def mark_timed_out(
+        self,
+        request_id: str,
+        *,
+        tenant_id: str | None = None,
+    ) -> BridgeRequestRecord | None:
+        record = self.requests.get(request_id)
+        if not record:
+            return None
+        if tenant_id is not None and record.tenant_id != tenant_id:
+            return None
+        if record.status in ACTIVE_REQUEST_STATUSES:
+            now = _now()
+            record.status = "timed_out"
+            record.updated_at = now
+            record.error = {"code": "request_timed_out", "message": "Bridge request timed out"}
+        return copy.deepcopy(record)
+
+    async def mark_bridge_requests_orphaned(
+        self,
+        *,
+        bridge_id: str,
+        tenant_id: str,
+        reason: str,
+    ) -> list[BridgeRequestRecord]:
+        updated: list[BridgeRequestRecord] = []
+        now = _now()
+        for record in self.requests.values():
+            if (
+                record.bridge_id != bridge_id
+                or record.tenant_id != tenant_id
+                or record.status not in ACTIVE_REQUEST_STATUSES
+            ):
+                continue
+            record.status = "orphaned"
+            record.updated_at = now
+            record.error = {"code": "bridge_disconnected", "message": reason}
+            updated.append(copy.deepcopy(record))
+        return updated
+
+    @staticmethod
+    def _record_duplicate(
+        record: BridgeRequestRecord,
+        response_metadata: dict[str, Any] | None,
+    ) -> None:
+        metadata = copy.deepcopy(record.response_metadata or {})
+        metadata["duplicate_response_count"] = int(metadata.get("duplicate_response_count") or 0) + 1
+        metadata["last_duplicate_at"] = _now().isoformat()
+        if response_metadata:
+            metadata["last_duplicate_metadata"] = copy.deepcopy(_json_safe(response_metadata))
+        record.response_metadata = metadata
+        record.updated_at = _now()
+
+
+class SqlAlchemyBridgeStateRepository:
+    def __init__(self, session_factory: Any) -> None:
+        self._session_factory = session_factory
+
+    async def connect_session(
+        self,
+        *,
+        bridge_id: str,
+        tenant_id: str,
+        connector_type: str,
+        tally_healthy: bool,
+        owner: str,
+        process_id: int,
+        metadata: dict[str, Any] | None = None,
+    ) -> BridgeSessionRecord:
+        from core.models.bridge import BridgeSession
+
+        now = _now()
+        async with self._session_factory() as session:
+            async with session.begin():
+                await _set_tenant(session, tenant_id)
+                row = (
+                    await session.execute(
+                        select(BridgeSession)
+                        .where(BridgeSession.bridge_id == bridge_id)
+                        .with_for_update()
+                    )
+                ).scalar_one_or_none()
+                if row is None:
+                    row = BridgeSession(
+                        bridge_id=bridge_id,
+                        tenant_id=uuid.UUID(tenant_id),
+                        connector_type=connector_type,
+                        status="connected",
+                        connected_at=now,
+                        disconnected_at=None,
+                        last_heartbeat=now,
+                        tally_healthy=tally_healthy,
+                        connection_owner=owner,
+                        process_id=process_id,
+                        reconnect_count=0,
+                        session_metadata=_json_safe(metadata or {}),
+                    )
+                    session.add(row)
+                    await session.flush()
+                else:
+                    row.connector_type = connector_type
+                    row.status = "connected"
+                    row.connected_at = now
+                    row.disconnected_at = None
+                    row.last_heartbeat = now
+                    row.tally_healthy = tally_healthy
+                    row.connection_owner = owner
+                    row.process_id = process_id
+                    row.reconnect_count = int(row.reconnect_count or 0) + 1
+                    if metadata:
+                        row.session_metadata = _json_safe(metadata)
+                    row.updated_at = now
+                return self._session_from_model(row)
+
+    async def heartbeat(
+        self,
+        *,
+        bridge_id: str,
+        tenant_id: str,
+        tally_healthy: bool,
+    ) -> BridgeSessionRecord:
+        from core.models.bridge import BridgeSession
+
+        async with self._session_factory() as session:
+            async with session.begin():
+                await _set_tenant(session, tenant_id)
+                row = (
+                    await session.execute(
+                        select(BridgeSession)
+                        .where(
+                            BridgeSession.bridge_id == bridge_id,
+                            BridgeSession.tenant_id == uuid.UUID(tenant_id),
+                        )
+                        .with_for_update()
+                    )
+                ).scalar_one()
+                now = _now()
+                row.status = "connected"
+                row.last_heartbeat = now
+                row.tally_healthy = tally_healthy
+                row.updated_at = now
+                return self._session_from_model(row)
+
+    async def disconnect_session(
+        self,
+        *,
+        bridge_id: str,
+        tenant_id: str,
+        reason: str,
+    ) -> BridgeSessionRecord | None:
+        from core.models.bridge import BridgeSession
+
+        async with self._session_factory() as session:
+            async with session.begin():
+                await _set_tenant(session, tenant_id)
+                row = (
+                    await session.execute(
+                        select(BridgeSession)
+                        .where(
+                            BridgeSession.bridge_id == bridge_id,
+                            BridgeSession.tenant_id == uuid.UUID(tenant_id),
+                        )
+                        .with_for_update()
+                    )
+                ).scalar_one_or_none()
+                if row is None:
+                    return None
+                now = _now()
+                row.status = "disconnected"
+                row.disconnected_at = now
+                row.updated_at = now
+                row.session_metadata = {
+                    **(row.session_metadata or {}),
+                    "disconnect_reason": reason,
+                }
+                return self._session_from_model(row)
+
+    async def get_session(
+        self,
+        *,
+        bridge_id: str,
+        tenant_id: str | None = None,
+    ) -> BridgeSessionRecord | None:
+        from core.models.bridge import BridgeSession
+
+        async with self._session_factory() as session:
+            if tenant_id:
+                await _set_tenant(session, tenant_id)
+            query = select(BridgeSession).where(BridgeSession.bridge_id == bridge_id)
+            if tenant_id:
+                query = query.where(BridgeSession.tenant_id == uuid.UUID(tenant_id))
+            row = (await session.execute(query)).scalar_one_or_none()
+            return self._session_from_model(row) if row else None
+
+    async def list_sessions(self, *, tenant_id: str) -> list[BridgeSessionRecord]:
+        from core.models.bridge import BridgeSession
+
+        async with self._session_factory() as session:
+            await _set_tenant(session, tenant_id)
+            rows = (
+                await session.execute(
+                    select(BridgeSession)
+                    .where(BridgeSession.tenant_id == uuid.UUID(tenant_id))
+                    .order_by(BridgeSession.created_at.desc())
+                )
+            ).scalars().all()
+            return [self._session_from_model(row) for row in rows]
+
+    async def create_request(
+        self,
+        *,
+        request_id: str,
+        bridge_id: str,
+        tenant_id: str,
+        connector_type: str,
+        method: str,
+        payload_hash_value: str,
+        timeout_seconds: float,
+        idempotency_key: str | None = None,
+    ) -> BridgeRequestRecord:
+        from core.models.bridge import BridgeRequest
+
+        async with self._session_factory() as session:
+            async with session.begin():
+                await _set_tenant(session, tenant_id)
+                if idempotency_key:
+                    existing = (
+                        await session.execute(
+                            select(BridgeRequest).where(
+                                BridgeRequest.tenant_id == uuid.UUID(tenant_id),
+                                BridgeRequest.bridge_id == bridge_id,
+                                BridgeRequest.idempotency_key == idempotency_key,
+                            )
+                        )
+                    ).scalar_one_or_none()
+                    if existing is not None:
+                        return self._request_from_model(existing)
+                now = _now()
+                row = BridgeRequest(
+                    request_id=request_id,
+                    bridge_id=bridge_id,
+                    tenant_id=uuid.UUID(tenant_id),
+                    connector_type=connector_type,
+                    method=method,
+                    payload_hash=payload_hash_value,
+                    status="pending",
+                    idempotency_key=idempotency_key,
+                    expires_at=now + timedelta(seconds=timeout_seconds),
+                )
+                session.add(row)
+                await session.flush()
+                return self._request_from_model(row)
+
+    async def get_request(
+        self,
+        request_id: str,
+        *,
+        tenant_id: str | None = None,
+    ) -> BridgeRequestRecord | None:
+        from core.models.bridge import BridgeRequest
+
+        async with self._session_factory() as session:
+            if tenant_id:
+                await _set_tenant(session, tenant_id)
+            query = select(BridgeRequest).where(BridgeRequest.request_id == request_id)
+            if tenant_id:
+                query = query.where(BridgeRequest.tenant_id == uuid.UUID(tenant_id))
+            row = (await session.execute(query)).scalar_one_or_none()
+            return self._request_from_model(row) if row else None
+
+    async def mark_sent(
+        self,
+        request_id: str,
+        *,
+        tenant_id: str | None = None,
+    ) -> BridgeRequestRecord | None:
+        async with self._session_factory() as session:
+            async with session.begin():
+                row = await self._locked_request(session, request_id, tenant_id=tenant_id)
+                if row is None:
+                    return None
+                if row.status == "pending":
+                    now = _now()
+                    row.status = "sent"
+                    row.sent_at = now
+                    row.updated_at = now
+                return self._request_from_model(row)
+
+    async def mark_responded(
+        self,
+        *,
+        request_id: str,
+        tenant_id: str | None = None,
+        result: dict[str, Any],
+        response_metadata: dict[str, Any] | None = None,
+    ) -> tuple[BridgeRequestRecord | None, bool]:
+        async with self._session_factory() as session:
+            async with session.begin():
+                row = await self._locked_request(session, request_id, tenant_id=tenant_id)
+                if row is None:
+                    return None, False
+                if row.status in TERMINAL_REQUEST_STATUSES:
+                    self._record_duplicate(row, response_metadata)
+                    return self._request_from_model(row), False
+                now = _now()
+                row.status = "responded"
+                row.responded_at = now
+                row.updated_at = now
+                row.result = _json_safe(result)
+                row.response_metadata = _json_safe(response_metadata or {})
+                return self._request_from_model(row), True
+
+    async def mark_failed(
+        self,
+        *,
+        request_id: str,
+        tenant_id: str | None = None,
+        code: str,
+        message: str,
+        response_metadata: dict[str, Any] | None = None,
+    ) -> tuple[BridgeRequestRecord | None, bool]:
+        async with self._session_factory() as session:
+            async with session.begin():
+                row = await self._locked_request(session, request_id, tenant_id=tenant_id)
+                if row is None:
+                    return None, False
+                if row.status in TERMINAL_REQUEST_STATUSES:
+                    self._record_duplicate(row, response_metadata)
+                    return self._request_from_model(row), False
+                now = _now()
+                row.status = "failed"
+                row.responded_at = now
+                row.updated_at = now
+                row.error = {"code": code, "message": message}
+                row.response_metadata = _json_safe(response_metadata or {})
+                return self._request_from_model(row), True
+
+    async def mark_timed_out(
+        self,
+        request_id: str,
+        *,
+        tenant_id: str | None = None,
+    ) -> BridgeRequestRecord | None:
+        async with self._session_factory() as session:
+            async with session.begin():
+                row = await self._locked_request(session, request_id, tenant_id=tenant_id)
+                if row is None:
+                    return None
+                if row.status in ACTIVE_REQUEST_STATUSES:
+                    now = _now()
+                    row.status = "timed_out"
+                    row.updated_at = now
+                    row.error = {
+                        "code": "request_timed_out",
+                        "message": "Bridge request timed out",
+                    }
+                return self._request_from_model(row)
+
+    async def mark_bridge_requests_orphaned(
+        self,
+        *,
+        bridge_id: str,
+        tenant_id: str,
+        reason: str,
+    ) -> list[BridgeRequestRecord]:
+        from core.models.bridge import BridgeRequest
+
+        async with self._session_factory() as session:
+            async with session.begin():
+                await _set_tenant(session, tenant_id)
+                rows = (
+                    await session.execute(
+                        select(BridgeRequest)
+                        .where(
+                            BridgeRequest.bridge_id == bridge_id,
+                            BridgeRequest.tenant_id == uuid.UUID(tenant_id),
+                            BridgeRequest.status.in_(list(ACTIVE_REQUEST_STATUSES)),
+                        )
+                        .with_for_update()
+                    )
+                ).scalars().all()
+                now = _now()
+                for row in rows:
+                    row.status = "orphaned"
+                    row.updated_at = now
+                    row.error = {"code": "bridge_disconnected", "message": reason}
+                return [self._request_from_model(row) for row in rows]
+
+    async def _locked_request(
+        self,
+        session: Any,
+        request_id: str,
+        *,
+        tenant_id: str | None = None,
+    ) -> Any | None:
+        from core.models.bridge import BridgeRequest
+
+        if tenant_id:
+            await _set_tenant(session, tenant_id)
+        query = select(BridgeRequest).where(BridgeRequest.request_id == request_id)
+        if tenant_id:
+            query = query.where(BridgeRequest.tenant_id == uuid.UUID(tenant_id))
+        return (
+            await session.execute(
+                query.with_for_update()
+            )
+        ).scalar_one_or_none()
+
+    @staticmethod
+    def _record_duplicate(row: Any, response_metadata: dict[str, Any] | None) -> None:
+        metadata = dict(row.response_metadata or {})
+        metadata["duplicate_response_count"] = int(metadata.get("duplicate_response_count") or 0) + 1
+        metadata["last_duplicate_at"] = _now().isoformat()
+        if response_metadata:
+            metadata["last_duplicate_metadata"] = _json_safe(response_metadata)
+        row.response_metadata = metadata
+        row.updated_at = _now()
+
+    @staticmethod
+    def _session_from_model(row: Any) -> BridgeSessionRecord:
+        return BridgeSessionRecord(
+            id=str(row.id),
+            bridge_id=row.bridge_id,
+            tenant_id=str(row.tenant_id),
+            connector_type=row.connector_type,
+            status=row.status,
+            connected_at=row.connected_at,
+            disconnected_at=row.disconnected_at,
+            last_heartbeat=row.last_heartbeat,
+            tally_healthy=bool(row.tally_healthy),
+            connection_owner=row.connection_owner,
+            process_id=row.process_id,
+            reconnect_count=int(row.reconnect_count or 0),
+            metadata=copy.deepcopy(row.session_metadata or {}),
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )
+
+    @staticmethod
+    def _request_from_model(row: Any) -> BridgeRequestRecord:
+        return BridgeRequestRecord(
+            id=str(row.id),
+            request_id=row.request_id,
+            bridge_id=row.bridge_id,
+            tenant_id=str(row.tenant_id),
+            connector_type=row.connector_type,
+            method=row.method,
+            payload_hash=row.payload_hash,
+            status=row.status,
+            idempotency_key=row.idempotency_key,
+            response_metadata=copy.deepcopy(row.response_metadata or {}),
+            result=copy.deepcopy(row.result),
+            error=copy.deepcopy(row.error),
+            created_at=row.created_at,
+            sent_at=row.sent_at,
+            responded_at=row.responded_at,
+            expires_at=row.expires_at,
+            updated_at=row.updated_at,
+        )
+
+
+class BrokerSubscription(Protocol):
+    async def close(self) -> None:
+        ...
+
+
+class BridgeBroker(Protocol):
+    async def publish_request(self, bridge_id: str, message: dict[str, Any]) -> None:
+        ...
+
+    async def subscribe_requests(
+        self,
+        bridge_id: str,
+        handler: BridgeRequestHandler,
+    ) -> BrokerSubscription:
+        ...
+
+    async def publish_response(self, request_id: str, message: dict[str, Any]) -> None:
+        ...
+
+    async def subscribe_response(
+        self,
+        request_id: str,
+        handler: BridgeResponseHandler,
+    ) -> BrokerSubscription:
+        ...
+
+
+class _InMemorySubscription:
+    def __init__(self, handlers: set[Any], handler: Any) -> None:
+        self._handlers = handlers
+        self._handler = handler
+
+    async def close(self) -> None:
+        self._handlers.discard(self._handler)
+
+
+class InMemoryBridgeBroker:
+    def __init__(self) -> None:
+        self.request_handlers: dict[str, set[BridgeRequestHandler]] = {}
+        self.response_handlers: dict[str, set[BridgeResponseHandler]] = {}
+        self.published_requests: list[dict[str, Any]] = []
+        self.published_responses: list[dict[str, Any]] = []
+
+    async def publish_request(self, bridge_id: str, message: dict[str, Any]) -> None:
+        safe_message = copy.deepcopy(_json_safe(message))
+        self.published_requests.append(safe_message)
+        for handler in list(self.request_handlers.get(bridge_id, set())):
+            await handler(copy.deepcopy(safe_message))
+
+    async def subscribe_requests(
+        self,
+        bridge_id: str,
+        handler: BridgeRequestHandler,
+    ) -> BrokerSubscription:
+        handlers = self.request_handlers.setdefault(bridge_id, set())
+        handlers.add(handler)
+        return _InMemorySubscription(handlers, handler)
+
+    async def publish_response(self, request_id: str, message: dict[str, Any]) -> None:
+        safe_message = copy.deepcopy(_json_safe(message))
+        self.published_responses.append(safe_message)
+        for handler in list(self.response_handlers.get(request_id, set())):
+            await handler(copy.deepcopy(safe_message))
+
+    async def subscribe_response(
+        self,
+        request_id: str,
+        handler: BridgeResponseHandler,
+    ) -> BrokerSubscription:
+        handlers = self.response_handlers.setdefault(request_id, set())
+        handlers.add(handler)
+        return _InMemorySubscription(handlers, handler)
+
+
+class _RedisSubscription:
+    def __init__(
+        self,
+        redis_url: str,
+        channel: str,
+        handler: Callable[[dict[str, Any]], Awaitable[None]],
+    ) -> None:
+        self._redis_url = redis_url
+        self._channel = channel
+        self._handler = handler
+        self._redis: aioredis.Redis | None = None
+        self._pubsub: Any = None
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        self._redis = aioredis.from_url(
+            self._redis_url,
+            decode_responses=True,
+            **redis_socket_timeout_kwargs(),
+        )
+        self._pubsub = self._redis.pubsub()
+        await self._pubsub.subscribe(self._channel)
+        self._task = asyncio.create_task(self._run())
+
+    async def _run(self) -> None:
+        assert self._pubsub is not None
+        try:
+            async for message in self._pubsub.listen():
+                if message.get("type") != "message":
+                    continue
+                try:
+                    payload = json.loads(message.get("data") or "{}")
+                except json.JSONDecodeError:
+                    logger.warning("bridge_broker_invalid_json", channel=self._channel)
+                    continue
+                await self._handler(payload)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - broker subscription should not crash process.
+            logger.warning("bridge_broker_subscription_failed", channel=self._channel, error=str(exc))
+
+    async def close(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        if self._pubsub is not None:
+            with suppress(Exception):
+                await self._pubsub.unsubscribe(self._channel)
+                await self._pubsub.close()
+        if self._redis is not None:
+            await _close_redis(self._redis)
+
+
+class RedisBridgeBroker:
+    def __init__(self, redis_url: str | None = None) -> None:
+        self._redis_url = redis_url or settings.redis_url
+        self._redis: aioredis.Redis | None = None
+
+    async def publish_request(self, bridge_id: str, message: dict[str, Any]) -> None:
+        await self._publish(_request_channel(bridge_id), message)
+
+    async def subscribe_requests(
+        self,
+        bridge_id: str,
+        handler: BridgeRequestHandler,
+    ) -> BrokerSubscription:
+        subscription = _RedisSubscription(self._redis_url, _request_channel(bridge_id), handler)
+        await subscription.start()
+        return subscription
+
+    async def publish_response(self, request_id: str, message: dict[str, Any]) -> None:
+        await self._publish(_response_channel(request_id), message)
+
+    async def subscribe_response(
+        self,
+        request_id: str,
+        handler: BridgeResponseHandler,
+    ) -> BrokerSubscription:
+        subscription = _RedisSubscription(self._redis_url, _response_channel(request_id), handler)
+        await subscription.start()
+        return subscription
+
+    async def _publish(self, channel: str, message: dict[str, Any]) -> None:
+        redis = await self._publisher()
+        await redis.publish(channel, json.dumps(_json_safe(message)))
+
+    async def _publisher(self) -> aioredis.Redis:
+        if self._redis is None:
+            self._redis = aioredis.from_url(
+                self._redis_url,
+                decode_responses=True,
+                **redis_socket_timeout_kwargs(),
+            )
+        return self._redis
+
+
+async def _close_redis(redis: aioredis.Redis) -> None:
+    close_fn = getattr(redis, "aclose", None) or getattr(redis, "close", None)
+    if close_fn is None:
+        return
+    result = close_fn()
+    if inspect.isawaitable(result):
+        await result
+
+
+async def _set_tenant(session: Any, tenant_id: str) -> None:
+    await session.execute(
+        text("SELECT set_config('agenticorg.tenant_id', :tenant_id, true)"),
+        {"tenant_id": str(uuid.UUID(str(tenant_id)))},
+    )
+
+
+def _request_channel(bridge_id: str) -> str:
+    return f"bridge:req:{bridge_id}"
+
+
+def _response_channel(request_id: str) -> str:
+    return f"bridge:resp:{request_id}"
+
+
+_repository_override: BridgeStateRepository | None = None
+_broker_override: BridgeBroker | None = None
+_default_repository: BridgeStateRepository | None = None
+_default_broker: BridgeBroker | None = None
+
+
+def get_bridge_state_repository() -> BridgeStateRepository:
+    global _default_repository
+    if _repository_override is not None:
+        return _repository_override
+    if _default_repository is None:
+        from core.database import async_session_factory
+
+        _default_repository = SqlAlchemyBridgeStateRepository(async_session_factory)
+    return _default_repository
+
+
+def get_bridge_broker() -> BridgeBroker:
+    global _default_broker
+    if _broker_override is not None:
+        return _broker_override
+    if _default_broker is None:
+        _default_broker = RedisBridgeBroker()
+    return _default_broker
+
+
+def configure_bridge_state_for_tests(
+    *,
+    repository: BridgeStateRepository | None = None,
+    broker: BridgeBroker | None = None,
+) -> None:
+    global _broker_override, _repository_override
+    _repository_override = repository
+    _broker_override = broker
+
+
+def reset_bridge_state_for_tests() -> None:
+    configure_bridge_state_for_tests(repository=None, broker=None)

--- a/connectors/finance/tally.py
+++ b/connectors/finance/tally.py
@@ -56,10 +56,12 @@ class TallyError(RuntimeError):
         *,
         detail: str | None = None,
         request_id: str | None = None,
+        error_category: str | None = None,
     ) -> None:
         super().__init__(message)
         self.detail = detail
         self.request_id = request_id
+        self.error_category = error_category
 
 
 class TallyConnectionError(TallyError):
@@ -188,6 +190,45 @@ def _extract_tally_error(parsed: dict[str, Any]) -> str | None:
     return None
 
 
+def _bridge_error_payload(resp: Any, fallback_request_id: str) -> dict[str, str]:
+    """Extract durable bridge error metadata from an HTTP response."""
+    try:
+        data = resp.json()
+    except ValueError:
+        return {
+            "message": resp.text[:500],
+            "detail": resp.text[:500],
+            "request_id": fallback_request_id,
+            "error_category": "bridge_http_error",
+        }
+
+    if not isinstance(data, dict):
+        return {
+            "message": resp.text[:500],
+            "detail": resp.text[:500],
+            "request_id": fallback_request_id,
+            "error_category": "bridge_http_error",
+        }
+
+    detail = data.get("detail")
+    if isinstance(detail, dict):
+        message = str(detail.get("message") or data.get("error") or resp.text[:500])
+        return {
+            "message": message,
+            "detail": message,
+            "request_id": str(detail.get("request_id") or fallback_request_id),
+            "error_category": str(detail.get("error_category") or "bridge_http_error"),
+        }
+
+    message = str(detail or data.get("error") or resp.text[:500])
+    return {
+        "message": message,
+        "detail": message,
+        "request_id": str(data.get("request_id") or fallback_request_id),
+        "error_category": str(data.get("error_category") or "bridge_http_error"),
+    }
+
+
 class TallyConnector(BaseConnector):
     """Tally connector with optional bridge routing for remote instances.
 
@@ -255,18 +296,24 @@ class TallyConnector(BaseConnector):
                 "status": "unreachable",
                 "error": str(exc),
                 "detail": exc.detail,
+                "request_id": exc.request_id,
+                "error_category": exc.error_category,
             }
         except TallyBridgeError as exc:
             return {
                 "status": "bridge_error",
                 "error": str(exc),
                 "detail": exc.detail,
+                "request_id": exc.request_id,
+                "error_category": exc.error_category,
             }
         except TallyError as exc:
             return {
                 "status": "unhealthy",
                 "error": str(exc),
                 "detail": exc.detail,
+                "request_id": exc.request_id,
+                "error_category": exc.error_category,
             }
         except Exception as exc:  # defensive — connector health must never raise
             return {"status": "unhealthy", "error": str(exc)}
@@ -322,35 +369,43 @@ class TallyConnector(BaseConnector):
                 "tunnel is live.",
                 detail=str(exc),
                 request_id=request_id,
+                error_category="bridge_unreachable",
             ) from exc
         except httpx.HTTPError as exc:
             raise TallyBridgeError(
                 f"Tally bridge HTTP error: {exc}",
                 detail=str(exc),
                 request_id=request_id,
+                error_category="bridge_http_error",
             ) from exc
 
         if resp.status_code == 401 or resp.status_code == 403:
+            err = _bridge_error_payload(resp, request_id)
             raise TallyBridgeError(
                 "Tally bridge rejected our token. Regenerate bridge "
                 "credentials in Settings → Tally Connection.",
-                detail=f"HTTP {resp.status_code}",
-                request_id=request_id,
+                detail=err["detail"] or f"HTTP {resp.status_code}",
+                request_id=err["request_id"],
+                error_category=err["error_category"],
             )
         if resp.status_code >= 500:
+            err = _bridge_error_payload(resp, request_id)
             raise TallyBridgeError(
                 f"Tally bridge returned HTTP {resp.status_code} — "
                 "the bridge itself may be in a bad state; try restarting "
                 "the agenticorg-bridge process.",
-                detail=resp.text[:500],
-                request_id=request_id,
+                detail=err["detail"],
+                request_id=err["request_id"],
+                error_category=err["error_category"],
             )
         if resp.status_code >= 400:
+            err = _bridge_error_payload(resp, request_id)
             raise TallyBridgeError(
                 f"Tally bridge rejected the request (HTTP "
                 f"{resp.status_code}).",
-                detail=resp.text[:500],
-                request_id=request_id,
+                detail=err["detail"],
+                request_id=err["request_id"],
+                error_category=err["error_category"],
             )
 
         try:
@@ -361,21 +416,25 @@ class TallyConnector(BaseConnector):
                 "an HTML error page from an upstream proxy.",
                 detail=resp.text[:500],
                 request_id=request_id,
+                error_category="bridge_non_json_response",
             ) from exc
 
         if result.get("status") == "error":
             raise TallyBridgeError(
                 f"Tally bridge error: {result.get('error', 'unknown')}",
                 detail=result.get("error"),
-                request_id=request_id,
+                request_id=result.get("request_id") or request_id,
+                error_category=result.get("error_category") or "bridge_error",
             )
 
         xml_response = result.get("xml_response", "")
+        durable_request_id = result.get("request_id") or request_id
         if not xml_response:
             raise TallyResponseError(
                 "Tally returned an empty response — usually means no "
                 "company is open on the client's Tally instance.",
-                request_id=request_id,
+                request_id=durable_request_id,
+                error_category="empty_tally_response",
             )
 
         try:
@@ -386,7 +445,8 @@ class TallyConnector(BaseConnector):
                 "instance is actually Tally Prime / ERP 9 and not "
                 "another service listening on the port.",
                 detail=str(exc),
-                request_id=request_id,
+                request_id=durable_request_id,
+                error_category="malformed_tally_xml",
             ) from exc
 
         parsed = _xml_to_dict(elem)
@@ -399,7 +459,8 @@ class TallyConnector(BaseConnector):
             raise TallyResponseError(
                 f"Tally rejected the request: {err_msg}",
                 detail=err_msg,
-                request_id=request_id,
+                request_id=durable_request_id,
+                error_category="tally_business_error",
             )
 
         return parsed

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -27,6 +27,8 @@ from core.models.base import TenantMixin as TenantMixin
 from core.models.base import TimestampMixin as TimestampMixin
 from core.models.branding import TenantBranding as TenantBranding
 from core.models.bridge import BridgeRegistration as BridgeRegistration
+from core.models.bridge import BridgeRequest as BridgeRequest
+from core.models.bridge import BridgeSession as BridgeSession
 from core.models.budget_alert import BudgetAlert as BudgetAlert
 from core.models.ca_subscription import CASubscription as CASubscription
 from core.models.company import Company as Company

--- a/core/models/bridge.py
+++ b/core/models/bridge.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, String
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -22,3 +22,71 @@ class BridgeRegistration(BaseModel, TenantMixin, TimestampMixin):
     status: Mapped[str] = mapped_column(String(20), server_default="active")
     last_heartbeat: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     metadata_: Mapped[dict] = mapped_column("metadata_", JSONB, server_default="{}")
+
+
+class BridgeSession(BaseModel, TenantMixin, TimestampMixin):
+    __tablename__ = "bridge_sessions"
+    __table_args__ = (
+        Index("ix_bridge_sessions_tenant_status", "tenant_id", "status"),
+        Index("ix_bridge_sessions_tenant_type", "tenant_id", "connector_type"),
+        Index("ix_bridge_sessions_last_heartbeat", "last_heartbeat"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    bridge_id: Mapped[str] = mapped_column(
+        String(100),
+        ForeignKey("bridge_registry.bridge_id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+    connector_type: Mapped[str] = mapped_column(String(50), nullable=False, default="tally")
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="disconnected")
+    connected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    disconnected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_heartbeat: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    tally_healthy: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    connection_owner: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    process_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    reconnect_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    session_metadata: Mapped[dict] = mapped_column(
+        "metadata", JSONB, nullable=False, default=dict, server_default=text("'{}'::jsonb")
+    )
+
+
+class BridgeRequest(BaseModel, TenantMixin, TimestampMixin):
+    __tablename__ = "bridge_requests"
+    __table_args__ = (
+        Index("ix_bridge_requests_request_id", "request_id", unique=True),
+        Index("ix_bridge_requests_tenant_status", "tenant_id", "status"),
+        Index("ix_bridge_requests_bridge_status", "bridge_id", "status"),
+        Index("ix_bridge_requests_expires_at", "expires_at"),
+        Index(
+            "uq_bridge_requests_idempotency",
+            "tenant_id",
+            "bridge_id",
+            "idempotency_key",
+            unique=True,
+            postgresql_where=text("idempotency_key IS NOT NULL"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    request_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    bridge_id: Mapped[str] = mapped_column(
+        String(100),
+        ForeignKey("bridge_registry.bridge_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    connector_type: Mapped[str] = mapped_column(String(50), nullable=False, default="tally")
+    method: Mapped[str] = mapped_column(String(100), nullable=False)
+    payload_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending")
+    idempotency_key: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    response_metadata: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'::jsonb")
+    )
+    result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    error: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    sent_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    responded_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/migrations/versions/v4_9_15_bridge_session_durability.py
+++ b/migrations/versions/v4_9_15_bridge_session_durability.py
@@ -1,0 +1,129 @@
+"""Durable bridge sessions and requests.
+
+Revision ID: v4915_bridge_durability
+Revises: v4912_workflow_event_waits
+Create Date: 2026-05-16
+
+This intentionally uses a unique v4915 revision while branching from v4912.
+PR #553 and PR #554 also branch from v4912 with their own heads; once those
+P0 PRs are merged together, Alembic will need a merge-head revision that
+joins v4913/v4914/v4915-style heads.
+"""
+
+from __future__ import annotations
+
+# ruff: noqa: S608
+
+from alembic import op
+
+revision = "v4915_bridge_durability"
+down_revision = "v4912_workflow_event_waits"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS bridge_sessions (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+            bridge_id VARCHAR(100) NOT NULL
+                REFERENCES bridge_registry(bridge_id) ON DELETE CASCADE,
+            connector_type VARCHAR(50) NOT NULL DEFAULT 'tally',
+            status VARCHAR(20) NOT NULL DEFAULT 'disconnected',
+            connected_at TIMESTAMPTZ,
+            disconnected_at TIMESTAMPTZ,
+            last_heartbeat TIMESTAMPTZ,
+            tally_healthy BOOLEAN NOT NULL DEFAULT FALSE,
+            connection_owner VARCHAR(255),
+            process_id INTEGER,
+            reconnect_count INTEGER NOT NULL DEFAULT 0,
+            metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ,
+            CONSTRAINT uq_bridge_sessions_bridge_id UNIQUE (bridge_id)
+        )
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_bridge_sessions_tenant_status "
+        "ON bridge_sessions (tenant_id, status)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_bridge_sessions_tenant_type "
+        "ON bridge_sessions (tenant_id, connector_type)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_bridge_sessions_last_heartbeat "
+        "ON bridge_sessions (last_heartbeat)"
+    )
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS bridge_requests (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+            request_id VARCHAR(100) NOT NULL,
+            bridge_id VARCHAR(100) NOT NULL
+                REFERENCES bridge_registry(bridge_id) ON DELETE CASCADE,
+            connector_type VARCHAR(50) NOT NULL DEFAULT 'tally',
+            method VARCHAR(100) NOT NULL,
+            payload_hash VARCHAR(64) NOT NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'pending',
+            idempotency_key VARCHAR(255),
+            response_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+            result JSONB,
+            error JSONB,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ,
+            sent_at TIMESTAMPTZ,
+            responded_at TIMESTAMPTZ,
+            expires_at TIMESTAMPTZ
+        )
+    """)
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_bridge_requests_request_id "
+        "ON bridge_requests (request_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_bridge_requests_tenant_status "
+        "ON bridge_requests (tenant_id, status)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_bridge_requests_bridge_status "
+        "ON bridge_requests (bridge_id, status)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_bridge_requests_expires_at "
+        "ON bridge_requests (expires_at)"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_bridge_requests_idempotency "
+        "ON bridge_requests (tenant_id, bridge_id, idempotency_key) "
+        "WHERE idempotency_key IS NOT NULL"
+    )
+
+    for table_name in ("bridge_sessions", "bridge_requests"):
+        op.execute(f"ALTER TABLE {table_name} ENABLE ROW LEVEL SECURITY")
+        op.execute(f"ALTER TABLE {table_name} FORCE ROW LEVEL SECURITY")
+        op.execute(f"DROP POLICY IF EXISTS {table_name}_tenant_isolation ON {table_name}")
+        op.execute(f"""
+            CREATE POLICY {table_name}_tenant_isolation ON {table_name}
+            USING (tenant_id::text = current_setting('agenticorg.tenant_id', true))
+            WITH CHECK (tenant_id::text = current_setting('agenticorg.tenant_id', true))
+        """)
+
+
+def downgrade() -> None:
+    for table_name in ("bridge_requests", "bridge_sessions"):
+        op.execute(f"DROP POLICY IF EXISTS {table_name}_tenant_isolation ON {table_name}")
+
+    op.drop_index("uq_bridge_requests_idempotency", table_name="bridge_requests")
+    op.drop_index("ix_bridge_requests_expires_at", table_name="bridge_requests")
+    op.drop_index("ix_bridge_requests_bridge_status", table_name="bridge_requests")
+    op.drop_index("ix_bridge_requests_tenant_status", table_name="bridge_requests")
+    op.drop_index("ix_bridge_requests_request_id", table_name="bridge_requests")
+    op.drop_table("bridge_requests")
+
+    op.drop_index("ix_bridge_sessions_last_heartbeat", table_name="bridge_sessions")
+    op.drop_index("ix_bridge_sessions_tenant_type", table_name="bridge_sessions")
+    op.drop_index("ix_bridge_sessions_tenant_status", table_name="bridge_sessions")
+    op.drop_table("bridge_sessions")

--- a/tests/unit/test_bridge_session_durability.py
+++ b/tests/unit/test_bridge_session_durability.py
@@ -1,0 +1,381 @@
+"""Regression tests for durable bridge session/request state."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from bridge.state import (
+    BRIDGE_HEARTBEAT_STALE_SECONDS,
+    BridgeRouteError,
+    InMemoryBridgeBroker,
+    InMemoryBridgeStateRepository,
+    configure_bridge_state_for_tests,
+    reset_bridge_state_for_tests,
+)
+
+TENANT_A = "11111111-1111-1111-1111-111111111111"
+TENANT_B = "22222222-2222-2222-2222-222222222222"
+
+
+@pytest.fixture
+def bridge_state() -> tuple[InMemoryBridgeStateRepository, InMemoryBridgeBroker]:
+    from bridge import server_handler
+
+    repo = InMemoryBridgeStateRepository()
+    broker = InMemoryBridgeBroker()
+    configure_bridge_state_for_tests(repository=repo, broker=broker)
+    server_handler._active_bridges.clear()
+    server_handler._pending_requests.clear()
+    try:
+        yield repo, broker
+    finally:
+        server_handler._active_bridges.clear()
+        server_handler._pending_requests.clear()
+        reset_bridge_state_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_bridge_heartbeat_persists_status_after_local_registry_clear(bridge_state) -> None:
+    from bridge import server_handler
+    from bridge.server_handler import get_bridge_status, handle_bridge_heartbeat
+
+    repo, _broker = bridge_state
+    await repo.connect_session(
+        bridge_id="bridge-1",
+        tenant_id=TENANT_A,
+        connector_type="tally",
+        tally_healthy=False,
+        owner="pod-a",
+        process_id=1,
+    )
+
+    heartbeat = await handle_bridge_heartbeat(
+        bridge_id="bridge-1",
+        tenant_id=TENANT_A,
+        tally_healthy=True,
+    )
+    server_handler._active_bridges.clear()
+
+    status = await get_bridge_status("bridge-1", tenant_id=TENANT_A)
+    assert heartbeat.tally_healthy is True
+    assert status["connected"] is True
+    assert status["local_connected"] is False
+    assert status["tally_healthy"] is True
+    assert status["last_heartbeat"] is not None
+
+
+@pytest.mark.asyncio
+async def test_route_to_bridge_persists_pending_request_before_publish(bridge_state) -> None:
+    from bridge.server_handler import route_to_bridge
+
+    repo, broker = bridge_state
+    await repo.connect_session(
+        bridge_id="bridge-1",
+        tenant_id=TENANT_A,
+        connector_type="tally",
+        tally_healthy=True,
+        owner="pod-a",
+        process_id=1,
+    )
+
+    saw_persisted_before_publish = False
+
+    async def respond_after_persist(message: dict) -> None:
+        nonlocal saw_persisted_before_publish
+        record = await repo.get_request(message["request_id"])
+        saw_persisted_before_publish = record is not None and record.status == "pending"
+        result = {
+            "type": "response",
+            "request_id": message["request_id"],
+            "status": "ok",
+            "xml_response": "<ENVELOPE/>",
+        }
+        await repo.mark_responded(
+            request_id=message["request_id"],
+            result=result,
+            response_metadata={"source": "test"},
+        )
+        await broker.publish_response(message["request_id"], result)
+
+    await broker.subscribe_requests("bridge-1", respond_after_persist)
+
+    result = await route_to_bridge(
+        "bridge-1",
+        "<ENVELOPE/>",
+        timeout=1,
+        tenant_id=TENANT_A,
+        connector_type="tally",
+        request_id="req-route",
+    )
+
+    record = await repo.get_request("req-route")
+    assert saw_persisted_before_publish is True
+    assert result["status"] == "ok"
+    assert record is not None
+    assert record.status == "responded"
+    assert record.payload_hash
+
+
+@pytest.mark.asyncio
+async def test_timeout_marks_durable_request_timed_out(bridge_state) -> None:
+    from bridge.server_handler import route_to_bridge
+
+    repo, _broker = bridge_state
+    await repo.connect_session(
+        bridge_id="bridge-timeout",
+        tenant_id=TENANT_A,
+        connector_type="tally",
+        tally_healthy=True,
+        owner="pod-a",
+        process_id=1,
+    )
+
+    with pytest.raises(BridgeRouteError) as exc:
+        await route_to_bridge(
+            "bridge-timeout",
+            "<ENVELOPE/>",
+            timeout=0.01,
+            tenant_id=TENANT_A,
+            request_id="req-timeout",
+        )
+
+    record = await repo.get_request("req-timeout")
+    assert exc.value.code == "request_timed_out"
+    assert record is not None
+    assert record.status == "timed_out"
+    assert record.error == {
+        "code": "request_timed_out",
+        "message": "Bridge request timed out",
+    }
+
+
+@pytest.mark.asyncio
+async def test_stale_heartbeat_status_is_unhealthy_and_route_fails(bridge_state) -> None:
+    from bridge.server_handler import get_bridge_status, route_to_bridge
+
+    repo, _broker = bridge_state
+    await repo.connect_session(
+        bridge_id="bridge-stale",
+        tenant_id=TENANT_A,
+        connector_type="tally",
+        tally_healthy=True,
+        owner="pod-a",
+        process_id=1,
+    )
+    repo.sessions["bridge-stale"].last_heartbeat = datetime.now(UTC) - timedelta(
+        seconds=BRIDGE_HEARTBEAT_STALE_SECONDS + 1,
+    )
+
+    status = await get_bridge_status("bridge-stale", tenant_id=TENANT_A)
+    with pytest.raises(BridgeRouteError) as exc:
+        await route_to_bridge(
+            "bridge-stale",
+            "<ENVELOPE/>",
+            timeout=1,
+            tenant_id=TENANT_A,
+            request_id="req-stale",
+        )
+
+    record = await repo.get_request("req-stale")
+    assert status["status"] == "unhealthy"
+    assert status["connected"] is False
+    assert exc.value.code == "bridge_disconnected"
+    assert record is not None
+    assert record.status == "failed"
+    assert record.error == {
+        "code": "bridge_disconnected",
+        "message": "Bridge bridge-stale is disconnected",
+    }
+
+
+@pytest.mark.asyncio
+async def test_broker_unavailable_marks_durable_request_failed(bridge_state) -> None:
+    from bridge.server_handler import route_to_bridge
+
+    repo, _broker = bridge_state
+
+    class FailingBroker(InMemoryBridgeBroker):
+        async def subscribe_response(self, request_id: str, handler):
+            raise RuntimeError("redis unavailable")
+
+    configure_bridge_state_for_tests(repository=repo, broker=FailingBroker())
+    await repo.connect_session(
+        bridge_id="bridge-broker-down",
+        tenant_id=TENANT_A,
+        connector_type="tally",
+        tally_healthy=True,
+        owner="pod-a",
+        process_id=1,
+    )
+
+    with pytest.raises(BridgeRouteError) as exc:
+        await route_to_bridge(
+            "bridge-broker-down",
+            "<ENVELOPE/>",
+            timeout=1,
+            tenant_id=TENANT_A,
+            request_id="req-broker-down",
+        )
+
+    record = await repo.get_request("req-broker-down")
+    assert exc.value.code == "bridge_broker_unavailable"
+    assert record is not None
+    assert record.status == "failed"
+    assert record.error == {
+        "code": "bridge_broker_unavailable",
+        "message": "redis unavailable",
+    }
+
+
+@pytest.mark.asyncio
+async def test_disconnect_marks_outstanding_requests_orphaned(bridge_state) -> None:
+    from bridge.server_handler import handle_bridge_disconnect
+
+    repo, _broker = bridge_state
+    await repo.connect_session(
+        bridge_id="bridge-disconnect",
+        tenant_id=TENANT_A,
+        connector_type="tally",
+        tally_healthy=True,
+        owner="pod-a",
+        process_id=1,
+    )
+    await repo.create_request(
+        request_id="req-orphan",
+        bridge_id="bridge-disconnect",
+        tenant_id=TENANT_A,
+        connector_type="tally",
+        method="post_xml",
+        payload_hash_value="abc123",
+        timeout_seconds=30,
+    )
+    await repo.mark_sent("req-orphan")
+
+    await handle_bridge_disconnect(
+        bridge_id="bridge-disconnect",
+        tenant_id=TENANT_A,
+        reason="socket closed",
+    )
+
+    session = await repo.get_session(bridge_id="bridge-disconnect", tenant_id=TENANT_A)
+    record = await repo.get_request("req-orphan")
+    assert session is not None
+    assert session.status == "disconnected"
+    assert record is not None
+    assert record.status == "orphaned"
+    assert record.error == {"code": "bridge_disconnected", "message": "socket closed"}
+
+
+@pytest.mark.asyncio
+async def test_duplicate_bridge_response_does_not_double_complete_request(bridge_state) -> None:
+    from bridge.server_handler import handle_bridge_response
+
+    repo, broker = bridge_state
+    await repo.create_request(
+        request_id="req-dup",
+        bridge_id="bridge-dup",
+        tenant_id=TENANT_A,
+        connector_type="tally",
+        method="post_xml",
+        payload_hash_value="abc123",
+        timeout_seconds=30,
+    )
+    await repo.mark_sent("req-dup")
+
+    response = {"type": "response", "request_id": "req-dup", "status": "ok", "xml_response": "<ENVELOPE/>"}
+    await handle_bridge_response(response)
+    await handle_bridge_response(response)
+
+    record = await repo.get_request("req-dup")
+    assert record is not None
+    assert record.status == "responded"
+    assert record.response_metadata["duplicate_response_count"] == 1
+    assert len(broker.published_responses) == 1
+
+
+@pytest.mark.asyncio
+async def test_malformed_bridge_response_is_recorded_failed(bridge_state) -> None:
+    from bridge.server_handler import handle_bridge_response
+
+    repo, _broker = bridge_state
+    await repo.create_request(
+        request_id="req-bad",
+        bridge_id="bridge-bad",
+        tenant_id=TENANT_A,
+        connector_type="tally",
+        method="post_xml",
+        payload_hash_value="abc123",
+        timeout_seconds=30,
+    )
+    await repo.mark_sent("req-bad")
+
+    await handle_bridge_response({"type": "response", "request_id": "req-bad", "status": "ok"})
+
+    record = await repo.get_request("req-bad")
+    assert record is not None
+    assert record.status == "failed"
+    assert record.error == {
+        "code": "malformed_response",
+        "message": "Bridge returned a malformed response",
+    }
+
+
+@pytest.mark.asyncio
+async def test_reconnect_updates_same_session(bridge_state) -> None:
+    repo, _broker = bridge_state
+    await repo.connect_session(
+        bridge_id="bridge-reconnect",
+        tenant_id=TENANT_A,
+        connector_type="tally",
+        tally_healthy=False,
+        owner="pod-a",
+        process_id=1,
+    )
+    await repo.disconnect_session(
+        bridge_id="bridge-reconnect",
+        tenant_id=TENANT_A,
+        reason="socket closed",
+    )
+
+    session = await repo.connect_session(
+        bridge_id="bridge-reconnect",
+        tenant_id=TENANT_A,
+        connector_type="tally",
+        tally_healthy=True,
+        owner="pod-b",
+        process_id=2,
+    )
+
+    assert len(repo.sessions) == 1
+    assert session.status == "connected"
+    assert session.reconnect_count == 1
+    assert session.connection_owner == "pod-b"
+
+
+@pytest.mark.asyncio
+async def test_tenant_mismatch_cannot_route_other_tenant_bridge(bridge_state) -> None:
+    from bridge.server_handler import route_to_bridge
+
+    repo, _broker = bridge_state
+    await repo.connect_session(
+        bridge_id="bridge-tenant",
+        tenant_id=TENANT_A,
+        connector_type="tally",
+        tally_healthy=True,
+        owner="pod-a",
+        process_id=1,
+    )
+
+    with pytest.raises(BridgeRouteError) as exc:
+        await route_to_bridge(
+            "bridge-tenant",
+            "<ENVELOPE/>",
+            timeout=0.01,
+            tenant_id=TENANT_B,
+            request_id="req-cross-tenant",
+        )
+
+    assert exc.value.code == "tenant_mismatch"
+    assert await repo.get_request("req-cross-tenant") is None

--- a/tests/unit/test_production_components.py
+++ b/tests/unit/test_production_components.py
@@ -448,14 +448,34 @@ class TestAAConsentTypes:
 class TestBridgeServerHandler:
     """Test the cloud-side bridge connection manager."""
 
-    def test_get_status_disconnected(self):
+    @pytest.mark.asyncio
+    async def test_get_status_disconnected(self):
         from bridge.server_handler import get_bridge_status
+        from bridge.state import (
+            InMemoryBridgeStateRepository,
+            configure_bridge_state_for_tests,
+            reset_bridge_state_for_tests,
+        )
 
-        status = get_bridge_status("nonexistent-bridge")
-        assert status["connected"] is False
+        configure_bridge_state_for_tests(repository=InMemoryBridgeStateRepository())
+        try:
+            status = await get_bridge_status("nonexistent-bridge")
+            assert status["connected"] is False
+        finally:
+            reset_bridge_state_for_tests()
 
-    def test_list_active_bridges_empty(self):
+    @pytest.mark.asyncio
+    async def test_list_active_bridges_empty(self):
         from bridge.server_handler import list_active_bridges
+        from bridge.state import (
+            InMemoryBridgeStateRepository,
+            configure_bridge_state_for_tests,
+            reset_bridge_state_for_tests,
+        )
 
-        bridges = list_active_bridges()
-        assert isinstance(bridges, list)
+        configure_bridge_state_for_tests(repository=InMemoryBridgeStateRepository())
+        try:
+            bridges = await list_active_bridges()
+            assert isinstance(bridges, list)
+        finally:
+            reset_bridge_state_for_tests()

--- a/tests/unit/test_tally_connector_health_and_errors.py
+++ b/tests/unit/test_tally_connector_health_and_errors.py
@@ -41,10 +41,12 @@ class TestTallyExceptionHierarchy:
             "Tally rejected it",
             detail="LINEERROR: Company not open",
             request_id="req-123",
+            error_category="tally_business_error",
         )
         assert str(exc) == "Tally rejected it"
         assert exc.detail == "LINEERROR: Company not open"
         assert exc.request_id == "req-123"
+        assert exc.error_category == "tally_business_error"
 
 
 class TestExtractTallyError:
@@ -127,6 +129,49 @@ class TestTallyHealthCheckBridge:
         ):
             result = await connector.health_check()
         assert result["status"] == "bridge_error"
+
+    @pytest.mark.asyncio
+    async def test_bridge_http_error_surfaces_durable_request_metadata(self) -> None:
+        connector = TallyConnector({
+            "bridge_url": "http://bridge.test/api",
+            "bridge_id": "bid-1",
+            "bridge_token": "tok-1",
+        })
+
+        class FakeResponse:
+            status_code = 504
+            text = "gateway timeout"
+
+            def json(self) -> dict:
+                return {
+                    "detail": {
+                        "message": "Bridge request timed out after 30s",
+                        "request_id": "durable-req-1",
+                        "error_category": "request_timed_out",
+                        "bridge_id": "bid-1",
+                    }
+                }
+
+        class FakeAsyncClient:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+            async def __aenter__(self) -> FakeAsyncClient:
+                return self
+
+            async def __aexit__(self, *args) -> None:
+                return None
+
+            async def post(self, *args, **kwargs) -> FakeResponse:
+                return FakeResponse()
+
+        with patch("httpx.AsyncClient", FakeAsyncClient):
+            with pytest.raises(TallyBridgeError) as exc_info:
+                await connector._send_via_bridge("<ENVELOPE/>")
+
+        assert exc_info.value.request_id == "durable-req-1"
+        assert exc_info.value.error_category == "request_timed_out"
+        assert exc_info.value.detail == "Bridge request timed out after 30s"
 
     @pytest.mark.asyncio
     async def test_health_check_never_raises(self) -> None:


### PR DESCRIPTION
## Summary
- Adds durable PostgreSQL bridge session and bridge request lifecycle tables/models with tenant RLS and idempotency indexes.
- Replaces process-local bridge status/request authority with a DB-first repository and broker abstraction; local maps remain socket/waiter acceleration only.
- Routes bridge requests through a shared broker, persists pending/sent/responded/timed_out/failed/orphaned states, and handles disconnects, duplicate responses, malformed responses, stale heartbeats, broker failures, and tenant mismatch deterministically.
- Updates bridge status/list APIs and Tally connector bridge errors to surface durable request IDs and categories.

## Validation
- `python -m pytest tests/unit/test_bridge_session_durability.py tests/unit/test_tally_connector_health_and_errors.py tests/unit/test_production_components.py -q`
- `python -m pytest tests/regression/test_ramesh_bugs_april2026.py -q`
- `python -m pytest tests/unit/test_ca_security.py -q`
- `python -m ruff check bridge/state.py bridge/server_handler.py api/v1/bridge.py core/models/bridge.py core/models/__init__.py connectors/finance/tally.py tests/unit/test_bridge_session_durability.py tests/unit/test_production_components.py tests/unit/test_tally_connector_health_and_errors.py migrations/versions/v4_9_15_bridge_session_durability.py`
- `python -m compileall bridge api/v1/bridge.py connectors/finance/tally.py core/models/bridge.py tests/unit/test_bridge_session_durability.py`
- `python -m alembic heads`
- `python -m alembic upgrade v4912_workflow_event_waits:v4915_bridge_durability --sql`

## Notes
- Based on PR #550 branch because it is still open/unmerged.
- This intentionally adds a unique `v4915_bridge_durability` head from `v4912_workflow_event_waits`; later merge-head handling is documented in the migration because PR #553/#554 also branch from v4912.
- Live DB integration tests were not run locally because `AGENTICORG_DB_URL` is unset.