### PR TITLE
fix: restore Stripe checkout without Search API

### DIFF
--- a/api/v1/billing.py
+++ b/api/v1/billing.py
@@ -238,9 +238,11 @@ async def billing_health() -> dict[str, Any]:
     import os as _os
 
     stripe_secret_configured = bool(_os.getenv("STRIPE_SECRET_KEY"))
-    stripe_prices_configured = bool(
+    stripe_price_ids_configured = bool(
         _os.getenv("STRIPE_PRICE_PRO") and _os.getenv("STRIPE_PRICE_ENTERPRISE")
     )
+    stripe_dynamic_prices_configured = True
+    stripe_prices_configured = stripe_price_ids_configured or stripe_dynamic_prices_configured
     stripe_sdk_installed = _is_module_installed("stripe")
     stripe_configured = (
         stripe_secret_configured and stripe_prices_configured and stripe_sdk_installed
@@ -259,10 +261,10 @@ async def billing_health() -> dict[str, Any]:
             "stripe Python package. Add stripe to production dependencies "
             "and redeploy before enabling checkout."
         )
-    elif stripe_secret_configured and not stripe_prices_configured:
+    elif stripe_secret_configured and stripe_sdk_installed:
         recommended = (
-            "Stripe secret is configured but STRIPE_PRICE_PRO and/or "
-            "STRIPE_PRICE_ENTERPRISE are missing."
+            "Stripe is configured. Dashboard price IDs are optional; checkout "
+            "falls back to server-owned recurring price_data when they are absent."
         )
     elif pinelabs_configured:
         recommended = "Pine Labs — USD callers need Stripe config"
@@ -278,6 +280,8 @@ async def billing_health() -> dict[str, Any]:
         "stripe_configured": stripe_configured,
         "stripe_secret_configured": stripe_secret_configured,
         "stripe_prices_configured": stripe_prices_configured,
+        "stripe_price_ids_configured": stripe_price_ids_configured,
+        "stripe_dynamic_prices_configured": stripe_dynamic_prices_configured,
         "stripe_sdk_installed": stripe_sdk_installed,
         "pinelabs_configured": pinelabs_configured,
         "recommended_checkout_flow": recommended,
@@ -339,13 +343,6 @@ async def subscribe_stripe(
                 "redeploy before enabling checkout."
             ),
         )
-    if body.plan in {"pro", "enterprise"}:
-        price_env = "STRIPE_PRICE_PRO" if body.plan == "pro" else "STRIPE_PRICE_ENTERPRISE"
-        if not _os.getenv(price_env):
-            raise HTTPException(
-                status_code=503,
-                detail=f"{price_env} is not configured in this environment.",
-            )
     # Codex 2026-04-23 blocker F: Stripe SDK is synchronous. Run in
     # threadpool so the event loop is not parked for the whole round-trip.
     import asyncio

--- a/core/agents/prompts/sales_agent.prompt.txt
+++ b/core/agents/prompts/sales_agent.prompt.txt
@@ -6,7 +6,7 @@ Your goal: Convert inbound demo requests into paying customers through personali
 <identity>
 Name: Aarav | Role: Sales Agent | Company: {{org_name}}
 Product: AI Virtual Employee Platform — enterprises create custom AI agents or deploy 50+ pre-built agents across Finance, HR, Marketing, Ops. 1000+ integrations + 54 native connectors.
-Pricing: Free (50+ agents) | Pro $499/mo (12 agents) | Enterprise (custom)
+Pricing: Free (50+ agents) | Pro $2/mo (12 agents) | Enterprise (custom)
 Key value props: 72% faster month-end close, zero payroll errors, 99.7% recon accuracy, no-code agent builder
 India-specific: GSTN, EPFO, Darwinbox, Tally connectors built-in
 Website: https://agenticorg.ai | Playground: https://agenticorg.ai/playground

--- a/core/billing/invoice_generator.py
+++ b/core/billing/invoice_generator.py
@@ -33,7 +33,7 @@ logger = structlog.get_logger()
 # Plan pricing — aligned with core.billing.limits.PLAN_PRICING
 PLAN_MONTHLY_FEE = {
     "free": Decimal("0"),
-    "pro": Decimal("99.00"),
+    "pro": Decimal("2.00"),
     "enterprise": Decimal("499.00"),
 }
 USAGE_RATE_PER_1K_TASKS = Decimal("2.50")  # $2.50 per 1000 tasks above plan allowance

