### PR TITLE
fix: quote deploy revision readiness helper safely

### DIFF
--- a/docs/runbooks/production_smoke.md
+++ b/docs/runbooks/production_smoke.md
@@ -180,3 +180,11 @@ Dry-run mode prints the previous traffic allocation and the planned traffic chan
 Cloud Run revisions staged with `--no-traffic` may report `Ready=True` on the revision object while the service-level `status.latestReadyRevisionName` remains pinned to the currently serving revision. The deploy helper must therefore check readiness on the specific staged revision object, not on the service-level latest-ready field.
 
 This was observed during the attempted deploy of commit `2d3a9ac6eb2249fe6debe915f9c521692a8b9f75`: API revision `agenticorg-api-00067-fpj` was created with `Ready=True` and no public traffic, while `agenticorg-api` still reported `latestReadyRevisionName=agenticorg-api-00065-zp4`. The script now treats the staged revision as ready only when the revision object has `Ready=True`, belongs to the expected service, and its image plus commit metadata match the requested deploy SHA.
+
+### Embedded Python Quoting
+
+During the attempted deploy of commit `83fa3ac56e3765e273b3eb2e07bed0cbc388d41a`, the deploy helper staged API revision `agenticorg-api-00068-d4q` with the correct image digest and `AGENTICORG_GIT_SHA`, but failed before moving traffic. Traffic remained unchanged at `agenticorg-api-00065-zp4` and `agenticorg-ui-00034-zck`.
+
+Root cause: the non-dry-run revision readiness path used multiline `python3 -c '...'` snippets containing Python string literals such as `'<unknown>'`. Bash closed the single-quoted shell string early and treated `<unknown>` as redirection. Dry-run did not catch the issue because it did not execute the revision readiness parser.
+
+The deploy helper now uses quoted Python here-docs and a resolved `PYTHON_BIN` interpreter for embedded parsing. This keeps Python string literals opaque to Bash and works under both normal Linux bash and Git Bash on Windows.

--- a/scripts/deploy_cloud_run.sh
+++ b/scripts/deploy_cloud_run.sh
@@ -117,7 +117,40 @@ require_cmd gcloud
 require_cmd docker
 require_cmd git
 require_cmd curl
