### PR TITLE
[codex] finish broad exception cleanup

### DIFF
--- a/api/v1/voice.py
+++ b/api/v1/voice.py
@@ -333,7 +333,7 @@ async def test_connection(
             status="network_error",
             message=f"Could not reach SIP endpoint {host}:{port}: {type(exc).__name__}",
         )
-    except Exception as exc:  # noqa: BLE001 — user-facing probe response
+    except RuntimeError as exc:
         return VoiceTestResponse(
             status="network_error",
             message=f"SIP probe failed: {type(exc).__name__}",

--- a/core/approvals/policy_engine.py
+++ b/core/approvals/policy_engine.py
@@ -51,6 +51,7 @@ def _condition_matches(condition: str | None, context: dict[str, Any]) -> bool:
         from workflows.condition_evaluator import evaluate_condition
 
         return bool(evaluate_condition(condition, context))
+    # enterprise-gate: broad-except-ok reason=approval-policy-condition-failure-defaults-safe-false
     except Exception:
         logger.warning("approval_policy_condition_eval_failed", condition=condition)
         return False

--- a/core/async_redis.py
+++ b/core/async_redis.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 
 import redis.asyncio as aioredis
+from redis.exceptions import RedisError
 
 from core.config import redis_socket_timeout_kwargs, redis_url_from_env
 
@@ -35,7 +36,7 @@ async def get_async_redis() -> aioredis.Redis | None:
         )
         await _pool.ping()
         return _pool
-    except Exception:
+    except (OSError, RedisError, ValueError):
         logger.warning("async_redis: Redis unavailable")
         _pool = None
         return None

--- a/core/crypto/backfill_connector_secrets.py
+++ b/core/crypto/backfill_connector_secrets.py
@@ -84,6 +84,7 @@ async def backfill() -> dict[str, int]:
                 connector_name=conn.name,
                 tenant_id=str(conn.tenant_id),
             )
+        # enterprise-gate: broad-except-ok reason=crypto-backfill-row-failure-records-error-count
         except Exception as e:
             errors += 1
             logger.error(

--- a/core/crypto/credential_vault.py
+++ b/core/crypto/credential_vault.py
@@ -181,5 +181,5 @@ def verify_credential(ciphertext: str) -> bool:
         return True
     except InvalidToken:
         return False
-    except Exception:
+    except (TypeError, ValueError):
         return False

--- a/core/crypto/migration_helpers.py
+++ b/core/crypto/migration_helpers.py
@@ -142,6 +142,7 @@ class EncryptedMigrationContext:
                     else:
                         decrypt_credential(ct if isinstance(ct, str) else ct.decode())
                     ok += 1
+                # enterprise-gate: broad-except-ok reason=encrypted-migration-preflight-failure-raises
                 except Exception as exc:  # noqa: BLE001
                     failures.append(f"{type(exc).__name__}: {str(exc)[:120]}")
             results[col] = ok

--- a/core/crypto/rewrap.py
+++ b/core/crypto/rewrap.py
@@ -130,6 +130,7 @@ def _fire_cache_invalidators(label: str) -> None:
                     column=label,
                     invalidator=dotted,
                 )
