### PR TITLE
docs(commerce): add merchant approval intake

### DIFF
--- a/docs/reports/commerce-agent-merchant-approval-intake-status.md
+++ b/docs/reports/commerce-agent-merchant-approval-intake-status.md
@@ -1,0 +1,86 @@
+# AgenticOrg Commerce Merchant Approval Intake Status
+
+Status: current intake status record
+Date: 2026-05-18
+Scope: C5G current-state gap analysis for AgenticOrg dependency on Grantex
+named merchant read-only discovery approval artifacts
+Production changes made by this record: none
+AgenticOrg commerce public discovery enabled by this record: no
+Grantex production Commerce V1 enabled by this record: no
+Checkout or payment creation enabled by this record: no
+Live payments enabled by this record: no
+Live Plural enabled by this record: no
+Merchant approved by this record: no
+Config values approved by this record: no
+Allowlist values approved by this record: no
+
+No named merchant approval artifacts were provided for C5G. This status record
+therefore keeps every merchant field, approval, evidence artifact, and owner in
+pending placeholder form. Placeholders are not approval.
+
+## Current Merchant Status
+
+| Field | Current value | Status |
+| --- | --- | --- |
+| Grantex merchant identifier | `<MERCHANT_ID_PENDING_APPROVAL>` | Missing approval |
+| Public display name | `<MERCHANT_PUBLIC_NAME_PENDING_APPROVAL>` | Missing approval |
+| Legal or entity reference | `<MERCHANT_LEGAL_ENTITY_PENDING_APPROVAL>` | Missing approval |
+| Public category | `<MERCHANT_CATEGORY_PENDING_APPROVAL>` | Missing approval |
+
+Merchant approval status: not approved.
+
+Hard blocker: missing named Grantex merchant approval remains unresolved.
+
+## Approval Artifact Status
+
+| Artifact | Status | Blocker |
+| --- | --- | --- |
+| Merchant owner approval | Missing | Required before AgenticOrg can consider public commerce metadata. |
+| Legal/compliance approval | Missing | Required before AgenticOrg public metadata review can complete. |
+| Product wording approval | Missing | Required before Grantex-only public wording can be used. |
+| Security approval | Missing | Required before MCP/A2A public metadata can be considered. |
+| Ops/on-call/support approval | Missing | Required before smoke, support, incident, and rollback ownership can be accepted. |
+| Backup/RPO approval | Missing | Required before rollout planning can proceed. |
+| AgenticOrg dependency approval | Missing | Required before enabling AgenticOrg commerce public discovery. |
+
+## Required Evidence Status
+
+| Evidence | Current status | Notes |
+| --- | --- | --- |
+| C5C deployed gate evidence | Available as prior Grantex evidence | Does not approve AgenticOrg public discovery. |
+| C5D rollout plan | Available as planning record | Keeps AgenticOrg hidden pending Grantex smoke and separate approval. |
+| C5E named merchant approval package | Available as template package | Still placeholder-only. |
+| C5F artifact checklist | Available as checklist | This C5G status maps current gaps to it. |
+| Approved public payload preview | Missing | Required before AgenticOrg can reference merchant metadata. |
+| No-go checklist | Missing | Required before AgenticOrg rollout consideration. |
+| Rollback checklist | Missing | Required before AgenticOrg rollout consideration. |
+| Read-only smoke checklist | Missing | Required before AgenticOrg rollout consideration. |
+
+## Ownership Status
+
+| Role | Current owner | Status |
+| --- | --- | --- |
+| Rollback owner | `<APPROVER_NAME_PENDING>` | Missing |
+| Read-only smoke owner | `<APPROVER_NAME_PENDING>` | Missing |
+| Support owner | `<APPROVER_NAME_PENDING>` | Missing |
+| Incident escalation owner | `<APPROVER_NAME_PENDING>` | Missing |
+| Evidence retention owner | `<APPROVER_NAME_PENDING>` | Missing |
+
+## Decision Status
+
+| Decision state | Current status | AgenticOrg public commerce discovery permitted |
+| --- | --- | --- |
+| Not approved | Selected | No |
+| Approved for internal review only | Not selected | No |
+| Approved for public read-only discovery | Not selected | No |
+
+## Explicit Non-Approval
+
+- No merchant is approved.
+- No placeholder is approval.
+- No config value is approved.
+- No allowlist value is approved.
+- No production rollout is approved.
+- Completed intake would still require separate AgenticOrg rollout approval.
+- AgenticOrg public commerce discovery remains hidden until Grantex read-only
+  smoke passes and separate AgenticOrg approval exists.

