### PR TITLE
fix: create cdc events during durability migration

### DIFF
--- a/migrations/versions/v4_9_13_cdc_webhook_durability.py
+++ b/migrations/versions/v4_9_13_cdc_webhook_durability.py
@@ -21,6 +21,28 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # Some legacy Alembic-cutover environments were stamped past v4.0.0
+    # without receiving the original CDC event table. The durability columns
+    # below extend that table, so recreate the canonical v4.0.0 table shape
+    # when it is missing before applying the durable ingestion schema.
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS cdc_events (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id UUID NOT NULL REFERENCES tenants(id),
+            connector VARCHAR(100) NOT NULL,
+            event_type VARCHAR(50) NOT NULL,
+            resource_type VARCHAR(100) NOT NULL,
+            resource_id VARCHAR(200) NOT NULL,
+            payload JSONB NOT NULL,
+            processed BOOLEAN NOT NULL DEFAULT FALSE,
+            event_hash VARCHAR(64) NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+    """)
+    op.execute("CREATE INDEX IF NOT EXISTS ix_cdc_events_tenant_id ON cdc_events (tenant_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_cdc_events_connector ON cdc_events (connector)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_cdc_events_event_hash ON cdc_events (event_hash)")
+
     op.execute("ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS provider_event_id VARCHAR(255)")
     op.execute("ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS fingerprint VARCHAR(64)")
     op.execute(

--- a/tests/unit/test_cdc_migration_hotfix.py
+++ b/tests/unit/test_cdc_migration_hotfix.py
@@ -1,0 +1,17 @@
+"""Regression coverage for CDC durability migration on legacy stamped DBs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_cdc_migration_recreates_legacy_events_table_before_alter() -> None:
+    migration = Path("migrations/versions/v4_9_13_cdc_webhook_durability.py").read_text()
+
+    create_pos = migration.index("CREATE TABLE IF NOT EXISTS cdc_events")
+    alter_pos = migration.index("ALTER TABLE cdc_events ADD COLUMN IF NOT EXISTS provider_event_id")
+
+    assert create_pos < alter_pos
+    assert "ix_cdc_events_tenant_id" in migration
+    assert "ix_cdc_events_connector" in migration
+    assert "ix_cdc_events_event_hash" in migration


### PR DESCRIPTION
## Summary
- Fixes the production migration blocker seen while deploying `5a4e1fa3068b7881f825067e52dda0d9c1d3f01f`.
- `agenticorg-migrate-mzgml` failed because production is stamped past the legacy v4.0 CDC table migration, but `cdc_events` is missing.
- Recreates the canonical legacy `cdc_events` table and base indexes if missing before applying the durable CDC migration columns/indexes.

## Validation
- `python scripts/check_enterprise_stability_gates.py --scorecard` passed: routes_missing_metadata=0, process_local_allowed=0, process_local_blocked=0, broad_exceptions_allowed=22, alembic_head_count=1.
- `python -m alembic heads` -> `v4916_merge_p0_heads (head)`.
- `python scripts/check_migration_required.py` passed.
- `python -m pytest tests/unit/test_cdc_migration_hotfix.py -q` passed.
- `python -m compileall migrations/versions/v4_9_13_cdc_webhook_durability.py tests/unit/test_cdc_migration_hotfix.py` passed.
- `python -m ruff check migrations/versions/v4_9_13_cdc_webhook_durability.py tests/unit/test_cdc_migration_hotfix.py` passed.
- `python -m alembic upgrade v4912_workflow_event_waits:v4913_cdc_webhook_durability --sql` rendered successfully and shows `CREATE TABLE IF NOT EXISTS cdc_events` before `ALTER TABLE cdc_events`.
- `git diff --check origin/main...HEAD` passed.

No secrets or dummy credentials added.