### PR TITLE
fix(commerce): align real staging fixture contract

### DIFF
--- a/core/commerce/staging_runtime.py
+++ b/core/commerce/staging_runtime.py
@@ -102,8 +102,24 @@ class CommerceFixtureConfig:
         return _int_value(self.values.get("AGENTICORG_COMMERCE_FIXTURE_AMOUNT_MINOR_UNITS"), 0)
 
     @property
+    def amount_minor_units_if_present(self) -> int | None:
+        return _optional_int_value(self.values.get("AGENTICORG_COMMERCE_FIXTURE_AMOUNT_MINOR_UNITS"))
+
+    @property
     def passport_max_amount_minor_units(self) -> int:
         return _int_value(self.values.get("AGENTICORG_COMMERCE_FIXTURE_PASSPORT_MAX_AMOUNT_MINOR_UNITS"), 250000)
+
+    @property
+    def passport_max_amount_minor_units_if_present(self) -> int | None:
+        return _optional_int_value(self.values.get("AGENTICORG_COMMERCE_FIXTURE_PASSPORT_MAX_AMOUNT_MINOR_UNITS"))
+
+    @property
+    def positive_payment_amount_cap_relation(self) -> str:
+        amount = self.amount_minor_units_if_present
+        cap = self.passport_max_amount_minor_units_if_present
+        if amount is None or cap is None:
+            return "missing_metadata"
+        return "within_cap" if amount <= cap else "amount_exceeds_cap"
 
     @property
     def browse_passport_jwt(self) -> str | None:
@@ -179,6 +195,16 @@ def _int_value(value: str | None, fallback: int) -> int:
     except ValueError:
         return fallback
     return parsed if parsed >= 0 else fallback
