### PR TITLE
[codex] Cost-capped production smoke readiness

### DIFF
--- a/docs/runbooks/production_smoke.md
+++ b/docs/runbooks/production_smoke.md
@@ -1,0 +1,162 @@
+# Production Smoke Readiness Runbook
+
+This runbook defines a cost-capped authenticated production smoke process for the existing AgenticOrg production services. It does not provision infrastructure, change production traffic, or run paid provider checks by default.
+
+Current reference state:
+
+- Production app commit: `46798ad20c82ee02cdf76e362f16f92c7163c081`
+- Main after smoke-tooling merge: `016da0b3c2fb0a3e42535e91bca270fae6ac620e`
+- API revision at last deploy: `agenticorg-api-00064-tqc`
+- UI revision at last deploy: `agenticorg-ui-00033-vvx`
+
+## No-New-Infra Policy
+
+Do not create new GCP infrastructure for smoke readiness unless the owner separately approves a costed proposal. This includes Cloud Run services, jobs, databases, queues, schedulers, buckets, VPC resources, Artifact Registry repositories, Pub/Sub topics, or service accounts.
+
+The smoke script uses only existing production URLs and credentials supplied through environment variables. By default it runs public read-only health checks and reports all missing or disabled authenticated checks as `SKIPPED`.
+
+## Cost Estimate
+
+Expected incremental monthly GCP cost for the default smoke process is near zero. The default checks make a small number of HTTP requests to already-running production services and do not create resources.
+
+Potential paid or usage-sensitive paths are skipped by default:
+
+- LLM/chat checks
+- RAG/vector/knowledge search checks
+- content-safety checks if backed by a paid provider
+- CA pack promotion checks
+- workflow run creation
+- signed CDC/event-wait dedupe checks that write smoke events
+- connector/provider/payment/email/SMS checks
+
+Any future provisioning proposal must include an estimated monthly cost before work starts.
+
+## Required Environment Variables
+
+Set the public API base URL when testing a non-default production endpoint:
+
+- `AGENTICORG_PROD_API_BASE_URL`
+
+Authentication requires either a bearer token or login credentials:
+
+- `AGENTICORG_SMOKE_BEARER_TOKEN`
+- `AGENTICORG_SMOKE_EMAIL`
+- `AGENTICORG_SMOKE_PASSWORD`
+
+If neither bearer token nor email/password is provided, authenticated checks are skipped.
+
+## Optional Environment Variables
+
+General runner controls:
+
+- `AGENTICORG_PROD_SMOKE_TIMEOUT_SECONDS`
+- `AGENTICORG_PROD_SMOKE_DRY_RUN`
+- `AGENTICORG_PROD_SMOKE_ENABLE_COST_RISKY`
+- `AGENTICORG_PROD_SMOKE_ENABLE_SIGNED_EVENT`
+
+Authenticated read-only checks:
+
+- `AGENTICORG_SMOKE_BRIDGE_ID`
+- `AGENTICORG_SMOKE_WORKFLOW_RUN_ID`
+
+Cost-risky or mutating checks, disabled unless `AGENTICORG_PROD_SMOKE_ENABLE_COST_RISKY=1`:
+
+- `AGENTICORG_SMOKE_CA_AGENT_ID`
+- `AGENTICORG_SMOKE_ZOHO_MISSING_AGENT_ID`
+- `AGENTICORG_SMOKE_WORKFLOW_ID`
+- `AGENTICORG_SMOKE_CHAT_QUERY`
+- `AGENTICORG_SMOKE_CHAT_AGENT_ID`
+- `AGENTICORG_SMOKE_KNOWLEDGE_QUERY`
+- `AGENTICORG_SMOKE_CONTENT_SAFETY_TEXT`
+
+Signed event check, disabled unless `AGENTICORG_PROD_SMOKE_ENABLE_SIGNED_EVENT=1`:
+
+- `AGENTICORG_SMOKE_CDC_TENANT_ID`
+- `AGENTICORG_SMOKE_CDC_CONNECTOR`
+- `AGENTICORG_SMOKE_CDC_SECRET`
+- `AGENTICORG_SMOKE_CDC_EVENT_ID`
+
+## Future Secret Manager Names
+
+If the owner approves managed smoke credentials later, use these exact Secret Manager names:
+
+- `agenticorg-prod-smoke-bearer-token`
+- `agenticorg-prod-smoke-email`
+- `agenticorg-prod-smoke-password`
+- `agenticorg-prod-smoke-tenant-id`
+- `agenticorg-prod-smoke-bridge-id`
+- `agenticorg-prod-smoke-workflow-run-id`
+- `agenticorg-prod-smoke-cdc-tenant-id`
+- `agenticorg-prod-smoke-cdc-connector`
+- `agenticorg-prod-smoke-cdc-secret`
+
+Do not store connector credentials, provider API keys, payment credentials, or customer data in smoke secrets.
+
+## Safe Manual Execution
+
+Default public smoke:
+
+```powershell
+python scripts/prod_smoke_check.py
+```
+
+Dry-run with authenticated credentials loaded into the environment:
+
+```powershell
+$env:AGENTICORG_PROD_SMOKE_DRY_RUN = "1"
+$env:AGENTICORG_SMOKE_BEARER_TOKEN = "<from approved secret source>"
+python scripts/prod_smoke_check.py --dry-run
+```
+
+Authenticated read-only smoke with a bearer token:
+
+```powershell
+$env:AGENTICORG_SMOKE_BEARER_TOKEN = "<from approved secret source>"
+$env:AGENTICORG_SMOKE_WORKFLOW_RUN_ID = "<approved smoke workflow run>"
+python scripts/prod_smoke_check.py
+```
+
+Signed CDC/event-wait dedupe smoke, only after the owner approves the smoke tenant and connector secret:
+
+```powershell
+$env:AGENTICORG_PROD_SMOKE_ENABLE_SIGNED_EVENT = "1"
+$env:AGENTICORG_SMOKE_CDC_TENANT_ID = "<approved smoke tenant>"
+$env:AGENTICORG_SMOKE_CDC_CONNECTOR = "<approved smoke connector>"
+$env:AGENTICORG_SMOKE_CDC_SECRET = "<from approved secret source>"
+python scripts/prod_smoke_check.py
+```
+
+Do not enable `AGENTICORG_PROD_SMOKE_ENABLE_COST_RISKY=1` unless the owner explicitly approves the specific check and accepts any provider usage cost.
+
+## Secret Handling
+
+The smoke script must never print secrets, tokens, cookies, auth headers, signatures, connector credentials, raw signed secrets, or raw provider credentials. Missing credentials produce explicit `SKIPPED` results with variable names only.
+
+Operators must source secrets from the approved secret source for the current environment. Do not paste secrets into docs, PR comments, shell history, screenshots, or logs.
+
+## Rotation and Disable Procedure
+
+To disable smoke access immediately:
+
+1. Revoke the smoke user's session or bearer token in the production auth system.
+2. Disable or rotate the corresponding Secret Manager secret version if one exists.
+3. Remove any locally exported `AGENTICORG_SMOKE_*` variables from the operator shell.
+4. Run default public smoke to confirm production remains reachable without authenticated smoke credentials.
+
+To rotate credentials:
+
+1. Create or reset the approved smoke account credential.
+2. Add a new Secret Manager version for the affected `agenticorg-prod-smoke-*` secret.
+3. Disable the old secret version after confirming the new value works.
+4. Run authenticated read-only smoke without enabling cost-risky checks.
+
+## Rollback and No-Op Guidance
+
+This runbook and `scripts/prod_smoke_check.py` are operational tooling only. Running default smoke does not deploy, migrate, or change traffic.
+
+If smoke checks fail after a deploy:
+
+1. Do not retry cost-risky checks until the failure mode is understood.
+2. Check Cloud Run revision health and application logs.
+3. Use the deployment rollback target documented in `docs/deployments/2026-05-17-post-deploy-46798ad.md` if the active revision is unhealthy.
+4. If credentials are missing or disabled, treat authenticated smoke as `SKIPPED`, not as a product outage.

