### PR TITLE
🔴 security: remove hardcoded live tester/Zoho credentials (pre-existing May-14 leak)

### DIFF
--- a/tests/regression/test_bugs_uday_14may2026.py
+++ b/tests/regression/test_bugs_uday_14may2026.py
@@ -156,7 +156,10 @@ def test_zoho_authorize_url_routes_to_india_region_when_user_picks_in() -> None:
 
     url_in = _build_authorization_url(
         spec,
-        client_id="1000.KN7KOTFZOEO6AEXNB12OT8CNGV3A9Z",
+        # Synthetic, non-live client id. The assertions below only check
+        # host/scope/params, never the client_id value, so a placeholder
+        # is sufficient and no real Zoho app id is committed.
+        client_id="1000.TESTCLIENTIDDONOTUSE0000000000",
         redirect_uri=(
             "https://agenticorg-api-490751771290.asia-southeast1.run.app"
             "/api/v1/oauth/callback"

--- a/ui/e2e/qa-uday-14may2026.spec.ts
+++ b/ui/e2e/qa-uday-14may2026.spec.ts
@@ -43,26 +43,27 @@
  *                       playwright.config.ts but Uday's report uses
  *                       ``https://agenticorg.ai`` so we override it
  *                       inside the spec.
- *   UDAY_EMAIL        — uday.chauhan@edumatica.io (per report)
- *   UDAY_PASSWORD     — Muneshvari12345@ (per report; also accept the
- *                       lowercase variant the report flagged).
- *   ZOHO_CLIENT_ID    — 1000.KN7KOTFZOEO6AEXNB12OT8CNGV3A9Z (defaults
- *                       to that value so the spec runs out of the box).
- *   ZOHO_CLIENT_SECRET — 163edae798054438557b9756d43d843e89f2cb1f0a
- *   ZOHO_ORG_ID       — 60069102279
+ *   UDAY_EMAIL        — tester email (per the May-14 bug report)
+ *   UDAY_PASSWORD     — tester password (env-only; never hardcoded).
+ *                       The lowercase variant is also tried at runtime.
+ *   ZOHO_CLIENT_ID    — Zoho OAuth client id (env-only).
+ *   ZOHO_CLIENT_SECRET — Zoho OAuth client secret (env-only).
+ *   ZOHO_ORG_ID       — Zoho Books organization id (env-only).
+ *
+ * SECURITY: no live credential is hardcoded here. All of the above are
+ * required env vars; the spec throws a directed error if any is unset.
  */
 
 import { expect, test } from "@playwright/test";
 
 const APP = process.env.BASE_URL || "https://agenticorg.ai";
+// Credentials are env-only. No live value is ever committed; see the
+// beforeAll guard which fails fast with a directed message if unset.
 const UDAY_EMAIL = process.env.UDAY_EMAIL || "uday.chauhan@edumatica.io";
-const UDAY_PASSWORD = process.env.UDAY_PASSWORD || "Muneshvari12345@";
-const ZOHO_CLIENT_ID =
-  process.env.ZOHO_CLIENT_ID || "1000.KN7KOTFZOEO6AEXNB12OT8CNGV3A9Z";
-const ZOHO_CLIENT_SECRET =
-  process.env.ZOHO_CLIENT_SECRET ||
-  "163edae798054438557b9756d43d843e89f2cb1f0a";
-const ZOHO_ORG_ID = process.env.ZOHO_ORG_ID || "60069102279";
+const UDAY_PASSWORD = process.env.UDAY_PASSWORD || "";
+const ZOHO_CLIENT_ID = process.env.ZOHO_CLIENT_ID || "";
+const ZOHO_CLIENT_SECRET = process.env.ZOHO_CLIENT_SECRET || "";
+const ZOHO_ORG_ID = process.env.ZOHO_ORG_ID || "";
 
 // We hit the same backend the UI calls — agenticorg.ai routes
 // /api/v1/* to the Cloud Run API. Tester report confirmed the path.
@@ -75,8 +76,8 @@ const API_BASE = APP;
 async function loginAsUday(
   request: import("@playwright/test").APIRequestContext,
 ): Promise<boolean> {
-  // Try the documented password first, then the lowercase variant the
-  // report flagged as an alternate ("Muneshvari12345@ or muneshvari12345@").
+  // Try the supplied password first, then its lowercase variant (the
+  // May-14 report flagged a case-variant alternate).
   for (const password of [UDAY_PASSWORD, UDAY_PASSWORD.toLowerCase()]) {
     const resp = await request.post(`${API_BASE}/api/v1/auth/login`, {
       data: { email: UDAY_EMAIL, password },
@@ -91,10 +92,19 @@ test.describe("Uday CA Firms 2026-05-14 — Zoho Books OAuth onboarding", () => 
   test.beforeAll(() => {
     // Surface the absent env vars loudly so a misconfigured CI run
     // fails with the right diagnostic instead of a redirect-uri timeout.
-    if (!UDAY_PASSWORD) {
+    const missing = [
+      ["UDAY_PASSWORD", UDAY_PASSWORD],
+      ["ZOHO_CLIENT_ID", ZOHO_CLIENT_ID],
+      ["ZOHO_CLIENT_SECRET", ZOHO_CLIENT_SECRET],
+      ["ZOHO_ORG_ID", ZOHO_ORG_ID],
+    ]
+      .filter(([, v]) => !v)
+      .map(([k]) => k);
+    if (missing.length > 0) {
       throw new Error(
-        "UDAY_PASSWORD env var is required — set it to the password from " +
-          "the May-14 bug report before running this spec.",
+        `Required env var(s) unset: ${missing.join(", ")}. These are ` +
+          "credentials and are intentionally NOT committed — supply them " +
+          "via the environment before running this spec.",
       );
     }
   });


### PR DESCRIPTION
## 🔴 URGENT: remove hardcoded live credentials from tracked May-14 e2e files

**Pre-existing leak — not introduced by the 17-May promotion fix (PR #582).** Surfaced during the security sweep requested on #582.

### Exposure
| File | What was hardcoded |
|---|---|
| `ui/e2e/qa-uday-14may2026.spec.ts` | Live **tester password**, Zoho OAuth **client_id**, **client_secret**, **organization_id** — as `process.env.X \|\| "<live value>"` fallbacks **and** spelled out in the header comment |
| `tests/regression/test_bugs_uday_14may2026.py` | Live Zoho **client_id** literal |

### Fix (minimal, behavior-preserving when env is set)
- `spec.ts`: all four credentials are **env-only** now (no literal fallback); header comment scrubbed; `beforeAll` guard extended to fail fast with a directed message if `UDAY_PASSWORD` / `ZOHO_CLIENT_ID` / `ZOHO_CLIENT_SECRET` / `ZOHO_ORG_ID` are unset.
- `test_bugs_uday_14may2026.py`: real client_id → clearly synthetic placeholder. Assertions only check host/scope/params, so coverage is unchanged — **14/14 pass**, ruff clean, compiles.

### Verification
- Repo-wide tracked sweep: **zero** remaining live secret strings (`Muneshvari12345`, the client_secret, the client_id) in any tracked file.
- `python -m pytest tests/regression/test_bugs_uday_14may2026.py` → 14 passed.
- TypeScript types: simple string consts + typed array filter/map; CI `tsc` validates.

### ⚠️ Rotation required (owner action — cannot be done from here)
Scrubbing the working copy does **not** remove these values from git history; they remain in prior commits/PRs (including the original May-14 PR) and on GitHub. **Treat as compromised and rotate now:**
1. **Zoho** OAuth app — regenerate `client_secret` (and ideally rotate `client_id`) in the Zoho API console; update the connector config + CI secrets.
2. **Tester account** (`uday.chauhan@edumatica.io`) password.
3. Any Zoho **refresh tokens** minted with the old secret.

Until rotated, this issue is not fully closed even with this PR merged. Optional follow-up: history rewrite/secret-scanning purge if policy requires removing them from past commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
