### PR TITLE
fix: build cloud run ui image for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -207,11 +207,11 @@ jobs:
         run: |
           docker build \
             --build-arg VITE_GA4_ID=${{ vars.VITE_GA4_ID }} \
-            -t ${{ env.GAR_REGISTRY }}/agenticorg-ui:${{ github.sha }} \
-            -t ${{ env.GAR_REGISTRY }}/agenticorg-ui:latest \
-            -f Dockerfile.ui .
-          docker push ${{ env.GAR_REGISTRY }}/agenticorg-ui:${{ github.sha }}
-          docker push ${{ env.GAR_REGISTRY }}/agenticorg-ui:latest
+            -t ${{ env.GAR_REGISTRY }}/agenticorg-ui-cloudrun:${{ github.sha }} \
+            -t ${{ env.GAR_REGISTRY }}/agenticorg-ui-cloudrun:latest \
+            -f Dockerfile.ui.cloudrun .
+          docker push ${{ env.GAR_REGISTRY }}/agenticorg-ui-cloudrun:${{ github.sha }}
+          docker push ${{ env.GAR_REGISTRY }}/agenticorg-ui-cloudrun:latest
 
   deploy-staging:
     needs: build

--- a/scripts/deploy_cloud_run.sh
+++ b/scripts/deploy_cloud_run.sh
@@ -11,8 +11,8 @@
 # What it does (in order):
 #   1. Sanity-check that the working tree is clean and on the
 #      requested commit (default: origin/main).
-#   2. Build + push the API image (Dockerfile) and UI image
-#      (Dockerfile.ui) tagged with the deploy SHA + :latest.
+#   2. Build + push the API image (Dockerfile) and Cloud Run UI image
+#      (Dockerfile.ui.cloudrun) tagged with the deploy SHA + :latest.
 #   3. Optionally run alembic migrations as a Cloud Run job
 #      (--with-migrations, requires an `agenticorg-migrate` job
 #      to already exist; create it with --create-migrate-job). Runtime
@@ -144,7 +144,7 @@ for svc in "$API_SERVICE" "$UI_SERVICE"; do
 done
 
 API_IMAGE="${GAR_REGISTRY}/agenticorg:${DEPLOY_SHA}"
-UI_IMAGE="${GAR_REGISTRY}/agenticorg-ui:${DEPLOY_SHA}"
+UI_IMAGE="${GAR_REGISTRY}/agenticorg-ui-cloudrun:${DEPLOY_SHA}"
 
 # ── 3. Build + push images ───────────────────────────────────────────
 if [[ $SKIP_BUILD -eq 0 ]]; then
@@ -159,10 +159,10 @@ if [[ $SKIP_BUILD -eq 0 ]]; then
 
   run docker build \
     -t "$UI_IMAGE" \
-    -t "${GAR_REGISTRY}/agenticorg-ui:latest" \
-    -f Dockerfile.ui .
+    -t "${GAR_REGISTRY}/agenticorg-ui-cloudrun:latest" \
+    -f Dockerfile.ui.cloudrun .
   run docker push "$UI_IMAGE"
-  run docker push "${GAR_REGISTRY}/agenticorg-ui:latest"
+  run docker push "${GAR_REGISTRY}/agenticorg-ui-cloudrun:latest"
 fi
 
 # ── 4. Create migrate job (optional, idempotent-ish) ────────────────


### PR DESCRIPTION
## Summary
- Fixes the manual Cloud Run deploy path discovered while deploying hotfix #591.
- CI and `scripts/deploy_cloud_run.sh` now build/deploy `agenticorg-ui-cloudrun` from `Dockerfile.ui.cloudrun` instead of the GKE/nginx image from `Dockerfile.ui`.
- The previous UI deploy attempt failed because `Dockerfile.ui` ships `ui/nginx.conf`, which points nginx at `agenticorg-api:8000`; that name is not resolvable in Cloud Run.

## Production Context
- API hotfix #591 merged as `8d652d65082d6c07b9fa476f3e84c4903f3f35bc`.
- The API image for `8d652d6` was built by CI and the new API revision `agenticorg-api-00062-cf7` became ready, but production traffic remained pinned to the previous API revision after rollback.
- The UI update for `8d652d6` failed on revision `agenticorg-ui-00031-ph8` because the non-Cloud-Run nginx config referenced `agenticorg-api:8000`.
- This PR makes the next verified main build produce the Cloud Run UI artifact needed for production deployment.

## Validation
- `C:\Program Files\Git\bin\bash.exe -n scripts/deploy_cloud_run.sh` passed
- `python scripts/check_enterprise_stability_gates.py --scorecard` passed
  - `routes_missing_metadata: 0`
  - `process_local_allowed: 0`
  - `process_local_blocked: 0`
  - `broad_exceptions_allowed: 22`
- `python -m alembic heads` passed: `v4916_merge_p0_heads (head)`
- `python scripts/check_migration_required.py` passed
- `git diff --check origin/main...HEAD` passed

## Skips
- No test suite was run for this deploy-script-only change; CI will build the Cloud Run UI image and run the full main gates after merge.