--- a/scripts/prod_smoke_check.py
+++ b/scripts/prod_smoke_check.py
@@ -10,6 +10,7 @@ Core environment:
   AGENTICORG_SMOKE_BEARER_TOKEN or AGENTICORG_SMOKE_EMAIL + AGENTICORG_SMOKE_PASSWORD
 
 Optional authenticated checks:
+  AGENTICORG_PROD_SMOKE_ENABLE_COST_RISKY=1
   AGENTICORG_SMOKE_CA_AGENT_ID
   AGENTICORG_SMOKE_ZOHO_MISSING_AGENT_ID
   AGENTICORG_SMOKE_WORKFLOW_RUN_ID or AGENTICORG_SMOKE_WORKFLOW_ID
@@ -19,6 +20,7 @@ Optional authenticated checks:
   AGENTICORG_SMOKE_CONTENT_SAFETY_TEXT
 
 Optional signed CDC/event-wait dedupe check:
+  AGENTICORG_PROD_SMOKE_ENABLE_SIGNED_EVENT=1
   AGENTICORG_SMOKE_CDC_TENANT_ID
   AGENTICORG_SMOKE_CDC_CONNECTOR
   AGENTICORG_SMOKE_CDC_SECRET
@@ -41,10 +43,46 @@ import httpx
 
 DEFAULT_API_BASE_URL = "https://app.agenticorg.ai/api/v1"
 DEFAULT_TIMEOUT_SECONDS = 20.0
+ENABLE_COST_RISKY_ENV = "AGENTICORG_PROD_SMOKE_ENABLE_COST_RISKY"
+ENABLE_SIGNED_EVENT_ENV = "AGENTICORG_PROD_SMOKE_ENABLE_SIGNED_EVENT"
+DRY_RUN_ENV = "AGENTICORG_PROD_SMOKE_DRY_RUN"
 
 PASS = "PASS"
 FAIL = "FAIL"
 SKIPPED = "SKIPPED"