+
+
+def _optional_int_value(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(str(value).strip())
+    except ValueError:
+        return None
+    return parsed if parsed >= 0 else None
 
 
 def _is_true(value: str | None) -> bool:

--- a/demos/commerce_sales_agent_demo.py
+++ b/demos/commerce_sales_agent_demo.py
@@ -31,6 +31,13 @@ REST_PATH_TO_ALIAS = {value: key for key, value in REST_CONSENT_ENDPOINTS.items(
 PROVIDER_MARKERS = ("stri" + "pe", "plu" + "ral", "pine", "provider_" + "credentials", "credential_" + "payload")
 STAGING_MERCHANT_ID = "mch_staging_electronics_pilot"
 STAGING_AGENT_ID = "cag_staging_agenticorg_sales"
+GRANTEX_CHECKOUT_CONSENT_SCOPES = [
+    "commerce:catalog.read",
+    "commerce:inventory.read",
+    "commerce:checkout.create",
+    "commerce:payment.initiate",
+    "commerce:payment.status.read",
+]
 
 DEMO_MCP_RESPONSES: dict[str, dict[str, Any]] = {
     "merchant_get_profile": {
@@ -332,25 +339,36 @@ async def run_real_staging_demo(
             evidence.add_case(name="catalog_get_item", status="skipped", blocker="catalog search returned no product")
 
         if variant_id:
-            inventory = await connector.inventory_check(merchant_id=merchant_id, variant_ids=[variant_id])
-            alias = "grantex_commerce:inventory_check"
-            tool_sequence.append(alias)
-            evidence.add_case(
-                name="inventory_check",
-                status=_case_status(inventory),
-                tool_alias=alias,
-                result=inventory,
-            )
-            caution = inventory_caution(inventory.get("data", inventory))
-            steps.append(
-                _step(
-                    "Inventory check",
-                    "Check staging inventory for the first variant.",
-                    alias,
-                    {"variant_id": variant_id, "caution_required": caution["caution_required"]},
-                    "Inventory was checked through Grantex staging.",
+            if fixture.browse_passport_jwt:
+                inventory = await connector.inventory_check(
+                    merchant_id=merchant_id,
+                    variant_ids=[variant_id],
+                    passport_jwt=fixture.browse_passport_jwt,
                 )
-            )
+                alias = "grantex_commerce:inventory_check"
+                tool_sequence.append(alias)
+                evidence.add_case(
+                    name="inventory_check",
+                    status=_case_status(inventory),
+                    tool_alias=alias,
+                    result=inventory,
+                )
+                caution = inventory_caution(inventory.get("data", inventory))
+                steps.append(
+                    _step(
+                        "Inventory check",
+                        "Check staging inventory for the first variant.",
+                        alias,
+                        {"variant_id": variant_id, "caution_required": caution["caution_required"]},
+                        "Inventory was checked through Grantex staging.",
+                    )
+                )
+            else:
+                evidence.add_case(
+                    name="inventory_check",
+                    status="skipped",
+                    blocker="requires browse passport fixture",
+                )
 
             cart = await connector.cart_create(
                 merchant_id=merchant_id,
@@ -384,8 +402,8 @@ async def run_real_staging_demo(
         consent = await connector.consent_request(
             merchant_id=merchant_id,
             passport_type="checkout",
-            requested_scopes=["checkout:create", "payment:create"],
-            max_amount=250000,
+            requested_scopes=GRANTEX_CHECKOUT_CONSENT_SCOPES,
+            max_amount=fixture.passport_max_amount_minor_units_if_present or 250000,
             currency=fixture.currency,
         )
         alias = "grantex_commerce:consent_request"
@@ -420,7 +438,7 @@ async def run_real_staging_demo(
                     alias,
                     {
                         "passport": "received_redacted" if checkout_passport_jwt else None,
-                        "max_amount_minor_units": fixture.passport_max_amount_minor_units,
+                        "amount_cap_relation": fixture.positive_payment_amount_cap_relation,
                     },
                     "Passport exchange ran through Grantex without exposing passport material.",
                 )
@@ -434,37 +452,52 @@ async def run_real_staging_demo(
 
         payment_intent_id: str | None = None
         if checkout_passport_jwt and cart_id:
-            payment = await connector.payment_create_intent(
-                merchant_id=merchant_id,
-                cart_id=cart_id,
-                passport_jwt=checkout_passport_jwt,
-                passport_max_amount_minor_units=fixture.passport_max_amount_minor_units,
-                amount_minor_units=fixture.amount_minor_units,
-                currency=fixture.currency,
-                idempotency_key=f"agenticorg-real-staging-payment-{uuid.uuid4().hex}",
-                provider_key="mock",
-            )
-            alias = "grantex_commerce:payment_create_intent"
-            tool_sequence.append(alias)
-            evidence.add_case(
-                name="payment_create_intent",
-                status=_case_status(payment),
-                tool_alias=alias,
-                result=payment,
-            )
-            payment_intent_id = _data(payment).get("payment_intent_id")
-            steps.append(
-                _step(
-                    "Payment intent",
-                    "Create a mock-provider staging payment intent.",
-                    alias,
-                    {
-                        "payment_intent_id": payment_intent_id,
-                        "status": _data(payment).get("status"),
-                    },
-                    "Payment intent ran through Grantex staging only.",
+            amount_cap_relation = fixture.positive_payment_amount_cap_relation
+            if amount_cap_relation == "missing_metadata":
+                evidence.add_case(
+                    name="payment_create_intent",
+                    status="skipped",
+                    blocker="requires fixture amount and passport cap metadata",
                 )
-            )
+            elif amount_cap_relation == "amount_exceeds_cap":
+                evidence.add_case(
+                    name="payment_create_intent",
+                    status="skipped",
+                    blocker="fixture amount exceeds passport cap",
+                )
+            else:
+                payment = await connector.payment_create_intent(
+                    merchant_id=merchant_id,
+                    cart_id=cart_id,
+                    passport_jwt=checkout_passport_jwt,
+                    passport_max_amount_minor_units=fixture.passport_max_amount_minor_units,
+                    amount_minor_units=fixture.amount_minor_units,
+                    currency=fixture.currency,
+                    idempotency_key=f"agenticorg-real-staging-payment-{uuid.uuid4().hex}",
+                    provider_key="mock",
+                )
+                alias = "grantex_commerce:payment_create_intent"
+                tool_sequence.append(alias)
+                evidence.add_case(
+                    name="payment_create_intent",
+                    status=_case_status(payment),
+                    tool_alias=alias,
+                    result=payment,
+                )
+                payment_intent_id = _data(payment).get("payment_intent_id")
+                steps.append(
+                    _step(
+                        "Payment intent",
+                        "Create a mock-provider staging payment intent.",
+                        alias,
+                        {
+                            "payment_intent_id": payment_intent_id,
+                            "status": _data(payment).get("status"),
+                            "amount_cap_relation": amount_cap_relation,
+                        },
+                        "Payment intent ran through Grantex staging only.",
+                    )
+                )
         else:
             evidence.add_case(
                 name="payment_create_intent",

--- a/tests/regression/test_commerce_sales_agent_real_staging_mode.py
+++ b/tests/regression/test_commerce_sales_agent_real_staging_mode.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -22,6 +24,136 @@ def _write_tmp_fixture(name: str, content: str) -> Path:
     path.parent.mkdir(exist_ok=True)
     path.write_text(content, encoding="utf-8")
     return path
+
+
+def _fixture_env_content(
+    *,
+    amount: int = 100,
+    cap: int = 200,
+    include_browse_passport: bool = True,
+    sensitive_values: dict[str, str] | None = None,
+) -> str:
+    smoke_url = "https://grantex-auth-smoke-example-uc.a.run.app"
+    runtime_values = {
+        "GRANTEX_API_KEY": f"auth-{uuid.uuid4().hex}",
+        "AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT": f"checkout-{uuid.uuid4().hex}",
+        "AGENTICORG_COMMERCE_BROWSE_PASSPORT_JWT": f"browse-{uuid.uuid4().hex}",
+        **(sensitive_values or {}),
+    }
+    lines = [
+        f'GRANTEX_COMMERCE_BASE_URL="{smoke_url}"',
+        f'AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL="{smoke_url}"',
+        'AGENTICORG_COMMERCE_REAL_STAGING="1"',
+        'AGENTICORG_COMMERCE_FIXTURE_PROVIDER="mock"',
+        'AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID="mch_staging_electronics_pilot"',
+        'AGENTICORG_COMMERCE_FIXTURE_AGENT_ID="cag_staging_agenticorg_sales"',
+        'AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID="cprd_stg_fixture"',
+        'AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID="cvar_stg_fixture"',
+        'AGENTICORG_COMMERCE_FIXTURE_CURRENCY="INR"',
+        f'AGENTICORG_COMMERCE_FIXTURE_AMOUNT_MINOR_UNITS="{amount}"',
+        f'AGENTICORG_COMMERCE_FIXTURE_PASSPORT_MAX_AMOUNT_MINOR_UNITS="{cap}"',
+        f'GRANTEX_API_KEY="{runtime_values["GRANTEX_API_KEY"]}"',
+        f'AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT="{runtime_values["AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT"]}"',
+    ]
+    if include_browse_passport:
+        lines.append(
+            f'AGENTICORG_COMMERCE_BROWSE_PASSPORT_JWT="'
+            f'{runtime_values["AGENTICORG_COMMERCE_BROWSE_PASSPORT_JWT"]}"'
+        )
+    return "\n".join([*lines, ""])
+
+
+class _FakeRealStagingConnector:
+    instances: list[_FakeRealStagingConnector] = []
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        self.config = config
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        _FakeRealStagingConnector.instances.append(self)
+
+    async def connect(self) -> None:
+        return None
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def health_check(self) -> dict[str, Any]:
+        return {"status": "healthy", "http_status": 200}
+
+    async def merchant_get_profile(self, **params: Any) -> dict[str, Any]:
+        self.calls.append(("merchant_get_profile", params))
+        return {"data": {"merchant_id": params["merchant_id"], "commerce_status": "enabled"}}
+
+    async def catalog_search(self, **params: Any) -> dict[str, Any]:
+        self.calls.append(("catalog_search", params))
+        return {"data": {"items": [{"product_id": "cprd_stg_fixture"}]}}
+
+    async def catalog_get_item(self, **params: Any) -> dict[str, Any]:
+        self.calls.append(("catalog_get_item", params))
+        return {
+            "data": {
+                "product_id": params["product_id"],
+                "variants": [{"variant_id": "cvar_stg_fixture", "price_amount": 100}],
+            }
+        }
+
+    async def inventory_check(self, **params: Any) -> dict[str, Any]:
+        self.calls.append(("inventory_check", params))
+        return {"data": {"items": [{"variant_id": "cvar_stg_fixture", "status": "in_stock"}]}}
+
+    async def cart_create(self, **params: Any) -> dict[str, Any]:
+        self.calls.append(("cart_create", params))
+        return {"data": {"cart_id": "cart_stg_fixture", "status": "draft"}}
+
+    async def consent_request(self, **params: Any) -> dict[str, Any]:
+        self.calls.append(("consent_request", params))
+        return {"data": {"consent_request_id": "consent_stg_fixture", "passport_type": params["passport_type"]}}
+
+    async def consent_exchange(self, **params: Any) -> dict[str, Any]:
+        self.calls.append(("consent_exchange", params))
+        return {"data": {}}
+
+    async def payment_create_intent(self, **params: Any) -> dict[str, Any]:
+        self.calls.append(("payment_create_intent", params))
+        if not params.get("passport_jwt"):
+            return {"error": "consent_required", "message": "passport required"}
+        if params.get("consent_status") == "denied":
+            return {"error": "consent_denied", "message": "consent denied"}
+        if params.get("passport_status") == "revoked":
+            return {"error": "passport_revoked", "message": "passport revoked"}
+        if params.get("passport_status") == "expired":
+            return {"error": "passport_expired", "message": "passport expired"}
+        if params.get("merchant_status") == "disabled":
+            return {"error": "merchant_disabled", "message": "merchant disabled"}
+        if params.get("agent_trust_status") == "untrusted":
+            return {"error": "agent_untrusted", "message": "agent untrusted"}
+        if params.get("amount_minor_units", 0) > params.get("passport_max_amount_minor_units", 0):
+            return {"error": "amount_cap_exceeded", "message": "amount cap exceeded"}
+        return {"data": {"payment_intent_id": "pi_stg_fixture", "status": "requires_checkout"}}
+
+    async def checkout_create(self, **params: Any) -> dict[str, Any]:
+        self.calls.append(("checkout_create", params))
+        return {"data": {"checkout_id": "checkout_stg_fixture", "status": "handoff_ready"}}
+
+    async def payment_get_status(self, **params: Any) -> dict[str, Any]:
+        self.calls.append(("payment_get_status", params))
+        return {"data": {"payment_intent_id": params["payment_intent_id"], "status": "requires_checkout"}}
+
+
+async def _run_real_staging_with_fake(
+    monkeypatch: pytest.MonkeyPatch,
+    fixture: Path,
+    *,
+    evidence_report: Path | None = None,
+) -> tuple[dict[str, Any], _FakeRealStagingConnector]:
+    _FakeRealStagingConnector.instances = []
+    monkeypatch.setattr(commerce_sales_agent_demo, "GrantexCommerceConnector", _FakeRealStagingConnector)
+    monkeypatch.setenv("AGENTICORG_TEST_FAKE_CONNECTORS", "0")
+    result = await commerce_sales_agent_demo.run_real_staging_demo(
+        fixture_env_path=str(fixture),
+        evidence_report=str(evidence_report) if evidence_report else None,
+    )
+    return result, _FakeRealStagingConnector.instances[0]
 
 
 @pytest.mark.asyncio
@@ -176,6 +308,94 @@ def test_real_staging_refuses_fake_connector_transport() -> None:
         )
 
     assert excinfo.value.code == "fake_connectors_refused"
+
+
+@pytest.mark.asyncio
+async def test_real_staging_inventory_passes_browse_passport_from_fixture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    browse_passport = f"browse-{uuid.uuid4().hex}"
+    fixture = _write_tmp_fixture(
+        "commerce-agent-real-staging-c2e-inventory.env",
+        _fixture_env_content(
+            sensitive_values={"AGENTICORG_COMMERCE_BROWSE_PASSPORT_JWT": browse_passport},
+        ),
+    )
+    try:
+        result, connector = await _run_real_staging_with_fake(monkeypatch, fixture)
+    finally:
+        fixture.unlink(missing_ok=True)
+
+    inventory_call = next(params for name, params in connector.calls if name == "inventory_check")
+    assert inventory_call["passport_jwt"] == browse_passport
+    assert "grantex_commerce:inventory_check" in result["audit_summary"]["tool_sequence"]
+
+
+@pytest.mark.asyncio
+async def test_real_staging_skips_inventory_when_browse_passport_fixture_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _write_tmp_fixture(
+        "commerce-agent-real-staging-c2e-inventory-missing.env",
+        _fixture_env_content(include_browse_passport=False),
+    )
+    report = Path(".tmp/commerce-agent-real-staging-c2e-inventory-missing.md")
+    try:
+        result, connector = await _run_real_staging_with_fake(monkeypatch, fixture, evidence_report=report)
+        report_text = report.read_text(encoding="utf-8")
+    finally:
+        fixture.unlink(missing_ok=True)
+        report.unlink(missing_ok=True)
+
+    assert not any(name == "inventory_check" for name, _params in connector.calls)
+    assert "grantex_commerce:inventory_check" not in result["audit_summary"]["tool_sequence"]
+    assert "| inventory_check | skipped |  |  |  |  | requires browse passport fixture |" in report_text
+
+
+@pytest.mark.asyncio
+async def test_real_staging_consent_request_uses_grantex_checkout_scope_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _write_tmp_fixture("commerce-agent-real-staging-c2e-consent.env", _fixture_env_content())
+    try:
+        _result, connector = await _run_real_staging_with_fake(monkeypatch, fixture)
+    finally:
+        fixture.unlink(missing_ok=True)
+
+    consent_call = next(params for name, params in connector.calls if name == "consent_request")
+    assert consent_call["requested_scopes"] == commerce_sales_agent_demo.GRANTEX_CHECKOUT_CONSENT_SCOPES
+
+
+@pytest.mark.asyncio
+async def test_real_staging_skips_positive_payment_when_fixture_amount_exceeds_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _write_tmp_fixture(
+        "commerce-agent-real-staging-c2e-amount-cap.env",
+        _fixture_env_content(amount=300, cap=200),
+    )
+    report = Path(".tmp/commerce-agent-real-staging-c2e-amount-cap.md")
+    try:
+        result, connector = await _run_real_staging_with_fake(monkeypatch, fixture, evidence_report=report)
+        report_text = report.read_text(encoding="utf-8")
+    finally:
+        fixture.unlink(missing_ok=True)
+        report.unlink(missing_ok=True)
+
+    positive_payment_calls = [
+        params
+        for name, params in connector.calls
+        if name == "payment_create_intent"
+        and params.get("passport_jwt")
+        and params.get("passport_max_amount_minor_units") == 200
+        and not any(
+            key in params for key in ("consent_status", "passport_status", "merchant_status", "agent_trust_status")
+        )
+    ]
+    assert positive_payment_calls == []
+    assert "grantex_commerce:payment_create_intent" not in result["audit_summary"]["tool_sequence"]
+    assert "| payment_create_intent | skipped |  |  |  |  | fixture amount exceeds passport cap |" in report_text
+    assert "| amount_cap_breach | pass |  |  |  | amount_cap_exceeded |  |" in report_text
 
 
 def test_redaction_removes_auth_passport_idempotency_and_raw_payload_material() -> None:


### PR DESCRIPTION
## Summary

- Pass the synthetic browse passport fixture into real-staging inventory checks, and skip inventory with an explicit blocker when the fixture is absent.
- Align checkout consent requests with Grantex-supported Commerce scopes.
- Gate positive payment intent creation on fixture amount/cap metadata, skipping with explicit blockers when metadata is missing or over cap while preserving the amount-cap breach negative case.

## Safety

- AgenticOrg implementation and focused regression tests only.
- No deploy, cloud resource creation, production config change, Commerce V1 production enablement, live payments, live Plural, or secret access.
- Real-staging guardrails remain in place: exact smoke allowlist, production URL refusal, arbitrary run.app refusal, HTTP localhost refusal, exactly-one-auth-source rule, fake connector refusal, Grantex-only commerce path, and no provider credential path.

## Validation

- `python -m ruff check demos/commerce_sales_agent_demo.py core/commerce tests/evals/test_commerce_sales_agent_real_staging.py tests/regression/test_commerce_sales_agent_real_staging_mode.py tests/regression/test_commerce_sales_agent_no_provider_calls.py`
- `python -m pytest tests/evals/test_commerce_sales_agent_real_staging.py -q` (skipped without approved real-staging env)
- `python -m pytest tests/regression/test_commerce_sales_agent_real_staging_mode.py -q`
- `python -m pytest tests/regression/test_commerce_sales_agent_no_provider_calls.py -q`
- `python demos/commerce_sales_agent_demo.py --mode=mock`
- Real-staging refusal checks for production URL, arbitrary run.app URL, and HTTP localhost
- Focused secret scan on changed files: no matches
- `git diff --check HEAD~1 HEAD`