### PR TITLE
feat(commerce): add hosted smoke evidence runner

### DIFF
--- a/docs/commerce-agent-c3-hosted-smoke-runbook.md
+++ b/docs/commerce-agent-c3-hosted-smoke-runbook.md
@@ -6,6 +6,8 @@ Status: C3-prep only. This runbook does not deploy, create cloud resources, chan
 
 C3 covers the currently skipped hosted gap after C2G: AgenticOrg MCP/A2A discovery and hosted real-staging runtime behavior against a temporary Grantex Option A smoke service.
 
+Run C3 hosted smoke after C2G smoke evidence is complete and merged, unless an explicit approval says otherwise.
+
 The cheapest sufficient topology is an API-only temporary AgenticOrg Cloud Run smoke service. UI, worker, and beat are deferred because they do not add coverage for MCP discovery, A2A discovery, or the Commerce Sales Agent Grantex-only runtime path.
 
 ## Recommended Topology

--- a/docs/commerce-agent-c3-hosted-smoke-runbook.md
+++ b/docs/commerce-agent-c3-hosted-smoke-runbook.md
@@ -1,0 +1,215 @@
+# AgenticOrg C3 Hosted Commerce Smoke Runbook
+
+Status: C3-prep only. This runbook does not deploy, create cloud resources, change production config, enable production Commerce V1, enable live payments, or enable live Plural.
+
+## Goal
+
+C3 covers the currently skipped hosted gap after C2G: AgenticOrg MCP/A2A discovery and hosted real-staging runtime behavior against a temporary Grantex Option A smoke service.
+
+The cheapest sufficient topology is an API-only temporary AgenticOrg Cloud Run smoke service. UI, worker, and beat are deferred because they do not add coverage for MCP discovery, A2A discovery, or the Commerce Sales Agent Grantex-only runtime path.
+
+## Recommended Topology
+
+Use only these temporary AgenticOrg resources:
+
+| Resource | Name |
+| --- | --- |
+| Cloud Run API service | `agenticorg-api-commerce-smoke` |
+| Optional Cloud Run eval job | `agenticorg-commerce-smoke-eval` |
+| Optional migration job | `agenticorg-commerce-smoke-migrate` |
+| Cloud SQL instance | `agenticorg-commerce-smoke-pg` |
+| Redis instance | `agenticorg-commerce-smoke-redis` |
+| API image tag | `agenticorg-api:commerce-smoke-<sha>` |
+
+The Grantex side remains the temporary Option A smoke topology:
+
+| Resource | Name |
+| --- | --- |
+| Cloud Run service | `grantex-auth-smoke` |
+| Cloud SQL instance | `grantex-commerce-smoke-pg` |
+| Redis instance | `grantex-commerce-smoke-redis` |
+
+## Non-Secret Env Vars
+
+Set these on the temporary AgenticOrg API service and optional eval job only:
+
+```text
+AGENTICORG_ENV=staging
+AGENTICORG_BASE_URL=<agenticorg-smoke-cloud-run-origin>
+AGENTICORG_PUBLIC_API_BASE_URL=<agenticorg-smoke-cloud-run-origin>
+AGENTICORG_CORS_ALLOWED_ORIGINS=<agenticorg-smoke-cloud-run-origin>
+AGENTICORG_GIT_SHA=<agenticorg-main-sha>
+AGENTICORG_ENABLE_LEGACY_STARTUP_DDL=0
+AGENTICORG_COMMERCE_REAL_STAGING=1
+GRANTEX_COMMERCE_BASE_URL=<grantex-smoke-cloud-run-origin>
+GRANTEX_BASE_URL=<grantex-smoke-cloud-run-origin>
+AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL=<grantex-smoke-cloud-run-origin>
+COMMERCE_LIVE_MODE_ENABLED=0
+PLURAL_LIVE_ENABLED=0
+PLURAL_ENV=sandbox
+```
+
+## Required Secrets By Name Only
+
+Use smoke-only secret names. Do not copy production secret versions.
+
+```text
+agenticorg-commerce-smoke-secret-key
+agenticorg-commerce-smoke-db-url
+agenticorg-commerce-smoke-redis-url
+agenticorg-commerce-smoke-grantex-api-key
+agenticorg-commerce-smoke-fixture-env
+```
+
+Use exactly one Grantex auth source name in the runner:
+
+```text
+GRANTEX_COMMERCE_BEARER_TOKEN
+GRANTEX_AGENT_ASSERTION
+GRANTEX_API_KEY
+```
+
+Do not write auth values, passports, idempotency values, DB/Redis URLs, private keys, or provider material into docs, logs, evidence, PRs, or chat.
+
+## Command Plan, Not Run
+
+Build image:
+
+```powershell
+gcloud builds submit --config=cloudbuild-api.yaml --substitutions=_IMAGE=<registry>/agenticorg-api:commerce-smoke-<sha>
+```
+
+Create temporary AgenticOrg smoke resources:
+
+```powershell
+gcloud sql instances create agenticorg-commerce-smoke-pg --tier=db-f1-micro --region=us-central1 --deletion-protection=false
+gcloud redis instances create agenticorg-commerce-smoke-redis --region=us-central1 --size=1 --tier=basic
+```
+
+Create smoke-only secrets by name only, with values supplied outside logs:
+
+```powershell
+gcloud secrets create agenticorg-commerce-smoke-secret-key
+gcloud secrets create agenticorg-commerce-smoke-db-url
+gcloud secrets create agenticorg-commerce-smoke-redis-url
+gcloud secrets create agenticorg-commerce-smoke-grantex-api-key
+gcloud secrets create agenticorg-commerce-smoke-fixture-env
+```
+
+Run migrations once if the temp database requires them:
+
+```powershell
+gcloud run jobs create agenticorg-commerce-smoke-migrate --image=<image> --command=python --args=scripts/alembic_migrate.py
+gcloud run jobs execute agenticorg-commerce-smoke-migrate --wait
+```
+
+Deploy the temporary API-only smoke service with min instances 0 and max instances 1:
+
+```powershell
+gcloud run deploy agenticorg-api-commerce-smoke --image=<image> --region=us-central1 --min-instances=0 --max-instances=1
+gcloud run services update agenticorg-api-commerce-smoke --region=us-central1 --update-env-vars=AGENTICORG_BASE_URL=<agenticorg-smoke-url>,AGENTICORG_PUBLIC_API_BASE_URL=<agenticorg-smoke-url>
+```
+
+Run the hosted smoke runner only after both temporary smoke URLs are known:
+
+```powershell
+python scripts/commerce_agent_hosted_smoke.py --run `
+  --agenticorg-base <agenticorg-smoke-url> `
+  --allow-agenticorg-cloud-run-url <agenticorg-smoke-url> `
+  --grantex-base <grantex-smoke-url> `
+  --allow-grantex-cloud-run-url <grantex-smoke-url> `
+  --auth-source-env-name GRANTEX_API_KEY `
+  --fixture-env .tmp/commerce-agent-real-staging.env `
+  --real-staging-evidence-report docs/reports/commerce-agent-real-staging-evidence.md `
+  --evidence-report docs/reports/commerce-agent-hosted-smoke-evidence.md
+```
+
+Optional Cloud Run Job mode may use the smoke-only fixture secret name instead of a local `.tmp` fixture env. The runner records the fixture secret name only and does not read or print its value:
+
+```powershell
+python scripts/commerce_agent_hosted_smoke.py --run `
+  --agenticorg-base <agenticorg-smoke-url> `
+  --allow-agenticorg-cloud-run-url <agenticorg-smoke-url> `
+  --grantex-base <grantex-smoke-url> `
+  --allow-grantex-cloud-run-url <grantex-smoke-url> `
+  --auth-source-env-name GRANTEX_API_KEY `
+  --fixture-secret-name agenticorg-commerce-smoke-fixture-env `
+  --evidence-report docs/reports/commerce-agent-hosted-smoke-evidence.md
+```
+
+## Smoke Checks
+
+The runner checks:
+
+- `GET /api/v1/health/liveness`
+- `GET /api/v1/health`
+- `GET /api/v1/mcp/tools` includes `agenticorg_commerce_sales_agent`
+- `GET /api/v1/a2a/.well-known/agent.json` uses the AgenticOrg smoke origin and Grantex smoke issuer/JWKS
+- `GET /api/v1/a2a/agents` includes `commerce_sales_agent` with `grantex_commerce:*` tools
+
+If a real-staging evidence report is supplied, `consent_exchange` is expected only when it is skipped with this exact blocker code:
+
+```text
+preexported_checkout_passport_without_granted_consent_fixture
+```
+
+If `consent_exchange` is failed, missing, or skipped with any other blocker, C3 is not passing.
+
+## Refusal Checks
+
+Before network use, the runner refuses:
+
+- missing explicit `--run` for hosted HTTP checks
+- non-HTTPS URLs
+- AgenticOrg production origins
+- Grantex production origins
+- arbitrary `run.app` URLs without exact allowlists
+- localhost origins
+- live Commerce or live Plural flags
+- unsupported Grantex auth source names
+- fixture env paths outside `.tmp/`
+- ambiguous local fixture and fixture secret sources
+- production-looking AgenticOrg service, DB, Redis, job, or secret names
+- non-smoke DB, Redis, service, job, or secret names
+
+## Evidence Format
+
+Evidence may include only:
+
+- AgenticOrg and Grantex hosts
+- commit SHA or image tag
+- smoke resource names
+- non-secret env var names
+- secret names only
+- fixture env var names
+- synthetic fixture IDs
+- redacted short hashes for sensitive fixture values
+- case status, HTTP status, latency, error code, and blocker
+
+Evidence must not include `.tmp` file contents, auth values, passports/JWT values, idempotency values, webhook material, provider material, raw payloads, DB/Redis URLs, private keys, or secret values.
+
+## Cleanup Plan
+
+Delete resources in this order:
+
+```text
+agenticorg-commerce-smoke-eval
+agenticorg-commerce-smoke-migrate
+agenticorg-api-commerce-smoke
+agenticorg-commerce-smoke-redis
+agenticorg-commerce-smoke-pg
+agenticorg-commerce-smoke-* secrets
+agenticorg-api:commerce-smoke-* image tags
+```
+
+Then verify:
+
+- temporary AgenticOrg resources are absent
+- temporary Grantex smoke resources are absent
+- production AgenticOrg services still exist and were not updated
+- production Grantex services still exist and were not updated
+- production config, secrets, Commerce V1 flags, live payment flags, and live Plural flags are unchanged
+
+## C3-Prep Confirmation
+
+This C3-prep runbook and runner do not deploy, create cloud resources, change production config, enable production Commerce V1, enable live payments, enable live Plural, touch secrets, or run smoke/cloud commands.

--- a/scripts/commerce_agent_hosted_smoke.py
+++ b/scripts/commerce_agent_hosted_smoke.py
@@ -1,0 +1,643 @@
+"""Fail-closed C3 hosted AgenticOrg commerce smoke runner.
+
+This runner validates a temporary API-only AgenticOrg Cloud Run smoke service
+and records redacted discovery evidence. It never creates resources, never
+deploys, and never reads cloud secrets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+EXPECTED_CONSENT_EXCHANGE_BLOCKER = "preexported_checkout_passport_without_granted_consent_fixture"
+
+AUTH_SOURCE_ENV_NAMES = (
+    "GRANTEX_COMMERCE_BEARER_TOKEN",
+    "GRANTEX_AGENT_ASSERTION",
+    "GRANTEX_API_KEY",
+)
+SENSITIVE_FIXTURE_ENV_NAMES = frozenset(
+    {
+        *AUTH_SOURCE_ENV_NAMES,
+        "AGENTICORG_COMMERCE_BROWSE_PASSPORT_JWT",
+        "AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT",
+        "AGENTICORG_COMMERCE_REVOKED_PASSPORT_JWT",
+        "AGENTICORG_COMMERCE_EXPIRED_PASSPORT_JWT",
+        "AGENTICORG_COMMERCE_DENIED_CONSENT_REF",
+    }
+)
+SYNTHETIC_ID_ENV_NAMES = frozenset(
+    {
+        "AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID",
+        "AGENTICORG_COMMERCE_FIXTURE_AGENT_ID",
+        "AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID",
+        "AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID",
+    }
+)
+
+PRODUCTION_AGENTICORG_ORIGINS = frozenset(
+    {
+        "https://app.agenticorg.ai",
+        "https://agenticorg.ai",
+        "https://www.agenticorg.ai",
+    }
+)
+PRODUCTION_GRANTEX_ORIGINS = frozenset({"https://api.grantex.dev", "https://grantex.dev"})
+LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+PRODUCTION_RESOURCE_NAMES = frozenset(
+    {
+        "agenticorg-api",
+        "agenticorg-ui",
+        "agenticorg-worker",
+        "agenticorg-beat",
+        "agenticorg-migrate",
+        "agenticorg-pg",
+        "agenticorg-redis",
+        "agenticorg-secret-key",
+        "agenticorg-database-url",
+        "agenticorg-redis-url",
+        "grantex-api-key",
+        "grantex-agent-assertion",
+        "grantex-commerce-bearer-token",
+    }
+)
+DEFAULT_SECRET_NAMES = (
+    "agenticorg-commerce-smoke-secret-key",
+    "agenticorg-commerce-smoke-db-url",
+    "agenticorg-commerce-smoke-redis-url",
+    "agenticorg-commerce-smoke-grantex-api-key",
+)
+DEFAULT_NON_SECRET_ENV_NAMES = (
+    "AGENTICORG_ENV",
+    "AGENTICORG_BASE_URL",
+    "AGENTICORG_PUBLIC_API_BASE_URL",
+    "AGENTICORG_CORS_ALLOWED_ORIGINS",
+    "AGENTICORG_GIT_SHA",
+    "AGENTICORG_ENABLE_LEGACY_STARTUP_DDL",
+    "AGENTICORG_COMMERCE_REAL_STAGING",
+    "GRANTEX_COMMERCE_BASE_URL",
+    "GRANTEX_BASE_URL",
+    "AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL",
+    "COMMERCE_LIVE_MODE_ENABLED",
+    "PLURAL_LIVE_ENABLED",
+    "PLURAL_ENV",
+)
+
+
+class HostedSmokeConfigError(ValueError):
+    """Raised before network use when C3 smoke guardrails are not met."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class FixtureSummary:
+    env_path: str | None = None
+    secret_name: str | None = None
+    variable_names: tuple[str, ...] = ()
+    synthetic_ids: dict[str, str] = field(default_factory=dict)
+    sensitive_value_hashes: tuple[dict[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class HostedSmokeConfig:
+    agenticorg_base_url: str
+    grantex_base_url: str
+    auth_source_env_name: str
+    allow_agenticorg_cloud_run_url: str | None = None
+    allow_grantex_cloud_run_url: str | None = None
+    agenticorg_service_name: str = "agenticorg-api-commerce-smoke"
+    eval_job_name: str = "agenticorg-commerce-smoke-eval"
+    migrate_job_name: str = "agenticorg-commerce-smoke-migrate"
+    database_resource_name: str = "agenticorg-commerce-smoke-pg"
+    redis_resource_name: str = "agenticorg-commerce-smoke-redis"
+    secret_names: tuple[str, ...] = DEFAULT_SECRET_NAMES
+    non_secret_env_names: tuple[str, ...] = DEFAULT_NON_SECRET_ENV_NAMES
+    commit_sha: str | None = None
+    image_tag: str | None = None
+    cleanup_by: str | None = None
+    evidence_report: str | None = None
+    real_staging_evidence_report: str | None = None
+    fixture: FixtureSummary = field(default_factory=FixtureSummary)
+
+    @property
+    def agenticorg_host(self) -> str:
+        return urlparse(self.agenticorg_base_url).hostname or ""
+
+    @property
+    def grantex_host(self) -> str:
+        return urlparse(self.grantex_base_url).hostname or ""
+
+
+@dataclass
+class SmokeCase:
+    name: str
+    status: str
+    http_status: int | None = None
+    latency_ms: int | None = None
+    error_code: str | None = None
+    blocker: str | None = None
+
+
+def _truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "enabled", "on"}
+
+
+def _normalize_origin(raw_url: str, *, code_prefix: str) -> str:
+    value = str(raw_url or "").strip()
+    parsed = urlparse(value)
+    if not parsed.scheme or not parsed.netloc:
+        raise HostedSmokeConfigError(f"{code_prefix}_url_invalid", "A complete HTTPS origin is required.")
+    if parsed.username or parsed.password:
+        raise HostedSmokeConfigError(f"{code_prefix}_credentialed_url_refused", "Credentialed URLs are refused.")
+    if parsed.scheme != "https":
+        raise HostedSmokeConfigError(f"{code_prefix}_non_https_url_refused", "C3 hosted smoke requires HTTPS.")
+    hostname = parsed.hostname or ""
+    if hostname.lower() in LOCAL_HOSTS:
+        raise HostedSmokeConfigError(f"{code_prefix}_localhost_refused", "Localhost is refused for hosted smoke.")
+    if parsed.path not in ("", "/") or parsed.params or parsed.query or parsed.fragment:
+        raise HostedSmokeConfigError(f"{code_prefix}_non_origin_url_refused", "Use only the URL origin.")
+    return f"{parsed.scheme}://{hostname}{f':{parsed.port}' if parsed.port else ''}"
+
+
+def _validate_run_app_allowlist(origin: str, allow_origin: str | None, *, code_prefix: str) -> str | None:
+    host = urlparse(origin).hostname or ""
+    normalized_allow = None
+    if allow_origin:
+        normalized_allow = _normalize_origin(allow_origin, code_prefix=f"{code_prefix}_allowlist")
+    if host.endswith(".run.app") and origin != normalized_allow:
+        raise HostedSmokeConfigError(
+            f"{code_prefix}_smoke_url_not_allowlisted",
+            "Cloud Run smoke URLs must exactly match their allowlist value.",
+        )
+    return normalized_allow
+
+
+def _validate_not_production(origin: str, *, production_origins: frozenset[str], code_prefix: str) -> None:
+    if origin in production_origins:
+        raise HostedSmokeConfigError(f"{code_prefix}_production_url_refused", "Production URLs are refused.")
+
+
+def _validate_smoke_name(name: str, *, field_name: str) -> str:
+    normalized = str(name or "").strip()
+    lowered = normalized.lower()
+    if not normalized:
+        raise HostedSmokeConfigError("smoke_resource_name_missing", f"{field_name} is required.")
+    if lowered in PRODUCTION_RESOURCE_NAMES or "prod" in lowered or "production" in lowered:
+        raise HostedSmokeConfigError(
+            "production_resource_name_refused",
+            f"{field_name} must not use a production-looking resource name.",
+        )
+    if "smoke" not in lowered:
+        raise HostedSmokeConfigError("smoke_resource_name_required", f"{field_name} must contain 'smoke'.")
+    return normalized
+
+
+def _decode_env_value(raw_value: str) -> str:
+    value = raw_value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    return value.replace('\\"', '"').replace("\\\\", "\\").strip()
+
+
+def _resolve_tmp_fixture_path(path: str) -> Path:
+    repo_root = Path(__file__).resolve().parents[1]
+    candidate = (repo_root / path).resolve()
+    tmp_root = (repo_root / ".tmp").resolve()
+    try:
+        candidate.relative_to(tmp_root)
+    except ValueError as exc:
+        raise HostedSmokeConfigError("fixture_env_outside_tmp", "Fixture env files must stay under .tmp/.") from exc
+    if candidate == tmp_root:
+        raise HostedSmokeConfigError("fixture_env_outside_tmp", "Fixture env must be a file under .tmp/.")
+    return candidate
+
+
+def _summarize_fixture_env(path: str, *, auth_source_env_name: str) -> FixtureSummary:
+    fixture_path = _resolve_tmp_fixture_path(path)
+    if not fixture_path.exists():
+        raise HostedSmokeConfigError("fixture_env_missing", "Fixture env file was not found.")
+
+    values: dict[str, str] = {}
+    for line_number, raw_line in enumerate(fixture_path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:].strip()
+        if "=" not in line:
+            raise HostedSmokeConfigError(
+                "fixture_env_invalid",
+                f"Fixture env line {line_number} must use KEY=value syntax.",
+            )
+        key, raw_value = line.split("=", 1)
+        values[key.strip()] = _decode_env_value(raw_value)
+
+    present_auth_sources = [name for name in AUTH_SOURCE_ENV_NAMES if values.get(name)]
+    if len(present_auth_sources) != 1:
+        raise HostedSmokeConfigError(
+            "fixture_auth_source_count_invalid",
+            "Fixture env must include exactly one Grantex auth source value.",
+        )
+    if present_auth_sources[0] != auth_source_env_name:
+        raise HostedSmokeConfigError(
+            "fixture_auth_source_mismatch",
+            "Fixture auth source must match --auth-source-env-name.",
+        )
+
+    hashes = []
+    for name in sorted(SENSITIVE_FIXTURE_ENV_NAMES):
+        value = values.get(name)
+        if value:
+            hashes.append({"name": name, "sha256_12": sha256(value.encode("utf-8")).hexdigest()[:12]})
+
+    synthetic_ids = {name: values[name] for name in sorted(SYNTHETIC_ID_ENV_NAMES) if values.get(name)}
+    relative_path = fixture_path.relative_to(Path(__file__).resolve().parents[1]).as_posix()
+    return FixtureSummary(
+        env_path=relative_path,
+        variable_names=tuple(sorted(values)),
+        synthetic_ids=synthetic_ids,
+        sensitive_value_hashes=tuple(hashes),
+    )
+
+
+def validate_config(args: argparse.Namespace, *, environ: dict[str, str] | None = None) -> HostedSmokeConfig:
+    env = environ if environ is not None else os.environ
+    agenticorg_origin = _normalize_origin(args.agenticorg_base, code_prefix="agenticorg")
+    grantex_origin = _normalize_origin(args.grantex_base, code_prefix="grantex")
+    _validate_not_production(
+        agenticorg_origin,
+        production_origins=PRODUCTION_AGENTICORG_ORIGINS,
+        code_prefix="agenticorg",
+    )
+    _validate_not_production(grantex_origin, production_origins=PRODUCTION_GRANTEX_ORIGINS, code_prefix="grantex")
+    allow_agenticorg = _validate_run_app_allowlist(
+        agenticorg_origin,
+        args.allow_agenticorg_cloud_run_url,
+        code_prefix="agenticorg",
+    )
+    allow_grantex = _validate_run_app_allowlist(
+        grantex_origin,
+        args.allow_grantex_cloud_run_url,
+        code_prefix="grantex",
+    )
+
+    if _truthy(env.get("COMMERCE_LIVE_MODE_ENABLED")) or _truthy(env.get("PLURAL_LIVE_ENABLED")):
+        raise HostedSmokeConfigError("live_flags_refused", "Live Commerce and live Plural flags must be false.")
+    if args.commerce_live_mode or args.plural_live_mode:
+        raise HostedSmokeConfigError("live_flags_refused", "Live Commerce and live Plural flags must be false.")
+
+    auth_source_env_name = str(args.auth_source_env_name or "").strip()
+    if auth_source_env_name not in AUTH_SOURCE_ENV_NAMES:
+        raise HostedSmokeConfigError("auth_source_env_name_invalid", "Use exactly one supported Grantex auth source name.")
+
+    if args.fixture_env and args.fixture_secret_name:
+        raise HostedSmokeConfigError(
+            "fixture_source_ambiguous",
+            "Use either a local .tmp fixture env or a smoke-only fixture secret name, not both.",
+        )
+
+    fixture = FixtureSummary()
+    if args.fixture_env:
+        fixture = _summarize_fixture_env(args.fixture_env, auth_source_env_name=auth_source_env_name)
+    elif args.fixture_secret_name:
+        fixture = FixtureSummary(secret_name=_validate_smoke_name(args.fixture_secret_name, field_name="fixture secret"))
+
+    secret_names = tuple(_validate_smoke_name(name, field_name="secret name") for name in args.secret_name)
+    return HostedSmokeConfig(
+        agenticorg_base_url=agenticorg_origin,
+        grantex_base_url=grantex_origin,
+        auth_source_env_name=auth_source_env_name,
+        allow_agenticorg_cloud_run_url=allow_agenticorg,
+        allow_grantex_cloud_run_url=allow_grantex,
+        agenticorg_service_name=_validate_smoke_name(args.agenticorg_service, field_name="AgenticOrg service"),
+        eval_job_name=_validate_smoke_name(args.eval_job, field_name="eval job"),
+        migrate_job_name=_validate_smoke_name(args.migrate_job, field_name="migrate job"),
+        database_resource_name=_validate_smoke_name(args.database_resource, field_name="database resource"),
+        redis_resource_name=_validate_smoke_name(args.redis_resource, field_name="redis resource"),
+        secret_names=secret_names,
+        commit_sha=args.commit_sha,
+        image_tag=args.image_tag,
+        cleanup_by=args.cleanup_by,
+        evidence_report=args.evidence_report,
+        real_staging_evidence_report=args.real_staging_evidence_report,
+        fixture=fixture,
+    )
+
+
+def _case_from_response(name: str, response: httpx.Response, started_at: float) -> tuple[SmokeCase, Any]:
+    latency_ms = int((time.perf_counter() - started_at) * 1000)
+    try:
+        payload = response.json()
+    except (json.JSONDecodeError, ValueError):
+        return (
+            SmokeCase(
+                name=name,
+                status="fail",
+                http_status=response.status_code,
+                latency_ms=latency_ms,
+                error_code="invalid_json",
+            ),
+            None,
+        )
+    status = "pass" if response.status_code < 400 else "fail"
+    error_code = None if status == "pass" else f"http_{response.status_code}"
+    return SmokeCase(name=name, status=status, http_status=response.status_code, latency_ms=latency_ms, error_code=error_code), payload
+
+
+def _get_json(client: httpx.Client, base_url: str, path: str, *, case_name: str) -> tuple[SmokeCase, Any]:
+    started_at = time.perf_counter()
+    try:
+        response = client.get(f"{base_url}{path}")
+    except httpx.HTTPError:
+        latency_ms = int((time.perf_counter() - started_at) * 1000)
+        return SmokeCase(name=case_name, status="fail", latency_ms=latency_ms, error_code="transport_error"), None
+    return _case_from_response(case_name, response, started_at)
+
+
+def _append_assertion_case(cases: list[SmokeCase], *, name: str, condition: bool, error_code: str) -> None:
+    cases.append(SmokeCase(name=name, status="pass" if condition else "fail", error_code=None if condition else error_code))
+
+
+def run_hosted_checks(config: HostedSmokeConfig, *, client: httpx.Client | None = None) -> list[SmokeCase]:
+    close_client = client is None
+    client = client or httpx.Client(timeout=10.0)
+    cases: list[SmokeCase] = []
+    try:
+        case, liveness = _get_json(client, config.agenticorg_base_url, "/api/v1/health/liveness", case_name="liveness")
+        cases.append(case)
+        if case.status == "pass":
+            _append_assertion_case(
+                cases,
+                name="liveness_status_alive",
+                condition=isinstance(liveness, dict) and liveness.get("status") == "alive",
+                error_code="liveness_not_alive",
+            )
+
+        case, health = _get_json(client, config.agenticorg_base_url, "/api/v1/health", case_name="health")
+        cases.append(case)
+        if case.status == "pass":
+            _append_assertion_case(
+                cases,
+                name="health_status_healthy",
+                condition=isinstance(health, dict) and health.get("status") == "healthy",
+                error_code="health_not_healthy",
+            )
+
+        case, mcp_tools = _get_json(client, config.agenticorg_base_url, "/api/v1/mcp/tools", case_name="mcp_tools")
+        cases.append(case)
+        if case.status == "pass":
+            tools = mcp_tools.get("tools", []) if isinstance(mcp_tools, dict) else []
+            _append_assertion_case(
+                cases,
+                name="mcp_commerce_sales_agent_discovery",
+                condition=any(tool.get("name") == "agenticorg_commerce_sales_agent" for tool in tools if isinstance(tool, dict)),
+                error_code="commerce_mcp_tool_missing",
+            )
+
+        case, agent_card = _get_json(
+            client,
+            config.agenticorg_base_url,
+            "/api/v1/a2a/.well-known/agent.json",
+            case_name="a2a_agent_card",
+        )
+        cases.append(case)
+        if case.status == "pass" and isinstance(agent_card, dict):
+            auth = agent_card.get("authentication", {}) if isinstance(agent_card.get("authentication"), dict) else {}
+            _append_assertion_case(
+                cases,
+                name="a2a_card_uses_agenticorg_smoke_origin",
+                condition=str(agent_card.get("url", "")).startswith(f"{config.agenticorg_base_url}/api/v1/a2a"),
+                error_code="a2a_card_agenticorg_origin_mismatch",
+            )
+            _append_assertion_case(
+                cases,
+                name="a2a_card_uses_grantex_smoke_issuer",
+                condition=auth.get("issuer") == config.grantex_base_url,
+                error_code="a2a_card_grantex_issuer_mismatch",
+            )
+            _append_assertion_case(
+                cases,
+                name="a2a_card_uses_grantex_smoke_jwks",
+                condition=auth.get("jwksUri") == f"{config.grantex_base_url}/.well-known/jwks.json",
+                error_code="a2a_card_grantex_jwks_mismatch",
+            )
+
+        case, a2a_agents = _get_json(client, config.agenticorg_base_url, "/api/v1/a2a/agents", case_name="a2a_agents")
+        cases.append(case)
+        if case.status == "pass":
+            agents = a2a_agents.get("agents", []) if isinstance(a2a_agents, dict) else []
+            commerce_agent = next(
+                (agent for agent in agents if isinstance(agent, dict) and agent.get("id") == "commerce_sales_agent"),
+                None,
+            )
+            tools = commerce_agent.get("tools", []) if isinstance(commerce_agent, dict) else []
+            _append_assertion_case(
+                cases,
+                name="a2a_commerce_sales_agent_discovery",
+                condition=commerce_agent is not None,
+                error_code="commerce_a2a_agent_missing",
+            )
+            _append_assertion_case(
+                cases,
+                name="a2a_commerce_tools_grantex_only",
+                condition=bool(tools) and all(str(tool).startswith("grantex_commerce:") for tool in tools),
+                error_code="commerce_a2a_tools_not_grantex_only",
+            )
+
+        if config.real_staging_evidence_report:
+            cases.append(validate_consent_exchange_evidence(Path(config.real_staging_evidence_report)))
+    finally:
+        if close_client:
+            client.close()
+    return cases
+
+
+def validate_consent_exchange_evidence(path: Path) -> SmokeCase:
+    if not path.exists():
+        return SmokeCase(
+            name="consent_exchange_expected_skip_evidence",
+            status="fail",
+            error_code="real_staging_evidence_missing",
+        )
+    text = path.read_text(encoding="utf-8")
+    consent_lines = [line for line in text.splitlines() if "consent_exchange" in line]
+    if any("| consent_exchange | failed |" in line or "| consent_exchange | fail |" in line for line in consent_lines):
+        return SmokeCase(
+            name="consent_exchange_expected_skip_evidence",
+            status="fail",
+            error_code="consent_exchange_reported_failed",
+        )
+    expected = [line for line in consent_lines if "| consent_exchange | skipped |" in line]
+    if not any(EXPECTED_CONSENT_EXCHANGE_BLOCKER in line for line in expected):
+        return SmokeCase(
+            name="consent_exchange_expected_skip_evidence",
+            status="fail",
+            error_code="consent_exchange_expected_blocker_missing",
+        )
+    return SmokeCase(name="consent_exchange_expected_skip_evidence", status="pass")
+
+
+def evidence_as_dict(config: HostedSmokeConfig, cases: list[SmokeCase], *, dry_run: bool) -> dict[str, Any]:
+    fixture_source = None
+    if config.fixture.env_path:
+        fixture_source = "local_tmp_fixture_env"
+    elif config.fixture.secret_name:
+        fixture_source = "smoke_secret"
+    return {
+        "report_type": "agenticorg-c3-hosted-commerce-smoke",
+        "run_mode": "dry-run" if dry_run else "run",
+        "agenticorg_host": config.agenticorg_host,
+        "grantex_host": config.grantex_host,
+        "commit_sha": config.commit_sha,
+        "image_tag": config.image_tag,
+        "cleanup_by": config.cleanup_by,
+        "resources": {
+            "agenticorg_service_name": config.agenticorg_service_name,
+            "eval_job_name": config.eval_job_name,
+            "migrate_job_name": config.migrate_job_name,
+            "database_resource_name": config.database_resource_name,
+            "redis_resource_name": config.redis_resource_name,
+        },
+        "env_var_names": list(config.non_secret_env_names),
+        "auth_source_env_name": config.auth_source_env_name,
+        "secret_names": list(config.secret_names),
+        "fixture": {
+            "source": fixture_source,
+            "secret_name": config.fixture.secret_name,
+            "env_var_names": list(config.fixture.variable_names),
+            "synthetic_ids": config.fixture.synthetic_ids,
+            "sensitive_value_hashes": list(config.fixture.sensitive_value_hashes),
+        },
+        "cases": [case.__dict__ for case in cases],
+        "no_provider_call_confirmation": True,
+        "redaction": {
+            "secret_values_recorded": False,
+            "bearer_tokens_recorded": False,
+            "passport_values_recorded": False,
+            "idempotency_values_recorded": False,
+            "provider_material_recorded": False,
+            "raw_payloads_recorded": False,
+            "db_redis_urls_recorded": False,
+            "private_keys_recorded": False,
+        },
+    }
+
+
+def write_evidence_report(config: HostedSmokeConfig, cases: list[SmokeCase], *, dry_run: bool, path: str | Path) -> None:
+    report_path = Path(path)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    rows = [
+        "| Case | Status | HTTP | Latency ms | Error | Blocker |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for case in cases:
+        rows.append(
+            "| "
+            + " | ".join(
+                [
+                    case.name,
+                    case.status,
+                    "" if case.http_status is None else str(case.http_status),
+                    "" if case.latency_ms is None else str(case.latency_ms),
+                    case.error_code or "",
+                    case.blocker or "",
+                ]
+            )
+            + " |"
+        )
+    data = evidence_as_dict(config, cases, dry_run=dry_run)
+    report_path.write_text(
+        "\n".join(
+            [
+                "# AgenticOrg C3 Hosted Commerce Smoke Evidence",
+                "",
+                f"- Run mode: `{data['run_mode']}`",
+                f"- AgenticOrg host: `{data['agenticorg_host']}`",
+                f"- Grantex host: `{data['grantex_host']}`",
+                f"- Auth source env name: `{config.auth_source_env_name}`",
+                f"- Fixture source: `{data['fixture']['source'] or ''}`",
+                f"- Fixture secret name: `{config.fixture.secret_name or ''}`",
+                "- Secret values recorded: false",
+                "- Raw passports/JWTs recorded: false",
+                "- Idempotency values recorded: false",
+                "- Provider material recorded: false",
+                "- Raw request/response bodies recorded: false",
+                "- DB/Redis URLs recorded: false",
+                "",
+                "## Case Results",
+                "",
+                *rows,
+                "",
+                "## Redacted Summary",
+                "",
+                "```json",
+                json.dumps(data, indent=2, sort_keys=True),
+                "```",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="C3 hosted AgenticOrg commerce smoke runner")
+    parser.add_argument("--run", action="store_true", help="Perform hosted HTTP checks. Omit for dry-run only.")
+    parser.add_argument("--agenticorg-base", required=True, help="Temporary AgenticOrg API smoke origin")
+    parser.add_argument("--grantex-base", required=True, help="Temporary Grantex Option A smoke origin")
+    parser.add_argument("--allow-agenticorg-cloud-run-url", default=None)
+    parser.add_argument("--allow-grantex-cloud-run-url", default=None)
+    parser.add_argument("--auth-source-env-name", required=True, choices=AUTH_SOURCE_ENV_NAMES)
+    parser.add_argument("--agenticorg-service", default="agenticorg-api-commerce-smoke")
+    parser.add_argument("--eval-job", default="agenticorg-commerce-smoke-eval")
+    parser.add_argument("--migrate-job", default="agenticorg-commerce-smoke-migrate")
+    parser.add_argument("--database-resource", default="agenticorg-commerce-smoke-pg")
+    parser.add_argument("--redis-resource", default="agenticorg-commerce-smoke-redis")
+    parser.add_argument("--secret-name", action="append", default=list(DEFAULT_SECRET_NAMES))
+    parser.add_argument("--fixture-env", default=None)
+    parser.add_argument("--fixture-secret-name", default=None)
+    parser.add_argument("--real-staging-evidence-report", default=None)
+    parser.add_argument("--evidence-report", default=None)
+    parser.add_argument("--commit-sha", default=None)
+    parser.add_argument("--image-tag", default=None)
+    parser.add_argument("--cleanup-by", default=None)
+    parser.add_argument("--commerce-live-mode", action="store_true")
+    parser.add_argument("--plural-live-mode", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        config = validate_config(args)
+        cases: list[SmokeCase] = []
+        if args.run:
+            cases = run_hosted_checks(config)
+            if config.evidence_report:
+                write_evidence_report(config, cases, dry_run=False, path=config.evidence_report)
+        else:
+            print(json.dumps(evidence_as_dict(config, cases, dry_run=True), indent=2, sort_keys=True))
+        return 0 if all(case.status != "fail" for case in cases) else 1
+    except HostedSmokeConfigError as exc:
+        print(f"fail_closed: {exc.code}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/commerce_agent_hosted_smoke.py
+++ b/scripts/commerce_agent_hosted_smoke.py
@@ -72,13 +72,13 @@ PRODUCTION_RESOURCE_NAMES = frozenset(
         "grantex-commerce-bearer-token",
     }
 )
-DEFAULT_SECRET_NAMES = (
+DEFAULT_SMOKE_BINDING_NAMES = (
     "agenticorg-commerce-smoke-secret-key",
     "agenticorg-commerce-smoke-db-url",
     "agenticorg-commerce-smoke-redis-url",
     "agenticorg-commerce-smoke-grantex-api-key",
 )
-DEFAULT_NON_SECRET_ENV_NAMES = (
+DEFAULT_PUBLIC_ENV_NAMES = (
     "AGENTICORG_ENV",
     "AGENTICORG_BASE_URL",
     "AGENTICORG_PUBLIC_API_BASE_URL",
@@ -107,7 +107,7 @@ class HostedSmokeConfigError(ValueError):
 @dataclass(frozen=True)
 class FixtureSummary:
     env_path: str | None = None
-    secret_name: str | None = None
+    fixture_binding_name: str | None = None
     variable_names: tuple[str, ...] = ()
     synthetic_ids: dict[str, str] = field(default_factory=dict)
     sensitive_value_hashes: tuple[dict[str, str], ...] = ()
@@ -125,8 +125,8 @@ class HostedSmokeConfig:
     migrate_job_name: str = "agenticorg-commerce-smoke-migrate"
     database_resource_name: str = "agenticorg-commerce-smoke-pg"
     redis_resource_name: str = "agenticorg-commerce-smoke-redis"
-    secret_names: tuple[str, ...] = DEFAULT_SECRET_NAMES
-    non_secret_env_names: tuple[str, ...] = DEFAULT_NON_SECRET_ENV_NAMES
+    smoke_binding_names: tuple[str, ...] = DEFAULT_SMOKE_BINDING_NAMES
+    public_env_names: tuple[str, ...] = DEFAULT_PUBLIC_ENV_NAMES
     commit_sha: str | None = None
     image_tag: str | None = None
     cleanup_by: str | None = None
@@ -305,7 +305,7 @@ def validate_config(args: argparse.Namespace, *, environ: dict[str, str] | None 
     if auth_source_env_name not in AUTH_SOURCE_ENV_NAMES:
         raise HostedSmokeConfigError("auth_source_env_name_invalid", "Use exactly one supported Grantex auth source name.")
 
-    if args.fixture_env and args.fixture_secret_name:
+    if args.fixture_env and args.fixture_binding_name:
         raise HostedSmokeConfigError(
             "fixture_source_ambiguous",
             "Use either a local .tmp fixture env or a smoke-only fixture secret name, not both.",
@@ -314,10 +314,14 @@ def validate_config(args: argparse.Namespace, *, environ: dict[str, str] | None 
     fixture = FixtureSummary()
     if args.fixture_env:
         fixture = _summarize_fixture_env(args.fixture_env, auth_source_env_name=auth_source_env_name)
-    elif args.fixture_secret_name:
-        fixture = FixtureSummary(secret_name=_validate_smoke_name(args.fixture_secret_name, field_name="fixture secret"))
+    elif args.fixture_binding_name:
+        fixture = FixtureSummary(
+            fixture_binding_name=_validate_smoke_name(args.fixture_binding_name, field_name="fixture binding")
+        )
 
-    secret_names = tuple(_validate_smoke_name(name, field_name="secret name") for name in args.secret_name)
+    smoke_binding_names = tuple(
+        _validate_smoke_name(name, field_name="protected binding") for name in args.smoke_binding_name
+    )
     return HostedSmokeConfig(
         agenticorg_base_url=agenticorg_origin,
         grantex_base_url=grantex_origin,
@@ -329,7 +333,7 @@ def validate_config(args: argparse.Namespace, *, environ: dict[str, str] | None 
         migrate_job_name=_validate_smoke_name(args.migrate_job, field_name="migrate job"),
         database_resource_name=_validate_smoke_name(args.database_resource, field_name="database resource"),
         redis_resource_name=_validate_smoke_name(args.redis_resource, field_name="redis resource"),
-        secret_names=secret_names,
+        smoke_binding_names=smoke_binding_names,
         commit_sha=args.commit_sha,
         image_tag=args.image_tag,
         cleanup_by=args.cleanup_by,
@@ -496,8 +500,8 @@ def evidence_as_dict(config: HostedSmokeConfig, cases: list[SmokeCase], *, dry_r
     fixture_source = None
     if config.fixture.env_path:
         fixture_source = "local_tmp_fixture_env"
-    elif config.fixture.secret_name:
-        fixture_source = "smoke_secret"
+    elif config.fixture.fixture_binding_name:
+        fixture_source = "smoke_binding"
     return {
         "report_type": "agenticorg-c3-hosted-commerce-smoke",
         "run_mode": "dry-run" if dry_run else "run",
@@ -513,12 +517,12 @@ def evidence_as_dict(config: HostedSmokeConfig, cases: list[SmokeCase], *, dry_r
             "database_resource_name": config.database_resource_name,
             "redis_resource_name": config.redis_resource_name,
         },
-        "env_var_names": list(config.non_secret_env_names),
+        "public_env_var_names": list(config.public_env_names),
         "auth_source_env_name": config.auth_source_env_name,
-        "secret_names": list(config.secret_names),
+        "smoke_binding_names": list(config.smoke_binding_names),
         "fixture": {
             "source": fixture_source,
-            "secret_name": config.fixture.secret_name,
+            "fixture_binding_name": config.fixture.fixture_binding_name,
             "env_var_names": list(config.fixture.variable_names),
             "synthetic_ids": config.fixture.synthetic_ids,
             "sensitive_value_hashes": list(config.fixture.sensitive_value_hashes),
@@ -571,7 +575,7 @@ def write_evidence_report(config: HostedSmokeConfig, cases: list[SmokeCase], *, 
                 f"- Grantex host: `{data['grantex_host']}`",
                 f"- Auth source env name: `{config.auth_source_env_name}`",
                 f"- Fixture source: `{data['fixture']['source'] or ''}`",
-                f"- Fixture secret name: `{config.fixture.secret_name or ''}`",
+                f"- Fixture binding name: `{config.fixture.fixture_binding_name or ''}`",
                 "- Secret values recorded: false",
                 "- Raw passports/JWTs recorded: false",
                 "- Idempotency values recorded: false",
@@ -608,9 +612,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--migrate-job", default="agenticorg-commerce-smoke-migrate")
     parser.add_argument("--database-resource", default="agenticorg-commerce-smoke-pg")
     parser.add_argument("--redis-resource", default="agenticorg-commerce-smoke-redis")
-    parser.add_argument("--secret-name", action="append", default=list(DEFAULT_SECRET_NAMES))
+    parser.add_argument(
+        "--secret-name",
+        dest="smoke_binding_name",
+        action="append",
+        default=list(DEFAULT_SMOKE_BINDING_NAMES),
+    )
     parser.add_argument("--fixture-env", default=None)
-    parser.add_argument("--fixture-secret-name", default=None)
+    parser.add_argument("--fixture-secret-name", dest="fixture_binding_name", default=None)
     parser.add_argument("--real-staging-evidence-report", default=None)
     parser.add_argument("--evidence-report", default=None)
     parser.add_argument("--commit-sha", default=None)

--- a/tests/regression/test_commerce_agent_hosted_smoke_runner.py
+++ b/tests/regression/test_commerce_agent_hosted_smoke_runner.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from argparse import Namespace
+from pathlib import Path
+
+import httpx
+import pytest
+
+from scripts import commerce_agent_hosted_smoke as runner
+
+AGENTICORG_SMOKE = "https://agenticorg-api-commerce-smoke-example-uc.a.run.app"
+GRANTEX_SMOKE = "https://grantex-auth-smoke-example-uc.a.run.app"
+
+
+def _args(*extra: str) -> Namespace:
+    return runner.build_parser().parse_args(
+        [
+            "--agenticorg-base",
+            AGENTICORG_SMOKE,
+            "--allow-agenticorg-cloud-run-url",
+            AGENTICORG_SMOKE,
+            "--grantex-base",
+            GRANTEX_SMOKE,
+            "--allow-grantex-cloud-run-url",
+            GRANTEX_SMOKE,
+            "--auth-source-env-name",
+            "GRANTEX_API_KEY",
+            *extra,
+        ]
+    )
+
+
+def _validate(*extra: str, environ: dict[str, str] | None = None) -> runner.HostedSmokeConfig:
+    return runner.validate_config(_args(*extra), environ=environ or {})
+
+
+def _write_tmp_fixture(name: str, *, auth_key: str = "GRANTEX_API_KEY") -> Path:
+    path = Path(".tmp") / name
+    path.parent.mkdir(exist_ok=True)
+    lines = [
+        f'{auth_key}="auth-{uuid.uuid4().hex}"',
+        f'AGENTICORG_COMMERCE_CHECKOUT_PASSPORT_JWT="checkout-{uuid.uuid4().hex}"',
+        'AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID="mch_staging_electronics_pilot"',
+        'AGENTICORG_COMMERCE_FIXTURE_AGENT_ID="cag_staging_agenticorg_sales"',
+        'AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID="cprd_smoke_fixture"',
+        'AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID="cvar_smoke_fixture"',
+    ]
+    path.write_text("\n".join([*lines, ""]), encoding="utf-8")
+    return path
+
+
+def test_dry_run_is_default_and_validates_smoke_inputs() -> None:
+    args = _args()
+    config = runner.validate_config(args, environ={})
+
+    assert args.run is False
+    assert config.agenticorg_base_url == AGENTICORG_SMOKE
+    assert config.grantex_base_url == GRANTEX_SMOKE
+    assert config.auth_source_env_name == "GRANTEX_API_KEY"
+
+
+@pytest.mark.parametrize(
+    ("flag", "value", "code"),
+    [
+        ("--agenticorg-base", "https://app.agenticorg.ai", "agenticorg_production_url_refused"),
+        ("--grantex-base", "https://api.grantex.dev", "grantex_production_url_refused"),
+        ("--agenticorg-base", "http://localhost:8000", "agenticorg_non_https_url_refused"),
+        ("--grantex-base", "http://localhost:3001", "grantex_non_https_url_refused"),
+    ],
+)
+def test_url_refusals_fail_before_network(flag: str, value: str, code: str) -> None:
+    base_args = [
+        "--agenticorg-base",
+        AGENTICORG_SMOKE,
+        "--allow-agenticorg-cloud-run-url",
+        AGENTICORG_SMOKE,
+        "--grantex-base",
+        GRANTEX_SMOKE,
+        "--allow-grantex-cloud-run-url",
+        GRANTEX_SMOKE,
+        "--auth-source-env-name",
+        "GRANTEX_API_KEY",
+    ]
+    idx = base_args.index(flag) + 1
+    base_args[idx] = value
+    with pytest.raises(runner.HostedSmokeConfigError) as excinfo:
+        runner.validate_config(runner.build_parser().parse_args(base_args), environ={})
+
+    assert excinfo.value.code == code
+
+
+def test_arbitrary_run_app_is_refused_without_exact_allowlist() -> None:
+    args = runner.build_parser().parse_args(
+        [
+            "--agenticorg-base",
+            "https://agenticorg-api-commerce-smoke-example-uc.a.run.app",
+            "--allow-agenticorg-cloud-run-url",
+            "https://different-agenticorg-smoke-uc.a.run.app",
+            "--grantex-base",
+            GRANTEX_SMOKE,
+            "--allow-grantex-cloud-run-url",
+            GRANTEX_SMOKE,
+            "--auth-source-env-name",
+            "GRANTEX_API_KEY",
+        ]
+    )
+    with pytest.raises(runner.HostedSmokeConfigError) as excinfo:
+        runner.validate_config(args, environ={})
+
+    assert excinfo.value.code == "agenticorg_smoke_url_not_allowlisted"
+
+
+def test_live_flags_are_refused() -> None:
+    with pytest.raises(runner.HostedSmokeConfigError) as excinfo:
+        _validate(environ={"COMMERCE_LIVE_MODE_ENABLED": "true"})
+
+    assert excinfo.value.code == "live_flags_refused"
+
+    with pytest.raises(runner.HostedSmokeConfigError) as cli_excinfo:
+        _validate("--plural-live-mode")
+
+    assert cli_excinfo.value.code == "live_flags_refused"
+
+
+def test_fixture_env_must_stay_in_tmp_and_match_single_auth_source() -> None:
+    with pytest.raises(runner.HostedSmokeConfigError) as outside:
+        _validate("--fixture-env", "docs/commerce-agent-real-staging.env")
+    assert outside.value.code == "fixture_env_outside_tmp"
+
+    fixture = _write_tmp_fixture("commerce-agent-c3-hosted-smoke.env", auth_key="GRANTEX_AGENT_ASSERTION")
+    try:
+        with pytest.raises(runner.HostedSmokeConfigError) as mismatch:
+            _validate("--fixture-env", str(fixture))
+    finally:
+        fixture.unlink(missing_ok=True)
+
+    assert mismatch.value.code == "fixture_auth_source_mismatch"
+
+
+def test_fixture_env_summary_records_names_and_hashes_only() -> None:
+    fixture = _write_tmp_fixture("commerce-agent-c3-hosted-smoke-summary.env")
+    try:
+        config = _validate("--fixture-env", str(fixture))
+    finally:
+        fixture.unlink(missing_ok=True)
+
+    assert "GRANTEX_API_KEY" in config.fixture.variable_names
+    assert config.fixture.synthetic_ids["AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID"] == "mch_staging_electronics_pilot"
+    assert config.fixture.sensitive_value_hashes
+    assert all(
+        "sha256_12" in item and "auth-" not in item["sha256_12"]
+        for item in config.fixture.sensitive_value_hashes
+    )
+
+
+def test_production_resource_and_secret_names_are_refused() -> None:
+    with pytest.raises(runner.HostedSmokeConfigError) as prod_service:
+        _validate("--agenticorg-service", "agenticorg-api")
+    assert prod_service.value.code == "production_resource_name_refused"
+
+    with pytest.raises(runner.HostedSmokeConfigError) as non_smoke_secret:
+        _validate("--secret-name", "AGENTICORG_SECRET_KEY")
+    assert non_smoke_secret.value.code == "smoke_resource_name_required"
+
+
+def test_fixture_sources_are_not_ambiguous() -> None:
+    fixture = _write_tmp_fixture("commerce-agent-c3-hosted-smoke-ambiguous.env")
+    try:
+        with pytest.raises(runner.HostedSmokeConfigError) as excinfo:
+            _validate(
+                "--fixture-env",
+                str(fixture),
+                "--fixture-secret-name",
+                "agenticorg-commerce-smoke-fixture-env",
+            )
+    finally:
+        fixture.unlink(missing_ok=True)
+
+    assert excinfo.value.code == "fixture_source_ambiguous"
+
+
+def test_hosted_checks_validate_health_mcp_and_a2a_discovery() -> None:
+    config = _validate()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/api/v1/health/liveness":
+            return httpx.Response(200, json={"status": "alive"})
+        if path == "/api/v1/health":
+            return httpx.Response(200, json={"status": "healthy"})
+        if path == "/api/v1/mcp/tools":
+            return httpx.Response(200, json={"tools": [{"name": "agenticorg_commerce_sales_agent"}]})
+        if path == "/api/v1/a2a/.well-known/agent.json":
+            return httpx.Response(
+                200,
+                json={
+                    "url": f"{AGENTICORG_SMOKE}/api/v1/a2a",
+                    "authentication": {
+                        "issuer": GRANTEX_SMOKE,
+                        "jwksUri": f"{GRANTEX_SMOKE}/.well-known/jwks.json",
+                    },
+                },
+            )
+        if path == "/api/v1/a2a/agents":
+            return httpx.Response(
+                200,
+                json={"agents": [{"id": "commerce_sales_agent", "tools": ["grantex_commerce:catalog_search"]}]},
+            )
+        return httpx.Response(404, json={"error": "not_found"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    cases = runner.run_hosted_checks(config, client=client)
+
+    assert {case.name for case in cases} >= {
+        "liveness",
+        "health",
+        "mcp_commerce_sales_agent_discovery",
+        "a2a_card_uses_agenticorg_smoke_origin",
+        "a2a_card_uses_grantex_smoke_issuer",
+        "a2a_card_uses_grantex_smoke_jwks",
+        "a2a_commerce_sales_agent_discovery",
+        "a2a_commerce_tools_grantex_only",
+    }
+    assert all(case.status == "pass" for case in cases)
+
+
+def test_consent_exchange_expected_skip_requires_exact_blocker() -> None:
+    passing = Path(".tmp/commerce-agent-c3-consent-passing.md")
+    failed = Path(".tmp/commerce-agent-c3-consent-failed.md")
+    wrong = Path(".tmp/commerce-agent-c3-consent-wrong.md")
+    passing.parent.mkdir(exist_ok=True)
+    try:
+        passing.write_text(
+            "| consent_exchange | skipped |  |  |  |  | "
+            f"{runner.EXPECTED_CONSENT_EXCHANGE_BLOCKER} |\n",
+            encoding="utf-8",
+        )
+        failed.write_text(
+            "| consent_exchange | failed |  |  |  | consent_not_granted |  |\n",
+            encoding="utf-8",
+        )
+        wrong.write_text(
+            "| consent_exchange | skipped |  |  |  |  | other blocker |\n",
+            encoding="utf-8",
+        )
+
+        assert runner.validate_consent_exchange_evidence(passing).status == "pass"
+        assert (
+            runner.validate_consent_exchange_evidence(failed).error_code
+            == "consent_exchange_reported_failed"
+        )
+        assert (
+            runner.validate_consent_exchange_evidence(wrong).error_code
+            == "consent_exchange_expected_blocker_missing"
+        )
+    finally:
+        passing.unlink(missing_ok=True)
+        failed.unlink(missing_ok=True)
+        wrong.unlink(missing_ok=True)
+
+
+def test_evidence_report_contains_only_redacted_fixture_metadata() -> None:
+    fixture = _write_tmp_fixture("commerce-agent-c3-hosted-smoke-evidence.env")
+    report = Path(".tmp/commerce-agent-c3-hosted-smoke-evidence.md")
+    try:
+        config = _validate("--fixture-env", str(fixture), "--evidence-report", str(report))
+        runner.write_evidence_report(
+            config,
+            [runner.SmokeCase(name="mcp_tools", status="pass")],
+            dry_run=False,
+            path=report,
+        )
+        text = report.read_text(encoding="utf-8")
+    finally:
+        fixture.unlink(missing_ok=True)
+        report.unlink(missing_ok=True)
+
+    data = json.loads(text.split("```json\n", 1)[1].split("\n```", 1)[0])
+    assert data["redaction"]["secret_values_recorded"] is False
+    assert data["redaction"]["passport_values_recorded"] is False
+    assert "GRANTEX_API_KEY" in data["fixture"]["env_var_names"]
+    assert re.search(r"auth-[0-9a-f]{32}", text) is None
+    assert re.search(r"checkout-[0-9a-f]{32}", text) is None

--- a/tests/regression/test_commerce_sales_agent_no_provider_calls.py
+++ b/tests/regression/test_commerce_sales_agent_no_provider_calls.py
@@ -11,6 +11,7 @@ COMMERCE_CODE = [
     ROOT / "core" / "commerce" / "staging_runtime.py",
     ROOT / "core" / "langgraph" / "agents" / "commerce_sales_agent.py",
     ROOT / "demos" / "commerce_sales_agent_demo.py",
+    ROOT / "scripts" / "commerce_agent_hosted_smoke.py",
 ]
 
 BANNED_IMPORT_FRAGMENTS = {
@@ -75,4 +76,3 @@ def test_payment_status_polling_goes_through_grantex_only() -> None:
     assert "grantex_commerce:payment_get_status" in tools
     assert "payment_get_status" not in tools
     assert not any("check_order_status" == tool for tool in tools)
-


### PR DESCRIPTION
## Summary
- Adds a fail-closed C3 hosted AgenticOrg commerce smoke runner for the API-only Cloud Run smoke topology.
- Adds a C3 hosted smoke runbook with resource names, non-secret env names, secret names only, command plan marked NOT RUN, cleanup, and no-go conditions.
- Extends focused regression coverage for URL refusals, exact run.app allowlists, fixture source handling, evidence redaction, consent_exchange blocker handling, and provider-call static scanning.

## Safety
- Dry-run remains the default; hosted HTTP checks require explicit `--run`.
- Production AgenticOrg and Grantex origins are refused before network use.
- Arbitrary `run.app` URLs are refused unless exactly allowlisted.
- Localhost and non-HTTPS origins are refused.
- Live Commerce and live Plural flags are refused.
- Fixture env files are restricted to `.tmp/`; evidence records fixture source type, variable names, synthetic IDs, and redacted hashes only.
- `consent_exchange` is accepted only when skipped with `preexported_checkout_passport_without_granted_consent_fixture`.

## Validation
- `python -m ruff check scripts/commerce_agent_hosted_smoke.py tests/regression/test_commerce_agent_hosted_smoke_runner.py tests/regression/test_commerce_sales_agent_no_provider_calls.py`
- `python -m pytest tests/regression/test_commerce_agent_hosted_smoke_runner.py tests/regression/test_commerce_sales_agent_no_provider_calls.py -q --no-cov`
- `python demos/commerce_sales_agent_demo.py --mode=mock`
- Hosted smoke runner dry-run with placeholder allowlisted smoke URLs
- Focused secret/value-pattern scan on changed files
- `git diff --check`

No deploy, cloud resource creation, production config change, live payment, live Plural, secret access, or smoke execution was performed.