+        # enterprise-gate: broad-except-ok reason=rewrap-cache-invalidator-failure-logs-after-durable-rewrap
         except Exception as exc:
             logger.warning(
                 "rewrap_cache_invalidator_failed",
@@ -343,6 +344,7 @@ async def run(
                     old_kid = _stamp_kid(ct)
                     try:
                         plaintext = decrypt_credential(ct)
+                    # enterprise-gate: broad-except-ok reason=rewrap-decrypt-failure-aborts-with-nonzero-status
                     except Exception as exc:
                         logger.exception(
                             "rewrap_decrypt_failed",

--- a/core/crypto/tenant_secrets.py
+++ b/core/crypto/tenant_secrets.py
@@ -22,6 +22,7 @@ import uuid
 
 import structlog
 from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 
 from core.crypto.credential_vault import (
     decrypt_credential as _legacy_decrypt,
@@ -54,7 +55,7 @@ async def _resolve_kek(tenant_id: uuid.UUID) -> str:
             row = result.scalar_one_or_none()
             if row:
                 return row
-    except Exception:
+    except SQLAlchemyError:
         logger.debug("tenant_kek_lookup_failed", tenant_id=str(tenant_id))
     return os.getenv("AGENTICORG_PLATFORM_KEK", "")
 
@@ -68,10 +69,7 @@ async def encrypt_for_tenant(plaintext: str, tenant_id: uuid.UUID) -> str:
     """
     kek = await _resolve_kek(tenant_id)
     if kek:
-        try:
-            return _ENVELOPE_PREFIX + encrypt_to_string(plaintext.encode(), kek)
-        except Exception:
-            logger.exception("envelope_encrypt_failed_falling_back", tenant_id=str(tenant_id))
+        return _ENVELOPE_PREFIX + encrypt_to_string(plaintext.encode(), kek)
     # Fallback — legacy Fernet
     return _legacy_encrypt(plaintext)
 

--- a/core/explainer.py
+++ b/core/explainer.py
@@ -135,6 +135,7 @@ async def _call_llm_for_summary(
             bullets = parsed.get("bullets", [])
             if isinstance(bullets, list) and bullets:
                 return [str(b) for b in bullets[:5]]
+    # enterprise-gate: broad-except-ok reason=explainer-llm-summary-failure-degrades-to-heuristic
     except Exception as exc:
         logger.warning("explainer_llm_failed", error=str(exc))
 

--- a/core/langgraph/agent_graph.py
+++ b/core/langgraph/agent_graph.py
@@ -604,7 +604,7 @@ def _check_hitl_trigger(
                 op_fn = ops.get(type(tree.body.ops[0]))
                 if op_fn and op_fn(float(left_val), float(right_val)):
                     return f"condition matched: {hitl_condition}"
-        except Exception:  # noqa: S110
+        except (AttributeError, KeyError, SyntaxError, TypeError, ValueError):  # noqa: S110
             pass  # HITL condition eval is best-effort; silent failure is intentional
 
     return ""

--- a/core/langgraph/llm_factory.py
+++ b/core/langgraph/llm_factory.py
@@ -125,6 +125,7 @@ def create_chat_model(
             routed_model = smart_router.route(query=query, config=cfg)
             if routed_model:
                 model = routed_model
+        # enterprise-gate: broad-except-ok reason=smart-routing-failure-falls-back-to-explicit-model
         except Exception as exc:  # noqa: BLE001
             logger.warning("smart_routing_failed", error=str(exc), fallback=model)
             # Fall through to normal model resolution
@@ -185,6 +186,7 @@ def _resolve_cloud_api_key(provider: str, tenant_id: str | None = None) -> str:
         # library surface the usual "missing API key" error so the
         # symptom is actionable.
         return ""
+    # enterprise-gate: broad-except-ok reason=llm-key-resolver-failure-returns-provider-unavailable
     except Exception as exc:
         logger.warning("llm_key_resolve_failed", provider=provider, error=str(exc))
         return ""

--- a/core/marketing/ab_test.py
+++ b/core/marketing/ab_test.py
@@ -10,6 +10,7 @@ from enum import StrEnum
 from typing import Any
 
 import structlog
+from redis.exceptions import RedisError
 
 logger = structlog.get_logger()
 
@@ -138,7 +139,7 @@ class ABTestEngine:
             self._redis = redis.from_url(url, decode_responses=True)
             self._redis.ping()
             logger.info("ab_test_engine_redis_connected")
-        except Exception as exc:
+        except (ImportError, OSError, RedisError, ValueError) as exc:
             logger.warning("ab_test_engine_redis_unavailable", error=str(exc))
             self._redis = None
 

--- a/core/marketing/intent_aggregator.py
+++ b/core/marketing/intent_aggregator.py
@@ -149,6 +149,7 @@ class IntentAggregator:
         try:
             await connector.connect()
             return await connector.get_surge_scores(domains=domain)
+        # enterprise-gate: broad-except-ok reason=bombora-provider-failure-returns-explicit-provider-error
         except Exception as exc:
             logger.warning("bombora_fetch_error", domain=domain, error=str(exc))
             return {"error": str(exc)}
@@ -163,6 +164,7 @@ class IntentAggregator:
         try:
             await connector.connect()
             return await connector.get_intent_signals(domain=domain)
+        # enterprise-gate: broad-except-ok reason=g2-provider-failure-returns-explicit-provider-error
         except Exception as exc:
             logger.warning("g2_fetch_error", domain=domain, error=str(exc))
             return {"error": str(exc)}
@@ -177,6 +179,7 @@ class IntentAggregator:
         try:
             await connector.connect()
             return await connector.get_buyer_intent(vendor_id=domain)
+        # enterprise-gate: broad-except-ok reason=trustradius-provider-failure-returns-explicit-provider-error
         except Exception as exc:
             logger.warning("trustradius_fetch_error", domain=domain, error=str(exc))
             return {"error": str(exc)}

--- a/core/seed_knowledge.py
+++ b/core/seed_knowledge.py
@@ -270,6 +270,7 @@ async def seed_knowledge_base(tenant_id_str: str) -> dict:
             f"{d['title']}\n\n{d['content'][:1500]}" for d in _KNOWLEDGE_DOCUMENTS
         ]
         vectors: list[list[float]] | None = _embed(payloads)
+    # enterprise-gate: broad-except-ok reason=seed-knowledge-embedding-failure-degrades-to-text-only-seed
     except Exception as exc:
         logger.warning("seed_knowledge_embedding_skipped", error=str(exc))
         vectors = None

--- a/core/voice/sip_config.py
+++ b/core/voice/sip_config.py
@@ -107,7 +107,7 @@ def decrypt_credentials(credentials: dict) -> dict:
         import hashlib
         import os
 
-        from cryptography.fernet import Fernet
+        from cryptography.fernet import Fernet, InvalidToken
 
         secret = os.getenv("AGENTICORG_SECRET_KEY", "")
         if not secret:
@@ -119,7 +119,7 @@ def decrypt_credentials(credentials: dict) -> dict:
             if isinstance(v, str) and v:
                 try:
                     decrypted[k] = f.decrypt(v.encode()).decode()
-                except Exception:
+                except InvalidToken:
                     decrypted[k] = v  # not encrypted, return as-is
             else:
                 decrypted[k] = v
@@ -218,6 +218,7 @@ async def _test_twilio(config: SIPConfig) -> dict[str, Any]:
             "message": "Twilio SDK not installed — run: pip install twilio",
             "details": {},
         }
+    # enterprise-gate: broad-except-ok reason=twilio-provider-probe-failure-returns-explicit-unhealthy
     except Exception as exc:
         return {
             "success": False,
@@ -249,6 +250,7 @@ async def _test_vonage(config: SIPConfig) -> dict[str, Any]:
             "message": "Vonage SDK not installed — run: pip install vonage",
             "details": {},
         }
+    # enterprise-gate: broad-except-ok reason=vonage-provider-probe-failure-returns-explicit-unhealthy
     except Exception as exc:
         return {
             "success": False,

--- a/docs/enterprise_stability_gate_baseline.json
+++ b/docs/enterprise_stability_gate_baseline.json
@@ -1,29 +1,6 @@
 {
   "allowed_findings": {
-    "broad_exception": [
-      "broad_exception:api/v1/voice.py:336:b6ce1f3ca752",
-      "broad_exception:core/approvals/policy_engine.py:54:0bc50f18028e",
-      "broad_exception:core/async_redis.py:38:76ee9880559b",
-      "broad_exception:core/crypto/backfill_connector_secrets.py:87:82601d37963c",
-      "broad_exception:core/crypto/credential_vault.py:184:769a5fd524b1",
-      "broad_exception:core/crypto/migration_helpers.py:145:454dc8178697",
-      "broad_exception:core/crypto/rewrap.py:133:b4cb59a2f12d",
-      "broad_exception:core/crypto/rewrap.py:346:530373f6b063",
-      "broad_exception:core/crypto/tenant_secrets.py:57:d015ac4e6358",
-      "broad_exception:core/crypto/tenant_secrets.py:73:bde78cfef094",
-      "broad_exception:core/explainer.py:138:658c378bbe3e",
-      "broad_exception:core/langgraph/agent_graph.py:607:28824f9b6c42",
-      "broad_exception:core/langgraph/llm_factory.py:128:2443358327e4",
-      "broad_exception:core/langgraph/llm_factory.py:188:498e61368f92",
-      "broad_exception:core/marketing/ab_test.py:141:7e4f76140361",
-      "broad_exception:core/marketing/intent_aggregator.py:152:1f608f2ca879",
-      "broad_exception:core/marketing/intent_aggregator.py:166:fed5e336de92",
-      "broad_exception:core/marketing/intent_aggregator.py:180:5a2f8b189684",
-      "broad_exception:core/seed_knowledge.py:273:a87993832fa9",
-      "broad_exception:core/voice/sip_config.py:122:11665f755ba7",
-      "broad_exception:core/voice/sip_config.py:221:d1a8368e334b",
-      "broad_exception:core/voice/sip_config.py:252:1184513c8219"
-    ],
+    "broad_exception": [],
     "stub_path": [
       "stub_path:workflows/collaboration.py:89:59ffc28f11d0",
       "stub_path:workflows/engine.py:669:facd4b3e7b16",

--- a/tests/unit/test_enterprise_stability_gates.py
+++ b/tests/unit/test_enterprise_stability_gates.py
@@ -469,6 +469,13 @@ def test_broad_exception_baseline_reduced_by_near_final_slice() -> None:
     assert len(broad_entries) <= 25
 
 
+def test_broad_exception_baseline_is_zero_after_final_cleanup() -> None:
+    baseline = gates.load_baseline(gates.DEFAULT_BASELINE)
+    broad_entries = baseline.get("allowed_findings", {}).get("broad_exception", [])
+
+    assert broad_entries == []
+
+
 def test_docs_tests_and_migrations_are_ignored(tmp_path: Path) -> None:
     paths = [
         _write(tmp_path, "tests/test_example.py", "try:\n    risky()\nexcept Exception:\n    pass\n"),

--- a/tests/unit/test_envelope_encryption.py
+++ b/tests/unit/test_envelope_encryption.py
@@ -216,3 +216,36 @@ class TestTenantSecretsRouting:
         assert result.startswith(_ENVELOPE_PREFIX)
         # Round-trip
         assert decrypt_for_tenant(result) == "byok-secret"
+
+    @patch("core.crypto.tenant_secrets.async_session_factory")
+    @patch("core.crypto.tenant_secrets.encrypt_to_string")
+    def test_encrypt_for_tenant_configured_kek_failure_does_not_downgrade_to_legacy(
+        self, mock_encrypt_to_string, mock_session_factory, monkeypatch
+    ):
+        """Configured envelope encryption failures fail closed instead of Fernet fallback."""
+        monkeypatch.setenv(
+            "AGENTICORG_PLATFORM_KEK",
+            "projects/platform/locations/asia-south1/keyRings/r/cryptoKeys/k",
+        )
+        mock_encrypt_to_string.side_effect = RuntimeError("kms unavailable")
+
+        from contextlib import asynccontextmanager
+
+        session = MagicMock()
+        scalar = MagicMock()
+        scalar.scalar_one_or_none = MagicMock(return_value="")
+        from unittest.mock import AsyncMock as _AsyncMock
+
+        session.execute = _AsyncMock(return_value=scalar)
+
+        @asynccontextmanager
+        async def _ctx():
+            yield session
+
+        mock_session_factory.side_effect = lambda: _ctx()
+
+        async def run():
+            return await encrypt_for_tenant("plaintext", uuid.uuid4())
+
+        with pytest.raises(RuntimeError, match="kms unavailable"):
+            asyncio.run(run())


### PR DESCRIPTION
## Summary
- Reduces `broad_exceptions_allowed` from 22 to 0 by narrowing clear handlers and moving safe residual boundaries to local enterprise-gate justifications.
- Removes the stale central broad-exception baseline and adds a zero-baseline unit test.
- Tightens tenant secret encryption behavior: when a KEK/envelope path is configured and encryption fails, the operation now fails closed instead of silently downgrading to legacy Fernet.

## Inventory and Classification
Previous 22 entries:
- Must narrow: `api/v1/voice.py:test_connection`, `core/async_redis.py:get_async_redis`, `core/crypto/credential_vault.py:verify_credential`, `core/crypto/tenant_secrets.py:_resolve_kek`, `core/crypto/tenant_secrets.py:encrypt_for_tenant`, `core/langgraph/agent_graph.py:_check_hitl_trigger`, `core/marketing/ab_test.py:_init_redis`, `core/voice/sip_config.py:decrypt_credentials`.
- Safe boundary with local justification: approval-policy condition eval, crypto backfill row accounting, encrypted migration preflight, rewrap cache invalidation/decrypt abort, explainer LLM summary fallback, smart routing fallback, LLM key resolver unavailable path, provider intent fetches, seed knowledge text-only degradation, Twilio/Vonage probe failures.
- Dead code removable: none found.
- Larger architectural follow-up: none required for the baseline entries in this PR.

## Remaining Broad Exceptions
- Central broad-exception baseline entries: none.
- `broad_exceptions_allowed`: 0.
- Existing locally justified broad boundaries remain where they either return explicit failure/unhealthy results, fail closed, abort with nonzero status, or degrade only optional sidecars.

## Behavior Changes
- Configured tenant envelope encryption no longer falls back to legacy Fernet after KEK/envelope encryption failure.
- Redis setup, SIP probing, credential verification, HITL expression parsing, and legacy voice credential decrypt handling now catch narrower exception classes.

## Validation
- `python scripts/check_enterprise_stability_gates.py --scorecard` - passed (`routes_missing_metadata: 0`, `process_local_allowed: 0`, `process_local_blocked: 0`, `broad_exceptions_allowed: 0`)
- `python scripts/check_enterprise_stability_gates.py` - passed
- `python -m pytest tests/unit/test_enterprise_stability_gates.py -q` - passed (`67 passed`)
- `python -m pytest tests/unit/test_envelope_encryption.py -q` - passed (`10 passed`)
- `python -m pytest tests/unit -q -rs -k "crypto or voice or sip or langgraph or llm or approval or seed_knowledge or explainer or marketing or broad_exception"` - passed (`421 passed, 2968 deselected`)
- `python -m ruff check <modified Python files>` - passed
- `python -m compileall <modified Python files>` - passed
- `python -m alembic heads` - `v4916_merge_p0_heads (head)`
- `python scripts/check_migration_required.py` - passed
- `git diff --check origin/main...HEAD` - passed

No production deploy was performed.