### PR TITLE
[codex] Align real staging payment intent contract

### DIFF
--- a/demos/commerce_sales_agent_demo.py
+++ b/demos/commerce_sales_agent_demo.py
@@ -21,7 +21,11 @@ from connectors.commerce.grantex_commerce import (  # noqa: E402
     TOOL_ALIAS_TO_GRANTEX,
     GrantexCommerceConnector,
 )
-from core.commerce.sales_guardrails import inventory_caution, validate_claims_against_tool_data  # noqa: E402
+from core.commerce.sales_guardrails import (  # noqa: E402
+    inventory_caution,
+    validate_claims_against_tool_data,
+    validate_payment_action,
+)
 from core.commerce.staging_evidence import StagingEvidence  # noqa: E402
 from core.commerce.staging_runtime import RealStagingConfigError, validate_real_staging_config  # noqa: E402
 
@@ -38,6 +42,16 @@ GRANTEX_CHECKOUT_CONSENT_SCOPES = [
     "commerce:payment.initiate",
     "commerce:payment.status.read",
 ]
+GRANTEX_PAYMENT_CREATE_INTENT_FIELDS = (
+    "merchant_id",
+    "cart_id",
+    "passport_jwt",
+    "amount_minor_units",
+    "currency",
+    "provider_key",
+    "metadata",
+    "idempotency_key",
+)
 
 DEMO_MCP_RESPONSES: dict[str, dict[str, Any]] = {
     "merchant_get_profile": {
@@ -209,6 +223,31 @@ def _amount_minor_units(item: dict[str, Any]) -> int:
 
 def _case_status(result: dict[str, Any]) -> str:
     return "fail" if result.get("error") else "pass"
+
+
+def _payment_create_intent_request(
+    *,
+    merchant_id: str,
+    cart_id: str,
+    passport_jwt: str,
+    amount_minor_units: int,
+    currency: str,
+    provider_key: str,
+    idempotency_key: str,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    request: dict[str, Any] = {
+        "merchant_id": merchant_id,
+        "cart_id": cart_id,
+        "passport_jwt": passport_jwt,
+        "amount_minor_units": amount_minor_units,
+        "currency": currency,
+        "provider_key": provider_key,
+        "idempotency_key": idempotency_key,
+    }
+    if metadata is not None:
+        request["metadata"] = metadata
+    return {field: request[field] for field in GRANTEX_PAYMENT_CREATE_INTENT_FIELDS if field in request}
 
 
 def _connector_config(config: Any) -> dict[str, Any]:
@@ -466,16 +505,16 @@ async def run_real_staging_demo(
                     blocker="fixture amount exceeds passport cap",
                 )
             else:
-                payment = await connector.payment_create_intent(
+                payment_request = _payment_create_intent_request(
                     merchant_id=merchant_id,
                     cart_id=cart_id,
                     passport_jwt=checkout_passport_jwt,
-                    passport_max_amount_minor_units=fixture.passport_max_amount_minor_units,
                     amount_minor_units=fixture.amount_minor_units,
                     currency=fixture.currency,
                     idempotency_key=f"agenticorg-real-staging-payment-{uuid.uuid4().hex}",
                     provider_key="mock",
                 )
+                payment = await connector.payment_create_intent(**payment_request)
                 alias = "grantex_commerce:payment_create_intent"
                 tool_sequence.append(alias)
                 evidence.add_case(
@@ -578,15 +617,15 @@ async def run_real_staging_demo(
             }
         )
         if checkout_passport_jwt:
-            amount_cap = await connector.payment_create_intent(
-                merchant_id=merchant_id,
-                cart_id=cart_id or "staging-cart-for-amount-cap",
-                passport_jwt=checkout_passport_jwt,
-                passport_max_amount_minor_units=1,
-                amount_minor_units=max(fixture.amount_minor_units, 2),
-                currency=fixture.currency,
-                idempotency_key=f"agenticorg-real-staging-amount-cap-{uuid.uuid4().hex}",
-                provider_key="mock",
+            amount_cap = validate_payment_action(
+                "payment_create_intent",
+                {
+                    "passport_jwt": checkout_passport_jwt,
+                    "passport_max_amount_minor_units": 1,
+                    "amount_minor_units": max(fixture.amount_minor_units, 2),
+                    "currency": fixture.currency,
+                    "provider_key": "mock",
+                },
             )
             evidence.add_case(
                 name="amount_cap_breach",
@@ -863,7 +902,7 @@ async def run_demo() -> dict[str, Any]:
             passport_jwt=passport_data["passport_jwt"],
             success_url="https://agenticorg.local/commerce/success",
             cancel_url="https://agenticorg.local/commerce/cancel",
-            idempotency_key="demo_checkout_001",
+            idempotency_key=f"agenticorg-mock-checkout-{uuid.uuid4().hex}",
         )
         steps.append(
             _step(
@@ -901,7 +940,7 @@ async def run_demo() -> dict[str, Any]:
             cart_id=checkout_input["cart_id"],
             amount_minor_units=checkout_input["amount_minor_units"],
             currency=checkout_input["currency"],
-            idempotency_key="demo_missing_consent",
+            idempotency_key=f"agenticorg-mock-missing-consent-{uuid.uuid4().hex}",
             provider_key="mock",
         )
         unsupported_emi = validate_claims_against_tool_data(

--- a/tests/regression/test_commerce_sales_agent_real_staging_mode.py
+++ b/tests/regression/test_commerce_sales_agent_real_staging_mode.py
@@ -31,6 +31,8 @@ def _fixture_env_content(
     amount: int = 100,
     cap: int = 200,
     include_browse_passport: bool = True,
+    include_amount_metadata: bool = True,
+    include_cap_metadata: bool = True,
     sensitive_values: dict[str, str] | None = None,
 ) -> str:
     smoke_url = "https://grantex-auth-smoke-example-uc.a.run.app"
@@ -50,11 +52,13 @@ def _fixture_env_content(
         'AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID="cprd_stg_fixture"',
         'AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID="cvar_stg_fixture"',
         'AGENTICORG_COMMERCE_FIXTURE_CURRENCY="INR"',
-        f'AGENTICORG_COMMERCE_FIXTURE_AMOUNT_MINOR_UNITS="{amount}"',
-        f'AGENTICORG_COMMERCE_FIXTURE_PASSPORT_MAX_AMOUNT_MINOR_UNITS="{cap}"',
         f'GRANTEX_API_KEY="{runtime_values["GRANTEX_API_KEY"]}"',
         f'AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT="{runtime_values["AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT"]}"',
     ]
+    if include_amount_metadata:
+        lines.append(f'AGENTICORG_COMMERCE_FIXTURE_AMOUNT_MINOR_UNITS="{amount}"')
+    if include_cap_metadata:
+        lines.append(f'AGENTICORG_COMMERCE_FIXTURE_PASSPORT_MAX_AMOUNT_MINOR_UNITS="{cap}"')
     if include_browse_passport:
         lines.append(
             f'AGENTICORG_COMMERCE_BROWSE_PASSPORT_JWT="'
@@ -127,7 +131,9 @@ class _FakeRealStagingConnector:
             return {"error": "merchant_disabled", "message": "merchant disabled"}
         if params.get("agent_trust_status") == "untrusted":
             return {"error": "agent_untrusted", "message": "agent untrusted"}
-        if params.get("amount_minor_units", 0) > params.get("passport_max_amount_minor_units", 0):
+        if "passport_max_amount_minor_units" in params and (
+            params.get("amount_minor_units", 0) > params.get("passport_max_amount_minor_units", 0)
+        ):
             return {"error": "amount_cap_exceeded", "message": "amount cap exceeded"}
         return {"data": {"payment_intent_id": "pi_stg_fixture", "status": "requires_checkout"}}
 
@@ -154,6 +160,26 @@ async def _run_real_staging_with_fake(
         evidence_report=str(evidence_report) if evidence_report else None,
     )
     return result, _FakeRealStagingConnector.instances[0]
+
+
+_LOCAL_PAYMENT_GUARD_KEYS = (
+    "consent_status",
+    "passport_status",
+    "merchant_status",
+    "agent_trust_status",
+    "passport_max_amount_minor_units",
+)
+
+
+def _positive_payment_calls(connector: _FakeRealStagingConnector) -> list[dict[str, Any]]:
+    return [
+        params
+        for name, params in connector.calls
+        if name == "payment_create_intent"
+        and params.get("cart_id") == "cart_stg_fixture"
+        and params.get("passport_jwt")
+        and not any(key in params for key in _LOCAL_PAYMENT_GUARD_KEYS)
+    ]
 
 
 @pytest.mark.asyncio
@@ -367,6 +393,87 @@ async def test_real_staging_consent_request_uses_grantex_checkout_scope_bundle(
 
 
 @pytest.mark.asyncio
+async def test_real_staging_positive_payment_sends_only_grantex_supported_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _write_tmp_fixture(
+        "commerce-agent-real-staging-c2f-payment.env",
+        _fixture_env_content(amount=100, cap=200),
+    )
+    try:
+        result, connector = await _run_real_staging_with_fake(monkeypatch, fixture)
+    finally:
+        fixture.unlink(missing_ok=True)
+
+    positive_payment_calls = _positive_payment_calls(connector)
+    assert len(positive_payment_calls) == 1
+    payment_request = positive_payment_calls[0]
+    assert set(payment_request) <= set(commerce_sales_agent_demo.GRANTEX_PAYMENT_CREATE_INTENT_FIELDS)
+    assert set(payment_request) == {
+        "merchant_id",
+        "cart_id",
+        "passport_jwt",
+        "amount_minor_units",
+        "currency",
+        "provider_key",
+        "idempotency_key",
+    }
+    assert "passport_max_amount_minor_units" not in payment_request
+    assert "grantex_commerce:payment_create_intent" in result["audit_summary"]["tool_sequence"]
+
+
+@pytest.mark.asyncio
+async def test_real_staging_skips_positive_payment_when_fixture_cap_metadata_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _write_tmp_fixture(
+        "commerce-agent-real-staging-c2f-missing-cap.env",
+        _fixture_env_content(include_cap_metadata=False),
+    )
+    report = Path(".tmp/commerce-agent-real-staging-c2f-missing-cap.md")
+    try:
+        result, connector = await _run_real_staging_with_fake(monkeypatch, fixture, evidence_report=report)
+        report_text = report.read_text(encoding="utf-8")
+    finally:
+        fixture.unlink(missing_ok=True)
+        report.unlink(missing_ok=True)
+
+    assert _positive_payment_calls(connector) == []
+    assert "grantex_commerce:payment_create_intent" not in result["audit_summary"]["tool_sequence"]
+    assert (
+        "| payment_create_intent | skipped |  |  |  |  | requires fixture amount and passport cap metadata |"
+        in report_text
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_staging_amount_cap_negative_uses_local_guardrail_without_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _write_tmp_fixture(
+        "commerce-agent-real-staging-c2f-negative-amount-cap.env",
+        _fixture_env_content(amount=100, cap=200),
+    )
+    report = Path(".tmp/commerce-agent-real-staging-c2f-negative-amount-cap.md")
+    try:
+        _result, connector = await _run_real_staging_with_fake(monkeypatch, fixture, evidence_report=report)
+        report_text = report.read_text(encoding="utf-8")
+    finally:
+        fixture.unlink(missing_ok=True)
+        report.unlink(missing_ok=True)
+
+    assert not any(
+        name == "payment_create_intent" and params.get("passport_max_amount_minor_units") == 1
+        for name, params in connector.calls
+    )
+    assert not any(
+        name == "payment_create_intent" and params.get("cart_id") == "staging-cart-for-amount-cap"
+        for name, params in connector.calls
+    )
+    assert "| amount_cap_breach | pass |  |  |  | amount_cap_exceeded |  |" in report_text
+
+
+@pytest.mark.asyncio
 async def test_real_staging_skips_positive_payment_when_fixture_amount_exceeds_cap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -382,17 +489,11 @@ async def test_real_staging_skips_positive_payment_when_fixture_amount_exceeds_c
         fixture.unlink(missing_ok=True)
         report.unlink(missing_ok=True)
 
-    positive_payment_calls = [
-        params
+    assert _positive_payment_calls(connector) == []
+    assert not any(
+        name == "payment_create_intent" and params.get("passport_max_amount_minor_units") == 1
         for name, params in connector.calls
-        if name == "payment_create_intent"
-        and params.get("passport_jwt")
-        and params.get("passport_max_amount_minor_units") == 200
-        and not any(
-            key in params for key in ("consent_status", "passport_status", "merchant_status", "agent_trust_status")
-        )
-    ]
-    assert positive_payment_calls == []
+    )
     assert "grantex_commerce:payment_create_intent" not in result["audit_summary"]["tool_sequence"]
     assert "| payment_create_intent | skipped |  |  |  |  | fixture amount exceeds passport cap |" in report_text
     assert "| amount_cap_breach | pass |  |  |  | amount_cap_exceeded |  |" in report_text


### PR DESCRIPTION
## Summary
- keeps fixture amount/cap metadata as AgenticOrg-local payment preflight data
- builds positive real-staging payment intent calls from the Grantex-supported MCP field allowlist
- preserves the amount-cap breach negative case as a local fail-safe guardrail without a payment network/tool call
- removes pre-existing hardcoded mock idempotency literals from the edited demo file

## Validation
- `python -m ruff check demos/commerce_sales_agent_demo.py core/commerce connectors/commerce tests/evals/test_commerce_sales_agent_real_staging.py tests/regression/test_commerce_sales_agent_real_staging_mode.py tests/regression/test_commerce_sales_agent_no_provider_calls.py`
- `python -m pytest tests/evals/test_commerce_sales_agent_real_staging.py -q`
- `python -m pytest tests/regression/test_commerce_sales_agent_real_staging_mode.py -q`
- `python -m pytest tests/regression/test_commerce_sales_agent_no_provider_calls.py -q`
- `python demos/commerce_sales_agent_demo.py --mode=mock`
- real-staging refusal checks for production URL, arbitrary run.app URL, and HTTP localhost
- focused secret/value scan on changed files
- `git diff --check`

No deploy, smoke run, cloud command, production config change, live payment enablement, or live Plural enablement was performed.