+
+CATEGORY_PUBLIC = "public"
+CATEGORY_AUTHENTICATED = "authenticated"
+CATEGORY_SIGNED_EVENT = "signed-event"
+CATEGORY_COST_RISKY = "cost-risky"
+
+REQUIRED_ENV_VARS = (
+    "AGENTICORG_PROD_API_BASE_URL",
+)
+AUTH_ENV_VARS = (
+    "AGENTICORG_SMOKE_BEARER_TOKEN",
+    "AGENTICORG_SMOKE_EMAIL",
+    "AGENTICORG_SMOKE_PASSWORD",
+)
+OPTIONAL_ENV_VARS = (
+    "AGENTICORG_PROD_SMOKE_TIMEOUT_SECONDS",
+    DRY_RUN_ENV,
+    ENABLE_COST_RISKY_ENV,
+    ENABLE_SIGNED_EVENT_ENV,
+    "AGENTICORG_SMOKE_BRIDGE_ID",
+    "AGENTICORG_SMOKE_CA_AGENT_ID",
+    "AGENTICORG_SMOKE_ZOHO_MISSING_AGENT_ID",
+    "AGENTICORG_SMOKE_WORKFLOW_RUN_ID",
+    "AGENTICORG_SMOKE_WORKFLOW_ID",
+    "AGENTICORG_SMOKE_CHAT_QUERY",
+    "AGENTICORG_SMOKE_CHAT_AGENT_ID",
+    "AGENTICORG_SMOKE_KNOWLEDGE_QUERY",
+    "AGENTICORG_SMOKE_CONTENT_SAFETY_TEXT",
+    "AGENTICORG_SMOKE_CDC_TENANT_ID",
+    "AGENTICORG_SMOKE_CDC_CONNECTOR",
+    "AGENTICORG_SMOKE_CDC_SECRET",
+    "AGENTICORG_SMOKE_CDC_EVENT_ID",
+)
 
 SENSITIVE_NAME_FRAGMENTS = (
     "AUTH",
@@ -82,6 +120,7 @@ class SmokeResult:
     status: str
     detail: str
     http_status: int | None = None
+    category: str = CATEGORY_PUBLIC
 
 
 @dataclass(frozen=True)
@@ -132,11 +171,20 @@ def _timeout_seconds() -> float:
     return max(1.0, timeout)
 
 
+def truthy_env(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def missing_env(names: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(name for name in names if not os.getenv(name))
 
 
-def skip_missing(name: str, required_env: tuple[str, ...]) -> SmokeResult | None:
+def skip_missing(
+    name: str,
+    required_env: tuple[str, ...],
+    *,
+    category: str = CATEGORY_PUBLIC,
+) -> SmokeResult | None:
     missing = missing_env(required_env)
     if not missing:
         return None
@@ -144,6 +192,25 @@ def skip_missing(name: str, required_env: tuple[str, ...]) -> SmokeResult | None
         name=name,
         status=SKIPPED,
         detail=f"missing required env: {', '.join(missing)}",
+        category=category,
+    )
+
+
+def skip_disabled(name: str, *, env_var: str, category: str) -> SmokeResult:
+    return SmokeResult(
+        name=name,
+        status=SKIPPED,
+        detail=f"{category} check disabled; set {env_var}=1 to run",
+        category=category,
+    )
+
+
+def skip_dry_run(name: str, *, category: str) -> SmokeResult:
+    return SmokeResult(
+        name=name,
+        status=SKIPPED,
+        detail="dry-run mode: mutating or provider-backed check was not called",
+        category=category,
     )
 
 
@@ -157,9 +224,24 @@ def _parse_json_body(text: str) -> Any:
 
 
 class ProdSmokeRunner:
-    def __init__(self, *, api_base_url: str | None = None, timeout_seconds: float | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        api_base_url: str | None = None,
+        timeout_seconds: float | None = None,
+        dry_run: bool | None = None,
+        enable_cost_risky: bool | None = None,
+        enable_signed_event: bool | None = None,
+    ) -> None:
         self.api_base_url = (api_base_url or _api_base_url()).rstrip("/")
         self.timeout_seconds = timeout_seconds or _timeout_seconds()
+        self.dry_run = truthy_env(DRY_RUN_ENV) if dry_run is None else dry_run
+        self.enable_cost_risky = (
+            truthy_env(ENABLE_COST_RISKY_ENV) if enable_cost_risky is None else enable_cost_risky
+        )
+        self.enable_signed_event = (
+            truthy_env(ENABLE_SIGNED_EVENT_ENV) if enable_signed_event is None else enable_signed_event
+        )
 
     def _url(self, path: str) -> str:
         normalized = path if path.startswith("/") else f"/{path}"
@@ -211,14 +293,22 @@ class ProdSmokeRunner:
         expected: set[int],
         *,
         detail: str,
+        category: str = CATEGORY_PUBLIC,
     ) -> SmokeResult:
         if result.status_code in expected:
-            return SmokeResult(name=name, status=PASS, detail=detail, http_status=result.status_code)
+            return SmokeResult(
+                name=name,
+                status=PASS,
+                detail=detail,
+                http_status=result.status_code,
+                category=category,
+            )
         return SmokeResult(
             name=name,
             status=FAIL,
             detail=f"unexpected HTTP status {result.status_code}; expected {sorted(expected)}",
             http_status=result.status_code or None,
+            category=category,
         )
 
     def health_checks(self) -> list[SmokeResult]:
@@ -231,7 +321,15 @@ class ProdSmokeRunner:
         results: list[SmokeResult] = []
         for name, method, path, expected in checks:
             response = self.request_json(method, path)
-            results.append(self.pass_if_status(name, response, expected, detail="endpoint reachable"))
+            results.append(
+                self.pass_if_status(
+                    name,
+                    response,
+                    expected,
+                    detail="endpoint reachable",
+                    category=CATEGORY_PUBLIC,
+                )
+            )
         return results
 
     def authenticate(self) -> tuple[AuthContext | None, SmokeResult]:
@@ -241,10 +339,11 @@ class ProdSmokeRunner:
                 name="auth.token",
                 status=PASS,
                 detail="using env-provided bearer token",
+                category=CATEGORY_AUTHENTICATED,
             )
 
         required = ("AGENTICORG_SMOKE_EMAIL", "AGENTICORG_SMOKE_PASSWORD")
