### PR TITLE
[codex] Fix CA firms report regressions

### DIFF
--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -13,7 +13,7 @@ from uuid import UUID
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.exc import SQLAlchemyError
 
 from api.deps import (
@@ -27,11 +27,14 @@ from core.commerce.sales_guardrails import GRANTEX_COMMERCE_DEFAULT_TOOLS
 from core.database import get_tenant_session
 from core.file_ingestion.limits import cleanup_tempfile, stream_to_tempfile
 from core.models.agent import Agent, AgentCostLedger, AgentLifecycleEvent, AgentVersion
+from core.models.approval_policy import ApprovalPolicy
 from core.models.audit import AuditLog
 from core.models.company import Company
 from core.models.hitl import HITLQueue
+from core.models.lead_pipeline import LeadPipeline
 from core.models.prompt_template import PromptEditHistory
 from core.models.tenant import Tenant
+from core.models.workflow import StepExecution
 from core.schemas.api import (
     AgentCloneRequest,
     AgentCreate,
@@ -3792,7 +3795,16 @@ async def delete_agent(
     tenant_id: str = Depends(get_current_tenant),
     user_domains: list[str] | None = Depends(get_user_domains),
 ):
-    """Permanently delete an agent. Only paused, retired, or inactive agents can be deleted."""
+    """Delete an agent without row-level FK fragility.
+
+    Agents have execution history, prompt history, HITL rows, workflow steps,
+    org-chart links, and optional sales assignments. A physical row delete
+    succeeds only for agents with no remaining references and fails
+    intermittently for agents that have actually been used. Treat user-facing
+    deletion as a lifecycle state transition instead: hide the agent from all
+    normal fleet surfaces, preserve audit/history, and clear live references
+    that could route new work to the deleted agent.
+    """
     tid = _uuid.UUID(tenant_id)
     async with get_tenant_session(tid) as session:
         result = await session.execute(
@@ -3802,6 +3814,9 @@ async def delete_agent(
         if not agent:
             raise HTTPException(404, "Agent not found")
         _enforce_domain_access(agent, user_domains)
+
+        if agent.status == "deleted":
+            return {"id": str(agent_id), "deleted": True, "status": "deleted", "already_deleted": True}
 
         deletable_statuses = {"paused", "retired", "inactive", "shadow"}
         if agent.status not in deletable_statuses:
@@ -3827,18 +3842,62 @@ async def delete_agent(
         )
         session.add(audit)
 
-        # Delete related records that may have FK constraints
-        for related_model in (AgentLifecycleEvent, AgentCostLedger, AgentVersion):
-            await session.execute(
-                related_model.__table__.delete().where(
-                    related_model.agent_id == agent_id
-                )
-            )
-        # Clear HITL queue entries for this agent
+        previous_status = agent.status
+
+        # Clear active/live references so deleted agents cannot remain in
+        # routing, approval, org-chart, workflow, or sales assignment paths.
         await session.execute(
-            HITLQueue.__table__.delete().where(HITLQueue.agent_id == agent_id)
+            update(Agent)
+            .where(Agent.tenant_id == tid, Agent.parent_agent_id == agent_id)
+            .values(parent_agent_id=None, reporting_to=None)
+        )
+        await session.execute(
+            update(Agent)
+            .where(Agent.tenant_id == tid, Agent.shadow_comparison_agent_id == agent_id)
+            .values(shadow_comparison_agent_id=None)
+        )
+        await session.execute(
+            update(StepExecution)
+            .where(StepExecution.tenant_id == tid, StepExecution.agent_id == agent_id)
+            .values(agent_id=None)
+        )
+        await session.execute(
+            update(LeadPipeline)
+            .where(LeadPipeline.tenant_id == tid, LeadPipeline.assigned_agent_id == agent_id)
+            .values(assigned_agent_id=None)
+        )
+        await session.execute(
+            update(ApprovalPolicy)
+            .where(ApprovalPolicy.tenant_id == tid, ApprovalPolicy.agent_id == agent_id)
+            .values(agent_id=None)
         )
 
-        await session.delete(agent)
+        # Pending HITL items should not remain actionable once the agent is
+        # deleted. Historical execution rows stay intact for explanations and
+        # audit review.
+        await session.execute(
+            HITLQueue.__table__.delete().where(
+                HITLQueue.tenant_id == tid,
+                HITLQueue.agent_id == agent_id,
+            )
+        )
 
-    return {"id": str(agent_id), "deleted": True}
+        lifecycle = AgentLifecycleEvent(
+            tenant_id=tid,
+            agent_id=agent_id,
+            from_status=previous_status,
+            to_status="deleted",
+            triggered_by="user",
+            reason="agent_deleted",
+        )
+        session.add(lifecycle)
+
+        config = dict(agent.config or {})
+        config["deleted_at"] = datetime.now(UTC).isoformat()
+        config["deleted_by"] = "api"
+        agent.config = config
+        agent.status = "deleted"
+        agent.updated_at = datetime.now(UTC)
+        session.add(agent)
+
+    return {"id": str(agent_id), "deleted": True, "status": "deleted"}

--- a/connectors/comms/github_connector.py
+++ b/connectors/comms/github_connector.py
@@ -1,7 +1,8 @@
-"""Github connector — real GitHub REST API v3 integration."""
+"""GitHub connector - real GitHub REST API v3 integration."""
 
 from __future__ import annotations
 
+import base64
 from typing import Any
 
 from connectors.framework.base_connector import BaseConnector
@@ -22,6 +23,16 @@ class GithubConnector(BaseConnector):
         self._tool_registry["create_pull_request"] = self.create_pull_request
         self._tool_registry["get_repository_statistics"] = self.get_repository_statistics
         self._tool_registry["search_code"] = self.search_code
+        self._tool_registry["repository_search"] = self.repository_search
+        self._tool_registry["list_files"] = self.list_files
+        self._tool_registry["get_directory_tree"] = self.get_directory_tree
+        self._tool_registry["read_file"] = self.read_file
+        self._tool_registry["create_file"] = self.create_file
+        self._tool_registry["update_file"] = self.update_file
+        self._tool_registry["delete_file"] = self.delete_file
+        self._tool_registry["create_branch"] = self.create_branch
+        self._tool_registry["commit_changes"] = self.commit_changes
+        self._tool_registry["push_changes"] = self.push_changes
         self._tool_registry["create_release"] = self.create_release
         self._tool_registry["trigger_github_action_workflow"] = self.trigger_github_action_workflow
 
@@ -42,7 +53,35 @@ class GithubConnector(BaseConnector):
         except Exception as e:
             return {"status": "unhealthy", "error": str(e)}
 
-    # ── Read-only tools ─────────────────────────────────────────────────
+    def _repo_parts(self, params: dict[str, Any]) -> tuple[str, str] | dict[str, str]:
+        owner = str(params.get("owner") or "").strip()
+        repo = str(params.get("repo") or "").strip()
+        full_name = str(params.get("repository") or params.get("full_name") or "").strip()
+        if full_name and (not owner or not repo):
+            if "/" not in full_name:
+                return {"error": "repository must be in owner/repo form"}
+            owner, repo = full_name.split("/", 1)
+        if not owner or not repo:
+            return {"error": "owner and repo are required"}
+        return owner, repo
+
+    @staticmethod
+    def _contents_path(path: Any) -> str:
+        return "/".join(part for part in str(path or "").strip("/").split("/") if part)
+
+    @staticmethod
+    def _b64(content: Any) -> str:
+        return base64.b64encode(str(content).encode("utf-8")).decode("ascii")
+
+    @staticmethod
+    def _decode_content(data: dict[str, Any]) -> str:
+        raw = str(data.get("content") or "")
+        if data.get("encoding") != "base64":
+            return raw
+        compact = "".join(raw.splitlines())
+        return base64.b64decode(compact.encode("ascii")).decode("utf-8")
+
+    # Read-only tools
 
     async def list_repos(self, **params) -> dict[str, Any]:
         """List repositories for the authenticated user."""
@@ -50,7 +89,7 @@ class GithubConnector(BaseConnector):
         sort = params.get("sort", "updated")
         data = await self._get("/user/repos", params={"per_page": per_page, "sort": sort})
         if not isinstance(data, list):
-            return data  # error response from API
+            return data
         return {
             "repos": [
                 {
@@ -68,16 +107,18 @@ class GithubConnector(BaseConnector):
 
     async def get_repo(self, **params) -> dict[str, Any]:
         """Get details of a specific repository."""
-        owner = params.get("owner", "")
-        repo = params.get("repo", "")
+        parts = self._repo_parts(params)
+        if isinstance(parts, dict):
+            return parts
+        owner, repo = parts
         return await self._get(f"/repos/{owner}/{repo}")
 
     async def list_repository_issues(self, **params) -> dict[str, Any]:
         """List issues for a repository."""
-        owner = params.get("owner", "")
-        repo = params.get("repo", "")
-        if not owner or not repo:
-            return {"error": "owner and repo are required"}
+        parts = self._repo_parts(params)
+        if isinstance(parts, dict):
+            return parts
+        owner, repo = parts
         state = params.get("state", "open")
         per_page = params.get("per_page", 30)
         data = await self._get(
@@ -85,7 +126,7 @@ class GithubConnector(BaseConnector):
             params={"state": state, "per_page": per_page},
         )
         if not isinstance(data, list):
-            return data  # error response from API
+            return data
         return {
             "issues": [
                 {
@@ -103,8 +144,10 @@ class GithubConnector(BaseConnector):
 
     async def get_repository_statistics(self, **params) -> dict[str, Any]:
         """Get repository stats (stars, forks, issues, etc.)."""
-        owner = params.get("owner", "")
-        repo = params.get("repo", "")
+        parts = self._repo_parts(params)
+        if isinstance(parts, dict):
+            return parts
+        owner, repo = parts
         data = await self._get(f"/repos/{owner}/{repo}")
         return {
             "full_name": data.get("full_name"),
@@ -121,8 +164,13 @@ class GithubConnector(BaseConnector):
 
     async def search_code(self, **params) -> dict[str, Any]:
         """Search code across GitHub repositories."""
-        query = params.get("query", "")
-        data = await self._get("/search/code", params={"q": query, "per_page": 10})
+        query = str(params.get("query") or "").strip()
+        if not query:
+            return {"error": "query is required"}
+        data = await self._get(
+            "/search/code",
+            params={"q": query, "per_page": params.get("per_page", 10)},
+        )
         return {
             "total_count": data.get("total_count", 0),
             "items": [
@@ -136,12 +184,110 @@ class GithubConnector(BaseConnector):
             ],
         }
 
-    # ── Write tools ─────────────────────────────────────────────────────
+    async def repository_search(self, **params) -> dict[str, Any]:
+        """Search code, scoped to a repository when owner/repo is supplied."""
+        query = str(params.get("query") or "").strip()
+        if not query:
+            return {"error": "query is required"}
+        parts = self._repo_parts(params)
+        if not isinstance(parts, dict):
+            owner, repo = parts
+            query = f"{query} repo:{owner}/{repo}"
+        return await self.search_code(query=query, per_page=params.get("per_page", 10))
+
+    async def list_files(self, **params) -> dict[str, Any]:
+        """List repository files/directories or the recursive git tree."""
+        parts = self._repo_parts(params)
+        if isinstance(parts, dict):
+            return parts
+        owner, repo = parts
+        ref = params.get("ref") or params.get("branch")
+        path = self._contents_path(params.get("path", ""))
+
+        if params.get("recursive"):
+            tree_ref = ref
+            if not tree_ref:
+                repo_data = await self.get_repo(owner=owner, repo=repo)
+                tree_ref = repo_data.get("default_branch") or "main"
+            data = await self._get(
+                f"/repos/{owner}/{repo}/git/trees/{tree_ref}",
+                params={"recursive": "1"},
+            )
+            tree = data.get("tree", []) if isinstance(data, dict) else []
+            return {
+                "files": [
+                    {
+                        "path": item.get("path"),
+                        "type": item.get("type"),
+                        "sha": item.get("sha"),
+                        "size": item.get("size"),
+                        "url": item.get("url"),
+                    }
+                    for item in tree
+                ],
+                "truncated": bool(data.get("truncated", False)) if isinstance(data, dict) else False,
+                "count": len(tree),
+            }
+
+        query: dict[str, Any] = {}
+        if ref:
+            query["ref"] = ref
+        data = await self._get(f"/repos/{owner}/{repo}/contents/{path}", params=query or None)
+        entries = data if isinstance(data, list) else [data]
+        return {
+            "files": [
+                {
+                    "name": item.get("name"),
+                    "path": item.get("path"),
+                    "type": item.get("type"),
+                    "sha": item.get("sha"),
+                    "size": item.get("size"),
+                    "download_url": item.get("download_url"),
+                    "url": item.get("html_url") or item.get("url"),
+                }
+                for item in entries
+                if isinstance(item, dict)
+            ],
+            "count": len(entries),
+        }
+
+    async def get_directory_tree(self, **params) -> dict[str, Any]:
+        """Return the recursive repository tree for an owner/repo/ref."""
+        params["recursive"] = True
+        return await self.list_files(**params)
+
+    async def read_file(self, **params) -> dict[str, Any]:
+        """Read and decode a text file from a repository."""
+        parts = self._repo_parts(params)
+        if isinstance(parts, dict):
+            return parts
+        owner, repo = parts
+        path = self._contents_path(params.get("path", ""))
+        if not path:
+            return {"error": "path is required"}
+        query: dict[str, Any] = {}
+        if params.get("ref") or params.get("branch"):
+            query["ref"] = params.get("ref") or params.get("branch")
+        data = await self._get(f"/repos/{owner}/{repo}/contents/{path}", params=query or None)
+        if isinstance(data, list):
+            return {"error": "path points to a directory"}
+        return {
+            "name": data.get("name"),
+            "path": data.get("path"),
+            "sha": data.get("sha"),
+            "encoding": data.get("encoding"),
+            "size": data.get("size"),
+            "content": self._decode_content(data),
+        }
+
+    # Write tools
 
     async def create_issue(self, **params) -> dict[str, Any]:
         """Create an issue in a repository."""
-        owner = params.get("owner", "")
-        repo = params.get("repo", "")
+        parts = self._repo_parts(params)
+        if isinstance(parts, dict):
+            return parts
+        owner, repo = parts
         body = {
             "title": params.get("title", ""),
             "body": params.get("body", ""),
@@ -152,8 +298,10 @@ class GithubConnector(BaseConnector):
 
     async def create_pull_request(self, **params) -> dict[str, Any]:
         """Create a pull request."""
-        owner = params.get("owner", "")
-        repo = params.get("repo", "")
+        parts = self._repo_parts(params)
+        if isinstance(parts, dict):
+            return parts
+        owner, repo = parts
         body = {
             "title": params.get("title", ""),
             "body": params.get("body", ""),
@@ -162,10 +310,198 @@ class GithubConnector(BaseConnector):
         }
         return await self._post(f"/repos/{owner}/{repo}/pulls", body)
 
+    async def create_file(self, **params) -> dict[str, Any]:
+        """Create a UTF-8 file through GitHub's contents API."""
+        parts = self._repo_parts(params)
+        if isinstance(parts, dict):
+            return parts
+        owner, repo = parts
+        path = self._contents_path(params.get("path", ""))
+        if not path:
+            return {"error": "path is required"}
+        if "content" not in params:
+            return {"error": "content is required"}
+        body: dict[str, Any] = {
+            "message": params.get("message") or f"Create {path}",
+            "content": self._b64(params["content"]),
+        }
+        if params.get("branch"):
+            body["branch"] = params["branch"]
+        return await self._put(f"/repos/{owner}/{repo}/contents/{path}", body)
+
+    async def update_file(self, **params) -> dict[str, Any]:
+        """Update a UTF-8 file through GitHub's contents API."""
+        parts = self._repo_parts(params)
+        if isinstance(parts, dict):
+            return parts
+        owner, repo = parts
+        path = self._contents_path(params.get("path", ""))
+        if not path:
+            return {"error": "path is required"}
+        if "content" not in params:
+            return {"error": "content is required"}
+        sha = params.get("sha")
+        if not sha:
+            current = await self.read_file(owner=owner, repo=repo, path=path, ref=params.get("branch"))
+            sha = current.get("sha")
+        if not sha:
+            return {"error": "sha is required for update_file"}
+        body: dict[str, Any] = {
+            "message": params.get("message") or f"Update {path}",
+            "content": self._b64(params["content"]),
+            "sha": sha,
+        }
+        if params.get("branch"):
+            body["branch"] = params["branch"]
+        return await self._put(f"/repos/{owner}/{repo}/contents/{path}", body)
+
+    async def delete_file(self, **params) -> dict[str, Any]:
+        """Delete a file through GitHub's contents API."""
+        parts = self._repo_parts(params)
+        if isinstance(parts, dict):
+            return parts
+        owner, repo = parts
+        path = self._contents_path(params.get("path", ""))
+        if not path:
+            return {"error": "path is required"}
+        sha = params.get("sha")
+        if not sha:
+            current = await self.read_file(owner=owner, repo=repo, path=path, ref=params.get("branch"))
+            sha = current.get("sha")
+        if not sha:
+            return {"error": "sha is required for delete_file"}
+        body: dict[str, Any] = {
+            "message": params.get("message") or f"Delete {path}",
+            "sha": sha,
+        }
+        if params.get("branch"):
+            body["branch"] = params["branch"]
+        if not self._client:
+            raise RuntimeError("Connector not connected")
+        resp = await self._client.request(
+            "DELETE",
+            f"/repos/{owner}/{repo}/contents/{path}",
+            json=body,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def create_branch(self, **params) -> dict[str, Any]:
+        """Create a branch from another branch or commit SHA."""
+        parts = self._repo_parts(params)
+        if isinstance(parts, dict):
+            return parts
+        owner, repo = parts
+        branch = str(params.get("branch") or params.get("branch_name") or "").strip()
+        if not branch:
+            return {"error": "branch is required"}
+        sha = params.get("sha")
+        if not sha:
+            base = params.get("base_branch") or params.get("base") or "main"
+            ref_data = await self._get(f"/repos/{owner}/{repo}/git/ref/heads/{base}")
+            sha = ref_data.get("object", {}).get("sha")
+        if not sha:
+            return {"error": "base sha could not be resolved"}
+        return await self._post(
+            f"/repos/{owner}/{repo}/git/refs",
+            {"ref": f"refs/heads/{branch}", "sha": sha},
+        )
+
+    async def commit_changes(self, **params) -> dict[str, Any]:
+        """Commit multiple file changes atomically through the git data API."""
+        parts = self._repo_parts(params)
+        if isinstance(parts, dict):
+            return parts
+        owner, repo = parts
+        branch = str(params.get("branch") or "main").strip()
+        message = str(params.get("message") or "Update repository files").strip()
+        changes = params.get("changes") or []
+        if not isinstance(changes, list) or not changes:
+            return {"error": "changes must be a non-empty list"}
+
+        ref_data = await self._get(f"/repos/{owner}/{repo}/git/ref/heads/{branch}")
+        parent_sha = ref_data.get("object", {}).get("sha")
+        if not parent_sha:
+            return {"error": "branch head sha could not be resolved"}
+        parent_commit = await self._get(f"/repos/{owner}/{repo}/git/commits/{parent_sha}")
+        base_tree_sha = parent_commit.get("tree", {}).get("sha")
+        if not base_tree_sha:
+            return {"error": "base tree sha could not be resolved"}
+
+        tree: list[dict[str, Any]] = []
+        for change in changes:
+            if not isinstance(change, dict):
+                return {"error": "each change must be an object"}
+            path = self._contents_path(change.get("path", ""))
+            if not path:
+                return {"error": "each change requires path"}
+            action = str(change.get("action") or "update").lower()
+            if action == "delete":
+                tree.append({"path": path, "mode": "100644", "type": "blob", "sha": None})
+                continue
+            if "content" not in change:
+                return {"error": f"content is required for {path}"}
+            blob = await self._post(
+                f"/repos/{owner}/{repo}/git/blobs",
+                {"content": str(change["content"]), "encoding": "utf-8"},
+            )
+            blob_sha = blob.get("sha")
+            if not blob_sha:
+                return {"error": f"blob sha missing for {path}"}
+            tree.append({"path": path, "mode": "100644", "type": "blob", "sha": blob_sha})
+
+        new_tree = await self._post(
+            f"/repos/{owner}/{repo}/git/trees",
+            {"base_tree": base_tree_sha, "tree": tree},
+        )
+        tree_sha = new_tree.get("sha")
+        if not tree_sha:
+            return {"error": "new tree sha missing"}
+        new_commit = await self._post(
+            f"/repos/{owner}/{repo}/git/commits",
+            {"message": message, "tree": tree_sha, "parents": [parent_sha]},
+        )
+        commit_sha = new_commit.get("sha")
+        if not commit_sha:
+            return {"error": "new commit sha missing"}
+        ref_update = await self.push_changes(
+            owner=owner,
+            repo=repo,
+            branch=branch,
+            sha=commit_sha,
+            force=bool(params.get("force", False)),
+        )
+        return {
+            "status": "committed",
+            "branch": branch,
+            "commit_sha": commit_sha,
+            "files_changed": len(changes),
+            "ref": ref_update,
+        }
+
+    async def push_changes(self, **params) -> dict[str, Any]:
+        """Move a branch ref to a commit SHA."""
+        parts = self._repo_parts(params)
+        if isinstance(parts, dict):
+            return parts
+        owner, repo = parts
+        branch = str(params.get("branch") or params.get("branch_name") or "").strip()
+        sha = str(params.get("sha") or "").strip()
+        if not branch:
+            return {"error": "branch is required"}
+        if not sha:
+            return {"error": "sha is required"}
+        return await self._patch(
+            f"/repos/{owner}/{repo}/git/refs/heads/{branch}",
+            {"sha": sha, "force": bool(params.get("force", False))},
+        )
+
     async def create_release(self, **params) -> dict[str, Any]:
         """Create a new release."""
-        owner = params.get("owner", "")
-        repo = params.get("repo", "")
+        parts = self._repo_parts(params)
+        if isinstance(parts, dict):
+            return parts
+        owner, repo = parts
         body = {
             "tag_name": params.get("tag_name", ""),
             "name": params.get("name", ""),
@@ -177,8 +513,10 @@ class GithubConnector(BaseConnector):
 
     async def trigger_github_action_workflow(self, **params) -> dict[str, Any]:
         """Trigger a GitHub Actions workflow dispatch."""
-        owner = params.get("owner", "")
-        repo = params.get("repo", "")
+        parts = self._repo_parts(params)
+        if isinstance(parts, dict):
+            return parts
+        owner, repo = parts
         workflow_id = params.get("workflow_id", "")
         body = {
             "ref": params.get("ref", "main"),

--- a/connectors/finance/income_tax_india.py
+++ b/connectors/finance/income_tax_india.py
@@ -5,6 +5,16 @@ from __future__ import annotations
 from connectors.framework.base_connector import BaseConnector
 
 
+def _as_bool(value, default: bool = True) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() not in {"0", "false", "no", "n", "missing", "unavailable"}
+    return bool(value)
+
+
 class IncomeTaxIndiaConnector(BaseConnector):
     name = "income_tax_india"
     category = "finance"
@@ -14,6 +24,10 @@ class IncomeTaxIndiaConnector(BaseConnector):
 
     def _register_tools(self):
         self._tool_registry["calculate_tds"] = self.calculate_tds
+        self._tool_registry["map_tds_section"] = self.map_tds_section
+        self._tool_registry["validate_pan"] = self.validate_pan
+        self._tool_registry["detect_tds_applicability"] = self.detect_tds_applicability
+        self._tool_registry["generate_tds_summary"] = self.generate_tds_summary
         self._tool_registry["file_form_26q"] = self.file_form_26q
         self._tool_registry["file_26q_return"] = self.file_26q_return
         self._tool_registry["file_24q_return"] = self.file_24q_return
@@ -40,7 +54,7 @@ class IncomeTaxIndiaConnector(BaseConnector):
         section = str(params.get("section") or "").upper().replace("SECTION", "").strip()
         section = section.replace(" ", "")
         deductee_type = str(params.get("deductee_type") or "individual").lower()
-        pan_available = bool(params.get("pan_available", True))
+        pan_available = _as_bool(params.get("pan_available"), True)
         rates = {
             "194A": 0.10,
             "194C": 0.01 if deductee_type in {"individual", "huf"} else 0.02,
@@ -63,6 +77,124 @@ class IncomeTaxIndiaConnector(BaseConnector):
             "tds_amount": tds_amount,
             "net_payable": round(amount - tds_amount, 2),
             "filing_required": True,
+        }
+
+    async def map_tds_section(self, **params):
+        """Map a ledger/category/vendor description to the likely TDS section."""
+        text = " ".join(
+            str(params.get(key) or "")
+            for key in (
+                "ledger_name",
+                "expense_category",
+                "description",
+                "vendor_type",
+                "service_type",
+            )
+        ).lower()
+        rules = [
+            ("194J", ("professional", "consulting", "legal", "audit", "technical", "royalty")),
+            ("194C", ("contractor", "contract", "labour", "labor", "transport", "works")),
+            ("194I", ("rent", "lease", "warehouse", "office premises", "building")),
+            ("194H", ("commission", "brokerage")),
+            ("194A", ("interest",)),
+            ("194O", ("ecommerce", "e-commerce", "marketplace")),
+            ("194Q", ("purchase", "goods", "material")),
+        ]
+        for section, keywords in rules:
+            if any(keyword in text for keyword in keywords):
+                calc = await self.calculate_tds(
+                    amount=params.get("amount") or 1,
+                    section=section,
+                    deductee_type=params.get("deductee_type"),
+                    pan_available=_as_bool(params.get("pan_available"), True),
+                )
+                return {
+                    "section": section,
+                    "confidence": 0.8,
+                    "reason": f"matched keywords for {section}",
+                    "rate": calc.get("rate"),
+                }
+        return {
+            "section": None,
+            "confidence": 0.0,
+            "reason": "no supported TDS section matched",
+        }
+
+    async def validate_pan(self, **params):
+        """Validate Indian PAN shape for structured 206AA handling."""
+        import re
+
+        pan = str(params.get("pan") or "").strip().upper()
+        if not pan:
+            return {"valid": False, "pan_available": False, "reason": "PAN missing"}
+        valid = re.fullmatch(r"[A-Z]{5}[0-9]{4}[A-Z]", pan) is not None
+        return {
+            "valid": valid,
+            "pan": pan,
+            "pan_available": valid,
+            "reason": "valid PAN format" if valid else "invalid PAN format",
+        }
+
+    async def detect_tds_applicability(self, **params):
+        """Determine section, PAN availability, and calculation for one transaction."""
+        section = str(params.get("section") or "").upper().replace("SECTION", "").replace(" ", "")
+        if not section:
+            mapped = await self.map_tds_section(**params)
+            section = mapped.get("section") or ""
+        pan_available = params.get("pan_available")
+        if pan_available is None and "pan" in params:
+            pan_available = (await self.validate_pan(pan=params.get("pan"))).get("valid", False)
+        if pan_available is None:
+            pan_available = True
+        pan_available = _as_bool(pan_available, True)
+        if not section:
+            return {
+                "applicable": False,
+                "reason": "section could not be determined",
+                "pan_available": bool(pan_available),
+            }
+        calc = await self.calculate_tds(
+            amount=params.get("amount") or params.get("payment_amount"),
+            section=section,
+            deductee_type=params.get("deductee_type"),
+            pan_available=pan_available,
+        )
+        if calc.get("error"):
+            return {"applicable": False, "section": section, "error": calc["error"]}
+        return {
+            "applicable": True,
+            "section": section,
+            "pan_available": bool(pan_available),
+            "calculation": calc,
+        }
+
+    async def generate_tds_summary(self, **params):
+        """Generate a section/vendor-wise TDS summary for transaction batches."""
+        transactions = params.get("transactions") or []
+        if not isinstance(transactions, list):
+            return {"error": "transactions must be a list"}
+        rows = []
+        totals_by_section: dict[str, float] = {}
+        total_tds = 0.0
+        for index, transaction in enumerate(transactions, start=1):
+            if not isinstance(transaction, dict):
+                rows.append({"index": index, "error": "transaction must be an object"})
+                continue
+            result = await self.detect_tds_applicability(**transaction)
+            row = {"index": index, **result}
+            if result.get("applicable") and isinstance(result.get("calculation"), dict):
+                calc = result["calculation"]
+                tds_amount = float(calc.get("tds_amount") or 0)
+                total_tds += tds_amount
+                section = str(calc.get("section") or "")
+                totals_by_section[section] = round(totals_by_section.get(section, 0.0) + tds_amount, 2)
+            rows.append(row)
+        return {
+            "status": "summarized",
+            "rows": rows,
+            "total_tds": round(total_tds, 2),
+            "sections": totals_by_section,
+            "transaction_count": len(transactions),
         }
 
     async def file_form_26q(self, **params):

--- a/connectors/finance/zoho_books.py
+++ b/connectors/finance/zoho_books.py
@@ -85,6 +85,16 @@ def _is_india_config(config: dict[str, Any]) -> bool:
     return _region_from_config(config) == "in"
 
 
+def _as_bool(value: Any, default: bool = True) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() not in {"0", "false", "no", "n", "missing", "unavailable"}
+    return bool(value)
+
+
 class ZohoBooksConnector(BaseConnector):
     name = "zoho_books"
     category = "finance"
@@ -94,8 +104,19 @@ class ZohoBooksConnector(BaseConnector):
     tools = [
         "create_invoice",
         "list_invoices",
+        "list_vendor_bills",
+        "get_bill_by_id",
+        "get_purchase_invoices",
         "list_overdue_invoices",
+        "list_expense_transactions",
+        "get_expense_transactions",
         "record_expense",
+        "get_vendor_payables",
+        "list_vendors",
+        "get_vendor_details",
+        "create_journal_entry",
+        "create_tds_entry",
+        "update_bill",
         "get_balance_sheet",
         "get_profit_loss",
         "get_ledger_balance",
@@ -123,8 +144,19 @@ class ZohoBooksConnector(BaseConnector):
     def _register_tools(self):
         self._tool_registry["create_invoice"] = self.create_invoice
         self._tool_registry["list_invoices"] = self.list_invoices
+        self._tool_registry["list_vendor_bills"] = self.list_vendor_bills
+        self._tool_registry["get_bill_by_id"] = self.get_bill_by_id
+        self._tool_registry["get_purchase_invoices"] = self.get_purchase_invoices
         self._tool_registry["list_overdue_invoices"] = self.list_overdue_invoices
+        self._tool_registry["list_expense_transactions"] = self.list_expense_transactions
+        self._tool_registry["get_expense_transactions"] = self.get_expense_transactions
         self._tool_registry["record_expense"] = self.record_expense
+        self._tool_registry["get_vendor_payables"] = self.get_vendor_payables
+        self._tool_registry["list_vendors"] = self.list_vendors
+        self._tool_registry["get_vendor_details"] = self.get_vendor_details
+        self._tool_registry["create_journal_entry"] = self.create_journal_entry
+        self._tool_registry["create_tds_entry"] = self.create_tds_entry
+        self._tool_registry["update_bill"] = self.update_bill
         self._tool_registry["get_balance_sheet"] = self.get_balance_sheet
         self._tool_registry["get_profit_loss"] = self.get_profit_loss
         self._tool_registry["get_ledger_balance"] = self.get_ledger_balance
@@ -343,6 +375,34 @@ class ZohoBooksConnector(BaseConnector):
             "page_context": data.get("page_context", {}),
         }
 
+    async def list_vendor_bills(self, **params) -> dict[str, Any]:
+        """List vendor bills / purchase invoices from Zoho Books.
+
+        Optional: vendor_id, status, date_start, date_end, bill_number, page.
+        """
+        qp: dict[str, Any] = {}
+        for field in ("vendor_id", "status", "date_start", "date_end", "bill_number", "page"):
+            if params.get(field):
+                qp[field] = params[field]
+        data = await self._get("/bills", params=self._org_params(qp))
+        bills = self._unwrap(data, "bills")
+        return {
+            "bills": bills if isinstance(bills, list) else [],
+            "page_context": data.get("page_context", {}),
+        }
+
+    async def get_bill_by_id(self, **params) -> dict[str, Any]:
+        """Fetch one vendor bill / purchase invoice by bill_id."""
+        bill_id = params.get("bill_id") or params.get("id")
+        if not bill_id:
+            return {"error": "bill_id is required"}
+        data = await self._get(f"/bills/{bill_id}", params=self._org_params())
+        return self._unwrap(data, "bill")
+
+    async def get_purchase_invoices(self, **params) -> dict[str, Any]:
+        """Alias for list_vendor_bills used by accounting agents."""
+        return await self.list_vendor_bills(**params)
+
     # ── Expenses ───────────────────────────────────────────────────────
 
     async def list_overdue_invoices(self, **params) -> dict[str, Any]:
@@ -353,6 +413,26 @@ class ZohoBooksConnector(BaseConnector):
         query = dict(params)
         query["status"] = "overdue"
         return await self.list_invoices(**query)
+
+    async def list_expense_transactions(self, **params) -> dict[str, Any]:
+        """List expense transactions from Zoho Books.
+
+        Optional: vendor_id, account_id, date_start, date_end, status, page.
+        """
+        qp: dict[str, Any] = {}
+        for field in ("vendor_id", "account_id", "date_start", "date_end", "status", "page"):
+            if params.get(field):
+                qp[field] = params[field]
+        data = await self._get("/expenses", params=self._org_params(qp))
+        expenses = self._unwrap(data, "expenses")
+        return {
+            "expenses": expenses if isinstance(expenses, list) else [],
+            "page_context": data.get("page_context", {}),
+        }
+
+    async def get_expense_transactions(self, **params) -> dict[str, Any]:
+        """Alias for list_expense_transactions."""
+        return await self.list_expense_transactions(**params)
 
     async def record_expense(self, **params) -> dict[str, Any]:
         """Record an expense in Zoho Books.
@@ -375,6 +455,121 @@ class ZohoBooksConnector(BaseConnector):
 
         data = await self._post("/expenses", data=body)
         return self._unwrap(data, "expense")
+
+    async def get_vendor_payables(self, **params) -> dict[str, Any]:
+        """Return unpaid/open vendor bills for payable and TDS workflows."""
+        query = dict(params)
+        query.setdefault("status", "open")
+        bills = await self.list_vendor_bills(**query)
+        return {
+            "payables": bills.get("bills", []),
+            "page_context": bills.get("page_context", {}),
+        }
+
+    async def list_vendors(self, **params) -> dict[str, Any]:
+        """List vendor contacts, including PAN/GST fields where Zoho returns them.
+
+        Optional: search_text, page.
+        """
+        qp: dict[str, Any] = {"contact_type": "vendor"}
+        for field in ("search_text", "page"):
+            if params.get(field):
+                qp[field] = params[field]
+        data = await self._get("/contacts", params=self._org_params(qp))
+        contacts = self._unwrap(data, "contacts")
+        return {
+            "vendors": contacts if isinstance(contacts, list) else [],
+            "page_context": data.get("page_context", {}),
+        }
+
+    async def get_vendor_details(self, **params) -> dict[str, Any]:
+        """Fetch one vendor/contact master record."""
+        vendor_id = params.get("vendor_id") or params.get("contact_id") or params.get("id")
+        if not vendor_id:
+            return {"error": "vendor_id is required"}
+        data = await self._get(f"/contacts/{vendor_id}", params=self._org_params())
+        return self._unwrap(data, "contact")
+
+    async def create_journal_entry(self, **params) -> dict[str, Any]:
+        """Create a Zoho Books journal entry.
+
+        Required: date, line_items. Optional: notes, reference_number.
+        """
+        if not params.get("date"):
+            return {"error": "date is required"}
+        line_items = params.get("line_items") or params.get("journal_line_items")
+        if not line_items:
+            return {"error": "line_items is required"}
+        body: dict[str, Any] = {"date": params["date"], "line_items": line_items}
+        for field in ("notes", "reference_number"):
+            if params.get(field):
+                body[field] = params[field]
+        data = await self._post("/journals", data=body)
+        return self._unwrap(data, "journal")
+
+    async def create_tds_entry(self, **params) -> dict[str, Any]:
+        """Create a TDS accounting journal entry."""
+        if params.get("line_items") or params.get("journal_line_items"):
+            return await self.create_journal_entry(**params)
+        for required in (
+            "date",
+            "expense_account_id",
+            "vendor_account_id",
+            "tds_payable_account_id",
+            "amount",
+            "tds_amount",
+        ):
+            if params.get(required) in (None, ""):
+                return {"error": f"{required} is required"}
+        try:
+            gross_amount = float(params["amount"])
+            tds_amount = float(params["tds_amount"])
+        except (TypeError, ValueError):
+            return {"error": "amount and tds_amount must be numeric"}
+        if gross_amount <= 0 or tds_amount < 0 or tds_amount > gross_amount:
+            return {"error": "tds_amount must be between 0 and amount"}
+        vendor_credit = round(gross_amount - tds_amount, 2)
+        line_items = [
+            {
+                "account_id": params["expense_account_id"],
+                "debit_or_credit": "debit",
+                "amount": round(gross_amount, 2),
+                "description": params.get("description", "Expense gross amount"),
+            },
+            {
+                "account_id": params["vendor_account_id"],
+                "debit_or_credit": "credit",
+                "amount": vendor_credit,
+                "description": params.get("vendor_description", "Vendor net payable"),
+            },
+            {
+                "account_id": params["tds_payable_account_id"],
+                "debit_or_credit": "credit",
+                "amount": round(tds_amount, 2),
+                "description": params.get("tds_description", "TDS payable"),
+            },
+        ]
+        return await self.create_journal_entry(
+            date=params["date"],
+            line_items=line_items,
+            notes=params.get("notes") or "TDS deduction entry",
+            reference_number=params.get("reference_number"),
+        )
+
+    async def update_bill(self, **params) -> dict[str, Any]:
+        """Update a vendor bill in Zoho Books."""
+        bill_id = params.get("bill_id") or params.get("id")
+        if not bill_id:
+            return {"error": "bill_id is required"}
+        body = {
+            key: value
+            for key, value in params.items()
+            if key not in {"bill_id", "id"} and value is not None
+        }
+        if not body:
+            return {"error": "at least one field is required"}
+        data = await self._put(f"/bills/{bill_id}", data=body)
+        return self._unwrap(data, "bill")
 
     # ── Reports ────────────────────────────────────────────────────────
 
@@ -484,7 +679,7 @@ class ZohoBooksConnector(BaseConnector):
         section = str(params.get("section") or "").upper().replace("SECTION", "").strip()
         section = section.replace(" ", "")
         deductee_type = str(params.get("deductee_type") or "individual").lower()
-        pan_available = bool(params.get("pan_available", True))
+        pan_available = _as_bool(params.get("pan_available"), True)
 
         section_rates = {
             "194A": 0.10,

--- a/core/agents/packs/ca/__init__.py
+++ b/core/agents/packs/ca/__init__.py
@@ -157,7 +157,21 @@ CA_PACK: dict[str, Any] = {
             "tools": [
                 "zoho_books:calculate_tds",
                 "zoho_books:get_ledger_balance",
+                "zoho_books:list_vendor_bills",
+                "zoho_books:get_bill_by_id",
+                "zoho_books:get_purchase_invoices",
+                "zoho_books:list_expense_transactions",
+                "zoho_books:get_vendor_payables",
+                "zoho_books:list_vendors",
+                "zoho_books:get_vendor_details",
+                "zoho_books:create_journal_entry",
+                "zoho_books:create_tds_entry",
+                "zoho_books:update_bill",
                 "income_tax_india:calculate_tds",
+                "income_tax_india:map_tds_section",
+                "income_tax_india:validate_pan",
+                "income_tax_india:detect_tds_applicability",
+                "income_tax_india:generate_tds_summary",
                 "income_tax_india:file_26q_return",
                 "income_tax_india:file_24q_return",
                 "income_tax_india:check_tds_credit_in_26as",
@@ -178,6 +192,13 @@ CA_PACK: dict[str, Any] = {
                 "genuinely needed for the filing step. Never ask the user to "
                 "repeat the amount, section, or period when they are already "
                 "in the prompt — that is the BUG-17 failure pattern.\n\n"
+                "TRANSACTION SOURCE: For batch or autonomous TDS work, first "
+                "fetch Zoho vendor bills, expense transactions, and vendor "
+                "master records with list_vendor_bills, "
+                "list_expense_transactions, list_vendors, and "
+                "get_vendor_details. Use structured pan_available=false from "
+                "missing or invalid PAN data so Section 206AA is applied by "
+                "the tool, not guessed from prose.\n\n"
                 "HIGH-VALUE HITL: Escalate when the gross transaction/"
                 "payment amount exceeds INR 5,00,000. This gate must use "
                 "the original payment amount, not the computed TDS amount.\n\n"

--- a/core/agents/packs/ca/config.yaml
+++ b/core/agents/packs/ca/config.yaml
@@ -34,7 +34,7 @@ agents:
   - type: tds_compliance
     domain: finance
     prompt_file: prompts/tds_compliance.prompt.txt
-    tools: [zoho_books:calculate_tds, zoho_books:get_ledger_balance, income_tax_india:calculate_tds, income_tax_india:file_26q_return, income_tax_india:file_24q_return, income_tax_india:check_tds_credit_in_26as, income_tax_india:download_form_16a, income_tax_india:pay_tax_challan, tally:get_ledger_balance, tally:post_voucher]
+    tools: [zoho_books:calculate_tds, zoho_books:get_ledger_balance, zoho_books:list_vendor_bills, zoho_books:get_bill_by_id, zoho_books:get_purchase_invoices, zoho_books:list_expense_transactions, zoho_books:get_vendor_payables, zoho_books:list_vendors, zoho_books:get_vendor_details, zoho_books:create_journal_entry, zoho_books:create_tds_entry, zoho_books:update_bill, income_tax_india:calculate_tds, income_tax_india:map_tds_section, income_tax_india:validate_pan, income_tax_india:detect_tds_applicability, income_tax_india:generate_tds_summary, income_tax_india:file_26q_return, income_tax_india:file_24q_return, income_tax_india:check_tds_credit_in_26as, income_tax_india:download_form_16a, income_tax_india:pay_tax_challan, tally:get_ledger_balance, tally:post_voucher]
     llm_model: gpt-4o
     hitl_condition: always_before_filing
     system_prompt_suffix: >
@@ -42,6 +42,8 @@ agents:
       ALWAYS trigger human-in-the-loop before filing returns or paying challans.
       ALWAYS trigger human-in-the-loop when the gross transaction/payment amount exceeds INR 5,00,000; do not evaluate this gate against the computed TDS amount.
       Validate PAN and section applicability for every deductee before computing TDS.
+      For autonomous/batch runs, fetch vendor bills, expense transactions, and vendor master records from Zoho Books before computing TDS.
+      Use structured pan_available=false when PAN is missing or invalid so Section 206AA is applied by calculate_tds.
       Never proceed if 26AS credit does not reconcile with books within 1% tolerance.
 
       INTERACTIVE EXTRACTION (issue #440): When the user message already

--- a/core/agents/packs/ca/prompts/tds_compliance.prompt.txt
+++ b/core/agents/packs/ca/prompts/tds_compliance.prompt.txt
@@ -1,7 +1,7 @@
 # core/agents/packs/ca/prompts/tds_compliance.prompt.txt  v1.0
 You are the TDS Compliance Agent for {{org_name}}, operating within a CA firm managing {{client_count}} clients.
 Domain: Finance | Confidence floor: 92% | Max retries: 3
-Token scope: income_tax_india(w:file_26q,w:file_24q,r:26as,r:form_16a,w:pay_challan) zoho_books(r:ledger_balance,w:calculate_tds) tally(r:ledger_balance,w:post_voucher)
+Token scope: income_tax_india(w:file_26q,w:file_24q,r:26as,r:form_16a,w:pay_challan,r:tds_intelligence) zoho_books(r:ledger_balance,r:vendor_bills,r:expenses,r:vendors,w:journal,w:bill_update,w:calculate_tds) tally(r:ledger_balance,w:post_voucher)
 
 <role>
 You are an expert Indian TDS compliance agent. You compute Tax Deducted at Source for all
@@ -32,6 +32,12 @@ the user has not yet provided enough information for a direct calculate_tds call
 For ad-hoc calculation queries with all fields present, the direct path above is
 the right behavior.
 
+For autonomous or batch TDS work, do not stop at ledger balances. Fetch transactional
+source data first: zoho_books:list_vendor_bills(), zoho_books:list_expense_transactions(),
+and zoho_books:list_vendors()/get_vendor_details(). Use structured pan_available=false
+when PAN is missing or invalid so Section 206AA applies through calculate_tds rather
+than prompt wording.
+
 For Challan 281 requests, prepare a draft from any amount and period already
 present. Do not block the draft on deductee PAN/type or post-payment BSR/challan
 evidence; defer those to return mapping/evidence. Actual payment submission still
@@ -45,11 +51,14 @@ Show the assumptions, Section 234E fee, 1% late-deduction interest scenario, and
 </interactive_extraction>
 
 <processing_sequence>
-1. EXTRACT — call tally:get_ledger_balance() for all TDS-applicable ledgers. Extract transactions
-   grouped by TDS section (194A, 194C, 194H, 194I, 194J, 194O, 192, etc.).
+1. EXTRACT — call zoho_books:list_vendor_bills(), zoho_books:list_expense_transactions(),
+   zoho_books:list_vendors(), and tally:get_ledger_balance() for all TDS-applicable ledgers.
+   Extract invoice/bill number, vendor, bill date, amount, expense category, PAN/GSTIN,
+   payment status, and transaction metadata grouped by TDS section.
 2. VALIDATE_DEDUCTEES — For each deductee, verify:
    - PAN is valid and matches the deductee name
    - Section applicability is correct (e.g., 194C for contractors, 194J for professionals)
+   - If needed, call income_tax_india:map_tds_section() / detect_tds_applicability()
    - Threshold limits are met (e.g., 194A: interest > INR 40,000 for banks / INR 5,000 otherwise)
    - Higher rate applies if PAN not furnished (Section 206AA: 20% or applicable rate, whichever higher)
    - Section 206AB: higher rate for non-filers (twice the prescribed rate or 5%, whichever higher)
@@ -73,7 +82,8 @@ Show the assumptions, Section 234E fee, 1% late-deduction interest scenario, and
    Record provisional receipt number and filing timestamp.
 9. GENERATE_16A — call income_tax_india:download_form_16a() for each deductee.
    Distribute certificates within 15 days of filing (per Rule 31).
-10. POST_ENTRIES — call tally:post_voucher() to post TDS journal entries to books.
+10. POST_ENTRIES — call zoho_books:create_tds_entry() or tally:post_voucher() to post
+   TDS journal entries to books after partner approval.
 </processing_sequence>
 
 <tds_rules>

--- a/core/schemas/api.py
+++ b/core/schemas/api.py
@@ -53,7 +53,7 @@ class AgentCreate(BaseModel):
     hitl_policy: HITLPolicyConfig = Field(
         default_factory=lambda: HITLPolicyConfig(condition="confidence < 0.88")
     )
-    confidence_floor: float = 0.88
+    confidence_floor: float = Field(0.88, ge=0.0, le=1.0)
     max_retries: int = 3
     output_schema: str | None = None
     initial_status: str = "shadow"
@@ -62,7 +62,7 @@ class AgentCreate(BaseModel):
     # BUG-012 (Ramesh 2026-04-20): aligned with the ORM default —
     # 0.95 was unrealistic for LLM-driven agents; see
     # core/models/agent.py for the full rationale.
-    shadow_accuracy_floor: float = 0.80
+    shadow_accuracy_floor: float = Field(0.80, ge=0.0, le=1.0)
     scaling: ScalingConfig = Field(default_factory=ScalingConfig)
     cost_controls: CostControlConfig = Field(default_factory=CostControlConfig)
     ttl_hours: int | None = None
@@ -93,7 +93,7 @@ class AgentUpdate(BaseModel):
     prompt_variables: dict[str, str] | None = None
     authorized_tools: list[str] | None = None
     hitl_policy: HITLPolicyConfig | None = None
-    confidence_floor: float | None = None
+    confidence_floor: float | None = Field(None, ge=0.0, le=1.0)
     llm: LLMConfig | None = None
     # Virtual employee persona fields
     employee_name: str | None = None

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -410,7 +410,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.list",
-    "source_line": 1301,
+    "source_line": 1304,
     "tenant_required": true
   },
   {
@@ -428,7 +428,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 1046,
+    "source_line": 1049,
     "tenant_required": true
   },
   {
@@ -446,7 +446,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.tools.sensitive.read",
-    "source_line": 1000,
+    "source_line": 1003,
     "tenant_required": true
   },
   {
@@ -464,7 +464,7 @@
     "public_exempt_reason": null,
     "rate_limit": "ai-generation",
     "scope": "agents.generate",
-    "source_line": 1715,
+    "source_line": 1718,
     "tenant_required": true
   },
   {
@@ -482,7 +482,7 @@
     "public_exempt_reason": null,
     "rate_limit": "file-upload",
     "scope": "agents.import",
-    "source_line": 1558,
+    "source_line": 1561,
     "tenant_required": true
   },
   {
@@ -500,7 +500,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.org_tree",
-    "source_line": 1421,
+    "source_line": 1424,
     "tenant_required": true
   },
   {
@@ -518,7 +518,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 3790,
+    "source_line": 3793,
     "tenant_required": true
   },
   {
@@ -536,7 +536,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.read",
-    "source_line": 1837,
+    "source_line": 1840,
     "tenant_required": true
   },
   {
@@ -554,7 +554,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 2007,
+    "source_line": 2010,
     "tenant_required": true
   },
   {
@@ -572,7 +572,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 1867,
+    "source_line": 1870,
     "tenant_required": true
   },
   {
@@ -590,7 +590,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.amendments.read",
-    "source_line": 3749,
+    "source_line": 3752,
     "tenant_required": true
   },
   {
@@ -608,7 +608,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.budget.read",
-    "source_line": 3463,
+    "source_line": 3466,
     "tenant_required": true
   },
   {
@@ -626,7 +626,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 3308,
+    "source_line": 3311,
     "tenant_required": true
   },
   {
@@ -644,7 +644,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.delegate",
-    "source_line": 1482,
+    "source_line": 1485,
     "tenant_required": true
   },
   {
@@ -662,7 +662,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.explanation.read",
-    "source_line": 3609,
+    "source_line": 3612,
     "tenant_required": true
   },
   {
@@ -680,7 +680,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.feedback.list",
-    "source_line": 3581,
+    "source_line": 3584,
     "tenant_required": true
   },
   {
@@ -698,7 +698,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-feedback",
     "scope": "agents.feedback.write",
-    "source_line": 3535,
+    "source_line": 3538,
     "tenant_required": true
   },
   {
@@ -716,7 +716,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.feedback.analyze",
-    "source_line": 3725,
+    "source_line": 3728,
     "tenant_required": true
   },
   {
@@ -734,7 +734,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 2818,
+    "source_line": 2821,
     "tenant_required": true
   },
   {
@@ -752,7 +752,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 2953,
+    "source_line": 2956,
     "tenant_required": true
   },
   {
@@ -770,7 +770,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.prompt_history",
-    "source_line": 3421,
+    "source_line": 3424,
     "tenant_required": true
   },
   {
@@ -788,7 +788,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 2866,
+    "source_line": 2869,
     "tenant_required": true
   },
   {
@@ -806,7 +806,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3123,
+    "source_line": 3126,
     "tenant_required": true
   },
   {
@@ -824,7 +824,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3072,
+    "source_line": 3075,
     "tenant_required": true
   },
   {
@@ -842,7 +842,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3184,
+    "source_line": 3187,
     "tenant_required": true
   },
   {
@@ -860,7 +860,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-execution",
     "scope": "agents.execute",
-    "source_line": 2168,
+    "source_line": 2171,
     "tenant_required": true
   },
   {

--- a/tests/regression/test_ca_firms_22may2026_report.py
+++ b/tests/regression/test_ca_firms_22may2026_report.py
@@ -1,0 +1,154 @@
+"""Regression coverage for the 22-May CA Firms report."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _mock_client_response(json_data=None):
+    resp = MagicMock()
+    resp.json.return_value = json_data or {}
+    resp.raise_for_status = MagicMock()
+    resp.status_code = 200
+    return resp
+
+
+def _async_response(json_data=None):
+    return AsyncMock(return_value=_mock_client_response(json_data))
+
+
+def test_agent_delete_is_not_a_physical_row_delete() -> None:
+    src = (ROOT / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    delete_block = src.split("# ── DELETE /agents/", 1)[1][:6000]
+
+    assert "await session.delete(agent)" not in delete_block
+    assert 'agent.status = "deleted"' in delete_block
+    assert "StepExecution.agent_id == agent_id" in delete_block
+    assert "LeadPipeline.assigned_agent_id == agent_id" in delete_block
+    assert "ApprovalPolicy.agent_id == agent_id" in delete_block
+    assert "HITLQueue.__table__.delete" in delete_block
+
+
+@pytest.mark.asyncio
+async def test_github_connector_reads_repository_files_and_decodes_content() -> None:
+    from connectors.comms.github_connector import GithubConnector
+
+    connector = GithubConnector({"personal_access_token": "token"})
+    connector._client = MagicMock()
+    encoded = base64.b64encode(b"hello world").decode("ascii")
+    connector._client.get = _async_response(
+        {
+            "name": "README.md",
+            "path": "README.md",
+            "sha": "abc123",
+            "encoding": "base64",
+            "size": 11,
+            "content": encoded,
+        }
+    )
+
+    out = await connector.read_file(owner="acme", repo="app", path="README.md", ref="main")
+
+    assert out["content"] == "hello world"
+    args = connector._client.get.call_args
+    assert args.args[0] == "/repos/acme/app/contents/README.md"
+    assert args.kwargs["params"]["ref"] == "main"
+
+
+@pytest.mark.asyncio
+async def test_github_connector_can_create_branch_and_commit_multi_file_changes() -> None:
+    from connectors.comms.github_connector import GithubConnector
+
+    connector = GithubConnector({"personal_access_token": "token"})
+    connector._client = MagicMock()
+    connector._client.get = AsyncMock(
+        side_effect=[
+            _mock_client_response({"object": {"sha": "parent-sha"}}),
+            _mock_client_response({"tree": {"sha": "base-tree"}}),
+        ]
+    )
+    connector._client.post = AsyncMock(
+        side_effect=[
+            _mock_client_response({"sha": "blob-a"}),
+            _mock_client_response({"sha": "new-tree"}),
+            _mock_client_response({"sha": "new-commit"}),
+        ]
+    )
+    connector._client.patch = _async_response({"ref": "refs/heads/work"})
+
+    out = await connector.commit_changes(
+        owner="acme",
+        repo="app",
+        branch="work",
+        message="Update app",
+        changes=[{"path": "src/app.ts", "content": "export const ok = true;"}],
+    )
+
+    assert out["status"] == "committed"
+    assert out["commit_sha"] == "new-commit"
+    post_paths = [call.args[0] for call in connector._client.post.call_args_list]
+    assert post_paths == [
+        "/repos/acme/app/git/blobs",
+        "/repos/acme/app/git/trees",
+        "/repos/acme/app/git/commits",
+    ]
+    connector._client.patch.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_zoho_books_exposes_vendor_bill_expense_vendor_and_tds_journal_tools() -> None:
+    from connectors.finance.zoho_books import ZohoBooksConnector
+
+    connector = ZohoBooksConnector({"access_token": "fake", "organization_id": "org123"})
+    connector._client = MagicMock()
+    connector._client.get = _async_response({"bills": [{"bill_id": "B1"}]})
+    bills = await connector.list_vendor_bills(vendor_id="V1")
+    assert bills["bills"][0]["bill_id"] == "B1"
+    assert connector._client.get.call_args.args[0] == "/bills"
+    assert connector._client.get.call_args.kwargs["params"]["organization_id"] == "org123"
+
+    connector._client.get = _async_response({"contacts": [{"contact_id": "V1"}]})
+    vendors = await connector.list_vendors(search_text="Acme")
+    assert vendors["vendors"][0]["contact_id"] == "V1"
+    assert connector._client.get.call_args.args[0] == "/contacts"
+    assert connector._client.get.call_args.kwargs["params"]["contact_type"] == "vendor"
+
+    connector._client.post = _async_response({"journal": {"journal_id": "J1"}})
+    journal = await connector.create_tds_entry(
+        date="2026-05-22",
+        expense_account_id="expense",
+        vendor_account_id="vendor",
+        tds_payable_account_id="tds",
+        amount=10000,
+        tds_amount=1000,
+    )
+    assert journal["journal_id"] == "J1"
+    body = connector._client.post.call_args.kwargs["json"]
+    assert connector._client.post.call_args.args[0] == "/journals"
+    assert [line["amount"] for line in body["line_items"]] == [10000.0, 9000.0, 1000.0]
+
+
+@pytest.mark.asyncio
+async def test_income_tax_tds_intelligence_handles_missing_pan_structurally() -> None:
+    from connectors.finance.income_tax_india import IncomeTaxIndiaConnector
+
+    connector = IncomeTaxIndiaConnector({})
+
+    calc = await connector.calculate_tds(amount=50000, section="194C", pan_available="false")
+    assert calc["rate"] == 0.20
+    assert calc["tds_amount"] == 10000.0
+
+    detected = await connector.detect_tds_applicability(
+        amount=50000,
+        ledger_name="Professional fees",
+        pan="",
+    )
+    assert detected["applicable"] is True
+    assert detected["section"] == "194J"
+    assert detected["pan_available"] is False

--- a/tests/unit/test_ca_pack.py
+++ b/tests/unit/test_ca_pack.py
@@ -170,7 +170,7 @@ class TestGSTFilingAgentTools:
 
 
 class TestTDSComplianceAgentTools:
-    """TDS Compliance Agent must have all Income Tax + Tally tools."""
+    """TDS Compliance Agent must have all Income Tax + accounting tools."""
 
     def test_tds_compliance_agent_tools(self):
         from core.agents.packs.ca import CA_PACK
@@ -181,7 +181,21 @@ class TestTDSComplianceAgentTools:
         # Income Tax + accounting source tools
         assert "zoho_books:calculate_tds" in tools
         assert "zoho_books:get_ledger_balance" in tools
+        assert "zoho_books:list_vendor_bills" in tools
+        assert "zoho_books:get_bill_by_id" in tools
+        assert "zoho_books:get_purchase_invoices" in tools
+        assert "zoho_books:list_expense_transactions" in tools
+        assert "zoho_books:get_vendor_payables" in tools
+        assert "zoho_books:list_vendors" in tools
+        assert "zoho_books:get_vendor_details" in tools
+        assert "zoho_books:create_journal_entry" in tools
+        assert "zoho_books:create_tds_entry" in tools
+        assert "zoho_books:update_bill" in tools
         assert "income_tax_india:calculate_tds" in tools
+        assert "income_tax_india:map_tds_section" in tools
+        assert "income_tax_india:validate_pan" in tools
+        assert "income_tax_india:detect_tds_applicability" in tools
+        assert "income_tax_india:generate_tds_summary" in tools
         assert "income_tax_india:file_26q_return" in tools
         assert "income_tax_india:file_24q_return" in tools
         assert "income_tax_india:check_tds_credit_in_26as" in tools
@@ -192,11 +206,11 @@ class TestTDSComplianceAgentTools:
         assert "tally:get_ledger_balance" in tools
         assert "tally:post_voucher" in tools
 
-    def test_tds_compliance_agent_has_10_tools(self):
+    def test_tds_compliance_agent_has_transactional_tool_surface(self):
         from core.agents.packs.ca import CA_PACK
 
         tds_agent = next(a for a in CA_PACK["agents"] if a["name"] == "TDS Compliance Agent")
-        assert len(tds_agent["tools"]) == 10
+        assert len(tds_agent["tools"]) == 24
 
     def test_tds_compliance_agent_uses_canonical_26q_tool_only(self):
         from core.agents.packs.ca import CA_PACK

--- a/tests/unit/test_module_27_negative_edge.py
+++ b/tests/unit/test_module_27_negative_edge.py
@@ -20,8 +20,8 @@ Pinned contracts:
 - AgentUpdate handles non-existent ids with 404 (not 5xx).
 - DELETE /agents/{id} refuses non-deletable statuses with 409 +
   the documented message ("Pause or retire the agent first.").
-- Audit log entry MUST be written BEFORE the row delete so the
-  audit trail isn't lost when the deletion succeeds.
+- Audit log entry MUST be written BEFORE the soft-delete status
+  transition so the audit trail isn't lost when deletion succeeds.
 - Concurrent agent creation is gated by tenant-scoped uniqueness
   + per-(name, version) constraints at the model layer.
 - UI logout removes BOTH token AND user from localStorage so
@@ -31,6 +31,9 @@ Pinned contracts:
 from __future__ import annotations
 
 from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
 
 REPO = Path(__file__).resolve().parents[2]
 
@@ -68,6 +71,38 @@ def test_tc_neg_001_jwt_validation_pins_audience_and_issuer() -> None:
     assert '"verify_iss": True' in src
 
 
+def test_tc_neg_003_confidence_floor_rejects_out_of_range_values() -> None:
+    """Create and update schemas must reject impossible confidence floors."""
+    from core.schemas.api import AgentCreate, AgentUpdate
+
+    with pytest.raises(ValidationError):
+        AgentCreate(
+            name="bad-high",
+            agent_type="test",
+            domain="test",
+            confidence_floor=1.5,
+        )
+    with pytest.raises(ValidationError):
+        AgentCreate(
+            name="bad-low",
+            agent_type="test",
+            domain="test",
+            confidence_floor=-0.01,
+        )
+    with pytest.raises(ValidationError):
+        AgentUpdate(confidence_floor=1.5)
+
+    assert (
+        AgentCreate(
+            name="boundary",
+            agent_type="test",
+            domain="test",
+            confidence_floor=1.0,
+        ).confidence_floor
+        == 1.0
+    )
+
+
 # ─────────────────────────────────────────────────────────────────
 # TC-NEG-003 — Create agent with confidence floor out of range
 # ─────────────────────────────────────────────────────────────────
@@ -75,12 +110,12 @@ def test_tc_neg_001_jwt_validation_pins_audience_and_issuer() -> None:
 
 def test_tc_neg_003_confidence_floor_default_documented() -> None:
     """confidence_floor defaults to 0.88 (the BUG-012 alignment
-    with the model's default). Pydantic typing is plain float,
-    so values <0 or >1 ARE accepted at the schema layer — the
-    handler enforces the [0, 1] range. Pin the default so a
+    with the model's default). The schema also enforces the [0, 1]
+    range so impossible values cannot reach the handler. Pin the default so a
     refactor can't silently shift it."""
-    src = (REPO / "core" / "schemas" / "api.py").read_text(encoding="utf-8")
-    assert "confidence_floor: float = 0.88" in src
+    from core.schemas.api import AgentCreate
+
+    assert AgentCreate.model_fields["confidence_floor"].default == 0.88
 
 
 def test_tc_neg_003_shadow_accuracy_floor_default_pinned() -> None:
@@ -88,8 +123,9 @@ def test_tc_neg_003_shadow_accuracy_floor_default_pinned() -> None:
     0.95 was unreachable for LLM agents). If the default
     moves to 0.95 again, every new agent gets stuck in shadow
     mode forever."""
-    src = (REPO / "core" / "schemas" / "api.py").read_text(encoding="utf-8")
-    assert "shadow_accuracy_floor: float = 0.80" in src
+    from core.schemas.api import AgentCreate
+
+    assert AgentCreate.model_fields["shadow_accuracy_floor"].default == 0.80
 
 
 # ─────────────────────────────────────────────────────────────────
@@ -192,23 +228,30 @@ def test_tc_neg_009_delete_refuses_non_deletable_status_with_409() -> None:
     assert "raise HTTPException(\n                409," in src or 'HTTPException(409' in src
 
 
-def test_tc_neg_009_delete_writes_audit_before_row_drop() -> None:
-    """The audit log MUST be written BEFORE the agent row is
-    deleted. If the order flips, a deletion that succeeds at
-    the row level but fails at the audit write would leave no
-    trail — Module 12 audit contract requires every mutation
-    be visible in the log."""
+def test_tc_neg_009_delete_writes_audit_before_soft_delete() -> None:
+    """The audit log MUST be written BEFORE the agent is marked deleted."""
     src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
-    delete_block = src.split("# ── DELETE /agents/", 1)[1][:3500]
+    delete_block = src.split("# ── DELETE /agents/", 1)[1].split("# ── ", 1)[0]
     audit_idx = delete_block.find("AuditLog(")
-    delete_idx = delete_block.find("session.delete(")
+    delete_idx = delete_block.find('agent.status = "deleted"')
     assert audit_idx > 0, "AuditLog write missing from delete handler"
-    assert delete_idx > 0, "session.delete missing from delete handler"
+    assert delete_idx > 0, "soft-delete status transition missing from delete handler"
     assert audit_idx < delete_idx, (
-        "AuditLog must be created BEFORE the row delete — "
+        "AuditLog must be created BEFORE the soft-delete transition — "
         "otherwise a successful delete with a failed audit "
         "leaves no trail"
     )
+
+
+def test_tc_neg_009_delete_is_fk_safe_soft_delete_not_row_drop() -> None:
+    """User-facing delete must not physically drop the agent row."""
+    src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
+    delete_block = src.split("# ── DELETE /agents/", 1)[1][:5000]
+    assert "await session.delete(agent)" not in delete_block
+    assert 'agent.status = "deleted"' in delete_block
+    assert "StepExecution.agent_id == agent_id" in delete_block
+    assert "LeadPipeline.assigned_agent_id == agent_id" in delete_block
+    assert "Agent.parent_agent_id == agent_id" in delete_block
 
 
 # ─────────────────────────────────────────────────────────────────

--- a/ui/e2e/qa-module-27-negative-edge.spec.ts
+++ b/ui/e2e/qa-module-27-negative-edge.spec.ts
@@ -156,9 +156,10 @@ test.describe("Module 27: Negative & Edge Cases @qa @negative", () => {
     expect(resp.status()).not.toBe(422);
     if (resp.status() < 300) {
       const body = await resp.json();
+      const agentId = body.agent_id || body.id;
       // Cleanup the agent we just created.
-      if (body.id) {
-        await request.delete(`${APP}/api/v1/agents/${body.id}`, {
+      if (agentId) {
+        await request.delete(`${APP}/api/v1/agents/${agentId}`, {
           headers: { Authorization: `Bearer ${E2E_TOKEN}` },
           failOnStatusCode: false,
         });
@@ -196,11 +197,19 @@ test.describe("Module 27: Negative & Edge Cases @qa @negative", () => {
     expect(resp.status()).toBeLessThan(500);
     if (resp.status() < 300) {
       const body = await resp.json();
+      const agentId = body.agent_id || body.id;
+      expect(agentId).toBeTruthy();
       // The name we sent must round-trip verbatim — no
       // server-side escaping/encoding.
-      expect(body.name).toBe(name);
+      const getResp = await request.get(`${APP}/api/v1/agents/${agentId}`, {
+        headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+        failOnStatusCode: false,
+      });
+      expect(getResp.status()).toBe(200);
+      const fetched = await getResp.json();
+      expect(fetched.name).toBe(name);
       // Cleanup.
-      await request.delete(`${APP}/api/v1/agents/${body.id}`, {
+      await request.delete(`${APP}/api/v1/agents/${agentId}`, {
         headers: { Authorization: `Bearer ${E2E_TOKEN}` },
         failOnStatusCode: false,
       });
@@ -224,25 +233,72 @@ test.describe("Module 27: Negative & Edge Cases @qa @negative", () => {
     expect(resp.status()).toBe(404);
   });
 
+  test("TC-NEG-009b DELETE /agents soft-deletes and hides from default list", async ({
+    request,
+  }) => {
+    const ts = Date.now();
+    const createResp = await request.post(`${APP}/api/v1/agents`, {
+      headers: {
+        Authorization: `Bearer ${E2E_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      data: {
+        name: `qa-delete-${ts}`,
+        agent_type: "test",
+        domain: "test",
+      },
+      failOnStatusCode: false,
+    });
+    expect(createResp.status()).toBeLessThan(300);
+    const created = await createResp.json();
+    const agentId = created.agent_id || created.id;
+    expect(agentId).toBeTruthy();
+
+    const deleteResp = await request.delete(`${APP}/api/v1/agents/${agentId}`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(deleteResp.status()).toBe(200);
+    const deleted = await deleteResp.json();
+    expect(deleted).toMatchObject({ id: agentId, deleted: true, status: "deleted" });
+
+    const listResp = await request.get(`${APP}/api/v1/agents?per_page=100`, {
+      headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+      failOnStatusCode: false,
+    });
+    expect(listResp.status()).toBe(200);
+    const listBody = await listResp.json();
+    const visibleIds = (listBody.items || []).map((agent: any) => agent.id);
+    expect(visibleIds).not.toContain(agentId);
+
+    const deletedListResp = await request.get(
+      `${APP}/api/v1/agents?status=deleted&per_page=100`,
+      {
+        headers: { Authorization: `Bearer ${E2E_TOKEN}` },
+        failOnStatusCode: false,
+      },
+    );
+    expect(deletedListResp.status()).toBe(200);
+    const deletedListBody = await deletedListResp.json();
+    const deletedIds = (deletedListBody.items || []).map((agent: any) => agent.id);
+    expect(deletedIds).toContain(agentId);
+  });
+
   // -------------------------------------------------------------------------
   // TC-NEG-010 — Browser back button after logout
   // -------------------------------------------------------------------------
 
-  test("TC-NEG-010 unauthenticated UI route redirects to /login", async ({
+  test("TC-NEG-010 unauthenticated UI route shows login, not protected content", async ({
     page,
   }) => {
     // After logout, hitting an authenticated route directly
     // (simulating the back button) must NOT show authenticated
-    // content. The ProtectedRoute wrapper redirects to /login.
-    // Test by going to /agents WITHOUT establishing a session.
+    // content. The ProtectedRoute gate must render the login surface.
+    // Test by going to the actual protected agent route WITHOUT establishing a session.
     await page.context().clearCookies();
-    await page.goto(`${APP}/agents`);
-    // The router redirects to /login (or similar). We assert
-    // the URL ends up on a public page, NOT /agents.
+    await page.goto(`${APP}/dashboard/agents`);
     await page.waitForLoadState("domcontentloaded");
-    const url = page.url();
-    expect(url, `expected redirect away from /agents, got ${url}`).not.toContain(
-      "/agents",
-    );
+    await expect(page.getByRole("button", { name: /sign in with email/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /agent fleet/i })).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the valid bugs/enhancements from `CA_FIRMS_TEST_REPORT22May2026.md`:

- makes `DELETE /agents/{id}` an audited FK-safe soft delete instead of physically dropping agent rows
- expands the GitHub connector with repository file, branch, commit, and push operations
- expands TDS compliance agent capability through Zoho Books transaction/vendor/journal tools and Income Tax PAN/section/applicability helpers
- closes a Playwright-exposed validation hole by bounding `confidence_floor` to `[0, 1]`

## Root Cause

The reopened cases were valid because the earlier behavior treated symptoms in isolated places instead of auditing the full data-model and agent-tool contract. Agent delete varied because physical deletion depended on downstream references. TDS and GitHub gaps existed because connector methods, pack allow-lists, and prompts were not aligned to the real workflows.

## Validation

- `python -m pytest tests\regression\test_ca_firms_22may2026_report.py tests\unit\test_ca_pack.py tests\unit\test_module_27_negative_edge.py` -> `44 passed`
- `python -m ruff check api\v1\agents.py connectors\comms\github_connector.py connectors\finance\zoho_books.py connectors\finance\income_tax_india.py core\schemas\api.py core\agents\packs\ca\__init__.py tests\regression\test_ca_firms_22may2026_report.py tests\unit\test_ca_pack.py tests\unit\test_module_27_negative_edge.py` -> passed
- `cd ui && npm run typecheck` -> passed
- `PYTHON_BIN=python PYTHONPATH=. SKIP_BUILD=1 RESET=1 bash scripts/local_e2e.sh ui/e2e/qa-module-27-negative-edge.spec.ts` -> `11 passed`

## Artifacts

A bug-fix summary workbook was created locally at `C:\Users\mishr\Downloads\CA_FIRMS_BUG_FIX_SUMMARY_22May2026.xlsx`.