### PR TITLE
[codex] Fix tenant context SQL injection alert

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -75,6 +75,7 @@ async def get_tenant_session(tenant_id: UUID) -> AsyncGenerator[AsyncSession, No
             raise ValueError(f"Invalid tenant_id format: {tid_str}")
         # set_config(..., is_local=true) is the parameterized equivalent of
         # SET LOCAL and avoids interpolating tenant context into SQL text.
+        # UUID validation remains defense-in-depth for tenant context boundaries.
         await session.execute(
             text("SELECT set_config('agenticorg.tenant_id', :tenant_id, true)"),
             {"tenant_id": tid_str},

--- a/core/database.py
+++ b/core/database.py
@@ -68,18 +68,17 @@ async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_o
 async def get_tenant_session(tenant_id: UUID) -> AsyncGenerator[AsyncSession, None]:
     """Yield a session with RLS tenant context set."""
     async with async_session_factory() as session:
-        # asyncpg does not support bound parameters in SET LOCAL.
-        # We MUST validate the UUID format before interpolating.
         import re as _re
 
         tid_str = str(tenant_id)
         if not _re.fullmatch(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", tid_str):
             raise ValueError(f"Invalid tenant_id format: {tid_str}")
-        # Construct the SQL statement from the validated, safe UUID string.
-        # This is NOT user-controlled — tenant_id comes from JWT claims validated
-        # by auth middleware. The regex above is defense-in-depth.
-        stmt = "SET LOCAL agenticorg.tenant_id = '" + tid_str + "'"  # noqa: S608
-        await session.execute(text(stmt))
+        # set_config(..., is_local=true) is the parameterized equivalent of
+        # SET LOCAL and avoids interpolating tenant context into SQL text.
+        await session.execute(
+            text("SELECT set_config('agenticorg.tenant_id', :tenant_id, true)"),
+            {"tenant_id": tid_str},
+        )
         try:
             yield session
             await session.commit()

--- a/tests/security/test_database_tenant_context_sql_safety.py
+++ b/tests/security/test_database_tenant_context_sql_safety.py
@@ -1,0 +1,57 @@
+"""Regression coverage for tenant RLS context SQL construction."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+TENANT_ID = "11111111-2222-3333-4444-555555555555"
+
+
+class _MaliciousTenantId:
+    def __str__(self) -> str:
+        return "11111111-2222-3333-4444-555555555555'; DROP TABLE tenants; --"
+
+
+def _session_factory_for(mock_session: AsyncMock) -> MagicMock:
+    mock_factory = MagicMock()
+    mock_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+    return mock_factory
+
+
+@pytest.mark.asyncio
+async def test_tenant_context_uses_bound_parameter_not_interpolated_sql() -> None:
+    from core.database import get_tenant_session
+
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    with patch("core.database.async_session_factory", _session_factory_for(mock_session)):
+        async with get_tenant_session(uuid.UUID(TENANT_ID)):
+            pass
+
+    statement, params = mock_session.execute.call_args.args
+    sql_text = getattr(statement, "text", str(statement))
+
+    assert "set_config('agenticorg.tenant_id', :tenant_id, true)" in sql_text
+    assert TENANT_ID not in sql_text
+    assert params == {"tenant_id": TENANT_ID}
+
+
+@pytest.mark.asyncio
+async def test_tenant_context_rejects_malicious_tenant_string_before_execute() -> None:
+    from core.database import get_tenant_session
+
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock()
+
+    with patch("core.database.async_session_factory", _session_factory_for(mock_session)):
+        with pytest.raises(ValueError):
+            async with get_tenant_session(_MaliciousTenantId()):  # type: ignore[arg-type]
+                pass
+
+    mock_session.execute.assert_not_called()

--- a/tests/unit/test_auth_and_core.py
+++ b/tests/unit/test_auth_and_core.py
@@ -1695,8 +1695,9 @@ class TestGetTenantSession:
             # The first arg to execute is a text() clause; check its .text attribute
             text_clause = calls[0][0][0]
             sql_text = getattr(text_clause, "text", str(text_clause))
-            assert TENANT_ID in sql_text
-            assert "SET LOCAL" in sql_text
+            assert TENANT_ID not in sql_text
+            assert "set_config" in sql_text
+            assert calls[0][0][1] == {"tenant_id": TENANT_ID}
 
     @pytest.mark.asyncio
     async def test_rollback_on_exception(self):

--- a/tests/unit/test_module_22_cross_cutting.py
+++ b/tests/unit/test_module_22_cross_cutting.py
@@ -13,8 +13,9 @@ Pinned contracts:
   scope check accepts the actor when scopes contain anything
   starting with ``agenticorg:admin``. The auditor role gets
   read scopes only — no write scope is derivable.
-- Tenant isolation = SET LOCAL agenticorg.tenant_id at session
-  open + RLS policies on every tenant-scoped table.
+- Tenant isolation = parameterized set_config('agenticorg.tenant_id', ...)
+  with transaction-local scope at session open + RLS policies on every
+  tenant-scoped table.
 - Error envelope is the E-series shape:
   ``{"error": {"code", "name", "message", "severity",
   "retryable", "timestamp"}}``. The codes are part of the
@@ -25,9 +26,9 @@ Pinned contracts:
   budget cap.
 - Prompt lock on active agents: PATCH/POST flows return 400
   with the exact message the UI parses.
-- SQL injection: all asyncpg queries use bind parameters; the
-  one place that interpolates (SET LOCAL tenant_id) validates
-  the UUID with a regex first.
+- SQL injection: all asyncpg queries use bind parameters; tenant context
+  setup binds the UUID through set_config and keeps regex validation as
+  defense-in-depth.
 - XSS / arbitrary-content: defusedxml is used for any XML
   parsing path (RPA scrapers); JSON is parsed by Pydantic
   with strict typing.
@@ -95,17 +96,19 @@ def test_tc_cc_003_auditor_role_does_not_get_write_scopes() -> None:
 
 
 # ─────────────────────────────────────────────────────────────────
-# TC-CC-004 — Tenant isolation (SET LOCAL + RLS)
+# TC-CC-004 — Tenant isolation (set_config + RLS)
 # ─────────────────────────────────────────────────────────────────
 
 
-def test_tc_cc_004_get_tenant_session_validates_uuid_before_set_local() -> None:
-    """asyncpg can't bind parameters in SET LOCAL, so we
-    interpolate. The interpolation is safe ONLY because we
-    regex-validate the UUID first. If the validation goes
-    away, the SET LOCAL becomes a SQL injection vector."""
+def test_tc_cc_004_get_tenant_session_sets_parameterized_local_context() -> None:
+    """Tenant context must be written with a bind parameter, not SQL
+    interpolation. set_config(..., is_local=true) provides the same
+    transaction-local behavior as SET LOCAL while keeping the value out
+    of the SQL text. UUID validation remains defense-in-depth."""
     src = (REPO / "core" / "database.py").read_text(encoding="utf-8")
-    assert "SET LOCAL agenticorg.tenant_id" in src
+    assert "set_config('agenticorg.tenant_id', :tenant_id, true)" in src
+    assert '{"tenant_id": tid_str}' in src
+    assert "SET LOCAL agenticorg.tenant_id = '" not in src
     # The defense-in-depth UUID regex must remain.
     assert "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" in src
     assert "ValueError" in src and "tenant_id" in src
@@ -114,7 +117,7 @@ def test_tc_cc_004_get_tenant_session_validates_uuid_before_set_local() -> None:
 def test_tc_cc_004_rls_policy_uses_current_setting() -> None:
     """RLS policies must filter on
     ``current_setting('agenticorg.tenant_id', true)`` — the
-    same key the session-open SET LOCAL writes. Mismatched
+    same key the session-open set_config call writes. Mismatched
     keys silently disable RLS without anyone noticing."""
     src = (REPO / "core" / "database.py").read_text(encoding="utf-8")
     assert "current_setting('agenticorg.tenant_id', true)" in src
@@ -227,13 +230,15 @@ def test_tc_cc_010_audit_event_type_uses_bind_parameter_not_concat() -> None:
     assert 'f"DELETE' not in src
 
 
-def test_tc_cc_010_set_local_uuid_validation_is_defense_in_depth() -> None:
-    """Cross-pin with TC-CC-004: the one place we DO interpolate
-    SQL (SET LOCAL agenticorg.tenant_id) is gated by a UUID
-    regex. This is defense-in-depth on top of the JWT-supplied
-    tenant_id."""
+def test_tc_cc_010_tenant_context_uses_bind_parameter_with_uuid_validation() -> None:
+    """Cross-pin with TC-CC-004: tenant context setup binds the
+    tenant_id value and keeps UUID validation as defense-in-depth
+    on top of the JWT-supplied tenant_id."""
     src = (REPO / "core" / "database.py").read_text(encoding="utf-8")
-    assert "defense-in-depth" in src.lower() or "regex above" in src.lower()
+    assert "set_config('agenticorg.tenant_id', :tenant_id, true)" in src
+    assert '{"tenant_id": tid_str}' in src
+    assert "SET LOCAL agenticorg.tenant_id = '" not in src
+    assert "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" in src
 
 
 # ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Replace interpolated tenant RLS SQL with parameterized `set_config('agenticorg.tenant_id', :tenant_id, true)`.
- Keep UUID-format validation before setting tenant context.
- Add security regression coverage proving the tenant ID is passed as a bind parameter and malicious tenant strings are rejected before execution.

## Root Cause
CodeQL alert #95 (`py/sql-injection`) flagged `core/database.py` because tenant context was embedded into a SQL text string before calling `session.execute(text(...))`. The UUID validation reduced practical exploitability, but the safer implementation is to avoid SQL interpolation entirely.

## Validation
- `python -m pytest tests\security\test_database_tenant_context_sql_safety.py tests\unit\test_auth_and_core.py::TestGetTenantSession`
- `python -m ruff check core\database.py tests\security\test_database_tenant_context_sql_safety.py tests\unit\test_auth_and_core.py`