-        skipped = skip_missing("auth.login", required)
+        skipped = skip_missing("auth.login", required, category=CATEGORY_AUTHENTICATED)
         if skipped:
             return None, skipped
 
@@ -259,6 +358,7 @@ class ProdSmokeRunner:
                 status=FAIL,
                 detail=f"login failed with HTTP {response.status_code}",
                 http_status=response.status_code,
+                category=CATEGORY_AUTHENTICATED,
             )
         access_token = response.body.get("access_token")
         if not isinstance(access_token, str) or not access_token:
@@ -267,6 +367,7 @@ class ProdSmokeRunner:
                 status=FAIL,
                 detail="login response did not include access_token",
                 http_status=response.status_code,
+                category=CATEGORY_AUTHENTICATED,
             )
         user = response.body.get("user") if isinstance(response.body.get("user"), dict) else {}
         tenant_id = user.get("tenant_id") if isinstance(user, dict) else None
@@ -275,6 +376,7 @@ class ProdSmokeRunner:
             status=PASS,
             detail="login returned bearer token",
             http_status=response.status_code,
+            category=CATEGORY_AUTHENTICATED,
         )
 
     def authenticated_checks(self, auth: AuthContext | None) -> list[SmokeResult]:
@@ -284,6 +386,7 @@ class ProdSmokeRunner:
                     name="authenticated.checks",
                     status=SKIPPED,
                     detail="missing authenticated smoke token or login credentials",
+                    category=CATEGORY_AUTHENTICATED,
                 )
             ]
 
@@ -293,6 +396,7 @@ class ProdSmokeRunner:
                 self.request_json("GET", "/bridge/list", token=auth.token),
                 {200},
                 detail="authenticated bridge list reachable",
+                category=CATEGORY_AUTHENTICATED,
             ),
             self.content_safety_check(auth),
             self.knowledge_search_check(auth),
@@ -309,6 +413,7 @@ class ProdSmokeRunner:
                     self.request_json("GET", f"/bridge/{bridge_id}/status", token=auth.token),
                     {200, 404},
                     detail="authenticated bridge status returned deterministic state",
+                    category=CATEGORY_AUTHENTICATED,
                 )
             )
         else:
@@ -317,11 +422,20 @@ class ProdSmokeRunner:
                     name="bridge.status",
                     status=SKIPPED,
                     detail="missing required env: AGENTICORG_SMOKE_BRIDGE_ID",
+                    category=CATEGORY_AUTHENTICATED,
                 )
             )
         return results
 
     def content_safety_check(self, auth: AuthContext) -> SmokeResult:
+        if not self.enable_cost_risky:
+            return skip_disabled(
+                "content_safety.check",
+                env_var=ENABLE_COST_RISKY_ENV,
+                category=CATEGORY_COST_RISKY,
+            )
+        if self.dry_run:
+            return skip_dry_run("content_safety.check", category=CATEGORY_COST_RISKY)
         text = os.getenv("AGENTICORG_SMOKE_CONTENT_SAFETY_TEXT", "AgenticOrg deployment smoke text.")
         response = self.request_json(
             "POST",
@@ -337,15 +451,21 @@ class ProdSmokeRunner:
             response,
             {200},
             detail="authenticated content-safety check returned a decision",
+            category=CATEGORY_COST_RISKY,
         )
 
     def knowledge_search_check(self, auth: AuthContext) -> SmokeResult:
+        if not self.enable_cost_risky:
+            return skip_disabled("knowledge.search", env_var=ENABLE_COST_RISKY_ENV, category=CATEGORY_COST_RISKY)
+        if self.dry_run:
+            return skip_dry_run("knowledge.search", category=CATEGORY_COST_RISKY)
         query = os.getenv("AGENTICORG_SMOKE_KNOWLEDGE_QUERY")
         if not query:
             return SmokeResult(
                 name="knowledge.search",
                 status=SKIPPED,
                 detail="missing required env: AGENTICORG_SMOKE_KNOWLEDGE_QUERY",
+                category=CATEGORY_COST_RISKY,
             )
         response = self.request_json(
             "POST",
@@ -358,15 +478,21 @@ class ProdSmokeRunner:
             response,
             {200, 500, 503},
             detail="knowledge search returned success or explicit deterministic failure",
+            category=CATEGORY_COST_RISKY,
         )
 
     def chat_query_check(self, auth: AuthContext) -> SmokeResult:
