### PR TITLE
docs(commerce): record c2e real staging evidence

### DIFF
--- a/docs/reports/commerce-agent-real-staging-evidence.md
+++ b/docs/reports/commerce-agent-real-staging-evidence.md
@@ -1,14 +1,14 @@
 # Commerce Sales Agent Real-Staging Evidence
 
-Status: C2D approved real-staging evidence captured locally against the temporary Grantex Option A smoke service. This report is scrubbed and contains no bearer token values, passports/JWTs, idempotency key values, provider credentials, raw payloads, DB/Redis URLs, private keys, or secret values.
+Status: C2E approved real-staging evidence captured locally against the temporary Grantex Option A smoke service. This report is scrubbed and contains no bearer token values, passports/JWTs, idempotency key values, provider credentials, raw payloads, DB/Redis URLs, private keys, or secret values.
 
 - Run mode: `real-staging`
-- Grantex host: `grantex-auth-smoke-dd4mtrt2gq-uc.a.run.app`
+- Grantex host: `grantex-auth-smoke-876335597959.us-central1.run.app`
 - Auth source env name: `GRANTEX_API_KEY`
 - Fixture env path: `.tmp/commerce-agent-real-staging.env`
 - Fixture env variable names recorded: 21
-- Fixture synthetic IDs recorded: true
-- Fixture sensitive value hashes recorded: true
+- Fixture synthetic IDs recorded: True
+- Fixture sensitive value hashes recorded: True
 - Secret values recorded: false
 - Raw passports/JWTs recorded: false
 - Request correlation values recorded: false
@@ -19,9 +19,9 @@ Status: C2D approved real-staging evidence captured locally against the temporar
 
 ## Summary
 
-- Passed: 8
-- Failed: 3
-- Skipped: 4
+- Passed: 10
+- Failed: 2
+- Skipped: 3
 - Provider: mock
 - Grantex-only path confirmed: true
 
@@ -33,11 +33,11 @@ Status: C2D approved real-staging evidence captured locally against the temporar
 | merchant_get_profile | pass | grantex_commerce:merchant_get_profile |  |  |  |  |
 | catalog_search | pass | grantex_commerce:catalog_search |  |  |  |  |
 | catalog_get_item | pass | grantex_commerce:catalog_get_item |  |  |  |  |
-| inventory_check | fail | grantex_commerce:inventory_check |  |  | passport_required |  |
+| inventory_check | pass | grantex_commerce:inventory_check |  |  |  |  |
 | cart_create | pass | grantex_commerce:cart_create |  |  |  |  |
-| consent_request | fail | grantex_commerce:consent_request |  |  | validation_failed |  |
-| consent_exchange | skipped |  |  |  |  | requires approved synthetic consent fixture |
-| payment_create_intent | fail | grantex_commerce:payment_create_intent |  |  | amount_cap_exceeded |  |
+| consent_request | pass | grantex_commerce:consent_request |  |  |  |  |
+| consent_exchange | fail | grantex_commerce:consent_exchange |  |  | consent_not_granted |  |
+| payment_create_intent | fail | grantex_commerce:payment_create_intent |  |  | validation_failed |  |
 | checkout_create | skipped |  |  |  |  | requires checkout passport fixture and payment intent |
 | payment_get_status | skipped |  |  |  |  | requires checkout passport fixture and payment intent |
 | amount_cap_breach | pass |  |  |  | amount_cap_exceeded |  |
@@ -49,25 +49,242 @@ Status: C2D approved real-staging evidence captured locally against the temporar
 
 - Merchant: `mch_staging_electronics_pilot`
 - Agent: `cag_staging_agenticorg_sales`
-- Product: `cprd_01KRR1DTSAXMY57RRPTDSB6KBZ`
-- Variant: `cvar_01KRR1DTSG62ZV9RFWFBHWTZ21`
+- Product: `cprd_01KRRN1K5HSQV7MGEDP8PD54Z2`
+- Variant: `cvar_01KRRN1K5TB1MQ10GJJB91H2YT`
+
+## C2E Expectations
+
+- Inventory used the browse passport fixture when present and passed.
+- Consent request used Grantex-supported checkout scopes.
+- Positive payment amount was within the passport cap, but Grantex returned `validation_failed` for AgenticOrg payment intent creation.
+- Amount-cap breach remained a fail-safe negative case with `amount_cap_exceeded`.
+- Commerce execution stayed on the Grantex connector path; no provider credentials or direct provider calls were used.
 
 ## Cleanup Status
 
