### PR TITLE
fix(commerce): gate public commerce discovery

### DIFF
--- a/api/v1/a2a.py
+++ b/api/v1/a2a.py
@@ -398,9 +398,10 @@ def _get_domain_for_type(agent_type: str) -> str:
 def _build_agent_skills() -> list[dict[str, Any]]:
     """Build the skills list for the Agent Card."""
     from api.v1.agents import _AGENT_TYPE_DEFAULT_TOOLS
+    from core.commerce.discovery_gate import iter_public_discovery_agent_tools
 
     skills = []
-    for agent_type, tools in _AGENT_TYPE_DEFAULT_TOOLS.items():
+    for agent_type, tools in iter_public_discovery_agent_tools(_AGENT_TYPE_DEFAULT_TOOLS):
         domain = _get_domain_for_type(agent_type)
         skills.append({
             "id": agent_type,

--- a/api/v1/mcp.py
+++ b/api/v1/mcp.py
@@ -47,9 +47,10 @@ async def list_tools():
     (ChatGPT, Claude) use to understand what they can call.
     """
     from api.v1.agents import _AGENT_TYPE_DEFAULT_TOOLS
+    from core.commerce.discovery_gate import iter_public_discovery_agent_tools
 
     tools = []
-    for agent_type, default_tools in _AGENT_TYPE_DEFAULT_TOOLS.items():
+    for agent_type, default_tools in iter_public_discovery_agent_tools(_AGENT_TYPE_DEFAULT_TOOLS):
         domain = _get_domain(agent_type)
         tools.append({
             "name": f"agenticorg_{agent_type}",

--- a/core/commerce/discovery_gate.py
+++ b/core/commerce/discovery_gate.py
@@ -1,0 +1,36 @@
+"""Fail-closed public discovery gate for commerce metadata."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator, Mapping, Sequence
+
+from core.commerce.sales_guardrails import COMMERCE_AGENT_TYPE
+
+COMMERCE_PUBLIC_DISCOVERY_ENV = "AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED"
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on", "enabled"})
+
+
+def is_commerce_public_discovery_enabled(
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    """Return true only for explicit safe true values.
+
+    Missing, empty, malformed, and ambiguous values all keep public commerce
+    discovery disabled.
+    """
+    source = os.environ if environ is None else environ
+    value = source.get(COMMERCE_PUBLIC_DISCOVERY_ENV, "")
+    return value.strip().lower() in _TRUE_VALUES
+
+
+def iter_public_discovery_agent_tools(
+    agent_tools: Mapping[str, Sequence[str]],
+) -> Iterator[tuple[str, Sequence[str]]]:
+    """Yield agent tool mappings allowed in public MCP/A2A discovery."""
+    commerce_enabled = is_commerce_public_discovery_enabled()
+    for agent_type, tools in agent_tools.items():
+        if agent_type == COMMERCE_AGENT_TYPE and not commerce_enabled:
+            continue
+        yield agent_type, tools

--- a/docs/commerce-agent-c3-hosted-smoke-runbook.md
+++ b/docs/commerce-agent-c3-hosted-smoke-runbook.md
@@ -43,6 +43,7 @@ AGENTICORG_CORS_ALLOWED_ORIGINS=<agenticorg-smoke-cloud-run-origin>
 AGENTICORG_GIT_SHA=<agenticorg-main-sha>
 AGENTICORG_ENABLE_LEGACY_STARTUP_DDL=0
 AGENTICORG_COMMERCE_REAL_STAGING=1
+AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED=true
 GRANTEX_COMMERCE_BASE_URL=<grantex-smoke-cloud-run-origin>
 GRANTEX_BASE_URL=<grantex-smoke-cloud-run-origin>
 AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL=<grantex-smoke-cloud-run-origin>
@@ -50,6 +51,11 @@ COMMERCE_LIVE_MODE_ENABLED=0
 PLURAL_LIVE_ENABLED=0
 PLURAL_ENV=sandbox
 ```
+
+`AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED=true` is for the explicitly
+approved temporary C3 smoke service only. Production remains fail-closed unless
+Grantex read-only production Commerce V1 discovery is approved and a separate
+production change is reviewed.
 
 ## Required Secrets By Name Only
 
@@ -148,6 +154,11 @@ The runner checks:
 - `GET /api/v1/mcp/tools` includes `agenticorg_commerce_sales_agent`
 - `GET /api/v1/a2a/.well-known/agent.json` uses the AgenticOrg smoke origin and Grantex smoke issuer/JWKS
 - `GET /api/v1/a2a/agents` includes `commerce_sales_agent` with `grantex_commerce:*` tools
+
+These commerce discovery checks require the temporary smoke service to set
+`AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED=true`. Without that explicit
+smoke-only setting, C5A hides commerce metadata from public MCP/A2A discovery by
+default.
 
 If a real-staging evidence report is supplied, `consent_exchange` is expected only when it is skipped with this exact blocker code:
 

--- a/docs/commerce-agent-developer-guide.md
+++ b/docs/commerce-agent-developer-guide.md
@@ -120,6 +120,21 @@ and it does not approve production discovery or live payments.
 See `docs/commerce-agent-c3-hosted-smoke-runbook.md` and
 `docs/reports/commerce-agent-hosted-smoke-evidence.md`.
 
+## Public Discovery Gate
+
+Public MCP/A2A commerce discovery is fail-closed behind the non-secret setting
+`AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED`.
+
+| Value | Result |
+| --- | --- |
+| absent, empty, invalid, or any non-true value | `/api/v1/mcp/tools`, `/api/v1/a2a/.well-known/agent.json`, and `/api/v1/a2a/agents` hide `commerce_sales_agent` and `grantex_commerce:*` metadata. |
+| `true`, `1`, `yes`, `on`, or `enabled` | Local/test or explicitly approved environments may expose existing Grantex-only commerce metadata. |
+
+This gate does not remove Commerce Sales Agent code, demos, evals, or Grantex
+connector behavior. It only prevents public discovery from implying production
+commerce readiness before Grantex read-only production Commerce V1 discovery is
+approved.
+
 ## Extending The Agent
 
 When adding commerce behavior:

--- a/docs/commerce-agent-overview.md
+++ b/docs/commerce-agent-overview.md
@@ -17,7 +17,7 @@ approve production discovery.
 | Real-staging eval | Explicitly gated; valid only against approved Grantex staging or exact temporary smoke URLs. |
 | C2G local handoff evidence | 13 passed, 0 failed, 2 skipped, with `consent_exchange` skipped using the stable fixture blocker. |
 | C3 hosted API-only smoke | 14 passed, 0 failed for liveness, health, MCP tools, A2A agent card, and A2A agents discovery. |
-| Production discovery | Commerce metadata may be publicly visible, but it is not final production readiness. |
+| Production discovery | Commerce metadata is gated by default behind `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED`; it is not final production readiness. |
 | Direct provider calls | Blocked for commerce. AgenticOrg commerce uses Grantex only. |
 | Live checkout/payments/Plural | Blocked. |
 
@@ -98,12 +98,14 @@ another code, the fixture-backed C2G behavior is not passing.
 
 ## Production Discovery Caveat
 
-`docs/reports/commerce-agent-production-discovery-readiness.md` records that
-AgenticOrg production MCP/A2A discovery currently exposes commerce metadata.
-That does not mean production commerce is ready. Grantex production Commerce V1
-discovery remains disabled/fail-closed, and AgenticOrg commerce metadata should
-remain gated, hidden, or explicitly reviewed until Grantex read-only production
-discovery is approved.
+`docs/reports/commerce-agent-production-discovery-readiness.md` records the C4
+finding that AgenticOrg production MCP/A2A discovery exposed commerce metadata
+while Grantex production Commerce V1 discovery remained disabled/fail-closed.
+C5A adds the fail-closed `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED` public
+discovery gate. Unless that non-secret setting is explicitly set to a safe true
+value in an approved environment, public MCP/A2A discovery hides
+`commerce_sales_agent` and `grantex_commerce:*` metadata. Do not enable that
+gate for production until Grantex read-only production discovery is approved.
 
 ## Evidence Links
 

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -3291,7 +3291,7 @@
     "public_exempt_reason": null,
     "rate_limit": "mcp-tool-call",
     "scope": "mcp.external_agent_execution.sensitive.write",
-    "source_line": 108,
+    "source_line": 109,
     "tenant_required": true
   },
   {

--- a/tests/regression/test_commerce_sales_agent_no_provider_calls.py
+++ b/tests/regression/test_commerce_sales_agent_no_provider_calls.py
@@ -6,6 +6,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 COMMERCE_CODE = [
     ROOT / "connectors" / "commerce" / "grantex_commerce.py",
+    ROOT / "core" / "commerce" / "discovery_gate.py",
     ROOT / "core" / "commerce" / "sales_guardrails.py",
     ROOT / "core" / "commerce" / "staging_evidence.py",
     ROOT / "core" / "commerce" / "staging_runtime.py",

--- a/tests/unit/test_a2a_mcp.py
+++ b/tests/unit/test_a2a_mcp.py
@@ -2,26 +2,42 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from fastapi import HTTPException
+
+from core.commerce.discovery_gate import COMMERCE_PUBLIC_DISCOVERY_ENV
+
+
+def _payload_contains(value: Any, needle: str) -> bool:
+    if isinstance(value, dict):
+        return any(_payload_contains(item, needle) for item in value.values())
+    if isinstance(value, list | tuple | set):
+        return any(_payload_contains(item, needle) for item in value)
+    return isinstance(value, str) and needle in value
 
 
 class TestA2AAgentCard:
     @pytest.mark.asyncio
-    async def test_agent_card_returns_skills(self):
+    async def test_agent_card_returns_skills(self, monkeypatch):
         from api.v1.a2a import agent_card
 
+        monkeypatch.delenv(COMMERCE_PUBLIC_DISCOVERY_ENV, raising=False)
         card = await agent_card()
         assert card["name"] == "AgenticOrg Agent Platform"
         assert card["protocol"] == "a2a/1.0"
         assert card["capabilities"]["tasks"] is True
         assert card["authentication"]["scheme"] == "grantex"
-        assert len(card["skills"]) == 37  # 28 original + 8 new + commerce = 37
+        assert len(card["skills"]) == 36  # Commerce discovery is disabled by default.
+        assert "commerce_sales_agent" not in {skill["id"] for skill in card["skills"]}
+        assert not _payload_contains(card["skills"], "grantex_commerce:")
 
     @pytest.mark.asyncio
-    async def test_agent_card_skills_have_required_fields(self):
+    async def test_agent_card_skills_have_required_fields(self, monkeypatch):
         from api.v1.a2a import agent_card
 
+        monkeypatch.delenv(COMMERCE_PUBLIC_DISCOVERY_ENV, raising=False)
         card = await agent_card()
         for skill in card["skills"]:
             assert "id" in skill
@@ -31,11 +47,36 @@ class TestA2AAgentCard:
             assert "inputSchema" in skill
 
     @pytest.mark.asyncio
-    async def test_list_available_agents(self):
+    async def test_list_available_agents(self, monkeypatch):
         from api.v1.a2a import list_available_agents
 
+        monkeypatch.delenv(COMMERCE_PUBLIC_DISCOVERY_ENV, raising=False)
         result = await list_available_agents()
-        assert len(result["agents"]) == 37
+        assert len(result["agents"]) == 36
+        assert "commerce_sales_agent" not in {agent["id"] for agent in result["agents"]}
+        assert not _payload_contains(result["agents"], "grantex_commerce:")
+
+    @pytest.mark.asyncio
+    async def test_agent_card_exposes_commerce_when_public_discovery_enabled(self, monkeypatch):
+        from api.v1.a2a import agent_card, list_available_agents
+
+        monkeypatch.setenv(COMMERCE_PUBLIC_DISCOVERY_ENV, "true")
+        card = await agent_card()
+        agents = await list_available_agents()
+
+        assert "commerce_sales_agent" in {skill["id"] for skill in card["skills"]}
+        assert "commerce_sales_agent" in {agent["id"] for agent in agents["agents"]}
+        assert _payload_contains(card["skills"], "grantex_commerce:")
+        assert _payload_contains(agents["agents"], "grantex_commerce:")
+
+    @pytest.mark.asyncio
+    async def test_invalid_public_discovery_value_hides_commerce(self, monkeypatch):
+        from api.v1.a2a import list_available_agents
+
+        monkeypatch.setenv(COMMERCE_PUBLIC_DISCOVERY_ENV, "maybe")
+        result = await list_available_agents()
+        assert "commerce_sales_agent" not in {agent["id"] for agent in result["agents"]}
+        assert not _payload_contains(result["agents"], "grantex_commerce:")
 
 
 class TestA2ATask:
@@ -59,21 +100,34 @@ class TestA2ATask:
 
 class TestMCPTools:
     @pytest.mark.asyncio
-    async def test_list_tools_returns_registered_agents(self):
+    async def test_list_tools_returns_registered_agents(self, monkeypatch):
         from api.v1.mcp import list_tools
 
+        monkeypatch.delenv(COMMERCE_PUBLIC_DISCOVERY_ENV, raising=False)
         result = await list_tools()
-        assert len(result["tools"]) == 37  # 28 original + 8 new + commerce
+        assert len(result["tools"]) == 36  # Commerce discovery is disabled by default.
+        assert "agenticorg_commerce_sales_agent" not in {tool["name"] for tool in result["tools"]}
+        assert not _payload_contains(result["tools"], "grantex_commerce:")
 
     @pytest.mark.asyncio
-    async def test_tool_names_prefixed(self):
+    async def test_tool_names_prefixed(self, monkeypatch):
         from api.v1.mcp import list_tools
 
+        monkeypatch.delenv(COMMERCE_PUBLIC_DISCOVERY_ENV, raising=False)
         result = await list_tools()
         for tool in result["tools"]:
             assert tool["name"].startswith("agenticorg_")
             assert "inputSchema" in tool
             assert "description" in tool
+
+    @pytest.mark.asyncio
+    async def test_list_tools_exposes_commerce_when_public_discovery_enabled(self, monkeypatch):
+        from api.v1.mcp import list_tools
+
+        monkeypatch.setenv(COMMERCE_PUBLIC_DISCOVERY_ENV, "enabled")
+        result = await list_tools()
+        names = {tool["name"] for tool in result["tools"]}
+        assert "agenticorg_commerce_sales_agent" in names
 
     @pytest.mark.asyncio
     async def test_call_unknown_tool_returns_404(self):


### PR DESCRIPTION
## Summary
- Add fail-closed public commerce discovery gate `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED`.
- Hide `commerce_sales_agent` and `grantex_commerce:*` metadata from public MCP/A2A discovery unless explicitly enabled.
- Preserve non-commerce discovery and document the C5A posture for future C3 smoke and production readiness review.

## Validation
- `python -m ruff check api/v1/a2a.py api/v1/mcp.py core/commerce/discovery_gate.py tests/unit/test_a2a_mcp.py tests/regression/test_commerce_sales_agent_no_provider_calls.py`
- `python -m pytest tests/unit/test_a2a_mcp.py -q`
- `python -m pytest tests/regression/test_commerce_sales_agent_no_provider_calls.py -q`
- `python demos/commerce_sales_agent_demo.py --mode=mock`
- `git diff --check`
- Focused secret scan on changed files

## Safety
- No deploy, cloud resource, production config, secret, live payment, or live Plural changes.
- Mock mode remains default.
- Commerce execution remains Grantex-only; no direct provider credential path added.