+        if not self.enable_cost_risky:
+            return skip_disabled("chat.query", env_var=ENABLE_COST_RISKY_ENV, category=CATEGORY_COST_RISKY)
+        if self.dry_run:
+            return skip_dry_run("chat.query", category=CATEGORY_COST_RISKY)
         query = os.getenv("AGENTICORG_SMOKE_CHAT_QUERY")
         if not query:
             return SmokeResult(
                 name="chat.query",
                 status=SKIPPED,
                 detail="missing required env: AGENTICORG_SMOKE_CHAT_QUERY",
+                category=CATEGORY_COST_RISKY,
             )
         payload: dict[str, Any] = {"query": query}
         agent_id = os.getenv("AGENTICORG_SMOKE_CHAT_AGENT_ID")
@@ -378,10 +504,15 @@ class ProdSmokeRunner:
             response,
             {200, 400, 409, 422, 500, 503},
             detail="chat query returned success or explicit deterministic failure",
+            category=CATEGORY_COST_RISKY,
         )
 
     def ca_pack_promotion_check(self, auth: AuthContext) -> SmokeResult:
-        skipped = skip_missing("ca_pack.promote", ("AGENTICORG_SMOKE_CA_AGENT_ID",))
+        if not self.enable_cost_risky:
+            return skip_disabled("ca_pack.promote", env_var=ENABLE_COST_RISKY_ENV, category=CATEGORY_COST_RISKY)
+        if self.dry_run:
+            return skip_dry_run("ca_pack.promote", category=CATEGORY_COST_RISKY)
+        skipped = skip_missing("ca_pack.promote", ("AGENTICORG_SMOKE_CA_AGENT_ID",), category=CATEGORY_COST_RISKY)
         if skipped:
             return skipped
         agent_id = os.environ["AGENTICORG_SMOKE_CA_AGENT_ID"]
@@ -391,10 +522,23 @@ class ProdSmokeRunner:
             response,
             {200},
             detail="approved CA pack promotion route succeeded",
+            category=CATEGORY_COST_RISKY,
         )
 
     def zoho_fail_closed_check(self, auth: AuthContext) -> SmokeResult:
-        skipped = skip_missing("ca_pack.zoho_missing_fail_closed", ("AGENTICORG_SMOKE_ZOHO_MISSING_AGENT_ID",))
+        if not self.enable_cost_risky:
+            return skip_disabled(
+                "ca_pack.zoho_missing_fail_closed",
+                env_var=ENABLE_COST_RISKY_ENV,
+                category=CATEGORY_COST_RISKY,
+            )
+        if self.dry_run:
+            return skip_dry_run("ca_pack.zoho_missing_fail_closed", category=CATEGORY_COST_RISKY)
+        skipped = skip_missing(
+            "ca_pack.zoho_missing_fail_closed",
+            ("AGENTICORG_SMOKE_ZOHO_MISSING_AGENT_ID",),
+            category=CATEGORY_COST_RISKY,
+        )
         if skipped:
             return skipped
         agent_id = os.environ["AGENTICORG_SMOKE_ZOHO_MISSING_AGENT_ID"]
@@ -405,12 +549,14 @@ class ProdSmokeRunner:
                 status=PASS,
                 detail="missing Zoho connector produced deterministic non-success",
                 http_status=response.status_code,
+                category=CATEGORY_COST_RISKY,
             )
         return SmokeResult(
             name="ca_pack.zoho_missing_fail_closed",
             status=FAIL,
             detail=f"expected fail-closed non-success, got HTTP {response.status_code}",
             http_status=response.status_code,
+            category=CATEGORY_COST_RISKY,
         )
 
     def workflow_state_check(self, auth: AuthContext) -> SmokeResult:
@@ -422,6 +568,7 @@ class ProdSmokeRunner:
                 response,
                 {200},
                 detail="existing workflow run state is readable",
+                category=CATEGORY_AUTHENTICATED,
             )
 
         workflow_id = os.getenv("AGENTICORG_SMOKE_WORKFLOW_ID")
@@ -430,7 +577,16 @@ class ProdSmokeRunner:
                 name="workflow.durable_state",
                 status=SKIPPED,
                 detail="missing required env: AGENTICORG_SMOKE_WORKFLOW_RUN_ID or AGENTICORG_SMOKE_WORKFLOW_ID",
+                category=CATEGORY_AUTHENTICATED,
             )
