### PR TITLE
fix(commerce): skip pending consent exchange with passport fixture

### DIFF
--- a/demos/commerce_sales_agent_demo.py
+++ b/demos/commerce_sales_agent_demo.py
@@ -52,6 +52,7 @@ GRANTEX_PAYMENT_CREATE_INTENT_FIELDS = (
     "metadata",
     "idempotency_key",
 )
+PREEXPORTED_CHECKOUT_PASSPORT_BLOCKER = "preexported_checkout_passport_without_granted_consent_fixture"
 
 DEMO_MCP_RESPONSES: dict[str, dict[str, Any]] = {
     "merchant_get_profile": {
@@ -463,7 +464,13 @@ async def run_real_staging_demo(
 
         consent_request_id = _data(consent).get("consent_request_id")
         checkout_passport_jwt = fixture.checkout_passport_jwt
-        if consent_request_id:
+        if checkout_passport_jwt:
+            evidence.add_case(
+                name="consent_exchange",
+                status="skipped",
+                blocker=PREEXPORTED_CHECKOUT_PASSPORT_BLOCKER,
+            )
+        elif consent_request_id:
             exchange = await connector.consent_exchange(consent_request_id=consent_request_id)
             alias = "grantex_commerce:consent_exchange"
             tool_sequence.append(alias)

--- a/tests/regression/test_commerce_sales_agent_real_staging_mode.py
+++ b/tests/regression/test_commerce_sales_agent_real_staging_mode.py
@@ -393,6 +393,33 @@ async def test_real_staging_consent_request_uses_grantex_checkout_scope_bundle(
 
 
 @pytest.mark.asyncio
+async def test_real_staging_skips_pending_consent_exchange_with_preexported_passport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _write_tmp_fixture(
+        "commerce-agent-real-staging-c2g-consent-exchange.env",
+        _fixture_env_content(amount=100, cap=200),
+    )
+    report = Path(".tmp/commerce-agent-real-staging-c2g-consent-exchange.md")
+    try:
+        result, connector = await _run_real_staging_with_fake(monkeypatch, fixture, evidence_report=report)
+        report_text = report.read_text(encoding="utf-8")
+    finally:
+        fixture.unlink(missing_ok=True)
+        report.unlink(missing_ok=True)
+
+    assert not any(name == "consent_exchange" for name, _params in connector.calls)
+    assert "grantex_commerce:consent_exchange" not in result["audit_summary"]["tool_sequence"]
+    assert "grantex_commerce:payment_create_intent" in result["audit_summary"]["tool_sequence"]
+    assert "grantex_commerce:checkout_create" in result["audit_summary"]["tool_sequence"]
+    assert "grantex_commerce:payment_get_status" in result["audit_summary"]["tool_sequence"]
+    assert (
+        "| consent_exchange | skipped |  |  |  |  | "
+        f"{commerce_sales_agent_demo.PREEXPORTED_CHECKOUT_PASSPORT_BLOCKER} |"
+    ) in report_text
+
+
+@pytest.mark.asyncio
 async def test_real_staging_positive_payment_sends_only_grantex_supported_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Skips `consent_exchange` in real-staging fixture-backed runs when a pre-exported checkout passport is already present.
- Uses the stable blocker code `preexported_checkout_passport_without_granted_consent_fixture` for deterministic evidence comparison.
- Preserves payment intent, checkout handoff, and payment status paths using the checkout passport fixture.

## Safety
- Does not print or record passport values or consent runtime material.
- Preserves Grantex-only commerce path and no provider credential handling.
- Keeps amount-cap negative behavior as a local fail-safe.

## Validation
- `python -m ruff check demos/commerce_sales_agent_demo.py core/commerce connectors/commerce tests/evals/test_commerce_sales_agent_real_staging.py tests/regression/test_commerce_sales_agent_real_staging_mode.py tests/regression/test_commerce_sales_agent_no_provider_calls.py`
- `python -m pytest tests/evals/test_commerce_sales_agent_real_staging.py -q` (skipped without approved real-staging env)
- `python -m pytest tests/regression/test_commerce_sales_agent_real_staging_mode.py -q`
- `python -m pytest tests/regression/test_commerce_sales_agent_no_provider_calls.py -q`
- `python demos/commerce_sales_agent_demo.py --mode=mock`
- `git diff --check`
- Diff-only focused secret scan on changed files