### PR TITLE
docs(commerce): expand agentic commerce education

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,37 @@
 
 ---
 
+## Commerce Sales Agent
+
+AgenticOrg includes a Commerce Sales Agent that talks to Grantex Commerce V1 through Grantex-only tools. It is designed for consent-first product discovery, cart drafting, Commerce Passport handling, provider-neutral payment intent handoff, checkout handoff, and payment status polling without calling payment providers directly.
+
+> Commerce production readiness is not final. AgenticOrg production MCP/A2A commerce metadata may be visible, but Grantex production Commerce V1 discovery remains disabled/fail-closed and live checkout, live payments, and live Plural are not enabled.
+
+```mermaid
+flowchart LR
+  user[User question] --> agent[Commerce Sales Agent]
+  agent --> tools[grantex_commerce:* tools]
+  tools --> grantex[Grantex Commerce REST/MCP]
+  grantex --> catalog[Catalog and inventory]
+  grantex --> consent[Consent and Commerce Passport]
+  grantex --> payment[Provider-neutral payment control]
+  payment --> mock[Mock provider smoke evidence]
+  payment -. blocked .-> live[Live provider / Plural gate]
+```
+
+| Area | Current posture |
+| --- | --- |
+| Default runtime mode | Mock mode remains the default for local demo use. |
+| Real-staging mode | Explicitly gated and only valid against approved Grantex staging or exact temporary smoke URLs. |
+| Hosted discovery smoke | API-only C3 smoke verified liveness, health, MCP tools, and A2A discovery. |
+| Provider boundary | No direct Stripe, Plural, Pine, or provider credential commerce path. |
+| Production discovery caveat | AgenticOrg commerce metadata should stay gated or explicitly reviewed until Grantex read-only discovery is approved. |
+| Live checkout/payments | Blocked; do not imply production payment readiness. |
+
+Read more in `docs/commerce-agent-overview.md`, `docs/commerce-agent-developer-guide.md`, `docs/commerce-agent-hosted-staging-e2e.md`, `docs/reports/commerce-agent-real-staging-evidence.md`, `docs/reports/commerce-agent-hosted-smoke-evidence.md`, and `docs/reports/commerce-agent-production-discovery-readiness.md`.
+
+Key tool aliases: `grantex_commerce:merchant_get_profile`, `grantex_commerce:catalog_search`, `grantex_commerce:catalog_get_item`, `grantex_commerce:inventory_check`, `grantex_commerce:cart_create`, `grantex_commerce:consent_request`, `grantex_commerce:consent_exchange`, `grantex_commerce:payment_create_intent`, `grantex_commerce:checkout_create`, and `grantex_commerce:payment_get_status`.
+
 ## What Is AgenticOrg?
 
 AgenticOrg deploys **AI virtual employees** that automate enterprise back-office work. Each agent has a name, designation, specialization, and tailored instructions — like a real team member. They process invoices, run payroll, triage support tickets, launch campaigns, and reconcile bank statements — with human approval on every critical decision.