+        if not self.enable_cost_risky:
+            return skip_disabled(
+                "workflow.durable_state",
+                env_var=ENABLE_COST_RISKY_ENV,
+                category=CATEGORY_COST_RISKY,
+            )
+        if self.dry_run:
+            return skip_dry_run("workflow.durable_state", category=CATEGORY_COST_RISKY)
 
         trigger_payload = {"source": "prod_smoke", "ts": int(time.time())}
         response = self.request_json(
@@ -445,6 +601,7 @@ class ProdSmokeRunner:
                 status=FAIL,
                 detail=f"workflow run creation failed with HTTP {response.status_code}",
                 http_status=response.status_code,
+                category=CATEGORY_COST_RISKY,
             )
         created_run_id = response.body.get("run_id")
         if not isinstance(created_run_id, str) or not created_run_id:
@@ -453,6 +610,7 @@ class ProdSmokeRunner:
                 status=FAIL,
                 detail="workflow run response missing run_id",
                 http_status=response.status_code,
+                category=CATEGORY_COST_RISKY,
             )
         state_response = self.request_json("GET", f"/workflows/runs/{created_run_id}", token=auth.token)
         return self.pass_if_status(
@@ -460,15 +618,24 @@ class ProdSmokeRunner:
             state_response,
             {200},
             detail="created workflow run state is readable",
+            category=CATEGORY_COST_RISKY,
         )
 
     def cdc_event_dedupe_check(self) -> SmokeResult:
+        if not self.enable_signed_event:
+            return skip_disabled(
+                "cdc.event_dedupe",
+                env_var=ENABLE_SIGNED_EVENT_ENV,
+                category=CATEGORY_SIGNED_EVENT,
+            )
+        if self.dry_run:
+            return skip_dry_run("cdc.event_dedupe", category=CATEGORY_SIGNED_EVENT)
         required = (
             "AGENTICORG_SMOKE_CDC_TENANT_ID",
             "AGENTICORG_SMOKE_CDC_CONNECTOR",
             "AGENTICORG_SMOKE_CDC_SECRET",
         )
-        skipped = skip_missing("cdc.event_dedupe", required)
+        skipped = skip_missing("cdc.event_dedupe", required, category=CATEGORY_SIGNED_EVENT)
         if skipped:
             return skipped
 
@@ -504,6 +671,7 @@ class ProdSmokeRunner:
                 status=PASS,
                 detail="signed CDC event accepted and duplicate delivery deduped",
                 http_status=second.status_code,
+                category=CATEGORY_SIGNED_EVENT,
             )
         return SmokeResult(
             name="cdc.event_dedupe",
@@ -513,6 +681,7 @@ class ProdSmokeRunner:
                 f"got HTTP {first.status_code}/{second.status_code}"
             ),
             http_status=second.status_code or first.status_code or None,
+            category=CATEGORY_SIGNED_EVENT,
         )
 
     def run(self) -> list[SmokeResult]:
@@ -527,8 +696,9 @@ class ProdSmokeRunner:
 def print_results(results: list[SmokeResult]) -> None:
     for result in results:
         status = result.status.ljust(7)
+        category = f"[{result.category}]"
         http = f" http={result.http_status}" if result.http_status is not None else ""
-        print(f"{status} {result.name}{http} - {result.detail}")
+        print(f"{status} {category} {result.name}{http} - {result.detail}")
 
 
 def exit_code(results: list[SmokeResult]) -> int:
@@ -542,8 +712,28 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="API base URL including /api/v1. Defaults to AGENTICORG_PROD_API_BASE_URL or production.",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run read-only checks and skip mutating/provider-backed checks.",
+    )
+    parser.add_argument(
+        "--enable-cost-risky",
+        action="store_true",
+        help=f"Run checks guarded by {ENABLE_COST_RISKY_ENV}=1.",
+    )
+    parser.add_argument(
+        "--enable-signed-event",
+        action="store_true",
+        help=f"Run the signed CDC/event-wait dedupe check guarded by {ENABLE_SIGNED_EVENT_ENV}=1.",
+    )
     args = parser.parse_args(argv)
-    runner = ProdSmokeRunner(api_base_url=args.api_base_url)
+    runner = ProdSmokeRunner(
+        api_base_url=args.api_base_url,
+        dry_run=args.dry_run or None,
+        enable_cost_risky=args.enable_cost_risky or None,
+        enable_signed_event=args.enable_signed_event or None,
+    )
     results = runner.run()
     print_results(results)
     return exit_code(results)

--- a/tests/unit/test_prod_smoke_check.py
+++ b/tests/unit/test_prod_smoke_check.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from pytest import MonkeyPatch
+from pathlib import Path
+
+from pytest import CaptureFixture, MonkeyPatch
 
 from scripts import prod_smoke_check as smoke
 
@@ -28,6 +30,7 @@ def test_authentication_skips_with_exact_missing_env(monkeypatch: MonkeyPatch) -
 
     assert auth is None
     assert result.status == smoke.SKIPPED
+    assert result.category == smoke.CATEGORY_AUTHENTICATED
     assert result.detail == "missing required env: AGENTICORG_SMOKE_EMAIL, AGENTICORG_SMOKE_PASSWORD"
 
 
@@ -41,11 +44,26 @@ def test_authenticated_checks_skip_without_auth_context() -> None:
             name="authenticated.checks",
             status=smoke.SKIPPED,
             detail="missing authenticated smoke token or login credentials",
