### PR TITLE
docs: record P0 enterprise stability status

### DIFF
--- a/docs/ENTERPRISE_STABILITY_STATUS_2026-05-16.md
+++ b/docs/ENTERPRISE_STABILITY_STATUS_2026-05-16.md
@@ -1,0 +1,31 @@
+# Enterprise Stability Status - 2026-05-16
+
+## P0 Implementation Status
+
+The P0 enterprise stability hardening stack has landed on `main`.
+
+| Item | Status | Closing PRs |
+| --- | --- | --- |
+| P0-1 workflow state and event-wait durability | Closed | #550, #560 |
+| P0-2 workflow no-false-success execution semantics | Closed | #560 |
+| P0-3 CDC webhook durable ingestion and dedupe | Closed | #560 |
+| P0-4 WebSocket live feed authentication, fanout, and catch-up | Closed | #560 |
+| P0-5 bridge session and request durability | Closed | #560 |
+| P0-6 Alembic strict runtime and one-head enforcement | Closed | #560 |
+| P0-7 enterprise stability release gates | Closed | #560 |
+
+## Verification Snapshot
+
+- `python -m alembic heads` reports one head: `v4916_merge_p0_heads`.
+- Enterprise stability gates pass on `main`.
+- Targeted P0 unit regression tests pass on `main`.
+- Superseded draft PRs #552, #553, #554, #556, #557, and #558 were absorbed by #560.
+
+## Remaining P1 Backlog
+
+P1 work remains open and should be planned separately from the P0 hardening merge:
+
+- Replace route metadata baseline entries with explicit per-route metadata annotations.
+- Reduce legacy broad-exception and process-local-state baseline debt.
+- Add broader database-backed integration coverage in CI for durability paths.
+- Continue non-P0 reliability, observability, and operational hardening items from the stability review backlog.


### PR DESCRIPTION
## Summary
- Add a concise P0 enterprise stability status document because `docs/BRUTAL_STABILITY_REVIEW_2026-05-16.md` is not present on main.
- Record P0-1 through P0-7 as closed by #550/#560.
- Capture remaining P1 backlog themes for follow-up planning.

## Validation
- Doc-only change; main verification was completed after #560 merged.
