### PR TITLE
fix: require alembic-managed schema at runtime

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
 from uuid import UUID
 
+from alembic.config import Config
+from alembic.script import ScriptDirectory
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import (
+    AsyncConnection,
     AsyncEngine,
     AsyncSession,
     async_sessionmaker,
@@ -16,7 +22,28 @@ from sqlalchemy.ext.asyncio import (
 )
 from sqlalchemy.orm import DeclarativeBase, MappedAsDataclass
 
-from core.config import settings
+from core.config import is_strict_runtime_env, settings
+
+logger = logging.getLogger(__name__)
+
+ALEMBIC_VERSION_TABLE = "alembic_version"
+ALEMBIC_CONFIG_PATH = Path(__file__).resolve().parents[1] / "alembic.ini"
+ALLOW_MULTIPLE_ALEMBIC_HEADS_ENV = "AGENTICORG_ALLOW_MULTIPLE_ALEMBIC_HEADS_FOR_MERGE_PR"
+ENABLE_LEGACY_STARTUP_DDL_ENV = "AGENTICORG_ENABLE_LEGACY_STARTUP_DDL"
+TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
+
+
+class RuntimeSchemaError(RuntimeError):
+    """Raised when a runtime DB is not at the Alembic revision this app expects."""
+
+
+@dataclass(frozen=True)
+class RuntimeSchemaVerification:
+    """Result of an Alembic runtime schema verification."""
+
+    database_versions: frozenset[str]
+    expected_heads: frozenset[str]
+    multiple_heads_allowed: bool = False
 
 
 class Base(DeclarativeBase, MappedAsDataclass):
@@ -72,25 +99,119 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
             raise
 
 
-async def init_db() -> None:
-    """Run on startup — verify connectivity and (legacy) apply schema additions.
+def _truthy_env(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in TRUTHY_ENV_VALUES
 
-    When ``AGENTICORG_DDL_MANAGED_BY_ALEMBIC`` is truthy (preferred), this
-    only verifies DB connectivity; schema evolution must come from
-    ``alembic upgrade head`` in the deploy pipeline.
 
-    The legacy DDL blocks below are kept as a safety net during the
-    cutover for existing environments that have not yet been stamped.
-    """
-    alembic_managed = os.getenv("AGENTICORG_DDL_MANAGED_BY_ALEMBIC", "").lower() in (
-        "1",
-        "true",
-        "yes",
+def get_expected_alembic_heads() -> frozenset[str]:
+    """Return the migration script heads bundled with this application build."""
+    script = ScriptDirectory.from_config(Config(str(ALEMBIC_CONFIG_PATH)))
+    return frozenset(script.get_heads())
+
+
+def _multiple_alembic_heads_allowed() -> bool:
+    return _truthy_env(ALLOW_MULTIPLE_ALEMBIC_HEADS_ENV)
+
+
+def _schema_error(message: str) -> RuntimeSchemaError:
+    return RuntimeSchemaError(f"{message} Run `python scripts/alembic_migrate.py` before starting the app.")
+
+
+async def get_database_alembic_versions(conn: AsyncConnection) -> frozenset[str]:
+    """Read the DB's Alembic revisions from the authoritative version table."""
+    table_exists = await conn.scalar(text("SELECT to_regclass('public.alembic_version') IS NOT NULL"))
+    if not table_exists:
+        raise _schema_error("Database is not Alembic-managed: missing `alembic_version` table.")
+
+    result = await conn.execute(text("SELECT version_num FROM alembic_version"))
+    versions = frozenset(str(version) for version in result.scalars().all() if version)
+    if not versions:
+        raise _schema_error("Database is not Alembic-managed: `alembic_version` has no rows.")
+    return versions
+
+
+async def verify_runtime_schema_current(
+    conn: AsyncConnection,
+    *,
+    expected_heads: frozenset[str] | set[str] | None = None,
+) -> RuntimeSchemaVerification:
+    """Fail if the connected DB is missing, stale, or divergent from Alembic heads."""
+    expected = frozenset(expected_heads or get_expected_alembic_heads())
+    if not expected:
+        raise _schema_error("Application has no Alembic heads to verify against.")
+
+    multiple_heads_allowed = _multiple_alembic_heads_allowed()
+    if len(expected) > 1 and not multiple_heads_allowed:
+        heads = ", ".join(sorted(expected))
+        raise _schema_error(
+            "Application has multiple Alembic heads without an approved merge-head plan "
+            f"({heads}). Add an Alembic merge revision or explicitly set "
+            f"`{ALLOW_MULTIPLE_ALEMBIC_HEADS_ENV}=1` only for a merge-head PR."
+        )
+
+    versions = await get_database_alembic_versions(conn)
+    if len(versions) > 1 and versions != expected:
+        current = ", ".join(sorted(versions))
+        wanted = ", ".join(sorted(expected))
+        raise _schema_error(
+            f"Database has multiple Alembic versions ({current}) but this build expects ({wanted})."
+        )
+
+    if versions != expected:
+        current = ", ".join(sorted(versions))
+        wanted = ", ".join(sorted(expected))
+        raise _schema_error(
+            f"Database schema revision is stale or divergent: current=({current}), expected=({wanted})."
+        )
+
+    return RuntimeSchemaVerification(
+        database_versions=versions,
+        expected_heads=expected,
+        multiple_heads_allowed=multiple_heads_allowed,
     )
+
+
+async def init_db() -> None:
+    """Run on startup: verify connectivity and Alembic-managed schema state.
+
+    Strict runtimes fail closed when the database is not at the exact Alembic
+    head(s) bundled with this app build. Startup DDL is forbidden there.
+    """
     async with engine.begin() as conn:
         await conn.execute(text("SELECT 1"))
-    if alembic_managed:
-        return
+        if is_strict_runtime_env(settings.env):
+            await verify_runtime_schema_current(conn)
+            return
+
+        if not _truthy_env(ENABLE_LEGACY_STARTUP_DDL_ENV):
+            try:
+                await verify_runtime_schema_current(conn)
+            except RuntimeSchemaError as exc:
+                logger.warning("Relaxed runtime schema verification did not pass: %s", exc)
+            await _seed_demo_ca_companies_if_enabled()
+            return
+
+    await _legacy_startup_schema_repair_for_local_only()
+
+
+async def _legacy_startup_schema_repair_for_local_only() -> None:
+    """Local-only emergency schema repair path retained for unstamped dev DBs."""
+    if is_strict_runtime_env(settings.env):
+        raise RuntimeSchemaError(
+            f"`{ENABLE_LEGACY_STARTUP_DDL_ENV}` is ignored in strict runtimes; "
+            "run `python scripts/alembic_migrate.py` instead."
+        )
+    if not _truthy_env(ENABLE_LEGACY_STARTUP_DDL_ENV):
+        raise RuntimeSchemaError(
+            f"Legacy startup DDL is disabled unless `{ENABLE_LEGACY_STARTUP_DDL_ENV}=1` is set "
+            "in a relaxed local/dev/test environment."
+        )
+    if os.getenv("AGENTICORG_DDL_MANAGED_BY_ALEMBIC"):
+        logger.warning(
+            "`AGENTICORG_DDL_MANAGED_BY_ALEMBIC` no longer controls startup DDL; "
+            "using `%s=1` because the runtime is relaxed.",
+            ENABLE_LEGACY_STARTUP_DDL_ENV,
+        )
 
     async with engine.begin() as conn:
         # Serialize startup DDL across concurrently-booting pods with a
@@ -845,18 +966,21 @@ async def init_db() -> None:
             FOR EACH ROW EXECUTE FUNCTION audit_log_reject_mutation();
         """))
 
-    # Seed demo CA companies ONLY in demo/dev environments — never in production
-    if os.getenv("AGENTICORG_ENV", "production").lower() in ("demo", "development", "dev"):
-        try:
-            from core.seed_ca_demo import seed_ca_demo
+    await _seed_demo_ca_companies_if_enabled()
 
-            async with async_session_factory() as session:
-                await seed_ca_demo(session)
-                await session.commit()
-        except Exception as exc:
-            import logging as _logging
 
-            _logging.getLogger(__name__).debug("CA demo seed skipped: %s", exc)
+async def _seed_demo_ca_companies_if_enabled() -> None:
+    """Seed demo CA companies in relaxed demo/dev environments only."""
+    if os.getenv("AGENTICORG_ENV", "production").lower() not in ("demo", "development", "dev"):
+        return
+    try:
+        from core.seed_ca_demo import seed_ca_demo
+
+        async with async_session_factory() as session:
+            await seed_ca_demo(session)
+            await session.commit()
+    except Exception as exc:
+        logger.debug("CA demo seed skipped: %s", exc)
 
 
 async def close_db() -> None:

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -11,13 +11,18 @@ step in `.github/workflows/deploy.yml`. The wrapper is idempotent:
 | Legacy schema (tables but no `alembic_version`)         | `stamp v480_baseline` + `upgrade head` |
 | Empty DB                                                | `alembic upgrade head` from base       |
 
-The Helm chart sets `AGENTICORG_DDL_MANAGED_BY_ALEMBIC=true` so the
-runtime startup path (`core.database.init_db()`) only verifies DB
-connectivity and does **not** issue DDL.
+Application startup is now verify-only in strict runtimes
+(`production`, `staging`, `preview`, and unknown environments).
+`core.database.init_db()` checks database connectivity, verifies that
+`alembic_version` exists, and fails fast unless the DB revision exactly
+matches the Alembic head(s) bundled with the running app. It does
+**not** issue `CREATE`, `ALTER`, `ENABLE RLS`, policy, trigger, or index
+DDL in strict runtimes.
 
-The legacy DDL blocks in `init_db()` are retained as a compatibility net
-for environments that have not yet been stamped; they are no-ops once the
-flag is set.
+The old `AGENTICORG_DDL_MANAGED_BY_ALEMBIC` flag is no longer a safety
+boundary. The only remaining legacy startup repair path is
+`AGENTICORG_ENABLE_LEGACY_STARTUP_DDL=1`, and that helper refuses to run
+outside relaxed local/dev/test/ci environments.
 
 ## Version chain
 
@@ -45,9 +50,10 @@ v480_baseline              → v4.8.0  Alembic cutover (kpi_cache,
 3. Write idempotent DDL in `upgrade()` (`CREATE ... IF NOT EXISTS`,
    guarded `ALTER`). Include a matching `downgrade()` when safe.
 4. Run `alembic upgrade head` locally against a dev DB to validate.
-5. Push. CI enforces that any change under `core/models/` or
-   `core/database.py` includes a new migration
-   (`scripts/check_migration_required.py`).
+5. Push. CI enforces that any ORM model change, or any new schema DDL
+   added to `core/database.py`, includes a new migration
+   (`scripts/check_migration_required.py`). The same guard fails on
+   multiple Alembic heads unless the PR is explicitly a merge-head PR.
 
 ## Stamping on an existing environment
 
@@ -73,11 +79,41 @@ alembic stamp v480_baseline
 alembic revision -m "add foo column to bar"
 ```
 
+Local startup defaults to verification, not mutation. To repair an old
+unstamped developer DB during migration testing, set
+`AGENTICORG_ENABLE_LEGACY_STARTUP_DDL=1` in a relaxed environment and
+start the app once. Do not use that flag for production, staging, or
+preview.
+
+Production and staging runtime users should not have DDL privileges when
+the platform can enforce separate migration and application DB roles.
+
 ## Why `init_db()` still contains DDL
 
-During cutover, some dev/staging environments may not yet be stamped.
-Keeping the legacy DDL behind the
-`AGENTICORG_DDL_MANAGED_BY_ALEMBIC` flag means those environments still
-self-heal on pod boot, while production and CI (which set the flag) get
-the strict Alembic-managed path. Once every environment is stamped, the
-legacy DDL can be deleted in a follow-up PR.
+The legacy DDL is quarantined in
+`_legacy_startup_schema_repair_for_local_only()` only for local
+unstamped database repair. It is not a production compatibility net.
+Once all developer and demo DBs are stamped, delete the helper in a
+follow-up PR.
+
+## Parallel-head merge strategy
+
+This branch is intentionally independent and currently contains only the
+workflow durability head `v4912_workflow_event_waits`, so it does not add
+a merge revision.
+
+The P0 durability branches that were expected to create parallel heads
+from `v4912` are:
+
+- PR #553 CDC webhook durability
+- PR #554 WebSocket feed durability
+- PR #556 bridge session durability
+
+When those migrations are all present in one branch, create an empty
+Alembic merge revision, for example
+`v4916_merge_p0_durability_heads`, with `down_revision` set to the
+tuple of the CDC, feed, and bridge head revisions. That merge revision
+must be the only head after the PR lands. CI should only allow multiple
+heads temporarily by setting
+`AGENTICORG_ALLOW_MULTIPLE_ALEMBIC_HEADS_FOR_MERGE_PR=1` on the
+explicit merge-head PR.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,8 +1,9 @@
 """Alembic environment for AgenticOrg.
 
 Schema authority: migration files under ``migrations/versions/``.
-Runtime startup DDL in ``core.database.init_db()`` is legacy compat only,
-and is skipped when ``AGENTICORG_DDL_MANAGED_BY_ALEMBIC=true``.
+Strict runtime startup in ``core.database.init_db()`` verifies the
+``alembic_version`` table and never issues DDL. Legacy startup repair is
+local-only and requires ``AGENTICORG_ENABLE_LEGACY_STARTUP_DDL=1``.
 
 Cutover steps for an existing environment:
 

--- a/scripts/check_migration_required.py
+++ b/scripts/check_migration_required.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""CI guard: fail if a PR changes ORM models or init_db() without a migration.
+"""CI guard: fail if a PR changes schema-bearing files without a migration.
 
 Compares the current ref to a base ref (``origin/main`` by default, override
-with ``BASE_REF``). If any file under ``core/models/`` or ``core/database.py``
-changed but no new file was added under ``migrations/versions/``, the script
-exits non-zero.
+with ``BASE_REF``). If any ORM model file changed, or ``core/database.py``
+adds startup-time DDL, but no new file was added under
+``migrations/versions/``, the script exits non-zero. It also rejects multiple
+Alembic heads unless this is an explicit merge-head PR.
 
 Run locally:
 
@@ -17,10 +18,23 @@ import os
 import subprocess
 import sys
 
-MODEL_PREFIXES = ("core/models/", "core/database.py")
 MIGRATION_PREFIX = "migrations/versions/"
+CORE_DATABASE_FILE = "core/database.py"
+ALLOW_MULTIPLE_ALEMBIC_HEADS_ENV = "AGENTICORG_ALLOW_MULTIPLE_ALEMBIC_HEADS_FOR_MERGE_PR"
 
-# Files under MODEL_PREFIXES that never carry schema DDL. Re-export-only
+SCHEMA_DDL_PATTERNS = (
+    "ALTER TABLE",
+    "CREATE INDEX",
+    "CREATE OR REPLACE FUNCTION",
+    "CREATE POLICY",
+    "CREATE TABLE",
+    "CREATE TRIGGER",
+    "DROP POLICY",
+    "DROP TRIGGER",
+    "ENABLE ROW LEVEL SECURITY",
+)
+
+# Files under schema-relevant paths that never carry schema DDL. Re-export-only
 # packages can be touched without a migration — adding them here keeps
 # the guard honest instead of forcing meaningless empty migrations.
 IGNORED_MODEL_FILES = frozenset({
@@ -51,19 +65,73 @@ def _added_files(base: str, head: str) -> list[str]:
     return [line.strip() for line in out.splitlines() if line.strip()]
 
 
+def _diff(base: str, head: str, path: str) -> str:
+    try:
+        return _git("diff", "-U0", f"{base}...{head}", "--", path)
+    except subprocess.CalledProcessError:
+        return _git("diff", "-U0", base, head, "--", path)
+
+
+def _core_database_added_schema_ddl(base: str, head: str) -> bool:
+    added_lines = [
+        line[1:].strip().upper()
+        for line in _diff(base, head, CORE_DATABASE_FILE).splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    ]
+    return any(pattern in line for line in added_lines for pattern in SCHEMA_DDL_PATTERNS)
+
+
+def _schema_relevant_changed_files(base: str, head: str, changed: list[str]) -> list[str]:
+    relevant = []
+    for path in changed:
+        if path in IGNORED_MODEL_FILES:
+            continue
+        if path == CORE_DATABASE_FILE:
+            if _core_database_added_schema_ddl(base, head):
+                relevant.append(path)
+            continue
+        if path.startswith("core/models/"):
+            relevant.append(path)
+    return relevant
+
+
+def _truthy_env(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _alembic_heads() -> list[str]:
+    out = subprocess.check_output(  # noqa: S603
+        [sys.executable, "-m", "alembic", "heads"],
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return [line.split()[0] for line in out.splitlines() if line.strip()]
+
+
+def _multiple_heads_allowed() -> bool:
+    return _truthy_env(ALLOW_MULTIPLE_ALEMBIC_HEADS_ENV)
+
+
 def main() -> int:
     base = os.getenv("BASE_REF", "origin/main")
     head = os.getenv("HEAD_REF", "HEAD")
 
+    alembic_heads = _alembic_heads()
+    if len(alembic_heads) > 1 and not _multiple_heads_allowed():
+        print("::error::Multiple Alembic heads detected without an explicit merge-head plan.", file=sys.stderr)
+        for revision in alembic_heads:
+            print(f"  - {revision}", file=sys.stderr)
+        print(
+            "\nAdd an Alembic merge revision so production has one head, or set "
+            f"{ALLOW_MULTIPLE_ALEMBIC_HEADS_ENV}=1 only on an explicit merge-head PR.",
+            file=sys.stderr,
+        )
+        return 1
+
     changed = _changed_files(base, head)
     added = _added_files(base, head)
 
-    model_touched = [
-        f
-        for f in changed
-        if any(f.startswith(p) or f == p for p in MODEL_PREFIXES)
-        and f not in IGNORED_MODEL_FILES
-    ]
+    model_touched = _schema_relevant_changed_files(base, head, changed)
     migration_added = [f for f in added if f.startswith(MIGRATION_PREFIX) and f.endswith(".py")]
 
     if model_touched and not migration_added:

--- a/scripts/deploy_cloud_run.sh
+++ b/scripts/deploy_cloud_run.sh
@@ -15,7 +15,8 @@
 #      (Dockerfile.ui) tagged with the deploy SHA + :latest.
 #   3. Optionally run alembic migrations as a Cloud Run job
 #      (--with-migrations, requires an `agenticorg-migrate` job
-#      to already exist; create it with --create-migrate-job).
+#      to already exist; create it with --create-migrate-job). Runtime
+#      app startup is verify-only; it must not perform schema DDL.
 #   4. `gcloud run services update agenticorg-api` with the new
 #      image + AGENTICORG_GIT_SHA env var so /health surfaces the
 #      deployed commit (Codex 2026-04-24 enterprise sign-off
@@ -174,7 +175,7 @@ if [[ $CREATE_MIGRATE_JOB -eq 1 ]]; then
       --image="$API_IMAGE" \
       --command="python" \
       --args="scripts/alembic_migrate.py" \
-      --set-env-vars="AGENTICORG_DDL_MANAGED_BY_ALEMBIC=true"
+      --set-env-vars="AGENTICORG_ENABLE_LEGACY_STARTUP_DDL=0"
   else
     run gcloud run jobs create "$MIGRATE_JOB" \
       --project="$GCP_PROJECT_ID" \
@@ -182,7 +183,7 @@ if [[ $CREATE_MIGRATE_JOB -eq 1 ]]; then
       --image="$API_IMAGE" \
       --command="python" \
       --args="scripts/alembic_migrate.py" \
-      --set-env-vars="AGENTICORG_DDL_MANAGED_BY_ALEMBIC=true"
+      --set-env-vars="AGENTICORG_ENABLE_LEGACY_STARTUP_DDL=0"
   fi
 fi
 

--- a/scripts/local_e2e.sh
+++ b/scripts/local_e2e.sh
@@ -244,12 +244,11 @@ export AGENTICORG_PII_MASKING="true"
 #
 # This mirrors what tests/integration/test_alembic_e2e.py does to stage
 # a legacy-shaped DB before the alembic chain takes over. Without this,
-# the API's init_db() would try ALTER TABLE on `agents` before the
-# table exists (since the compose postgres is fresh and we skipped the
-# legacy initdb.d SQL). We tell init_db to no-op via
-# AGENTICORG_DDL_MANAGED_BY_ALEMBIC=1 and let alembic own the schema.
+# app startup verifies Alembic state and does not run schema DDL unless
+# the local-only repair flag is explicitly enabled. Keep that flag unset
+# here so Alembic owns the schema.
 # ---------------------------------------------------------------------------
-export AGENTICORG_DDL_MANAGED_BY_ALEMBIC=1
+unset AGENTICORG_ENABLE_LEGACY_STARTUP_DDL
 
 log "Bootstrapping schema (ORM metadata.create_all + alembic stamp + upgrade)"
 "$PYTHON_BIN" -c "
@@ -268,9 +267,8 @@ print('ORM create_all complete')
 ok "schema bootstrap complete"
 
 # Seed the CA demo tenant + demo user (ceo@agenticorg.local). In the
-# normal API startup path this runs inside init_db(), but we disabled
-# that path with AGENTICORG_DDL_MANAGED_BY_ALEMBIC=1 so the schema owner
-# is alembic, not init_db. Call the seeder directly here.
+# normal API startup path can skip demo seed when schema verification is
+# the only startup action, so call the seeder directly here.
 log "Seeding CA demo tenant + users"
 "$PYTHON_BIN" -c "
 import asyncio

--- a/tests/regression/test_qa_27apr_sweep.py
+++ b/tests/regression/test_qa_27apr_sweep.py
@@ -55,22 +55,29 @@ def test_tc_001_report_schedule_surfaces_exception_class() -> None:
     assert "Could not load report schedules ({exc_class}:" in src
 
 
-def test_tc_001_report_schedules_table_self_heal_in_init_db() -> None:
-    """init_db must create report_schedules + index + RLS.
+def test_tc_001_report_schedules_table_is_alembic_managed_not_startup_ddl() -> None:
+    """report_schedules must be created by Alembic, not strict startup DDL.
 
     Pinned because the 27-Apr re-reopen of TC_001 had a hidden second
     layer: instrumentation surfaced the exception class but the
     underlying error was ``UndefinedTableError: relation
-    "report_schedules" does not exist``. The v4.4.0 alembic migration
-    was the canonical creator, but envs stamped past that revision
-    (e.g. prod 2026-04-22 cutover) ended up with no table. Without
-    this safety net, every fresh prod env regresses TC_001.
+    "report_schedules" does not exist``. The fix is now an Alembic
+    migration plus strict startup verification, not production self-heal
+    DDL in ``init_db``.
     """
+    migration = (REPO / "migrations" / "versions" / "v4_9_6_report_schedules_recreate.py").read_text(
+        encoding="utf-8"
+    )
+    assert "CREATE TABLE IF NOT EXISTS report_schedules" in migration
+    assert "ix_report_schedules_tenant_company" in migration
+    assert "CREATE POLICY report_schedules_tenant_isolation" in migration
+
     src = (REPO / "core" / "database.py").read_text(encoding="utf-8")
-    assert "CREATE TABLE IF NOT EXISTS report_schedules" in src
-    assert "ix_report_schedules_tenant_company" in src
-    # Must be in the RLS list so cross-tenant reads are blocked.
-    assert '"report_schedules",' in src
+    init_db_block = src.split("async def init_db", 1)[1].split(
+        "async def _legacy_startup_schema_repair_for_local_only", 1
+    )[0]
+    assert "CREATE TABLE IF NOT EXISTS report_schedules" not in init_db_block
+    assert "verify_runtime_schema_current" in init_db_block
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/tests/unit/test_migration_guard.py
+++ b/tests/unit/test_migration_guard.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from scripts import check_migration_required as guard
+
+
+def test_core_database_verification_changes_do_not_require_migration(monkeypatch) -> None:
+    monkeypatch.setattr(
+        guard,
+        "_diff",
+        lambda *_args: "+async def verify_runtime_schema_current(conn):\n+    raise RuntimeSchemaError('stale')",
+    )
+
+    assert guard._schema_relevant_changed_files("base", "head", ["core/database.py"]) == []
+
+
+def test_core_database_added_ddl_requires_migration(monkeypatch) -> None:
+    monkeypatch.setattr(
+        guard,
+        "_diff",
+        lambda *_args: '+await conn.execute(text("ALTER TABLE agents ADD COLUMN foo TEXT"))',
+    )
+
+    assert guard._schema_relevant_changed_files("base", "head", ["core/database.py"]) == ["core/database.py"]
+
+
+def test_multiple_alembic_heads_fail_without_merge_plan(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(guard, "_alembic_heads", lambda: ["head_a", "head_b"])
+    monkeypatch.setattr(guard, "_changed_files", lambda *_args: [])
+    monkeypatch.setattr(guard, "_added_files", lambda *_args: [])
+    monkeypatch.delenv(guard.ALLOW_MULTIPLE_ALEMBIC_HEADS_ENV, raising=False)
+
+    assert guard.main() == 1
+    assert "Multiple Alembic heads detected" in capsys.readouterr().err
+
+
+def test_multiple_alembic_heads_allowed_for_explicit_merge_plan(monkeypatch) -> None:
+    monkeypatch.setattr(guard, "_alembic_heads", lambda: ["head_a", "head_b"])
+    monkeypatch.setattr(guard, "_changed_files", lambda *_args: [])
+    monkeypatch.setattr(guard, "_added_files", lambda *_args: [])
+    monkeypatch.setenv(guard.ALLOW_MULTIPLE_ALEMBIC_HEADS_ENV, "1")
+
+    assert guard.main() == 0

--- a/tests/unit/test_module_22_cross_cutting.py
+++ b/tests/unit/test_module_22_cross_cutting.py
@@ -136,12 +136,23 @@ def test_tc_cc_005_per_agent_advisory_lock_pattern_pinned() -> None:
     assert "lock_key = abs(hash(str(agent_id))) % (2**31)" in src
 
 
-def test_tc_cc_005_init_db_advisory_lock_for_startup_ddl() -> None:
-    """Rolling deploys can race on ALTER TABLE ENABLE ROW LEVEL
-    SECURITY (the April 16 outage). The startup DDL block must
-    use a transaction-scoped advisory lock to serialize."""
+def test_tc_cc_005_init_db_strict_path_is_verify_only() -> None:
+    """Strict startup must verify Alembic state and never enter DDL."""
     src = (REPO / "core" / "database.py").read_text(encoding="utf-8")
-    assert "pg_advisory_xact_lock(4815162342)" in src
+    init_db_block = src.split("async def init_db", 1)[1].split(
+        "async def _legacy_startup_schema_repair_for_local_only", 1
+    )[0]
+    assert "verify_runtime_schema_current" in init_db_block
+    for ddl in ("CREATE TABLE", "ALTER TABLE", "CREATE POLICY", "ENABLE ROW LEVEL SECURITY"):
+        assert ddl not in init_db_block
+
+
+def test_tc_cc_005_legacy_startup_ddl_still_serializes_when_opted_in() -> None:
+    """The local-only legacy repair helper still serializes DDL if explicitly enabled."""
+    src = (REPO / "core" / "database.py").read_text(encoding="utf-8")
+    legacy_block = src.split("async def _legacy_startup_schema_repair_for_local_only", 1)[1]
+    assert "ENABLE_LEGACY_STARTUP_DDL_ENV" in legacy_block
+    assert "pg_advisory_xact_lock(4815162342)" in legacy_block
 
 
 # ─────────────────────────────────────────────────────────────────

--- a/tests/unit/test_runtime_schema_verification.py
+++ b/tests/unit/test_runtime_schema_verification.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from core import database
+
+DDL_PATTERNS = (
+    "ALTER TABLE",
+    "CREATE INDEX",
+    "CREATE POLICY",
+    "CREATE TABLE",
+    "CREATE TRIGGER",
+    "ENABLE ROW LEVEL SECURITY",
+)
+
+
+class _FakeScalars:
+    def __init__(self, values: list[str]) -> None:
+        self._values = values
+
+    def all(self) -> list[str]:
+        return self._values
+
+
+class _FakeResult:
+    def __init__(self, values: list[str] | None = None) -> None:
+        self._values = values or []
+
+    def scalars(self) -> _FakeScalars:
+        return _FakeScalars(self._values)
+
+
+class _FakeConnection:
+    def __init__(self, *, alembic_table_exists: bool = True, versions: list[str] | None = None) -> None:
+        self.alembic_table_exists = alembic_table_exists
+        self.versions = versions or ["head"]
+        self.statements: list[str] = []
+
+    async def execute(self, statement: object) -> _FakeResult:
+        sql = str(statement)
+        self.statements.append(sql)
+        if "SELECT version_num FROM alembic_version" in sql:
+            return _FakeResult(self.versions)
+        return _FakeResult()
+
+    async def scalar(self, statement: object) -> bool:
+        sql = str(statement)
+        self.statements.append(sql)
+        if "to_regclass" in sql:
+            return self.alembic_table_exists
+        return True
+
+
+class _FakeBegin:
+    def __init__(self, conn: _FakeConnection) -> None:
+        self.conn = conn
+
+    async def __aenter__(self) -> _FakeConnection:
+        return self.conn
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+
+class _FakeEngine:
+    def __init__(self, conn: _FakeConnection) -> None:
+        self.conn = conn
+
+    def begin(self) -> _FakeBegin:
+        return _FakeBegin(self.conn)
+
+
+def _contains_ddl(statements: list[str]) -> bool:
+    joined = "\n".join(statements).upper()
+    return any(pattern in joined for pattern in DDL_PATTERNS)
+
+
+def _patch_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    conn: _FakeConnection,
+    *,
+    env: str,
+    expected_heads: set[str] | None = None,
+) -> None:
+    monkeypatch.setattr(database, "engine", _FakeEngine(conn))
+    monkeypatch.setattr(database, "settings", SimpleNamespace(env=env))
+    monkeypatch.setattr(database, "get_expected_alembic_heads", lambda: frozenset(expected_heads or {"head"}))
+
+    async def _noop_seed() -> None:
+        return None
+
+    monkeypatch.setattr(database, "_seed_demo_ca_companies_if_enabled", _noop_seed)
+
+
+@pytest.mark.asyncio
+async def test_strict_env_missing_alembic_version_fails_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = _FakeConnection(alembic_table_exists=False)
+    _patch_runtime(monkeypatch, conn, env="production")
+
+    with pytest.raises(database.RuntimeSchemaError, match="missing `alembic_version`"):
+        await database.init_db()
+
+    assert not _contains_ddl(conn.statements)
+
+
+@pytest.mark.asyncio
+async def test_strict_env_stale_revision_fails_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = _FakeConnection(versions=["old_head"])
+    _patch_runtime(monkeypatch, conn, env="staging")
+
+    with pytest.raises(database.RuntimeSchemaError, match="stale or divergent"):
+        await database.init_db()
+
+    assert not _contains_ddl(conn.statements)
+
+
+@pytest.mark.asyncio
+async def test_strict_env_current_revision_passes_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = _FakeConnection(versions=["head"])
+    _patch_runtime(monkeypatch, conn, env="preview")
+
+    await database.init_db()
+
+    assert not _contains_ddl(conn.statements)
+
+
+@pytest.mark.asyncio
+async def test_strict_env_ignores_legacy_flags_and_never_runs_ddl(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = _FakeConnection(versions=["head"])
+    _patch_runtime(monkeypatch, conn, env="production")
+    monkeypatch.delenv("AGENTICORG_DDL_MANAGED_BY_ALEMBIC", raising=False)
+    monkeypatch.setenv(database.ENABLE_LEGACY_STARTUP_DDL_ENV, "1")
+
+    await database.init_db()
+
+    assert not _contains_ddl(conn.statements)
+
+
+@pytest.mark.asyncio
+async def test_old_alembic_flag_no_longer_bypasses_strict_verification(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = _FakeConnection(versions=["old_head"])
+    _patch_runtime(monkeypatch, conn, env="production")
+    monkeypatch.setenv("AGENTICORG_DDL_MANAGED_BY_ALEMBIC", "true")
+
+    with pytest.raises(database.RuntimeSchemaError, match="stale or divergent"):
+        await database.init_db()
+
+
+@pytest.mark.asyncio
+async def test_relaxed_env_does_not_run_legacy_ddl_without_explicit_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = _FakeConnection(alembic_table_exists=False)
+    _patch_runtime(monkeypatch, conn, env="development")
+    monkeypatch.delenv(database.ENABLE_LEGACY_STARTUP_DDL_ENV, raising=False)
+
+    await database.init_db()
+
+    assert not _contains_ddl(conn.statements)
+
+
+@pytest.mark.asyncio
+async def test_legacy_helper_refuses_strict_env_even_with_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(database, "settings", SimpleNamespace(env="production"))
+    monkeypatch.setenv(database.ENABLE_LEGACY_STARTUP_DDL_ENV, "1")
+
+    with pytest.raises(database.RuntimeSchemaError, match="ignored in strict runtimes"):
+        await database._legacy_startup_schema_repair_for_local_only()
+
+
+@pytest.mark.asyncio
+async def test_multiple_alembic_heads_fail_without_merge_plan(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = _FakeConnection(versions=["head_a", "head_b"])
+    monkeypatch.delenv(database.ALLOW_MULTIPLE_ALEMBIC_HEADS_ENV, raising=False)
+
+    with pytest.raises(database.RuntimeSchemaError, match="multiple Alembic heads"):
+        await database.verify_runtime_schema_current(conn, expected_heads={"head_a", "head_b"})

--- a/tests/unit/test_v490_reqs.py
+++ b/tests/unit/test_v490_reqs.py
@@ -252,19 +252,21 @@ class TestREQ02AlembicDDL:
         content = Path(".github/workflows/deploy.yml").read_text()
         assert "scripts/alembic_migrate.py" in content
 
-    def test_init_db_respects_alembic_flag(self):
-        """init_db() must short-circuit when AGENTICORG_DDL_MANAGED_BY_ALEMBIC is truthy."""
+    def test_init_db_verifies_alembic_in_strict_runtime(self):
+        """init_db() must verify Alembic state instead of relying on startup DDL."""
         from pathlib import Path
         content = Path("core/database.py").read_text()
-        assert "AGENTICORG_DDL_MANAGED_BY_ALEMBIC" in content
+        assert "verify_runtime_schema_current" in content
+        assert "is_strict_runtime_env(settings.env)" in content
+        assert "AGENTICORG_ENABLE_LEGACY_STARTUP_DDL" in content
 
     @pytest.mark.skip(
         reason="Helm chart removed in Stage 4 of the Cloud Run cost-cut migration. "
-        "AGENTICORG_DDL_MANAGED_BY_ALEMBIC is now set in the Cloud Run service env "
-        "vars. Followup: rewrite to assert against Cloud Run config."
+        "Runtime schema safety is now enforced by strict init_db() verification "
+        "and the Cloud Run migration job."
     )
     def test_helm_sets_alembic_flag(self):
         """Helm production values must enable alembic-managed DDL."""
         from pathlib import Path
         content = Path("helm/values.yaml").read_text()
-        assert 'AGENTICORG_DDL_MANAGED_BY_ALEMBIC: "true"' in content
+        assert 'AGENTICORG_ENABLE_LEGACY_STARTUP_DDL: "0"' in content


### PR DESCRIPTION
## Summary
- Make strict runtime startup verify Alembic state and fail closed on missing, stale, divergent, or unplanned multi-head schema state.
- Quarantine legacy startup DDL behind local-only `AGENTICORG_ENABLE_LEGACY_STARTUP_DDL=1` and remove `AGENTICORG_DDL_MANAGED_BY_ALEMBIC` as the safety boundary.
- Add migration-head guard/docs for PR #553/#554/#556 parallel-head merge handling.
- Update deploy/local scripts and source-pin tests to reflect Alembic as the production schema authority.

## Validation
- `python -m pytest tests/unit/test_runtime_schema_verification.py tests/unit/test_migration_guard.py -q`
- `python -m pytest tests/unit/test_module_22_cross_cutting.py::test_tc_cc_005_init_db_strict_path_is_verify_only tests/unit/test_module_22_cross_cutting.py::test_tc_cc_005_legacy_startup_ddl_still_serializes_when_opted_in tests/regression/test_qa_27apr_sweep.py::test_tc_001_report_schedules_table_is_alembic_managed_not_startup_ddl tests/unit/test_v490_reqs.py::TestREQ02AlembicDDL -q`
- `python -m pytest tests/integration/test_alembic_e2e.py -q -rs` (skipped: Postgres is not reachable)
- `python -m ruff check core/database.py scripts/check_migration_required.py migrations/env.py tests/unit/test_runtime_schema_verification.py tests/unit/test_migration_guard.py tests/unit/test_v490_reqs.py tests/unit/test_module_22_cross_cutting.py tests/regression/test_qa_27apr_sweep.py`
- `python -m compileall core/database.py scripts/check_migration_required.py migrations/env.py tests/unit/test_runtime_schema_verification.py tests/unit/test_migration_guard.py tests/unit/test_v490_reqs.py tests/unit/test_module_22_cross_cutting.py tests/regression/test_qa_27apr_sweep.py`
- `python -m alembic heads`
- `python scripts/check_migration_required.py`

## Notes
- No migration was added because this branch only changes startup behavior and merge-head enforcement; current branch has one Alembic head: `v4912_workflow_event_waits`.
- A full `tests/unit/test_v490_reqs.py` run was attempted and the unrelated `TestREQ01ComposioRuntime.test_composio_sdk_importable` failed locally because `composio` is not installed in this environment.