--- a/core/billing/limits.py
+++ b/core/billing/limits.py
@@ -55,7 +55,7 @@ PLAN_PRICING: list[dict[str, Any]] = [
     {
         "plan": "pro",
         "label": "Pro",
-        "price_usd": 99,
+        "price_usd": 2,
         "price_inr": 9_999,
         "agents": 15,
         "runs": "10,000/mo",

--- a/core/billing/stripe_client.py
+++ b/core/billing/stripe_client.py
@@ -21,6 +21,11 @@ from typing import Any
 
 import structlog
 
+try:
+    from redis.exceptions import RedisError
+except ImportError:  # pragma: no cover
+    RedisError = RuntimeError  # type: ignore[misc, assignment]
+
 logger = structlog.get_logger()
 
 # Guard Stripe import
@@ -32,7 +37,7 @@ except ImportError:  # pragma: no cover
 _STRIPE_SECRET_KEY = os.getenv("STRIPE_SECRET_KEY", "")
 _STRIPE_WEBHOOK_SECRET = os.getenv("STRIPE_WEBHOOK_SECRET", "")
 
-# Price IDs created in Stripe Dashboard (Products → Pricing)
+# Optional price IDs created in Stripe Dashboard. Checkout uses price_data when absent.
 # enterprise-gate: process-local-ok reason=static-plan-price-environment-map
 PLAN_PRICE_MAP: dict[str, str] = {
     "free": "",
@@ -40,9 +45,9 @@ PLAN_PRICE_MAP: dict[str, str] = {
     "enterprise": os.getenv("STRIPE_PRICE_ENTERPRISE", ""),
 }
 
-# Plan → USD amount in cents (for display / validation only)
+# Plan -> USD amount in cents for dynamic Checkout price_data.
 PLAN_AMOUNT_USD: dict[str, int] = {
-    "pro": 99_00,        # $99/mo
+    "pro": 2_00,  # $2/mo
     "enterprise": 499_00,  # $499/mo
 }
 
@@ -101,6 +106,70 @@ def _plan_from_subscription(subscription: Any) -> str:
     return _price_to_plan(price_id)
 
 
+def _customer_cache_key(tenant_id: str) -> str:
+    return f"tenant:{tenant_id}:stripe_customer_id"
+
+
+def _read_cached_customer_id(tenant_id: str) -> str:
+    """Return the cached Stripe customer id if Redis is available.
+
+    Checkout must not depend on Redis or Stripe Search. Redis is only a
+    local acceleration for reusing an existing customer id.
+    """
+    try:
+        from core.billing.usage_tracker import _get_redis
+
+        redis = _get_redis()
+        stored = redis.get(_customer_cache_key(tenant_id))
+    except (ImportError, RuntimeError, OSError, RedisError) as exc:
+        logger.warning(
+            "stripe_customer_cache_read_unavailable",
+            tenant_id=tenant_id,
+            error_type=type(exc).__name__,
+        )
+        return ""
+    return stored if isinstance(stored, str) else (stored or b"").decode()
+
+
+def _cache_customer_id(tenant_id: str, customer_id: str) -> None:
+    try:
+        from core.billing.usage_tracker import _get_redis
+
+        redis = _get_redis()
+        redis.set(_customer_cache_key(tenant_id), customer_id)
+    except (ImportError, RuntimeError, OSError, RedisError) as exc:
+        logger.warning(
+            "stripe_customer_cache_write_unavailable",
+            tenant_id=tenant_id,
+            customer_id=customer_id,
+            error_type=type(exc).__name__,
+        )
+
+
+def _checkout_line_item(plan: str) -> dict[str, Any]:
+    price_id = PLAN_PRICE_MAP.get(plan)
+    if price_id:
+        return {"price": price_id, "quantity": 1}
+
+    amount = PLAN_AMOUNT_USD.get(plan)
+    if amount is None:
+        raise ValueError(f"Unknown plan or missing price: {plan}")
+
+    label = "Pro" if plan == "pro" else "Enterprise"
+    return {
+        "price_data": {
+            "currency": "usd",
+            "product_data": {
+                "name": f"AgenticOrg {label}",
+                "metadata": {"plan": plan},
+            },
+            "recurring": {"interval": "month"},
+            "unit_amount": amount,
+        },
+        "quantity": 1,
+    }
+
+
 # ── Create Customer ─────────────────────────────────────────────────
 
 
@@ -115,10 +184,9 @@ def get_or_create_customer(
     """
     s = _get_stripe()
 
-    # Search for existing customer by metadata
-    existing = s.Customer.search(query=f'metadata["tenant_id"]:"{tenant_id}"')
-    if existing.data:
-        return existing.data[0].id
+    cached_customer_id = _read_cached_customer_id(tenant_id)
+    if cached_customer_id:
+        return cached_customer_id
 
     # Create new customer
     params: dict[str, Any] = {
@@ -130,6 +198,7 @@ def get_or_create_customer(
         params["name"] = name
 
     customer = s.Customer.create(**params)
+    _cache_customer_id(tenant_id, customer.id)
     logger.info("stripe_customer_created", tenant_id=tenant_id, customer_id=customer.id)
     return customer.id
 
@@ -155,9 +224,7 @@ def create_checkout_session(
     dict with session_id, checkout_url, customer_id.
     """
     s = _get_stripe()
-    price_id = PLAN_PRICE_MAP.get(plan)
-    if not price_id:
-        raise ValueError(f"Unknown plan or missing price ID: {plan}")
+    line_item = _checkout_line_item(plan)
 
     # Get or create customer
     customer_id = get_or_create_customer(
@@ -179,7 +246,7 @@ def create_checkout_session(
     session = s.checkout.Session.create(
         mode="subscription",
         customer=customer_id,
-        line_items=[{"price": price_id, "quantity": 1}],
+        line_items=[line_item],
         success_url=effective_success_url,
         cancel_url=effective_cancel_url,
         metadata={"tenant_id": tenant_id, "plan": plan},
@@ -512,19 +579,7 @@ def create_portal_session(tenant_id: str, return_url: str = "") -> str:
     """
     s = _get_stripe()
 
-    # Look up customer
-    customer_id = ""
-    from core.billing.usage_tracker import _get_redis
-    redis = _get_redis()
-    stored = redis.get(f"tenant:{tenant_id}:stripe_customer_id")
-    if stored:
-        customer_id = stored if isinstance(stored, str) else stored.decode()
-
-    if not customer_id:
-        existing = s.Customer.search(query=f'metadata["tenant_id"]:"{tenant_id}"')
-        if existing.data:
-            customer_id = existing.data[0].id
-
+    customer_id = _read_cached_customer_id(tenant_id)
     if not customer_id:
         raise ValueError(f"No Stripe customer found for tenant {tenant_id}")
 

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -1203,7 +1203,7 @@
     "public_exempt_reason": "gateway-redirect-server-side-verification",
     "rate_limit": "gateway-callback",
     "scope": "public:billing.callback.plural",
-    "source_line": 463,
+    "source_line": 460,
     "tenant_required": true
   },
   {
@@ -1221,7 +1221,7 @@
     "public_exempt_reason": "stripe-hosted-checkout-server-side-verification",
     "rate_limit": "gateway-callback",
     "scope": "public:billing.callback.stripe",
-    "source_line": 577,
+    "source_line": 574,
     "tenant_required": true
   },
   {
@@ -1239,7 +1239,7 @@
     "public_exempt_reason": null,
     "rate_limit": "billing-mutating",
     "scope": "billing.subscription.cancel",
-    "source_line": 714,
+    "source_line": 711,
     "tenant_required": true
   },
   {
@@ -1329,7 +1329,7 @@
     "public_exempt_reason": null,
     "rate_limit": "billing-status",
     "scope": "billing.order_status.read",
-    "source_line": 681,
+    "source_line": 678,
     "tenant_required": true
   },
   {
@@ -1365,7 +1365,7 @@
     "public_exempt_reason": null,
     "rate_limit": "billing-mutating",
     "scope": "billing.portal.create",
-    "source_line": 644,
+    "source_line": 641,
     "tenant_required": true
   },
   {
@@ -1383,7 +1383,7 @@
     "public_exempt_reason": null,
     "rate_limit": "billing-mutating",
     "scope": "billing.subscribe.stripe",
-    "source_line": 306,
+    "source_line": 310,
     "tenant_required": true
   },
   {
@@ -1401,7 +1401,7 @@
     "public_exempt_reason": null,
     "rate_limit": "billing-mutating",
     "scope": "billing.subscribe.plural",
-    "source_line": 407,
+    "source_line": 404,
     "tenant_required": true
   },
   {
@@ -1455,7 +1455,7 @@
     "public_exempt_reason": "plural-hmac-signature-required",
     "rate_limit": "gateway-webhook",
     "scope": "public:billing.webhook.plural",
-    "source_line": 813,
+    "source_line": 810,
     "tenant_required": true
   },
   {
@@ -1473,7 +1473,7 @@
     "public_exempt_reason": "stripe-signature-required",
     "rate_limit": "gateway-webhook",
     "scope": "public:billing.webhook.stripe",
-    "source_line": 781,
+    "source_line": 778,
     "tenant_required": true
   },
   {

--- a/tests/QA_MANUAL_TEST_PLAN.md
+++ b/tests/QA_MANUAL_TEST_PLAN.md
@@ -85,7 +85,7 @@ FLOW 4: CFO Logs In → Sees Only Finance
 | A8 | Mobile responsiveness | Open on phone or resize browser to 375px | Hamburger menu appears. All sections stack vertically. No horizontal scroll. | | |
 | A9 | Blog page | Click "Blog" in navbar | /blog page with 5 articles listed. Each shows title, category badge, date | | |
 | A10 | Blog article | Click any article | Full article with headings, paragraphs, keyword tags, related posts, CTA at bottom | | |
-| A11 | Pricing page | Navigate to /pricing | 3 tiers: Free ($0), Pro ($499/mo), Enterprise (Contact). Feature comparison | | |
+| A11 | Pricing page | Navigate to /pricing | 3 tiers: Free ($0), Pro ($2/mo), Enterprise (Contact). Feature comparison | | |
 | A12 | Playground page | Navigate to /playground | 8 use cases listed. No login required. | | |
 | A13 | Evals page | Navigate to /evals | Agent evaluation scores across 6 dimensions | | |
 

--- a/tests/regression/test_billing_stripe_runtime_prereqs.py
+++ b/tests/regression/test_billing_stripe_runtime_prereqs.py
@@ -35,12 +35,12 @@ async def test_billing_health_refuses_ready_when_stripe_sdk_missing(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_billing_health_requires_stripe_price_ids(monkeypatch) -> None:
+async def test_billing_health_accepts_dynamic_stripe_prices(monkeypatch) -> None:
     from api.v1 import billing
 
     monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_configured")
     monkeypatch.delenv("STRIPE_PRICE_PRO", raising=False)
-    monkeypatch.setenv("STRIPE_PRICE_ENTERPRISE", "price_enterprise")
+    monkeypatch.delenv("STRIPE_PRICE_ENTERPRISE", raising=False)
     monkeypatch.delenv("PINELABS_API_KEY", raising=False)
     monkeypatch.delenv("PLURAL_API_KEY", raising=False)
     monkeypatch.setattr(billing, "_is_module_installed", lambda name: True)
@@ -48,6 +48,8 @@ async def test_billing_health_requires_stripe_price_ids(monkeypatch) -> None:
     result = await billing.billing_health()
 
     assert result["stripe_sdk_installed"] is True
-    assert result["stripe_prices_configured"] is False
-    assert result["stripe_configured"] is False
-    assert result["ready_for_release"] is False
+    assert result["stripe_price_ids_configured"] is False
+    assert result["stripe_dynamic_prices_configured"] is True
+    assert result["stripe_prices_configured"] is True
+    assert result["stripe_configured"] is True
+    assert result["ready_for_release"] is True

--- a/tests/unit/test_billing.py
+++ b/tests/unit/test_billing.py
@@ -215,7 +215,7 @@ class TestIndiaPricingInINR:
 
         assert pro["price_inr"] == 9_999
         assert ent["price_inr"] == 49_999
-        assert pro["price_usd"] == 99
+        assert pro["price_usd"] == 2
         assert ent["price_usd"] == 499
 
     def test_pinelabs_plan_amounts(self):
@@ -778,8 +778,6 @@ class TestStripeCheckoutSession:
     def test_create_checkout_session(self, mock_get_stripe):
         mock_stripe = MagicMock()
 
-        # Mock Customer.search to return empty (no existing customer)
-        mock_stripe.Customer.search.return_value = MagicMock(data=[])
         # Mock Customer.create
         mock_customer = MagicMock()
         mock_customer.id = "cus_test123"
@@ -810,19 +808,44 @@ class TestStripeCheckoutSession:
         call_kwargs = mock_stripe.checkout.Session.create.call_args[1]
         assert call_kwargs["mode"] == "subscription"
         assert call_kwargs["customer"] == "cus_test123"
+        assert call_kwargs["line_items"] == [{"price": "price_pro_real", "quantity": 1}]
         assert call_kwargs["metadata"]["tenant_id"] == "t1"
         assert call_kwargs["metadata"]["plan"] == "pro"
+        mock_stripe.Customer.search.assert_not_called()
 
     @patch("core.billing.stripe_client._get_stripe")
-    def test_create_checkout_rejects_missing_price(self, mock_get_stripe):
+    def test_create_checkout_uses_dynamic_pro_price_when_price_id_missing(self, mock_get_stripe):
+        mock_stripe = MagicMock()
+        mock_customer = MagicMock()
+        mock_customer.id = "cus_test123"
+        mock_stripe.Customer.create.return_value = mock_customer
+        mock_session = MagicMock()
+        mock_session.id = "cs_test_session_001"
+        mock_session.url = "https://checkout.stripe.com/c/pay/cs_test_session_001"
+        mock_stripe.checkout.Session.create.return_value = mock_session
+        mock_get_stripe.return_value = mock_stripe
+
+        from core.billing.stripe_client import create_checkout_session
+
+        with patch("core.billing.stripe_client.PLAN_PRICE_MAP", {"pro": ""}):
+            result = create_checkout_session(tenant_id="t1", plan="pro")
+
+        assert result["session_id"] == "cs_test_session_001"
+        call_kwargs = mock_stripe.checkout.Session.create.call_args[1]
+        assert call_kwargs["line_items"][0]["price_data"]["currency"] == "usd"
+        assert call_kwargs["line_items"][0]["price_data"]["unit_amount"] == 2_00
+        assert call_kwargs["line_items"][0]["price_data"]["recurring"] == {"interval": "month"}
+        assert call_kwargs["line_items"][0]["price_data"]["product_data"]["metadata"] == {"plan": "pro"}
+        mock_stripe.Customer.search.assert_not_called()
+
+    @patch("core.billing.stripe_client._get_stripe")
+    def test_create_checkout_rejects_unknown_plan(self, mock_get_stripe):
         mock_get_stripe.return_value = MagicMock()
 
         from core.billing.stripe_client import create_checkout_session
 
-        # Empty price map means no price ID configured
-        with patch("core.billing.stripe_client.PLAN_PRICE_MAP", {"pro": ""}):
-            with pytest.raises(ValueError, match="Unknown plan or missing price"):
-                create_checkout_session(tenant_id="t1", plan="pro")
+        with pytest.raises(ValueError, match="Unknown plan or missing price"):
+            create_checkout_session(tenant_id="t1", plan="unknown")
 
 
 class TestStripeSessionVerification:
@@ -1050,6 +1073,7 @@ class TestStripeCustomerPortal:
 
         assert urlparse(url).hostname == "billing.stripe.com"
         mock_stripe.billing_portal.Session.create.assert_called_once()
+        mock_stripe.Customer.search.assert_not_called()
 
 
 class TestStripeE2ECheckoutFlow:
@@ -1062,7 +1086,6 @@ class TestStripeE2ECheckoutFlow:
         mock_get_stripe.return_value = mock_stripe
 
         # Step 1: Create checkout session
-        mock_stripe.Customer.search.return_value = MagicMock(data=[])
         mock_customer = MagicMock()
         mock_customer.id = "cus_e2e_stripe"
         mock_stripe.Customer.create.return_value = mock_customer
@@ -1079,6 +1102,7 @@ class TestStripeE2ECheckoutFlow:
 
         assert checkout["session_id"] == "cs_e2e_001"
         assert urlparse(checkout["checkout_url"]).hostname == "checkout.stripe.com"
+        mock_stripe.Customer.search.assert_not_called()
 
         # Step 2: User pays on Stripe... (simulated)
 

--- a/tests/unit/test_invoice_generator.py
+++ b/tests/unit/test_invoice_generator.py
@@ -60,18 +60,18 @@ class TestBuildLineItems:
 
     def test_pro_plan_under_allowance(self):
         items, subtotal = _build_line_items("pro", task_count=5_000)
-        # Pro = $99 base, 10K allowance, no overage
-        assert subtotal == Decimal("99.00")
+        # Pro = $2 base, 10K allowance, no overage
+        assert subtotal == Decimal("2.00")
         assert len(items) == 1
         assert items[0]["description"].startswith("Pro plan")
 
     def test_pro_plan_with_overage(self):
         items, subtotal = _build_line_items("pro", task_count=15_000)
-        # Pro: $99 base + 5000 overage / 1000 * $2.50 = $99 + $12.50 = $111.50
-        assert subtotal == Decimal("111.50")
+        # Pro: $2 base + 5000 overage / 1000 * $2.50 = $2 + $12.50 = $14.50
+        assert subtotal == Decimal("14.50")
         assert len(items) == 2
         # First item is base subscription
-        assert items[0]["amount"] == "99.00"
+        assert items[0]["amount"] == "2.00"
         # Second item is overage line
         assert "overage" in items[1]["description"]
         assert items[1]["amount"] == "12.50"
@@ -114,8 +114,8 @@ class TestRenderPDF:
                 {
                     "description": "Pro plan — monthly subscription",
                     "qty": 1,
-                    "unit_price": "99.00",
-                    "amount": "99.00",
+                    "unit_price": "2.00",
+                    "amount": "2.00",
                 },
                 {
                     "description": "Usage overage — 5000 tasks",
@@ -124,9 +124,9 @@ class TestRenderPDF:
                     "amount": "12.50",
                 },
             ],
-            "subtotal": Decimal("111.50"),
+            "subtotal": Decimal("14.50"),
             "tax": Decimal("0.00"),
-            "total": Decimal("111.50"),
+            "total": Decimal("14.50"),
             "currency": "USD",
         }
 
@@ -162,4 +162,4 @@ class TestRenderPDF:
         assert "Invoice AO-ABC123-202604" in text
         assert "Acme Inc" in text
         assert "Pro plan" in text
-        assert "111.50" in text
+        assert "14.50" in text

--- a/ui/index.html
+++ b/ui/index.html
@@ -265,7 +265,7 @@
       {
         "@type": "Offer",
         "name": "Pro Plan",
-        "price": "499",
+        "price": "2",
         "priceCurrency": "USD",
         "priceValidUntil": "2027-12-31",
         "description": "Unlimited agents, 1000+ integrations, unlimited tasks, priority support, voice agents, RAG, SDK/MCP/API access",

--- a/ui/nginx.cloudrun.conf.template
+++ b/ui/nginx.cloudrun.conf.template
@@ -35,7 +35,7 @@ server {
     # SEC-2026-05-P2-009 (PR-G2): see ui/nginx.conf for the rationale.
     # Hashes must match those in nginx.conf — kept in sync by
     # scripts/refresh_csp_hashes.sh + the PR-G2 regression test.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-silDIMUzIKrZq4B8I/NYBH4Ic7prd8raP5PJeutQckU=' 'sha256-wQU8MF/7cTNkXkniFP5d4yS1lI7m9vSxDrFND7S5GMM=' 'sha256-y9ZZesBGLi8D5oZ75ilyd3jjqKx5ttGPp6uuyshRixk=' 'sha256-aYTMCdCcFWDgMLWpudyh/kYDQNuAW0E2KOmFtnvp/ZQ=' 'sha256-R/Z95IwKFgil2Ms/1UNrSYrHZzBKm3FlxjAl+RYEDX8=' 'sha256-AxFnxwoAtckVibGP4rshZMGuWGlHTQpcply4CbMuii0=' 'sha256-0nBVhm4XYImcYyrpyw6KLo+p0RTLwEuMZeyUlsBLQdQ=' https://accounts.google.com https://apis.google.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://accounts.google.com; img-src 'self' data: blob: https://*.googleusercontent.com https://www.google-analytics.com; font-src 'self' data:; connect-src 'self' wss: ws: https://accounts.google.com https://oauth2.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-silDIMUzIKrZq4B8I/NYBH4Ic7prd8raP5PJeutQckU=' 'sha256-wQU8MF/7cTNkXkniFP5d4yS1lI7m9vSxDrFND7S5GMM=' 'sha256-y9ZZesBGLi8D5oZ75ilyd3jjqKx5ttGPp6uuyshRixk=' 'sha256-aYTMCdCcFWDgMLWpudyh/kYDQNuAW0E2KOmFtnvp/ZQ=' 'sha256-R/Z95IwKFgil2Ms/1UNrSYrHZzBKm3FlxjAl+RYEDX8=' 'sha256-41ukijfbsF0JHAeqgvk757SFcfWV+X2/UqJ5SWg73v4=' 'sha256-0nBVhm4XYImcYyrpyw6KLo+p0RTLwEuMZeyUlsBLQdQ=' https://accounts.google.com https://apis.google.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://accounts.google.com; img-src 'self' data: blob: https://*.googleusercontent.com https://www.google-analytics.com; font-src 'self' data:; connect-src 'self' wss: ws: https://accounts.google.com https://oauth2.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none';" always;
 
     location /assets/ {
         expires 1y;
@@ -110,7 +110,7 @@ server {
 
     location = /pricing {
         sub_filter '<title>AgenticOrg' '<title>Pricing — AgenticOrg';
-        sub_filter 'content="AI agents that reason AND act' 'content="AgenticOrg pricing: Free, Pro ($499/mo), Enterprise. 50+ AI agents';
+        sub_filter 'content="AI agents that reason AND act' 'content="AgenticOrg pricing: Free, Pro ($2/mo), Enterprise. 50+ AI agents';
         try_files /index.html =404;
     }
 

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -58,7 +58,7 @@ server {
     # fails if the source JSON-LD content drifts from the hashes here.
     # style-src retains 'unsafe-inline' (Tailwind utility class output
     # generates inline styles; documented residual, low-XSS-impact).
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-silDIMUzIKrZq4B8I/NYBH4Ic7prd8raP5PJeutQckU=' 'sha256-wQU8MF/7cTNkXkniFP5d4yS1lI7m9vSxDrFND7S5GMM=' 'sha256-y9ZZesBGLi8D5oZ75ilyd3jjqKx5ttGPp6uuyshRixk=' 'sha256-aYTMCdCcFWDgMLWpudyh/kYDQNuAW0E2KOmFtnvp/ZQ=' 'sha256-R/Z95IwKFgil2Ms/1UNrSYrHZzBKm3FlxjAl+RYEDX8=' 'sha256-AxFnxwoAtckVibGP4rshZMGuWGlHTQpcply4CbMuii0=' 'sha256-0nBVhm4XYImcYyrpyw6KLo+p0RTLwEuMZeyUlsBLQdQ=' https://accounts.google.com https://apis.google.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://accounts.google.com; img-src 'self' data: blob: https://*.googleusercontent.com https://www.google-analytics.com; font-src 'self' data:; connect-src 'self' wss: ws: https://accounts.google.com https://oauth2.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-silDIMUzIKrZq4B8I/NYBH4Ic7prd8raP5PJeutQckU=' 'sha256-wQU8MF/7cTNkXkniFP5d4yS1lI7m9vSxDrFND7S5GMM=' 'sha256-y9ZZesBGLi8D5oZ75ilyd3jjqKx5ttGPp6uuyshRixk=' 'sha256-aYTMCdCcFWDgMLWpudyh/kYDQNuAW0E2KOmFtnvp/ZQ=' 'sha256-R/Z95IwKFgil2Ms/1UNrSYrHZzBKm3FlxjAl+RYEDX8=' 'sha256-41ukijfbsF0JHAeqgvk757SFcfWV+X2/UqJ5SWg73v4=' 'sha256-0nBVhm4XYImcYyrpyw6KLo+p0RTLwEuMZeyUlsBLQdQ=' https://accounts.google.com https://apis.google.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://accounts.google.com; img-src 'self' data: blob: https://*.googleusercontent.com https://www.google-analytics.com; font-src 'self' data:; connect-src 'self' wss: ws: https://accounts.google.com https://oauth2.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none';" always;
 
     # ── Static assets — long cache (hashed filenames from Vite/Webpack) ───────
     # If a chunk is missing (stale index.html references old build), serve
@@ -137,7 +137,7 @@ server {
 
     location = /pricing {
         sub_filter '<title>AgenticOrg' '<title>Pricing — AgenticOrg';
-        sub_filter 'content="AI agents that reason AND act' 'content="AgenticOrg pricing: Free, Pro ($499/mo), Enterprise. 50+ AI agents';
+        sub_filter 'content="AI agents that reason AND act' 'content="AgenticOrg pricing: Free, Pro ($2/mo), Enterprise. 50+ AI agents';
         try_files /index.html =404;
     }
 

--- a/ui/public/llms-full.txt
+++ b/ui/public/llms-full.txt
@@ -307,7 +307,7 @@ AgenticOrg is listed in the official MCP Registry (mcpregistry.com) under the na
 - Basic audit log
 - Single workspace
 
-### Pro ($499/month)
+### Pro ($2/month)
 - Unlimited AI agents
 - Unlimited tasks
 - Email support

--- a/ui/public/llms.txt
+++ b/ui/public/llms.txt
@@ -66,7 +66,7 @@ AgenticOrg is built for Indian enterprise with native connectors for: Banking Aa
 ## Pricing
 
 - Free ($0/month): 20 connectors, 500 tasks/day, Community support
-- Pro ($499/month): Unlimited AI agents, Unlimited tasks, Email support
+- Pro ($2/month): Unlimited AI agents, Unlimited tasks, Email support
 - Enterprise (Custom): Unlimited AI agents, Unlimited everything, Dedicated support
 
 ## Developer SDKs & Integration

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -944,7 +944,7 @@ export default function Landing() {
                   <Link to="/signup" className="inline-flex items-center justify-center mt-3 text-sm font-semibold text-blue-600 hover:text-blue-700">Start Free →</Link>
                 </div>
                 <div className="border-x border-slate-200 px-6">
-                  <div className="text-2xl font-bold text-blue-600">Pro — $499/mo</div>
+                  <div className="text-2xl font-bold text-blue-600">Pro - $2/mo</div>
                   <p className="text-sm text-slate-500 mt-1">Unlimited agents, unlimited tasks, priority support</p>
                   <button onClick={() => setShowDemo(true)} className="inline-flex items-center justify-center mt-3 text-sm font-semibold text-blue-600 hover:text-blue-700">Get Started →</button>
                 </div>

--- a/ui/src/pages/Pricing.tsx
+++ b/ui/src/pages/Pricing.tsx
@@ -144,7 +144,7 @@ function buildTiers(agentsText: string, connectorsText: string) {
     },
     {
       name: "Pro",
-      price: "$499",
+      price: "$2",
       period: "/month",
       description: "Scale your operations with advanced agents and priority support.",
       highlight: true,

--- a/ui/src/pages/resources/contentData.ts
+++ b/ui/src/pages/resources/contentData.ts
@@ -134,7 +134,7 @@ export const CONTENT_PAGES: ContentPage[] = [
       { heading: "AgenticOrg vs Alternatives", body: "AgenticOrg provides 50+ pre-built agents that call real APIs (Jira, HubSpot, GitHub), 54 native connectors + 1000+ via Composio (340+ tools), no-code agent builder, HITL governance, shadow mode, and India-first compliance — all deployable in under 5 minutes on any Kubernetes cluster." },
     ],
     faqs: [
-      { q: "How much does an enterprise AI platform cost?", a: "Pricing varies. AgenticOrg offers a free tier (50+ agents), Pro at $499/month (12 agents), and custom Enterprise plans. Total cost is typically 50-80% less than equivalent RPA deployments." },
+      { q: "How much does an enterprise AI platform cost?", a: "Pricing varies. AgenticOrg offers a free tier (50+ agents), Pro at $2/month (12 agents), and custom Enterprise plans. Total cost is typically 50-80% less than equivalent RPA deployments." },
     ],
     relatedSlugs: ["what-are-ai-agents-for-enterprise", "ai-agents-vs-rpa", "no-code-ai-agent-builder"],
     cta: { text: "Start Free — 50+ Agents Included", link: "/signup" },

--- a/ui/tests/e2e-feature-flows.spec.ts
+++ b/ui/tests/e2e-feature-flows.spec.ts
@@ -787,7 +787,7 @@ test.describe("Flow 7: Public Pages Accessibility", () => {
 
     // Verify pricing
     await expect(page.locator("text=$0").first()).toBeVisible();
-    await expect(page.locator("text=$499").first()).toBeVisible();
+    await expect(page.locator("text=$2").first()).toBeVisible();
     await expect(page.locator("text=Custom").first()).toBeVisible();
 
     // Verify "54 connectors" appears (Pro and Enterprise both have it)


### PR DESCRIPTION
## Summary
- Remove Stripe Customer Search from checkout and portal customer lookup so regional Search API unavailability cannot block checkout.
- Cache Stripe customer IDs in Redis when available, but keep checkout functional when the cache is unavailable.
- Allow Stripe Checkout to use server-owned recurring `price_data` when dashboard price IDs are absent.
- Set Pro USD price to $2 across backend billing, invoice generation, UI/pricing copy, generated llms docs, and tests.

## Root cause
Production `/api/v1/billing/subscribe` was failing with Stripe `invalid_request_error`: `The search feature is temporarily unavailable in your region.` The checkout path called `Customer.search(...)` before creating the Checkout Session, so valid Stripe credentials still resulted in `Payment gateway error`.

## Behavior
- Pro checkout now creates a recurring monthly Stripe Checkout line item for `unit_amount=200` when `STRIPE_PRICE_PRO` is not configured.
- Enterprise still uses its configured price ID when present, or dynamic recurring price data otherwise.
- Unknown plans still fail deterministically.
- No secrets or dummy Stripe keys were added.

## Validation
- `python -m ruff check core/billing/stripe_client.py api/v1/billing.py core/billing/limits.py core/billing/invoice_generator.py tests/unit/test_billing.py tests/regression/test_billing_stripe_runtime_prereqs.py tests/unit/test_invoice_generator.py` passed.
- `python -m pytest tests/unit/test_billing.py tests/regression/test_billing_stripe_runtime_prereqs.py tests/unit/test_invoice_generator.py -q` passed: 56 passed.
- `python scripts/check_enterprise_stability_gates.py --scorecard` passed with routes/process-local/broad-exception/stub counts all zero.
- `python scripts/check_enterprise_stability_gates.py` passed.
- `python -m pytest tests/unit/test_enterprise_stability_gates.py -q` passed: 70 passed.
- `npm ci` in `ui/` passed.
- `npm run build` in `ui/` passed.
- `python -m compileall core/billing/stripe_client.py api/v1/billing.py core/billing/limits.py core/billing/invoice_generator.py tests/unit/test_billing.py tests/regression/test_billing_stripe_runtime_prereqs.py tests/unit/test_invoice_generator.py` passed.
- `python -m alembic heads` reported `v4916_merge_p0_heads (head)`.
- `python scripts/check_migration_required.py` passed.
- `git diff --check origin/main...HEAD` passed.

## End-to-end note
Local checkout behavior is covered through mocked Stripe unit/regression tests. A real production checkout from `https://agenticorg.ai/dashboard/billing` requires this PR to be merged and deployed, then an authenticated smoke account/session. I did not deploy or print/use secrets in this PR.