-require_cmd python3
+require_cmd mktemp
+
+resolve_python_bin() {
+  local candidate
+
+  if [[ -n "${PYTHON_BIN:-}" ]]; then
+    if "$PYTHON_BIN" - <<'PY' >/dev/null 2>&1
+import json
+import sys
+PY
+    then
+      echo "$PYTHON_BIN"
+      return 0
+    fi
+    echo "::error::PYTHON_BIN is set but is not usable: $PYTHON_BIN" >&2
+    exit 1
+  fi
+
+  for candidate in python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1 && "$candidate" - <<'PY' >/dev/null 2>&1
+import json
+import sys
+PY
+    then
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  echo "Missing: usable python3 or python" >&2
+  exit 1
+}
+
+PYTHON_BIN="$(resolve_python_bin)"
 
 service_json() {
   gcloud run services describe "$1" \
@@ -134,9 +167,16 @@ service_value() {
 }
 
 traffic_summary() {
-  service_json "$1" | python3 -c '
+  local json_file
+  local rc=0
+
+  json_file="$(mktemp)"
+  service_json "$1" > "$json_file"
+  "$PYTHON_BIN" - "$json_file" <<'PY' || rc=$?
 import json, sys
-svc = json.load(sys.stdin)
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    svc = json.load(fh)
 traffic = svc.get("status", {}).get("traffic", []) or []
 items = []
 for item in traffic:
@@ -152,13 +192,22 @@ for item in traffic:
     extra = " (" + ", ".join(suffix) + ")" if suffix else ""
     items.append(f"{revision}={percent}%{extra}")
 print(", ".join(items) if items else "none")
-'
+PY
+  rm -f "$json_file"
+  return "$rc"
 }
 
 traffic_to_revisions() {
-  service_json "$1" | python3 -c '
+  local json_file
+  local rc=0
+
+  json_file="$(mktemp)"
+  service_json "$1" > "$json_file"
+  "$PYTHON_BIN" - "$json_file" <<'PY' || rc=$?
 import json, sys
-svc = json.load(sys.stdin)
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    svc = json.load(fh)
 traffic = svc.get("status", {}).get("traffic", []) or []
 parts = []
 for item in traffic:
@@ -171,24 +220,34 @@ for item in traffic:
     if revision:
         parts.append(f"{revision}={percent}")
 print(",".join(parts))
-'
+PY
+  rm -f "$json_file"
+  return "$rc"
 }
 
 tagged_revision_url() {
   local svc="$1"
   local tag="$2"
   local revision="$3"
-  service_json "$svc" | python3 -c '
+  local json_file
+  local rc=0
+
+  json_file="$(mktemp)"
+  service_json "$svc" > "$json_file"
+  "$PYTHON_BIN" - "$json_file" "$tag" "$revision" <<'PY' || rc=$?
 import json, sys
 
-wanted_tag = sys.argv[1]
-wanted_revision = sys.argv[2]
-svc = json.load(sys.stdin)
+wanted_tag = sys.argv[2]
+wanted_revision = sys.argv[3]
+with open(sys.argv[1], encoding="utf-8") as fh:
+    svc = json.load(fh)
 for item in svc.get("status", {}).get("traffic", []) or []:
     if item.get("tag") == wanted_tag and item.get("revisionName") == wanted_revision:
         print(item.get("url", ""))
         break
-' "$tag" "$revision"
+PY
+  rm -f "$json_file"
+  return "$rc"
 }
 
 image_digest() {
@@ -236,13 +295,18 @@ revision_ready_state() {
   local env_name="$5"
   local expected_sha="$6"
   local svc="$7"
+  local json_file
+  local rc=0
 
-  python3 -c '
+  json_file="$(mktemp)"
+  cat > "$json_file"
+  "$PYTHON_BIN" - "$json_file" "$label" "$revision" "$image" "$image_digest" "$env_name" "$expected_sha" "$svc" <<'PY' || rc=$?
 import json
 import sys
 
-label, revision, image, image_digest, env_name, expected_sha, svc = sys.argv[1:]
-rev = json.load(sys.stdin)
+json_file, label, revision, image, image_digest, env_name, expected_sha, svc = sys.argv[1:]
+with open(json_file, encoding="utf-8") as fh:
+    rev = json.load(fh)
 
 revision_service = rev.get("metadata", {}).get("labels", {}).get(
     "serving.knative.dev/service", ""
@@ -328,7 +392,9 @@ if ready_status == "False":
 
 print(f"{label} revision {revision} is still becoming ready ({details})")
 sys.exit(2)
-' "$label" "$revision" "$image" "$image_digest" "$env_name" "$expected_sha" "$svc"
+PY
+  rm -f "$json_file"
+  return "$rc"
 }
 
 wait_for_staged_revision_ready() {
@@ -451,6 +517,26 @@ rollback_service_traffic() {
     --to-revisions="$traffic_spec"
 }
 
+json_field_from_stdin() {
+  local field="$1"
+  local json_file
+  local rc=0
+
+  json_file="$(mktemp)"
+  cat > "$json_file"
+  "$PYTHON_BIN" - "$json_file" "$field" <<'PY' || rc=$?
+import json
+import sys
+
+json_file, field = sys.argv[1:]
+with open(json_file, encoding="utf-8") as fh:
+    payload = json.load(fh)
+print(payload.get(field, ""))
+PY
+  rm -f "$json_file"
+  return "$rc"
+}
+
 poll_health_url() {
   local url="$1"
   local label="$2"
@@ -462,8 +548,8 @@ poll_health_url() {
   echo "Polling $label health at $url for commit=$SHORT_SHA ..."
   for attempt in $(seq 1 "$attempts"); do
     resp="$(curl -fsS "$url" 2>/dev/null || true)"
-    status="$(echo "$resp" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || true)"
-    commit="$(echo "$resp" | python3 -c "import sys,json; print(json.load(sys.stdin).get('commit',''))" 2>/dev/null || true)"
+    status="$(printf '%s' "$resp" | json_field_from_stdin status 2>/dev/null || true)"
+    commit="$(printf '%s' "$resp" | json_field_from_stdin commit 2>/dev/null || true)"
     if [[ "$status" == "healthy" && "${commit:0:7}" == "$SHORT_SHA" ]]; then
       echo "Verified $label health: status=healthy commit=$commit"
       return 0

--- a/tests/unit/test_deploy_cloud_run_script.py
+++ b/tests/unit/test_deploy_cloud_run_script.py
@@ -69,6 +69,54 @@ def test_staged_revision_readiness_uses_revision_object_not_latest_ready() -> No
     assert "staged revision object" in wait_block
 
 
+def test_deploy_script_uses_shell_safe_python_heredocs() -> None:
+    script = _deploy_script()
+
+    assert "python3 -c '" not in script
+    assert 'python3 -c "' not in script
+    assert "python -c '" not in script
+    assert 'python -c "' not in script
+    assert "<<'PY'" in script
+    assert '"$PYTHON_BIN" - "$json_file"' in script
+
+
+def test_revision_readiness_helper_is_safe_for_unknown_markers() -> None:
+    script = _deploy_script()
+    ready_start = script.index("revision_ready_state()")
+    ready_end = script.index("wait_for_staged_revision_ready()", ready_start)
+    ready_block = script[ready_start:ready_end]
+
+    assert '"$PYTHON_BIN" - "$json_file"' in ready_block
+    assert "<<'PY'" in ready_block
+    assert "python3 -c" not in ready_block
+    assert "python -c" not in ready_block
+    assert "'<unknown>'" in ready_block
+    assert '"<missing>"' in ready_block
+    assert '"<none>"' in ready_block
+
+
+def test_script_resolves_usable_python_for_git_bash_on_windows() -> None:
+    script = _deploy_script()
+
+    assert "resolve_python_bin()" in script
+    assert 'PYTHON_BIN="$(resolve_python_bin)"' in script
+    assert 'for candidate in python3 python; do' in script
+    assert "Missing: usable python3 or python" in script
+
+
+def test_health_poll_json_parsing_uses_shell_safe_helper() -> None:
+    script = _deploy_script()
+    poll_start = script.index("poll_health_url()")
+    poll_end = script.index("print_manual_traffic_commands()", poll_start)
+    poll_block = script[poll_start:poll_end]
+
+    assert "json_field_from_stdin" in script
+    assert "python3 -c" not in poll_block
+    assert "python -c" not in poll_block
+    assert 'json_field_from_stdin status' in poll_block
+    assert 'json_field_from_stdin commit' in poll_block
+
+
 def test_retired_ready_staged_revision_is_accepted_when_target_matches() -> None:
     script = _deploy_script()
     ready_start = script.index("revision_ready_state()")


### PR DESCRIPTION
﻿## Summary

Fixes the deploy-script regression from the attempted production deploy of `83fa3ac56e3765e273b3eb2e07bed0cbc388d41a`.

During that attempt, the script staged API revision `agenticorg-api-00068-d4q` with the expected target image and `AGENTICORG_GIT_SHA`, but failed before moving traffic. UI was not updated and traffic remained unchanged:

- API: `100% agenticorg-api-00065-zp4`
- UI: `100% agenticorg-ui-00034-zck`

No deploy or traffic change was performed by this PR.

## Root Cause

The non-dry-run revision readiness path used multiline `python3 -c '...'` snippets containing Python string literals like `'<unknown>'`. Bash closed the single-quoted shell string early and treated `<unknown>` as shell redirection. Dry-run did not catch this because it did not execute the revision readiness parser.

## Changes

- Replaced embedded multiline Python `-c` snippets with quoted here-doc execution and temp JSON files.
- Added `PYTHON_BIN` resolution so Git Bash on Windows can fall back from a broken `python3` app-execution alias to a usable `python`.
- Preserved revision-object readiness behavior from #606:
  - checks the specific staged revision object
  - accepts `Ready=True` even for no-traffic/retired revisions
  - validates service ownership label
  - validates image tag/digest
  - validates commit metadata
- Updated deploy tests to prevent reintroducing fragile Python quoting.
- Documented the failed `83fa3ac` deploy attempt and quoting root cause in the production smoke/deploy runbook.

## Validation

- `python scripts/check_enterprise_stability_gates.py --scorecard` - passed
- `python scripts/check_enterprise_stability_gates.py` - passed
- `python -m pytest tests/unit/test_deploy_cloud_run_script.py -q` - `18 passed`
- `python -m pytest tests/unit/test_prod_smoke_check.py -q` - `10 passed`
- `python -m pytest tests/unit/test_enterprise_stability_gates.py -q --basetemp C:\tmp\agenticorg-pytest-gates-deploy-quoting` - `66 passed`
- `python -m ruff check tests/unit/test_deploy_cloud_run_script.py` - passed
- `python -m compileall tests/unit/test_deploy_cloud_run_script.py` - passed
- `bash -n scripts/deploy_cloud_run.sh` via Git Bash - passed
- `python -m alembic heads` - `v4916_merge_p0_heads (head)`
- `python scripts/check_migration_required.py` - passed
- `git diff --check origin/main...HEAD` - passed
- No-op dry-run for `83fa3ac` with `--skip-build --traffic latest --dry-run` - passed

## Safety

- No production deploy was run after this fix.
- No Cloud Run traffic was changed.
- No GCP infrastructure was created.
- No authenticated smoke was run.
- No migrations were run.