--- a/docs/templates/commerce-agent-merchant-discovery-approval-intake.md
+++ b/docs/templates/commerce-agent-merchant-discovery-approval-intake.md
@@ -1,0 +1,91 @@
+# AgenticOrg Commerce Merchant Discovery Approval Intake Template
+
+Status: reusable intake template only
+Scope: future human artifact intake for AgenticOrg dependency on Grantex named
+merchant read-only discovery
+Production changes authorized by this template: none
+AgenticOrg commerce public discovery authorized by this template: none
+Merchant approval granted by this template: none
+
+Use this template to collect AgenticOrg dependency artifacts for a future public
+commerce discovery review after Grantex read-only merchant discovery is
+approved and smoke-tested. This template does not approve a merchant, approve
+configuration, set an allowlist value, or approve a production rollout.
+Placeholders are not approval.
+
+## Merchant Placeholder Fields
+
+| Field | Intake value | Reviewer notes |
+| --- | --- | --- |
+| Grantex merchant identifier | `<MERCHANT_ID_PENDING_APPROVAL>` | Pending |
+| Public display name | `<MERCHANT_PUBLIC_NAME_PENDING_APPROVAL>` | Pending |
+| Legal or entity reference | `<MERCHANT_LEGAL_ENTITY_PENDING_APPROVAL>` | Pending |
+| Public category | `<MERCHANT_CATEGORY_PENDING_APPROVAL>` | Pending |
+
+## Approval Artifact Intake
+
+| Artifact | Evidence reference | Approver | Date | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Merchant owner approval | `<ARTIFACT_REFERENCE_PENDING>` | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | Pending | Grantex merchant owner approval is not provided. |
+| Legal/compliance approval | `<ARTIFACT_REFERENCE_PENDING>` | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | Pending | AgenticOrg public metadata review remains pending. |
+| Product wording approval | `<ARTIFACT_REFERENCE_PENDING>` | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | Pending | Grantex-only wording review remains pending. |
+| Security approval | `<ARTIFACT_REFERENCE_PENDING>` | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | Pending | MCP/A2A non-secret metadata and provider-boundary review remains pending. |
+| Ops/on-call/support approval | `<ARTIFACT_REFERENCE_PENDING>` | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | Pending | AgenticOrg support, smoke, incident, and rollback ownership remain pending. |
+| Backup/RPO approval | `<ARTIFACT_REFERENCE_PENDING>` | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | Pending | Backup and recovery posture review remains pending. |
+| AgenticOrg dependency approval | `<ARTIFACT_REFERENCE_PENDING>` | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | Pending | Separate AgenticOrg approval remains pending. |
+
+## Public Discovery Profile Review
+
+| Profile field | Proposed value | Required review | Status |
+| --- | --- | --- | --- |
+| Display name | `<MERCHANT_PUBLIC_NAME_PENDING_APPROVAL>` | Legal/compliance, product wording | Pending |
+| Legal/entity reference | `<MERCHANT_LEGAL_ENTITY_PENDING_APPROVAL>` | Legal/compliance | Pending |
+| Category | `<MERCHANT_CATEGORY_PENDING_APPROVAL>` | Legal/compliance, product wording | Pending |
+| Description | `<PUBLIC_DESCRIPTION_PENDING_APPROVAL>` | Legal/compliance, product wording | Pending |
+| Supported capabilities | `<SUPPORTED_CAPABILITIES_PENDING_APPROVAL>` | Security, product wording | Pending |
+| Support contact | `<SUPPORT_CONTACT_PENDING_APPROVAL>` | Ops/support, legal/compliance | Pending |
+| Escalation path | `<ESCALATION_PATH_PENDING_APPROVAL>` | Ops/on-call/support | Pending |
+| Issuer/JWKS references | `<ISSUER_JWKS_REFERENCE_PENDING_APPROVAL>` | Security | Pending |
+| Discovery posture wording | `<DISCOVERY_POSTURE_WORDING_PENDING_APPROVAL>` | Security, product wording | Pending |
+| No-go wording | `<NO_GO_WORDING_PENDING_APPROVAL>` | Security, legal/compliance, product wording | Pending |
+
+## Required Evidence Intake
+
+| Evidence | Reference | Status | Notes |
+| --- | --- | --- | --- |
+| C5C deployed gate evidence | `<EVIDENCE_REFERENCE_PENDING>` | Pending | Confirms Grantex has a narrow discovery gate. |
+| C5D rollout plan | `<EVIDENCE_REFERENCE_PENDING>` | Pending | Confirms AgenticOrg stays hidden through Grantex rollout planning. |
+| C5E named merchant approval package | `<EVIDENCE_REFERENCE_PENDING>` | Pending | Confirms merchant approval package exists but needs human completion. |
+| C5F artifact checklist | `<EVIDENCE_REFERENCE_PENDING>` | Pending | Confirms this intake maps to the current checklist. |
+| Approved public payload preview | `<EVIDENCE_REFERENCE_PENDING>` | Pending | Must be Grantex-reviewed before AgenticOrg references it. |
+| No-go checklist | `<EVIDENCE_REFERENCE_PENDING>` | Pending | Must show no AgenticOrg exposure blocker is present. |
+| Rollback checklist | `<EVIDENCE_REFERENCE_PENDING>` | Pending | Must name AgenticOrg rollback owner and hide-discovery steps. |
+| Read-only smoke checklist | `<EVIDENCE_REFERENCE_PENDING>` | Pending | Must cover AgenticOrg health, MCP, A2A, marker scans, and Grantex-only metadata. |
+
+## Ownership Intake
+
+| Role | Owner | Date | Status |
+| --- | --- | --- | --- |
+| Rollback owner | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | Pending |
+| Read-only smoke owner | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | Pending |
+| Support owner | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | Pending |
+| Incident escalation owner | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | Pending |
+| Evidence retention owner | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | Pending |
+
+## Decision
+
+| Decision state | Selected | Meaning |
+| --- | --- | --- |
+| Not approved | Yes | Required Grantex and AgenticOrg artifacts are not complete. |
+| Approved for internal review only | No | Metadata may be reviewed internally, but not published. |
+| Approved for public read-only discovery | No | Metadata may be used only in a later separately approved rollout. |
+
+## Hard Blockers
+
+- Missing named Grantex merchant approval remains a hard blocker.
+- No config value is approved by this intake.
+- No allowlist value is approved by this intake.
+- No production rollout is approved by this intake.
+- Completed intake still requires separate AgenticOrg rollout approval.
+- AgenticOrg public commerce discovery remains hidden pending Grantex
+  read-only smoke and separate AgenticOrg approval.