--- a/docs/commerce-agent-developer-guide.md
+++ b/docs/commerce-agent-developer-guide.md
@@ -1,0 +1,132 @@
+# Commerce Sales Agent Developer Guide
+
+This guide explains how to run, inspect, and extend the AgenticOrg Commerce
+Sales Agent without weakening the Grantex-only commerce boundary.
+
+## Quick Rules
+
+- Use `python demos/commerce_sales_agent_demo.py --mode=mock` for normal local
+  development.
+- Use `--mode=real-staging` only with explicit approval and an approved Grantex
+  staging or exact temporary smoke URL.
+- Use only `grantex_commerce:*` commerce tools.
+- Do not call Stripe, Plural, Pine, or provider credential paths for commerce.
+- Do not print fixture env values, passports/JWTs, auth material, idempotency
+  values, raw payloads, DB/Redis URLs, private keys, or secrets.
+- Do not present mocked output as hosted or real-staging evidence.
+
+## Mock Demo
+
+```powershell
+python demos/commerce_sales_agent_demo.py --mode=mock
+```
+
+Mock mode is the default. It is safe for local demonstration and documentation
+checks, but it is not hosted evidence and does not prove production readiness.
+
+## Real-Staging Eval
+
+Real-staging mode is fail-closed. It requires an approved Grantex base URL, exact
+smoke allowlist for `run.app` origins, and exactly one auth source name supplied
+through runtime environment outside logs.
+
+Example shape, using placeholders only:
+
+```powershell
+python demos/commerce_sales_agent_demo.py --mode=real-staging `
+  --grantex-base <approved-smoke-origin> `
+  --allow-smoke-cloud-run-url <same-approved-smoke-origin> `
+  --fixture-env .tmp/commerce-agent-real-staging.env `
+  --evidence-report docs/reports/commerce-agent-real-staging-evidence.md
+```
+
+The fixture file path must stay under `.tmp/`. The file may contain usable
+runtime material during approved runs. Never commit it, print it, or quote it in
+docs, PR bodies, logs, or chat.
+
+## Env Var Names
+
+Evidence and docs may name variables, but must not include their values.
+Common names include:
+
+| Variable name | Purpose |
+| --- | --- |
+| `GRANTEX_COMMERCE_BASE_URL` | Approved Grantex commerce origin. |
+| `GRANTEX_BASE_URL` | Approved Grantex base origin. |
+| `AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL` | Exact allowed smoke `run.app` origin. |
+| `AGENTICORG_COMMERCE_FIXTURE_ENV` | Local `.tmp` fixture file path. |
+| `GRANTEX_API_KEY` | One possible Grantex auth source name. |
+| `GRANTEX_COMMERCE_BEARER_TOKEN` | One possible Grantex auth source name. |
+| `GRANTEX_AGENT_ASSERTION` | One possible Grantex auth source name. |
+
+Use exactly one Grantex auth source. Ambiguous or missing auth fails before
+network work.
+
+## Refusal Behavior
+
+| Refusal | Expected result |
+| --- | --- |
+| Production Grantex URL | Refused before auth/network. |
+| Arbitrary `run.app` URL without exact allowlist | Refused before auth/network. |
+| HTTP localhost or non-HTTPS real-staging URL | Refused before auth/network. |
+| Fixture path outside `.tmp/` | Refused. |
+| Fake connector/provider path | Refused by regression tests and runtime guardrails. |
+| Direct provider imports/calls in commerce code | Blocked by static regression. |
+
+## Evidence Interpretation
+
+Evidence may record:
+
+- host names and endpoint names;
+- case status;
+- HTTP status and latency;
+- error or blocker codes;
+- synthetic fixture IDs;
+- variable names used;
+- redacted short hashes.
+
+Evidence must not record:
+
+- bearer token values;
+- Commerce Passport or JWT values;
+- idempotency key values;
+- webhook secrets;
+- provider credentials;
+- raw request or response payloads;
+- DB/Redis URLs;
+- private keys;
+- secret values.
+
+## Skipped And Blocked Cases
+
+Skipped cases are acceptable only when they record a stable blocker that explains
+the missing fixture or approved gate. Current fixture-backed consent exchange
+behavior is expected only when the blocker is:
+
+`preexported_checkout_passport_without_granted_consent_fixture`
+
+Missing or inconsistent amount-cap metadata must skip the positive payment path
+with an explicit blocker rather than sending an unsafe request. The separate
+amount-cap breach negative case must fail locally before network or provider
+work.
+
+## Hosted Smoke
+
+C3 hosted smoke is API-only. It verifies liveness, health, MCP tools, A2A agent
+card, A2A agent listing, Grantex-only commerce tools, refusal checks, and cleanup
+of temporary resources. It does not certify the full UI/worker/beat staging shape
+and it does not approve production discovery or live payments.
+
+See `docs/commerce-agent-c3-hosted-smoke-runbook.md` and
+`docs/reports/commerce-agent-hosted-smoke-evidence.md`.
+
+## Extending The Agent
+
+When adding commerce behavior:
+
+1. Keep requests built from explicit allowlists, not arbitrary fixture dicts.
+2. Add tests for refusal and redaction behavior.
+3. Update `tests/regression/test_commerce_sales_agent_no_provider_calls.py` if
+   new commerce files are added.
+4. Keep all payment-affecting work on Grantex tools.
+5. Update evidence docs only with scrubbed, non-secret summaries.

--- a/docs/commerce-agent-hosted-staging-e2e.md
+++ b/docs/commerce-agent-hosted-staging-e2e.md
@@ -6,6 +6,9 @@ This guide defines the M11 hosted staging E2E plan for the AgenticOrg Commerce S
 
 AgenticOrg consumes Grantex staging data only. Commerce execution must stay on the Grantex Commerce API and `grantex_commerce:*` tool path.
 
+For the D1 developer-facing overview and safe local run instructions, start with
+`docs/commerce-agent-overview.md` and `docs/commerce-agent-developer-guide.md`.
+
 ## Required Staging Targets
 
 - AgenticOrg base: `https://staging.agenticorg.ai`