-Cleanup completed after evidence capture.
-
-- Temporary Grantex smoke Cloud Run service, Cloud SQL instance, Redis instance, smoke secrets, and smoke image tag were deleted.
-- Temporary smoke resources were verified absent after cleanup.
-- Production Grantex resources were verified present after cleanup: `grantex-auth`, `grantex-pg16`, `grantex-redis`.
-- Production Commerce V1, live payment, and live Plural flags were not changed by this run.
-
-## Remaining Real-Staging Gaps
-
-- AgenticOrg inventory check did not pass the browse passport through this path and failed safely with `passport_required`.
-- AgenticOrg consent request still sends an unsupported requested-scope shape and failed safely with `validation_failed`.
-- AgenticOrg payment intent path used a fixture-side amount-cap guard and failed safely with `amount_cap_exceeded`.
-- Hosted AgenticOrg discovery remains skipped because this run was local AgenticOrg against a temporary Grantex smoke service only.
+Temporary smoke resources were cleaned up after evidence capture. Production Grantex resources were verified present after cleanup, and production Commerce V1 config, live payment flags, and live Plural flags were not changed.
 
 ## Redaction
 
 The evidence records only host, variable names, synthetic IDs, case status, error code, cleanup status, and provider-safety confirmations. It does not record raw response payloads, usable passports/JWTs, auth material, idempotency key values, provider credentials, DB/Redis URLs, private keys, or secret values.