### PR DESCRIPTION
## Summary
- Adds a C5G reusable AgenticOrg merchant discovery approval intake template.
- Adds the current AgenticOrg intake status record showing no named merchant is approved and every approval artifact/owner remains pending.
- Keeps AgenticOrg public commerce discovery hidden pending Grantex read-only smoke and separate AgenticOrg approval.

## Safety
- Planning docs/templates only; no deployment, cloud resources, production config, commerce public discovery, allowlist values, checkout/payment, live payment, live Plural, provider path, or secret changes.
- Placeholder-only: `<MERCHANT_ID_PENDING_APPROVAL>`, `<MERCHANT_PUBLIC_NAME_PENDING_APPROVAL>`, `<MERCHANT_LEGAL_ENTITY_PENDING_APPROVAL>`, `<MERCHANT_CATEGORY_PENDING_APPROVAL>`, `<APPROVER_NAME_PENDING>`, and `<APPROVAL_DATE_PENDING>` remain explicit.
- No merchant, config value, allowlist value, discovery enablement, or production rollout is approved.

## Validation
- Focused secret scan on changed docs/templates: clean.
- Focused overclaim scan on changed docs/templates: clean.
- Placeholder scan: required placeholders present; no production-looking merchant ID or realistic merchant name found.
- `git diff --check` / `git diff --cached --check`.