--- a/docs/commerce-agent-overview.md
+++ b/docs/commerce-agent-overview.md
@@ -1,0 +1,114 @@
+# Commerce Sales Agent Overview
+
+The AgenticOrg Commerce Sales Agent is the agent and workflow layer for
+Grantex-controlled commerce. It helps users discover products, draft carts,
+request consent, use Commerce Passport fixtures during approved smoke runs, and
+follow Grantex payment-intent and checkout status flows.
+
+This page is documentation only. It does not deploy, change production config,
+enable production Commerce V1, enable live payments, enable live Plural, or
+approve production discovery.
+
+## Current Posture
+
+| Area | Status |
+| --- | --- |
+| Mock demo | Default local mode. |
+| Real-staging eval | Explicitly gated; valid only against approved Grantex staging or exact temporary smoke URLs. |
+| C2G local handoff evidence | 13 passed, 0 failed, 2 skipped, with `consent_exchange` skipped using the stable fixture blocker. |
+| C3 hosted API-only smoke | 14 passed, 0 failed for liveness, health, MCP tools, A2A agent card, and A2A agents discovery. |
+| Production discovery | Commerce metadata may be publicly visible, but it is not final production readiness. |
+| Direct provider calls | Blocked for commerce. AgenticOrg commerce uses Grantex only. |
+| Live checkout/payments/Plural | Blocked. |
+
+## Architecture
+
+```mermaid
+flowchart LR
+  user[User] --> agent[Commerce Sales Agent]
+  agent --> aliases[grantex_commerce:* aliases]
+  aliases --> grantex[Grantex Commerce REST/MCP]
+  grantex --> catalog[Catalog and inventory]
+  grantex --> consent[Consent request and passport]
+  grantex --> policy[Policy and amount caps]
+  grantex --> payment[Provider-neutral payment intent]
+  payment --> mock[Mock provider smoke evidence]
+  payment -. blocked .-> providers[Live providers / Plural]
+```
+
+AgenticOrg does not own catalog truth, consent grants, Commerce Passport
+issuance, merchant policy enforcement, provider credentials, provider webhooks,
+or payment reconciliation. Those controls stay in Grantex.
+
+## Tool Aliases
+
+| Alias | Purpose |
+| --- | --- |
+| `grantex_commerce:merchant_get_profile` | Read merchant and policy status. |
+| `grantex_commerce:catalog_search` | Search grounded product data. |
+| `grantex_commerce:catalog_get_item` | Fetch exact product or variant details. |
+| `grantex_commerce:inventory_check` | Check availability, using a browse passport when required. |
+| `grantex_commerce:cart_create` | Create a cart draft from grounded items. |
+| `grantex_commerce:consent_request` | Request user consent with supported checkout scopes. |
+| `grantex_commerce:consent_exchange` | Exchange granted consent only when granted consent fixture material exists. |
+| `grantex_commerce:payment_create_intent` | Create Grantex provider-neutral payment intent with supported fields only. |
+| `grantex_commerce:checkout_create` | Create Grantex checkout handoff. |
+| `grantex_commerce:payment_get_status` | Poll Grantex payment status. |
+
+## Consent And Fixture Behavior
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant A as AgenticOrg
+  participant G as Grantex
+  A->>G: catalog and inventory tools
+  A->>G: cart_create
+  A->>G: consent_request
+  alt granted consent fixture exists
+    A->>G: consent_exchange
+    G-->>A: Commerce Passport
+  else checkout passport fixture exists
+    A-->>A: skip exchange with stable blocker
+  end
+  A->>G: payment_create_intent with checkout passport
+  A->>G: checkout_create
+  A->>G: payment_get_status
+```
+
+Fixture-backed runs accept a skipped `consent_exchange` only with:
+
+`preexported_checkout_passport_without_granted_consent_fixture`
+
+If a future evidence report records `consent_exchange` as failed or skipped with
+another code, the fixture-backed C2G behavior is not passing.
+
+## Safety Guardrails
+
+- Mock mode remains the default demo mode.
+- Real-staging mode refuses production URLs.
+- Arbitrary `run.app` URLs are refused unless the exact smoke URL is allowlisted.
+- HTTP localhost and non-HTTPS are refused in real-staging.
+- Exactly one Grantex auth source name is accepted.
+- Fixture files must stay under `.tmp/` and values must not be printed.
+- Evidence records names, statuses, latency, error/blocker codes, synthetic IDs,
+  and redacted hashes only.
+- Commerce code must not import or call direct Stripe, Plural, Pine, or provider
+  credential paths.
+
+## Production Discovery Caveat
+
+`docs/reports/commerce-agent-production-discovery-readiness.md` records that
+AgenticOrg production MCP/A2A discovery currently exposes commerce metadata.
+That does not mean production commerce is ready. Grantex production Commerce V1
+discovery remains disabled/fail-closed, and AgenticOrg commerce metadata should
+remain gated, hidden, or explicitly reviewed until Grantex read-only production
+discovery is approved.
+
+## Evidence Links
+
+- `docs/reports/commerce-agent-real-staging-evidence.md`
+- `docs/reports/commerce-agent-hosted-smoke-evidence.md`
+- `docs/reports/commerce-agent-production-discovery-readiness.md`
+- `docs/commerce-agent-c3-hosted-smoke-runbook.md`
+- `docs/commerce-agent-hosted-staging-e2e.md`

--- a/ui/src/pages/resources/contentData.ts
+++ b/ui/src/pages/resources/contentData.ts
@@ -34,6 +34,29 @@ export const CLUSTERS = [
 ];
 
 export const CONTENT_PAGES: ContentPage[] = [
+  {
+    slug: "commerce-sales-agent-grantex",
+    cluster: "platform",
+    title: "Commerce Sales Agent with Grantex Controls",
+    metaTitle: "Commerce Sales Agent with Grantex Controls | AgenticOrg",
+    metaDescription: "How AgenticOrg's Commerce Sales Agent uses Grantex-only commerce tools for grounded product data, consent, Commerce Passports, and provider-neutral checkout handoff.",
+    keywords: ["commerce sales agent", "Grantex commerce", "agentic commerce", "commerce passport", "AI shopping agent safety"],
+    heroStat: { value: "0", label: "Direct provider calls in the commerce path" },
+    sections: [
+      { heading: "A Commerce Agent With A Control Layer", body: "AgenticOrg's Commerce Sales Agent is designed to help users ask product questions, compare grounded catalog results, draft carts, request consent, and follow checkout status without taking direct payment-provider control.\n\nThe commerce boundary is Grantex. AgenticOrg uses Grantex commerce tools for catalog, inventory, cart, consent, Commerce Passport handling, payment intent creation, checkout handoff, and payment status polling." },
+      { heading: "How The Flow Works", body: "The flow is intentionally staged: user question -> grounded product data -> inventory check -> cart draft -> consent request -> Commerce Passport -> Grantex payment intent -> checkout handoff -> Grantex status polling.\n\nAgenticOrg does not mint Commerce Passports locally. It does not call Stripe, Plural, Pine, or provider credential paths for commerce. Provider abstraction, policy enforcement, amount caps, audit, and webhook reconciliation belong to Grantex." },
+      { heading: "Current Readiness Posture", body: "The commerce path has internal sandbox and temporary smoke evidence. The local real-staging eval has exercised Grantex-only commerce tools, and the API-only hosted smoke has verified liveness, health, MCP tools, and A2A discovery against temporary Grantex smoke resources.\n\nThis does not mean production checkout or live payments are enabled. Grantex production Commerce V1 discovery remains disabled/fail-closed, live payments are blocked, live Plural is blocked, and external pilot or live-provider readiness requires additional human gates." },
+      { heading: "What Users Should Expect", body: "The agent can help explain products and prepare a cart, but payment-affecting steps require Grantex consent and policy checks. Amount caps, merchant status, trusted agent checks, and passport state determine whether a checkout path may continue.\n\nIf a required consent or fixture is missing, the evaluated path records a skipped or blocked case instead of pretending that hosted evidence passed." },
+      { heading: "What Operators Should Watch", body: "Operators should review the evidence reports, confirm no provider credential handling exists in commerce code, keep production discovery gated until Grantex read-only discovery is approved, and treat live payment or live Plural enablement as blocked until legal, compliance, security, operations, product, and provider gates are complete." },
+    ],
+    faqs: [
+      { q: "Does AgenticOrg call payment providers directly for commerce?", a: "No. The Commerce Sales Agent uses Grantex-only commerce tools. Direct Stripe, Plural, Pine, or provider credential paths are not part of the commerce flow." },
+      { q: "Is production checkout live?", a: "No. Production checkout, live payments, and live Plural are blocked. Current evidence covers internal sandbox and temporary smoke paths only." },
+      { q: "Why can production discovery metadata appear before production readiness?", a: "Production MCP/A2A commerce metadata may be visible, but Grantex production Commerce V1 discovery remains disabled/fail-closed. The metadata should be gated or explicitly reviewed before any production discovery readiness decision." },
+    ],
+    relatedSlugs: ["enterprise-ai-automation-platform", "human-in-the-loop-ai", "ai-agent-governance"],
+    cta: { text: "Open the safe playground", link: "/playground" },
+  },
   // ═══════════════════════════════════════════════════════════════
   // CLUSTER 1: Enterprise AI Agents
   // ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Add Commerce Sales Agent README coverage plus overview and developer guide.
- Cross-link hosted staging E2E docs and add a product education resource page for the Grantex-controlled commerce flow.
- Preserve current safety posture: mock mode default, Grantex-only commerce tools, production discovery caveat, no direct provider credential path, live payments/live Plural blocked.

## Validation
- `npm run build` from `ui/`
- `python demos/commerce_sales_agent_demo.py --mode=mock`
- `python -m pytest tests/regression/test_commerce_agent_hosted_staging_plan.py -q`
- `git diff --check`
- Focused staged added-line secret scan: clean

No deploy, cloud resource, production config, secret, Commerce V1, live payment, or live Plural action was performed.