### PR TITLE
fix: create bridge registry during durability migration

### DIFF
--- a/migrations/versions/v4_9_15_bridge_session_durability.py
+++ b/migrations/versions/v4_9_15_bridge_session_durability.py
@@ -23,6 +23,29 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # Some legacy Alembic-cutover environments were stamped past v4.4.0
+    # without receiving the bridge registry table. The durable session/request
+    # tables below depend on it, so recreate the canonical v4.4.0 table shape
+    # when it is missing before adding the new foreign keys.
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS bridge_registry (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+            bridge_id VARCHAR(100) NOT NULL UNIQUE,
+            bridge_type VARCHAR(50) NOT NULL,
+            url VARCHAR(500) NOT NULL,
+            status VARCHAR(20) DEFAULT 'active',
+            last_heartbeat TIMESTAMPTZ,
+            metadata_ JSONB DEFAULT '{}'::jsonb,
+            created_at TIMESTAMPTZ DEFAULT now(),
+            updated_at TIMESTAMPTZ
+        )
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_bridge_registry_tenant "
+        "ON bridge_registry (tenant_id)"
+    )
+
     op.execute("""
         CREATE TABLE IF NOT EXISTS bridge_sessions (
             id UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
## Summary
- Fixes the production Alembic blocker in `v4915_bridge_durability` by recreating the canonical `bridge_registry` table when legacy Alembic-cutover environments were stamped past v4.4.0 without that table.
- Keeps the bridge sessions/requests migration DB-first and idempotent.

## Production Context
- API hotfix deploy for main `468f3c8b4388880d2e1c6c7a12df40e1222bc257` reached strict schema verification.
- Alembic job failed at `v4915_bridge_durability` with `relation "bridge_registry" does not exist`.
- This PR avoids manual production DDL; the fix runs through Alembic only.

## Validation
- `python scripts/check_enterprise_stability_gates.py --scorecard` passed: routes_missing_metadata=0, process_local_allowed=0, process_local_blocked=0, broad_exceptions_allowed=22, alembic_head_count=1.
- `python -m alembic heads` -> `v4916_merge_p0_heads (head)`.
- `python scripts/check_migration_required.py` passed.
- `python -m compileall migrations/versions/v4_9_15_bridge_session_durability.py` passed.
- `python -m ruff check migrations/versions/v4_9_15_bridge_session_durability.py` passed.
- `python -m alembic upgrade v4912_workflow_event_waits:v4915_bridge_durability --sql` rendered expected SQL.
- `python -m pytest tests/unit/test_bridge_session_durability.py -q -rs` passed: 10 passed.

## Secrets
No secrets or dummy provider keys were added.