### PR TITLE
fix: lazy load routellm openai startup dependency

### DIFF
--- a/core/langgraph/llm_factory.py
+++ b/core/langgraph/llm_factory.py
@@ -17,7 +17,7 @@ import socket
 import structlog
 from langchain_core.language_models import BaseChatModel
 
-from core.llm.router import smart_router
+from core.llm.router import LLMProviderConfigurationError, smart_router
 
 logger = structlog.get_logger()
 
@@ -215,50 +215,66 @@ def _build_model(
 
     # Cloud: Gemini
     if "gemini" in resolved:
+        api_key = _resolve_cloud_api_key("gemini", tenant_id)
+        if not api_key:
+            raise LLMProviderConfigurationError("Gemini provider is not configured")
+
         from langchain_google_genai import ChatGoogleGenerativeAI
 
         return ChatGoogleGenerativeAI(
             model=resolved,
             temperature=temperature,
             max_output_tokens=max_tokens,
-            google_api_key=_resolve_cloud_api_key("gemini", tenant_id),
+            google_api_key=api_key,
         )
 
     # Cloud: Claude
     if "claude" in resolved:
+        api_key = _resolve_cloud_api_key("anthropic", tenant_id)
+        if not api_key:
+            raise LLMProviderConfigurationError("Anthropic provider is not configured")
+
         from langchain_anthropic import ChatAnthropic
 
         return ChatAnthropic(  # type: ignore[call-arg]
             model_name=resolved,
             temperature=temperature,
             max_tokens=max_tokens,
-            anthropic_api_key=_resolve_cloud_api_key("anthropic", tenant_id),
+            anthropic_api_key=api_key,
         )
 
     # Cloud: GPT
     if "gpt" in resolved:
+        api_key = _resolve_cloud_api_key("openai", tenant_id)
+        if not api_key:
+            raise LLMProviderConfigurationError("OpenAI provider is not configured")
+
         from langchain_openai import ChatOpenAI
 
         return ChatOpenAI(
             model=resolved,
             temperature=temperature,
             max_tokens=max_tokens,
-            openai_api_key=_resolve_cloud_api_key("openai", tenant_id),
+            openai_api_key=api_key,
         )
 
     # Default fallback — Gemini Flash (free)
+    api_key = _resolve_cloud_api_key("gemini", tenant_id)
+    if not api_key:
+        raise LLMProviderConfigurationError("Gemini provider is not configured")
+
     from langchain_google_genai import ChatGoogleGenerativeAI
 
     return ChatGoogleGenerativeAI(
         model="gemini-2.5-flash",
         temperature=temperature,
         max_output_tokens=max_tokens,
-        google_api_key=_resolve_cloud_api_key("gemini", tenant_id),
+        google_api_key=api_key,
     )
 
 
 def _resolve_model(model: str) -> str:
-    """Resolve model to a usable one, falling back to Gemini if API key missing."""
+    """Resolve the model name without constructing optional provider clients."""
     if not model:
         return os.getenv("AGENTICORG_LLM_PRIMARY", "gemini-2.5-flash")
 
@@ -271,21 +287,14 @@ def _resolve_model(model: str) -> str:
     if "gemini" in m:
         return model
 
-    # S0-08: capability gate — before PR-2 this read the provider env
-    # var directly. Route through the resolver so a tenant BYO token
-    # counts as "available" too. No tenant context here (we're running
-    # inside _resolve_model which is called before the request-level
-    # tenant propagates down), so the resolver falls back to platform
-    # env. Keeps the old behaviour verbatim when no BYO is set.
+    # Explicit cloud-provider selections are honored here. Missing
+    # credentials are reported by _build_model as provider configuration
+    # errors instead of silently falling back to another provider.
     if "claude" in m:
-        if _resolve_cloud_api_key("anthropic"):
-            return model
-        return "gemini-2.5-flash"
+        return model
 
     if "gpt" in m:
-        if _resolve_cloud_api_key("openai"):
-            return model
-        return "gemini-2.5-flash"
+        return model
 
     return "gemini-2.5-flash"
 

--- a/core/llm/__init__.py
+++ b/core/llm/__init__.py
@@ -7,6 +7,7 @@ Exports:
 """
 
 from core.llm.router import (
+    LLMProviderConfigurationError,
     LLMResponse,
     LLMRouter,
     SmartLLMRouter,
@@ -16,6 +17,7 @@ from core.llm.router import (
 
 __all__ = [
     "LLMResponse",
+    "LLMProviderConfigurationError",
     "LLMRouter",
     "SmartLLMRouter",
     "llm_router",

--- a/core/llm/router.py
+++ b/core/llm/router.py
@@ -45,15 +45,54 @@ from core.config import external_keys, settings
 logger = structlog.get_logger()
 
 # ---------------------------------------------------------------------------
-# Try to import RouteLLM; fall back to heuristic if unavailable
+# RouteLLM is optional. Do not import it at module import time: installed
+# routellm imports OpenAI and can construct an OpenAI client during import.
+# Production Gemini-only deployments must be able to start without OpenAI
+# credentials.
 # ---------------------------------------------------------------------------
-_ROUTELLM_AVAILABLE = False
-try:
-    from routellm.controller import Controller as RouteLLMController  # type: ignore[import-untyped,import-not-found]
+_ROUTELLM_AVAILABLE: bool | None = None
+RouteLLMController: type[Any] | None = None
 
+
+class LLMProviderConfigurationError(RuntimeError):
+    """Raised when an explicitly selected LLM provider is not configured."""
+
+
+def _load_routellm_controller_cls() -> type[Any] | None:
+    """Lazily import RouteLLM and return its controller when usable."""
+    global RouteLLMController, _ROUTELLM_AVAILABLE
+
+    if _ROUTELLM_AVAILABLE is not None:
+        return RouteLLMController
+
+    try:
+        from openai import OpenAIError
+    except ImportError:
+        openai_error_types: tuple[type[BaseException], ...] = ()
+    else:
+        openai_error_types = (OpenAIError,)
+
+    try:
+        from routellm.controller import (
+            Controller as RouteLLMControllerClass,  # type: ignore[import-untyped,import-not-found]
+        )
+    except ImportError as exc:
+        logger.info("routellm_unavailable", error=str(exc))
+        _ROUTELLM_AVAILABLE = False
+        RouteLLMController = None
+        return None
+    except openai_error_types as exc:
+        logger.warning(
+            "routellm_unavailable_missing_optional_openai_config",
+            error=str(exc),
+        )
+        _ROUTELLM_AVAILABLE = False
+        RouteLLMController = None
+        return None
+
+    RouteLLMController = RouteLLMControllerClass
     _ROUTELLM_AVAILABLE = True
-except ImportError:
-    RouteLLMController = None  # type: ignore[assignment,misc]
+    return RouteLLMControllerClass
 
 # ---------------------------------------------------------------------------
 # Tier model definitions
@@ -307,7 +346,7 @@ class SmartLLMRouter:
         Uses RouteLLM's similarity-weighted router when available,
         otherwise falls back to a simple length-based heuristic.
         """
-        if _ROUTELLM_AVAILABLE:
+        if _ROUTELLM_AVAILABLE is not False:
             try:
                 return self._classify_with_routellm(query)
             # enterprise-gate: broad-except-ok reason=routellm-classification-failure-falls-back-to-heuristic
@@ -319,10 +358,14 @@ class SmartLLMRouter:
 
     def _classify_with_routellm(self, query: str) -> str:
         """Use RouteLLM's similarity-weighted (SW) router to score complexity."""
+        controller_cls = _load_routellm_controller_cls()
+        if controller_cls is None:
+            return self._classify_heuristic(query)
+
         if not self._routellm_init_attempted:
             self._routellm_init_attempted = True
             try:
-                self._routellm_controller = RouteLLMController(
+                self._routellm_controller = controller_cls(
                     routers=["sw_ranking"],
                     strong_model=CLOUD_TIERS["tier3"],
                     weak_model=CLOUD_TIERS["tier1"],
@@ -477,6 +520,9 @@ class LLMRouter:
         # Hard daily cap — fail-closed BEFORE we mint a new charge.
         await assert_under_gemini_cap()
 
+        if not external_keys.google_gemini_api_key:
+            raise LLMProviderConfigurationError("Gemini provider is not configured")
+
         client = genai.Client(api_key=external_keys.google_gemini_api_key)
 
         # Separate system instruction from conversation
@@ -529,6 +575,9 @@ class LLMRouter:
         """Call Anthropic Claude API."""
         import anthropic
 
+        if not external_keys.anthropic_api_key:
+            raise LLMProviderConfigurationError("Anthropic provider is not configured")
+
         client = anthropic.AsyncAnthropic(api_key=external_keys.anthropic_api_key)
 
         system_msg = ""
@@ -561,6 +610,9 @@ class LLMRouter:
     async def _call_openai(self, model, messages, temperature, max_tokens, start) -> LLMResponse:
         """Call OpenAI API."""
         import openai
+
+        if not external_keys.openai_api_key:
+            raise LLMProviderConfigurationError("OpenAI provider is not configured")
 
         client = openai.AsyncOpenAI(api_key=external_keys.openai_api_key)
         response = await client.chat.completions.create(

--- a/tests/unit/test_langgraph_runtime.py
+++ b/tests/unit/test_langgraph_runtime.py
@@ -43,11 +43,11 @@ class TestLLMFactory:
 
         assert _resolve_model("gemini-2.5-pro") == "gemini-2.5-pro"
 
-    def test_resolve_model_claude_no_key_falls_back(self):
+    def test_resolve_model_claude_no_key_preserves_explicit_selection(self):
         from core.langgraph.llm_factory import _resolve_model
 
         with patch.dict("os.environ", {}, clear=True):
-            assert _resolve_model("claude-3-5-sonnet") == "gemini-2.5-flash"
+            assert _resolve_model("claude-3-5-sonnet") == "claude-3-5-sonnet"
 
     def test_resolve_model_claude_with_key(self):
         from core.langgraph.llm_factory import _resolve_model
@@ -55,11 +55,11 @@ class TestLLMFactory:
         with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-test"}):
             assert _resolve_model("claude-3-5-sonnet") == "claude-3-5-sonnet"
 
-    def test_resolve_model_gpt_no_key_falls_back(self):
+    def test_resolve_model_gpt_no_key_preserves_explicit_selection(self):
         from core.langgraph.llm_factory import _resolve_model
 
         with patch.dict("os.environ", {}, clear=True):
-            assert _resolve_model("gpt-4o") == "gemini-2.5-flash"
+            assert _resolve_model("gpt-4o") == "gpt-4o"
 
     def test_resolve_model_unknown_passes_through(self):
         from core.langgraph.llm_factory import _resolve_model

--- a/tests/unit/test_llm_router.py
+++ b/tests/unit/test_llm_router.py
@@ -5,7 +5,14 @@ All tests use mocks so RouteLLM need not be installed in CI.
 
 from __future__ import annotations
 
+import builtins
+import os
+import subprocess
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 # ---------------------------------------------------------------------------
 # Helpers — import under mock so we never hit real config / RouteLLM
@@ -300,6 +307,29 @@ class TestFallbackWhenRouteLLMUnavailable:
         # Heuristic short-query path -> tier1 -> flash-lite.
         assert model == "gemini-2.5-flash-lite"
 
+    def test_routellm_openai_config_error_falls_back_to_heuristic(self, monkeypatch):
+        """RouteLLM import-time OpenAI credential errors must not block routing."""
+        from openai import OpenAIError
+
+        import core.llm.router as router_mod
+
+        real_import = builtins.__import__
+
+        def fake_import(name, global_vars=None, local_vars=None, fromlist=(), level=0):
+            if name == "routellm.controller":
+                raise OpenAIError("Missing credentials")
+            return real_import(name, global_vars, local_vars, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        monkeypatch.setattr(router_mod, "_ROUTELLM_AVAILABLE", None)
+        monkeypatch.setattr(router_mod, "RouteLLMController", None)
+
+        router = router_mod.SmartLLMRouter()
+        model = router.route(query="x" * 600, config={})
+
+        assert model == "gemini-2.5-pro"
+        assert router_mod._ROUTELLM_AVAILABLE is False
+
 
 # ===================================================================
 # Integration: llm_factory uses router
@@ -364,6 +394,70 @@ class TestLLMFactoryIntegration:
             query="Test query",
         )
         assert result is not None
+
+    def test_api_import_succeeds_without_openai_credentials(self):
+        env = os.environ.copy()
+        env.pop("OPENAI_API_KEY", None)
+        env.pop("OPENAI_ADMIN_KEY", None)
+
+        result = subprocess.run(
+            [sys.executable, "-c", "import api.main; print('import ok')"],
+            cwd=Path(__file__).resolve().parents[2],
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=60,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "import ok" in result.stdout
+
+    @patch("core.langgraph.llm_factory._resolve_cloud_api_key")
+    @patch("langchain_google_genai.ChatGoogleGenerativeAI")
+    def test_gemini_factory_does_not_require_openai_credentials(
+        self,
+        mock_gemini_cls,
+        mock_resolve_key,
+        monkeypatch,
+    ):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_ADMIN_KEY", raising=False)
+        mock_resolve_key.return_value = "gemini-key"
+        mock_gemini_cls.return_value = MagicMock()
+
+        from core.langgraph.llm_factory import create_chat_model
+
+        result = create_chat_model(
+            model="gemini-2.5-flash",
+            routing_config={"routing": "disabled"},
+        )
+
+        assert result is not None
+        mock_gemini_cls.assert_called_once()
+        assert mock_gemini_cls.call_args.kwargs["google_api_key"] == "gemini-key"
+
+    @patch("core.langgraph.llm_factory._resolve_cloud_api_key")
+    def test_explicit_openai_without_credentials_fails_configuration(
+        self,
+        mock_resolve_key,
+        monkeypatch,
+    ):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_ADMIN_KEY", raising=False)
+        mock_resolve_key.return_value = ""
+
+        from core.langgraph.llm_factory import create_chat_model
+        from core.llm.router import LLMProviderConfigurationError
+
+        with pytest.raises(
+            LLMProviderConfigurationError,
+            match="OpenAI provider is not configured",
+        ):
+            create_chat_model(
+                model="gpt-4o",
+                routing_config={"routing": "disabled"},
+            )
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
- Fixes the production startup failure on Cloud Run revision `agenticorg-api-00059-hsb` from commit `6dae0be71eb7e7bc92bb63bc9c65a06cf2e0b5b8`.
- Stops importing RouteLLM at module import time because installed `routellm` can construct an OpenAI client during import.
- Adds deterministic provider configuration errors when an explicit Gemini/Anthropic/OpenAI path is requested without credentials.
- Preserves Gemini/default startup without requiring `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY`.

## Behavior
- API startup/import succeeds with OpenAI env vars unset.
- RouteLLM classifier import failures caused by missing OpenAI config fall back to heuristic routing instead of killing startup.
- Explicit GPT/OpenAI requests without credentials now raise `LLMProviderConfigurationError("OpenAI provider is not configured")` instead of silently falling back to Gemini or constructing an OpenAI client.
- No secrets or dummy OpenAI keys were added.

## Validation
- `python scripts/check_enterprise_stability_gates.py --scorecard` passed
  - `routes_missing_metadata: 0`
  - `process_local_allowed: 0`
  - `process_local_blocked: 0`
  - `broad_exceptions_allowed: 22`
- `python scripts/check_enterprise_stability_gates.py` passed
- `python -m pytest tests/unit/test_enterprise_stability_gates.py -q` passed
- `python -m pytest tests/unit/test_llm_router.py tests/unit/test_langgraph_runtime.py tests/unit/test_airgap.py -q -rs` passed
- `python -m pytest tests/unit -q -rs -k "llm or routellm or openai or gemini or provider or startup or health"` passed: 161 passed, 3194 deselected
- `python -m ruff check core\llm\router.py core\langgraph\llm_factory.py core\llm\__init__.py tests\unit\test_llm_router.py tests\unit\test_langgraph_runtime.py` passed
- `python -m compileall core\llm\router.py core\langgraph\llm_factory.py core\llm\__init__.py tests\unit\test_llm_router.py tests\unit\test_langgraph_runtime.py` passed
- `python -m alembic heads` passed: `v4916_merge_p0_heads (head)`
- `python scripts/check_migration_required.py` passed
- `git diff --check origin/main...HEAD` passed

## Skips
- No requested local validation was skipped.