+            category=smoke.CATEGORY_AUTHENTICATED,
         )
     ]
 
 
-def test_cdc_dedupe_skips_when_signed_event_env_missing(monkeypatch: MonkeyPatch) -> None:
+def test_cdc_dedupe_skips_by_default_even_when_signed_event_env_exists(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.delenv(smoke.ENABLE_SIGNED_EVENT_ENV, raising=False)
+    monkeypatch.setenv("AGENTICORG_SMOKE_CDC_TENANT_ID", "tenant-1")
+    monkeypatch.setenv("AGENTICORG_SMOKE_CDC_CONNECTOR", "zoho")
+    monkeypatch.setenv("AGENTICORG_SMOKE_CDC_SECRET", "do-not-print")
+
+    runner = smoke.ProdSmokeRunner(api_base_url="https://example.test/api/v1")
+    result = runner.cdc_event_dedupe_check()
+
+    assert result.status == smoke.SKIPPED
+    assert result.category == smoke.CATEGORY_SIGNED_EVENT
+    assert smoke.ENABLE_SIGNED_EVENT_ENV in result.detail
+
+
+def test_cdc_dedupe_skips_when_enabled_but_signed_event_env_missing(monkeypatch: MonkeyPatch) -> None:
     for name in (
         "AGENTICORG_SMOKE_CDC_TENANT_ID",
         "AGENTICORG_SMOKE_CDC_CONNECTOR",
@@ -53,10 +71,11 @@ def test_cdc_dedupe_skips_when_signed_event_env_missing(monkeypatch: MonkeyPatch
     ):
         monkeypatch.delenv(name, raising=False)
 
-    runner = smoke.ProdSmokeRunner(api_base_url="https://example.test/api/v1")
+    runner = smoke.ProdSmokeRunner(api_base_url="https://example.test/api/v1", enable_signed_event=True)
     result = runner.cdc_event_dedupe_check()
 
     assert result.status == smoke.SKIPPED
+    assert result.category == smoke.CATEGORY_SIGNED_EVENT
     assert "AGENTICORG_SMOKE_CDC_SECRET" in result.detail
 
 
@@ -82,10 +101,69 @@ def test_cdc_dedupe_uses_signature_without_printing_secret(monkeypatch: MonkeyPa
                 return smoke.HttpResult(status_code=202, body={"status": "accepted"}, body_text="")
             return smoke.HttpResult(status_code=200, body={"status": "duplicate"}, body_text="")
 
-    result = FakeRunner(api_base_url="https://example.test/api/v1").cdc_event_dedupe_check()
+    result = FakeRunner(
+        api_base_url="https://example.test/api/v1",
+        enable_signed_event=True,
+    ).cdc_event_dedupe_check()
 
     assert result.status == smoke.PASS
+    assert result.category == smoke.CATEGORY_SIGNED_EVENT
     assert "do-not-print" not in result.detail
     assert len(calls) == 2
     assert calls[0]["headers"]
     assert calls[0]["headers"]["X-CDC-Signature"] != "do-not-print"
+
+
+def test_cost_risky_checks_skip_by_default_even_when_inputs_exist(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.delenv(smoke.ENABLE_COST_RISKY_ENV, raising=False)
+    monkeypatch.setenv("AGENTICORG_SMOKE_KNOWLEDGE_QUERY", "do not call vector search")
+
+    runner = smoke.ProdSmokeRunner(api_base_url="https://example.test/api/v1")
+    result = runner.knowledge_search_check(smoke.AuthContext(token="token"))
+
+    assert result.status == smoke.SKIPPED
+    assert result.category == smoke.CATEGORY_COST_RISKY
+    assert smoke.ENABLE_COST_RISKY_ENV in result.detail
+
+
+def test_dry_run_skips_mutating_or_provider_backed_checks(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTICORG_SMOKE_CHAT_QUERY", "do not call llm")
+
+    class NoNetworkRunner(smoke.ProdSmokeRunner):
+        def request_json(self, *args: object, **kwargs: object) -> smoke.HttpResult:
+            raise AssertionError("dry-run must not perform provider-backed calls")
+
+    runner = NoNetworkRunner(
+        api_base_url="https://example.test/api/v1",
+        dry_run=True,
+        enable_cost_risky=True,
+    )
+    result = runner.chat_query_check(smoke.AuthContext(token="token"))
+
+    assert result.status == smoke.SKIPPED
+    assert result.category == smoke.CATEGORY_COST_RISKY
+    assert "dry-run mode" in result.detail
+
+
+def test_required_smoke_env_vars_are_documented() -> None:
+    runbook = Path("docs/runbooks/production_smoke.md").read_text(encoding="utf-8")
+
+    for name in smoke.REQUIRED_ENV_VARS + smoke.AUTH_ENV_VARS + smoke.OPTIONAL_ENV_VARS:
+        assert name in runbook
+
+
+def test_print_results_includes_check_category(capsys: CaptureFixture[str]) -> None:
+    smoke.print_results(
+        [
+            smoke.SmokeResult(
+                name="health.readiness",
+                status=smoke.PASS,
+                detail="endpoint reachable",
+                http_status=200,
+                category=smoke.CATEGORY_PUBLIC,
+            )
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert "[public] health.readiness" in captured.out


### PR DESCRIPTION
## Summary

Adds cost-capped authenticated production smoke readiness without provisioning infrastructure or changing production traffic.

Changes:
- Adds `docs/runbooks/production_smoke.md` with the no-new-infra policy, cost posture, env contract, future Secret Manager names, rotation/disable steps, and safe manual execution guidance.
- Updates `scripts/prod_smoke_check.py` to label checks as `public`, `authenticated`, `signed-event`, or `cost-risky`.
- Makes cost-risky checks skip by default unless `AGENTICORG_PROD_SMOKE_ENABLE_COST_RISKY=1` or `--enable-cost-risky` is provided.
- Makes signed CDC/event-wait dedupe skip by default unless `AGENTICORG_PROD_SMOKE_ENABLE_SIGNED_EVENT=1` or `--enable-signed-event` is provided.
- Adds dry-run support so mutating/provider-backed checks do not execute.
- Extends smoke tests for skip behavior, redaction, dry-run safety, category output, and runbook env-var coverage.

## No infrastructure / deploy

- No GCP infrastructure was created.
- No Cloud Run services, jobs, DBs, queues, schedulers, buckets, VPC resources, Artifact Registry repos, or other resources were provisioned.
- No production deploy was performed.
- This PR only changes docs, smoke tooling, and unit tests.

## Cost estimate

Default expected incremental monthly GCP cost: near zero. The default smoke path only performs a small number of HTTP requests against already-running production services.

Checks skipped by default because they may incur provider cost, mutate smoke state, or require explicit owner approval:
- LLM/chat checks
- RAG/knowledge/vector checks
- content-safety checks if backed by paid provider behavior
- CA pack promotion / missing Zoho fail-closed checks
- workflow run creation
- signed CDC/event-wait dedupe
- connector/provider/payment/email/SMS style checks

## Env vars

Required / core:
- `AGENTICORG_PROD_API_BASE_URL`

Authentication, one path required for authenticated smoke:
- `AGENTICORG_SMOKE_BEARER_TOKEN`
- or `AGENTICORG_SMOKE_EMAIL` and `AGENTICORG_SMOKE_PASSWORD`

Optional controls:
- `AGENTICORG_PROD_SMOKE_TIMEOUT_SECONDS`
- `AGENTICORG_PROD_SMOKE_DRY_RUN`
- `AGENTICORG_PROD_SMOKE_ENABLE_COST_RISKY`
- `AGENTICORG_PROD_SMOKE_ENABLE_SIGNED_EVENT`

Optional read-only authenticated inputs:
- `AGENTICORG_SMOKE_BRIDGE_ID`
- `AGENTICORG_SMOKE_WORKFLOW_RUN_ID`

Optional cost-risky/mutating inputs:
- `AGENTICORG_SMOKE_CA_AGENT_ID`
- `AGENTICORG_SMOKE_ZOHO_MISSING_AGENT_ID`
- `AGENTICORG_SMOKE_WORKFLOW_ID`
- `AGENTICORG_SMOKE_CHAT_QUERY`
- `AGENTICORG_SMOKE_CHAT_AGENT_ID`
- `AGENTICORG_SMOKE_KNOWLEDGE_QUERY`
- `AGENTICORG_SMOKE_CONTENT_SAFETY_TEXT`

Optional signed-event inputs:
- `AGENTICORG_SMOKE_CDC_TENANT_ID`
- `AGENTICORG_SMOKE_CDC_CONNECTOR`
- `AGENTICORG_SMOKE_CDC_SECRET`
- `AGENTICORG_SMOKE_CDC_EVENT_ID`

## Validation

- `python scripts/check_enterprise_stability_gates.py --scorecard` passed
- `python scripts/check_enterprise_stability_gates.py` passed
- `python -m pytest tests/unit/test_prod_smoke_check.py -q` passed: 10 passed
- `python -m pytest tests/unit/test_enterprise_stability_gates.py -q --basetemp C:\tmp\agenticorg-pytest-gates-smoke-readiness` passed: 66 passed
- `python -m ruff check scripts/prod_smoke_check.py tests/unit/test_prod_smoke_check.py` passed
- `python -m compileall scripts/prod_smoke_check.py tests/unit/test_prod_smoke_check.py` passed
- `python -m alembic heads` passed: `v4916_merge_p0_heads (head)`
- `python scripts/check_migration_required.py` passed
- `git diff --check origin/main...HEAD` passed

Note: running `python -m pytest tests/unit/test_enterprise_stability_gates.py -q` without `--basetemp` hit a local Windows/OneDrive pytest temp cleanup permission error on `codex-pytest-basetemp`. The same test file passed with pytest basetemp redirected to `C:\tmp`.

## Remaining owner action

Approve/provide smoke credentials only if desired. Without approved credentials, authenticated and signed-event checks intentionally report `SKIPPED` rather than failing or triggering provider cost.