+
+## Redacted Summary
+
+```json
+{
+  "auth_source_env_name": "GRANTEX_API_KEY",
+  "cases": [
+    {
+      "blocker": null,
+      "error_code": null,
+      "http_status": null,
+      "latency_ms": null,
+      "name": "connector_health_tools_list",
+      "status": "pass",
+      "tool_alias": null
+    },
+    {
+      "blocker": null,
+      "error_code": null,
+      "http_status": null,
+      "latency_ms": null,
+      "name": "merchant_get_profile",
+      "status": "pass",
+      "tool_alias": "grantex_commerce:merchant_get_profile"
+    },
+    {
+      "blocker": null,
+      "error_code": null,
+      "http_status": null,
+      "latency_ms": null,
+      "name": "catalog_search",
+      "status": "pass",
+      "tool_alias": "grantex_commerce:catalog_search"
+    },
+    {
+      "blocker": null,
+      "error_code": null,
+      "http_status": null,
+      "latency_ms": null,
+      "name": "catalog_get_item",
+      "status": "pass",
+      "tool_alias": "grantex_commerce:catalog_get_item"
+    },
+    {
+      "blocker": null,
+      "error_code": null,
+      "http_status": null,
+      "latency_ms": null,
+      "name": "inventory_check",
+      "status": "pass",
+      "tool_alias": "grantex_commerce:inventory_check"
+    },
+    {
+      "blocker": null,
+      "error_code": null,
+      "http_status": null,
+      "latency_ms": null,
+      "name": "cart_create",
+      "status": "pass",
+      "tool_alias": "grantex_commerce:cart_create"
+    },
+    {
+      "blocker": null,
+      "error_code": null,
+      "http_status": null,
+      "latency_ms": null,
+      "name": "consent_request",
+      "status": "pass",
+      "tool_alias": "grantex_commerce:consent_request"
+    },
+    {
+      "blocker": null,
+      "error_code": "consent_not_granted",
+      "http_status": null,
+      "latency_ms": null,
+      "name": "consent_exchange",
+      "status": "fail",
+      "tool_alias": "grantex_commerce:consent_exchange"
+    },
+    {
+      "blocker": null,
+      "error_code": "validation_failed",
+      "http_status": null,
+      "latency_ms": null,
+      "name": "payment_create_intent",
+      "status": "fail",
+      "tool_alias": "grantex_commerce:payment_create_intent"
+    },
+    {
+      "blocker": "requires checkout passport fixture and payment intent",
+      "error_code": null,
+      "http_status": null,
+      "latency_ms": null,
+      "name": "checkout_create",
+      "status": "skipped",
+      "tool_alias": null
+    },
+    {
+      "blocker": "requires checkout passport fixture and payment intent",
+      "error_code": null,
+      "http_status": null,
+      "latency_ms": null,
+      "name": "payment_get_status",
+      "status": "skipped",
+      "tool_alias": null
+    },
+    {
+      "blocker": null,
+      "error_code": "amount_cap_exceeded",
+      "http_status": null,
+      "latency_ms": null,
+      "name": "amount_cap_breach",
+      "status": "pass",
+      "tool_alias": null
+    },
+    {
+      "blocker": null,
+      "error_code": "consent_denied",
+      "http_status": null,
+      "latency_ms": null,
+      "name": "denied_revoked_expired_passport",
+      "status": "pass",
+      "tool_alias": null
+    },
+    {
+      "blocker": null,
+      "error_code": "merchant_disabled",
+      "http_status": null,
+      "latency_ms": null,
+      "name": "disabled_merchant_untrusted_agent",
+      "status": "pass",
+      "tool_alias": null
+    },
+    {
+      "blocker": "requires hosted AgenticOrg service",
+      "error_code": null,
+      "http_status": null,
+      "latency_ms": null,
+      "name": "hosted_agenticorg_discovery",
+      "status": "skipped",
+      "tool_alias": null
+    }
+  ],
+  "fixture_env_path": ".tmp/commerce-agent-real-staging.env",
+  "fixture_env_var_names": [
+    "AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL",
+    "AGENTICORG_COMMERCE_BROWSE_PASSPORT_JWT",
+    "AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT",
+    "AGENTICORG_COMMERCE_DENIED_CONSENT_REF",
+    "AGENTICORG_COMMERCE_EXPIRED_PASSPORT_JWT",
+    "AGENTICORG_COMMERCE_FIXTURE_AGENT_ID",
+    "AGENTICORG_COMMERCE_FIXTURE_AMOUNT_MINOR_UNITS",
+    "AGENTICORG_COMMERCE_FIXTURE_AUTH_ENV_NAME",
+    "AGENTICORG_COMMERCE_FIXTURE_CURRENCY",
+    "AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID",
+    "AGENTICORG_COMMERCE_FIXTURE_PASSPORT_MAX_AMOUNT_MINOR_UNITS",
+    "AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID",
+    "AGENTICORG_COMMERCE_FIXTURE_PROVIDER",
+    "AGENTICORG_COMMERCE_FIXTURE_SYNTHETIC_ONLY",
+    "AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID",
+    "AGENTICORG_COMMERCE_FIXTURE_VERSION",
+    "AGENTICORG_COMMERCE_REAL_STAGING",
+    "AGENTICORG_COMMERCE_REVOKED_PASSPORT_JWT",
+    "GRANTEX_API_KEY",
+    "GRANTEX_BASE_URL",
+    "GRANTEX_COMMERCE_BASE_URL"
+  ],
+  "fixture_synthetic_ids": {
+    "AGENTICORG_COMMERCE_FIXTURE_AGENT_ID": "cag_staging_agenticorg_sales",
+    "AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID": "mch_staging_electronics_pilot",
+    "AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID": "cprd_01KRRN1K5HSQV7MGEDP8PD54Z2",
+    "AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID": "cvar_01KRRN1K5TB1MQ10GJJB91H2YT"
+  },
+  "fixture_value_hashes": [
+    {
+      "name": "AGENTICORG_COMMERCE_BROWSE_PASSPORT_JWT",
+      "sha256_12": "a7ba849a221c"
+    },
+    {
+      "name": "AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT",
+      "sha256_12": "3b7c61c9fbf3"
+    },
+    {
+      "name": "AGENTICORG_COMMERCE_DENIED_CONSENT_REF",
+      "sha256_12": "198f071592a6"
+    },
+    {
+      "name": "AGENTICORG_COMMERCE_EXPIRED_PASSPORT_JWT",
+      "sha256_12": "866ab9c5589c"
+    },
+    {
+      "name": "AGENTICORG_COMMERCE_REVOKED_PASSPORT_JWT",
+      "sha256_12": "1fe9fcebc894"
+    },
+    {
+      "name": "GRANTEX_API_KEY",
+      "sha256_12": "9450cfa462a1"
+    }
+  ],
+  "grantex_host": "grantex-auth-smoke-876335597959.us-central1.run.app",
+  "no_provider_call_confirmation": true,
+  "redaction": {
+    "auth_values_recorded": false,
+    "idempotency_values_recorded": "[redacted]",
+    "passport_values_recorded": "[redacted]",
+    "provider_material_recorded": false,
+    "raw_payloads_recorded": "[redacted]"
+  },
+  "run_mode": "real-staging",
+  "tool_sequence": [
+    "grantex_commerce:merchant_get_profile",
+    "grantex_commerce:catalog_search",
+    "grantex_commerce:catalog_get_item",
+    "grantex_commerce:inventory_check",
+    "grantex_commerce:cart_create",
+    "grantex_commerce:consent_request",
+    "grantex_commerce:consent_exchange",
+    "grantex_commerce:payment_create_intent"
+  ]
+}
+```


### PR DESCRIPTION
## Summary

- Records the C2E AgenticOrg real-staging eval evidence against the temporary Grantex Option A smoke service.
- Documents C2E expectations: inventory passed with browse passport, consent request passed with supported scopes, amount-cap breach remained fail-safe, and payment intent still returned `validation_failed`.
- Keeps evidence scrubbed and limited to variable names, synthetic IDs, redacted hashes, case status, error code, and cleanup/safety status.

## Validation

- `python demos/commerce_sales_agent_demo.py --mode=mock`
- AgenticOrg real-staging eval against the approved temporary smoke URL using `.tmp/commerce-agent-real-staging.env`
- Production URL, arbitrary run.app, and HTTP localhost refusal checks
- Focused evidence secret scan
- `git diff --check`

## Safety

No deploy, cloud resource creation, production config change, live payments, live Plural, or production secrets change is included in this PR.