### PR TITLE
feat: add CMO vendor sandbox connector setup

### DIFF
--- a/api/v1/connectors.py
+++ b/api/v1/connectors.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
@@ -23,6 +24,115 @@ from core.models.connector import Connector
 from core.schemas.api import ConnectorCreate, ConnectorUpdate
 
 _log = logging.getLogger(__name__)
+
+_CMO_SANDBOX_CATEGORIES = ("CRM", "Ads", "Analytics", "Email")
+_CMO_SECRET_KEY_MARKERS = (
+    "secret",
+    "token",
+    "password",
+    "credential",
+    "api_key",
+    "authorization",
+)
+_CMO_PLACEHOLDER_MARKERS = (
+    "REAL_",
+    "PLACEHOLDER",
+    "TODO",
+    "CHANGEME",
+    "REPLACE_ME",
+    "example.com",
+)
+_CMO_VENDOR_SANDBOX_PROVIDERS: dict[str, dict[str, dict[str, Any]]] = {
+    "CRM": {
+        "hubspot": {
+            "aliases": ("hubspot", "hubspot_sandbox"),
+            "display_name": "HubSpot Sandbox",
+            "auth_type": "oauth2",
+            "required_credentials": ("access_token",),
+        },
+        "salesforce": {
+            "aliases": ("salesforce", "salesforce_sandbox"),
+            "display_name": "Salesforce Sandbox",
+            "auth_type": "oauth2",
+            "required_credentials": (
+                "instance_url",
+                "refresh_token",
+                "client_id",
+                "client_secret",
+            ),
+        },
+    },
+    "Ads": {
+        "google_ads": {
+            "aliases": ("google_ads", "google_ads_sandbox"),
+            "display_name": "Google Ads Test Customer",
+            "auth_type": "oauth2",
+            "required_credentials": (
+                "developer_token",
+                "refresh_token",
+                "customer_id",
+                "client_id",
+                "client_secret",
+            ),
+        },
+        "meta_ads": {
+            "aliases": ("meta_ads", "meta_ads_sandbox"),
+            "display_name": "Meta Ads Sandbox",
+            "auth_type": "oauth2",
+            "required_credentials": ("access_token", "ad_account_id"),
+        },
+        "linkedin_ads": {
+            "aliases": ("linkedin_ads", "linkedin_ads_sandbox"),
+            "display_name": "LinkedIn Ads Sandbox",
+            "auth_type": "oauth2",
+            "required_credentials": (
+                "refresh_token",
+                "account_id",
+                "client_id",
+                "client_secret",
+            ),
+        },
+    },
+    "Analytics": {
+        "ga4": {
+            "aliases": ("ga4", "ga4_sandbox"),
+            "display_name": "GA4 Sandbox Property",
+            "auth_type": "oauth2",
+            "required_credentials": (
+                "property_id",
+                "refresh_token",
+                "client_id",
+                "client_secret",
+            ),
+        },
+    },
+    "Email": {
+        "sendgrid": {
+            "aliases": ("sendgrid", "sendgrid_sandbox"),
+            "display_name": "SendGrid Sandbox",
+            "auth_type": "api_key",
+            "required_credentials": ("api_key", "sender_identity"),
+        },
+        "mailchimp": {
+            "aliases": ("mailchimp", "mailchimp_sandbox"),
+            "display_name": "Mailchimp Test Account",
+            "auth_type": "api_key",
+            "required_credentials": ("api_key", "server_prefix", "audience_id"),
+        },
+    },
+}
+
+
+class CMOVendorSandboxConnectorInput(BaseModel):
+    connector_name: str
+    display_name: str | None = None
+    auth_type: str | None = None
+    credentials: dict[str, Any] = Field(default_factory=dict)
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+class CMOVendorSandboxConnectorsRequest(BaseModel):
+    connectors: dict[str, CMOVendorSandboxConnectorInput] = Field(default_factory=dict)
 
 _ZOHO_IN_BASE = "https://books.zoho.in/api/v3"
 _ZOHO_GLOBAL_BASE = "https://www.zohoapis.com/books/v3"
@@ -130,6 +240,124 @@ def _clean_auth_config(auth_config: dict[str, Any] | None) -> dict[str, Any]:
         else:
             cleaned[str(key)] = value
     return cleaned
+
+
+def _normalise_cmo_sandbox_category(value: Any) -> str | None:
+    text = str(value or "").strip().lower().replace("_", " ")
+    for category in _CMO_SANDBOX_CATEGORIES:
+        if text == category.lower():
+            return category
+    return None
+
+
+def _cmo_provider_for(category: str, connector_name: str) -> tuple[str, dict[str, Any]] | None:
+    normalized = str(connector_name or "").strip().lower().replace("-", "_")
+    for canonical, provider in _CMO_VENDOR_SANDBOX_PROVIDERS[category].items():
+        aliases = {str(alias).lower().replace("-", "_") for alias in provider["aliases"]}
+        if normalized in aliases or normalized == canonical:
+            return canonical, provider
+    return None
+
+
+def _cmo_safe_non_secret_config(config: dict[str, Any] | None) -> dict[str, Any]:
+    safe: dict[str, Any] = {}
+    for key, value in (config or {}).items():
+        if _cmo_is_secret_key(str(key)):
+            continue
+        if isinstance(value, dict | list):
+            continue
+        if value is None:
+            continue
+        safe[str(key)] = value
+    return safe
+
+
+def _cmo_is_secret_key(key: str) -> bool:
+    normalized = key.lower().replace("-", "_")
+    return any(marker in normalized for marker in _CMO_SECRET_KEY_MARKERS)
+
+
+def _cmo_looks_placeholder(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    text = value.strip()
+    if not text:
+        return True
+    upper = text.upper()
+    return any(marker.upper() in upper for marker in _CMO_PLACEHOLDER_MARKERS)
+
+
+def _cmo_vendor_sandbox_config(
+    category: str,
+    connector_name: str,
+    raw_config: dict[str, Any],
+    credentials: dict[str, Any],
+) -> dict[str, Any]:
+    public_identifiers = {
+        key: credentials[key]
+        for key in (
+            "account_id",
+            "ad_account_id",
+            "audience_id",
+            "customer_id",
+            "instance_url",
+            "property_id",
+            "sender_identity",
+            "server_prefix",
+        )
+        if credentials.get(key)
+    }
+    return {
+        **public_identifiers,
+        **_cmo_safe_non_secret_config(raw_config),
+        "cmo_category": category,
+        "connector_provider": connector_name,
+        "proof_scope": "vendor_sandbox",
+        "environment_type": "vendor_sandbox",
+        "local_test_only": False,
+        "mock_or_test_double": False,
+        "sandbox_preflight_ready": True,
+        "configured_by": "ui:cmo_vendor_sandbox_connectors",
+        "configured_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def _cmo_connector_readiness(row: Any) -> tuple[str, str | None]:
+    config = row.config or {}
+    status = str(row.status or "").lower()
+    health = str(row.health_status or "").lower()
+    if status not in {"active", "configured", "connected", "healthy", "ok", "ready"}:
+        return "blocked", "status_not_ready"
+    if health not in {"", "active", "configured", "connected", "healthy", "ok", "ready", "unknown"}:
+        return "blocked", "health_not_ready"
+    if config.get("local_test_only") is True:
+        return "blocked", "local_test_only"
+    if config.get("mock_or_test_double") is True:
+        return "blocked", "mock_or_test_double"
+    if config.get("proof_scope") != "vendor_sandbox":
+        return "blocked", "not_vendor_sandbox"
+    if config.get("environment_type") != "vendor_sandbox":
+        return "blocked", "not_vendor_sandbox"
+    return "ready", None
+
+
+def _cmo_connector_summary(category: str, row: Any) -> dict[str, Any]:
+    readiness, reason = _cmo_connector_readiness(row)
+    return {
+        "category": category,
+        "connector_name": str(row.connector_name or ""),
+        "display_name": str(row.display_name or row.connector_name or ""),
+        "source": "db",
+        "readiness_state": readiness,
+        "missing_reason": reason,
+        "status": str(row.status or ""),
+        "health_status": str(row.health_status or "unknown"),
+        "proof_scope": (row.config or {}).get("proof_scope"),
+        "environment_type": (row.config or {}).get("environment_type"),
+        "local_test_only": bool((row.config or {}).get("local_test_only")),
+        "mock_or_test_double": bool((row.config or {}).get("mock_or_test_double")),
+        "credential_values_redacted": True,
+    }
 
 
 def _prepare_zoho_books_registration(
@@ -786,6 +1014,247 @@ async def register_connector(
             await session.flush()
 
     return _connector_to_dict(connector, bool(secret_fields))
+
+
+@router.get("/connectors/cmo-vendor-sandbox")
+@route_meta(
+    auth_required=True,
+    tenant_required=True,
+    scope="connectors.read",
+    rate_limit="standard",
+    idempotency="read-only",
+    audit_event="connectors.cmo_vendor_sandbox.read",
+)
+async def get_cmo_vendor_sandbox_connectors(
+    tenant_id: str = Depends(get_current_tenant),
+):
+    from core.models.connector_config import ConnectorConfig
+
+    tid = _uuid.UUID(tenant_id)
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(ConnectorConfig).where(ConnectorConfig.tenant_id == tid)
+        )
+        rows = result.scalars().all()
+
+    by_category: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        category = _normalise_cmo_sandbox_category((row.config or {}).get("cmo_category"))
+        if category is None:
+            continue
+        summary = _cmo_connector_summary(category, row)
+        existing = by_category.get(category)
+        if existing is None or (
+            summary["readiness_state"] == "ready"
+            and existing.get("readiness_state") != "ready"
+        ):
+            by_category[category] = summary
+
+    return {
+        "status": "ready"
+        if all(category in by_category for category in _CMO_SANDBOX_CATEGORIES)
+        else "blocked",
+        "categories": [
+            by_category[category]
+            for category in _CMO_SANDBOX_CATEGORIES
+            if category in by_category
+        ],
+        "missing_categories": [
+            category for category in _CMO_SANDBOX_CATEGORIES if category not in by_category
+        ],
+        "providers": {
+            category: [
+                {
+                    "connector_name": canonical,
+                    "display_name": str(provider["display_name"]),
+                    "auth_type": str(provider["auth_type"]),
+                    "required_credentials": list(provider["required_credentials"]),
+                }
+                for canonical, provider in providers.items()
+            ]
+            for category, providers in _CMO_VENDOR_SANDBOX_PROVIDERS.items()
+        },
+    }
+
+
+@router.post("/connectors/cmo-vendor-sandbox")
+@route_meta(
+    auth_required=True,
+    tenant_required=True,
+    scope="connectors.create",
+    rate_limit="admin-mutating",
+    idempotency="tenant-cmo-vendor-sandbox-upsert",
+    audit_event="connectors.cmo_vendor_sandbox.upsert",
+)
+async def upsert_cmo_vendor_sandbox_connectors(
+    body: CMOVendorSandboxConnectorsRequest,
+    tenant_id: str = Depends(get_current_tenant),
+):
+    from core.crypto import encrypt_for_tenant
+    from core.models.connector_config import ConnectorConfig
+
+    tid = _uuid.UUID(tenant_id)
+    inputs_by_category: dict[str, CMOVendorSandboxConnectorInput] = {}
+    for raw_category, connector_input in body.connectors.items():
+        category = _normalise_cmo_sandbox_category(raw_category)
+        if category is None:
+            raise HTTPException(400, f"Unsupported CMO connector category: {raw_category}")
+        inputs_by_category[category] = connector_input
+
+    missing_categories = [
+        category for category in _CMO_SANDBOX_CATEGORIES if category not in inputs_by_category
+    ]
+    if missing_categories:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "missing_cmo_vendor_sandbox_categories",
+                "missing_categories": missing_categories,
+                "message": "Configure exactly one CRM, Ads, Analytics, and Email sandbox connector.",
+            },
+        )
+
+    prepared: dict[str, dict[str, Any]] = {}
+    for category in _CMO_SANDBOX_CATEGORIES:
+        connector_input = inputs_by_category[category]
+        provider_match = _cmo_provider_for(category, connector_input.connector_name)
+        if provider_match is None:
+            allowed = sorted(_CMO_VENDOR_SANDBOX_PROVIDERS[category])
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "unsupported_cmo_vendor_sandbox_provider",
+                    "category": category,
+                    "allowed": allowed,
+                    "message": f"Unsupported {category} provider.",
+                },
+            )
+        connector_name, provider = provider_match
+        credentials = _clean_auth_config(connector_input.credentials)
+        missing_credentials = [
+            name
+            for name in provider["required_credentials"]
+            if not credentials.get(name)
+        ]
+        placeholder_credentials = [
+            name
+            for name in provider["required_credentials"]
+            if _cmo_looks_placeholder(credentials.get(name))
+        ]
+        if missing_credentials or placeholder_credentials:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "invalid_cmo_vendor_sandbox_credentials",
+                    "category": category,
+                    "connector_name": connector_name,
+                    "missing_credentials": missing_credentials,
+                    "placeholder_credentials": placeholder_credentials,
+                    "message": "Real vendor-sandbox credential values are required.",
+                },
+            )
+        auth_type = connector_input.auth_type or str(provider["auth_type"])
+        prepared[category] = {
+            "connector_name": connector_name,
+            "display_name": connector_input.display_name or str(provider["display_name"]),
+            "auth_type": auth_type,
+            "credentials": credentials,
+            "config": _cmo_vendor_sandbox_config(
+                category,
+                connector_name,
+                connector_input.config,
+                credentials,
+            ),
+        }
+
+    summaries: list[dict[str, Any]] = []
+    async with get_tenant_session(tid) as session:
+        for category in _CMO_SANDBOX_CATEGORIES:
+            row = prepared[category]
+            encrypted = await encrypt_for_tenant(
+                json.dumps(row["credentials"], sort_keys=True),
+                tid,
+            )
+
+            connector_result = await session.execute(
+                select(Connector).where(
+                    Connector.tenant_id == tid,
+                    Connector.name == row["connector_name"],
+                )
+            )
+            connector = connector_result.scalar_one_or_none()
+            if connector is None:
+                session.add(
+                    Connector(
+                        tenant_id=tid,
+                        name=row["connector_name"],
+                        category="marketing",
+                        auth_type=row["auth_type"],
+                        auth_config={},
+                        status="active",
+                        description=row["display_name"],
+                    )
+                )
+            else:
+                connector.category = "marketing"
+                connector.auth_type = row["auth_type"]
+                connector.auth_config = {}
+                connector.status = "active"
+                connector.description = row["display_name"]
+
+            config_result = await session.execute(
+                select(ConnectorConfig).where(
+                    ConnectorConfig.tenant_id == tid,
+                    ConnectorConfig.connector_name == row["connector_name"],
+                )
+            )
+            existing = config_result.scalar_one_or_none()
+            action = "updated" if existing is not None else "inserted"
+            if existing is None:
+                session.add(
+                    ConnectorConfig(
+                        tenant_id=tid,
+                        connector_name=row["connector_name"],
+                        display_name=row["display_name"],
+                        auth_type=row["auth_type"],
+                        credentials_encrypted={"_encrypted": encrypted},
+                        config=row["config"],
+                        status="configured",
+                        health_status="healthy",
+                    )
+                )
+            else:
+                existing.display_name = row["display_name"]
+                existing.auth_type = row["auth_type"]
+                existing.credentials_encrypted = {"_encrypted": encrypted}
+                existing.config = row["config"]
+                existing.status = "configured"
+                existing.health_status = "healthy"
+                existing.sync_error = None
+            summaries.append(
+                {
+                    "category": category,
+                    "connector_name": row["connector_name"],
+                    "display_name": row["display_name"],
+                    "action": action,
+                    "source": "db",
+                    "readiness_state": "ready",
+                    "credential_keys_present": sorted(row["credentials"]),
+                    "credential_values_redacted": True,
+                    "proof_scope": "vendor_sandbox",
+                    "environment_type": "vendor_sandbox",
+                    "local_test_only": False,
+                    "mock_or_test_double": False,
+                }
+            )
+        await session.commit()
+
+    return {
+        "status": "ready",
+        "message": "CMO vendor-sandbox ConnectorConfig rows configured.",
+        "categories": summaries,
+        "missing_categories": [],
+    }
 
 
 # ── GET /connectors/{conn_id} ────────────────────────────────────────────────

--- a/api/v1/kpis.py
+++ b/api/v1/kpis.py
@@ -13,13 +13,38 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.exc import SQLAlchemyError
 
 from api.deps import get_current_tenant
 from api.route_metadata import route_meta
+from core.config import is_strict_runtime_env, settings
 from core.database import get_tenant_session
 from core.kpi_cache import KPICache
+from core.marketing.approval_review import build_cmo_approval_review_projection
+from core.marketing.approval_timeouts import build_approval_timeout_risk
+from core.marketing.connector_contracts import (
+    build_marketing_connector_contracts,
+    summarize_marketing_connector_contracts,
+)
+from core.marketing.connector_setup import (
+    build_marketing_connector_setup,
+    marketing_connector_keys,
+    summarize_marketing_connector_setup,
+)
+from core.marketing.data_readiness import build_marketing_data_readiness
+from core.marketing.decision_audit import build_marketing_decision_audit_projection
+from core.marketing.escalation_matrix import build_marketing_escalation_projection
+from core.marketing.kpi_drilldown import build_cmo_kpi_drilldown_projection
+from core.marketing.kpi_schema import build_unified_cmo_kpi_projection, collect_cmo_kpi_facts
+from core.marketing.pilot_proof import build_cmo_pilot_proof_projection
+from core.marketing.policy_manifest import build_marketing_policy_projection
+from core.marketing.report_quality import build_cmo_report_quality_projection
+from core.marketing.weekly_report_pilot_proof import (
+    build_weekly_marketing_report_proof_projection,
+)
+from core.marketing.work_queue import build_cmo_work_queue_projection
+from core.marketing.workflow_activation import build_cmo_workflow_activation
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -459,6 +484,384 @@ async def _build_kpi_response(
     }
 
 
+async def _load_marketing_connector_configs(tenant_id: str) -> list[Any]:
+    """Load marketing ConnectorConfig rows for CMO readiness projections."""
+
+    from core.models.connector_config import ConnectorConfig
+
+    connector_keys = marketing_connector_keys()
+    try:
+        async with get_tenant_session(tenant_id) as session:
+            rows = (
+                await session.execute(
+                    select(ConnectorConfig).where(
+                        ConnectorConfig.tenant_id == tenant_id,
+                        ConnectorConfig.connector_name.in_(connector_keys)
+                    )
+                )
+            ).scalars().all()
+    except SQLAlchemyError:
+        logger.debug("cmo_connector_setup_query_failed", exc_info=True)
+        return []
+    return list(rows)
+
+
+async def _load_latest_weekly_report_pilot_proof(
+    tenant_id: str, company_id: str | None
+) -> dict[str, Any] | None:
+    """Load the most recent persisted weekly-report pilot proof for the tenant.
+
+    Returns ``None`` when no row exists or the DB query fails — the
+    caller falls back to exposing only the ad-hoc CMO-PROD-1 projection.
+    """
+
+    try:
+        from core.marketing.weekly_report_pilot_persistence import (
+            latest_weekly_report_pilot_proof,
+            serialize_persisted_proof,
+            summarize_persisted_proof,
+        )
+    except ImportError:
+        return None
+
+    try:
+        async with get_tenant_session(tenant_id) as session:
+            row = await latest_weekly_report_pilot_proof(
+                session,
+                tenant_id=tenant_id,
+                company_id=company_id if company_id and company_id != "default" else None,
+            )
+    except SQLAlchemyError:
+        logger.debug("cmo_weekly_report_pilot_proof_query_failed", exc_info=True)
+        return None
+    # enterprise-gate: broad-except-ok reason=missing-table-pre-migration-returns-no-pilot-proof
+    except Exception:  # noqa: BLE001
+        logger.debug("cmo_weekly_report_pilot_proof_lookup_failed", exc_info=True)
+        return None
+    if row is None:
+        return None
+    return {
+        "latest_weekly_report_pilot_proof": serialize_persisted_proof(row),
+        "latest_weekly_report_pilot_proof_summary": summarize_persisted_proof(row),
+    }
+
+
+async def _load_marketing_connector_setup(tenant_id: str) -> list[dict[str, Any]]:
+    """Load CMO connector setup states from existing ConnectorConfig rows."""
+
+    rows = await _load_marketing_connector_configs(tenant_id)
+    return build_marketing_connector_setup(rows)
+
+
+async def _load_cmo_approval_timeout_risk(
+    tenant_id: str,
+    company_id: str | None = None,
+) -> dict[str, Any]:
+    """Project pending marketing HITL approvals into timeout risk state."""
+
+    from core.models.agent import Agent
+    from core.models.hitl import HITLQueue
+
+    company_uuid = _parse_company_uuid(company_id)
+    try:
+        async with get_tenant_session(tenant_id) as session:
+            query = (
+                select(HITLQueue, Agent)
+                .join(Agent, Agent.id == HITLQueue.agent_id)
+                .where(
+                    HITLQueue.tenant_id == tenant_id,
+                    HITLQueue.status == "pending",
+                    Agent.domain.in_(["marketing", "content", "sales"]),
+                )
+            )
+            if company_uuid is not None:
+                query = query.where(Agent.company_id == company_uuid)
+            rows = (await session.execute(query)).all()
+    except SQLAlchemyError:
+        logger.debug("cmo_approval_timeout_risk_query_failed", exc_info=True)
+        return build_approval_timeout_risk([])
+
+    approvals: list[dict[str, Any]] = []
+    for item, agent in rows:
+        context = item.context if isinstance(item.context, dict) else {}
+        approvals.append(
+            {
+                **context,
+                "approval_id": str(item.id),
+                "title": item.title,
+                "workflow_run_id": str(item.workflow_run_id) if item.workflow_run_id else None,
+                "workflow_id": context.get("workflow_id"),
+                "step_id": context.get("step_id"),
+                "action": (
+                    context.get("approval_action")
+                    or context.get("action")
+                    or context.get("blocked_action")
+                    or item.trigger_type
+                ),
+                "approval_type": context.get("approval_type"),
+                "requested_approver": context.get("requested_approver"),
+                "requested_approver_role": item.assignee_role,
+                "agent_id": str(agent.id),
+                "agent_type": agent.agent_type,
+                "assignee_role": item.assignee_role,
+                "decision_options": item.decision_options,
+                "status": item.status,
+                "created_at": item.created_at,
+                "due_at": item.expires_at,
+            }
+        )
+    risk = build_approval_timeout_risk(approvals)
+    risk["approval_records"] = approvals
+    return risk
+
+
+def _attach_approval_review_refs(
+    approval_timeout_risk: dict[str, Any],
+    approval_reviews: list[dict[str, Any]],
+) -> None:
+    """Link timeout-risk decisions to their richer CMO approval review rows."""
+
+    by_approval_id = {
+        str(review.get("approval_id")): review
+        for review in approval_reviews
+        if review.get("approval_id")
+    }
+    for decision in approval_timeout_risk.get("approval_timeout_decisions") or []:
+        if not isinstance(decision, dict):
+            continue
+        review = by_approval_id.get(str(decision.get("approval_id")))
+        if not review:
+            continue
+        decision["approval_review_id"] = review.get("approval_review_id")
+        decision["approval_review_status"] = review.get("status")
+
+
+def _apply_cmo_production_data_policy(
+    base: dict[str, Any],
+    connector_summary: dict[str, int | bool | str],
+    kpi_readiness: dict[str, Any] | None = None,
+    connector_contract_summary: dict[str, Any] | None = None,
+    *,
+    strict_runtime: bool,
+) -> dict[str, Any]:
+    """Prevent strict-runtime CMO paths from presenting demo KPI fallback."""
+
+    if not strict_runtime:
+        return base
+
+    readiness = str(connector_summary.get("readiness") or "")
+    kpi_status = str((kpi_readiness or {}).get("status") or "")
+    contract_readiness = str((connector_contract_summary or {}).get("readiness") or "")
+    mock_or_test_double = int((connector_contract_summary or {}).get("mock_or_test_double") or 0)
+    blocked_by_readiness = kpi_status == "blocked" or contract_readiness == "blocked" or mock_or_test_double > 0
+    degraded_by_readiness = kpi_status == "degraded" or contract_readiness == "degraded"
+
+    if base.get("demo") or blocked_by_readiness:
+        data_coverage_status = "blocked_mapping_or_backfill"
+        if base.get("demo"):
+            data_coverage_status = "blocked_setup" if readiness != "ready" else "empty_real_data"
+        return {
+            **base,
+            "demo": False,
+            "demo_suppressed": bool(base.get("demo")),
+            "production_data_blocked": True,
+            "kpi_confidence_status": "blocked",
+            "data_coverage_status": data_coverage_status,
+            "source": "empty_real_tenant" if base.get("demo") else base.get("source"),
+            "message": (
+                "CMO KPI readiness is blocked for this production tenant. "
+                "Configure connectors, complete field mappings, and finish "
+                "historical backfill with production connector contracts before "
+                "treating these KPIs as production-ready."
+            ),
+        }
+
+    if degraded_by_readiness:
+        return {
+            **base,
+            "production_data_blocked": False,
+            "kpi_confidence_status": "degraded",
+            "data_coverage_status": "degraded_mapping_or_backfill",
+            "message": (
+                "CMO KPI readiness is degraded because mappings or historical "
+                "backfill or connector contracts are incomplete. Treat KPI "
+                "values as directional."
+            ),
+        }
+
+    return {
+        **base,
+        "production_data_blocked": False,
+        "kpi_confidence_status": "ready",
+    }
+
+
+async def _build_cmo_kpi_response(tenant_id: str, company_id: str) -> dict[str, Any]:
+    base = await _build_kpi_response(tenant_id, "cmo", company_id)
+    connector_configs = await _load_marketing_connector_configs(tenant_id)
+    connector_setup = build_marketing_connector_setup(connector_configs)
+    connector_summary = summarize_marketing_connector_setup(connector_setup)
+    connector_contracts = build_marketing_connector_contracts(
+        connector_setup,
+        connector_configs,
+    )
+    connector_contract_summary = summarize_marketing_connector_contracts(connector_contracts)
+    data_readiness = build_marketing_data_readiness(
+        connector_setup,
+        connector_configs,
+        connector_contracts=connector_contracts,
+    )
+    workflow_activation = build_cmo_workflow_activation(
+        connector_setup,
+        data_readiness,
+        connector_configs,
+        connector_contracts=connector_contracts,
+    )
+    policy_projection = build_marketing_policy_projection(connector_configs)
+    escalation_projection = build_marketing_escalation_projection(connector_configs)
+    decision_audit_projection = build_marketing_decision_audit_projection(connector_configs)
+    unified_kpi_projection = build_unified_cmo_kpi_projection(
+        connector_setup=connector_setup,
+        data_readiness=data_readiness,
+        connector_contracts=connector_contracts,
+        connector_configs=connector_configs,
+    )
+    approval_timeout_risk = await _load_cmo_approval_timeout_risk(tenant_id, company_id)
+    approval_review_projection = build_cmo_approval_review_projection(
+        approval_timeout_risk.get("approval_records") or [],
+        connector_contracts=connector_contracts,
+        policy_projection=policy_projection,
+        escalation_projection=escalation_projection,
+        decision_audit_projection=decision_audit_projection,
+        approval_timeout_risk=approval_timeout_risk,
+    )
+    _attach_approval_review_refs(
+        approval_timeout_risk,
+        approval_review_projection["cmo_approval_reviews"],
+    )
+    base = _apply_cmo_production_data_policy(
+        base,
+        connector_summary,
+        data_readiness["kpi_readiness"],
+        connector_contract_summary,
+        strict_runtime=is_strict_runtime_env(settings.env),
+    )
+    report_quality_projection = build_cmo_report_quality_projection(
+        kpi_results=unified_kpi_projection["unified_cmo_kpi_results"],
+        reconciliation_checks=unified_kpi_projection["cmo_kpi_reconciliation_checks"],
+        connector_setup=connector_setup,
+        data_readiness=data_readiness,
+        connector_contracts=connector_contracts,
+        workflow_activation=workflow_activation,
+        policy_projection=policy_projection,
+        escalation_projection=escalation_projection,
+        decision_audit_projection=decision_audit_projection,
+        source_context=base,
+        production_tenant=is_strict_runtime_env(settings.env),
+    )
+    work_queue_projection = build_cmo_work_queue_projection(
+        approval_timeout_risk=approval_timeout_risk,
+        escalation_projection=escalation_projection,
+        connector_setup=connector_setup,
+        connector_contracts=connector_contracts,
+        data_readiness=data_readiness,
+        workflow_activation=workflow_activation,
+        policy_projection=policy_projection,
+        decision_audit_projection=decision_audit_projection,
+        source_context={**base, **approval_review_projection},
+        kpi_results=unified_kpi_projection["unified_cmo_kpi_results"],
+        reconciliation_checks=unified_kpi_projection["cmo_kpi_reconciliation_checks"],
+        report_quality_gates=report_quality_projection["report_quality_gates"],
+    )
+    kpi_source_facts = collect_cmo_kpi_facts(connector_configs=connector_configs)
+    kpi_drilldown_projection = build_cmo_kpi_drilldown_projection(
+        kpi_schema=unified_kpi_projection["unified_cmo_kpi_schema"],
+        kpi_results=unified_kpi_projection["unified_cmo_kpi_results"],
+        reconciliation_checks=unified_kpi_projection["cmo_kpi_reconciliation_checks"],
+        connector_setup=connector_setup,
+        data_readiness=data_readiness,
+        connector_contracts=connector_contracts,
+        work_queue=work_queue_projection["cmo_work_queue"],
+        report_quality_gates=report_quality_projection["report_quality_gates"],
+        source_data=kpi_source_facts,
+        source_context=base,
+    )
+    weekly_report_proof_projection = build_weekly_marketing_report_proof_projection(
+        {
+            "tenant_id": tenant_id,
+            "company_id": company_id,
+            "environment_type": base.get("cmo_pilot_environment_type")
+            or base.get("pilot_environment_type")
+            or base.get("environment_type"),
+            "connector_evidence": connector_setup,
+            "mapping_evidence": data_readiness.get("field_mapping_status") or [],
+            "backfill_evidence": data_readiness.get("backfill_status") or [],
+            "kpi_results": unified_kpi_projection["unified_cmo_kpi_results"],
+            "reconciliation_checks": unified_kpi_projection["cmo_kpi_reconciliation_checks"],
+            "report_quality_gates": report_quality_projection["report_quality_gates"],
+            "report_artifact_refs": base.get("weekly_report_artifact_refs")
+            or base.get("report_artifact_refs")
+            or [],
+            "decision_audit_refs": base.get("weekly_report_audit_refs")
+            or base.get("decision_audit_refs")
+            or [],
+            "source_refs": base.get("weekly_report_source_refs") or [],
+            "source_context": base,
+        },
+    )
+    pilot_proof_projection = build_cmo_pilot_proof_projection(
+        tenant_id=tenant_id,
+        company_id=company_id,
+        source_context=base,
+        connector_setup=connector_setup,
+        connector_contracts=connector_contracts,
+        data_readiness=data_readiness,
+        workflow_activation=workflow_activation,
+        workflow_lint_results=base.get("workflow_lint_results") or base.get("marketing_workflow_lint_results") or [],
+        policy_projection=policy_projection,
+        escalation_projection=escalation_projection,
+        approval_timeout_risk=approval_timeout_risk,
+        external_write_results=base.get("external_write_results") or base.get("marketing_external_write_results") or [],
+        decision_audit_projection=decision_audit_projection,
+        kpi_schema=unified_kpi_projection["unified_cmo_kpi_schema"],
+        kpi_results=unified_kpi_projection["unified_cmo_kpi_results"],
+        reconciliation_checks=unified_kpi_projection["cmo_kpi_reconciliation_checks"],
+        report_quality_gates=report_quality_projection["report_quality_gates"],
+        work_queue=work_queue_projection["cmo_work_queue"],
+        kpi_drilldowns=kpi_drilldown_projection["cmo_kpi_drilldowns"],
+        approval_review_projection=approval_review_projection,
+        agent_contracts=base.get("marketing_agent_contracts") or base.get("agent_contracts") or [],
+        scenario_evidence=base.get("cmo_scenario_evidence") or [],
+        chaos_evidence=base.get("cmo_chaos_evidence") or [],
+    )
+    latest_weekly_report_persisted = await _load_latest_weekly_report_pilot_proof(
+        tenant_id, company_id
+    )
+    response: dict[str, Any] = {
+        **base,
+        "connector_setup": connector_setup,
+        "connector_setup_summary": connector_summary,
+        "connector_contracts": connector_contracts,
+        "connector_contract_summary": connector_contract_summary,
+        **data_readiness,
+        **policy_projection,
+        **escalation_projection,
+        **decision_audit_projection,
+        **unified_kpi_projection,
+        **report_quality_projection,
+        **approval_review_projection,
+        **work_queue_projection,
+        **kpi_drilldown_projection,
+        **pilot_proof_projection,
+        **weekly_report_proof_projection,
+        **workflow_activation,
+        "approval_timeout_risk": approval_timeout_risk,
+    }
+    if latest_weekly_report_persisted is not None:
+        response.update(latest_weekly_report_persisted)
+    return response
+
+
 # ── CEO KPIs ───────────────────────────────────────────────────────────
 
 @router.get("/kpis/ceo")
@@ -557,7 +960,7 @@ async def get_cmo_kpis(
     company_id: str = Query("default", description="Multi-company selector"),
 ):
     """Marketing KPIs for the CMO executive dashboard."""
-    return await _build_kpi_response(tenant_id, "cmo", company_id)
+    return await _build_cmo_kpi_response(tenant_id, company_id)
 
 
 # ── COO KPIs ───────────────────────────────────────────────────────────

--- a/core/agents/__init__.py
+++ b/core/agents/__init__.py
@@ -28,11 +28,14 @@ from core.agents.hr import (
 
 # Marketing agents
 from core.agents.marketing import (
+    abm_agent,  # noqa: F401
     brand_monitor,  # noqa: F401
     campaign_pilot,  # noqa: F401
+    competitive_intel,  # noqa: F401
     content_factory,  # noqa: F401
     crm_intelligence,  # noqa: F401
     seo_strategist,  # noqa: F401
+    social_media,  # noqa: F401
 )
 
 # Ops agents

--- a/core/agents/marketing/abm_agent.py
+++ b/core/agents/marketing/abm_agent.py
@@ -1,0 +1,1208 @@
+"""Account-Based Marketing agent implementation."""
+
+from __future__ import annotations
+
+import csv
+import io
+import time
+import uuid
+from typing import Any
+
+import structlog
+
+from core.agents.base import BaseAgent
+from core.agents.registry import AgentRegistry
+from core.marketing.escalation_matrix import evaluate_marketing_escalation
+from core.marketing.policy_manifest import evaluate_marketing_policy
+from core.schemas.messages import (
+    DecisionOption,
+    DecisionRequired,
+    HITLAssignee,
+    HITLContext,
+    HITLRequest,
+    ToolCallRecord,
+)
+
+logger = structlog.get_logger()
+
+ABM_AGENT_MATURITY = "beta"
+ABM_CONFIDENCE_FLOOR = 0.83
+
+DEFAULT_SOURCE_WEIGHTS = {
+    "bombora": 0.40,
+    "g2": 0.25,
+    "trustradius": 0.25,
+    "crm": 0.10,
+}
+READ_ONLY_ACTIONS = {
+    "account_scoring",
+    "aggregate_engagement",
+    "aggregate_intent",
+    "csv_account_ingest_validation",
+    "icp_fit_scoring",
+    "intent_heat_scoring",
+    "next_best_action",
+    "query_target_accounts",
+    "recommend_next_best_action",
+    "score_accounts",
+    "score_icp_fit",
+    "score_intent_heat",
+    "validate_account_csv",
+}
+WRITE_ACTIONS = {
+    "create_abm_campaign",
+    "launch_abm_campaign",
+    "set_abm_budget",
+    "sync_target_accounts",
+    "target_account_list_change",
+    "update_target_accounts",
+}
+SHADOW_MODES = {"shadow", "draft", "internal", "internal_only", "recommendation", "simulation"}
+TARGET_ACCOUNT_WRITE_ACTIONS = {"sync_target_accounts", "target_account_list_change", "update_target_accounts"}
+BUDGET_WRITE_ACTIONS = {"create_abm_campaign", "launch_abm_campaign", "set_abm_budget"}
+
+
+@AgentRegistry.register
+class ABMAgent(BaseAgent):
+    agent_type = "abm"
+    domain = "marketing"
+    confidence_floor = ABM_CONFIDENCE_FLOOR
+    prompt_file = "abm_agent.prompt.txt"
+
+    async def execute(self, task):
+        """Run deterministic ABM scoring, validation, planning, or guarded writes."""
+
+        start = time.monotonic()
+        trace: list[str] = []
+        tool_calls: list[ToolCallRecord] = []
+        msg_id = f"msg_{uuid.uuid4().hex[:12]}"
+
+        try:
+            inputs = _task_inputs(task)
+            action = _normalize_action(_task_action(task))
+            mode = _workflow_mode(inputs)
+            trace.append(f"ABM action={action}, mode={mode}")
+
+            if action in {"score_accounts", "account_scoring", "query_target_accounts"}:
+                output = self._score_accounts(task, inputs, trace)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+            if action in {"score_icp_fit", "icp_fit_scoring"}:
+                output = self._score_icp_fit(task, inputs, trace)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+            if action in {"score_intent_heat", "intent_heat_scoring", "aggregate_intent"}:
+                output = self._score_intent_heat(task, inputs, trace)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+            if action == "aggregate_engagement":
+                output = self._aggregate_engagement(task, inputs, trace)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+            if action in {"recommend_next_best_action", "next_best_action"}:
+                output = self._recommend_next_best_action(task, inputs, trace)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+            if action in {"validate_account_csv", "csv_account_ingest_validation"}:
+                output = self._validate_account_csv(task, inputs, trace)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+            if action in WRITE_ACTIONS:
+                output = await self._guarded_abm_write(task, action, inputs, mode, trace, tool_calls)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+
+            output = self._base_output(
+                task,
+                action=action,
+                status="blocked",
+                confidence=0.0,
+                rationale=f"Unsupported ABM action '{action}'.",
+                recommended_actions=[
+                    {
+                        "action": "use_supported_abm_action",
+                        "reason": "The ABM agent only executes declared deterministic actions.",
+                    }
+                ],
+                blocked_reasons=[f"Unsupported ABM action '{action}'."],
+                policy_context={"workflow_mode": mode},
+            )
+            return self._make_result(
+                task,
+                msg_id,
+                "failed",
+                output,
+                0.0,
+                trace,
+                tool_calls,
+                error={"code": "ABM_ACTION_UNSUPPORTED", "message": output["blocked_reasons"][0]},
+                start=start,
+            )
+        # enterprise-gate: broad-except-ok reason=agent-execution-boundary-returns-failed-result
+        except Exception as exc:
+            logger.error("abm_agent_error", agent=self.agent_id, error=str(exc))
+            trace.append(f"Error: {exc}")
+            return self._make_result(
+                task,
+                msg_id,
+                "failed",
+                {},
+                0.0,
+                trace,
+                tool_calls,
+                error={"code": "ABM_AGENT_ERR", "message": str(exc)},
+                start=start,
+            )
+
+    def _score_accounts(
+        self,
+        task,
+        inputs: dict[str, Any],
+        trace: list[str],
+    ) -> dict[str, Any]:
+        accounts = _account_rows(inputs)
+        weights = _normalized_weights(inputs.get("source_weights") or inputs.get("weights"))
+        high_threshold = _float(inputs.get("high_intent_threshold"), 75.0)
+        rows = [_score_account(account, weights, inputs) for account in accounts]
+        rows.sort(key=lambda row: (-row["overall_score"], row["domain"]))
+        alerts = _high_intent_alerts(rows, high_threshold)
+        trace.append(f"Scored {len(rows)} ABM accounts; alerts={len(alerts)}")
+        return self._base_output(
+            task,
+            action="score_accounts",
+            status="accounts_scored" if rows else "degraded",
+            confidence=0.87 if rows else 0.5,
+            rationale=(
+                f"Scored {len(rows)} accounts using ICP fit, intent heat, and engagement inputs."
+                if rows
+                else "No structured account rows were supplied for ABM scoring."
+            ),
+            recommended_actions=_scoring_recommendations(rows, alerts),
+            source_refs=_source_refs_for_accounts(rows, weights),
+            degraded_reasons=[] if rows else ["No account rows supplied."],
+            policy_context={"workflow_mode": _workflow_mode(inputs), "workflow_id": "abm_sprint"},
+            extra={
+                "account_scores": rows,
+                "scoring_summary": _scoring_summary(rows, weights),
+                "intent_alerts": alerts,
+                "source_weights": weights,
+            },
+        )
+
+    def _score_icp_fit(
+        self,
+        task,
+        inputs: dict[str, Any],
+        trace: list[str],
+    ) -> dict[str, Any]:
+        accounts = _account_rows(inputs)
+        rows = []
+        for account in accounts:
+            base = _account_identity(account)
+            base["icp_fit_score"] = _icp_fit_score(account, inputs)
+            base["icp_fit_reasons"] = _icp_fit_reasons(account, inputs)
+            rows.append(base)
+        rows.sort(key=lambda row: (-row["icp_fit_score"], row["domain"]))
+        trace.append(f"Computed ICP fit for {len(rows)} accounts")
+        return self._base_output(
+            task,
+            action="score_icp_fit",
+            status="icp_fit_scored" if rows else "degraded",
+            confidence=0.86 if rows else 0.5,
+            rationale="Computed ICP fit against configured industry, size, revenue, region, and tier rules.",
+            recommended_actions=[
+                {
+                    "action": "prioritize_high_fit_accounts",
+                    "reason": "Use high-fit accounts for ABM tiering before budget or outreach changes.",
+                }
+            ],
+            source_refs=[{"kind": "icp_config", "fields": sorted(_icp_fields(inputs))}],
+            degraded_reasons=[] if rows else ["No account rows supplied."],
+            policy_context={"workflow_mode": _workflow_mode(inputs), "workflow_id": "abm_sprint"},
+            extra={"account_scores": rows, "scoring_summary": {"account_count": len(rows)}},
+        )
+
+    def _score_intent_heat(
+        self,
+        task,
+        inputs: dict[str, Any],
+        trace: list[str],
+    ) -> dict[str, Any]:
+        accounts = _account_rows(inputs)
+        weights = _normalized_weights(inputs.get("source_weights") or inputs.get("weights"))
+        rows = []
+        for account in accounts:
+            base = _account_identity(account)
+            source_scores = _source_scores(account)
+            base["intent_heat_score"] = _intent_heat_score(source_scores, weights)
+            base["source_scores"] = source_scores
+            rows.append(base)
+        rows.sort(key=lambda row: (-row["intent_heat_score"], row["domain"]))
+        trace.append(f"Computed intent heat for {len(rows)} accounts")
+        return self._base_output(
+            task,
+            action="score_intent_heat",
+            status="intent_heat_scored" if rows else "degraded",
+            confidence=0.85 if rows else 0.5,
+            rationale="Aggregated Bombora, G2, TrustRadius, and CRM-style signals into intent heat scores.",
+            recommended_actions=_intent_recommendations(rows),
+            source_refs=_source_refs_for_accounts(rows, weights),
+            degraded_reasons=[] if rows else ["No intent account rows supplied."],
+            policy_context={"workflow_mode": _workflow_mode(inputs), "workflow_id": "abm_sprint"},
+            extra={
+                "account_scores": rows,
+                "scoring_summary": {"account_count": len(rows), "source_weights": weights},
+                "source_weights": weights,
+            },
+        )
+
+    def _aggregate_engagement(
+        self,
+        task,
+        inputs: dict[str, Any],
+        trace: list[str],
+    ) -> dict[str, Any]:
+        accounts = _account_rows(inputs)
+        rows = []
+        for account in accounts:
+            base = _account_identity(account)
+            base["engagement_score"] = _engagement_score(account)
+            base["engagement_inputs"] = {
+                "website_visits": _float(account.get("website_visits"), 0.0),
+                "email_clicks": _float(account.get("email_clicks"), 0.0),
+                "form_submissions": _float(account.get("form_submissions"), 0.0),
+                "meetings": _float(account.get("meetings"), 0.0),
+            }
+            rows.append(base)
+        rows.sort(key=lambda row: (-row["engagement_score"], row["domain"]))
+        trace.append(f"Aggregated engagement for {len(rows)} accounts")
+        return self._base_output(
+            task,
+            action="aggregate_engagement",
+            status="engagement_aggregated" if rows else "degraded",
+            confidence=0.82 if rows else 0.5,
+            rationale="Aggregated website, email, form, and meeting engagement signals by account.",
+            recommended_actions=[
+                {
+                    "action": "route_engaged_accounts_to_sdr",
+                    "reason": "High engagement accounts should be reviewed before outbound actions.",
+                }
+            ],
+            source_refs=[{"kind": "crm_engagement", "count": len(rows)}],
+            degraded_reasons=[] if rows else ["No engagement account rows supplied."],
+            policy_context={"workflow_mode": _workflow_mode(inputs), "workflow_id": "abm_sprint"},
+            extra={"account_scores": rows, "scoring_summary": {"account_count": len(rows)}},
+        )
+
+    def _recommend_next_best_action(
+        self,
+        task,
+        inputs: dict[str, Any],
+        trace: list[str],
+    ) -> dict[str, Any]:
+        accounts = _account_rows(inputs)
+        weights = _normalized_weights(inputs.get("source_weights") or inputs.get("weights"))
+        scored = [_score_account(account, weights, inputs) for account in accounts]
+        scored.sort(key=lambda row: (-row["overall_score"], row["domain"]))
+        recommendations = [_next_best_action(row) for row in scored]
+        trace.append(f"Recommended next-best actions for {len(recommendations)} accounts")
+        return self._base_output(
+            task,
+            action="recommend_next_best_action",
+            status="next_best_actions_recommended" if recommendations else "degraded",
+            confidence=0.84 if recommendations else 0.5,
+            rationale="Generated read-only ABM next-best-action recommendations from score bands.",
+            recommended_actions=recommendations,
+            source_refs=_source_refs_for_accounts(scored, weights),
+            degraded_reasons=[] if recommendations else ["No account rows supplied for next-best action planning."],
+            policy_context={"workflow_mode": _workflow_mode(inputs), "workflow_id": "abm_sprint"},
+            extra={"account_scores": scored, "scoring_summary": _scoring_summary(scored, weights)},
+        )
+
+    def _validate_account_csv(
+        self,
+        task,
+        inputs: dict[str, Any],
+        trace: list[str],
+    ) -> dict[str, Any]:
+        csv_text = str(inputs.get("csv_content") or inputs.get("account_csv") or "")
+        valid_accounts, invalid_rows, missing_headers = _validate_account_csv(csv_text)
+        blocked = []
+        if missing_headers:
+            blocked.append(f"CSV is missing required fields: {', '.join(missing_headers)}.")
+        if invalid_rows:
+            blocked.append(f"CSV has {len(invalid_rows)} malformed account row(s).")
+        trace.append(f"Validated ABM CSV: valid={len(valid_accounts)}, invalid={len(invalid_rows)}")
+        return self._base_output(
+            task,
+            action="validate_account_csv",
+            status="csv_validated" if not blocked else "blocked",
+            confidence=0.88 if not blocked else 0.0,
+            rationale=(
+                f"Validated {len(valid_accounts)} target account rows."
+                if not blocked
+                else "CSV account ingest validation failed closed."
+            ),
+            recommended_actions=[
+                {
+                    "action": "import_target_accounts" if not blocked else "fix_csv_account_rows",
+                    "reason": "Rows are ready for review." if not blocked else "Correct required fields before ingest.",
+                }
+            ],
+            source_refs=[{"kind": "csv_account_ingest", "valid_rows": len(valid_accounts)}],
+            blocked_reasons=blocked,
+            policy_context={"workflow_mode": _workflow_mode(inputs), "workflow_id": "abm_sprint"},
+            extra={
+                "valid_accounts": valid_accounts,
+                "invalid_rows": invalid_rows,
+                "missing_headers": missing_headers,
+                "scoring_summary": {"valid_accounts": len(valid_accounts), "invalid_rows": len(invalid_rows)},
+            },
+        )
+
+    async def _guarded_abm_write(
+        self,
+        task,
+        action: str,
+        inputs: dict[str, Any],
+        mode: str,
+        trace: list[str],
+        tool_calls: list[ToolCallRecord],
+    ) -> dict[str, Any]:
+        policy_context = _policy_context_for_write(action, inputs, mode)
+        policy = evaluate_marketing_policy(policy_context)
+        escalation = _escalation_for_context(task, action, inputs, policy)
+        blocked_reasons: list[str] = []
+        hitl_reasons: list[str] = []
+
+        if mode in SHADOW_MODES:
+            blocked_reasons.append("Shadow/draft/internal ABM workflows are read-only.")
+            trace.append("ABM write converted to shadow-only recommendation")
+            return self._base_output(
+                task,
+                action=action,
+                status="shadow_only",
+                confidence=0.78,
+                rationale="Prepared ABM recommendation without mutating target lists, budgets, or campaigns.",
+                recommended_actions=[
+                    {
+                        "action": "create_internal_approval",
+                        "reason": "Review the ABM change before any active external write is attempted.",
+                    }
+                ],
+                approval_required=True,
+                hitl_required=True,
+                policy_result=policy,
+                blocked_reasons=blocked_reasons,
+                escalation=escalation,
+                external_write_status="not_required",
+                external_write_required=False,
+                extra={"write_payload": _abm_write_payload(action, inputs)},
+            )
+
+        connector_safe, connector_reason = _connector_write_safe(inputs)
+        if not connector_safe:
+            blocked_reasons.append(connector_reason)
+        if policy.get("decision") in {"requires_approval", "requires_escalation"} and not _has_approval(inputs):
+            hitl_reasons.append(str(policy.get("reason") or "ABM external action requires approval."))
+        if policy.get("decision") == "blocked":
+            blocked_reasons.append(str(policy.get("reason") or "Marketing policy blocks this ABM action."))
+        escalation_needs_review = escalation.get("decision") not in {
+            None,
+            "",
+            "no_escalation",
+            "notify_owner",
+        }
+        if escalation_needs_review and not _has_escalation_approval(inputs):
+            hitl_reasons.append("ABM action requires escalation review.")
+
+        if blocked_reasons or hitl_reasons:
+            return self._base_output(
+                task,
+                action=action,
+                status="blocked",
+                confidence=0.0,
+                rationale="ABM external action failed closed before vendor mutation.",
+                recommended_actions=[
+                    {
+                        "action": "resolve_abm_write_prerequisites",
+                        "reason": "; ".join(_dedupe(blocked_reasons + hitl_reasons)),
+                    }
+                ],
+                approval_required=bool(hitl_reasons),
+                hitl_required=True,
+                policy_result=policy,
+                escalation=escalation,
+                blocked_reasons=blocked_reasons + hitl_reasons,
+                external_write_status="write_unconfirmed",
+                external_write_required=True,
+                extra={"write_payload": _abm_write_payload(action, inputs)},
+            )
+
+        result = _dict_or_none(inputs.get("external_write_result"))
+        connector, tool = _connector_tool(action, inputs)
+        idempotency_key = str(
+            inputs.get("idempotency_key")
+            or inputs.get("request_fingerprint")
+            or f"abm:{task.correlation_id}:{task.step_id}:{action}"
+        )
+        if result is None:
+            result = await self._safe_tool_call(
+                connector,
+                tool,
+                _abm_write_payload(action, inputs),
+                trace,
+                tool_calls,
+                idempotency_key=idempotency_key,
+            )
+
+        write_status = _external_write_confirmation_status(result)
+        write_confirmed = _is_confirmed_external_write(result)
+        external_ref = _external_write_ref(result)
+        if not write_confirmed:
+            blocked_reasons.append("ABM external write is unconfirmed and cannot be marked complete.")
+        trace.append(f"ABM write status={write_status}, confirmed={write_confirmed}")
+        return self._base_output(
+            task,
+            action=action,
+            status="write_confirmed" if write_confirmed else "write_unconfirmed",
+            confidence=0.9 if write_confirmed else 0.0,
+            rationale=(
+                "ABM external write was confirmed by the connector."
+                if write_confirmed
+                else "ABM external write did not return confirmed vendor evidence."
+            ),
+            recommended_actions=[
+                {
+                    "action": "monitor_abm_change" if write_confirmed else "verify_abm_write_before_retry",
+                    "reason": (
+                        "Track target-account and campaign performance."
+                        if write_confirmed
+                        else "Check vendor state using the idempotency key before retrying."
+                    ),
+                }
+            ],
+            approval_required=False,
+            hitl_required=not write_confirmed,
+            policy_result=policy,
+            approval_satisfied=_has_approval(inputs),
+            escalation=escalation,
+            blocked_reasons=blocked_reasons,
+            external_write_status=write_status,
+            external_write_required=True,
+            external_write_ref=external_ref,
+            extra={
+                "write_payload": _abm_write_payload(action, inputs),
+                "account_scores": [
+                    _score_account(row, _normalized_weights(inputs.get("source_weights")), inputs)
+                    for row in _account_rows(inputs)
+                ],
+            },
+        )
+
+    async def _safe_tool_call(
+        self,
+        connector: str,
+        tool: str,
+        params: dict[str, Any],
+        trace: list[str],
+        tool_records: list[ToolCallRecord],
+        *,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        call_start = time.monotonic()
+        try:
+            result = await self._call_tool(
+                connector_name=connector,
+                tool_name=tool,
+                params=params,
+                idempotency_key=idempotency_key,
+            )
+            latency = int((time.monotonic() - call_start) * 1000)
+            status = "error" if "error" in result else "success"
+            trace.append(f"[tool] {connector}.{tool} -> {status} ({latency}ms)")
+            tool_records.append(ToolCallRecord(tool_name=f"{connector}.{tool}", status=status, latency_ms=latency))
+            return result
+        # enterprise-gate: broad-except-ok reason=agent-tool-call-failure-returns-explicit-error-result
+        except Exception as exc:
+            latency = int((time.monotonic() - call_start) * 1000)
+            trace.append(f"[tool] {connector}.{tool} -> exception: {exc} ({latency}ms)")
+            tool_records.append(ToolCallRecord(tool_name=f"{connector}.{tool}", status="error", latency_ms=latency))
+            return {"error": str(exc)}
+
+    def _base_output(
+        self,
+        task,
+        *,
+        action: str,
+        status: str,
+        confidence: float,
+        rationale: str,
+        recommended_actions: list[dict[str, Any]],
+        approval_required: bool = False,
+        hitl_required: bool = False,
+        policy_context: dict[str, Any] | None = None,
+        policy_result: dict[str, Any] | None = None,
+        approval_satisfied: bool = False,
+        escalation: dict[str, Any] | None = None,
+        source_refs: list[dict[str, Any]] | None = None,
+        degraded_reasons: list[str] | None = None,
+        blocked_reasons: list[str] | None = None,
+        external_write_status: str = "not_required",
+        external_write_required: bool = False,
+        external_write_ref: dict[str, Any] | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        policy = policy_result or evaluate_marketing_policy(
+            {
+                "workflow_id": "abm_sprint",
+                "workflow_mode": "shadow",
+                "action": action,
+                "external_write_required": external_write_required,
+                **(policy_context or {}),
+            }
+        )
+        escalation_ref = None
+        if escalation and escalation.get("decision") != "no_escalation":
+            escalation_ref = escalation.get("decision_audit_ref") or escalation.get("audit_reference")
+        policy_needs_review = (
+            policy.get("decision") in {"requires_approval", "requires_escalation", "read_only_only"}
+            and not approval_satisfied
+        )
+        output: dict[str, Any] = {
+            "status": status,
+            "agent_type": self.agent_type,
+            "action": action,
+            "confidence": round(max(0.0, min(confidence, 1.0)), 3),
+            "rationale": rationale,
+            "recommended_actions": recommended_actions,
+            "source_refs": source_refs or [],
+            "policy_result": policy,
+            "policy_ref": policy.get("decision_audit_ref") or policy.get("policy_id"),
+            "approval_required": approval_required or policy_needs_review,
+            "hitl_required": hitl_required,
+            "escalation_ref": escalation_ref,
+            "escalation_result": escalation,
+            "audit_ref": f"abm:{task.correlation_id}:{task.step_id}:{action}",
+            "degraded_reasons": _dedupe(degraded_reasons or []),
+            "blocked_reasons": _dedupe(blocked_reasons or []),
+            "external_write_confirmation_status": external_write_status,
+            "external_writes_completed": external_write_status == "write_confirmed",
+            "external_write_required": external_write_required,
+            "external_write_ref": external_write_ref,
+            "production_status": ABM_AGENT_MATURITY,
+        }
+        if extra:
+            output.update(extra)
+        return output
+
+    def _complete_or_hitl(
+        self,
+        task,
+        msg_id: str,
+        output: dict[str, Any],
+        trace: list[str],
+        tool_calls: list[ToolCallRecord],
+        start: float,
+    ):
+        if output.get("hitl_required") or output.get("approval_required") or output.get("blocked_reasons"):
+            hitl = _hitl_request(task, output)
+            return self._make_result(
+                task,
+                msg_id,
+                "hitl_triggered",
+                output,
+                float(output.get("confidence") or 0.0),
+                trace,
+                tool_calls,
+                hitl_request=hitl,
+                start=start,
+            )
+        return self._make_result(
+            task,
+            msg_id,
+            "completed",
+            output,
+            float(output.get("confidence") or 0.0),
+            trace,
+            tool_calls,
+            start=start,
+        )
+
+
+def _task_inputs(task) -> dict[str, Any]:
+    payload = task.task.inputs if hasattr(task.task, "inputs") else task.task.get("inputs", {})
+    return payload if isinstance(payload, dict) else {}
+
+
+def _task_action(task) -> str:
+    return str(task.task.action if hasattr(task.task, "action") else task.task.get("action", "score_accounts"))
+
+
+def _normalize_action(action: str) -> str:
+    normalized = str(action or "").strip().lower().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "account_score": "score_accounts",
+        "account_scoring": "score_accounts",
+        "csv_account_ingest_validation": "validate_account_csv",
+        "icp_fit_scoring": "score_icp_fit",
+        "intent_heat_scoring": "score_intent_heat",
+        "next_best_action": "recommend_next_best_action",
+        "query_target_accounts": "score_accounts",
+        "sync_target_account_list": "sync_target_accounts",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def _workflow_mode(inputs: dict[str, Any]) -> str:
+    return str(inputs.get("workflow_mode") or inputs.get("mode") or "shadow").strip().lower()
+
+
+def _account_rows(inputs: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = inputs.get("accounts") or inputs.get("target_accounts") or inputs.get("account_rows") or []
+    if isinstance(raw, dict):
+        return [dict(raw)]
+    if not isinstance(raw, list | tuple):
+        return []
+    return [dict(row) for row in raw if isinstance(row, dict)]
+
+
+def _normalized_weights(value: Any) -> dict[str, float]:
+    if not isinstance(value, dict):
+        return dict(DEFAULT_SOURCE_WEIGHTS)
+    weights = {}
+    for key in DEFAULT_SOURCE_WEIGHTS:
+        weights[key] = max(_float(value.get(key), DEFAULT_SOURCE_WEIGHTS[key]), 0.0)
+    total = sum(weights.values())
+    if total <= 0:
+        return dict(DEFAULT_SOURCE_WEIGHTS)
+    return {key: round(score / total, 4) for key, score in weights.items()}
+
+
+def _score_account(
+    account: dict[str, Any],
+    weights: dict[str, float],
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    identity = _account_identity(account)
+    source_scores = _source_scores(account)
+    intent = _intent_heat_score(source_scores, weights)
+    icp = _icp_fit_score(account, inputs)
+    engagement = _engagement_score(account)
+    overall = round((intent * 0.45) + (icp * 0.40) + (engagement * 0.15), 2)
+    row = {
+        **identity,
+        "overall_score": overall,
+        "icp_fit_score": icp,
+        "intent_heat_score": intent,
+        "engagement_score": engagement,
+        "score_band": _score_band(overall),
+        "source_scores": source_scores,
+        "recommended_action": _recommended_action_for_score(overall, intent, icp),
+    }
+    return row
+
+
+def _account_identity(account: dict[str, Any]) -> dict[str, Any]:
+    domain = str(account.get("domain") or account.get("account_domain") or "").strip().lower()
+    name = str(account.get("company_name") or account.get("company") or account.get("name") or domain or "unknown")
+    return {
+        "account_name": name,
+        "domain": domain,
+        "industry": str(account.get("industry") or ""),
+        "tier": str(account.get("tier") or account.get("account_tier") or ""),
+    }
+
+
+def _source_scores(account: dict[str, Any]) -> dict[str, float]:
+    signals = account.get("signals") if isinstance(account.get("signals"), dict) else {}
+    return {
+        "bombora": _bounded_score(account.get("bombora") or signals.get("bombora")),
+        "g2": _bounded_score(account.get("g2") or signals.get("g2")),
+        "trustradius": _bounded_score(account.get("trustradius") or signals.get("trustradius")),
+        "crm": _bounded_score(account.get("crm") or signals.get("crm") or account.get("crm_score")),
+    }
+
+
+def _intent_heat_score(source_scores: dict[str, float], weights: dict[str, float]) -> float:
+    return round(sum(source_scores[key] * weights.get(key, 0.0) for key in DEFAULT_SOURCE_WEIGHTS), 2)
+
+
+def _icp_fit_score(account: dict[str, Any], inputs: dict[str, Any]) -> float:
+    rules = _icp_rules(inputs)
+    score = 0.0
+    if _domain(account):
+        score += 10
+    if not rules["target_industries"] or _normalize(account.get("industry")) in rules["target_industries"]:
+        score += 25
+    employees = _float(account.get("employee_count") or account.get("employees"), 0.0)
+    if _in_range(employees, rules["employee_min"], rules["employee_max"]):
+        score += 20
+    revenue = _float(account.get("annual_revenue") or account.get("revenue"), 0.0)
+    if _in_range(revenue, rules["revenue_min"], rules["revenue_max"]):
+        score += 20
+    if not rules["regions"] or _normalize(account.get("region")) in rules["regions"]:
+        score += 15
+    if not rules["tiers"] or _normalize(account.get("tier") or account.get("account_tier")) in rules["tiers"]:
+        score += 10
+    return round(min(score, 100.0), 2)
+
+
+def _icp_fit_reasons(account: dict[str, Any], inputs: dict[str, Any]) -> list[str]:
+    rules = _icp_rules(inputs)
+    reasons = []
+    if _domain(account):
+        reasons.append("account_domain_present")
+    if not rules["target_industries"] or _normalize(account.get("industry")) in rules["target_industries"]:
+        reasons.append("industry_matches_icp")
+    employees = _float(account.get("employee_count") or account.get("employees"), 0.0)
+    if _in_range(employees, rules["employee_min"], rules["employee_max"]):
+        reasons.append("employee_count_matches_icp")
+    revenue = _float(account.get("annual_revenue") or account.get("revenue"), 0.0)
+    if _in_range(revenue, rules["revenue_min"], rules["revenue_max"]):
+        reasons.append("revenue_matches_icp")
+    if not rules["regions"] or _normalize(account.get("region")) in rules["regions"]:
+        reasons.append("region_matches_icp")
+    if not rules["tiers"] or _normalize(account.get("tier") or account.get("account_tier")) in rules["tiers"]:
+        reasons.append("tier_matches_icp")
+    return reasons
+
+
+def _icp_rules(inputs: dict[str, Any]) -> dict[str, Any]:
+    raw = inputs.get("icp") if isinstance(inputs.get("icp"), dict) else inputs
+    return {
+        "target_industries": _normalized_set(raw.get("target_industries") or raw.get("industries")),
+        "employee_min": _float(raw.get("employee_min") or raw.get("min_employees"), 0.0),
+        "employee_max": _float(raw.get("employee_max") or raw.get("max_employees"), 0.0),
+        "revenue_min": _float(raw.get("revenue_min") or raw.get("min_revenue"), 0.0),
+        "revenue_max": _float(raw.get("revenue_max") or raw.get("max_revenue"), 0.0),
+        "regions": _normalized_set(raw.get("regions") or raw.get("target_regions")),
+        "tiers": _normalized_set(raw.get("tiers") or raw.get("target_tiers")),
+    }
+
+
+def _icp_fields(inputs: dict[str, Any]) -> set[str]:
+    rules = _icp_rules(inputs)
+    fields = set()
+    for key, value in rules.items():
+        if isinstance(value, set):
+            if value:
+                fields.add(key)
+        elif value:
+            fields.add(key)
+    return fields
+
+
+def _engagement_score(account: dict[str, Any]) -> float:
+    direct = account.get("engagement_score")
+    if direct not in {None, ""}:
+        return _bounded_score(direct)
+    visits = _float(account.get("website_visits"), 0.0)
+    clicks = _float(account.get("email_clicks"), 0.0)
+    forms = _float(account.get("form_submissions"), 0.0)
+    meetings = _float(account.get("meetings"), 0.0)
+    score = min((visits * 0.5) + (clicks * 2.0) + (forms * 12.0) + (meetings * 18.0), 100.0)
+    return round(score, 2)
+
+
+def _next_best_action(row: dict[str, Any]) -> dict[str, Any]:
+    action = row.get("recommended_action") or _recommended_action_for_score(
+        _float(row.get("overall_score"), 0.0),
+        _float(row.get("intent_heat_score"), 0.0),
+        _float(row.get("icp_fit_score"), 0.0),
+    )
+    reasons = []
+    if _float(row.get("intent_heat_score"), 0.0) >= 80:
+        reasons.append("high intent heat")
+    if _float(row.get("icp_fit_score"), 0.0) >= 80:
+        reasons.append("strong ICP fit")
+    if _float(row.get("engagement_score"), 0.0) >= 70:
+        reasons.append("high engagement")
+    return {
+        "action": action,
+        "account_domain": row.get("domain"),
+        "account_name": row.get("account_name"),
+        "score": row.get("overall_score"),
+        "reason": ", ".join(reasons) or "score band review",
+    }
+
+
+def _recommended_action_for_score(overall: float, intent: float, icp: float) -> str:
+    if intent >= 80 and icp >= 70:
+        return "create_sales_alert"
+    if overall >= 75:
+        return "prioritize_1_to_1_outreach"
+    if intent >= 70:
+        return "route_to_sdr_research"
+    if icp >= 75:
+        return "add_to_nurture_segment"
+    return "monitor_intent"
+
+
+def _score_band(score: float) -> str:
+    if score >= 80:
+        return "hot"
+    if score >= 65:
+        return "warm"
+    if score >= 45:
+        return "nurture"
+    return "monitor"
+
+
+def _high_intent_alerts(rows: list[dict[str, Any]], threshold: float) -> list[dict[str, Any]]:
+    return [
+        {
+            "account_domain": row["domain"],
+            "account_name": row["account_name"],
+            "intent_heat_score": row["intent_heat_score"],
+            "recommended_action": row["recommended_action"],
+            "reason": f"Intent heat score {row['intent_heat_score']} exceeds threshold {threshold}.",
+        }
+        for row in rows
+        if row["intent_heat_score"] >= threshold
+    ]
+
+
+def _scoring_recommendations(
+    rows: list[dict[str, Any]],
+    alerts: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    if not rows:
+        return [{"action": "connect_abm_and_crm_sources", "reason": "No account rows were supplied."}]
+    recommendations = []
+    if alerts:
+        recommendations.append(
+            {
+                "action": "review_high_intent_alerts",
+                "reason": f"{len(alerts)} account(s) crossed the high-intent threshold.",
+            }
+        )
+    recommendations.append(
+        {
+            "action": "review_abm_score_rankings",
+            "reason": "Approve any target-list or outreach changes before execution.",
+        }
+    )
+    return recommendations
+
+
+def _intent_recommendations(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not rows:
+        return [{"action": "connect_intent_sources", "reason": "No intent rows were supplied."}]
+    return [_next_best_action(row) for row in rows[:5]]
+
+
+def _scoring_summary(rows: list[dict[str, Any]], weights: dict[str, float]) -> dict[str, Any]:
+    if not rows:
+        return {"account_count": 0, "source_weights": weights}
+    return {
+        "account_count": len(rows),
+        "hot_accounts": sum(1 for row in rows if row["score_band"] == "hot"),
+        "warm_accounts": sum(1 for row in rows if row["score_band"] == "warm"),
+        "average_overall_score": round(sum(row["overall_score"] for row in rows) / len(rows), 2),
+        "source_weights": weights,
+    }
+
+
+def _source_refs_for_accounts(rows: list[dict[str, Any]], weights: dict[str, float]) -> list[dict[str, Any]]:
+    domains = [row["domain"] for row in rows if row.get("domain")]
+    return [
+        {"kind": "abm_account_scores", "count": len(rows), "domains": domains[:10]},
+        {"kind": "intent_source_weights", "weights": weights},
+    ]
+
+
+def _validate_account_csv(csv_text: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str]]:
+    if not csv_text.strip():
+        return [], [{"row_number": 0, "reason": "CSV content is empty."}], ["company_name", "domain"]
+    try:
+        reader = csv.DictReader(io.StringIO(csv_text))
+    except csv.Error as exc:
+        return [], [{"row_number": 0, "reason": str(exc)}], ["company_name", "domain"]
+    headers = {_normalize(field) for field in (reader.fieldnames or []) if field}
+    has_company = bool({"company_name", "company", "name"} & headers)
+    missing = []
+    if not has_company:
+        missing.append("company_name")
+    if "domain" not in headers and "account_domain" not in headers:
+        missing.append("domain")
+    valid: list[dict[str, Any]] = []
+    invalid: list[dict[str, Any]] = []
+    if missing:
+        return valid, invalid, missing
+    for index, row in enumerate(reader, start=2):
+        company = _csv_value(row, "company_name", "company", "name")
+        domain = _csv_value(row, "domain", "account_domain")
+        if not company or not domain or "." not in domain:
+            invalid.append(
+                {
+                    "row_number": index,
+                    "company_name": company,
+                    "domain": domain,
+                    "reason": "Required company name/domain is missing or malformed.",
+                }
+            )
+            continue
+        valid.append(
+            {
+                "company_name": company,
+                "domain": domain.lower(),
+                "industry": _csv_value(row, "industry"),
+                "tier": _csv_value(row, "tier"),
+            }
+        )
+    return valid, invalid, []
+
+
+def _policy_context_for_write(action: str, inputs: dict[str, Any], mode: str) -> dict[str, Any]:
+    return {
+        "workflow_id": "abm_sprint",
+        "workflow_mode": mode,
+        "action": action,
+        "external_write_required": True,
+        "customer_facing": action in BUDGET_WRITE_ACTIONS,
+        "target_account_delta": _target_account_delta(inputs),
+        "target_account_change": action in TARGET_ACCOUNT_WRITE_ACTIONS,
+        "budget_amount": _float(
+            inputs.get("budget_amount")
+            or inputs.get("budget")
+            or inputs.get("monthly_budget")
+            or inputs.get("daily_budget"),
+            0.0,
+        ),
+        "budget_delta": _float(inputs.get("budget_delta") or inputs.get("budget_increase"), 0.0),
+        "channel": str(inputs.get("channel") or "abm"),
+    }
+
+
+def _escalation_for_context(
+    task,
+    action: str,
+    inputs: dict[str, Any],
+    policy_result: dict[str, Any],
+) -> dict[str, Any]:
+    context = {
+        "workflow_id": "abm_sprint",
+        "workflow_run_id": getattr(task, "workflow_run_id", None),
+        "step_id": getattr(task, "step_id", None),
+        "event_type": (
+            "target_account_change"
+            if action in TARGET_ACCOUNT_WRITE_ACTIONS
+            else "budget_threshold_exceeded"
+        ),
+        "target_account_change": action in TARGET_ACCOUNT_WRITE_ACTIONS,
+        "budget_threshold_exceeded": action in BUDGET_WRITE_ACTIONS,
+        "severity": "high",
+        "reason": "ABM external action requires owner routing.",
+        "marketing_policy_decision": policy_result,
+        "target_account_delta": _target_account_delta(inputs),
+    }
+    return evaluate_marketing_escalation(context)
+
+
+def _connector_write_safe(inputs: dict[str, Any]) -> tuple[bool, str]:
+    if inputs.get("connector_write_ready") is True or inputs.get("write_ready") is True:
+        return True, ""
+    if inputs.get("connector_write_ready") is False or inputs.get("write_ready") is False:
+        return False, "ABM connector is not write-safe."
+    contracts = _dict_list(inputs.get("connector_contracts"))
+    direct = _dict_or_none(inputs.get("connector_contract"))
+    if direct:
+        contracts.insert(0, direct)
+    if contracts:
+        for contract in contracts:
+            category = str(contract.get("category") or "").strip().lower()
+            key = str(contract.get("connector_key") or contract.get("key") or "").strip().lower()
+            known_keys = {"6sense", "bombora", "g2", "trustradius", "hubspot", "salesforce"}
+            if category not in {"abm", "crm"} and key not in known_keys:
+                continue
+            if contract.get("mock_or_test_double"):
+                return False, "Test-double connector proof cannot satisfy active ABM writes."
+            if bool(contract.get("write_safe", contract.get("write_ready"))):
+                return True, ""
+            status = str(contract.get("write_status") or contract.get("contract_state") or "unknown")
+            return False, f"ABM connector contract is not write-safe ({status})."
+        return False, "No ABM/CRM connector contract is write-safe."
+    return False, "ABM connector write-readiness evidence is missing."
+
+
+def _has_approval(inputs: dict[str, Any]) -> bool:
+    return bool(
+        inputs.get("approved")
+        or inputs.get("approval_ref")
+        or inputs.get("approval_result_ref")
+        or inputs.get("policy_approval_ref")
+    )
+
+
+def _has_escalation_approval(inputs: dict[str, Any]) -> bool:
+    return bool(inputs.get("escalation_ref") or inputs.get("escalation_result_ref") or inputs.get("approved"))
+
+
+def _connector_tool(action: str, inputs: dict[str, Any]) -> tuple[str, str]:
+    explicit = str(inputs.get("connector_key") or inputs.get("connector") or "").strip().lower()
+    if action in TARGET_ACCOUNT_WRITE_ACTIONS:
+        return explicit or "hubspot", "update_target_accounts"
+    return explicit or "linkedin_ads", "create_abm_campaign"
+
+
+def _abm_write_payload(action: str, inputs: dict[str, Any]) -> dict[str, Any]:
+    accounts = _account_rows(inputs)
+    return {
+        "action": action,
+        "accounts": [_account_identity(row) for row in accounts],
+        "budget_amount": _float(
+            inputs.get("budget_amount")
+            or inputs.get("budget")
+            or inputs.get("monthly_budget")
+            or inputs.get("daily_budget"),
+            0.0,
+        ),
+        "campaign_name": inputs.get("campaign_name") or inputs.get("name") or "ABM campaign",
+        "target_account_delta": _target_account_delta(inputs),
+    }
+
+
+def _external_write_confirmation_status(result: dict[str, Any] | None) -> str:
+    if not result:
+        return "write_unconfirmed"
+    return str(
+        result.get("external_write_confirmation_status")
+        or result.get("write_confirmation_status")
+        or result.get("status")
+        or "write_unconfirmed"
+    )
+
+
+def _is_confirmed_external_write(result: dict[str, Any] | None) -> bool:
+    if not result or "error" in result:
+        return False
+    status = _external_write_confirmation_status(result)
+    return status == "write_confirmed" and bool(
+        result.get("external_object_id") or result.get("external_id") or result.get("confirmed_at")
+    )
+
+
+def _external_write_ref(result: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not result:
+        return None
+    return {
+        "connector_key": result.get("connector_key"),
+        "external_object_id": result.get("external_object_id") or result.get("external_id"),
+        "source_url": result.get("source_url") or result.get("url"),
+        "idempotency_key": result.get("idempotency_key"),
+        "confirmed_at": result.get("confirmed_at"),
+        "audit_ref": result.get("audit_ref") or result.get("audit_reference"),
+    }
+
+
+def _hitl_request(task, output: dict[str, Any]) -> HITLRequest:
+    reasons = output.get("blocked_reasons") or []
+    if not reasons and output.get("policy_result"):
+        reasons = [str(output["policy_result"].get("reason") or "ABM action requires review.")]
+    escalation = output.get("escalation_result") or {}
+    role = escalation.get("owner_role") or escalation.get("primary_owner_role") or "revops_lead"
+    return HITLRequest(
+        hitl_id=f"hitl_{uuid.uuid4().hex[:12]}",
+        trigger_condition="; ".join(str(reason) for reason in reasons) or "ABM review required.",
+        trigger_type="abm_review",
+        decision_required=DecisionRequired(
+            question="Review ABM recommendation or external action safeguard.",
+            options=[
+                DecisionOption(id="approve", label="Approve", action="proceed"),
+                DecisionOption(id="request_changes", label="Request changes", action="defer"),
+                DecisionOption(id="escalate", label="Escalate", action="defer"),
+                DecisionOption(id="reject", label="Reject", action="reject"),
+            ],
+        ),
+        context=HITLContext(
+            summary=output.get("rationale") or "ABM review",
+            recommendation=output.get("recommended_actions", [{}])[0].get("action", "review"),
+            agent_confidence=float(output.get("confidence") or 0.0),
+            supporting_data={
+                "policy_decision": (output.get("policy_result") or {}).get("decision"),
+                "blocked_reasons": output.get("blocked_reasons") or [],
+                "external_write_status": output.get("external_write_confirmation_status"),
+                "target_account_delta": (output.get("write_payload") or {}).get("target_account_delta"),
+            },
+        ),
+        assignee=HITLAssignee(role=str(role), notify_channels=["slack", "email"]),
+    )
+
+
+def _target_account_delta(inputs: dict[str, Any]) -> int:
+    direct = _int(
+        inputs.get("target_account_delta")
+        or inputs.get("target_account_change_count")
+        or inputs.get("account_list_change_count"),
+        0,
+    )
+    if direct:
+        return direct
+    return len(_account_rows(inputs)) if inputs.get("accounts_are_new") else 0
+
+
+def _domain(account: dict[str, Any]) -> str:
+    return str(account.get("domain") or account.get("account_domain") or "").strip().lower()
+
+
+def _in_range(value: float, minimum: float, maximum: float) -> bool:
+    if value <= 0:
+        return minimum <= 0 and maximum <= 0
+    if minimum and value < minimum:
+        return False
+    if maximum and value > maximum:
+        return False
+    return True
+
+
+def _csv_value(row: dict[str, Any], *keys: str) -> str:
+    normalized = {_normalize(key): value for key, value in row.items()}
+    for key in keys:
+        value = normalized.get(_normalize(key))
+        if value is not None:
+            return str(value).strip()
+    return ""
+
+
+def _dict_or_none(value: Any) -> dict[str, Any] | None:
+    return dict(value) if isinstance(value, dict) else None
+
+
+def _dict_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list | tuple):
+        return []
+    return [dict(item) for item in value if isinstance(item, dict)]
+
+
+def _normalized_set(value: Any) -> set[str]:
+    if isinstance(value, str):
+        return {_normalize(part) for part in value.split(",") if _normalize(part)}
+    if isinstance(value, list | tuple | set):
+        return {_normalize(item) for item in value if _normalize(item)}
+    return set()
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _bounded_score(value: Any) -> float:
+    return round(max(0.0, min(_float(value, 0.0), 100.0)), 2)
+
+
+def _float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result

--- a/core/agents/marketing/brand_monitor.py
+++ b/core/agents/marketing/brand_monitor.py
@@ -1,18 +1,1153 @@
-"""Brand Monitor agent implementation."""
+"""Brand Monitor agent implementation.
+
+The Brand Monitor is deterministic and vendor-neutral: it analyzes structured
+mentions supplied by connectors or tests, emits contract-shaped CMO outputs,
+and fails closed before any public/customer-facing response.
+"""
 
 from __future__ import annotations
 
+import time
+import uuid
+from typing import Any
+
+import structlog
+
 from core.agents.base import BaseAgent
 from core.agents.registry import AgentRegistry
+from core.marketing.escalation_matrix import evaluate_marketing_escalation
+from core.marketing.policy_manifest import evaluate_marketing_policy
+from core.schemas.messages import (
+    DecisionOption,
+    DecisionRequired,
+    HITLAssignee,
+    HITLContext,
+    HITLRequest,
+    ToolCallRecord,
+)
+
+logger = structlog.get_logger()
+
+BRAND_MONITOR_AGENT_MATURITY = "beta"
+BRAND_MONITOR_CONFIDENCE_FLOOR = 0.85
+
+READ_ONLY_ACTIONS = {
+    "aggregate_mentions",
+    "classify_crisis_severity",
+    "classify_sentiment",
+    "competitor_brand_grouping",
+    "detect_crisis",
+    "detect_negative_spike",
+    "escalation_recommendation",
+    "false_positive_suppression",
+    "get_sentiment",
+    "group_mentions",
+    "mention_aggregation",
+    "monitor_mentions",
+    "negative_spike_detection",
+    "recommend_response_playbook",
+    "response_playbook_recommendation",
+    "sentiment_trend",
+    "suppress_false_positives",
+}
+WRITE_ACTIONS = {
+    "brand_claim",
+    "comparative_claim",
+    "crisis_response",
+    "pricing_claim",
+    "public_response",
+    "publish_brand_response",
+}
+SHADOW_MODES = {"shadow", "draft", "internal", "internal_only", "recommendation", "simulation"}
+
+POSITIVE_TERMS = (
+    "amazing",
+    "excellent",
+    "fast",
+    "good",
+    "great",
+    "happy",
+    "love",
+    "recommended",
+    "reliable",
+    "resolved",
+)
+NEGATIVE_TERMS = (
+    "angry",
+    "bad",
+    "broken",
+    "complaint",
+    "down",
+    "failed",
+    "fraud",
+    "hate",
+    "lawsuit",
+    "legal",
+    "outage",
+    "poor",
+    "refund",
+    "scam",
+    "security",
+    "unacceptable",
+)
+CRISIS_TERMS = (
+    "boycott",
+    "breach",
+    "class action",
+    "crisis",
+    "data leak",
+    "lawsuit",
+    "outage",
+    "regulator",
+    "safety",
+    "security incident",
+    "viral",
+)
+DEFAULT_FALSE_POSITIVE_TERMS = (
+    "brand new",
+    "personal brand",
+    "wrong company",
+    "not our brand",
+    "unrelated",
+)
 
 
 @AgentRegistry.register
 class BrandMonitorAgent(BaseAgent):
     agent_type = "brand_monitor"
     domain = "marketing"
-    confidence_floor = 0.85
+    confidence_floor = BRAND_MONITOR_CONFIDENCE_FLOOR
     prompt_file = "brand_monitor.prompt.txt"
 
     async def execute(self, task):
-        """Execute brand monitor task with domain-specific logic."""
-        return await super().execute(task)
+        """Run deterministic brand monitoring or guarded public-response logic."""
+
+        start = time.monotonic()
+        trace: list[str] = []
+        tool_calls: list[ToolCallRecord] = []
+        msg_id = f"msg_{uuid.uuid4().hex[:12]}"
+
+        try:
+            inputs = _task_inputs(task)
+            action = _normalize_action(_task_action(task))
+            mode = _workflow_mode(inputs)
+            trace.append(f"Brand Monitor action={action}, mode={mode}")
+
+            if action in READ_ONLY_ACTIONS:
+                output = self._read_only_action(task, action, inputs, mode, trace)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+            if action in WRITE_ACTIONS:
+                output = await self._guarded_brand_write(task, action, inputs, mode, trace, tool_calls)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+
+            output = self._base_output(
+                task,
+                action=action,
+                status="blocked",
+                confidence=0.0,
+                rationale=f"Unsupported Brand Monitor action '{action}'.",
+                recommended_actions=[
+                    {
+                        "action": "use_supported_brand_monitor_action",
+                        "reason": "Brand Monitor only executes declared deterministic actions.",
+                    }
+                ],
+                blocked_reasons=[f"Unsupported Brand Monitor action '{action}'."],
+                policy_context={"workflow_mode": mode},
+            )
+            return self._make_result(
+                task,
+                msg_id,
+                "failed",
+                output,
+                0.0,
+                trace,
+                tool_calls,
+                error={"code": "BRAND_MONITOR_ACTION_UNSUPPORTED", "message": output["blocked_reasons"][0]},
+                start=start,
+            )
+        # enterprise-gate: broad-except-ok reason=agent-execution-boundary-returns-failed-result
+        except Exception as exc:
+            logger.error("brand_monitor_agent_error", agent=self.agent_id, error=str(exc))
+            trace.append(f"Error: {exc}")
+            return self._make_result(
+                task,
+                msg_id,
+                "failed",
+                {},
+                0.0,
+                trace,
+                tool_calls,
+                error={"code": "BRAND_MONITOR_AGENT_ERR", "message": str(exc)},
+                start=start,
+            )
+
+    def _read_only_action(
+        self,
+        task,
+        action: str,
+        inputs: dict[str, Any],
+        mode: str,
+        trace: list[str],
+    ) -> dict[str, Any]:
+        mentions = _normalized_mentions(inputs)
+        retained, suppressed = _suppress_false_positives(mentions, inputs)
+        groups = _mention_groups(retained)
+        sentiment = _sentiment_trend(retained, inputs)
+        spike = _negative_spike(sentiment, inputs)
+        crisis = _crisis_classification(retained, sentiment, spike, inputs)
+        playbook = _playbook_recommendations(crisis, spike, groups, inputs)
+        degraded = _read_degraded_reasons(inputs)
+        confidence = _monitor_confidence(retained, degraded, crisis)
+        needs_escalation = crisis["severity"] in {"high", "critical"} or spike["triggered"]
+        escalation = (
+            _escalation_for_brand_event(task, action, inputs, crisis=crisis, spike=spike)
+            if needs_escalation
+            else {}
+        )
+        summary = {
+            "total_mentions": len(mentions),
+            "retained_mentions": len(retained),
+            "suppressed_mentions": len(suppressed),
+            "sentiment_trend": sentiment,
+            "negative_spike": spike,
+            "crisis_severity": crisis,
+            "mention_groups": groups,
+            "playbook": playbook,
+        }
+        trace.append(
+            "Brand monitoring mentions="
+            f"{len(mentions)}, retained={len(retained)}, severity={crisis['severity']}, degraded={len(degraded)}"
+        )
+
+        status = "monitoring_degraded" if degraded else "monitoring_ready"
+        rationale = "Built a deterministic brand monitoring summary from structured mentions."
+        extra: dict[str, Any] = {"brand_monitoring": summary}
+        if action in {"aggregate_mentions", "mention_aggregation", "monitor_mentions"}:
+            extra.update({"mentions": retained, "suppressed_mentions": suppressed, "mention_groups": groups})
+            status = "mentions_aggregated" if not degraded else "mentions_degraded"
+            rationale = "Aggregated mentions by source, channel, topic, and brand/competitor grouping."
+        elif action in {"get_sentiment", "classify_sentiment", "sentiment_trend"}:
+            extra.update({"sentiment_trend": sentiment})
+            status = "sentiment_trend_ready" if not degraded else "sentiment_trend_degraded"
+            rationale = "Calculated deterministic positive, neutral, and negative sentiment distribution."
+        elif action in {"detect_negative_spike", "negative_spike_detection"}:
+            extra.update({"negative_spike": spike})
+            status = "negative_spike_detected" if spike["triggered"] else "negative_spike_clear"
+            rationale = "Compared current negative mention volume against baseline and threshold policy."
+        elif action in {"false_positive_suppression", "suppress_false_positives"}:
+            extra.update({"mentions": retained, "suppressed_mentions": suppressed})
+            status = "false_positives_suppressed"
+            rationale = "Suppressed irrelevant mentions before calculating sentiment and crisis risk."
+        elif action == "classify_crisis_severity":
+            extra.update({"crisis_severity": crisis})
+            status = "crisis_classified"
+            rationale = "Classified crisis severity from volume, sentiment, source, and crisis terms."
+        elif action in {"group_mentions", "competitor_brand_grouping"}:
+            extra.update({"mention_groups": groups})
+            status = "mentions_grouped"
+            rationale = "Grouped brand and competitor mentions from structured input."
+        elif action in {"recommend_response_playbook", "response_playbook_recommendation", "escalation_recommendation"}:
+            extra.update({"response_playbook": playbook})
+            status = "playbook_recommended"
+            rationale = "Recommended a deterministic response playbook for the current brand-risk level."
+        elif action == "detect_crisis":
+            extra.update({"crisis_severity": crisis, "negative_spike": spike})
+            status = "crisis_detected" if crisis["severity"] in {"high", "critical"} else "crisis_clear"
+            rationale = "Evaluated mentions for crisis signals and public-response escalation needs."
+
+        return self._base_output(
+            task,
+            action=action,
+            status=status,
+            confidence=confidence,
+            rationale=rationale,
+            recommended_actions=playbook,
+            approval_required=needs_escalation,
+            hitl_required=needs_escalation,
+            policy_context={
+                "workflow_id": "brand_crisis_response",
+                "workflow_mode": mode,
+                "crisis_response": needs_escalation,
+                "public_response": False,
+            },
+            escalation=escalation,
+            source_refs=_source_refs(inputs, retained),
+            degraded_reasons=degraded,
+            extra=extra,
+        )
+
+    async def _guarded_brand_write(
+        self,
+        task,
+        action: str,
+        inputs: dict[str, Any],
+        mode: str,
+        trace: list[str],
+        tool_calls: list[ToolCallRecord],
+    ) -> dict[str, Any]:
+        policy_context = _policy_context_for_write(action, inputs, mode)
+        policy = evaluate_marketing_policy(policy_context)
+        escalation = _escalation_for_write(task, action, inputs, policy)
+        blocked_reasons: list[str] = []
+        hitl_reasons: list[str] = []
+
+        if mode in SHADOW_MODES:
+            blocked_reasons.append("Shadow/draft/internal Brand Monitor workflows are read-only.")
+            trace.append("Brand Monitor write converted to shadow-only recommendation")
+            return self._base_output(
+                task,
+                action=action,
+                status="shadow_only",
+                confidence=0.78,
+                rationale="Prepared brand response recommendation without publishing or changing external systems.",
+                recommended_actions=[
+                    {
+                        "action": "review_brand_response_recommendation",
+                        "reason": "Review the response before any active public write is attempted.",
+                    }
+                ],
+                approval_required=True,
+                hitl_required=True,
+                policy_result=policy,
+                escalation=escalation,
+                blocked_reasons=blocked_reasons,
+                external_write_status="shadow_only",
+                external_write_required=True,
+                extra={"write_payload": _brand_write_payload(action, inputs)},
+            )
+
+        write_safe, write_reason = _connector_write_safe(inputs)
+        if not write_safe:
+            blocked_reasons.append(write_reason)
+        if not _has_approval(inputs):
+            hitl_reasons.append(str(policy.get("reason") or "Brand public response requires approval."))
+        if policy.get("decision") in {"blocked", "missing_policy"}:
+            blocked_reasons.append(str(policy.get("reason") or "Marketing policy blocks this brand action."))
+        escalation_needs_review = escalation.get("decision") not in {None, "", "no_escalation", "notify_owner"}
+        if escalation_needs_review and not _has_escalation_approval(inputs):
+            hitl_reasons.append("Brand response requires escalation review.")
+
+        if blocked_reasons or hitl_reasons:
+            return self._base_output(
+                task,
+                action=action,
+                status="blocked",
+                confidence=0.0,
+                rationale="Brand Monitor external action failed closed before vendor mutation.",
+                recommended_actions=[
+                    {
+                        "action": "resolve_brand_response_prerequisites",
+                        "reason": "; ".join(_dedupe(blocked_reasons + hitl_reasons)),
+                    }
+                ],
+                approval_required=bool(hitl_reasons),
+                hitl_required=True,
+                policy_result=policy,
+                escalation=escalation,
+                blocked_reasons=blocked_reasons + hitl_reasons,
+                external_write_status="write_unconfirmed",
+                external_write_required=True,
+                extra={"write_payload": _brand_write_payload(action, inputs)},
+            )
+
+        result = _dict_or_none(inputs.get("external_write_result"))
+        connector, tool = _connector_tool(action, inputs)
+        idempotency_key = str(
+            inputs.get("idempotency_key")
+            or inputs.get("request_fingerprint")
+            or f"brand_monitor:{task.correlation_id}:{task.step_id}:{action}"
+        )
+        if result is None:
+            result = await self._safe_tool_call(
+                connector,
+                tool,
+                _brand_write_payload(action, inputs),
+                trace,
+                tool_calls,
+                idempotency_key=idempotency_key,
+            )
+
+        write_status = _external_write_confirmation_status(result)
+        write_confirmed = _is_confirmed_external_write(result)
+        external_ref = _external_write_ref(result)
+        blocked_reasons = [] if write_confirmed else ["Brand response write is unconfirmed and cannot complete."]
+        trace.append(f"Brand Monitor write status={write_status}, confirmed={write_confirmed}")
+        return self._base_output(
+            task,
+            action=action,
+            status="write_confirmed" if write_confirmed else "write_unconfirmed",
+            confidence=0.9 if write_confirmed else 0.0,
+            rationale=(
+                "Brand Monitor external write was confirmed by the connector."
+                if write_confirmed
+                else "Brand Monitor external write did not return confirmed vendor evidence."
+            ),
+            recommended_actions=[
+                {
+                    "action": "monitor_brand_response" if write_confirmed else "verify_brand_write_before_retry",
+                    "reason": (
+                        "Track follow-up sentiment and crisis volume."
+                        if write_confirmed
+                        else "Check vendor state with the idempotency key before retrying."
+                    ),
+                }
+            ],
+            approval_required=False,
+            hitl_required=not write_confirmed,
+            policy_result=policy,
+            approval_satisfied=_has_approval(inputs),
+            escalation=escalation,
+            blocked_reasons=blocked_reasons,
+            external_write_status=write_status,
+            external_write_required=True,
+            external_write_ref=external_ref,
+            extra={"write_payload": _brand_write_payload(action, inputs)},
+        )
+
+    async def _safe_tool_call(
+        self,
+        connector: str,
+        tool: str,
+        params: dict[str, Any],
+        trace: list[str],
+        tool_records: list[ToolCallRecord],
+        *,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        call_start = time.monotonic()
+        try:
+            result = await self._call_tool(
+                connector_name=connector,
+                tool_name=tool,
+                params=params,
+                idempotency_key=idempotency_key,
+            )
+            latency = int((time.monotonic() - call_start) * 1000)
+            status = "error" if "error" in result else "success"
+            trace.append(f"[tool] {connector}.{tool} -> {status} ({latency}ms)")
+            tool_records.append(ToolCallRecord(tool_name=f"{connector}.{tool}", status=status, latency_ms=latency))
+            return result
+        # enterprise-gate: broad-except-ok reason=agent-tool-call-failure-returns-explicit-error-result
+        except Exception as exc:
+            latency = int((time.monotonic() - call_start) * 1000)
+            trace.append(f"[tool] {connector}.{tool} -> exception: {exc} ({latency}ms)")
+            tool_records.append(ToolCallRecord(tool_name=f"{connector}.{tool}", status="error", latency_ms=latency))
+            return {"error": str(exc)}
+
+    def _base_output(
+        self,
+        task,
+        *,
+        action: str,
+        status: str,
+        confidence: float,
+        rationale: str,
+        recommended_actions: list[dict[str, Any]],
+        approval_required: bool = False,
+        hitl_required: bool = False,
+        policy_context: dict[str, Any] | None = None,
+        policy_result: dict[str, Any] | None = None,
+        approval_satisfied: bool = False,
+        escalation: dict[str, Any] | None = None,
+        source_refs: list[dict[str, Any]] | None = None,
+        degraded_reasons: list[str] | None = None,
+        blocked_reasons: list[str] | None = None,
+        external_write_status: str = "not_required",
+        external_write_required: bool = False,
+        external_write_ref: dict[str, Any] | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        policy = policy_result or evaluate_marketing_policy(
+            {
+                "workflow_id": "brand_crisis_response",
+                "workflow_mode": "shadow",
+                "action": action,
+                "external_write_required": external_write_required,
+                **(policy_context or {}),
+            }
+        )
+        escalation_ref = None
+        if escalation and escalation.get("decision") != "no_escalation":
+            escalation_ref = escalation.get("decision_audit_ref") or escalation.get("audit_reference")
+        policy_needs_review = (
+            policy.get("decision") in {"requires_approval", "requires_escalation", "read_only_only"}
+            and not approval_satisfied
+        )
+        output: dict[str, Any] = {
+            "status": status,
+            "agent_type": self.agent_type,
+            "action": action,
+            "confidence": round(max(0.0, min(confidence, 1.0)), 3),
+            "rationale": rationale,
+            "recommended_actions": recommended_actions,
+            "source_refs": source_refs or [],
+            "policy_result": policy,
+            "policy_ref": policy.get("decision_audit_ref") or policy.get("policy_id"),
+            "approval_required": approval_required or policy_needs_review,
+            "hitl_required": hitl_required,
+            "escalation_ref": escalation_ref,
+            "escalation_result": escalation,
+            "audit_ref": f"brand_monitor:{task.correlation_id}:{task.step_id}:{action}",
+            "degraded_reasons": _dedupe(degraded_reasons or []),
+            "blocked_reasons": _dedupe(blocked_reasons or []),
+            "external_write_confirmation_status": external_write_status,
+            "external_writes_completed": external_write_status == "write_confirmed",
+            "external_write_required": external_write_required,
+            "external_write_ref": external_write_ref,
+            "production_status": BRAND_MONITOR_AGENT_MATURITY,
+        }
+        if extra:
+            output.update(extra)
+        return output
+
+    def _complete_or_hitl(
+        self,
+        task,
+        msg_id: str,
+        output: dict[str, Any],
+        trace: list[str],
+        tool_calls: list[ToolCallRecord],
+        start: float,
+    ):
+        if output.get("hitl_required") or output.get("approval_required") or output.get("blocked_reasons"):
+            return self._make_result(
+                task,
+                msg_id,
+                "hitl_triggered",
+                output,
+                float(output.get("confidence") or 0.0),
+                trace,
+                tool_calls,
+                hitl_request=_hitl_request(task, output),
+                start=start,
+            )
+        return self._make_result(
+            task,
+            msg_id,
+            "completed",
+            output,
+            float(output.get("confidence") or 0.0),
+            trace,
+            tool_calls,
+            start=start,
+        )
+
+
+def _task_inputs(task) -> dict[str, Any]:
+    payload = task.task.inputs if hasattr(task.task, "inputs") else task.task.get("inputs", {})
+    return payload if isinstance(payload, dict) else {}
+
+
+def _task_action(task) -> str:
+    return str(task.task.action if hasattr(task.task, "action") else task.task.get("action", "monitor_mentions"))
+
+
+def _normalize_action(action: str) -> str:
+    normalized = _normalize(action)
+    aliases = {
+        "aggregate": "mention_aggregation",
+        "aggregate_brand_mentions": "mention_aggregation",
+        "brand_claim_review": "brand_claim",
+        "brand_sentiment": "sentiment_trend",
+        "crisis_severity": "classify_crisis_severity",
+        "negative_volume_spike": "detect_negative_spike",
+        "playbook": "recommend_response_playbook",
+        "publish_response": "publish_brand_response",
+        "response_recommendation": "recommend_response_playbook",
+        "sentiment": "sentiment_trend",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def _normalized_mentions(inputs: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = _dict_list(
+        inputs.get("mentions")
+        or inputs.get("brand_mentions")
+        or inputs.get("social_mentions")
+        or inputs.get("news_mentions")
+    )
+    return [_normalize_mention(row, index) for index, row in enumerate(rows)]
+
+
+def _normalize_mention(row: dict[str, Any], index: int) -> dict[str, Any]:
+    text = str(row.get("text") or row.get("body") or row.get("content") or row.get("summary") or "").strip()
+    explicit_sentiment = str(row.get("sentiment") or "").strip().lower()
+    sentiment = _classify_sentiment(text, explicit_sentiment)
+    entity = str(row.get("entity") or row.get("brand") or row.get("company") or "brand").strip() or "brand"
+    entity_type = str(row.get("entity_type") or row.get("type") or "").strip().lower()
+    if not entity_type:
+        entity_type = "competitor" if row.get("competitor") or row.get("competitor_name") else "brand"
+    topic = str(row.get("topic") or row.get("category") or _topic_from_text(text)).strip().lower()
+    return {
+        "mention_id": str(row.get("mention_id") or row.get("id") or f"mention-{index + 1}"),
+        "text": text,
+        "source": str(row.get("source") or row.get("connector_key") or "provided_input").strip().lower(),
+        "channel": str(row.get("channel") or row.get("platform") or row.get("source") or "unknown").strip().lower(),
+        "topic": topic or "general",
+        "entity": entity,
+        "entity_type": entity_type,
+        "competitor": str(row.get("competitor") or row.get("competitor_name") or "").strip(),
+        "sentiment": sentiment,
+        "sentiment_score": _sentiment_score(sentiment, row.get("sentiment_score")),
+        "influence": str(row.get("influence") or row.get("author_tier") or "normal").strip().lower(),
+        "created_at": str(row.get("created_at") or row.get("observed_at") or row.get("timestamp") or ""),
+        "source_url": row.get("source_url") or row.get("url"),
+        "false_positive": bool(row.get("false_positive") or row.get("irrelevant") or row.get("is_false_positive")),
+    }
+
+
+def _classify_sentiment(text: str, explicit: str) -> str:
+    if explicit in {"positive", "neutral", "negative"}:
+        return explicit
+    normalized = text.lower()
+    negative_score = sum(1 for term in NEGATIVE_TERMS if term in normalized)
+    positive_score = sum(1 for term in POSITIVE_TERMS if term in normalized)
+    if negative_score > positive_score:
+        return "negative"
+    if positive_score > negative_score:
+        return "positive"
+    return "neutral"
+
+
+def _sentiment_score(sentiment: str, explicit: Any) -> float:
+    if explicit is not None:
+        return _float(explicit, {"positive": 0.7, "neutral": 0.0, "negative": -0.7}.get(sentiment, 0.0))
+    return {"positive": 0.75, "neutral": 0.0, "negative": -0.75}.get(sentiment, 0.0)
+
+
+def _suppress_false_positives(
+    mentions: list[dict[str, Any]],
+    inputs: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    terms = [term.lower() for term in _string_list(inputs.get("false_positive_terms"))]
+    if not terms:
+        terms = list(DEFAULT_FALSE_POSITIVE_TERMS)
+    retained: list[dict[str, Any]] = []
+    suppressed: list[dict[str, Any]] = []
+    brand_terms = [term.lower() for term in _string_list(inputs.get("brand_terms") or inputs.get("brand_names"))]
+    for mention in mentions:
+        text = str(mention.get("text") or "").lower()
+        explicit = bool(mention.get("false_positive"))
+        term_match = any(term and term in text for term in terms)
+        missing_brand_when_required = bool(brand_terms) and not any(term in text for term in brand_terms)
+        if explicit or term_match or missing_brand_when_required:
+            suppressed.append({**mention, "suppression_reason": "false_positive_or_irrelevant"})
+        else:
+            retained.append(mention)
+    return retained, suppressed
+
+
+def _mention_groups(mentions: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "by_source": _count_by(mentions, "source"),
+        "by_channel": _count_by(mentions, "channel"),
+        "by_topic": _count_by(mentions, "topic"),
+        "by_entity": _count_by(mentions, "entity_type"),
+        "competitors": _count_by(
+            [mention for mention in mentions if mention.get("competitor")],
+            "competitor",
+        ),
+    }
+
+
+def _sentiment_trend(mentions: list[dict[str, Any]], inputs: dict[str, Any]) -> dict[str, Any]:
+    counts = {
+        "positive": sum(1 for mention in mentions if mention.get("sentiment") == "positive"),
+        "neutral": sum(1 for mention in mentions if mention.get("sentiment") == "neutral"),
+        "negative": sum(1 for mention in mentions if mention.get("sentiment") == "negative"),
+    }
+    total = sum(counts.values())
+    distribution = {key: _pct(value, total) for key, value in counts.items()}
+    previous = _previous_sentiment(inputs)
+    delta = {key: counts[key] - int(previous.get(key, 0)) for key in counts}
+    baseline_negative = _float(inputs.get("baseline_negative_mentions"), float(previous.get("negative", 0)))
+    if baseline_negative <= 0:
+        baseline_negative = _float(inputs.get("baseline_negative_volume"), 0.0)
+    return {
+        "counts": counts,
+        "total": total,
+        "distribution": distribution,
+        "negative_ratio": distribution["negative"],
+        "previous_counts": previous,
+        "delta": delta,
+        "baseline_negative_mentions": baseline_negative,
+    }
+
+
+def _negative_spike(sentiment: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
+    current = int((sentiment.get("counts") or {}).get("negative") or 0)
+    baseline = _float(sentiment.get("baseline_negative_mentions"), 0.0)
+    threshold_multiplier = _float(inputs.get("negative_spike_multiplier"), 2.0)
+    min_count = int(_float(inputs.get("negative_spike_min_count"), 5.0))
+    threshold = max(float(min_count), baseline * threshold_multiplier)
+    triggered = current >= threshold and current >= min_count
+    ratio = _float(sentiment.get("negative_ratio"), 0.0)
+    severity = "none"
+    if triggered:
+        if current >= 10 and ((baseline and current >= baseline * 4) or ratio >= 0.65):
+            severity = "critical"
+        elif current >= 5 and ((baseline and current >= baseline * 3) or ratio >= 0.45):
+            severity = "high"
+        else:
+            severity = "medium"
+    return {
+        "triggered": triggered,
+        "current_negative_mentions": current,
+        "baseline_negative_mentions": baseline,
+        "threshold": round(threshold, 2),
+        "threshold_multiplier": threshold_multiplier,
+        "severity": severity,
+    }
+
+
+def _crisis_classification(
+    mentions: list[dict[str, Any]],
+    sentiment: dict[str, Any],
+    spike: dict[str, Any],
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    text = " ".join(str(mention.get("text") or "").lower() for mention in mentions)
+    crisis_term_hits = sorted({term for term in CRISIS_TERMS if term in text})
+    executive_mentions = sum(
+        1
+        for mention in mentions
+        if mention.get("influence") in {"executive", "journalist", "analyst"}
+    )
+    negative = int((sentiment.get("counts") or {}).get("negative") or 0)
+    negative_ratio = _float(sentiment.get("negative_ratio"), 0.0)
+    if inputs.get("crisis_severity"):
+        severity = str(inputs["crisis_severity"]).strip().lower()
+    elif inputs.get("crisis_response") or len(crisis_term_hits) >= 2 or spike.get("severity") == "critical":
+        severity = "critical"
+    elif crisis_term_hits or spike.get("severity") == "high" or (negative >= 8 and negative_ratio >= 0.45):
+        severity = "high"
+    elif spike.get("triggered") or negative >= 3 or negative_ratio >= 0.25:
+        severity = "medium"
+    else:
+        severity = "low"
+    if severity not in {"low", "medium", "high", "critical"}:
+        severity = "medium"
+    return {
+        "severity": severity,
+        "negative_mentions": negative,
+        "negative_ratio": round(negative_ratio, 3),
+        "crisis_terms": crisis_term_hits,
+        "executive_or_media_mentions": executive_mentions,
+        "public_response_required": severity in {"high", "critical"},
+        "escalation_required": severity in {"high", "critical"},
+    }
+
+
+def _playbook_recommendations(
+    crisis: dict[str, Any],
+    spike: dict[str, Any],
+    groups: dict[str, Any],
+    _inputs: dict[str, Any],
+) -> list[dict[str, Any]]:
+    severity = str(crisis.get("severity") or "low")
+    if severity == "critical":
+        return [
+            {
+                "action": "escalate_brand_crisis",
+                "reason": "Critical brand risk requires Brand Comms, CMO, Legal, and CEO review.",
+            },
+            {
+                "action": "prepare_approved_holding_statement",
+                "reason": "Public response must be reviewed before publication.",
+            },
+            {
+                "action": "pause_scheduled_sensitive_posts",
+                "reason": "Avoid amplifying brand risk while crisis response is reviewed.",
+            },
+        ]
+    if severity == "high":
+        return [
+            {
+                "action": "escalate_to_brand_comms_and_cmo",
+                "reason": "High brand risk needs owner routing and response approval.",
+            },
+            {
+                "action": "draft_response_options",
+                "reason": "Prepare reviewed response variants without publishing.",
+            },
+        ]
+    if severity == "medium" or spike.get("triggered"):
+        return [
+            {
+                "action": "assign_brand_owner_review",
+                "reason": "Negative mention volume is elevated and should be reviewed.",
+            },
+            {
+                "action": "monitor_followup_mentions",
+                "reason": f"Track channels: {', '.join(sorted((groups.get('by_channel') or {}).keys())) or 'unknown'}.",
+            },
+        ]
+    return [
+        {
+            "action": "continue_brand_monitoring",
+            "reason": "Mention volume and sentiment are within normal operating range.",
+        }
+    ]
+
+
+def _read_degraded_reasons(inputs: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    if inputs.get("connector_read_ready") is False or inputs.get("connector_degraded") is True:
+        reasons.append("Brand monitoring connector is degraded or unavailable.")
+    contracts = _dict_list(inputs.get("connector_contracts"))
+    direct = _dict_or_none(inputs.get("connector_contract"))
+    if direct:
+        contracts.insert(0, direct)
+    if contracts:
+        relevant = [contract for contract in contracts if _is_brand_contract(contract)]
+        if relevant and not any(bool(contract.get("read_ready", contract.get("configured"))) for contract in relevant):
+            reasons.append("Brand monitoring source connector is not read-ready.")
+        if any(contract.get("degraded") or contract.get("health_status") == "degraded" for contract in relevant):
+            reasons.append("One or more brand monitoring sources are degraded.")
+    return _dedupe(reasons)
+
+
+def _monitor_confidence(
+    retained_mentions: list[dict[str, Any]],
+    degraded_reasons: list[str],
+    crisis: dict[str, Any],
+) -> float:
+    if not retained_mentions:
+        base = 0.58
+    elif len(retained_mentions) < 3:
+        base = 0.72
+    else:
+        base = 0.88
+    if crisis.get("severity") in {"high", "critical"}:
+        base = min(0.92, base + 0.04)
+    if degraded_reasons:
+        base -= 0.22
+    return max(0.0, min(base, 1.0))
+
+
+def _policy_context_for_write(action: str, inputs: dict[str, Any], mode: str) -> dict[str, Any]:
+    return {
+        "workflow_id": "brand_crisis_response",
+        "workflow_mode": mode,
+        "action": action,
+        "external_write_required": True,
+        "public_response": action in {"crisis_response", "public_response", "publish_brand_response"},
+        "crisis_response": (
+            action in {"crisis_response", "publish_brand_response"}
+            or bool(inputs.get("crisis_response"))
+        ),
+        "brand_claim": action == "brand_claim",
+        "comparative_claim": action == "comparative_claim",
+        "pricing_claim": action == "pricing_claim",
+        "legal_claim": bool(inputs.get("legal_claim")),
+    }
+
+
+def _escalation_for_brand_event(
+    task,
+    action: str,
+    inputs: dict[str, Any],
+    *,
+    crisis: dict[str, Any],
+    spike: dict[str, Any],
+) -> dict[str, Any]:
+    severity = str(crisis.get("severity") or spike.get("severity") or "medium")
+    return evaluate_marketing_escalation(
+        {
+            "workflow_id": "brand_crisis_response",
+            "workflow_run_id": getattr(task, "workflow_run_id", None),
+            "step_id": getattr(task, "step_id", None),
+            "action": action,
+            "event_type": "crisis_public_response",
+            "crisis_response": severity in {"high", "critical"},
+            "public_response": False,
+            "severity": severity,
+            "reason": str(inputs.get("escalation_reason") or "Brand monitoring signal requires owner routing."),
+        }
+    )
+
+
+def _escalation_for_write(
+    task,
+    action: str,
+    inputs: dict[str, Any],
+    policy_result: dict[str, Any],
+) -> dict[str, Any]:
+    return evaluate_marketing_escalation(
+        {
+            "workflow_id": "brand_crisis_response",
+            "workflow_run_id": getattr(task, "workflow_run_id", None),
+            "step_id": getattr(task, "step_id", None),
+            "action": action,
+            "public_response": action in {"crisis_response", "public_response", "publish_brand_response"},
+            "crisis_response": (
+                action in {"crisis_response", "publish_brand_response"}
+                or bool(inputs.get("crisis_response"))
+            ),
+            "brand_claim": action == "brand_claim",
+            "comparative_claim": action == "comparative_claim",
+            "pricing_claim": action == "pricing_claim",
+            "legal_claim": bool(inputs.get("legal_claim")),
+            "severity": str(inputs.get("severity") or inputs.get("crisis_severity") or "high"),
+            "reason": "Brand Monitor external action requires owner routing.",
+            "marketing_policy_decision": policy_result,
+        }
+    )
+
+
+def _connector_write_safe(inputs: dict[str, Any]) -> tuple[bool, str]:
+    if inputs.get("connector_write_ready") is True or inputs.get("write_ready") is True:
+        return True, ""
+    if inputs.get("connector_write_ready") is False or inputs.get("write_ready") is False:
+        return False, "Brand Monitor connector is not write-safe."
+    contracts = _dict_list(inputs.get("connector_contracts"))
+    direct = _dict_or_none(inputs.get("connector_contract"))
+    if direct:
+        contracts.insert(0, direct)
+    if contracts:
+        for contract in contracts:
+            if not _is_brand_write_contract(contract):
+                continue
+            if contract.get("mock_or_test_double"):
+                return False, "Test-double connector proof cannot satisfy active Brand Monitor writes."
+            if bool(contract.get("write_safe", contract.get("write_ready"))):
+                return True, ""
+            status = str(contract.get("write_status") or contract.get("contract_state") or "unknown")
+            return False, f"Brand Monitor connector contract is not write-safe ({status})."
+        return False, "No Social/Brand connector contract is write-safe for Brand Monitor action."
+    return False, "Brand Monitor connector write-readiness evidence is missing."
+
+
+def _is_brand_contract(contract: dict[str, Any]) -> bool:
+    category = str(contract.get("category") or "").strip().lower()
+    key = str(contract.get("connector_key") or contract.get("key") or "").strip().lower()
+    return category in {"brand", "social"} or key in {"brandwatch", "buffer", "twitter", "x", "youtube"}
+
+
+def _is_brand_write_contract(contract: dict[str, Any]) -> bool:
+    category = str(contract.get("category") or "").strip().lower()
+    key = str(contract.get("connector_key") or contract.get("key") or "").strip().lower()
+    return category in {"social", "brand"} or key in {"brandwatch", "buffer", "twitter", "x"}
+
+
+def _has_approval(inputs: dict[str, Any]) -> bool:
+    return bool(
+        inputs.get("approved")
+        or inputs.get("approval_ref")
+        or inputs.get("approval_result_ref")
+        or inputs.get("policy_approval_ref")
+    )
+
+
+def _has_escalation_approval(inputs: dict[str, Any]) -> bool:
+    return bool(inputs.get("escalation_ref") or inputs.get("escalation_result_ref") or inputs.get("approved"))
+
+
+def _connector_tool(action: str, inputs: dict[str, Any]) -> tuple[str, str]:
+    explicit = str(inputs.get("connector_key") or inputs.get("connector") or "").strip().lower()
+    if action in {"crisis_response", "public_response", "publish_brand_response"}:
+        return explicit or "buffer", "publish_brand_response"
+    return explicit or "brandwatch", "record_brand_claim"
+
+
+def _brand_write_payload(action: str, inputs: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "action": action,
+        "message": inputs.get("message") or inputs.get("copy") or inputs.get("claim"),
+        "severity": inputs.get("severity") or inputs.get("crisis_severity"),
+        "source_refs": _dict_list(inputs.get("source_refs")),
+        "rollback_plan": inputs.get("rollback_plan") or "retract or pause public response after review",
+    }
+
+
+def _external_write_confirmation_status(result: dict[str, Any] | None) -> str:
+    if not result:
+        return "write_unconfirmed"
+    return str(
+        result.get("external_write_confirmation_status")
+        or result.get("write_confirmation_status")
+        or result.get("status")
+        or "write_unconfirmed"
+    )
+
+
+def _is_confirmed_external_write(result: dict[str, Any] | None) -> bool:
+    if not result or "error" in result:
+        return False
+    status = _external_write_confirmation_status(result)
+    return status == "write_confirmed" and bool(
+        result.get("external_object_id") or result.get("external_id") or result.get("confirmed_at")
+    )
+
+
+def _external_write_ref(result: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not result:
+        return None
+    return {
+        "connector_key": result.get("connector_key"),
+        "external_object_id": result.get("external_object_id") or result.get("external_id"),
+        "source_url": result.get("source_url") or result.get("url"),
+        "idempotency_key": result.get("idempotency_key"),
+        "confirmed_at": result.get("confirmed_at"),
+        "audit_ref": result.get("audit_ref") or result.get("audit_reference"),
+    }
+
+
+def _hitl_request(task, output: dict[str, Any]) -> HITLRequest:
+    reasons = output.get("blocked_reasons") or []
+    if not reasons and output.get("policy_result"):
+        reasons = [str(output["policy_result"].get("reason") or "Brand Monitor action requires review.")]
+    escalation = output.get("escalation_result") or {}
+    role = escalation.get("owner_role") or escalation.get("primary_owner_role") or "cmo"
+    return HITLRequest(
+        hitl_id=f"hitl_{uuid.uuid4().hex[:12]}",
+        trigger_condition="; ".join(str(reason) for reason in reasons) or "Brand Monitor review required.",
+        trigger_type="brand_monitor_review",
+        decision_required=DecisionRequired(
+            question="Review brand monitoring recommendation or public-response safeguard.",
+            options=[
+                DecisionOption(id="approve", label="Approve", action="proceed"),
+                DecisionOption(id="request_changes", label="Request changes", action="defer"),
+                DecisionOption(id="escalate", label="Escalate", action="defer"),
+                DecisionOption(id="reject", label="Reject", action="reject"),
+            ],
+        ),
+        context=HITLContext(
+            summary=output.get("rationale") or "Brand Monitor review",
+            recommendation=output.get("recommended_actions", [{}])[0].get("action", "review"),
+            agent_confidence=float(output.get("confidence") or 0.0),
+            supporting_data={
+                "policy_decision": (output.get("policy_result") or {}).get("decision"),
+                "blocked_reasons": output.get("blocked_reasons") or [],
+                "external_write_status": output.get("external_write_confirmation_status"),
+                "crisis_severity": (
+                    (output.get("brand_monitoring") or {}).get("crisis_severity") or {}
+                ).get("severity"),
+            },
+        ),
+        assignee=HITLAssignee(role=str(role), notify_channels=["slack", "email"]),
+    )
+
+
+def _source_refs(inputs: dict[str, Any], mentions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    refs = _dict_list(inputs.get("source_refs"))
+    for mention in mentions:
+        refs.append(
+            {
+                "type": str(mention.get("source") or "brand_source"),
+                "ref_id": str(mention.get("mention_id") or "provided_input"),
+                "source_url": mention.get("source_url"),
+            }
+        )
+    return _dedupe_refs(refs)
+
+
+def _previous_sentiment(inputs: dict[str, Any]) -> dict[str, int]:
+    direct = inputs.get("previous_sentiment_counts") or inputs.get("baseline_sentiment_counts")
+    if isinstance(direct, dict):
+        return {
+            "positive": int(_float(direct.get("positive"), 0.0)),
+            "neutral": int(_float(direct.get("neutral"), 0.0)),
+            "negative": int(_float(direct.get("negative"), 0.0)),
+        }
+    previous_mentions = [
+        _normalize_mention(row, index)
+        for index, row in enumerate(_dict_list(inputs.get("previous_mentions")))
+    ]
+    return {
+        "positive": sum(1 for mention in previous_mentions if mention.get("sentiment") == "positive"),
+        "neutral": sum(1 for mention in previous_mentions if mention.get("sentiment") == "neutral"),
+        "negative": sum(1 for mention in previous_mentions if mention.get("sentiment") == "negative"),
+    }
+
+
+def _topic_from_text(text: str) -> str:
+    normalized = text.lower()
+    if any(term in normalized for term in ("price", "pricing", "cost")):
+        return "pricing"
+    if any(term in normalized for term in ("outage", "down", "broken")):
+        return "reliability"
+    if any(term in normalized for term in ("security", "breach", "data")):
+        return "security"
+    if any(term in normalized for term in ("support", "service", "response")):
+        return "support"
+    return "general"
+
+
+def _count_by(rows: list[dict[str, Any]], field: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in rows:
+        value = str(row.get(field) or "unknown").strip().lower() or "unknown"
+        counts[value] = counts.get(value, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _pct(value: int, total: int) -> float:
+    return round(value / total, 3) if total else 0.0
+
+
+def _workflow_mode(inputs: dict[str, Any]) -> str:
+    return _normalize(
+        inputs.get("workflow_mode")
+        or inputs.get("mode")
+        or inputs.get("readiness")
+        or inputs.get("capability_state")
+        or "shadow"
+    )
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _dict_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _dict_or_none(value: Any) -> dict[str, Any] | None:
+    return value if isinstance(value, dict) else None
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return []
+
+
+def _float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _dedupe_refs(refs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[tuple[str, str]] = set()
+    result: list[dict[str, Any]] = []
+    for ref in refs:
+        key = (
+            str(ref.get("type") or ref.get("connector_key") or ""),
+            str(ref.get("ref_id") or ref.get("object") or ""),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(ref)
+    return result

--- a/core/agents/marketing/campaign_pilot.py
+++ b/core/agents/marketing/campaign_pilot.py
@@ -38,6 +38,26 @@ DEFAULT_CHANNEL_ALLOCATION = {
 HITL_BUDGET_THRESHOLD = 500_000  # INR 5 lakhs
 
 
+def _external_write_confirmation_status(result: dict[str, Any] | None) -> str:
+    if not result:
+        return "write_unconfirmed"
+    return str(
+        result.get("external_write_confirmation_status")
+        or result.get("write_confirmation_status")
+        or result.get("status")
+        or "write_unconfirmed"
+    )
+
+
+def _is_confirmed_external_write(result: dict[str, Any] | None) -> bool:
+    if not result or "error" in result:
+        return False
+    status = _external_write_confirmation_status(result)
+    return status == "write_confirmed" and bool(
+        result.get("external_object_id") or result.get("external_id") or result.get("confirmed_at")
+    )
+
+
 @AgentRegistry.register
 class CampaignPilotAgent(BaseAgent):
     agent_type = "campaign_pilot"
@@ -136,6 +156,7 @@ class CampaignPilotAgent(BaseAgent):
             actions_taken: list[dict] = []
             channels_paused: list[str] = []
             channels_scaled: list[str] = []
+            unconfirmed_external_writes: list[str] = []
 
             for channel, perf in channel_performance.items():
                 roas = perf.get("roas", 0)
@@ -155,13 +176,27 @@ class CampaignPilotAgent(BaseAgent):
                             {"campaign_id": campaign_id, "campaign_name": campaign_name},
                             trace, tool_calls,
                         )
-                        paused = pause_result and "error" not in pause_result
-                        actions_taken.append({
+                        confirmation_status = _external_write_confirmation_status(pause_result)
+                        paused = _is_confirmed_external_write(pause_result)
+                        action_record = {
                             "channel": channel,
                             "action": "paused",
                             "reason": f"ROAS {roas:.2f} < {ROAS_PAUSE_THRESHOLD}",
                             "success": paused,
-                        })
+                            "external_write_confirmation_status": confirmation_status,
+                            "external_object_id": (
+                                pause_result.get("external_object_id")
+                                if isinstance(pause_result, dict)
+                                else None
+                            ),
+                        }
+                        if not paused:
+                            action_record["blocked_reason"] = (
+                                "Pause action is not complete because connector write confirmation "
+                                "with an external object ID was not returned."
+                            )
+                            unconfirmed_external_writes.append(f"{channel}:pause_campaign")
+                        actions_taken.append(action_record)
                         if paused:
                             channels_paused.append(channel)
 
@@ -177,14 +212,28 @@ class CampaignPilotAgent(BaseAgent):
                             },
                             trace, tool_calls,
                         )
-                        scaled = scale_result and "error" not in scale_result
-                        actions_taken.append({
+                        confirmation_status = _external_write_confirmation_status(scale_result)
+                        scaled = _is_confirmed_external_write(scale_result)
+                        action_record = {
                             "channel": channel,
                             "action": "scaled_up",
                             "reason": f"ROAS {roas:.2f} > {ROAS_SCALE_THRESHOLD}",
                             "budget_increase": scale_amount,
                             "success": scaled,
-                        })
+                            "external_write_confirmation_status": confirmation_status,
+                            "external_object_id": (
+                                scale_result.get("external_object_id")
+                                if isinstance(scale_result, dict)
+                                else None
+                            ),
+                        }
+                        if not scaled:
+                            action_record["blocked_reason"] = (
+                                "Budget update is not complete because connector write confirmation "
+                                "with an external object ID was not returned."
+                            )
+                            unconfirmed_external_writes.append(f"{channel}:update_budget")
+                        actions_taken.append(action_record)
                         if scaled:
                             channels_scaled.append(channel)
 
@@ -244,6 +293,35 @@ class CampaignPilotAgent(BaseAgent):
                 hitl_reasons.append(f"budget overspent by {budget_utilization - 100:.1f}%")
             if confidence < self.confidence_floor:
                 hitl_reasons.append(f"confidence {confidence:.3f} < floor")
+            if unconfirmed_external_writes:
+                hitl_reasons.append(
+                    "external write confirmation missing for "
+                    + ", ".join(unconfirmed_external_writes)
+                )
+
+            source_refs = [
+                {"kind": "tool_call", "tool_name": call.tool_name, "status": call.status}
+                for call in tool_calls
+            ]
+            blocked_reasons = [
+                action["blocked_reason"]
+                for action in actions_taken
+                if action.get("blocked_reason")
+            ]
+            degraded_reasons = [
+                f"{channel} performance data unavailable"
+                for channel, perf in channel_performance.items()
+                if perf.get("status") == "data_unavailable"
+            ]
+            write_actions = [
+                action for action in actions_taken if action.get("action") in {"paused", "scaled_up"}
+            ]
+            if write_actions and all(action.get("success") for action in write_actions):
+                write_status = "write_confirmed"
+            elif write_actions:
+                write_status = "write_unconfirmed"
+            else:
+                write_status = "not_required"
 
             output = {
                 "status": "optimized",
@@ -257,6 +335,27 @@ class CampaignPilotAgent(BaseAgent):
                 "channels_scaled": channels_scaled,
                 "confidence": confidence,
                 "hitl_required": len(hitl_reasons) > 0,
+                "approval_required": len(hitl_reasons) > 0,
+                "rationale": (
+                    f"Evaluated {len(channels)} channels for {objective}; "
+                    f"overall ROAS is {overall_roas:.2f} with {budget_utilization:.1f}% budget utilization."
+                ),
+                "recommended_actions": actions_taken,
+                "source_refs": source_refs,
+                "policy_result": {
+                    "decision": "requires_approval" if hitl_reasons else "allowed",
+                    "reason": (
+                        "; ".join(hitl_reasons)
+                        if hitl_reasons
+                        else "Campaign optimization is advisory or confirmed."
+                    ),
+                },
+                "audit_ref": f"campaign_pilot:{task.correlation_id}:{task.step_id}",
+                "degraded_reasons": degraded_reasons,
+                "blocked_reasons": blocked_reasons,
+                "external_write_confirmation_status": write_status,
+                "external_writes_completed": write_status == "write_confirmed",
+                "production_status": "production",
             }
 
             if hitl_reasons:

--- a/core/agents/marketing/competitive_intel.py
+++ b/core/agents/marketing/competitive_intel.py
@@ -1,0 +1,1214 @@
+"""Competitive Intel agent implementation."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+import structlog
+
+from core.agents.base import BaseAgent
+from core.agents.registry import AgentRegistry
+from core.marketing.escalation_matrix import evaluate_marketing_escalation
+from core.marketing.policy_manifest import evaluate_marketing_policy
+from core.schemas.messages import (
+    DecisionOption,
+    DecisionRequired,
+    HITLAssignee,
+    HITLContext,
+    HITLRequest,
+    ToolCallRecord,
+)
+
+logger = structlog.get_logger()
+
+COMPETITIVE_INTEL_AGENT_MATURITY = "beta"
+COMPETITIVE_INTEL_CONFIDENCE_FLOOR = 0.82
+
+READ_ONLY_ACTIONS = {
+    "change_confidence_score",
+    "competitor_profile_normalization",
+    "duplicate_change_suppression",
+    "evaluate_alert_thresholds",
+    "extract_win_loss_signals",
+    "feature_capability_diffing",
+    "normalize_competitor_profiles",
+    "positioning_recommendation",
+    "pricing_change_detection",
+    "recommend_positioning",
+    "suppress_duplicate_changes",
+    "weekly_benchmark",
+    "weekly_competitor_snapshot",
+    "weekly_market_snapshot",
+    "win_loss_signal_extraction",
+}
+WRITE_ACTIONS = {
+    "comparative_claim",
+    "launch_competitive_campaign",
+    "pricing_claim",
+    "public_response",
+    "publish_competitive_response",
+}
+SHADOW_MODES = {"shadow", "draft", "internal", "internal_only", "recommendation", "simulation"}
+
+DEFAULT_ALERT_THRESHOLDS = {"critical": 0.85, "high": 0.7, "medium": 0.5}
+MAJOR_LAUNCH_TERMS = ("launch", "announced", "released", "rolled out", "major")
+CRISIS_TERMS = ("lawsuit", "breach", "outage", "regulator", "security incident", "crisis")
+PRICING_TERMS = ("price", "pricing", "discount", "free", "plan", "package")
+WIN_TERMS = ("won", "selected", "replaced", "chose us", "closed won")
+LOSS_TERMS = ("lost", "churned", "selected competitor", "closed lost", "switched to")
+
+
+@AgentRegistry.register
+class CompetitiveIntelAgent(BaseAgent):
+    agent_type = "competitive_intel"
+    domain = "marketing"
+    confidence_floor = COMPETITIVE_INTEL_CONFIDENCE_FLOOR
+    prompt_file = "competitive_intel.prompt.txt"
+
+    async def execute(self, task):
+        """Run deterministic competitive analysis or guarded external actions."""
+
+        start = time.monotonic()
+        trace: list[str] = []
+        tool_calls: list[ToolCallRecord] = []
+        msg_id = f"msg_{uuid.uuid4().hex[:12]}"
+
+        try:
+            inputs = _task_inputs(task)
+            action = _normalize_action(_task_action(task))
+            mode = _workflow_mode(inputs)
+            trace.append(f"Competitive Intel action={action}, mode={mode}")
+
+            if action in READ_ONLY_ACTIONS:
+                output = self._read_only_action(task, action, inputs, mode, trace)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+            if action in WRITE_ACTIONS:
+                output = await self._guarded_competitive_write(task, action, inputs, mode, trace, tool_calls)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+
+            output = self._base_output(
+                task,
+                action=action,
+                status="blocked",
+                confidence=0.0,
+                rationale=f"Unsupported Competitive Intel action '{action}'.",
+                recommended_actions=[
+                    {
+                        "action": "use_supported_competitive_intel_action",
+                        "reason": "The Competitive Intel agent only executes declared deterministic actions.",
+                    }
+                ],
+                blocked_reasons=[f"Unsupported Competitive Intel action '{action}'."],
+                policy_context={"workflow_mode": mode},
+            )
+            return self._make_result(
+                task,
+                msg_id,
+                "failed",
+                output,
+                0.0,
+                trace,
+                tool_calls,
+                error={"code": "COMPETITIVE_INTEL_ACTION_UNSUPPORTED", "message": output["blocked_reasons"][0]},
+                start=start,
+            )
+        # enterprise-gate: broad-except-ok reason=agent-execution-boundary-returns-failed-result
+        except Exception as exc:
+            logger.error("competitive_intel_agent_error", agent=self.agent_id, error=str(exc))
+            trace.append(f"Error: {exc}")
+            return self._make_result(
+                task,
+                msg_id,
+                "failed",
+                {},
+                0.0,
+                trace,
+                tool_calls,
+                error={"code": "COMPETITIVE_INTEL_AGENT_ERR", "message": str(exc)},
+                start=start,
+            )
+
+    def _read_only_action(
+        self,
+        task,
+        action: str,
+        inputs: dict[str, Any],
+        mode: str,
+        trace: list[str],
+    ) -> dict[str, Any]:
+        profiles = _normalize_profiles(_profiles(inputs))
+        previous_profiles = _profile_index(_normalize_profiles(_previous_profiles(inputs)))
+        current_profiles = _profile_index(profiles)
+        pricing_changes = _pricing_changes(inputs, previous_profiles, current_profiles)
+        feature_diffs = _feature_diffs(inputs, previous_profiles, current_profiles)
+        win_loss_signals = _win_loss_signals(inputs)
+        explicit_changes = _explicit_changes(inputs)
+        changes = _dedupe_changes([*explicit_changes, *pricing_changes, *feature_diffs, *win_loss_signals])
+        alerts = _alerts(changes, inputs)
+        recommendations = _positioning_recommendations(profiles, changes, alerts, inputs)
+        degraded = _read_degraded_reasons(inputs)
+        confidence = _snapshot_confidence(profiles, changes, degraded)
+        major_or_crisis = _has_major_or_crisis_signal(changes, alerts)
+        escalation = (
+            _escalation_for_competitive_event(task, action, inputs, major_or_crisis=major_or_crisis)
+            if major_or_crisis
+            else {}
+        )
+        trace.append(
+            "Competitive snapshot profiles="
+            f"{len(profiles)}, changes={len(changes)}, alerts={len(alerts)}, degraded={len(degraded)}"
+        )
+
+        if action in {"competitor_profile_normalization", "normalize_competitor_profiles"}:
+            extra = {"normalized_profiles": profiles}
+            status = "profiles_normalized"
+            rationale = "Normalized competitor profiles into stable names, domains, segments, pricing, and features."
+        elif action == "pricing_change_detection":
+            extra = {"pricing_changes": pricing_changes, "change_summary": pricing_changes}
+            status = "pricing_changes_detected"
+            rationale = "Detected pricing deltas from current and prior competitor snapshots."
+        elif action == "feature_capability_diffing":
+            extra = {"feature_diffs": feature_diffs, "change_summary": feature_diffs}
+            status = "feature_diffs_ready"
+            rationale = "Compared current and prior feature sets for each competitor."
+        elif action == "win_loss_signal_extraction":
+            extra = {"win_loss_signals": win_loss_signals}
+            status = "win_loss_signals_extracted"
+            rationale = "Extracted deterministic win/loss signals from structured notes."
+        elif action == "change_confidence_score":
+            extra = {"change_confidence": _overall_change_confidence(changes), "change_summary": changes}
+            status = "change_confidence_scored"
+            rationale = "Calculated confidence scores from source count, severity, and explicit evidence."
+        elif action == "duplicate_change_suppression":
+            raw_for_suppression = explicit_changes or [*pricing_changes, *feature_diffs]
+            extra = {
+                "suppressed_duplicate_count": max(
+                    0,
+                    len(raw_for_suppression) - len(_dedupe_changes(raw_for_suppression)),
+                )
+            }
+            status = "duplicates_suppressed"
+            rationale = "Suppressed duplicate competitive changes by competitor, type, summary, and observed date."
+        elif action == "evaluate_alert_thresholds":
+            extra = {"alerts": alerts, "alert_thresholds": _thresholds(inputs)}
+            status = "alert_thresholds_evaluated"
+            rationale = "Applied severity thresholds to competitor changes and market signals."
+        elif action == "positioning_recommendation":
+            extra = {"positioning_recommendations": recommendations}
+            status = "positioning_recommended"
+            rationale = "Generated read-only competitive positioning recommendations."
+        else:
+            extra = {
+                "competitor_snapshot": {
+                    "profiles": profiles,
+                    "pricing_changes": pricing_changes,
+                    "feature_diffs": feature_diffs,
+                    "win_loss_signals": win_loss_signals,
+                    "alerts": alerts,
+                    "positioning_recommendations": recommendations,
+                },
+                "change_summary": changes,
+                "change_confidence": _overall_change_confidence(changes),
+            }
+            status = "snapshot_degraded" if degraded else "snapshot_ready"
+            rationale = "Built a deterministic weekly competitive intelligence snapshot."
+
+        return self._base_output(
+            task,
+            action=action,
+            status=status,
+            confidence=confidence,
+            rationale=rationale,
+            recommended_actions=recommendations or _default_recommendations(changes, alerts),
+            approval_required=major_or_crisis,
+            hitl_required=major_or_crisis,
+            policy_context={"workflow_mode": mode, "workflow_id": "competitive_intel_monitoring"},
+            escalation=escalation,
+            source_refs=_source_refs(inputs, profiles, changes),
+            degraded_reasons=degraded,
+            extra=extra,
+        )
+
+    async def _guarded_competitive_write(
+        self,
+        task,
+        action: str,
+        inputs: dict[str, Any],
+        mode: str,
+        trace: list[str],
+        tool_calls: list[ToolCallRecord],
+    ) -> dict[str, Any]:
+        policy_context = _policy_context_for_write(action, inputs, mode)
+        policy = evaluate_marketing_policy(policy_context)
+        escalation = _escalation_for_write(task, action, inputs, policy)
+        blocked_reasons: list[str] = []
+        hitl_reasons: list[str] = []
+
+        if mode in SHADOW_MODES:
+            blocked_reasons.append("Shadow/draft/internal Competitive Intel workflows are read-only.")
+            trace.append("Competitive Intel write converted to shadow-only recommendation")
+            return self._base_output(
+                task,
+                action=action,
+                status="shadow_only",
+                confidence=0.76,
+                rationale=(
+                    "Prepared competitive recommendation without publishing, launching, "
+                    "or changing external systems."
+                ),
+                recommended_actions=[
+                    {
+                        "action": "review_competitive_recommendation",
+                        "reason": "Review the competitive response before any active external write is attempted.",
+                    }
+                ],
+                approval_required=True,
+                hitl_required=True,
+                policy_result=policy,
+                escalation=escalation,
+                blocked_reasons=blocked_reasons,
+                external_write_status="shadow_only",
+                external_write_required=True,
+                extra={"write_payload": _competitive_write_payload(action, inputs)},
+            )
+
+        write_safe, write_reason = _connector_write_safe(inputs)
+        if not write_safe:
+            blocked_reasons.append(write_reason)
+        if not _has_approval(inputs):
+            hitl_reasons.append(str(policy.get("reason") or "Competitive external action requires approval."))
+        if policy.get("decision") in {"blocked", "missing_policy"}:
+            blocked_reasons.append(str(policy.get("reason") or "Marketing policy blocks this competitive action."))
+        escalation_needs_review = escalation.get("decision") not in {None, "", "no_escalation", "notify_owner"}
+        if escalation_needs_review and not _has_escalation_approval(inputs):
+            hitl_reasons.append("Competitive Intel action requires escalation review.")
+
+        if blocked_reasons or hitl_reasons:
+            return self._base_output(
+                task,
+                action=action,
+                status="blocked",
+                confidence=0.0,
+                rationale="Competitive Intel external action failed closed before vendor mutation.",
+                recommended_actions=[
+                    {
+                        "action": "resolve_competitive_write_prerequisites",
+                        "reason": "; ".join(_dedupe(blocked_reasons + hitl_reasons)),
+                    }
+                ],
+                approval_required=bool(hitl_reasons),
+                hitl_required=True,
+                policy_result=policy,
+                escalation=escalation,
+                blocked_reasons=blocked_reasons + hitl_reasons,
+                external_write_status="write_unconfirmed",
+                external_write_required=True,
+                extra={"write_payload": _competitive_write_payload(action, inputs)},
+            )
+
+        result = _dict_or_none(inputs.get("external_write_result"))
+        connector, tool = _connector_tool(action, inputs)
+        idempotency_key = str(
+            inputs.get("idempotency_key")
+            or inputs.get("request_fingerprint")
+            or f"competitive_intel:{task.correlation_id}:{task.step_id}:{action}"
+        )
+        if result is None:
+            result = await self._safe_tool_call(
+                connector,
+                tool,
+                _competitive_write_payload(action, inputs),
+                trace,
+                tool_calls,
+                idempotency_key=idempotency_key,
+            )
+
+        write_status = _external_write_confirmation_status(result)
+        write_confirmed = _is_confirmed_external_write(result)
+        external_ref = _external_write_ref(result)
+        blocked_reasons = (
+            []
+            if write_confirmed
+            else ["Competitive Intel external write is unconfirmed and cannot be marked complete."]
+        )
+        trace.append(f"Competitive Intel write status={write_status}, confirmed={write_confirmed}")
+        return self._base_output(
+            task,
+            action=action,
+            status="write_confirmed" if write_confirmed else "write_unconfirmed",
+            confidence=0.9 if write_confirmed else 0.0,
+            rationale=(
+                "Competitive Intel external write was confirmed by the connector."
+                if write_confirmed
+                else "Competitive Intel external write did not return confirmed vendor evidence."
+            ),
+            recommended_actions=[
+                {
+                    "action": (
+                        "monitor_competitive_response"
+                        if write_confirmed
+                        else "verify_competitive_write_before_retry"
+                    ),
+                    "reason": (
+                        "Track response, campaign, or battlecard impact."
+                        if write_confirmed
+                        else "Check vendor state using the idempotency key before retrying."
+                    ),
+                }
+            ],
+            approval_required=False,
+            hitl_required=not write_confirmed,
+            policy_result=policy,
+            approval_satisfied=_has_approval(inputs),
+            escalation=escalation,
+            blocked_reasons=blocked_reasons,
+            external_write_status=write_status,
+            external_write_required=True,
+            external_write_ref=external_ref,
+            extra={"write_payload": _competitive_write_payload(action, inputs)},
+        )
+
+    async def _safe_tool_call(
+        self,
+        connector: str,
+        tool: str,
+        params: dict[str, Any],
+        trace: list[str],
+        tool_records: list[ToolCallRecord],
+        *,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        call_start = time.monotonic()
+        try:
+            result = await self._call_tool(
+                connector_name=connector,
+                tool_name=tool,
+                params=params,
+                idempotency_key=idempotency_key,
+            )
+            latency = int((time.monotonic() - call_start) * 1000)
+            status = "error" if "error" in result else "success"
+            trace.append(f"[tool] {connector}.{tool} -> {status} ({latency}ms)")
+            tool_records.append(ToolCallRecord(tool_name=f"{connector}.{tool}", status=status, latency_ms=latency))
+            return result
+        # enterprise-gate: broad-except-ok reason=agent-tool-call-failure-returns-explicit-error-result
+        except Exception as exc:
+            latency = int((time.monotonic() - call_start) * 1000)
+            trace.append(f"[tool] {connector}.{tool} -> exception: {exc} ({latency}ms)")
+            tool_records.append(ToolCallRecord(tool_name=f"{connector}.{tool}", status="error", latency_ms=latency))
+            return {"error": str(exc)}
+
+    def _base_output(
+        self,
+        task,
+        *,
+        action: str,
+        status: str,
+        confidence: float,
+        rationale: str,
+        recommended_actions: list[dict[str, Any]],
+        approval_required: bool = False,
+        hitl_required: bool = False,
+        policy_context: dict[str, Any] | None = None,
+        policy_result: dict[str, Any] | None = None,
+        approval_satisfied: bool = False,
+        escalation: dict[str, Any] | None = None,
+        source_refs: list[dict[str, Any]] | None = None,
+        degraded_reasons: list[str] | None = None,
+        blocked_reasons: list[str] | None = None,
+        external_write_status: str = "not_required",
+        external_write_required: bool = False,
+        external_write_ref: dict[str, Any] | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        policy = policy_result or evaluate_marketing_policy(
+            {
+                "workflow_id": "competitive_intel_monitoring",
+                "workflow_mode": "shadow",
+                "action": action,
+                "external_write_required": external_write_required,
+                **(policy_context or {}),
+            }
+        )
+        escalation_ref = None
+        if escalation and escalation.get("decision") != "no_escalation":
+            escalation_ref = escalation.get("decision_audit_ref") or escalation.get("audit_reference")
+        policy_needs_review = (
+            policy.get("decision") in {"requires_approval", "requires_escalation", "read_only_only"}
+            and not approval_satisfied
+        )
+        output: dict[str, Any] = {
+            "status": status,
+            "agent_type": self.agent_type,
+            "action": action,
+            "confidence": round(max(0.0, min(confidence, 1.0)), 3),
+            "rationale": rationale,
+            "recommended_actions": recommended_actions,
+            "source_refs": source_refs or [],
+            "policy_result": policy,
+            "policy_ref": policy.get("decision_audit_ref") or policy.get("policy_id"),
+            "approval_required": approval_required or policy_needs_review,
+            "hitl_required": hitl_required,
+            "escalation_ref": escalation_ref,
+            "escalation_result": escalation,
+            "audit_ref": f"competitive_intel:{task.correlation_id}:{task.step_id}:{action}",
+            "degraded_reasons": _dedupe(degraded_reasons or []),
+            "blocked_reasons": _dedupe(blocked_reasons or []),
+            "external_write_confirmation_status": external_write_status,
+            "external_writes_completed": external_write_status == "write_confirmed",
+            "external_write_required": external_write_required,
+            "external_write_ref": external_write_ref,
+            "production_status": COMPETITIVE_INTEL_AGENT_MATURITY,
+        }
+        if extra:
+            output.update(extra)
+        return output
+
+    def _complete_or_hitl(
+        self,
+        task,
+        msg_id: str,
+        output: dict[str, Any],
+        trace: list[str],
+        tool_calls: list[ToolCallRecord],
+        start: float,
+    ):
+        if output.get("hitl_required") or output.get("approval_required") or output.get("blocked_reasons"):
+            hitl = _hitl_request(task, output)
+            return self._make_result(
+                task,
+                msg_id,
+                "hitl_triggered",
+                output,
+                float(output.get("confidence") or 0.0),
+                trace,
+                tool_calls,
+                hitl_request=hitl,
+                start=start,
+            )
+        return self._make_result(
+            task,
+            msg_id,
+            "completed",
+            output,
+            float(output.get("confidence") or 0.0),
+            trace,
+            tool_calls,
+            start=start,
+        )
+
+
+def _task_inputs(task) -> dict[str, Any]:
+    payload = task.task.inputs if hasattr(task.task, "inputs") else task.task.get("inputs", {})
+    return payload if isinstance(payload, dict) else {}
+
+
+def _task_action(task) -> str:
+    return str(task.task.action if hasattr(task.task, "action") else task.task.get("action", "weekly_market_snapshot"))
+
+
+def _normalize_action(action: str) -> str:
+    normalized = _normalize(action)
+    aliases = {
+        "build_weekly_snapshot": "weekly_market_snapshot",
+        "change_confidence": "change_confidence_score",
+        "competitor_snapshot": "weekly_market_snapshot",
+        "diff_capabilities": "feature_capability_diffing",
+        "feature_diffing": "feature_capability_diffing",
+        "next_best_action": "positioning_recommendation",
+        "pricing_detection": "pricing_change_detection",
+        "weekly_competitor_snapshot": "weekly_market_snapshot",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def _read_degraded_reasons(inputs: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    if inputs.get("connector_read_ready") is False or inputs.get("connector_degraded") is True:
+        reasons.append("Competitive intelligence connector is degraded or unavailable.")
+    contracts = _dict_list(inputs.get("connector_contracts"))
+    direct = _dict_or_none(inputs.get("connector_contract"))
+    if direct:
+        contracts.insert(0, direct)
+    if contracts:
+        relevant = [contract for contract in contracts if _is_competitive_contract(contract)]
+        if relevant and not any(bool(contract.get("read_ready", contract.get("configured"))) for contract in relevant):
+            reasons.append("Competitive intelligence source connector is not read-ready.")
+        if any(contract.get("degraded") or contract.get("health_status") == "degraded" for contract in contracts):
+            reasons.append("One or more competitive intelligence sources are degraded.")
+    return _dedupe(reasons)
+
+
+def _profiles(inputs: dict[str, Any]) -> list[dict[str, Any]]:
+    return _dict_list(inputs.get("competitors") or inputs.get("profiles") or inputs.get("current_profiles"))
+
+
+def _previous_profiles(inputs: dict[str, Any]) -> list[dict[str, Any]]:
+    return _dict_list(inputs.get("previous_competitors") or inputs.get("previous_profiles"))
+
+
+def _normalize_profiles(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for row in rows:
+        name = str(row.get("name") or row.get("competitor") or row.get("company_name") or "").strip()
+        domain = _domain(row)
+        key = (domain or name).lower()
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        feature_values = _string_list(row.get("features") or row.get("capabilities"))
+        features = sorted({_clean_feature(item) for item in feature_values})
+        normalized.append(
+            {
+                "name": name or domain,
+                "domain": domain,
+                "segment": str(row.get("segment") or row.get("market_segment") or "unknown").strip().lower(),
+                "pricing": _pricing(row),
+                "features": [feature for feature in features if feature],
+                "source": str(row.get("source") or row.get("connector_key") or "provided_input"),
+                "source_url": row.get("source_url") or row.get("url"),
+                "observed_at": str(row.get("observed_at") or row.get("updated_at") or ""),
+            }
+        )
+    return normalized
+
+
+def _profile_index(profiles: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {_profile_key(row): row for row in profiles if _profile_key(row)}
+
+
+def _pricing_changes(
+    inputs: dict[str, Any],
+    previous: dict[str, dict[str, Any]],
+    current: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    changes: list[dict[str, Any]] = []
+    for key, current_row in current.items():
+        previous_row = previous.get(key)
+        if not previous_row:
+            continue
+        old_price = _float((previous_row.get("pricing") or {}).get("amount"), 0.0)
+        new_price = _float((current_row.get("pricing") or {}).get("amount"), 0.0)
+        if old_price <= 0 or new_price <= 0 or old_price == new_price:
+            continue
+        delta = new_price - old_price
+        percent = round((delta / old_price) * 100, 2)
+        severity = "high" if abs(percent) >= _float(inputs.get("pricing_high_delta_pct"), 15.0) else "medium"
+        changes.append(
+            _change(
+                competitor=str(current_row.get("name")),
+                change_type="pricing",
+                summary=f"Pricing changed from {old_price:g} to {new_price:g} ({percent:+.2f}%).",
+                severity=severity,
+                confidence=_change_confidence(severity=severity, source_count=2, explicit_confidence=None),
+                source_refs=[_source_ref_from_profile(current_row), _source_ref_from_profile(previous_row)],
+                observed_at=str(current_row.get("observed_at") or ""),
+                value_delta={"old": old_price, "new": new_price, "delta": delta, "delta_pct": percent},
+            )
+        )
+    for row in _explicit_changes(inputs):
+        text = f"{row.get('change_type', '')} {row.get('summary', '')}".lower()
+        if any(term in text for term in PRICING_TERMS):
+            row["change_type"] = "pricing"
+            changes.append(row)
+    return _dedupe_changes(changes)
+
+
+def _feature_diffs(
+    _inputs: dict[str, Any],
+    previous: dict[str, dict[str, Any]],
+    current: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    changes: list[dict[str, Any]] = []
+    for key, current_row in current.items():
+        previous_row = previous.get(key)
+        if not previous_row:
+            continue
+        old_features = set(_string_list(previous_row.get("features")))
+        new_features = set(_string_list(current_row.get("features")))
+        added = sorted(new_features - old_features)
+        removed = sorted(old_features - new_features)
+        if not added and not removed:
+            continue
+        severity = "high" if len(added) + len(removed) >= 3 else "medium"
+        changes.append(
+            _change(
+                competitor=str(current_row.get("name")),
+                change_type="feature",
+                summary=f"Feature changes: added {added or []}; removed {removed or []}.",
+                severity=severity,
+                confidence=_change_confidence(severity=severity, source_count=2, explicit_confidence=None),
+                source_refs=[_source_ref_from_profile(current_row), _source_ref_from_profile(previous_row)],
+                observed_at=str(current_row.get("observed_at") or ""),
+                value_delta={"added": added, "removed": removed},
+            )
+        )
+    return changes
+
+
+def _win_loss_signals(inputs: dict[str, Any]) -> list[dict[str, Any]]:
+    signals: list[dict[str, Any]] = []
+    for note in _dict_list(inputs.get("win_loss_notes") or inputs.get("deal_notes")):
+        text = str(note.get("text") or note.get("summary") or note.get("reason") or "").strip()
+        normalized = text.lower()
+        outcome = str(note.get("outcome") or "").lower()
+        if not outcome:
+            if any(term in normalized for term in WIN_TERMS):
+                outcome = "win"
+            elif any(term in normalized for term in LOSS_TERMS):
+                outcome = "loss"
+            else:
+                outcome = "unknown"
+        reason = _win_loss_reason(normalized)
+        severity = "high" if outcome == "loss" else "medium"
+        signals.append(
+            _change(
+                competitor=str(note.get("competitor") or note.get("competitor_name") or "unknown"),
+                change_type=f"win_loss_{outcome}",
+                summary=text or f"{outcome} signal from CRM notes.",
+                severity=severity,
+                confidence=_change_confidence(
+                    severity=severity,
+                    source_count=1,
+                    explicit_confidence=note.get("confidence"),
+                ),
+                source_refs=[_source_ref("crm", note.get("source_id") or note.get("deal_id"), note.get("source_url"))],
+                observed_at=str(note.get("observed_at") or note.get("created_at") or ""),
+                value_delta={"outcome": outcome, "reason": reason},
+            )
+        )
+    return signals
+
+
+def _explicit_changes(inputs: dict[str, Any]) -> list[dict[str, Any]]:
+    changes: list[dict[str, Any]] = []
+    for row in _dict_list(inputs.get("changes") or inputs.get("events") or inputs.get("signals")):
+        severity = _severity(row.get("severity"), default="medium")
+        confidence = _change_confidence(
+            severity=severity,
+            source_count=max(1, len(_dict_list(row.get("source_refs")))),
+            explicit_confidence=row.get("confidence"),
+        )
+        changes.append(
+            _change(
+                competitor=str(row.get("competitor") or row.get("name") or "unknown"),
+                change_type=str(row.get("change_type") or row.get("type") or "market_signal"),
+                summary=str(row.get("summary") or row.get("description") or row.get("title") or "Competitive signal."),
+                severity=severity,
+                confidence=confidence,
+                source_refs=_dict_list(row.get("source_refs"))
+                or [_source_ref(row.get("source"), row.get("source_id"), row.get("source_url"))],
+                observed_at=str(row.get("observed_at") or row.get("created_at") or ""),
+                value_delta=_dict_or_none(row.get("value_delta")) or {},
+            )
+        )
+    return changes
+
+
+def _alerts(changes: list[dict[str, Any]], inputs: dict[str, Any]) -> list[dict[str, Any]]:
+    thresholds = _thresholds(inputs)
+    alerts: list[dict[str, Any]] = []
+    for change in changes:
+        severity = _severity(change.get("severity"), default="medium")
+        threshold = thresholds.get(severity, thresholds["medium"])
+        confidence = _float(change.get("confidence"), 0.0)
+        if confidence >= threshold:
+            alerts.append(
+                {
+                    "competitor": change.get("competitor"),
+                    "severity": severity,
+                    "change_type": change.get("change_type"),
+                    "confidence": confidence,
+                    "threshold": threshold,
+                    "summary": change.get("summary"),
+                    "requires_escalation": severity == "critical" or _is_major_or_crisis(change),
+                }
+            )
+    return alerts
+
+
+def _positioning_recommendations(
+    profiles: list[dict[str, Any]],
+    changes: list[dict[str, Any]],
+    alerts: list[dict[str, Any]],
+    inputs: dict[str, Any],
+) -> list[dict[str, Any]]:
+    if alerts:
+        top = alerts[0]
+        return [
+            {
+                "action": (
+                    "escalate_competitive_response"
+                    if top.get("requires_escalation")
+                    else "prepare_battlecard_update"
+                ),
+                "competitor": top.get("competitor"),
+                "reason": str(top.get("summary") or "Competitive alert crossed threshold."),
+                "mode": "read_only_recommendation",
+            }
+        ]
+    if changes:
+        change = changes[0]
+        return [
+            {
+                "action": "prepare_positioning_update",
+                "competitor": change.get("competitor"),
+                "reason": str(change.get("summary") or "Competitive change detected."),
+                "mode": "read_only_recommendation",
+            }
+        ]
+    if profiles:
+        return [
+            {
+                "action": "maintain_weekly_monitoring",
+                "reason": "No material competitor change crossed alert thresholds.",
+                "mode": "read_only_recommendation",
+            }
+        ]
+    return [
+        {
+            "action": "connect_competitive_sources",
+            "reason": str(inputs.get("missing_source_reason") or "No competitor profiles or signals were supplied."),
+            "mode": "setup",
+        }
+    ]
+
+
+def _default_recommendations(changes: list[dict[str, Any]], alerts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if alerts:
+        return [{"action": "review_competitive_alerts", "reason": "One or more alerts crossed severity thresholds."}]
+    if changes:
+        return [
+            {
+                "action": "review_competitive_changes",
+                "reason": "Competitive changes were detected below alert threshold.",
+            }
+        ]
+    return [{"action": "continue_monitoring", "reason": "No material competitive change was detected."}]
+
+
+def _snapshot_confidence(profiles: list[dict[str, Any]], changes: list[dict[str, Any]], degraded: list[str]) -> float:
+    if not profiles and not changes:
+        return 0.35
+    base = 0.78
+    if profiles:
+        base += 0.08
+    if changes:
+        base += min(0.08, len(changes) * 0.02)
+    if degraded:
+        base -= 0.2
+    return round(max(0.0, min(base, 0.94)), 3)
+
+
+def _overall_change_confidence(changes: list[dict[str, Any]]) -> float:
+    if not changes:
+        return 0.0
+    return round(sum(_float(change.get("confidence"), 0.0) for change in changes) / len(changes), 3)
+
+
+def _change_confidence(*, severity: str, source_count: int, explicit_confidence: Any) -> float:
+    explicit = _float(explicit_confidence, -1.0)
+    if explicit >= 0:
+        return round(max(0.0, min(explicit, 1.0)), 3)
+    base = {"critical": 0.82, "high": 0.74, "medium": 0.62, "low": 0.48}.get(severity, 0.55)
+    return round(min(0.96, base + max(0, source_count - 1) * 0.06), 3)
+
+
+def _has_major_or_crisis_signal(changes: list[dict[str, Any]], alerts: list[dict[str, Any]]) -> bool:
+    return any(_is_major_or_crisis(change) for change in changes) or any(
+        alert.get("requires_escalation") for alert in alerts
+    )
+
+
+def _is_major_or_crisis(change: dict[str, Any]) -> bool:
+    text = f"{change.get('change_type', '')} {change.get('summary', '')}".lower()
+    return _severity(change.get("severity"), default="medium") == "critical" or any(
+        term in text for term in (*MAJOR_LAUNCH_TERMS, *CRISIS_TERMS)
+    )
+
+
+def _change(
+    *,
+    competitor: str,
+    change_type: str,
+    summary: str,
+    severity: str,
+    confidence: float,
+    source_refs: list[dict[str, Any]],
+    observed_at: str,
+    value_delta: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "competitor": competitor,
+        "change_type": _normalize(change_type),
+        "summary": summary,
+        "severity": _severity(severity, default="medium"),
+        "confidence": round(max(0.0, min(confidence, 1.0)), 3),
+        "source_refs": [ref for ref in source_refs if ref],
+        "observed_at": observed_at,
+        "value_delta": value_delta,
+    }
+
+
+def _dedupe_changes(changes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    deduped: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for change in changes:
+        key = "|".join(
+            [
+                str(change.get("competitor") or "").lower(),
+                str(change.get("change_type") or "").lower(),
+                str(change.get("summary") or "").lower(),
+                str(change.get("observed_at") or "")[:10],
+            ]
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(change)
+    return deduped
+
+
+def _thresholds(inputs: dict[str, Any]) -> dict[str, float]:
+    configured = _dict_or_none(inputs.get("alert_thresholds")) or {}
+    thresholds = dict(DEFAULT_ALERT_THRESHOLDS)
+    for key in ("critical", "high", "medium"):
+        if key in configured:
+            thresholds[key] = max(0.0, min(_float(configured[key], thresholds[key]), 1.0))
+    return thresholds
+
+
+def _source_refs(
+    inputs: dict[str, Any],
+    profiles: list[dict[str, Any]],
+    changes: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    refs = _dict_list(inputs.get("source_refs"))
+    for profile in profiles:
+        refs.append(_source_ref_from_profile(profile))
+    for change in changes:
+        refs.extend(_dict_list(change.get("source_refs")))
+    compact: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for ref in refs:
+        ref_id = str(ref.get("ref_id") or ref.get("source_url") or ref.get("url") or ref.get("type") or "")
+        if not ref_id or ref_id in seen:
+            continue
+        seen.add(ref_id)
+        compact.append(ref)
+    return compact[:20]
+
+
+def _policy_context_for_write(action: str, inputs: dict[str, Any], mode: str) -> dict[str, Any]:
+    return {
+        "workflow_id": "competitive_intel_monitoring",
+        "workflow_mode": mode,
+        "action": action,
+        "external_write_required": True,
+        "public_response": action in {"public_response", "publish_competitive_response"},
+        "comparative_claim": action in {"comparative_claim", "publish_competitive_response"},
+        "pricing_claim": action in {"pricing_claim"},
+        "competitor_mention": True,
+        "crisis_response": bool(inputs.get("crisis_response") or inputs.get("major_competitor_launch")),
+        "budget_amount": _float(inputs.get("budget_amount") or inputs.get("budget"), 0.0),
+    }
+
+
+def _escalation_for_competitive_event(
+    task,
+    action: str,
+    inputs: dict[str, Any],
+    *,
+    major_or_crisis: bool,
+) -> dict[str, Any]:
+    return evaluate_marketing_escalation(
+        {
+            "workflow_id": "competitive_intel_monitoring",
+            "workflow_run_id": getattr(task, "workflow_run_id", None),
+            "step_id": getattr(task, "step_id", None),
+            "action": action,
+            "event_type": "crisis_public_response" if major_or_crisis else "high_risk_copy",
+            "crisis_response": major_or_crisis,
+            "competitor_mention": True,
+            "severity": "critical" if major_or_crisis else "medium",
+            "reason": str(inputs.get("escalation_reason") or "Competitive signal requires owner routing."),
+        }
+    )
+
+
+def _escalation_for_write(
+    task,
+    action: str,
+    inputs: dict[str, Any],
+    policy_result: dict[str, Any],
+) -> dict[str, Any]:
+    return evaluate_marketing_escalation(
+        {
+            "workflow_id": "competitive_intel_monitoring",
+            "workflow_run_id": getattr(task, "workflow_run_id", None),
+            "step_id": getattr(task, "step_id", None),
+            "action": action,
+            "public_response": action in {"public_response", "publish_competitive_response"},
+            "comparative_claim": action in {"comparative_claim", "publish_competitive_response"},
+            "pricing_claim": action == "pricing_claim",
+            "crisis_response": bool(inputs.get("crisis_response") or inputs.get("major_competitor_launch")),
+            "competitor_mention": True,
+            "budget_threshold_exceeded": action == "launch_competitive_campaign",
+            "severity": "high",
+            "reason": "Competitive Intel external action requires owner routing.",
+            "marketing_policy_decision": policy_result,
+        }
+    )
+
+
+def _connector_write_safe(inputs: dict[str, Any]) -> tuple[bool, str]:
+    if inputs.get("connector_write_ready") is True or inputs.get("write_ready") is True:
+        return True, ""
+    if inputs.get("connector_write_ready") is False or inputs.get("write_ready") is False:
+        return False, "Competitive Intel connector is not write-safe."
+    contracts = _dict_list(inputs.get("connector_contracts"))
+    direct = _dict_or_none(inputs.get("connector_contract"))
+    if direct:
+        contracts.insert(0, direct)
+    if contracts:
+        for contract in contracts:
+            if not _is_competitive_write_contract(contract):
+                continue
+            if contract.get("mock_or_test_double"):
+                return False, "Test-double connector proof cannot satisfy active Competitive Intel writes."
+            if bool(contract.get("write_safe", contract.get("write_ready"))):
+                return True, ""
+            status = str(contract.get("write_status") or contract.get("contract_state") or "unknown")
+            return False, f"Competitive Intel connector contract is not write-safe ({status})."
+        return False, "No Social/Ads/Brand connector contract is write-safe for Competitive Intel action."
+    return False, "Competitive Intel connector write-readiness evidence is missing."
+
+
+def _is_competitive_contract(contract: dict[str, Any]) -> bool:
+    category = str(contract.get("category") or "").strip().lower()
+    key = str(contract.get("connector_key") or contract.get("key") or "").strip().lower()
+    return category in {"brand", "seo", "abm", "social", "ads"} or key in {
+        "ahrefs",
+        "brandwatch",
+        "buffer",
+        "google_ads",
+        "linkedin_ads",
+        "meta_ads",
+        "twitter",
+    }
+
+
+def _is_competitive_write_contract(contract: dict[str, Any]) -> bool:
+    category = str(contract.get("category") or "").strip().lower()
+    key = str(contract.get("connector_key") or contract.get("key") or "").strip().lower()
+    return category in {"social", "ads", "brand"} or key in {
+        "buffer",
+        "brandwatch",
+        "google_ads",
+        "linkedin_ads",
+        "meta_ads",
+        "twitter",
+    }
+
+
+def _has_approval(inputs: dict[str, Any]) -> bool:
+    return bool(
+        inputs.get("approved")
+        or inputs.get("approval_ref")
+        or inputs.get("approval_result_ref")
+        or inputs.get("policy_approval_ref")
+    )
+
+
+def _has_escalation_approval(inputs: dict[str, Any]) -> bool:
+    return bool(inputs.get("escalation_ref") or inputs.get("escalation_result_ref") or inputs.get("approved"))
+
+
+def _connector_tool(action: str, inputs: dict[str, Any]) -> tuple[str, str]:
+    explicit = str(inputs.get("connector_key") or inputs.get("connector") or "").strip().lower()
+    if action in {"public_response", "publish_competitive_response"}:
+        return explicit or "buffer", "publish_competitive_response"
+    if action == "launch_competitive_campaign":
+        return explicit or "linkedin_ads", "launch_competitive_campaign"
+    return explicit or "brandwatch", "record_competitive_claim"
+
+
+def _competitive_write_payload(action: str, inputs: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "action": action,
+        "competitor": inputs.get("competitor") or inputs.get("competitor_name"),
+        "claim": inputs.get("claim") or inputs.get("message") or inputs.get("copy"),
+        "campaign_name": inputs.get("campaign_name") or "Competitive response",
+        "budget_amount": _float(inputs.get("budget_amount") or inputs.get("budget"), 0.0),
+        "source_refs": _dict_list(inputs.get("source_refs")),
+        "rollback_plan": inputs.get("rollback_plan") or "pause campaign or retract public response after review",
+    }
+
+
+def _external_write_confirmation_status(result: dict[str, Any] | None) -> str:
+    if not result:
+        return "write_unconfirmed"
+    return str(
+        result.get("external_write_confirmation_status")
+        or result.get("write_confirmation_status")
+        or result.get("status")
+        or "write_unconfirmed"
+    )
+
+
+def _is_confirmed_external_write(result: dict[str, Any] | None) -> bool:
+    if not result or "error" in result:
+        return False
+    status = _external_write_confirmation_status(result)
+    return status == "write_confirmed" and bool(
+        result.get("external_object_id") or result.get("external_id") or result.get("confirmed_at")
+    )
+
+
+def _external_write_ref(result: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not result:
+        return None
+    return {
+        "connector_key": result.get("connector_key"),
+        "external_object_id": result.get("external_object_id") or result.get("external_id"),
+        "source_url": result.get("source_url") or result.get("url"),
+        "idempotency_key": result.get("idempotency_key"),
+        "confirmed_at": result.get("confirmed_at"),
+        "audit_ref": result.get("audit_ref") or result.get("audit_reference"),
+    }
+
+
+def _hitl_request(task, output: dict[str, Any]) -> HITLRequest:
+    reasons = output.get("blocked_reasons") or []
+    if not reasons and output.get("policy_result"):
+        reasons = [str(output["policy_result"].get("reason") or "Competitive Intel action requires review.")]
+    escalation = output.get("escalation_result") or {}
+    role = escalation.get("owner_role") or escalation.get("primary_owner_role") or "cmo"
+    return HITLRequest(
+        hitl_id=f"hitl_{uuid.uuid4().hex[:12]}",
+        trigger_condition="; ".join(str(reason) for reason in reasons) or "Competitive Intel review required.",
+        trigger_type="competitive_intel_review",
+        decision_required=DecisionRequired(
+            question="Review competitive recommendation or external action safeguard.",
+            options=[
+                DecisionOption(id="approve", label="Approve", action="proceed"),
+                DecisionOption(id="request_changes", label="Request changes", action="defer"),
+                DecisionOption(id="escalate", label="Escalate", action="defer"),
+                DecisionOption(id="reject", label="Reject", action="reject"),
+            ],
+        ),
+        context=HITLContext(
+            summary=output.get("rationale") or "Competitive Intel review",
+            recommendation=output.get("recommended_actions", [{}])[0].get("action", "review"),
+            agent_confidence=float(output.get("confidence") or 0.0),
+            supporting_data={
+                "policy_decision": (output.get("policy_result") or {}).get("decision"),
+                "blocked_reasons": output.get("blocked_reasons") or [],
+                "external_write_status": output.get("external_write_confirmation_status"),
+                "alerts": (output.get("competitor_snapshot") or {}).get("alerts") or [],
+            },
+        ),
+        assignee=HITLAssignee(role=str(role), notify_channels=["slack", "email"]),
+    )
+
+
+def _profile_key(row: dict[str, Any]) -> str:
+    return str(row.get("domain") or row.get("name") or "").strip().lower()
+
+
+def _source_ref_from_profile(profile: dict[str, Any]) -> dict[str, Any]:
+    return _source_ref(profile.get("source"), profile.get("domain") or profile.get("name"), profile.get("source_url"))
+
+
+def _source_ref(source: Any, ref_id: Any, url: Any = None) -> dict[str, Any]:
+    return {
+        "type": str(source or "competitive_source"),
+        "ref_id": str(ref_id or "provided_input"),
+        "source_url": url,
+    }
+
+
+def _pricing(row: dict[str, Any]) -> dict[str, Any]:
+    raw = row.get("pricing")
+    if isinstance(raw, dict):
+        amount = _float(raw.get("amount") or raw.get("price"), 0.0)
+        currency = str(raw.get("currency") or row.get("currency") or "USD")
+        plan = str(raw.get("plan") or row.get("plan") or "default")
+    else:
+        amount = _float(row.get("price") or row.get("monthly_price") or row.get("annual_price"), 0.0)
+        currency = str(row.get("currency") or "USD")
+        plan = str(row.get("plan") or "default")
+    return {"amount": amount, "currency": currency, "plan": plan}
+
+
+def _domain(row: dict[str, Any]) -> str:
+    return str(row.get("domain") or row.get("account_domain") or row.get("website") or "").strip().lower()
+
+
+def _clean_feature(value: Any) -> str:
+    return str(value or "").strip().lower().replace("_", " ")
+
+
+def _win_loss_reason(text: str) -> str:
+    if "price" in text or "pricing" in text or "cost" in text or "budget" in text:
+        return "pricing"
+    if "feature" in text or "integration" in text or "capability" in text:
+        return "feature_gap"
+    if "security" in text or "compliance" in text:
+        return "security_compliance"
+    if "support" in text or "service" in text:
+        return "support"
+    return "unspecified"
+
+
+def _workflow_mode(inputs: dict[str, Any]) -> str:
+    return str(inputs.get("workflow_mode") or inputs.get("mode") or "shadow").strip().lower()
+
+
+def _severity(value: Any, *, default: str) -> str:
+    normalized = _normalize(str(value or default))
+    return normalized if normalized in {"critical", "high", "medium", "low"} else default
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _dict_or_none(value: Any) -> dict[str, Any] | None:
+    return dict(value) if isinstance(value, dict) else None
+
+
+def _dict_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list | tuple):
+        return []
+    return [dict(item) for item in value if isinstance(item, dict)]
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, list | tuple | set):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [str(value).strip()]
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            deduped.append(value)
+    return deduped

--- a/core/agents/marketing/content_factory.py
+++ b/core/agents/marketing/content_factory.py
@@ -46,6 +46,17 @@ BRAND_VOICE_CHECKS = {
 }
 
 
+def _external_write_confirmation_status(result: dict[str, Any] | None) -> str:
+    if not result:
+        return "write_unconfirmed"
+    return str(
+        result.get("external_write_confirmation_status")
+        or result.get("write_confirmation_status")
+        or result.get("status")
+        or "write_unconfirmed"
+    )
+
+
 @AgentRegistry.register
 class ContentFactoryAgent(BaseAgent):
     agent_type = "content_factory"
@@ -188,6 +199,8 @@ class ContentFactoryAgent(BaseAgent):
             # --- Step 6: Schedule publication ---
             scheduled = False
             schedule_result_data: dict[str, Any] = {}
+            schedule_write_status = "not_required"
+            schedule_blocker: str | None = None
             if publish_date and not compliance_issues:
                 publish_channel = channel or (type_config["channels"][0] if type_config["channels"] else "")
 
@@ -204,12 +217,17 @@ class ContentFactoryAgent(BaseAgent):
                         trace, tool_calls,
                     )
                     if sched_result and "error" not in sched_result:
+                        schedule_write_status = _external_write_confirmation_status(sched_result)
                         scheduled = True
                         schedule_result_data = {
                             "platform": "wordpress",
                             "post_id": sched_result.get("id", ""),
                             "url": sched_result.get("url", ""),
+                            "external_write_confirmation_status": schedule_write_status,
                         }
+                    else:
+                        schedule_write_status = "write_unconfirmed"
+                        schedule_blocker = "WordPress draft was not created or confirmed."
                 elif publish_channel in ("linkedin", "twitter", "facebook"):
                     sched_result = await self._safe_tool_call(
                         "buffer", "create_post",
@@ -221,11 +239,16 @@ class ContentFactoryAgent(BaseAgent):
                         trace, tool_calls,
                     )
                     if sched_result and "error" not in sched_result:
+                        schedule_write_status = _external_write_confirmation_status(sched_result)
                         scheduled = True
                         schedule_result_data = {
                             "platform": "buffer",
                             "post_id": sched_result.get("id", ""),
+                            "external_write_confirmation_status": schedule_write_status,
                         }
+                    else:
+                        schedule_write_status = "write_unconfirmed"
+                        schedule_blocker = "Social scheduling was not confirmed by the connector."
                 elif publish_channel == "email":
                     sched_result = await self._safe_tool_call(
                         "sendgrid", "create_campaign",
@@ -238,11 +261,16 @@ class ContentFactoryAgent(BaseAgent):
                         trace, tool_calls,
                     )
                     if sched_result and "error" not in sched_result:
+                        schedule_write_status = _external_write_confirmation_status(sched_result)
                         scheduled = True
                         schedule_result_data = {
                             "platform": "sendgrid",
                             "campaign_id": sched_result.get("id", ""),
+                            "external_write_confirmation_status": schedule_write_status,
                         }
+                    else:
+                        schedule_write_status = "write_unconfirmed"
+                        schedule_blocker = "Email campaign draft was not confirmed by the connector."
 
                 if scheduled:
                     trace.append(f"Content scheduled on {publish_channel} for {publish_date}")
@@ -272,6 +300,22 @@ class ContentFactoryAgent(BaseAgent):
                 hitl_reasons.append(f"low keyword coverage ({keyword_coverage:.0f}%)")
             if confidence < self.confidence_floor:
                 hitl_reasons.append(f"confidence {confidence:.3f} < floor")
+            if publish_date:
+                hitl_reasons.append("publish approval required before external delivery")
+
+            source_refs = [
+                {"kind": "tool_call", "tool_name": call.tool_name, "status": call.status}
+                for call in tool_calls
+            ]
+            blocked_reasons = [schedule_blocker] if schedule_blocker else []
+            degraded_reasons = []
+            if publish_date and not scheduled and not compliance_issues:
+                degraded_reasons.append("Publish connector did not create a confirmed draft.")
+            publish_state = (
+                "draft_created_pending_approval"
+                if scheduled and schedule_write_status in {"draft_created", "write_confirmed", "created"}
+                else "not_scheduled"
+            )
 
             output = {
                 "status": "generated",
@@ -286,6 +330,33 @@ class ContentFactoryAgent(BaseAgent):
                 "schedule_details": schedule_result_data,
                 "confidence": confidence,
                 "hitl_required": len(hitl_reasons) > 0,
+                "approval_required": len(hitl_reasons) > 0,
+                "rationale": (
+                    f"Generated {content_type} draft for {target_audience or 'unspecified audience'} "
+                    f"with {word_count} words and {keyword_coverage:.0f}% keyword coverage."
+                ),
+                "recommended_actions": [
+                    {
+                        "action": "review_content",
+                        "reason": "; ".join(hitl_reasons) if hitl_reasons else "Content meets baseline checks.",
+                    }
+                ],
+                "source_refs": source_refs,
+                "policy_result": {
+                    "decision": "requires_approval" if publish_date or compliance_issues else "allowed",
+                    "reason": (
+                        "Content has publish/compliance review requirements."
+                        if publish_date or compliance_issues
+                        else "Draft-only content generation is allowed."
+                    ),
+                },
+                "audit_ref": f"content_factory:{task.correlation_id}:{task.step_id}",
+                "degraded_reasons": degraded_reasons,
+                "blocked_reasons": blocked_reasons,
+                "external_write_confirmation_status": schedule_write_status,
+                "external_writes_completed": schedule_write_status == "write_confirmed",
+                "publish_state": publish_state,
+                "production_status": "beta",
             }
 
             if hitl_reasons:

--- a/core/agents/marketing/crm_intelligence.py
+++ b/core/agents/marketing/crm_intelligence.py
@@ -1,18 +1,1457 @@
-"""CRM Intelligence agent implementation."""
+"""CRM Intelligence agent implementation.
+
+The CRM Intelligence agent is deterministic and vendor-neutral: it analyzes
+structured CRM, pipeline, and lifecycle inputs supplied by connectors or
+tests, emits contract-shaped CMO outputs, and fails closed before any active
+CRM write (lead score push, lifecycle stage change, segment/list change,
+target account change, or bulk CRM update). Production claims require real
+CRM/intent connector readiness, policy/approval/audit evidence, confirmed
+external writes, and pilot proof — none of which is supplied by this module
+alone.
+"""
 
 from __future__ import annotations
 
+import time
+import uuid
+from typing import Any
+
+import structlog
+
 from core.agents.base import BaseAgent
 from core.agents.registry import AgentRegistry
+from core.marketing.escalation_matrix import evaluate_marketing_escalation
+from core.marketing.policy_manifest import evaluate_marketing_policy
+from core.schemas.messages import (
+    DecisionOption,
+    DecisionRequired,
+    HITLAssignee,
+    HITLContext,
+    HITLRequest,
+    ToolCallRecord,
+)
+
+logger = structlog.get_logger()
+
+CRM_INTELLIGENCE_AGENT_MATURITY = "beta"
+CRM_INTELLIGENCE_CONFIDENCE_FLOOR = 0.85
+
+READ_ONLY_ACTIONS = {
+    "account_deal_health_summary",
+    "account_health_summary",
+    "analyze_pipeline_velocity",
+    "churn_risk_signal_extraction",
+    "extract_churn_signals",
+    "funnel_conversion_analysis",
+    "lead_scoring_refresh",
+    "pipeline_velocity_analysis",
+    "promote_to_sql",
+    "recommend_segments",
+    "refresh_lead_scores",
+    "score_lead",
+    "segment_recommendation",
+    "sql_promotion_criteria",
+}
+WRITE_ACTIONS = {
+    "bulk_crm_update",
+    "change_segment_membership",
+    "change_target_accounts",
+    "promote_lifecycle_stage",
+    "update_crm",
+    "update_lead_scores",
+    "update_lifecycle_stage",
+    "update_segment_membership",
+}
+SHADOW_MODES = {"shadow", "draft", "internal", "internal_only", "recommendation", "simulation"}
+
+# Lead scoring weights (sum to 1.0). Deterministic, explainable.
+LEAD_SCORE_WEIGHTS: dict[str, float] = {
+    "firmographic_fit": 0.30,
+    "title_seniority": 0.20,
+    "engagement_recency": 0.20,
+    "engagement_depth": 0.15,
+    "intent_signal": 0.10,
+    "demo_request": 0.05,
+}
+TITLE_SENIORITY_WEIGHTS: dict[str, float] = {
+    "cxo": 1.0,
+    "vp": 0.9,
+    "director": 0.75,
+    "manager": 0.55,
+    "ic": 0.3,
+    "intern": 0.05,
+}
+MQL_SCORE_FLOOR = 55.0
+SQL_SCORE_FLOOR = 75.0
+CHURN_RISK_FLOOR = 0.6
+# Pipeline velocity bottleneck: any stage whose average days-in-stage is
+# >= this multiple of the median is flagged.
+VELOCITY_BOTTLENECK_MULTIPLIER = 1.75
+# Minimum funnel sample size before conversion rates are considered
+# statistically meaningful.
+MIN_FUNNEL_SAMPLE = 25
 
 
 @AgentRegistry.register
 class CrmIntelligenceAgent(BaseAgent):
     agent_type = "crm_intelligence"
     domain = "marketing"
-    confidence_floor = 0.88
+    confidence_floor = CRM_INTELLIGENCE_CONFIDENCE_FLOOR
     prompt_file = "crm_intelligence.prompt.txt"
 
     async def execute(self, task):
-        """Execute crm intelligence task with domain-specific logic."""
-        return await super().execute(task)
+        """Run deterministic CRM/pipeline analysis or guarded CRM writes."""
+
+        start = time.monotonic()
+        trace: list[str] = []
+        tool_calls: list[ToolCallRecord] = []
+        msg_id = f"msg_{uuid.uuid4().hex[:12]}"
+
+        try:
+            inputs = _task_inputs(task)
+            action = _normalize_action(_task_action(task))
+            mode = _workflow_mode(inputs)
+            trace.append(f"CRM Intelligence action={action}, mode={mode}")
+
+            if action in READ_ONLY_ACTIONS:
+                output = self._read_only_action(task, action, inputs, mode, trace)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+            if action in WRITE_ACTIONS:
+                output = await self._guarded_crm_write(task, action, inputs, mode, trace, tool_calls)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+
+            output = self._base_output(
+                task,
+                action=action,
+                status="blocked",
+                confidence=0.0,
+                rationale=f"Unsupported CRM Intelligence action '{action}'.",
+                recommended_actions=[
+                    {
+                        "action": "use_supported_crm_intelligence_action",
+                        "reason": "CRM Intelligence only executes declared deterministic actions.",
+                    }
+                ],
+                blocked_reasons=[f"Unsupported CRM Intelligence action '{action}'."],
+                policy_context={"workflow_mode": mode},
+            )
+            return self._make_result(
+                task,
+                msg_id,
+                "failed",
+                output,
+                0.0,
+                trace,
+                tool_calls,
+                error={
+                    "code": "CRM_INTELLIGENCE_ACTION_UNSUPPORTED",
+                    "message": output["blocked_reasons"][0],
+                },
+                start=start,
+            )
+        # enterprise-gate: broad-except-ok reason=agent-execution-boundary-returns-failed-result
+        except Exception as exc:
+            logger.error("crm_intelligence_agent_error", agent=self.agent_id, error=str(exc))
+            trace.append(f"Error: {exc}")
+            return self._make_result(
+                task,
+                msg_id,
+                "failed",
+                {},
+                0.0,
+                trace,
+                tool_calls,
+                error={"code": "CRM_INTELLIGENCE_AGENT_ERR", "message": str(exc)},
+                start=start,
+            )
+
+    def _read_only_action(
+        self,
+        task,
+        action: str,
+        inputs: dict[str, Any],
+        mode: str,
+        trace: list[str],
+    ) -> dict[str, Any]:
+        pipeline_velocity = _pipeline_velocity_analysis(inputs)
+        funnel_conversion = _funnel_conversion_analysis(inputs)
+        scored_contacts = _lead_scoring_refresh(inputs)
+        churn_signals = _churn_risk_signals(inputs)
+        segments = _segment_recommendations(scored_contacts, inputs)
+        sql_classification = _sql_promotion_classification(scored_contacts, inputs)
+        account_health = _account_deal_health_summary(inputs)
+        degraded = _read_degraded_reasons(inputs)
+        confidence = _analysis_confidence(
+            pipeline_velocity,
+            funnel_conversion,
+            scored_contacts,
+            churn_signals,
+            account_health,
+            degraded,
+        )
+        source_refs = _source_refs(
+            inputs,
+            scored_contacts,
+            churn_signals["scored_accounts"],
+            pipeline_velocity["deals"],
+        )
+        summary = {
+            "pipeline_velocity": pipeline_velocity,
+            "funnel_conversion": funnel_conversion,
+            "lead_scoring": scored_contacts,
+            "churn_signals": churn_signals,
+            "segments": segments,
+            "sql_promotion": sql_classification,
+            "account_health": account_health,
+        }
+        trace.append(
+            "CRM Intelligence analysis deals="
+            f"{pipeline_velocity['deal_count']}, scored_contacts={len(scored_contacts['contacts'])}, "
+            f"at_risk_accounts={len(churn_signals['at_risk_accounts'])}, degraded={len(degraded)}"
+        )
+
+        status = "crm_analysis_degraded" if degraded else "crm_analysis_ready"
+        rationale = (
+            "Built deterministic CRM/pipeline intelligence from structured deal, "
+            "contact, account, and funnel inputs."
+        )
+        extra: dict[str, Any] = {"crm_analysis": summary}
+        recommended = _default_recommendations(degraded)
+
+        if action in {"pipeline_velocity_analysis", "analyze_pipeline_velocity"}:
+            status = "pipeline_velocity_analyzed" if not degraded else "pipeline_velocity_degraded"
+            rationale = "Computed deterministic stage velocity, bottlenecks, and stuck deals."
+            recommended = pipeline_velocity["recommended_actions"] or recommended
+            extra.update({"pipeline_velocity": pipeline_velocity})
+        elif action == "funnel_conversion_analysis":
+            status = "funnel_conversion_computed" if not degraded else "funnel_conversion_degraded"
+            rationale = "Computed safe stage-to-stage conversion rates with low-sample handling."
+            recommended = funnel_conversion["recommended_actions"] or recommended
+            extra.update({"funnel_conversion": funnel_conversion})
+        elif action in {"lead_scoring_refresh", "refresh_lead_scores", "score_lead"}:
+            status = "lead_scores_refreshed" if not degraded else "lead_scoring_degraded"
+            rationale = "Refreshed deterministic, explainable lead scores from canonical signals."
+            recommended = scored_contacts["recommended_actions"] or recommended
+            extra.update({"lead_scoring": scored_contacts})
+        elif action in {"churn_risk_signal_extraction", "extract_churn_signals"}:
+            status = "churn_signals_extracted" if not degraded else "churn_signals_degraded"
+            rationale = (
+                "Extracted churn risk signals from login activity, support load, NPS, "
+                "payment health, and usage trend."
+            )
+            recommended = churn_signals["recommended_actions"] or recommended
+            extra.update({"churn_signals": churn_signals})
+        elif action in {"segment_recommendation", "recommend_segments"}:
+            status = "segments_recommended" if not degraded else "segments_degraded"
+            rationale = "Recommended deterministic segments by lifecycle, fit, and engagement."
+            recommended = segments["recommended_actions"] or recommended
+            extra.update({"segments": segments})
+        elif action in {"sql_promotion_criteria", "promote_to_sql"}:
+            status = "sql_promotion_classified" if not degraded else "sql_promotion_degraded"
+            rationale = "Classified contacts as promotable or non-promotable to SQL."
+            recommended = sql_classification["recommended_actions"] or recommended
+            extra.update({"sql_promotion": sql_classification})
+        elif action in {"account_health_summary", "account_deal_health_summary"}:
+            status = "account_health_summarized" if not degraded else "account_health_degraded"
+            rationale = "Summarized composite account/deal health from CRM-shaped inputs."
+            recommended = account_health["recommended_actions"] or recommended
+            extra.update({"account_health": account_health})
+
+        return self._base_output(
+            task,
+            action=action,
+            status=status,
+            confidence=confidence,
+            rationale=rationale,
+            recommended_actions=recommended,
+            policy_context={"workflow_id": "crm_pipeline_intelligence", "workflow_mode": mode},
+            source_refs=source_refs,
+            degraded_reasons=degraded,
+            extra=extra,
+        )
+
+    async def _guarded_crm_write(
+        self,
+        task,
+        action: str,
+        inputs: dict[str, Any],
+        mode: str,
+        trace: list[str],
+        tool_calls: list[ToolCallRecord],
+    ) -> dict[str, Any]:
+        policy_context = _policy_context_for_write(action, inputs, mode)
+        policy = evaluate_marketing_policy(policy_context)
+        escalation = _escalation_for_write(task, action, inputs, policy)
+        blocked_reasons: list[str] = []
+        hitl_reasons: list[str] = []
+
+        if mode in SHADOW_MODES:
+            blocked_reasons.append("Shadow/draft/internal CRM Intelligence workflows are read-only.")
+            trace.append("CRM Intelligence write converted to shadow-only recommendation")
+            return self._base_output(
+                task,
+                action=action,
+                status="shadow_only",
+                confidence=0.76,
+                rationale="Prepared CRM change recommendation without mutating the CRM.",
+                recommended_actions=[
+                    {
+                        "action": "create_internal_approval",
+                        "reason": "Review the CRM change before any active external write is attempted.",
+                    }
+                ],
+                approval_required=True,
+                hitl_required=True,
+                policy_result=policy,
+                escalation=escalation,
+                blocked_reasons=blocked_reasons,
+                external_write_status="shadow_only",
+                external_write_required=True,
+                extra={"write_payload": _crm_write_payload(action, inputs)},
+            )
+
+        write_safe, write_reason = _connector_write_safe(inputs)
+        if not write_safe:
+            blocked_reasons.append(write_reason)
+        if policy.get("decision") in {"requires_approval", "requires_escalation"} and not _has_approval(inputs):
+            hitl_reasons.append(
+                str(policy.get("reason") or "CRM Intelligence write requires approval.")
+            )
+        if policy.get("decision") in {"blocked", "missing_policy"}:
+            blocked_reasons.append(
+                str(policy.get("reason") or "Marketing policy blocks this CRM action.")
+            )
+        escalation_needs_review = escalation.get("decision") not in {None, "", "no_escalation", "notify_owner"}
+        if escalation_needs_review and not _has_escalation_approval(inputs):
+            hitl_reasons.append("CRM Intelligence write requires escalation review.")
+
+        if blocked_reasons or hitl_reasons:
+            return self._base_output(
+                task,
+                action=action,
+                status="blocked",
+                confidence=0.0,
+                rationale="CRM Intelligence external action failed closed before vendor mutation.",
+                recommended_actions=[
+                    {
+                        "action": "resolve_crm_write_prerequisites",
+                        "reason": "; ".join(_dedupe(blocked_reasons + hitl_reasons)),
+                    }
+                ],
+                approval_required=bool(hitl_reasons),
+                hitl_required=True,
+                policy_result=policy,
+                escalation=escalation,
+                blocked_reasons=blocked_reasons + hitl_reasons,
+                external_write_status="write_unconfirmed",
+                external_write_required=True,
+                extra={"write_payload": _crm_write_payload(action, inputs)},
+            )
+
+        result = _dict_or_none(inputs.get("external_write_result"))
+        connector, tool = _connector_tool(action, inputs)
+        idempotency_key = str(
+            inputs.get("idempotency_key")
+            or inputs.get("request_fingerprint")
+            or f"crm_intelligence:{task.correlation_id}:{task.step_id}:{action}"
+        )
+        if result is None:
+            result = await self._safe_tool_call(
+                connector,
+                tool,
+                _crm_write_payload(action, inputs),
+                trace,
+                tool_calls,
+                idempotency_key=idempotency_key,
+            )
+
+        write_status = _external_write_confirmation_status(result)
+        write_confirmed = _is_confirmed_external_write(result)
+        external_ref = _external_write_ref(result)
+        blocked_reasons = [] if write_confirmed else [
+            "CRM Intelligence write is unconfirmed and cannot be marked complete."
+        ]
+        trace.append(f"CRM Intelligence write status={write_status}, confirmed={write_confirmed}")
+        return self._base_output(
+            task,
+            action=action,
+            status="write_confirmed" if write_confirmed else "write_unconfirmed",
+            confidence=0.9 if write_confirmed else 0.0,
+            rationale=(
+                "CRM Intelligence external write was confirmed by the connector."
+                if write_confirmed
+                else "CRM Intelligence external write did not return confirmed vendor evidence."
+            ),
+            recommended_actions=[
+                {
+                    "action": (
+                        "monitor_lifecycle_after_change"
+                        if write_confirmed
+                        else "verify_crm_write_before_retry"
+                    ),
+                    "reason": (
+                        "Track lifecycle/segment impact after the confirmed CRM change."
+                        if write_confirmed
+                        else "Check vendor state with the idempotency key before retrying."
+                    ),
+                }
+            ],
+            approval_required=False,
+            hitl_required=not write_confirmed,
+            policy_result=policy,
+            approval_satisfied=_has_approval(inputs),
+            escalation=escalation,
+            blocked_reasons=blocked_reasons,
+            external_write_status=write_status,
+            external_write_required=True,
+            external_write_ref=external_ref,
+            extra={"write_payload": _crm_write_payload(action, inputs)},
+        )
+
+    async def _safe_tool_call(
+        self,
+        connector: str,
+        tool: str,
+        params: dict[str, Any],
+        trace: list[str],
+        tool_records: list[ToolCallRecord],
+        *,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        call_start = time.monotonic()
+        try:
+            result = await self._call_tool(
+                connector_name=connector,
+                tool_name=tool,
+                params=params,
+                idempotency_key=idempotency_key,
+            )
+            latency = int((time.monotonic() - call_start) * 1000)
+            status = "error" if "error" in result else "success"
+            trace.append(f"[tool] {connector}.{tool} -> {status} ({latency}ms)")
+            tool_records.append(ToolCallRecord(tool_name=f"{connector}.{tool}", status=status, latency_ms=latency))
+            return result
+        # enterprise-gate: broad-except-ok reason=agent-tool-call-failure-returns-explicit-error-result
+        except Exception as exc:
+            latency = int((time.monotonic() - call_start) * 1000)
+            trace.append(f"[tool] {connector}.{tool} -> exception: {exc} ({latency}ms)")
+            tool_records.append(ToolCallRecord(tool_name=f"{connector}.{tool}", status="error", latency_ms=latency))
+            return {"error": str(exc)}
+
+    def _base_output(
+        self,
+        task,
+        *,
+        action: str,
+        status: str,
+        confidence: float,
+        rationale: str,
+        recommended_actions: list[dict[str, Any]],
+        approval_required: bool = False,
+        hitl_required: bool = False,
+        policy_context: dict[str, Any] | None = None,
+        policy_result: dict[str, Any] | None = None,
+        approval_satisfied: bool = False,
+        escalation: dict[str, Any] | None = None,
+        source_refs: list[dict[str, Any]] | None = None,
+        degraded_reasons: list[str] | None = None,
+        blocked_reasons: list[str] | None = None,
+        external_write_status: str = "not_required",
+        external_write_required: bool = False,
+        external_write_ref: dict[str, Any] | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        policy = policy_result or evaluate_marketing_policy(
+            {
+                "workflow_id": "crm_pipeline_intelligence",
+                "workflow_mode": "shadow",
+                "action": action,
+                "external_write_required": external_write_required,
+                **(policy_context or {}),
+            }
+        )
+        escalation_ref = None
+        if escalation and escalation.get("decision") != "no_escalation":
+            escalation_ref = escalation.get("decision_audit_ref") or escalation.get("audit_reference")
+        policy_needs_review = (
+            policy.get("decision") in {"requires_approval", "requires_escalation", "read_only_only"}
+            and not approval_satisfied
+        )
+        output: dict[str, Any] = {
+            "status": status,
+            "agent_type": self.agent_type,
+            "action": action,
+            "confidence": round(max(0.0, min(confidence, 1.0)), 3),
+            "rationale": rationale,
+            "recommended_actions": recommended_actions,
+            "source_refs": source_refs or [],
+            "policy_result": policy,
+            "policy_ref": policy.get("decision_audit_ref") or policy.get("policy_id"),
+            "approval_required": approval_required or policy_needs_review,
+            "hitl_required": hitl_required,
+            "escalation_ref": escalation_ref,
+            "escalation_result": escalation,
+            "audit_ref": f"crm_intelligence:{task.correlation_id}:{task.step_id}:{action}",
+            "degraded_reasons": _dedupe(degraded_reasons or []),
+            "blocked_reasons": _dedupe(blocked_reasons or []),
+            "external_write_confirmation_status": external_write_status,
+            "external_writes_completed": external_write_status == "write_confirmed",
+            "external_write_required": external_write_required,
+            "external_write_ref": external_write_ref,
+            "production_status": CRM_INTELLIGENCE_AGENT_MATURITY,
+        }
+        if extra:
+            output.update(extra)
+        return output
+
+    def _complete_or_hitl(
+        self,
+        task,
+        msg_id: str,
+        output: dict[str, Any],
+        trace: list[str],
+        tool_calls: list[ToolCallRecord],
+        start: float,
+    ):
+        if output.get("hitl_required") or output.get("approval_required") or output.get("blocked_reasons"):
+            hitl = _hitl_request(task, output)
+            return self._make_result(
+                task,
+                msg_id,
+                "hitl_triggered",
+                output,
+                float(output.get("confidence") or 0.0),
+                trace,
+                tool_calls,
+                hitl_request=hitl,
+                start=start,
+            )
+        return self._make_result(
+            task,
+            msg_id,
+            "completed",
+            output,
+            float(output.get("confidence") or 0.0),
+            trace,
+            tool_calls,
+            start=start,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task / input helpers
+# ---------------------------------------------------------------------------
+
+
+def _task_inputs(task) -> dict[str, Any]:
+    payload = task.task.inputs if hasattr(task.task, "inputs") else task.task.get("inputs", {})
+    return payload if isinstance(payload, dict) else {}
+
+
+def _task_action(task) -> str:
+    return str(
+        task.task.action
+        if hasattr(task.task, "action")
+        else task.task.get("action", "pipeline_velocity_analysis")
+    )
+
+
+def _normalize_action(action: str) -> str:
+    normalized = _normalize(action)
+    aliases = {
+        "analyze_funnel": "funnel_conversion_analysis",
+        "funnel_analysis": "funnel_conversion_analysis",
+        "funnel_conversion": "funnel_conversion_analysis",
+        "lead_score_refresh": "lead_scoring_refresh",
+        "lead_scoring": "lead_scoring_refresh",
+        "pipeline_velocity": "pipeline_velocity_analysis",
+        "promote_lead_to_sql": "sql_promotion_criteria",
+        "promote_sql": "sql_promotion_criteria",
+        "segment": "segment_recommendation",
+        "segment_plan": "segment_recommendation",
+        "sql_promotion": "sql_promotion_criteria",
+        "update_lead_score": "update_lead_scores",
+        "update_lifecycle": "update_lifecycle_stage",
+        "update_segment": "update_segment_membership",
+        "target_account_list_change": "change_target_accounts",
+        "update_target_accounts": "change_target_accounts",
+        "churn_extraction": "extract_churn_signals",
+        "churn_risk": "extract_churn_signals",
+        "promote_to_sql_classification": "promote_to_sql",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def _workflow_mode(inputs: dict[str, Any]) -> str:
+    return _normalize(
+        inputs.get("workflow_mode")
+        or inputs.get("mode")
+        or inputs.get("readiness")
+        or inputs.get("capability_state")
+        or "shadow"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Domain logic — pipeline velocity / funnel conversion
+# ---------------------------------------------------------------------------
+
+
+def _pipeline_velocity_analysis(inputs: dict[str, Any]) -> dict[str, Any]:
+    rows = _dict_list(inputs.get("deals") or inputs.get("pipeline_deals") or inputs.get("opportunities"))
+    stage_totals: dict[str, float] = {}
+    stage_counts: dict[str, int] = {}
+    stuck: list[dict[str, Any]] = []
+    stuck_threshold = _float(inputs.get("stuck_deal_threshold_days"), 30.0) or 30.0
+    for deal in rows:
+        stage = _normalize(deal.get("stage") or deal.get("pipeline_stage") or "unknown")
+        days = deal.get("days_in_stage")
+        if days is None:
+            continue
+        days_value = _float(days, None)
+        if days_value is None:
+            continue
+        stage_totals[stage] = stage_totals.get(stage, 0.0) + days_value
+        stage_counts[stage] = stage_counts.get(stage, 0) + 1
+        if days_value >= stuck_threshold and stage not in {"closed_won", "closed_lost"}:
+            stuck.append(
+                {
+                    "deal_id": str(deal.get("id") or deal.get("deal_id") or "deal"),
+                    "stage": stage,
+                    "days_in_stage": round(days_value, 2),
+                    "amount": _float(deal.get("amount") or deal.get("value"), 0.0),
+                }
+            )
+
+    avg_by_stage = {
+        stage: round(stage_totals[stage] / stage_counts[stage], 2)
+        for stage in stage_totals
+        if stage_counts[stage] > 0
+    }
+    bottlenecks: list[dict[str, Any]] = []
+    if avg_by_stage:
+        values = sorted(avg_by_stage.values())
+        mid = len(values) // 2
+        median = (
+            values[mid]
+            if len(values) % 2
+            else (values[mid - 1] + values[mid]) / 2
+        )
+        threshold = max(median * VELOCITY_BOTTLENECK_MULTIPLIER, median + 1)
+        for stage, avg in avg_by_stage.items():
+            if avg >= threshold:
+                bottlenecks.append(
+                    {
+                        "stage": stage,
+                        "avg_days_in_stage": avg,
+                        "median_days_in_stage": round(median, 2),
+                        "multiplier": round(avg / max(median, 0.01), 2),
+                    }
+                )
+
+    recommended_actions: list[dict[str, Any]] = [
+        {
+            "action": "investigate_pipeline_bottleneck",
+            "stage": bottleneck["stage"],
+            "reason": (
+                f"avg {bottleneck['avg_days_in_stage']}d >= "
+                f"{VELOCITY_BOTTLENECK_MULTIPLIER}x median {bottleneck['median_days_in_stage']}d"
+            ),
+        }
+        for bottleneck in bottlenecks
+    ]
+    if stuck:
+        recommended_actions.append(
+            {
+                "action": "review_stuck_deals",
+                "reason": f"{len(stuck)} deal(s) idle >= {stuck_threshold:.0f} days.",
+            }
+        )
+
+    return {
+        "deal_count": sum(stage_counts.values()),
+        "deals": rows,
+        "stage_counts": stage_counts,
+        "avg_days_in_stage": avg_by_stage,
+        "bottlenecks": bottlenecks,
+        "stuck_deals": stuck,
+        "recommended_actions": recommended_actions,
+    }
+
+
+def _funnel_conversion_analysis(inputs: dict[str, Any]) -> dict[str, Any]:
+    raw = inputs.get("funnel_stage_counts") or inputs.get("stage_counts") or {}
+    if not isinstance(raw, dict):
+        raw = {}
+    ordered: list[tuple[str, int]] = []
+    for key, value in raw.items():
+        try:
+            count = int(value or 0)
+        except (TypeError, ValueError):
+            count = 0
+        ordered.append((str(key), max(count, 0)))
+
+    rates: dict[str, float | None] = {}
+    for i in range(1, len(ordered)):
+        prev_name, prev_count = ordered[i - 1]
+        curr_name, curr_count = ordered[i]
+        key = f"{prev_name}->{curr_name}"
+        if prev_count <= 0:
+            rates[key] = None
+            continue
+        rates[key] = round(curr_count / prev_count, 4)
+
+    total = sum(count for _, count in ordered)
+    sufficient_sample = total >= MIN_FUNNEL_SAMPLE
+    recommended_actions: list[dict[str, Any]] = []
+    if not sufficient_sample:
+        recommended_actions.append(
+            {
+                "action": "increase_funnel_sample_size",
+                "reason": (
+                    f"Total funnel volume {total} < {MIN_FUNNEL_SAMPLE} minimum; "
+                    "rates remain directional only."
+                ),
+            }
+        )
+    for key, rate in rates.items():
+        if rate is not None and rate < 0.10:
+            recommended_actions.append(
+                {
+                    "action": "investigate_low_funnel_conversion",
+                    "transition": key,
+                    "rate": rate,
+                }
+            )
+    return {
+        "stage_counts": dict(ordered),
+        "conversion_rates": rates,
+        "total_leads": total,
+        "sufficient_sample": sufficient_sample,
+        "min_required_sample": MIN_FUNNEL_SAMPLE,
+        "recommended_actions": recommended_actions,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Lead scoring / SQL promotion / segments
+# ---------------------------------------------------------------------------
+
+
+def _lead_scoring_refresh(inputs: dict[str, Any]) -> dict[str, Any]:
+    rows = _dict_list(inputs.get("contacts") or inputs.get("leads"))
+    scored: list[dict[str, Any]] = []
+    promotions: list[dict[str, Any]] = []
+    for contact in rows:
+        score, breakdown = _score_contact(contact)
+        previous = _float(contact.get("lead_score"), 0.0) or 0.0
+        delta = round(score - previous, 2)
+        qualification = _qualification_from_score(score, contact)
+        entry = {
+            "contact_id": str(contact.get("id") or contact.get("contact_id") or "contact"),
+            "score": round(score, 2),
+            "previous_score": round(previous, 2),
+            "delta": delta,
+            "qualification": qualification,
+            "breakdown": breakdown,
+            "explanation": _scoring_explanation(breakdown, qualification, score),
+        }
+        scored.append(entry)
+        if qualification in {"mql", "sql"} and previous < MQL_SCORE_FLOOR:
+            promotions.append(
+                {
+                    "contact_id": entry["contact_id"],
+                    "to": qualification,
+                    "score": entry["score"],
+                }
+            )
+    return {
+        "contacts": scored,
+        "promotions": promotions,
+        "weights": dict(LEAD_SCORE_WEIGHTS),
+        "thresholds": {"mql": MQL_SCORE_FLOOR, "sql": SQL_SCORE_FLOOR},
+        "recommended_actions": [
+            {
+                "action": "promote_lifecycle_stage",
+                "contact_id": p["contact_id"],
+                "to": p["to"],
+                "reason": f"score crossed {p['to'].upper()} floor",
+            }
+            for p in promotions
+        ],
+    }
+
+
+def _score_contact(contact: dict[str, Any]) -> tuple[float, dict[str, float]]:
+    breakdown: dict[str, float] = {}
+    fit = max(0.0, min(_float(contact.get("firmographic_fit"), 0.0) or 0.0, 1.0))
+    breakdown["firmographic_fit"] = round(fit * LEAD_SCORE_WEIGHTS["firmographic_fit"] * 100.0, 2)
+
+    title = _normalize(contact.get("title_seniority"))
+    title_factor = TITLE_SENIORITY_WEIGHTS.get(title, 0.4)
+    breakdown["title_seniority"] = round(title_factor * LEAD_SCORE_WEIGHTS["title_seniority"] * 100.0, 2)
+
+    days = _float(contact.get("days_since_last_activity"), 999.0) or 999.0
+    if days <= 1:
+        recency = 1.0
+    elif days <= 7:
+        recency = 0.85
+    elif days <= 30:
+        recency = 0.55
+    elif days <= 90:
+        recency = 0.25
+    else:
+        recency = 0.0
+    breakdown["engagement_recency"] = round(recency * LEAD_SCORE_WEIGHTS["engagement_recency"] * 100.0, 2)
+
+    depth = max(0.0, min(_float(contact.get("engagement_depth"), 0.0) or 0.0, 1.0))
+    breakdown["engagement_depth"] = round(depth * LEAD_SCORE_WEIGHTS["engagement_depth"] * 100.0, 2)
+
+    intent = max(0.0, min((_float(contact.get("intent_score"), 0.0) or 0.0) / 100.0, 1.0))
+    breakdown["intent_signal"] = round(intent * LEAD_SCORE_WEIGHTS["intent_signal"] * 100.0, 2)
+
+    breakdown["demo_request"] = (
+        round(LEAD_SCORE_WEIGHTS["demo_request"] * 100.0, 2)
+        if bool(contact.get("demo_request"))
+        else 0.0
+    )
+
+    score = sum(breakdown.values())
+    return score, breakdown
+
+
+def _qualification_from_score(score: float, contact: dict[str, Any]) -> str:
+    if score >= SQL_SCORE_FLOOR and bool(contact.get("demo_request")):
+        return "sql"
+    if score >= MQL_SCORE_FLOOR:
+        return "mql"
+    return "lead"
+
+
+def _scoring_explanation(breakdown: dict[str, float], qualification: str, score: float) -> str:
+    sorted_components = sorted(breakdown.items(), key=lambda kv: kv[1], reverse=True)
+    top_two = ", ".join(f"{name}={value}" for name, value in sorted_components[:2])
+    return f"Composite score {round(score, 2)} -> {qualification.upper()} (top drivers: {top_two})."
+
+
+def _sql_promotion_classification(
+    lead_scoring: dict[str, Any],
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    contacts = _dict_list(inputs.get("contacts") or inputs.get("leads"))
+    promotable: list[dict[str, Any]] = []
+    non_promotable: list[dict[str, Any]] = []
+    scored_by_id = {row["contact_id"]: row for row in lead_scoring.get("contacts", [])}
+    for contact in contacts:
+        contact_id = str(contact.get("id") or contact.get("contact_id") or "contact")
+        scored = scored_by_id.get(contact_id)
+        if scored is not None:
+            score = float(scored["score"])
+        else:
+            score, _ = _score_contact(contact)
+        days_since = _float(contact.get("days_since_last_activity"), 999.0) or 999.0
+        recent_engagement = bool(contact.get("recent_engagement")) or days_since <= 7
+        demo_request = bool(contact.get("demo_request"))
+        intent_score = _float(contact.get("intent_score"), 0.0) or 0.0
+        strong_intent = intent_score >= 60
+        reasons: list[str] = []
+        if score < SQL_SCORE_FLOOR:
+            reasons.append(f"score {score:.1f} below SQL floor {SQL_SCORE_FLOOR}")
+        if not recent_engagement:
+            reasons.append("no recent engagement in last 7 days")
+        if not (demo_request or strong_intent):
+            reasons.append("no demo request and intent < 60")
+        entry = {
+            "contact_id": contact_id,
+            "score": round(score, 2),
+            "demo_request": demo_request,
+            "intent_score": intent_score,
+            "reasons": reasons,
+        }
+        if not reasons:
+            promotable.append(entry)
+        else:
+            non_promotable.append(entry)
+    return {
+        "promotable": promotable,
+        "non_promotable": non_promotable,
+        "criteria": {
+            "min_score": SQL_SCORE_FLOOR,
+            "max_days_since_activity": 7,
+            "min_intent_score_or_demo_request": 60,
+        },
+        "recommended_actions": [
+            {
+                "action": "promote_to_sql",
+                "contact_id": entry["contact_id"],
+                "reason": "Meets SQL promotion criteria.",
+            }
+            for entry in promotable
+        ],
+    }
+
+
+def _segment_recommendations(
+    lead_scoring: dict[str, Any],
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    contacts = _dict_list(inputs.get("contacts") or inputs.get("leads"))
+    by_industry: dict[str, list[str]] = {}
+    by_size: dict[str, list[str]] = {}
+    by_behaviour: dict[str, list[str]] = {}
+    for contact in contacts:
+        contact_id = str(contact.get("id") or contact.get("contact_id") or "contact")
+        industry = _normalize(contact.get("industry") or contact.get("vertical")) or "unknown"
+        size = _normalize(contact.get("company_size") or contact.get("segment_size")) or "unknown"
+        engagement_raw = contact.get("engagement_score")
+        if engagement_raw is None:
+            engagement = (_float(contact.get("engagement_depth"), 0.0) or 0.0) * 100.0
+        else:
+            engagement = _float(engagement_raw, 0.0) or 0.0
+        if engagement >= 70:
+            behaviour = "high_intent"
+        elif engagement >= 40:
+            behaviour = "warm"
+        else:
+            behaviour = "dormant"
+        by_industry.setdefault(industry, []).append(contact_id)
+        by_size.setdefault(size, []).append(contact_id)
+        by_behaviour.setdefault(behaviour, []).append(contact_id)
+
+    recommended_actions: list[dict[str, Any]] = []
+    if by_behaviour.get("high_intent"):
+        recommended_actions.append(
+            {
+                "action": "enroll_in_nurture",
+                "segment": "high_intent",
+                "contact_ids": by_behaviour["high_intent"],
+            }
+        )
+    if by_behaviour.get("warm"):
+        recommended_actions.append(
+            {
+                "action": "schedule_followup",
+                "segment": "warm",
+                "contact_ids": by_behaviour["warm"],
+            }
+        )
+    if by_behaviour.get("dormant"):
+        recommended_actions.append(
+            {
+                "action": "win_back_campaign",
+                "segment": "dormant",
+                "contact_ids": by_behaviour["dormant"],
+            }
+        )
+    return {
+        "by_industry": by_industry,
+        "by_size": by_size,
+        "by_behaviour": by_behaviour,
+        "recommended_actions": recommended_actions,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Churn risk / account health
+# ---------------------------------------------------------------------------
+
+
+def _churn_risk_signals(inputs: dict[str, Any]) -> dict[str, Any]:
+    rows = _dict_list(inputs.get("accounts") or inputs.get("customer_accounts"))
+    scored: list[dict[str, Any]] = []
+    at_risk: list[dict[str, Any]] = []
+    signal_summary: dict[str, int] = {}
+    for account in rows:
+        score, factors = _churn_score(account)
+        for factor in factors:
+            signal_summary[factor] = signal_summary.get(factor, 0) + 1
+        entry = {
+            "account_id": str(account.get("id") or account.get("account_id") or "account"),
+            "score": round(score, 3),
+            "factors": factors,
+        }
+        scored.append(entry)
+        if score >= CHURN_RISK_FLOOR:
+            at_risk.append(entry)
+    return {
+        "scored_accounts": scored,
+        "at_risk_accounts": at_risk,
+        "risk_floor": CHURN_RISK_FLOOR,
+        "signal_summary": signal_summary,
+        "recommended_actions": [
+            {
+                "action": "open_retention_play",
+                "account_id": entry["account_id"],
+                "reasons": entry["factors"],
+            }
+            for entry in at_risk
+        ],
+    }
+
+
+def _churn_score(account: dict[str, Any]) -> tuple[float, list[str]]:
+    score = 0.0
+    factors: list[str] = []
+    days_inactive = _float(account.get("days_since_last_login"), 0.0) or 0.0
+    if days_inactive >= 30:
+        score += 0.3
+        factors.append(f"login_inactive_{int(days_inactive)}d")
+    elif days_inactive >= 14:
+        score += 0.15
+        factors.append(f"login_inactive_{int(days_inactive)}d")
+
+    support = int(_float(account.get("open_support_tickets"), 0.0) or 0.0)
+    if support >= 5:
+        score += 0.25
+        factors.append(f"support_tickets_{support}")
+
+    nps = _float(account.get("nps"), 0.0) or 0.0
+    if nps <= -50:
+        score += 0.2
+        factors.append(f"nps_detractor_{nps:.0f}")
+    elif nps <= 0:
+        score += 0.1
+        factors.append(f"nps_passive_{nps:.0f}")
+
+    payment_health = _normalize(account.get("payment_health") or "ok")
+    if payment_health != "ok":
+        score += 0.25
+        factors.append(f"payment_{payment_health}")
+
+    usage_trend = _normalize(account.get("usage_trend") or "stable")
+    if usage_trend in {"declining", "dropping"}:
+        score += 0.2
+        factors.append("usage_declining")
+    return min(score, 1.0), factors
+
+
+def _account_deal_health_summary(inputs: dict[str, Any]) -> dict[str, Any]:
+    rows = _dict_list(inputs.get("accounts") or inputs.get("customer_accounts"))
+    summary: list[dict[str, Any]] = []
+    unhealthy: list[dict[str, Any]] = []
+    for account in rows:
+        mrr = _float(account.get("mrr"), 0.0) or 0.0
+        engagement = max(
+            0.0,
+            min((_float(account.get("engagement_score"), 0.0) or 0.0) / 100.0, 1.0),
+        )
+        support = int(_float(account.get("open_support_tickets"), 0.0) or 0.0)
+        nps = _float(account.get("nps"), 0.0) or 0.0
+        payment_health = _normalize(account.get("payment_health") or "ok")
+        support_component = 1.0 - min(support / 10.0, 1.0)
+        nps_component = max(0.0, min((nps + 100.0) / 200.0, 1.0))
+        payment_component = 1.0 if payment_health == "ok" else 0.4
+        health = round(
+            0.35 * engagement
+            + 0.25 * support_component
+            + 0.20 * nps_component
+            + 0.20 * payment_component,
+            3,
+        )
+        entry = {
+            "account_id": str(account.get("id") or account.get("account_id") or "account"),
+            "health_score": health,
+            "mrr": round(mrr, 2),
+            "components": {
+                "engagement": round(engagement, 3),
+                "support": round(support_component, 3),
+                "nps": round(nps_component, 3),
+                "payment": round(payment_component, 3),
+            },
+        }
+        summary.append(entry)
+        if health < 0.5:
+            unhealthy.append(entry)
+    return {
+        "accounts": summary,
+        "unhealthy_accounts": unhealthy,
+        "recommended_actions": [
+            {"action": "csm_intervention", "account_id": entry["account_id"]}
+            for entry in unhealthy
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Readiness, confidence, source refs
+# ---------------------------------------------------------------------------
+
+
+def _read_degraded_reasons(inputs: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    if inputs.get("connector_read_ready") is False or inputs.get("connector_degraded") is True:
+        reasons.append("CRM connector is degraded or unavailable.")
+    freshness = _normalize(inputs.get("data_freshness_status") or inputs.get("freshness_status"))
+    if freshness in {"stale", "partial", "degraded"}:
+        reasons.append(f"CRM source data is {freshness}.")
+    if inputs.get("stale_data") is True:
+        reasons.append("CRM source data is stale.")
+    if inputs.get("partial_data") is True:
+        reasons.append("CRM source data is partial.")
+    mapping_status = _normalize(inputs.get("mapping_status") or inputs.get("field_mapping_status"))
+    if mapping_status in {"invalid", "missing", "unmapped", "partial", "stale"}:
+        reasons.append(f"CRM field mapping is {mapping_status}.")
+    if inputs.get("missing_mapping") is True:
+        reasons.append("Required CRM field mapping is missing.")
+    contracts = _dict_list(inputs.get("connector_contracts"))
+    direct = _dict_or_none(inputs.get("connector_contract"))
+    if direct:
+        contracts.insert(0, direct)
+    if contracts:
+        relevant = [c for c in contracts if _is_crm_read_contract(c)]
+        if relevant and not any(bool(c.get("read_ready", c.get("configured"))) for c in relevant):
+            reasons.append("CRM source connector is not read-ready.")
+        if any(
+            c.get("degraded") or c.get("health_status") in {"stale", "degraded"}
+            for c in relevant
+        ):
+            reasons.append("One or more CRM source connectors are degraded or stale.")
+        if any(c.get("mock_or_test_double") or c.get("stub_only") for c in relevant):
+            reasons.append("Mock, test-double, or stub CRM connector proof is not production lineage.")
+    return _dedupe(reasons)
+
+
+def _analysis_confidence(
+    pipeline_velocity: dict[str, Any],
+    funnel_conversion: dict[str, Any],
+    lead_scoring: dict[str, Any],
+    churn_signals: dict[str, Any],
+    account_health: dict[str, Any],
+    degraded: list[str],
+) -> float:
+    signal_count = (
+        pipeline_velocity.get("deal_count", 0)
+        + funnel_conversion.get("total_leads", 0)
+        + len(lead_scoring.get("contacts", []))
+        + len(churn_signals.get("scored_accounts", []))
+        + len(account_health.get("accounts", []))
+    )
+    if signal_count == 0:
+        base = 0.52
+    elif signal_count < 6:
+        base = 0.74
+    else:
+        base = 0.88
+    if not funnel_conversion.get("sufficient_sample", True):
+        base = min(base, 0.78)
+    if degraded:
+        base -= 0.22
+    return round(max(0.0, min(base, 0.94)), 3)
+
+
+def _default_recommendations(degraded: list[str]) -> list[dict[str, Any]]:
+    if degraded:
+        return [{"action": "restore_crm_data_readiness", "reason": "; ".join(degraded)}]
+    return [{"action": "continue_crm_monitoring", "reason": "No material CRM blocker was detected."}]
+
+
+def _source_refs(
+    inputs: dict[str, Any],
+    lead_scoring: dict[str, Any],
+    accounts: list[dict[str, Any]],
+    deals: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    refs = _dict_list(inputs.get("source_refs"))
+    for entry in lead_scoring.get("contacts", [])[:10]:
+        refs.append({"type": "crm_contact", "ref_id": entry["contact_id"]})
+    for entry in accounts[:10]:
+        refs.append({"type": "crm_account", "ref_id": entry["account_id"]})
+    for deal in deals[:10]:
+        refs.append(
+            {
+                "type": "crm_deal",
+                "ref_id": str(deal.get("id") or deal.get("deal_id") or "deal"),
+            }
+        )
+    return _dedupe_refs(refs)
+
+
+# ---------------------------------------------------------------------------
+# Write helpers
+# ---------------------------------------------------------------------------
+
+
+def _policy_context_for_write(action: str, inputs: dict[str, Any], mode: str) -> dict[str, Any]:
+    context: dict[str, Any] = {
+        "workflow_id": "crm_pipeline_intelligence",
+        "workflow_mode": mode,
+        "action": action,
+        "external_write_required": True,
+        "customer_facing": True,
+        "channel": _normalize(inputs.get("channel") or inputs.get("connector_key") or "crm"),
+    }
+    if action == "change_target_accounts":
+        context.update(
+            {
+                "target_account_change": True,
+                "target_account_delta": _int(
+                    inputs.get("target_account_delta")
+                    or inputs.get("target_account_change_count")
+                    or inputs.get("affected_accounts"),
+                    0,
+                ),
+            }
+        )
+    if action in {"update_lifecycle_stage", "promote_lifecycle_stage", "update_lead_scores"}:
+        context["audience_size"] = _int(
+            inputs.get("affected_contacts") or inputs.get("audience_size"), 0
+        )
+    if action in {"bulk_crm_update", "update_crm"}:
+        context["audience_size"] = _int(
+            inputs.get("affected_contacts") or inputs.get("audience_size"), 0
+        )
+    return context
+
+
+def _escalation_for_write(
+    task,
+    action: str,
+    inputs: dict[str, Any],
+    policy_result: dict[str, Any],
+) -> dict[str, Any]:
+    return evaluate_marketing_escalation(
+        {
+            "workflow_id": "crm_pipeline_intelligence",
+            "workflow_run_id": getattr(task, "workflow_run_id", None),
+            "step_id": getattr(task, "step_id", None),
+            "action": action,
+            "event_type": "approval_timeout",
+            "target_account_change": action == "change_target_accounts"
+            or bool(inputs.get("target_account_change")),
+            "severity": str(inputs.get("severity") or "medium"),
+            "reason": "CRM Intelligence external write requires owner routing.",
+            "marketing_policy_decision": policy_result,
+        }
+    )
+
+
+def _connector_write_safe(inputs: dict[str, Any]) -> tuple[bool, str]:
+    if inputs.get("connector_write_ready") is True or inputs.get("write_ready") is True:
+        return True, ""
+    if inputs.get("connector_write_ready") is False or inputs.get("write_ready") is False:
+        return False, "CRM connector is not write-safe."
+    contracts = _dict_list(inputs.get("connector_contracts"))
+    direct = _dict_or_none(inputs.get("connector_contract"))
+    if direct:
+        contracts.insert(0, direct)
+    if contracts:
+        for contract in contracts:
+            if not _is_crm_write_contract(contract):
+                continue
+            if contract.get("mock_or_test_double"):
+                return False, "Test-double connector proof cannot satisfy active CRM writes."
+            if bool(contract.get("write_safe", contract.get("write_ready"))):
+                return True, ""
+            status = str(contract.get("write_status") or contract.get("contract_state") or "unknown")
+            return False, f"CRM connector contract is not write-safe ({status})."
+        return False, "No CRM connector contract is write-safe for CRM Intelligence action."
+    return False, "CRM connector write-readiness evidence is missing."
+
+
+def _is_crm_read_contract(contract: dict[str, Any]) -> bool:
+    category = _normalize(contract.get("category"))
+    key = _normalize(contract.get("connector_key") or contract.get("key"))
+    return category in {"crm", "abm", "intent"} or key in {
+        "hubspot",
+        "salesforce",
+        "bombora",
+        "g2",
+        "trustradius",
+    }
+
+
+def _is_crm_write_contract(contract: dict[str, Any]) -> bool:
+    category = _normalize(contract.get("category"))
+    key = _normalize(contract.get("connector_key") or contract.get("key"))
+    return category in {"crm", "abm"} or key in {"hubspot", "salesforce"}
+
+
+def _has_approval(inputs: dict[str, Any]) -> bool:
+    return bool(
+        inputs.get("approved")
+        or inputs.get("approval_ref")
+        or inputs.get("approval_result_ref")
+        or inputs.get("policy_approval_ref")
+    )
+
+
+def _has_escalation_approval(inputs: dict[str, Any]) -> bool:
+    return bool(inputs.get("escalation_ref") or inputs.get("escalation_result_ref") or inputs.get("approved"))
+
+
+def _connector_tool(action: str, inputs: dict[str, Any]) -> tuple[str, str]:
+    explicit = _normalize(inputs.get("connector_key") or inputs.get("connector"))
+    if action == "update_lead_scores":
+        return explicit or "hubspot", "update_lead_scores"
+    if action in {"update_lifecycle_stage", "promote_lifecycle_stage"}:
+        return explicit or "hubspot", "update_lifecycle_stage"
+    if action in {"change_segment_membership", "update_segment_membership"}:
+        return explicit or "hubspot", "update_segment_membership"
+    if action == "change_target_accounts":
+        return explicit or "salesforce", "update_target_accounts"
+    if action == "bulk_crm_update":
+        return explicit or "hubspot", "bulk_crm_update"
+    return explicit or "hubspot", "apply_crm_change"
+
+
+def _crm_write_payload(action: str, inputs: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "action": action,
+        "contact_ids": _string_list(inputs.get("contact_ids") or inputs.get("contacts")),
+        "account_ids": _string_list(inputs.get("account_ids") or inputs.get("accounts")),
+        "lifecycle_stage": inputs.get("lifecycle_stage") or inputs.get("to_stage"),
+        "lead_score_updates": inputs.get("lead_score_updates"),
+        "segment_id": inputs.get("segment_id"),
+        "target_account_delta": inputs.get("target_account_delta")
+        or inputs.get("target_account_change_count"),
+        "affected_contacts": inputs.get("affected_contacts"),
+        "affected_accounts": inputs.get("affected_accounts"),
+        "source_refs": _dict_list(inputs.get("source_refs")),
+        "rollback_plan": inputs.get("rollback_plan")
+        or "revert CRM lifecycle / score / segment / target-account change",
+    }
+
+
+def _external_write_confirmation_status(result: dict[str, Any] | None) -> str:
+    if not result:
+        return "write_unconfirmed"
+    return str(
+        result.get("external_write_confirmation_status")
+        or result.get("write_confirmation_status")
+        or result.get("status")
+        or "write_unconfirmed"
+    )
+
+
+def _is_confirmed_external_write(result: dict[str, Any] | None) -> bool:
+    if not result or "error" in result:
+        return False
+    status = _external_write_confirmation_status(result)
+    return status == "write_confirmed" and bool(
+        result.get("external_object_id") or result.get("external_id") or result.get("confirmed_at")
+    )
+
+
+def _external_write_ref(result: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not result:
+        return None
+    return {
+        "connector_key": result.get("connector_key"),
+        "external_object_id": result.get("external_object_id") or result.get("external_id"),
+        "source_url": result.get("source_url") or result.get("url"),
+        "idempotency_key": result.get("idempotency_key"),
+        "confirmed_at": result.get("confirmed_at"),
+        "audit_ref": result.get("audit_ref") or result.get("audit_reference"),
+    }
+
+
+def _hitl_request(task, output: dict[str, Any]) -> HITLRequest:
+    reasons = output.get("blocked_reasons") or []
+    if not reasons and output.get("policy_result"):
+        reasons = [str(output["policy_result"].get("reason") or "CRM Intelligence action requires review.")]
+    escalation = output.get("escalation_result") or {}
+    role = escalation.get("owner_role") or escalation.get("primary_owner_role") or "revops_lead"
+    return HITLRequest(
+        hitl_id=f"hitl_{uuid.uuid4().hex[:12]}",
+        trigger_condition="; ".join(str(reason) for reason in reasons) or "CRM Intelligence review required.",
+        trigger_type="crm_intelligence_review",
+        decision_required=DecisionRequired(
+            question="Review CRM Intelligence recommendation or CRM-write safeguard.",
+            options=[
+                DecisionOption(id="approve", label="Approve", action="proceed"),
+                DecisionOption(id="request_changes", label="Request changes", action="defer"),
+                DecisionOption(id="escalate", label="Escalate", action="defer"),
+                DecisionOption(id="reject", label="Reject", action="reject"),
+            ],
+        ),
+        context=HITLContext(
+            summary=output.get("rationale") or "CRM Intelligence review",
+            recommendation=output.get("recommended_actions", [{}])[0].get("action", "review"),
+            agent_confidence=float(output.get("confidence") or 0.0),
+            supporting_data={
+                "policy_decision": (output.get("policy_result") or {}).get("decision"),
+                "blocked_reasons": output.get("blocked_reasons") or [],
+                "degraded_reasons": output.get("degraded_reasons") or [],
+                "external_write_status": output.get("external_write_confirmation_status"),
+            },
+        ),
+        assignee=HITLAssignee(role=str(role), notify_channels=["slack", "email"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Primitive helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _dict_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list | tuple):
+        return []
+    return [dict(item) for item in value if isinstance(item, dict)]
+
+
+def _dict_or_none(value: Any) -> dict[str, Any] | None:
+    return dict(value) if isinstance(value, dict) else None
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    if isinstance(value, list | tuple | set):
+        result: list[str] = []
+        for item in value:
+            if isinstance(item, dict):
+                text = str(item.get("id") or item.get("contact_id") or "").strip()
+            else:
+                text = str(item).strip()
+            if text:
+                result.append(text)
+        return result
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _float(value: Any, default: float | None = 0.0) -> float | None:
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _dedupe_refs(refs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[tuple[str, str]] = set()
+    result: list[dict[str, Any]] = []
+    for ref in refs:
+        key = (
+            str(ref.get("type") or ref.get("connector_key") or ""),
+            str(ref.get("ref_id") or ref.get("object") or ""),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(ref)
+    return result

--- a/core/agents/marketing/seo_strategist.py
+++ b/core/agents/marketing/seo_strategist.py
@@ -1,18 +1,1178 @@
-"""SEO Strategist agent implementation."""
+"""SEO Strategist agent implementation.
+
+The SEO Strategist is deterministic and vendor-neutral: it analyzes structured
+SEO, analytics, and CMS inputs supplied by connectors or tests, emits
+contract-shaped CMO outputs, and fails closed before any technical site write.
+"""
 
 from __future__ import annotations
 
+import time
+import uuid
+from typing import Any
+
+import structlog
+
 from core.agents.base import BaseAgent
 from core.agents.registry import AgentRegistry
+from core.marketing.escalation_matrix import evaluate_marketing_escalation
+from core.marketing.policy_manifest import evaluate_marketing_policy
+from core.schemas.messages import (
+    DecisionOption,
+    DecisionRequired,
+    HITLAssignee,
+    HITLContext,
+    HITLRequest,
+    ToolCallRecord,
+)
+
+logger = structlog.get_logger()
+
+SEO_AGENT_MATURITY = "beta"
+SEO_CONFIDENCE_FLOOR = 0.84
+
+READ_ONLY_ACTIONS = {
+    "analyze_keyword_gaps",
+    "bundle_recommendations",
+    "compute_ranking_deltas",
+    "content_optimization_recommendation",
+    "get_keyword_rankings",
+    "identify_content_gaps",
+    "keyword_gap_analysis",
+    "optimize_content",
+    "plan_seo_sprint",
+    "prioritize_technical_issues",
+    "ranking_delta_computation",
+    "recommendation_bundling",
+    "seo_sprint_planning",
+    "technical_issue_prioritization",
+}
+WRITE_ACTIONS = {
+    "apply_redirect",
+    "publish_landing_page",
+    "publish_seo_change",
+    "publish_to_wordpress",
+    "submit_url_to_index",
+    "update_canonical_tag",
+    "update_landing_page",
+    "update_page_metadata",
+    "update_robots_txt",
+    "update_sitemap",
+}
+SHADOW_MODES = {"shadow", "draft", "internal", "internal_only", "recommendation", "simulation"}
+
+SEVERITY_WEIGHTS = {"critical": 4, "high": 3, "medium": 2, "low": 1}
+EFFORT_WEIGHTS = {"low": 1, "medium": 2, "high": 3}
 
 
 @AgentRegistry.register
 class SeoStrategistAgent(BaseAgent):
     agent_type = "seo_strategist"
     domain = "marketing"
-    confidence_floor = 0.9
+    confidence_floor = SEO_CONFIDENCE_FLOOR
     prompt_file = "seo_strategist.prompt.txt"
 
     async def execute(self, task):
-        """Execute seo strategist task with domain-specific logic."""
-        return await super().execute(task)
+        """Run deterministic SEO analysis or guarded technical site writes."""
+
+        start = time.monotonic()
+        trace: list[str] = []
+        tool_calls: list[ToolCallRecord] = []
+        msg_id = f"msg_{uuid.uuid4().hex[:12]}"
+
+        try:
+            inputs = _task_inputs(task)
+            action = _normalize_action(_task_action(task))
+            mode = _workflow_mode(inputs)
+            trace.append(f"SEO Strategist action={action}, mode={mode}")
+
+            if action in READ_ONLY_ACTIONS:
+                output = self._read_only_action(task, action, inputs, mode, trace)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+            if action in WRITE_ACTIONS:
+                output = await self._guarded_site_write(task, action, inputs, mode, trace, tool_calls)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+
+            output = self._base_output(
+                task,
+                action=action,
+                status="blocked",
+                confidence=0.0,
+                rationale=f"Unsupported SEO Strategist action '{action}'.",
+                recommended_actions=[
+                    {
+                        "action": "use_supported_seo_action",
+                        "reason": "SEO Strategist only executes declared deterministic actions.",
+                    }
+                ],
+                blocked_reasons=[f"Unsupported SEO Strategist action '{action}'."],
+                policy_context={"workflow_mode": mode},
+            )
+            return self._make_result(
+                task,
+                msg_id,
+                "failed",
+                output,
+                0.0,
+                trace,
+                tool_calls,
+                error={"code": "SEO_STRATEGIST_ACTION_UNSUPPORTED", "message": output["blocked_reasons"][0]},
+                start=start,
+            )
+        # enterprise-gate: broad-except-ok reason=agent-execution-boundary-returns-failed-result
+        except Exception as exc:
+            logger.error("seo_strategist_agent_error", agent=self.agent_id, error=str(exc))
+            trace.append(f"Error: {exc}")
+            return self._make_result(
+                task,
+                msg_id,
+                "failed",
+                {},
+                0.0,
+                trace,
+                tool_calls,
+                error={"code": "SEO_STRATEGIST_AGENT_ERR", "message": str(exc)},
+                start=start,
+            )
+
+    def _read_only_action(
+        self,
+        task,
+        action: str,
+        inputs: dict[str, Any],
+        mode: str,
+        trace: list[str],
+    ) -> dict[str, Any]:
+        keyword_gaps = _keyword_gap_analysis(inputs)
+        ranking_deltas = _ranking_deltas(inputs)
+        technical_issues = _prioritized_technical_issues(inputs)
+        content_recommendations = _content_optimization_recommendations(inputs, keyword_gaps)
+        bundled = _bundled_recommendations(keyword_gaps, technical_issues, content_recommendations)
+        sprint_plan = _seo_sprint_plan(keyword_gaps, technical_issues, content_recommendations, inputs)
+        degraded = _read_degraded_reasons(inputs)
+        confidence = _analysis_confidence(
+            keyword_gaps,
+            ranking_deltas,
+            technical_issues,
+            content_recommendations,
+            degraded,
+        )
+        source_refs = _source_refs(inputs, keyword_gaps, ranking_deltas, technical_issues)
+        summary = {
+            "keyword_gaps": keyword_gaps,
+            "ranking_deltas": ranking_deltas,
+            "technical_issues": technical_issues,
+            "recommendation_bundles": bundled,
+            "content_recommendations": content_recommendations,
+            "sprint_plan": sprint_plan,
+        }
+        trace.append(
+            "SEO analysis gaps="
+            f"{len(keyword_gaps)}, deltas={len(ranking_deltas)}, "
+            f"issues={len(technical_issues)}, degraded={len(degraded)}"
+        )
+
+        status = "seo_analysis_degraded" if degraded else "seo_analysis_ready"
+        rationale = "Built deterministic SEO analysis from structured keyword, ranking, site audit, and content inputs."
+        extra: dict[str, Any] = {"seo_analysis": summary}
+        if action in {"keyword_gap_analysis", "analyze_keyword_gaps", "identify_content_gaps"}:
+            status = "keyword_gaps_identified" if not degraded else "keyword_gaps_degraded"
+            rationale = "Identified missing and underperforming keyword opportunities against competitors."
+            extra.update({"keyword_gaps": keyword_gaps})
+        elif action in {"get_keyword_rankings", "compute_ranking_deltas", "ranking_delta_computation"}:
+            status = "ranking_deltas_computed" if not degraded else "ranking_deltas_degraded"
+            rationale = "Compared current and previous rankings for improvements, drops, new, and lost terms."
+            extra.update({"ranking_deltas": ranking_deltas})
+        elif action in {"technical_issue_prioritization", "prioritize_technical_issues"}:
+            status = "technical_issues_prioritized" if not degraded else "technical_issues_degraded"
+            rationale = "Prioritized technical SEO issues by severity, impact, effort, and affected pages."
+            extra.update({"technical_issues": technical_issues})
+        elif action in {"recommendation_bundling", "bundle_recommendations"}:
+            status = "recommendations_bundled"
+            rationale = "Bundled SEO recommendations by effort and impact for planning."
+            extra.update({"recommendation_bundles": bundled})
+        elif action in {"content_optimization_recommendation", "optimize_content"}:
+            status = "content_optimization_recommended" if not degraded else "content_optimization_degraded"
+            rationale = "Recommended deterministic title, metadata, heading, internal-link, and content improvements."
+            extra.update({"content_recommendations": content_recommendations})
+        elif action in {"seo_sprint_planning", "plan_seo_sprint"}:
+            status = "seo_sprint_planned" if not degraded else "seo_sprint_degraded"
+            rationale = "Planned an SEO sprint from prioritized technical, keyword, and content opportunities."
+            extra.update({"sprint_plan": sprint_plan})
+
+        return self._base_output(
+            task,
+            action=action,
+            status=status,
+            confidence=confidence,
+            rationale=rationale,
+            recommended_actions=sprint_plan["actions"] or _default_recommendations(degraded),
+            policy_context={"workflow_mode": mode, "workflow_id": "seo_sprint"},
+            source_refs=source_refs,
+            degraded_reasons=degraded,
+            extra=extra,
+        )
+
+    async def _guarded_site_write(
+        self,
+        task,
+        action: str,
+        inputs: dict[str, Any],
+        mode: str,
+        trace: list[str],
+        tool_calls: list[ToolCallRecord],
+    ) -> dict[str, Any]:
+        policy_context = _policy_context_for_write(action, inputs, mode)
+        policy = evaluate_marketing_policy(policy_context)
+        escalation = _escalation_for_write(task, action, inputs, policy)
+        blocked_reasons: list[str] = []
+        hitl_reasons: list[str] = []
+
+        if mode in SHADOW_MODES:
+            blocked_reasons.append("Shadow/draft/internal SEO workflows are read-only.")
+            trace.append("SEO site write converted to shadow-only recommendation")
+            return self._base_output(
+                task,
+                action=action,
+                status="shadow_only",
+                confidence=0.76,
+                rationale="Prepared technical SEO change recommendation without mutating the site.",
+                recommended_actions=[
+                    {
+                        "action": "create_internal_approval",
+                        "reason": "Review the SEO site change before any active external write is attempted.",
+                    }
+                ],
+                approval_required=True,
+                hitl_required=True,
+                policy_result=policy,
+                escalation=escalation,
+                blocked_reasons=blocked_reasons,
+                external_write_status="shadow_only",
+                external_write_required=True,
+                extra={"write_payload": _site_write_payload(action, inputs)},
+            )
+
+        write_safe, write_reason = _connector_write_safe(inputs)
+        if not write_safe:
+            blocked_reasons.append(write_reason)
+        if policy.get("decision") in {"requires_approval", "requires_escalation"} and not _has_approval(inputs):
+            hitl_reasons.append(str(policy.get("reason") or "Technical SEO site change requires approval."))
+        if policy.get("decision") in {"blocked", "missing_policy"}:
+            blocked_reasons.append(str(policy.get("reason") or "Marketing policy blocks this SEO site action."))
+        escalation_needs_review = escalation.get("decision") not in {None, "", "no_escalation", "notify_owner"}
+        if escalation_needs_review and not _has_escalation_approval(inputs):
+            hitl_reasons.append("SEO site change requires escalation review.")
+
+        if blocked_reasons or hitl_reasons:
+            return self._base_output(
+                task,
+                action=action,
+                status="blocked",
+                confidence=0.0,
+                rationale="SEO Strategist external site action failed closed before vendor mutation.",
+                recommended_actions=[
+                    {
+                        "action": "resolve_seo_write_prerequisites",
+                        "reason": "; ".join(_dedupe(blocked_reasons + hitl_reasons)),
+                    }
+                ],
+                approval_required=bool(hitl_reasons),
+                hitl_required=True,
+                policy_result=policy,
+                escalation=escalation,
+                blocked_reasons=blocked_reasons + hitl_reasons,
+                external_write_status="write_unconfirmed",
+                external_write_required=True,
+                extra={"write_payload": _site_write_payload(action, inputs)},
+            )
+
+        result = _dict_or_none(inputs.get("external_write_result"))
+        connector, tool = _connector_tool(action, inputs)
+        idempotency_key = str(
+            inputs.get("idempotency_key")
+            or inputs.get("request_fingerprint")
+            or f"seo_strategist:{task.correlation_id}:{task.step_id}:{action}"
+        )
+        if result is None:
+            result = await self._safe_tool_call(
+                connector,
+                tool,
+                _site_write_payload(action, inputs),
+                trace,
+                tool_calls,
+                idempotency_key=idempotency_key,
+            )
+
+        write_status = _external_write_confirmation_status(result)
+        write_confirmed = _is_confirmed_external_write(result)
+        external_ref = _external_write_ref(result)
+        blocked_reasons = [] if write_confirmed else ["SEO site write is unconfirmed and cannot be marked complete."]
+        trace.append(f"SEO site write status={write_status}, confirmed={write_confirmed}")
+        return self._base_output(
+            task,
+            action=action,
+            status="write_confirmed" if write_confirmed else "write_unconfirmed",
+            confidence=0.9 if write_confirmed else 0.0,
+            rationale=(
+                "SEO Strategist external site write was confirmed by the connector."
+                if write_confirmed
+                else "SEO Strategist external site write did not return confirmed vendor evidence."
+            ),
+            recommended_actions=[
+                {
+                    "action": "monitor_rankings_after_change" if write_confirmed else "verify_seo_write_before_retry",
+                    "reason": (
+                        "Track ranking and crawl impact after the confirmed technical change."
+                        if write_confirmed
+                        else "Check vendor state with the idempotency key before retrying."
+                    ),
+                }
+            ],
+            approval_required=False,
+            hitl_required=not write_confirmed,
+            policy_result=policy,
+            approval_satisfied=_has_approval(inputs),
+            escalation=escalation,
+            blocked_reasons=blocked_reasons,
+            external_write_status=write_status,
+            external_write_required=True,
+            external_write_ref=external_ref,
+            extra={"write_payload": _site_write_payload(action, inputs)},
+        )
+
+    async def _safe_tool_call(
+        self,
+        connector: str,
+        tool: str,
+        params: dict[str, Any],
+        trace: list[str],
+        tool_records: list[ToolCallRecord],
+        *,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        call_start = time.monotonic()
+        try:
+            result = await self._call_tool(
+                connector_name=connector,
+                tool_name=tool,
+                params=params,
+                idempotency_key=idempotency_key,
+            )
+            latency = int((time.monotonic() - call_start) * 1000)
+            status = "error" if "error" in result else "success"
+            trace.append(f"[tool] {connector}.{tool} -> {status} ({latency}ms)")
+            tool_records.append(ToolCallRecord(tool_name=f"{connector}.{tool}", status=status, latency_ms=latency))
+            return result
+        # enterprise-gate: broad-except-ok reason=agent-tool-call-failure-returns-explicit-error-result
+        except Exception as exc:
+            latency = int((time.monotonic() - call_start) * 1000)
+            trace.append(f"[tool] {connector}.{tool} -> exception: {exc} ({latency}ms)")
+            tool_records.append(ToolCallRecord(tool_name=f"{connector}.{tool}", status="error", latency_ms=latency))
+            return {"error": str(exc)}
+
+    def _base_output(
+        self,
+        task,
+        *,
+        action: str,
+        status: str,
+        confidence: float,
+        rationale: str,
+        recommended_actions: list[dict[str, Any]],
+        approval_required: bool = False,
+        hitl_required: bool = False,
+        policy_context: dict[str, Any] | None = None,
+        policy_result: dict[str, Any] | None = None,
+        approval_satisfied: bool = False,
+        escalation: dict[str, Any] | None = None,
+        source_refs: list[dict[str, Any]] | None = None,
+        degraded_reasons: list[str] | None = None,
+        blocked_reasons: list[str] | None = None,
+        external_write_status: str = "not_required",
+        external_write_required: bool = False,
+        external_write_ref: dict[str, Any] | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        policy = policy_result or evaluate_marketing_policy(
+            {
+                "workflow_id": "seo_sprint",
+                "workflow_mode": "shadow",
+                "action": action,
+                "external_write_required": external_write_required,
+                **(policy_context or {}),
+            }
+        )
+        escalation_ref = None
+        if escalation and escalation.get("decision") != "no_escalation":
+            escalation_ref = escalation.get("decision_audit_ref") or escalation.get("audit_reference")
+        policy_needs_review = (
+            policy.get("decision") in {"requires_approval", "requires_escalation", "read_only_only"}
+            and not approval_satisfied
+        )
+        output: dict[str, Any] = {
+            "status": status,
+            "agent_type": self.agent_type,
+            "action": action,
+            "confidence": round(max(0.0, min(confidence, 1.0)), 3),
+            "rationale": rationale,
+            "recommended_actions": recommended_actions,
+            "source_refs": source_refs or [],
+            "policy_result": policy,
+            "policy_ref": policy.get("decision_audit_ref") or policy.get("policy_id"),
+            "approval_required": approval_required or policy_needs_review,
+            "hitl_required": hitl_required,
+            "escalation_ref": escalation_ref,
+            "escalation_result": escalation,
+            "audit_ref": f"seo_strategist:{task.correlation_id}:{task.step_id}:{action}",
+            "degraded_reasons": _dedupe(degraded_reasons or []),
+            "blocked_reasons": _dedupe(blocked_reasons or []),
+            "external_write_confirmation_status": external_write_status,
+            "external_writes_completed": external_write_status == "write_confirmed",
+            "external_write_required": external_write_required,
+            "external_write_ref": external_write_ref,
+            "production_status": SEO_AGENT_MATURITY,
+        }
+        if extra:
+            output.update(extra)
+        return output
+
+    def _complete_or_hitl(
+        self,
+        task,
+        msg_id: str,
+        output: dict[str, Any],
+        trace: list[str],
+        tool_calls: list[ToolCallRecord],
+        start: float,
+    ):
+        if output.get("hitl_required") or output.get("approval_required") or output.get("blocked_reasons"):
+            hitl = _hitl_request(task, output)
+            return self._make_result(
+                task,
+                msg_id,
+                "hitl_triggered",
+                output,
+                float(output.get("confidence") or 0.0),
+                trace,
+                tool_calls,
+                hitl_request=hitl,
+                start=start,
+            )
+        return self._make_result(
+            task,
+            msg_id,
+            "completed",
+            output,
+            float(output.get("confidence") or 0.0),
+            trace,
+            tool_calls,
+            start=start,
+        )
+
+
+def _task_inputs(task) -> dict[str, Any]:
+    payload = task.task.inputs if hasattr(task.task, "inputs") else task.task.get("inputs", {})
+    return payload if isinstance(payload, dict) else {}
+
+
+def _task_action(task) -> str:
+    return str(task.task.action if hasattr(task.task, "action") else task.task.get("action", "keyword_gap_analysis"))
+
+
+def _normalize_action(action: str) -> str:
+    normalized = str(action or "").strip().lower().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "content_gap_analysis": "keyword_gap_analysis",
+        "get_keyword_rankings": "ranking_delta_computation",
+        "identify_content_gaps": "keyword_gap_analysis",
+        "keyword_gaps": "keyword_gap_analysis",
+        "optimize_content": "content_optimization_recommendation",
+        "ranking_delta": "ranking_delta_computation",
+        "ranking_deltas": "ranking_delta_computation",
+        "recommendation_bundle": "recommendation_bundling",
+        "seo_sprint": "seo_sprint_planning",
+        "technical_issue_prioritization": "technical_issue_prioritization",
+        "technical_seo_issue_prioritization": "technical_issue_prioritization",
+        "update_metadata": "update_page_metadata",
+        "technical_site_change": "publish_seo_change",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def _keyword_gap_analysis(inputs: dict[str, Any]) -> list[dict[str, Any]]:
+    owned = {_keyword_key(row): row for row in _keyword_rows(inputs.get("owned_keywords") or inputs.get("keywords"))}
+    current_rows = _keyword_rows(inputs.get("rankings") or inputs.get("current_rankings"))
+    current = {_keyword_key(row): row for row in current_rows}
+    for key, row in current.items():
+        owned.setdefault(key, row)
+    competitors = _keyword_rows(inputs.get("competitor_keywords") or inputs.get("target_keywords"))
+    target_keywords = _keyword_rows(inputs.get("target_keywords"))
+    if not competitors and target_keywords:
+        competitors = target_keywords
+
+    opportunities: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for row in competitors:
+        keyword = _keyword_key(row)
+        if not keyword or keyword in seen:
+            continue
+        seen.add(keyword)
+        owned_row = owned.get(keyword)
+        own_rank = _rank_value(owned_row)
+        competitor_rank = _rank_value(row)
+        missing = owned_row is None or own_rank is None
+        underperforming = own_rank is not None and competitor_rank is not None and own_rank - competitor_rank >= 5
+        below_page_one = own_rank is not None and own_rank > 10
+        if not (missing or underperforming or below_page_one):
+            continue
+        volume = _float(row.get("volume") or row.get("search_volume"), 0.0)
+        difficulty = _float(row.get("difficulty") or row.get("keyword_difficulty"), 50.0)
+        if missing:
+            rank_gap = 20.0
+        else:
+            assert own_rank is not None
+            rank_gap = max(0.0, own_rank - (competitor_rank or 1.0))
+        opportunity_score = round(min(100.0, (volume / 100.0) + rank_gap * 2.0 + max(0.0, 70.0 - difficulty) * 0.6), 2)
+        opportunities.append(
+            {
+                "keyword": keyword,
+                "reason": "missing" if missing else ("underperforming" if underperforming else "below_page_one"),
+                "own_rank": own_rank,
+                "competitor_rank": competitor_rank,
+                "search_volume": volume,
+                "difficulty": difficulty,
+                "intent": str(row.get("intent") or "unknown"),
+                "opportunity_score": opportunity_score,
+                "recommended_action": "create_or_refresh_content" if missing else "optimize_existing_page",
+                "source": row.get("source") or "seo_keyword_input",
+            }
+        )
+    opportunities.sort(key=lambda item: (-item["opportunity_score"], item["difficulty"], item["keyword"]))
+    return opportunities
+
+
+def _ranking_deltas(inputs: dict[str, Any]) -> list[dict[str, Any]]:
+    current_rows = _keyword_rows(inputs.get("rankings") or inputs.get("current_rankings"))
+    current = {_keyword_key(row): row for row in current_rows}
+    previous = {_keyword_key(row): row for row in _keyword_rows(inputs.get("previous_rankings"))}
+    rows: list[dict[str, Any]] = []
+    for keyword in sorted(set(current) | set(previous)):
+        cur = current.get(keyword)
+        prev = previous.get(keyword)
+        current_rank = _rank_value(cur)
+        previous_rank = _rank_value(prev)
+        if previous_rank is None and current_rank is not None:
+            status = "new"
+            delta = None
+        elif current_rank is None and previous_rank is not None:
+            status = "lost"
+            delta = None
+        else:
+            delta = round(float(previous_rank or 0) - float(current_rank or 0), 2)
+            status = "improved" if delta > 0 else ("dropped" if delta < 0 else "unchanged")
+        rows.append(
+            {
+                "keyword": keyword,
+                "previous_rank": previous_rank,
+                "current_rank": current_rank,
+                "delta": delta,
+                "status": status,
+                "url": (cur or prev or {}).get("url") or (cur or prev or {}).get("page_url"),
+                "source": (cur or prev or {}).get("source") or "seo_rank_input",
+            }
+        )
+    status_order = {"dropped": 0, "lost": 1, "new": 2, "improved": 3, "unchanged": 4}
+    rows.sort(key=lambda row: (status_order.get(row["status"], 9), row["keyword"]))
+    return rows
+
+
+def _prioritized_technical_issues(inputs: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for index, issue in enumerate(_dict_list(inputs.get("technical_issues") or inputs.get("site_audit_issues"))):
+        severity = _severity(issue.get("severity"), "medium")
+        impact = _float(issue.get("impact") or issue.get("impact_score"), 50.0)
+        effort = _effort_score(issue.get("effort") or issue.get("effort_score"))
+        pages = _int(issue.get("affected_pages") or issue.get("pages") or 1, 1)
+        priority_score = round(
+            SEVERITY_WEIGHTS[severity] * 25.0
+            + impact * 0.7
+            + min(pages, 100) * 0.1
+            - effort * 10.0,
+            2,
+        )
+        rows.append(
+            {
+                "issue_id": str(issue.get("issue_id") or issue.get("id") or f"issue-{index + 1}"),
+                "type": str(issue.get("type") or issue.get("category") or "technical"),
+                "severity": severity,
+                "impact_score": round(impact, 2),
+                "effort": _effort_label(issue.get("effort") or issue.get("effort_score")),
+                "affected_pages": pages,
+                "priority_score": priority_score,
+                "recommended_action": _technical_action(issue),
+                "source": issue.get("source") or "site_audit_input",
+            }
+        )
+    rows.sort(key=lambda row: (-row["priority_score"], row["issue_id"]))
+    return rows
+
+
+def _content_optimization_recommendations(
+    inputs: dict[str, Any],
+    keyword_gaps: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    pages = _dict_list(inputs.get("pages") or inputs.get("content_items"))
+    target_keywords = _string_list(inputs.get("keywords") or inputs.get("target_keywords"))
+    if not target_keywords:
+        target_keywords = [str(item["keyword"]) for item in keyword_gaps[:3]]
+    if not pages and target_keywords:
+        pages = [{"url": inputs.get("url") or "proposed_content", "title": inputs.get("title") or "", "word_count": 0}]
+    recommendations: list[dict[str, Any]] = []
+    for index, page in enumerate(pages):
+        keyword = str(
+            page.get("target_keyword")
+            or (target_keywords[index % len(target_keywords)] if target_keywords else "")
+        )
+        title = str(page.get("title") or "")
+        meta = str(page.get("meta_description") or page.get("meta") or "")
+        headings = [item.lower() for item in _string_list(page.get("headings") or page.get("h1") or page.get("h2"))]
+        word_count = _int(page.get("word_count") or page.get("words"), 0)
+        actions: list[str] = []
+        if keyword and keyword.lower() not in title.lower():
+            actions.append("add_target_keyword_to_title")
+        if keyword and keyword.lower() not in meta.lower():
+            actions.append("refresh_meta_description_with_target_keyword")
+        if keyword and not any(keyword.lower() in heading for heading in headings):
+            actions.append("add_keyword_aligned_h1_or_h2")
+        if word_count and word_count < 800:
+            actions.append("expand_content_depth")
+        if not page.get("internal_links"):
+            actions.append("add_internal_links")
+        if actions:
+            recommendations.append(
+                {
+                    "url": str(page.get("url") or page.get("page_url") or f"page-{index + 1}"),
+                    "target_keyword": keyword,
+                    "actions": actions,
+                    "impact": "high" if len(actions) >= 3 else "medium",
+                    "effort": "low" if len(actions) <= 2 else "medium",
+                    "reason": "Page can better satisfy the target search intent.",
+                }
+            )
+    recommendations.sort(key=lambda row: (-len(row["actions"]), row["url"]))
+    return recommendations
+
+
+def _bundled_recommendations(
+    keyword_gaps: list[dict[str, Any]],
+    technical_issues: list[dict[str, Any]],
+    content_recommendations: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    bundles: dict[str, list[dict[str, Any]]] = {
+        "quick_wins": [],
+        "strategic": [],
+        "maintenance": [],
+        "deprioritized": [],
+    }
+    for issue in technical_issues:
+        item = {
+            "type": "technical_issue",
+            "action": issue["recommended_action"],
+            "impact": "high" if issue["impact_score"] >= 65 or issue["severity"] in {"critical", "high"} else "medium",
+            "effort": issue["effort"],
+            "priority_score": issue["priority_score"],
+        }
+        bundles[_bundle_key(item["impact"], item["effort"])].append(item)
+    for gap in keyword_gaps:
+        item = {
+            "type": "keyword_gap",
+            "action": gap["recommended_action"],
+            "keyword": gap["keyword"],
+            "impact": "high" if gap["opportunity_score"] >= 55 else "medium",
+            "effort": "medium" if gap["reason"] == "missing" else "low",
+            "priority_score": gap["opportunity_score"],
+        }
+        bundles[_bundle_key(item["impact"], item["effort"])].append(item)
+    for rec in content_recommendations:
+        item = {
+            "type": "content_optimization",
+            "action": "optimize_content",
+            "url": rec["url"],
+            "impact": rec["impact"],
+            "effort": rec["effort"],
+            "priority_score": len(rec["actions"]) * 20,
+        }
+        bundles[_bundle_key(item["impact"], item["effort"])].append(item)
+    for rows in bundles.values():
+        rows.sort(key=lambda row: (-_float(row.get("priority_score"), 0.0), str(row.get("action") or "")))
+    return bundles
+
+
+def _seo_sprint_plan(
+    keyword_gaps: list[dict[str, Any]],
+    technical_issues: list[dict[str, Any]],
+    content_recommendations: list[dict[str, Any]],
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    capacity = max(1, min(_int(inputs.get("sprint_capacity") or inputs.get("capacity"), 6), 12))
+    actions: list[dict[str, Any]] = []
+    for issue in technical_issues[:capacity]:
+        actions.append(
+            {
+                "action": issue["recommended_action"],
+                "type": "technical",
+                "priority_score": issue["priority_score"],
+                "expected_impact": issue["impact_score"],
+                "reason": f"{issue['severity']} issue affects {issue['affected_pages']} page(s).",
+            }
+        )
+    for gap in keyword_gaps[:capacity]:
+        actions.append(
+            {
+                "action": gap["recommended_action"],
+                "type": "keyword",
+                "keyword": gap["keyword"],
+                "priority_score": gap["opportunity_score"],
+                "expected_impact": gap["search_volume"],
+                "reason": f"Keyword is {gap['reason']} with opportunity score {gap['opportunity_score']}.",
+            }
+        )
+    for rec in content_recommendations[:capacity]:
+        actions.append(
+            {
+                "action": "optimize_content",
+                "type": "content",
+                "url": rec["url"],
+                "priority_score": len(rec["actions"]) * 20,
+                "expected_impact": rec["impact"],
+                "reason": ", ".join(rec["actions"]),
+            }
+        )
+    actions.sort(key=lambda row: (-_float(row.get("priority_score"), 0.0), str(row.get("type") or "")))
+    actions = actions[:capacity]
+    return {
+        "capacity": capacity,
+        "actions": actions,
+        "expected_impact": {
+            "technical_fixes": sum(1 for row in actions if row["type"] == "technical"),
+            "keyword_opportunities": sum(1 for row in actions if row["type"] == "keyword"),
+            "content_updates": sum(1 for row in actions if row["type"] == "content"),
+        },
+        "requires_approval_for_writes": True,
+    }
+
+
+def _read_degraded_reasons(inputs: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    if inputs.get("connector_read_ready") is False or inputs.get("connector_degraded") is True:
+        reasons.append("SEO connector is degraded or unavailable.")
+    freshness = _normalize(inputs.get("data_freshness_status") or inputs.get("freshness_status"))
+    if freshness in {"stale", "partial", "degraded"}:
+        reasons.append(f"SEO source data is {freshness}.")
+    if inputs.get("stale_data") is True:
+        reasons.append("SEO source data is stale.")
+    if inputs.get("partial_data") is True:
+        reasons.append("SEO source data is partial.")
+    contracts = _dict_list(inputs.get("connector_contracts"))
+    direct = _dict_or_none(inputs.get("connector_contract"))
+    if direct:
+        contracts.insert(0, direct)
+    if contracts:
+        relevant = [contract for contract in contracts if _is_seo_read_contract(contract)]
+        if relevant and not any(bool(contract.get("read_ready", contract.get("configured"))) for contract in relevant):
+            reasons.append("SEO source connector is not read-ready.")
+        if any(
+            contract.get("degraded") or contract.get("health_status") in {"stale", "degraded"}
+            for contract in relevant
+        ):
+            reasons.append("One or more SEO source connectors are degraded or stale.")
+        if any(contract.get("mock_or_test_double") or contract.get("stub_only") for contract in relevant):
+            reasons.append("Mock, test-double, or stub SEO connector proof is not production lineage.")
+    return _dedupe(reasons)
+
+
+def _analysis_confidence(
+    keyword_gaps: list[dict[str, Any]],
+    ranking_deltas: list[dict[str, Any]],
+    technical_issues: list[dict[str, Any]],
+    content_recommendations: list[dict[str, Any]],
+    degraded: list[str],
+) -> float:
+    signal_count = len(keyword_gaps) + len(ranking_deltas) + len(technical_issues) + len(content_recommendations)
+    if signal_count == 0:
+        base = 0.52
+    elif signal_count < 4:
+        base = 0.74
+    else:
+        base = 0.88
+    if degraded:
+        base -= 0.22
+    return round(max(0.0, min(base, 0.94)), 3)
+
+
+def _policy_context_for_write(action: str, inputs: dict[str, Any], mode: str) -> dict[str, Any]:
+    return {
+        "workflow_id": "seo_sprint",
+        "workflow_mode": mode,
+        "action": action,
+        "external_write_required": True,
+        "customer_facing": True,
+        "channel": str(inputs.get("channel") or inputs.get("connector_key") or "cms"),
+        "legal_claim": bool(inputs.get("legal_claim") or inputs.get("claims_review_required")),
+        "pricing_claim": bool(inputs.get("pricing_claim")),
+        "comparative_claim": bool(inputs.get("comparative_claim")),
+        "high_risk_copy": bool(inputs.get("high_risk_copy")),
+    }
+
+
+def _escalation_for_write(
+    task,
+    action: str,
+    inputs: dict[str, Any],
+    policy_result: dict[str, Any],
+) -> dict[str, Any]:
+    high_risk = any(
+        bool(inputs.get(field))
+        for field in ("legal_claim", "pricing_claim", "comparative_claim", "claims_review_required", "high_risk_copy")
+    )
+    return evaluate_marketing_escalation(
+        {
+            "workflow_id": "seo_sprint",
+            "workflow_run_id": getattr(task, "workflow_run_id", None),
+            "step_id": getattr(task, "step_id", None),
+            "action": action,
+            "event_type": "pricing_or_legal_claim" if high_risk else "approval_timeout",
+            "pricing_claim": bool(inputs.get("pricing_claim")),
+            "legal_claim": bool(inputs.get("legal_claim") or inputs.get("claims_review_required")),
+            "comparative_claim": bool(inputs.get("comparative_claim")),
+            "high_risk_copy": bool(inputs.get("high_risk_copy")),
+            "approval_sensitive": True,
+            "severity": "high" if high_risk else "medium",
+            "reason": "SEO technical site action requires owner routing.",
+            "marketing_policy_decision": policy_result,
+        }
+    )
+
+
+def _connector_write_safe(inputs: dict[str, Any]) -> tuple[bool, str]:
+    if inputs.get("connector_write_ready") is True or inputs.get("write_ready") is True:
+        return True, ""
+    if inputs.get("connector_write_ready") is False or inputs.get("write_ready") is False:
+        return False, "SEO/CMS connector is not write-safe."
+    contracts = _dict_list(inputs.get("connector_contracts"))
+    direct = _dict_or_none(inputs.get("connector_contract"))
+    if direct:
+        contracts.insert(0, direct)
+    if contracts:
+        for contract in contracts:
+            if not _is_seo_write_contract(contract):
+                continue
+            if contract.get("mock_or_test_double"):
+                return False, "Test-double connector proof cannot satisfy active SEO site writes."
+            if bool(contract.get("write_safe", contract.get("write_ready"))):
+                return True, ""
+            status = str(contract.get("write_status") or contract.get("contract_state") or "unknown")
+            return False, f"SEO/CMS connector contract is not write-safe ({status})."
+        return False, "No SEO/CMS connector contract is write-safe for SEO site action."
+    return False, "SEO/CMS connector write-readiness evidence is missing."
+
+
+def _is_seo_read_contract(contract: dict[str, Any]) -> bool:
+    category = str(contract.get("category") or "").strip().lower()
+    key = str(contract.get("connector_key") or contract.get("key") or "").strip().lower()
+    return category in {"seo", "analytics", "cms"} or key in {"ahrefs", "ga4", "google_search_console", "wordpress"}
+
+
+def _is_seo_write_contract(contract: dict[str, Any]) -> bool:
+    category = str(contract.get("category") or "").strip().lower()
+    key = str(contract.get("connector_key") or contract.get("key") or "").strip().lower()
+    return category in {"cms", "seo"} or key in {"wordpress", "webflow", "google_search_console"}
+
+
+def _has_approval(inputs: dict[str, Any]) -> bool:
+    return bool(
+        inputs.get("approved")
+        or inputs.get("approval_ref")
+        or inputs.get("approval_result_ref")
+        or inputs.get("policy_approval_ref")
+    )
+
+
+def _has_escalation_approval(inputs: dict[str, Any]) -> bool:
+    return bool(inputs.get("escalation_ref") or inputs.get("escalation_result_ref") or inputs.get("approved"))
+
+
+def _connector_tool(action: str, inputs: dict[str, Any]) -> tuple[str, str]:
+    explicit = str(inputs.get("connector_key") or inputs.get("connector") or "").strip().lower()
+    if action == "submit_url_to_index":
+        return explicit or "google_search_console", "submit_url_to_index"
+    return explicit or "wordpress", "apply_seo_site_change"
+
+
+def _site_write_payload(action: str, inputs: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "action": action,
+        "url": inputs.get("url") or inputs.get("page_url"),
+        "title": inputs.get("title"),
+        "meta_description": inputs.get("meta_description"),
+        "canonical_url": inputs.get("canonical_url"),
+        "redirect_from": inputs.get("redirect_from"),
+        "redirect_to": inputs.get("redirect_to"),
+        "robots_txt": inputs.get("robots_txt"),
+        "sitemap_url": inputs.get("sitemap_url"),
+        "source_refs": _dict_list(inputs.get("source_refs")),
+        "rollback_plan": inputs.get("rollback_plan") or "revert CMS metadata, redirect, robots, or sitemap change",
+    }
+
+
+def _external_write_confirmation_status(result: dict[str, Any] | None) -> str:
+    if not result:
+        return "write_unconfirmed"
+    return str(
+        result.get("external_write_confirmation_status")
+        or result.get("write_confirmation_status")
+        or result.get("status")
+        or "write_unconfirmed"
+    )
+
+
+def _is_confirmed_external_write(result: dict[str, Any] | None) -> bool:
+    if not result or "error" in result:
+        return False
+    status = _external_write_confirmation_status(result)
+    return status == "write_confirmed" and bool(
+        result.get("external_object_id") or result.get("external_id") or result.get("confirmed_at")
+    )
+
+
+def _external_write_ref(result: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not result:
+        return None
+    return {
+        "connector_key": result.get("connector_key"),
+        "external_object_id": result.get("external_object_id") or result.get("external_id"),
+        "source_url": result.get("source_url") or result.get("url"),
+        "idempotency_key": result.get("idempotency_key"),
+        "confirmed_at": result.get("confirmed_at"),
+        "audit_ref": result.get("audit_ref") or result.get("audit_reference"),
+    }
+
+
+def _keyword_rows(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, str):
+        return [{"keyword": item.strip()} for item in value.split(",") if item.strip()]
+    if isinstance(value, list | tuple):
+        rows = []
+        for item in value:
+            if isinstance(item, dict):
+                rows.append(dict(item))
+            elif str(item).strip():
+                rows.append({"keyword": str(item).strip()})
+        return rows
+    return []
+
+
+def _keyword_key(row: dict[str, Any] | None) -> str:
+    if not isinstance(row, dict):
+        return ""
+    return str(row.get("keyword") or row.get("query") or row.get("term") or "").strip().lower()
+
+
+def _rank_value(row: dict[str, Any] | None) -> float | None:
+    if not isinstance(row, dict):
+        return None
+    for key in ("rank", "position", "current_rank", "google_rank"):
+        if row.get(key) not in {None, ""}:
+            value = _float(row.get(key), 0.0)
+            return value if value > 0 else None
+    return None
+
+
+def _technical_action(issue: dict[str, Any]) -> str:
+    issue_type = _normalize(issue.get("type") or issue.get("category"))
+    if "redirect" in issue_type:
+        return "fix_redirect_chain"
+    if "canonical" in issue_type:
+        return "fix_canonical_tag"
+    if "sitemap" in issue_type:
+        return "update_sitemap"
+    if "robots" in issue_type:
+        return "review_robots_txt"
+    if "speed" in issue_type or "core_web_vitals" in issue_type:
+        return "improve_page_performance"
+    if "metadata" in issue_type or "title" in issue_type:
+        return "update_page_metadata"
+    return "resolve_technical_seo_issue"
+
+
+def _bundle_key(impact: str, effort: str) -> str:
+    high_impact = impact == "high"
+    low_effort = effort == "low"
+    if high_impact and low_effort:
+        return "quick_wins"
+    if high_impact:
+        return "strategic"
+    if low_effort:
+        return "maintenance"
+    return "deprioritized"
+
+
+def _default_recommendations(degraded: list[str]) -> list[dict[str, Any]]:
+    if degraded:
+        return [{"action": "restore_seo_data_readiness", "reason": "; ".join(degraded)}]
+    return [{"action": "continue_seo_monitoring", "reason": "No material SEO blocker was detected."}]
+
+
+def _source_refs(
+    inputs: dict[str, Any],
+    keyword_gaps: list[dict[str, Any]],
+    ranking_deltas: list[dict[str, Any]],
+    technical_issues: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    refs = _dict_list(inputs.get("source_refs"))
+    for gap in keyword_gaps[:10]:
+        refs.append({"type": "seo_keyword", "ref_id": gap["keyword"], "source": gap.get("source")})
+    for row in ranking_deltas[:10]:
+        refs.append(
+            {
+                "type": "seo_ranking",
+                "ref_id": row["keyword"],
+                "source": row.get("source"),
+                "url": row.get("url"),
+            }
+        )
+    for issue in technical_issues[:10]:
+        refs.append({"type": "site_audit", "ref_id": issue["issue_id"], "source": issue.get("source")})
+    return _dedupe_refs(refs)
+
+
+def _hitl_request(task, output: dict[str, Any]) -> HITLRequest:
+    reasons = output.get("blocked_reasons") or []
+    if not reasons and output.get("policy_result"):
+        reasons = [str(output["policy_result"].get("reason") or "SEO Strategist action requires review.")]
+    escalation = output.get("escalation_result") or {}
+    role = escalation.get("owner_role") or escalation.get("primary_owner_role") or "growth_lead"
+    return HITLRequest(
+        hitl_id=f"hitl_{uuid.uuid4().hex[:12]}",
+        trigger_condition="; ".join(str(reason) for reason in reasons) or "SEO Strategist review required.",
+        trigger_type="seo_strategist_review",
+        decision_required=DecisionRequired(
+            question="Review SEO recommendation or technical site-change safeguard.",
+            options=[
+                DecisionOption(id="approve", label="Approve", action="proceed"),
+                DecisionOption(id="request_changes", label="Request changes", action="defer"),
+                DecisionOption(id="escalate", label="Escalate", action="defer"),
+                DecisionOption(id="reject", label="Reject", action="reject"),
+            ],
+        ),
+        context=HITLContext(
+            summary=output.get("rationale") or "SEO Strategist review",
+            recommendation=output.get("recommended_actions", [{}])[0].get("action", "review"),
+            agent_confidence=float(output.get("confidence") or 0.0),
+            supporting_data={
+                "policy_decision": (output.get("policy_result") or {}).get("decision"),
+                "blocked_reasons": output.get("blocked_reasons") or [],
+                "degraded_reasons": output.get("degraded_reasons") or [],
+                "external_write_status": output.get("external_write_confirmation_status"),
+            },
+        ),
+        assignee=HITLAssignee(role=str(role), notify_channels=["slack", "email"]),
+    )
+
+
+def _workflow_mode(inputs: dict[str, Any]) -> str:
+    return _normalize(inputs.get("workflow_mode") or inputs.get("mode") or "shadow")
+
+
+def _dict_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list | tuple):
+        return []
+    return [dict(item) for item in value if isinstance(item, dict)]
+
+
+def _dict_or_none(value: Any) -> dict[str, Any] | None:
+    return dict(value) if isinstance(value, dict) else None
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    if isinstance(value, list | tuple | set):
+        result = []
+        for item in value:
+            if isinstance(item, dict):
+                text = str(item.get("keyword") or item.get("query") or "").strip()
+            else:
+                text = str(item).strip()
+            if text:
+                result.append(text)
+        return result
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _severity(value: Any, default: str) -> str:
+    normalized = _normalize(value or default)
+    return normalized if normalized in SEVERITY_WEIGHTS else default
+
+
+def _effort_label(value: Any) -> str:
+    if isinstance(value, int | float):
+        if value <= 2:
+            return "low"
+        if value <= 5:
+            return "medium"
+        return "high"
+    normalized = _normalize(value)
+    return normalized if normalized in EFFORT_WEIGHTS else "medium"
+
+
+def _effort_score(value: Any) -> float:
+    if isinstance(value, int | float):
+        return max(1.0, min(float(value), 10.0)) / 3.0
+    return float(EFFORT_WEIGHTS.get(_effort_label(value), 2))
+
+
+def _float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _dedupe_refs(refs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[tuple[str, str]] = set()
+    result: list[dict[str, Any]] = []
+    for ref in refs:
+        key = (
+            str(ref.get("type") or ref.get("connector_key") or ""),
+            str(ref.get("ref_id") or ref.get("object") or ref.get("url") or ""),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(ref)
+    return result

--- a/core/agents/marketing/social_media.py
+++ b/core/agents/marketing/social_media.py
@@ -1,0 +1,1131 @@
+"""Social Media agent implementation."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+
+from core.agents.base import BaseAgent
+from core.agents.registry import AgentRegistry
+from core.marketing.escalation_matrix import evaluate_marketing_escalation
+from core.marketing.policy_manifest import evaluate_marketing_policy
+from core.schemas.messages import (
+    DecisionOption,
+    DecisionRequired,
+    HITLAssignee,
+    HITLContext,
+    HITLRequest,
+    ToolCallRecord,
+)
+
+logger = structlog.get_logger()
+
+SOCIAL_AGENT_MATURITY = "beta"
+SOCIAL_CONFIDENCE_FLOOR = 0.82
+DEFAULT_CHANNELS = ("linkedin", "twitter", "youtube")
+CHANNEL_LIMITS = {
+    "twitter": 280,
+    "x": 280,
+    "linkedin": 1300,
+    "facebook": 1200,
+    "instagram": 1000,
+    "youtube": 1000,
+}
+CHANNEL_CONNECTORS = {
+    "buffer": ("buffer", "create_post"),
+    "linkedin": ("buffer", "create_post"),
+    "facebook": ("buffer", "create_post"),
+    "instagram": ("buffer", "create_post"),
+    "twitter": ("twitter", "create_tweet"),
+    "x": ("twitter", "create_tweet"),
+    "youtube": ("youtube", "create_community_post"),
+}
+READ_ONLY_ACTIONS = {
+    "classify_reply_risk",
+    "content_calendar",
+    "draft_social_post",
+    "engagement_triage",
+    "generate_content_calendar",
+    "get_weekly_engagement",
+    "optimize_posting_schedule",
+    "posting_schedule_optimization",
+    "reply_risk_classification",
+    "social_post_draft",
+    "triage_engagement",
+}
+WRITE_ACTIONS = {
+    "publish_post",
+    "reply_to_mention",
+    "schedule_campaign_posts",
+    "schedule_content_promotion",
+    "schedule_post",
+}
+SHADOW_MODES = {"shadow", "draft", "internal", "internal_only", "recommendation", "simulation"}
+
+CRISIS_TERMS = (
+    "breach",
+    "boycott",
+    "crisis",
+    "data leak",
+    "fraud",
+    "lawsuit",
+    "outage",
+    "regulator",
+    "scam",
+    "unsafe",
+)
+LEGAL_PRICING_TERMS = (
+    "compliance",
+    "contract",
+    "guarantee",
+    "guaranteed",
+    "legal",
+    "pricing",
+    "refund",
+    "risk-free",
+    "terms",
+)
+COMPARATIVE_TERMS = ("competitor", "versus", " vs ", "better than", "cheaper than")
+EXECUTIVE_TERMS = ("board", "ceo", "cfo", "cmo", "founder", "minister", "press")
+NEGATIVE_TERMS = (
+    "angry",
+    "bad",
+    "broken",
+    "cancel",
+    "complaint",
+    "hate",
+    "poor",
+    "terrible",
+    "unhappy",
+)
+
+
+@AgentRegistry.register
+class SocialMediaAgent(BaseAgent):
+    agent_type = "social_media"
+    domain = "marketing"
+    confidence_floor = SOCIAL_CONFIDENCE_FLOOR
+    prompt_file = "social_media.prompt.txt"
+
+    async def execute(self, task):
+        """Run deterministic social planning, triage, drafting, or guarded publishing."""
+
+        start = time.monotonic()
+        trace: list[str] = []
+        tool_calls: list[ToolCallRecord] = []
+        msg_id = f"msg_{uuid.uuid4().hex[:12]}"
+
+        try:
+            inputs = _task_inputs(task)
+            action = _normalize_action(_task_action(task))
+            mode = _workflow_mode(inputs)
+            trace.append(f"Social Media action={action}, mode={mode}")
+
+            if action == "content_calendar":
+                output = self._build_content_calendar(task, inputs, trace)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+            if action == "posting_schedule_optimization":
+                output = self._optimize_posting_schedule(task, inputs, trace)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+            if action == "engagement_triage":
+                output = self._triage_engagement(task, inputs, trace)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+            if action == "reply_risk_classification":
+                output = self._classify_reply_risk(task, inputs, trace)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+            if action == "social_post_draft":
+                output = self._draft_social_post(task, inputs, trace)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+            if action in WRITE_ACTIONS:
+                output = await self._guarded_social_write(task, action, inputs, mode, trace, tool_calls)
+                return self._complete_or_hitl(task, msg_id, output, trace, tool_calls, start)
+
+            output = self._base_output(
+                task,
+                action=action,
+                status="blocked",
+                confidence=0.0,
+                rationale=f"Unsupported Social Media action '{action}'.",
+                recommended_actions=[
+                    {
+                        "action": "use_supported_social_action",
+                        "reason": "The Social Media agent only executes declared deterministic actions.",
+                    }
+                ],
+                blocked_reasons=[f"Unsupported Social Media action '{action}'."],
+                policy_context={"workflow_mode": mode},
+            )
+            return self._make_result(
+                task,
+                msg_id,
+                "failed",
+                output,
+                0.0,
+                trace,
+                tool_calls,
+                error={"code": "SOCIAL_ACTION_UNSUPPORTED", "message": output["blocked_reasons"][0]},
+                start=start,
+            )
+        # enterprise-gate: broad-except-ok reason=agent-execution-boundary-returns-failed-result
+        except Exception as exc:
+            logger.error("social_media_error", agent=self.agent_id, error=str(exc))
+            trace.append(f"Error: {exc}")
+            return self._make_result(
+                task,
+                msg_id,
+                "failed",
+                {},
+                0.0,
+                trace,
+                tool_calls,
+                error={"code": "SOCIAL_MEDIA_ERR", "message": str(exc)},
+                start=start,
+            )
+
+    def _build_content_calendar(
+        self,
+        task,
+        inputs: dict[str, Any],
+        trace: list[str],
+    ) -> dict[str, Any]:
+        channels = _channels(inputs)
+        weeks = max(1, min(_int(inputs.get("weeks"), 2), 8))
+        start_date = _parse_date(inputs.get("start_date")) or datetime(2026, 5, 25, tzinfo=UTC)
+        themes = _string_list(inputs.get("themes")) or [
+            inputs.get("campaign_theme") or inputs.get("topic") or "brand trust"
+        ]
+        audience = str(inputs.get("target_audience") or "marketing audience")
+        calendar: list[dict[str, Any]] = []
+        for week in range(weeks):
+            for index, channel in enumerate(channels):
+                theme = str(themes[(week + index) % len(themes)])
+                slot = DEFAULT_BEST_SLOTS.get(channel, DEFAULT_BEST_SLOTS["linkedin"])
+                scheduled_for = start_date + timedelta(days=week * 7 + index)
+                calendar.append(
+                    {
+                        "date": scheduled_for.date().isoformat(),
+                        "channel": channel,
+                        "slot": slot,
+                        "theme": theme,
+                        "post_type": _post_type(channel, index),
+                        "objective": _objective_for_theme(theme),
+                        "approval_required": False,
+                    }
+                )
+        trace.append(f"Generated {len(calendar)} calendar items for {len(channels)} channels")
+        return self._base_output(
+            task,
+            action="generate_content_calendar",
+            status="calendar_generated",
+            confidence=0.86,
+            rationale=f"Built a {weeks}-week social calendar for {audience} across {len(channels)} channels.",
+            recommended_actions=[
+                {"action": "review_calendar", "reason": "Confirm channel mix and campaign themes."},
+                {"action": "draft_posts", "reason": "Generate drafts for approved calendar slots."},
+            ],
+            policy_context={"workflow_mode": _workflow_mode(inputs), "workflow_id": "social_publishing"},
+            extra={"content_calendar": calendar, "channels": channels, "weeks": weeks},
+        )
+
+    def _optimize_posting_schedule(
+        self,
+        task,
+        inputs: dict[str, Any],
+        trace: list[str],
+    ) -> dict[str, Any]:
+        channels = _channels(inputs)
+        history = _dict_list(inputs.get("historical_engagement"))
+        recommendations: list[dict[str, Any]] = []
+        for channel in channels:
+            rows = [row for row in history if _normalize_channel(row.get("channel")) == channel]
+            if rows:
+                best = max(rows, key=lambda row: _float(row.get("engagement_rate"), 0.0))
+                slot = f"{best.get('day', 'Tue')} {best.get('hour', '10:00')}"
+                score = round(_float(best.get("engagement_rate"), 0.0), 4)
+                source = "historical_engagement"
+            else:
+                slot = DEFAULT_BEST_SLOTS.get(channel, DEFAULT_BEST_SLOTS["linkedin"])
+                score = DEFAULT_SLOT_SCORES.get(channel, 0.04)
+                source = "default_benchmark"
+            recommendations.append(
+                {
+                    "channel": channel,
+                    "recommended_slot": slot,
+                    "expected_engagement_rate": score,
+                    "source": source,
+                }
+            )
+        recommendations.sort(key=lambda row: (-row["expected_engagement_rate"], row["channel"]))
+        trace.append(f"Optimized posting schedule for {len(recommendations)} channels")
+        return self._base_output(
+            task,
+            action="optimize_posting_schedule",
+            status="schedule_recommended",
+            confidence=0.84 if history else 0.72,
+            rationale=(
+                "Selected highest observed engagement slots where history exists; "
+                "used conservative defaults otherwise."
+            ),
+            recommended_actions=[
+                {
+                    "action": "apply_recommended_slots",
+                    "reason": "Use these slots when scheduling drafts after approval.",
+                }
+            ],
+            degraded_reasons=[] if history else ["No historical engagement rows supplied; benchmark defaults used."],
+            source_refs=[{"kind": "fixture", "source": "historical_engagement", "count": len(history)}],
+            policy_context={"workflow_mode": _workflow_mode(inputs), "workflow_id": "social_publishing"},
+            extra={"schedule_recommendations": recommendations},
+        )
+
+    def _triage_engagement(
+        self,
+        task,
+        inputs: dict[str, Any],
+        trace: list[str],
+    ) -> dict[str, Any]:
+        mentions = _mention_rows(inputs)
+        triaged = []
+        for mention in mentions:
+            triaged.append({**mention, **_classify_social_risk(str(mention.get("text") or ""))})
+        counts = _risk_counts(triaged)
+        high_risk = [row for row in triaged if row["severity"] in {"high", "critical"}]
+        trace.append(f"Triaged {len(triaged)} mentions; high_risk={len(high_risk)}")
+        escalation = _escalation_for_rows(task, triaged)
+        hitl_reasons = _hitl_reasons_for_risks(triaged)
+        return self._base_output(
+            task,
+            action="triage_engagement",
+            status="engagement_triaged",
+            confidence=0.88 if triaged else 0.55,
+            rationale=f"Classified {len(triaged)} social mentions by reply and escalation risk.",
+            recommended_actions=_triage_recommendations(triaged),
+            approval_required=bool(hitl_reasons),
+            hitl_required=bool(hitl_reasons),
+            escalation=escalation,
+            source_refs=[{"kind": "social_mentions", "count": len(triaged)}],
+            policy_context={
+                "workflow_mode": _workflow_mode(inputs),
+                "workflow_id": "social_engagement_triage",
+                "risk_flags": _risk_flags(triaged),
+                "crisis_response": any(row["risk_type"] == "crisis" for row in triaged),
+            },
+            extra={
+                "mentions": triaged,
+                "risk_counts": counts,
+                "hitl_reasons": hitl_reasons,
+            },
+        )
+
+    def _classify_reply_risk(
+        self,
+        task,
+        inputs: dict[str, Any],
+        trace: list[str],
+    ) -> dict[str, Any]:
+        text = str(inputs.get("reply_text") or inputs.get("text") or inputs.get("mention_text") or "")
+        classification = _classify_social_risk(text)
+        trace.append(f"Reply risk classified as {classification['severity']}:{classification['risk_type']}")
+        escalation = _escalation_for_rows(task, [{"text": text, **classification}])
+        hitl_reasons = _hitl_reasons_for_risks([{**classification, "text": text}])
+        return self._base_output(
+            task,
+            action="classify_reply_risk",
+            status="risk_classified",
+            confidence=classification["confidence"],
+            rationale=f"Reply risk is {classification['severity']} because {classification['reason']}",
+            recommended_actions=[
+                {
+                    "action": classification["next_action"],
+                    "reason": classification["reason"],
+                }
+            ],
+            approval_required=bool(hitl_reasons),
+            hitl_required=bool(hitl_reasons),
+            escalation=escalation,
+            policy_context={
+                "workflow_mode": _workflow_mode(inputs),
+                "workflow_id": "social_reply_review",
+                "risk_flags": classification["risk_flags"],
+                "crisis_response": classification["risk_type"] == "crisis",
+                "pricing_claim": "pricing_or_legal" in classification["risk_flags"],
+                "comparative_claim": "comparative_claim" in classification["risk_flags"],
+            },
+            extra={"classification": classification, "hitl_reasons": hitl_reasons},
+        )
+
+    def _draft_social_post(
+        self,
+        task,
+        inputs: dict[str, Any],
+        trace: list[str],
+    ) -> dict[str, Any]:
+        channel = _channels(inputs)[0]
+        topic = str(inputs.get("topic") or inputs.get("campaign_theme") or "customer trust")
+        audience = str(inputs.get("target_audience") or "operators")
+        cta = str(inputs.get("cta") or "Review the full update")
+        claims = _string_list(inputs.get("claims"))
+        draft = _compose_post(topic, audience, cta, claims, channel)
+        classification = _classify_social_risk(draft)
+        hitl_reasons = _hitl_reasons_for_risks([{**classification, "text": draft}])
+        trace.append(f"Drafted social post for {channel} with risk={classification['severity']}")
+        return self._base_output(
+            task,
+            action="draft_social_post",
+            status="draft_created",
+            confidence=min(0.9, classification["confidence"] + 0.05),
+            rationale=f"Drafted a {channel} post for {audience}; risk classification is {classification['severity']}.",
+            recommended_actions=[
+                {
+                    "action": "review_draft" if hitl_reasons else "approve_calendar_slot",
+                    "reason": "; ".join(hitl_reasons) if hitl_reasons else "Draft is recommendation-only.",
+                }
+            ],
+            approval_required=bool(hitl_reasons),
+            hitl_required=bool(hitl_reasons),
+            escalation=_escalation_for_rows(task, [{"text": draft, **classification}]),
+            policy_context={
+                "workflow_mode": _workflow_mode(inputs),
+                "workflow_id": "social_post_draft",
+                "risk_flags": classification["risk_flags"],
+                "pricing_claim": "pricing_or_legal" in classification["risk_flags"],
+                "comparative_claim": "comparative_claim" in classification["risk_flags"],
+            },
+            extra={
+                "draft": draft,
+                "channel": channel,
+                "classification": classification,
+                "hitl_reasons": hitl_reasons,
+            },
+        )
+
+    async def _guarded_social_write(
+        self,
+        task,
+        action: str,
+        inputs: dict[str, Any],
+        mode: str,
+        trace: list[str],
+        tool_calls: list[ToolCallRecord],
+    ) -> dict[str, Any]:
+        channel = _channels(inputs)[0]
+        text = str(inputs.get("post_text") or inputs.get("reply_text") or inputs.get("draft") or "")
+        if not text:
+            text = _compose_post(
+                str(inputs.get("topic") or "company update"),
+                str(inputs.get("target_audience") or "followers"),
+                str(inputs.get("cta") or "Read more"),
+                _string_list(inputs.get("claims")),
+                channel,
+            )
+        classification = _classify_social_risk(text)
+        policy_context = {
+            "workflow_id": "social_publishing",
+            "workflow_mode": mode,
+            "action": (
+                "schedule_post"
+                if action in {"schedule_campaign_posts", "schedule_content_promotion"}
+                else action
+            ),
+            "external_write_required": True,
+            "customer_facing": True,
+            "risk_flags": classification["risk_flags"],
+            "crisis_response": classification["risk_type"] == "crisis",
+            "public_response": action in {"public_response", "reply_to_mention"},
+            "pricing_claim": "pricing_or_legal" in classification["risk_flags"],
+            "legal_claim": "pricing_or_legal" in classification["risk_flags"],
+            "comparative_claim": "comparative_claim" in classification["risk_flags"],
+        }
+        policy = evaluate_marketing_policy(policy_context)
+        hitl_reasons = _hitl_reasons_for_risks([{**classification, "text": text}])
+        blocked_reasons: list[str] = []
+        degraded_reasons: list[str] = []
+
+        if mode in SHADOW_MODES:
+            blocked_reasons.append("Shadow/draft/internal Social Media workflows are read-only.")
+            trace.append("Social write converted to shadow-only recommendation")
+            return self._base_output(
+                task,
+                action=action,
+                status="shadow_only",
+                confidence=0.78,
+                rationale="Prepared social recommendation without external publishing because workflow is read-only.",
+                recommended_actions=[
+                    {
+                        "action": "create_internal_approval",
+                        "reason": "Review the draft before any active social write is attempted.",
+                    }
+                ],
+                approval_required=True,
+                hitl_required=True,
+                policy_result=policy,
+                blocked_reasons=blocked_reasons,
+                external_write_status="not_required",
+                external_write_required=False,
+                escalation=_escalation_for_rows(task, [{"text": text, **classification}]),
+                extra={"draft": text, "channel": channel, "classification": classification},
+            )
+
+        connector_safe, connector_reason = _connector_write_safe(inputs)
+        if not connector_safe:
+            blocked_reasons.append(connector_reason)
+        if policy.get("decision") in {"requires_approval", "requires_escalation"} and not _has_approval(inputs):
+            hitl_reasons.append(str(policy.get("reason") or "Social publishing requires approval."))
+        if policy.get("decision") in {"blocked", "missing_policy", "read_only_only"}:
+            blocked_reasons.append(str(policy.get("reason") or "Marketing policy blocks this social write."))
+
+        escalation = _escalation_for_rows(task, [{"text": text, **classification}], policy_result=policy)
+        if escalation and escalation.get("decision") != "no_escalation":
+            if policy.get("decision") == "requires_escalation" and not _has_escalation_approval(inputs):
+                hitl_reasons.append(str(escalation.get("reason") or "Social write requires escalation."))
+
+        if blocked_reasons or hitl_reasons:
+            trace.append(f"Social write blocked or approval-gated: {blocked_reasons + hitl_reasons}")
+            return self._base_output(
+                task,
+                action=action,
+                status="blocked",
+                confidence=0.66,
+                rationale=(
+                    "Social write is blocked until connector, policy, approval, "
+                    "and escalation prerequisites pass."
+                ),
+                recommended_actions=[
+                    {
+                        "action": "resolve_social_write_prerequisites",
+                        "reason": "; ".join(blocked_reasons + hitl_reasons),
+                    }
+                ],
+                approval_required=True,
+                hitl_required=True,
+                policy_result=policy,
+                blocked_reasons=blocked_reasons,
+                degraded_reasons=degraded_reasons,
+                external_write_status="write_unconfirmed",
+                external_write_required=True,
+                escalation=escalation,
+                extra={
+                    "draft": text,
+                    "channel": channel,
+                    "classification": classification,
+                    "hitl_reasons": hitl_reasons,
+                },
+            )
+
+        write_result = _dict_or_none(inputs.get("external_write_result"))
+        if write_result is None:
+            connector, tool = _connector_tool(inputs, channel)
+            write_result = await self._safe_tool_call(
+                connector,
+                tool,
+                {
+                    "text": text,
+                    "channel": channel,
+                    "scheduled_at": inputs.get("scheduled_at") or inputs.get("publish_at"),
+                    "profile_id": inputs.get("profile_id"),
+                },
+                trace,
+                tool_calls,
+                idempotency_key=str(inputs.get("idempotency_key") or ""),
+            )
+
+        write_status = _external_write_confirmation_status(write_result)
+        write_confirmed = _is_confirmed_external_write(write_result)
+        if not write_confirmed:
+            blocked_reasons.append("External social write is unconfirmed and cannot be marked published.")
+        trace.append(f"Social write result status={write_status}, confirmed={write_confirmed}")
+        external_ref = _external_write_ref(write_result) if write_confirmed else None
+        return self._base_output(
+            task,
+            action=action,
+            status="write_confirmed" if write_confirmed else "blocked",
+            confidence=0.9 if write_confirmed else 0.62,
+            rationale=(
+                "Social write was confirmed by the connector."
+                if write_confirmed
+                else "Social write did not return confirmed external object evidence."
+            ),
+            recommended_actions=[
+                {
+                    "action": "monitor_social_post" if write_confirmed else "verify_connector_write",
+                    "reason": (
+                        "Track engagement and replies."
+                        if write_confirmed
+                        else "Check vendor state using the idempotency key before retrying."
+                    ),
+                }
+            ],
+            approval_required=False,
+            hitl_required=not write_confirmed,
+            policy_result=policy,
+            approval_satisfied=_has_approval(inputs),
+            blocked_reasons=blocked_reasons,
+            external_write_status=write_status,
+            external_write_required=True,
+            external_write_ref=external_ref,
+            escalation=escalation,
+            extra={"draft": text, "channel": channel, "classification": classification},
+        )
+
+    async def _safe_tool_call(
+        self,
+        connector: str,
+        tool: str,
+        params: dict[str, Any],
+        trace: list[str],
+        tool_records: list[ToolCallRecord],
+        *,
+        idempotency_key: str = "",
+    ) -> dict[str, Any]:
+        call_start = time.monotonic()
+        try:
+            result = await self._call_tool(
+                connector_name=connector,
+                tool_name=tool,
+                params=params,
+                idempotency_key=idempotency_key,
+            )
+            latency = int((time.monotonic() - call_start) * 1000)
+            status = "error" if "error" in result else "success"
+            trace.append(f"[tool] {connector}.{tool} -> {status} ({latency}ms)")
+            tool_records.append(ToolCallRecord(tool_name=f"{connector}.{tool}", status=status, latency_ms=latency))
+            return result
+        # enterprise-gate: broad-except-ok reason=agent-tool-call-failure-returns-explicit-error-result
+        except Exception as exc:
+            latency = int((time.monotonic() - call_start) * 1000)
+            trace.append(f"[tool] {connector}.{tool} -> exception: {exc} ({latency}ms)")
+            tool_records.append(ToolCallRecord(tool_name=f"{connector}.{tool}", status="error", latency_ms=latency))
+            return {"error": str(exc)}
+
+    def _base_output(
+        self,
+        task,
+        *,
+        action: str,
+        status: str,
+        confidence: float,
+        rationale: str,
+        recommended_actions: list[dict[str, Any]],
+        approval_required: bool = False,
+        hitl_required: bool = False,
+        policy_context: dict[str, Any] | None = None,
+        policy_result: dict[str, Any] | None = None,
+        approval_satisfied: bool = False,
+        escalation: dict[str, Any] | None = None,
+        source_refs: list[dict[str, Any]] | None = None,
+        degraded_reasons: list[str] | None = None,
+        blocked_reasons: list[str] | None = None,
+        external_write_status: str = "not_required",
+        external_write_required: bool = False,
+        external_write_ref: dict[str, Any] | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        policy = policy_result or evaluate_marketing_policy(
+            {
+                "workflow_id": "social_media",
+                "workflow_mode": "shadow",
+                "action": action,
+                "external_write_required": external_write_required,
+                **(policy_context or {}),
+            }
+        )
+        escalation_ref = None
+        if escalation and escalation.get("decision") != "no_escalation":
+            escalation_ref = escalation.get("decision_audit_ref") or escalation.get("audit_reference")
+        policy_needs_review = (
+            policy.get("decision") in {"requires_approval", "requires_escalation", "read_only_only"}
+            and not approval_satisfied
+        )
+        output: dict[str, Any] = {
+            "status": status,
+            "agent_type": self.agent_type,
+            "action": action,
+            "confidence": round(max(0.0, min(confidence, 1.0)), 3),
+            "rationale": rationale,
+            "recommended_actions": recommended_actions,
+            "source_refs": source_refs or [],
+            "policy_result": policy,
+            "policy_ref": policy.get("decision_audit_ref") or policy.get("policy_id"),
+            "approval_required": approval_required or policy_needs_review,
+            "hitl_required": hitl_required,
+            "escalation_ref": escalation_ref,
+            "escalation_result": escalation,
+            "audit_ref": f"social_media:{task.correlation_id}:{task.step_id}:{action}",
+            "degraded_reasons": _dedupe(degraded_reasons or []),
+            "blocked_reasons": _dedupe(blocked_reasons or []),
+            "external_write_confirmation_status": external_write_status,
+            "external_writes_completed": external_write_status == "write_confirmed",
+            "external_write_required": external_write_required,
+            "external_write_ref": external_write_ref,
+            "production_status": SOCIAL_AGENT_MATURITY,
+        }
+        if extra:
+            output.update(extra)
+        return output
+
+    def _complete_or_hitl(
+        self,
+        task,
+        msg_id: str,
+        output: dict[str, Any],
+        trace: list[str],
+        tool_calls: list[ToolCallRecord],
+        start: float,
+    ):
+        if output.get("hitl_required") or output.get("approval_required") or output.get("blocked_reasons"):
+            hitl = _hitl_request(task, output)
+            return self._make_result(
+                task,
+                msg_id,
+                "hitl_triggered",
+                output,
+                float(output.get("confidence") or 0.0),
+                trace,
+                tool_calls,
+                hitl_request=hitl,
+                start=start,
+            )
+        return self._make_result(
+            task,
+            msg_id,
+            "completed",
+            output,
+            float(output.get("confidence") or 0.0),
+            trace,
+            tool_calls,
+            start=start,
+        )
+
+
+DEFAULT_BEST_SLOTS = {
+    "linkedin": "Tue 10:00",
+    "twitter": "Wed 11:00",
+    "x": "Wed 11:00",
+    "facebook": "Thu 14:00",
+    "instagram": "Fri 12:00",
+    "youtube": "Tue 16:00",
+}
+DEFAULT_SLOT_SCORES = {
+    "linkedin": 0.058,
+    "twitter": 0.046,
+    "x": 0.046,
+    "facebook": 0.035,
+    "instagram": 0.052,
+    "youtube": 0.041,
+}
+
+
+def _task_inputs(task) -> dict[str, Any]:
+    payload = task.task.inputs if hasattr(task.task, "inputs") else task.task.get("inputs", {})
+    return payload if isinstance(payload, dict) else {}
+
+
+def _task_action(task) -> str:
+    return str(task.task.action if hasattr(task.task, "action") else task.task.get("action", "triage_engagement"))
+
+
+def _normalize_action(action: str) -> str:
+    normalized = str(action or "").strip().lower()
+    aliases = {
+        "classify_reply": "reply_risk_classification",
+        "classify_reply_risk": "reply_risk_classification",
+        "content_calendar": "content_calendar",
+        "draft_post": "social_post_draft",
+        "draft_social_post": "social_post_draft",
+        "generate_calendar": "content_calendar",
+        "generate_content_calendar": "content_calendar",
+        "get_weekly_engagement": "engagement_triage",
+        "optimize_posting_schedule": "posting_schedule_optimization",
+        "publish": "publish_post",
+        "recommend_reply": "social_post_draft",
+        "schedule_content_promotion": "schedule_content_promotion",
+        "triage_engagement": "engagement_triage",
+        "triage_mentions": "engagement_triage",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def _workflow_mode(inputs: dict[str, Any]) -> str:
+    return str(inputs.get("workflow_mode") or inputs.get("mode") or "shadow").strip().lower()
+
+
+def _channels(inputs: dict[str, Any]) -> list[str]:
+    raw = inputs.get("channels") or inputs.get("platforms") or inputs.get("channel") or list(DEFAULT_CHANNELS)
+    if isinstance(raw, str):
+        values = [raw]
+    elif isinstance(raw, list | tuple | set):
+        values = [str(item) for item in raw]
+    else:
+        values = list(DEFAULT_CHANNELS)
+    normalized = [_normalize_channel(value) for value in values if str(value).strip()]
+    return normalized or list(DEFAULT_CHANNELS)
+
+
+def _normalize_channel(value: Any) -> str:
+    normalized = str(value or "").strip().lower()
+    return "twitter" if normalized in {"x", "twitter/x"} else normalized
+
+
+def _parse_date(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).replace(tzinfo=None)
+    except ValueError:
+        return None
+
+
+def _post_type(channel: str, index: int) -> str:
+    if channel in {"twitter", "x"}:
+        return "short_thread" if index % 2 else "single_update"
+    if channel == "youtube":
+        return "community_post"
+    if channel == "instagram":
+        return "carousel_caption"
+    return "thought_leadership"
+
+
+def _objective_for_theme(theme: str) -> str:
+    lower = theme.lower()
+    if "case" in lower or "proof" in lower:
+        return "build_trust"
+    if "event" in lower or "webinar" in lower:
+        return "drive_registration"
+    if "launch" in lower:
+        return "announce_launch"
+    return "educate_audience"
+
+
+def _compose_post(topic: str, audience: str, cta: str, claims: list[str], channel: str) -> str:
+    claim_text = f" {' '.join(claims)}" if claims else ""
+    post = f"{topic}: a practical update for {audience}.{claim_text} {cta}."
+    limit = CHANNEL_LIMITS.get(channel, 600)
+    if len(post) > limit:
+        return post[: max(limit - 1, 0)].rstrip() + "."
+    return post
+
+
+def _classify_social_risk(text: str) -> dict[str, Any]:
+    lower = f" {text.lower()} "
+    flags: list[str] = []
+    matched: list[str] = []
+    if _contains_any(lower, CRISIS_TERMS, matched):
+        flags.append("crisis_public_response")
+        return {
+            "risk_type": "crisis",
+            "severity": "critical",
+            "confidence": 0.93,
+            "risk_flags": flags,
+            "matched_terms": matched,
+            "reason": "crisis or public trust terms were detected",
+            "next_action": "escalate_crisis_response_to_exec",
+        }
+    if _contains_any(lower, LEGAL_PRICING_TERMS, matched):
+        flags.append("pricing_or_legal")
+    if _contains_any(lower, COMPARATIVE_TERMS, matched):
+        flags.append("comparative_claim")
+    if flags:
+        return {
+            "risk_type": "pricing_legal_or_comparative",
+            "severity": "high",
+            "confidence": 0.9,
+            "risk_flags": flags,
+            "matched_terms": matched,
+            "reason": "pricing, legal, compliance, or comparative claim terms were detected",
+            "next_action": "request_legal_review",
+        }
+    if _contains_any(lower, EXECUTIVE_TERMS, matched):
+        return {
+            "risk_type": "executive_or_press",
+            "severity": "high",
+            "confidence": 0.86,
+            "risk_flags": ["executive_mention"],
+            "matched_terms": matched,
+            "reason": "executive, board, press, or public official mention detected",
+            "next_action": "route_to_comms_lead",
+        }
+    if _contains_any(lower, NEGATIVE_TERMS, matched):
+        return {
+            "risk_type": "negative_feedback",
+            "severity": "medium",
+            "confidence": 0.82,
+            "risk_flags": ["negative_sentiment"],
+            "matched_terms": matched,
+            "reason": "negative sentiment terms were detected",
+            "next_action": "draft_service_recovery_reply",
+        }
+    return {
+        "risk_type": "normal",
+        "severity": "low",
+        "confidence": 0.8,
+        "risk_flags": [],
+        "matched_terms": [],
+        "reason": "no high-risk social reply signals were detected",
+        "next_action": "reply_from_standard_playbook",
+    }
+
+
+def _contains_any(text: str, terms: tuple[str, ...], matched: list[str]) -> bool:
+    found = False
+    for term in terms:
+        if term in text:
+            matched.append(term.strip())
+            found = True
+    return found
+
+
+def _mention_rows(inputs: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = inputs.get("mentions") or inputs.get("engagement_items") or []
+    if isinstance(raw, str):
+        return [{"mention_id": "mention-1", "text": raw, "channel": _channels(inputs)[0]}]
+    rows = _dict_list(raw)
+    if rows:
+        return [
+            {
+                "mention_id": str(row.get("mention_id") or row.get("id") or f"mention-{idx + 1}"),
+                "text": str(row.get("text") or row.get("body") or row.get("message") or ""),
+                "channel": _normalize_channel(row.get("channel") or _channels(inputs)[0]),
+                "author": row.get("author"),
+                "url": row.get("url"),
+            }
+            for idx, row in enumerate(rows)
+        ]
+    return []
+
+
+def _risk_counts(rows: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {"low": 0, "medium": 0, "high": 0, "critical": 0}
+    for row in rows:
+        severity = str(row.get("severity") or "low")
+        counts[severity] = counts.get(severity, 0) + 1
+    return counts
+
+
+def _triage_recommendations(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not rows:
+        return [{"action": "connect_social_mentions", "reason": "No mentions were supplied for triage."}]
+    recs = []
+    for row in rows:
+        recs.append(
+            {
+                "action": row["next_action"],
+                "mention_id": row.get("mention_id"),
+                "severity": row["severity"],
+                "reason": row["reason"],
+            }
+        )
+    return recs
+
+
+def _hitl_reasons_for_risks(rows: list[dict[str, Any]]) -> list[str]:
+    reasons = []
+    for row in rows:
+        severity = str(row.get("severity") or "low")
+        if severity == "critical":
+            reasons.append("crisis/public response requires escalation")
+        elif severity == "high":
+            reasons.append("high-risk social reply requires approval")
+    return _dedupe(reasons)
+
+
+def _risk_flags(rows: list[dict[str, Any]]) -> list[str]:
+    flags: list[str] = []
+    for row in rows:
+        flags.extend(str(flag) for flag in row.get("risk_flags") or [])
+    return _dedupe(flags)
+
+
+def _escalation_for_rows(
+    task,
+    rows: list[dict[str, Any]],
+    *,
+    policy_result: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    flags = _risk_flags(rows)
+    crisis = any(row.get("risk_type") == "crisis" for row in rows)
+    high = any(row.get("severity") in {"high", "critical"} for row in rows)
+    if not crisis and not high and not policy_result:
+        return evaluate_marketing_escalation(
+            {
+                "workflow_id": "social_media",
+                "workflow_run_id": getattr(task, "workflow_run_id", None),
+                "step_id": getattr(task, "step_id", None),
+                "event_type": "social_engagement_triage",
+            }
+        )
+    context = {
+        "workflow_id": "social_media",
+        "workflow_run_id": getattr(task, "workflow_run_id", None),
+        "step_id": getattr(task, "step_id", None),
+        "event_type": "crisis_public_response" if crisis else "high_risk_copy",
+        "crisis_response": crisis,
+        "public_response": crisis,
+        "pricing_claim": "pricing_or_legal" in flags,
+        "legal_claim": "pricing_or_legal" in flags,
+        "comparative_claim": "comparative_claim" in flags,
+        "severity": "critical" if crisis else ("high" if high else "medium"),
+        "reason": "Social Media risk classification requires escalation review.",
+    }
+    if policy_result:
+        context["marketing_policy_decision"] = policy_result
+    return evaluate_marketing_escalation(context)
+
+
+def _connector_write_safe(inputs: dict[str, Any]) -> tuple[bool, str]:
+    if inputs.get("connector_write_ready") is True or inputs.get("write_ready") is True:
+        return True, ""
+    if inputs.get("connector_write_ready") is False or inputs.get("write_ready") is False:
+        return False, "Social connector is not write-safe."
+    contract = _dict_or_none(inputs.get("connector_contract")) or _first_dict(inputs.get("connector_contracts"))
+    if contract:
+        if contract.get("mock_or_test_double"):
+            return False, "Test-double connector proof cannot satisfy active Social Media writes."
+        write_safe = bool(contract.get("write_safe", contract.get("write_ready")))
+        health = str(
+            contract.get("health_status")
+            or contract.get("contract_state")
+            or contract.get("write_status")
+            or ""
+        )
+        if write_safe:
+            return True, ""
+        return False, f"Social connector contract is not write-safe ({health or 'unknown'})."
+    return False, "Social connector write-readiness evidence is missing."
+
+
+def _has_approval(inputs: dict[str, Any]) -> bool:
+    return bool(
+        inputs.get("approved")
+        or inputs.get("approval_ref")
+        or inputs.get("approval_result_ref")
+        or inputs.get("policy_approval_ref")
+    )
+
+
+def _has_escalation_approval(inputs: dict[str, Any]) -> bool:
+    return bool(inputs.get("escalation_ref") or inputs.get("escalation_result_ref") or inputs.get("approved"))
+
+
+def _connector_tool(inputs: dict[str, Any], channel: str) -> tuple[str, str]:
+    connector_key = str(inputs.get("connector_key") or inputs.get("connector") or "").strip().lower()
+    if connector_key and connector_key in CHANNEL_CONNECTORS:
+        return CHANNEL_CONNECTORS[connector_key]
+    return CHANNEL_CONNECTORS.get(channel, CHANNEL_CONNECTORS["buffer"])
+
+
+def _external_write_confirmation_status(result: dict[str, Any] | None) -> str:
+    if not result:
+        return "write_unconfirmed"
+    return str(
+        result.get("external_write_confirmation_status")
+        or result.get("write_confirmation_status")
+        or result.get("status")
+        or "write_unconfirmed"
+    )
+
+
+def _is_confirmed_external_write(result: dict[str, Any] | None) -> bool:
+    if not result or "error" in result:
+        return False
+    status = _external_write_confirmation_status(result)
+    return status == "write_confirmed" and bool(
+        result.get("external_object_id") or result.get("external_id") or result.get("confirmed_at")
+    )
+
+
+def _external_write_ref(result: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not result:
+        return None
+    return {
+        "connector_key": result.get("connector_key"),
+        "external_object_id": result.get("external_object_id") or result.get("external_id"),
+        "source_url": result.get("source_url") or result.get("url"),
+        "idempotency_key": result.get("idempotency_key"),
+        "confirmed_at": result.get("confirmed_at"),
+        "audit_ref": result.get("audit_ref") or result.get("audit_reference"),
+    }
+
+
+def _hitl_request(task, output: dict[str, Any]) -> HITLRequest:
+    reasons = output.get("blocked_reasons") or output.get("hitl_reasons") or []
+    if not reasons and output.get("policy_result"):
+        reasons = [str(output["policy_result"].get("reason") or "Social Media action requires review.")]
+    escalation = output.get("escalation_result") or {}
+    role = escalation.get("owner_role") or escalation.get("primary_owner_role") or "social_media_lead"
+    return HITLRequest(
+        hitl_id=f"hitl_{uuid.uuid4().hex[:12]}",
+        trigger_condition="; ".join(str(reason) for reason in reasons) or "Social Media review required.",
+        trigger_type="social_media_review",
+        decision_required=DecisionRequired(
+            question="Review Social Media recommendation or publishing safeguard.",
+            options=[
+                DecisionOption(id="approve", label="Approve", action="proceed"),
+                DecisionOption(id="request_changes", label="Request changes", action="defer"),
+                DecisionOption(id="escalate", label="Escalate", action="defer"),
+                DecisionOption(id="reject", label="Reject", action="reject"),
+            ],
+        ),
+        context=HITLContext(
+            summary=output.get("rationale") or "Social Media review",
+            recommendation=output.get("recommended_actions", [{}])[0].get("action", "review"),
+            agent_confidence=float(output.get("confidence") or 0.0),
+            supporting_data={
+                "policy_decision": (output.get("policy_result") or {}).get("decision"),
+                "blocked_reasons": output.get("blocked_reasons") or [],
+                "degraded_reasons": output.get("degraded_reasons") or [],
+                "external_write_status": output.get("external_write_confirmation_status"),
+            },
+        ),
+        assignee=HITLAssignee(role=str(role), notify_channels=["slack", "email"]),
+    )
+
+
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, list | tuple | set):
+        return [str(item) for item in value if str(item).strip()]
+    return []
+
+
+def _dict_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list | tuple):
+        return []
+    return [dict(item) for item in value if isinstance(item, dict)]
+
+
+def _dict_or_none(value: Any) -> dict[str, Any] | None:
+    return dict(value) if isinstance(value, dict) else None
+
+
+def _first_dict(value: Any) -> dict[str, Any] | None:
+    rows = _dict_list(value)
+    return rows[0] if rows else None
+
+
+def _int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result

--- a/core/marketing/agent_contracts.py
+++ b/core/marketing/agent_contracts.py
@@ -1,0 +1,496 @@
+"""CMO marketing agent contract registry and output normalization.
+
+CMO-9.1 keeps agent status and result shape explicit without pretending that
+target or wrapper-level agents are production-ready. The helpers here are
+deterministic and test-oriented: they do not call LLMs, vendors, or connectors.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from core.marketing.policy_manifest import CUSTOMER_FACING_WRITE_ACTIONS
+
+CMO_AGENT_CONTRACT_VERSION = "2026-05-24.cmo-9.1"
+
+REQUIRED_AGENT_CONTRACT_KEYS = (
+    "status",
+    "confidence",
+    "rationale",
+    "recommended_actions",
+    "source_refs",
+    "policy_result",
+    "approval_required",
+    "hitl_required",
+    "audit_ref",
+    "degraded_reasons",
+    "blocked_reasons",
+    "external_write_confirmation_status",
+    "external_writes_completed",
+)
+
+
+@dataclass(frozen=True)
+class MarketingAgentContractSpec:
+    agent_type: str
+    maturity: str
+    production_ready: bool
+    actions: tuple[str, ...]
+    surface: str
+    blocker: str | None = None
+    aliases: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agent_type": self.agent_type,
+            "maturity": self.maturity,
+            "production_ready": self.production_ready,
+            "actions": list(self.actions),
+            "surface": self.surface,
+            "blocker": self.blocker,
+            "aliases": list(self.aliases),
+            "contract_version": CMO_AGENT_CONTRACT_VERSION,
+        }
+
+
+MARKETING_AGENT_CONTRACT_SPECS: tuple[MarketingAgentContractSpec, ...] = (
+    MarketingAgentContractSpec(
+        agent_type="campaign_pilot",
+        maturity="production",
+        production_ready=True,
+        surface="core.agents.marketing.campaign_pilot",
+        actions=(
+            "create",
+            "setup",
+            "manage_campaign",
+            "create_plan",
+            "launch_campaign",
+            "mutate_ad_budget",
+            "pause_campaign",
+            "generate_weekly_report",
+        ),
+    ),
+    MarketingAgentContractSpec(
+        agent_type="content_factory",
+        maturity="beta",
+        production_ready=False,
+        surface="core.agents.marketing.content_factory",
+        actions=(
+            "generate_content",
+            "create_draft",
+            "schedule_content",
+            "publish",
+            "publish_to_wordpress",
+        ),
+        blocker="Beta: requires approval, policy, audit, and write confirmation before production publishing.",
+    ),
+    MarketingAgentContractSpec(
+        agent_type="email_marketing",
+        maturity="beta",
+        production_ready=False,
+        surface="core.langgraph.agents.email_marketing",
+        actions=(
+            "segment_list",
+            "send_email",
+            "send_to_segment",
+            "start_nurture_sequence",
+        ),
+        blocker="Beta LangGraph path: sends require approval and connector write confirmation.",
+        aliases=("email_agent",),
+    ),
+    MarketingAgentContractSpec(
+        agent_type="brand_monitor",
+        maturity="beta",
+        production_ready=False,
+        surface="core.agents.marketing.brand_monitor",
+        actions=(
+            "aggregate_mentions",
+            "brand_claim",
+            "classify_crisis_severity",
+            "classify_sentiment",
+            "comparative_claim",
+            "competitor_brand_grouping",
+            "crisis_response",
+            "detect_crisis",
+            "detect_negative_spike",
+            "false_positive_suppression",
+            "get_sentiment",
+            "group_mentions",
+            "mention_aggregation",
+            "monitor_mentions",
+            "pricing_claim",
+            "public_response",
+            "publish_brand_response",
+            "recommend_response_playbook",
+            "sentiment_trend",
+        ),
+        blocker=(
+            "Beta: first-class Brand Monitor logic exists, but production proof "
+            "still requires real brand/social connector readiness, policy, "
+            "approval, escalation, audit, confirmed-write, and pilot evidence."
+        ),
+    ),
+    MarketingAgentContractSpec(
+        agent_type="seo_strategist",
+        maturity="beta",
+        production_ready=False,
+        surface="core.agents.marketing.seo_strategist",
+        actions=(
+            "apply_redirect",
+            "content_optimization_recommendation",
+            "get_keyword_rankings",
+            "identify_content_gaps",
+            "keyword_gap_analysis",
+            "publish_seo_change",
+            "ranking_delta_computation",
+            "recommendation_bundling",
+            "seo_sprint_planning",
+            "submit_url_to_index",
+            "technical_issue_prioritization",
+            "update_canonical_tag",
+            "update_page_metadata",
+            "update_robots_txt",
+            "update_sitemap",
+        ),
+        blocker=(
+            "Beta: first-class SEO Strategist logic exists, but production proof "
+            "still requires real SEO/Analytics/CMS connector readiness, policy, "
+            "approval, audit, confirmed-write, and pilot evidence."
+        ),
+    ),
+    MarketingAgentContractSpec(
+        agent_type="crm_intelligence",
+        maturity="beta",
+        production_ready=False,
+        surface="core.agents.marketing.crm_intelligence",
+        actions=(
+            "account_deal_health_summary",
+            "account_health_summary",
+            "analyze_pipeline_velocity",
+            "bulk_crm_update",
+            "change_segment_membership",
+            "change_target_accounts",
+            "churn_risk_signal_extraction",
+            "extract_churn_signals",
+            "funnel_conversion_analysis",
+            "lead_scoring_refresh",
+            "pipeline_velocity_analysis",
+            "promote_lifecycle_stage",
+            "promote_to_sql",
+            "recommend_segments",
+            "refresh_lead_scores",
+            "score_lead",
+            "segment_recommendation",
+            "sql_promotion_criteria",
+            "update_crm",
+            "update_lead_scores",
+            "update_lifecycle_stage",
+            "update_segment_membership",
+        ),
+        blocker=(
+            "Beta: first-class CRM Intelligence logic exists, but production "
+            "proof still requires real CRM/intent connector readiness, policy, "
+            "approval, audit, confirmed-write, and pilot evidence."
+        ),
+    ),
+    MarketingAgentContractSpec(
+        agent_type="social_media",
+        maturity="beta",
+        production_ready=False,
+        surface="core.agents.marketing.social_media",
+        actions=(
+            "classify_reply_risk",
+            "draft_social_post",
+            "generate_content_calendar",
+            "get_weekly_engagement",
+            "optimize_posting_schedule",
+            "publish_post",
+            "reply_to_mention",
+            "schedule_campaign_posts",
+            "schedule_content_promotion",
+            "schedule_post",
+            "triage_engagement",
+        ),
+        blocker=(
+            "Beta: first-class Social Media logic exists, but production proof still "
+            "requires real connector/write, policy, approval, audit, and pilot evidence."
+        ),
+    ),
+    MarketingAgentContractSpec(
+        agent_type="abm",
+        maturity="beta",
+        production_ready=False,
+        surface="core.agents.marketing.abm_agent",
+        actions=(
+            "aggregate_engagement",
+            "aggregate_intent",
+            "create_abm_campaign",
+            "launch_abm_campaign",
+            "query_target_accounts",
+            "recommend_next_best_action",
+            "score_accounts",
+            "score_icp_fit",
+            "score_intent_heat",
+            "set_abm_budget",
+            "sync_target_accounts",
+            "target_account_list_change",
+            "update_target_accounts",
+            "validate_account_csv",
+        ),
+        blocker=(
+            "Beta: first-class ABM logic exists, but production proof still "
+            "requires real ABM/CRM connector-write, policy, approval, audit, "
+            "confirmed-write, and pilot evidence."
+        ),
+        aliases=("abm_agent",),
+    ),
+    MarketingAgentContractSpec(
+        agent_type="competitive_intel",
+        maturity="beta",
+        production_ready=False,
+        surface="core.agents.marketing.competitive_intel",
+        actions=(
+            "change_confidence_score",
+            "comparative_claim",
+            "duplicate_change_suppression",
+            "evaluate_alert_thresholds",
+            "extract_win_loss_signals",
+            "feature_capability_diffing",
+            "launch_competitive_campaign",
+            "normalize_competitor_profiles",
+            "positioning_recommendation",
+            "pricing_change_detection",
+            "pricing_claim",
+            "public_response",
+            "publish_competitive_response",
+            "weekly_benchmark",
+            "weekly_market_snapshot",
+        ),
+        blocker=(
+            "Beta: first-class Competitive Intel logic exists, but production "
+            "proof still requires real competitive-source connector readiness, "
+            "policy, approval, escalation, audit, confirmed-write, and pilot evidence."
+        ),
+    ),
+)
+
+
+def marketing_agent_contract_specs() -> list[dict[str, Any]]:
+    return [spec.to_dict() for spec in MARKETING_AGENT_CONTRACT_SPECS]
+
+
+def get_marketing_agent_contract_spec(agent_type: str) -> dict[str, Any]:
+    normalized = _normalize_agent_type(agent_type)
+    for spec in MARKETING_AGENT_CONTRACT_SPECS:
+        if normalized == spec.agent_type or normalized in spec.aliases:
+            return spec.to_dict()
+    return {
+        "agent_type": normalized,
+        "maturity": "unknown",
+        "production_ready": False,
+        "actions": [],
+        "surface": "unknown",
+        "blocker": "Unknown CMO marketing agent surface.",
+        "aliases": [],
+        "contract_version": CMO_AGENT_CONTRACT_VERSION,
+    }
+
+
+def build_marketing_agent_contract_output(
+    agent_type: str,
+    action: str,
+    *,
+    result: Any | None = None,
+    task_input: dict[str, Any] | None = None,
+    policy_result: dict[str, Any] | None = None,
+    audit_ref: str | None = None,
+    source_refs: list[dict[str, Any]] | None = None,
+    workflow_mode: str = "shadow",
+    connector_ready: bool = True,
+    external_write_confirmation_status: str | None = None,
+) -> dict[str, Any]:
+    """Return a stable CMO agent contract output for test and readiness checks."""
+
+    spec = get_marketing_agent_contract_spec(agent_type)
+    canonical_agent_type = str(spec["agent_type"])
+    output = _result_output(result)
+    status = _result_status(result, output)
+    confidence = _result_confidence(result, output)
+    blocked_reasons = list(output.get("blocked_reasons") or [])
+    degraded_reasons = list(output.get("degraded_reasons") or [])
+    write_required = _external_write_required(action, output)
+    write_status = (
+        external_write_confirmation_status
+        or str(output.get("external_write_confirmation_status") or "")
+        or ("not_required" if not write_required else "write_unconfirmed")
+    )
+    policy = policy_result or output.get("policy_result") or _default_policy_result(
+        action,
+        write_required=write_required,
+        workflow_mode=workflow_mode,
+    )
+
+    if spec["maturity"] in {"stub", "unavailable", "unknown"}:
+        blocked_reasons.append(str(spec.get("blocker") or "Agent is not production-ready."))
+        status = str(spec["maturity"])
+        confidence = 0.0
+        write_status = "not_applicable"
+
+    if not connector_ready:
+        degraded_reasons.append("Required connector is unavailable or degraded.")
+
+    if write_required and write_status != "write_confirmed":
+        blocked_reasons.append("External write is not confirmed and cannot be treated as complete.")
+
+    final_audit_ref = audit_ref or str(output.get("audit_ref") or "")
+    if spec["maturity"] not in {"stub", "unavailable", "unknown"} and not final_audit_ref:
+        blocked_reasons.append("Decision audit evidence is missing.")
+
+    normalized = {
+        "agent_type": canonical_agent_type,
+        "action": action,
+        "maturity": spec["maturity"],
+        "production_ready": bool(spec["production_ready"]),
+        "status": status,
+        "confidence": confidence,
+        "rationale": _rationale(result, output, spec),
+        "recommended_actions": _recommended_actions(output),
+        "source_refs": source_refs if source_refs is not None else _source_refs(result, output),
+        "policy_result": policy,
+        "approval_required": _approval_required(result, output, policy),
+        "hitl_required": _hitl_required(result, output),
+        "audit_ref": final_audit_ref or None,
+        "degraded_reasons": degraded_reasons,
+        "blocked_reasons": _dedupe(blocked_reasons),
+        "external_write_confirmation_status": write_status,
+        "external_writes_completed": write_required and write_status == "write_confirmed",
+        "shadow_read_only": workflow_mode in {"shadow", "draft", "internal", "internal_only"},
+        "task_input": task_input or {},
+        "contract_version": CMO_AGENT_CONTRACT_VERSION,
+    }
+    return normalized
+
+
+def contract_has_required_shape(contract_output: dict[str, Any]) -> bool:
+    return all(key in contract_output for key in REQUIRED_AGENT_CONTRACT_KEYS)
+
+
+def _normalize_agent_type(agent_type: str) -> str:
+    return str(agent_type or "").strip().lower()
+
+
+def _result_output(result: Any | None) -> dict[str, Any]:
+    if result is None:
+        return {}
+    if isinstance(result, dict):
+        maybe_output = result.get("output")
+        return maybe_output if isinstance(maybe_output, dict) else result
+    maybe_output = getattr(result, "output", None)
+    return maybe_output if isinstance(maybe_output, dict) else {}
+
+
+def _result_status(result: Any | None, output: dict[str, Any]) -> str:
+    return str(getattr(result, "status", None) or output.get("status") or "unknown")
+
+
+def _result_confidence(result: Any | None, output: dict[str, Any]) -> float:
+    raw = getattr(result, "confidence", None)
+    if raw is None:
+        raw = output.get("confidence", 0.0)
+    try:
+        return max(0.0, min(float(raw), 1.0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _rationale(result: Any | None, output: dict[str, Any], spec: dict[str, Any]) -> str:
+    direct = output.get("rationale") or output.get("explanation")
+    if direct:
+        return str(direct)
+    trace = getattr(result, "reasoning_trace", None) or []
+    if trace:
+        return str(trace[-1])
+    return str(spec.get("blocker") or "CMO agent contract output.")
+
+
+def _recommended_actions(output: dict[str, Any]) -> list[Any]:
+    for key in ("recommended_actions", "actions_taken", "recommendations"):
+        value = output.get(key)
+        if isinstance(value, list):
+            return value
+    return []
+
+
+def _source_refs(result: Any | None, output: dict[str, Any]) -> list[dict[str, Any]]:
+    refs = output.get("source_refs")
+    if isinstance(refs, list):
+        return [ref for ref in refs if isinstance(ref, dict)]
+    tool_calls = getattr(result, "tool_calls", None) or []
+    return [
+        {"kind": "tool_call", "tool_name": call.tool_name, "status": call.status}
+        for call in tool_calls
+    ]
+
+
+def _default_policy_result(
+    action: str,
+    *,
+    write_required: bool,
+    workflow_mode: str,
+) -> dict[str, Any]:
+    if workflow_mode in {"shadow", "draft", "internal", "internal_only"} and write_required:
+        return {
+            "decision": "read_only_only",
+            "reason": "Shadow/draft/internal CMO workflow cannot execute external writes.",
+        }
+    if write_required:
+        return {
+            "decision": "requires_approval",
+            "reason": "Customer-facing marketing write requires approval.",
+        }
+    return {
+        "decision": "allowed",
+        "reason": f"Action {action} is read-only or recommendation-only.",
+    }
+
+
+def _approval_required(
+    result: Any | None,
+    output: dict[str, Any],
+    policy: dict[str, Any],
+) -> bool:
+    decision = str(policy.get("decision") or "")
+    return (
+        bool(output.get("approval_required"))
+        or _hitl_required(result, output)
+        or decision in {"requires_approval", "requires_escalation", "read_only_only"}
+    )
+
+
+def _hitl_required(result: Any | None, output: dict[str, Any]) -> bool:
+    return bool(output.get("hitl_required")) or getattr(result, "status", None) == "hitl_triggered"
+
+
+def _external_write_required(action: str, output: dict[str, Any]) -> bool:
+    if output.get("external_write_confirmation_status") == "not_required":
+        return False
+    if output.get("external_write_required") is True:
+        return True
+    if action in CUSTOMER_FACING_WRITE_ACTIONS:
+        return True
+    return bool(output.get("actions_taken")) and any(
+        str(item.get("action") or "") in {"paused", "scaled_up", "published", "sent"}
+        for item in output.get("actions_taken", [])
+        if isinstance(item, dict)
+    )
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result

--- a/core/marketing/approval_review.py
+++ b/core/marketing/approval_review.py
@@ -1,0 +1,1146 @@
+"""CMO approval review projection and decision request helpers.
+
+CMO-8.3 turns pending marketing HITL rows into an actionable approval-review
+payload. The projection is intentionally storage-free: it gives reviewers the
+preview, diff, impact, risk, policy, escalation, timeout, write-readiness, and
+audit evidence needed to decide safely, while preserving the existing HITL
+decision endpoint as the source of persistence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from core.marketing.approval_timeouts import (
+    approval_type_for_action,
+    evaluate_approval_timeout,
+)
+from core.marketing.decision_audit import build_cmo_decision_audit_package
+from core.marketing.escalation_matrix import evaluate_marketing_escalation
+from core.marketing.policy_manifest import (
+    CUSTOMER_FACING_WRITE_ACTIONS,
+    evaluate_marketing_policy,
+)
+
+CMO_APPROVAL_REVIEW_VERSION = "2026-05-23.cmo-8.3"
+
+APPROVAL_REVIEW_STATUSES = (
+    "pending",
+    "approved",
+    "rejected",
+    "overridden",
+    "timed_out",
+    "escalated",
+    "blocked",
+)
+
+APPROVAL_REVIEW_ACTION_TYPES = (
+    "campaign_launch",
+    "ad_budget_change",
+    "content_publish",
+    "email_send",
+    "landing_page_change",
+    "target_account_list_change",
+    "crisis_public_response",
+    "high_risk_copy_pricing_legal_claim",
+    "workflow_promotion",
+)
+
+REVIEWER_ACTIONS = (
+    "approve",
+    "reject",
+    "override",
+    "escalate",
+    "request_changes",
+    "pause",
+)
+
+ACTION_TYPE_ALIASES = {
+    "ad_campaign_launch": "campaign_launch",
+    "campaign_launch": "campaign_launch",
+    "launch_campaign": "campaign_launch",
+    "create_campaign": "campaign_launch",
+    "activate_campaign": "campaign_launch",
+    "ad_budget_change": "ad_budget_change",
+    "budget_change": "ad_budget_change",
+    "mutate_ad_budget": "ad_budget_change",
+    "update_ad_budget": "ad_budget_change",
+    "spend": "ad_budget_change",
+    "content_publish": "content_publish",
+    "publish": "content_publish",
+    "publish_to_wordpress": "content_publish",
+    "schedule_content": "content_publish",
+    "email_send": "email_send",
+    "send": "email_send",
+    "send_email": "email_send",
+    "send_to_segment": "email_send",
+    "landing_page_change": "landing_page_change",
+    "publish_landing_page": "landing_page_change",
+    "update_landing_page": "landing_page_change",
+    "target_account_list_change": "target_account_list_change",
+    "target_account_change": "target_account_list_change",
+    "update_target_accounts": "target_account_list_change",
+    "crisis_public_response": "crisis_public_response",
+    "crisis_response": "crisis_public_response",
+    "public_response": "crisis_public_response",
+    "high_risk_copy_or_pricing_claims": "high_risk_copy_pricing_legal_claim",
+    "high_risk_copy_pricing_legal_claim": "high_risk_copy_pricing_legal_claim",
+    "high_risk_copy": "high_risk_copy_pricing_legal_claim",
+    "pricing_claim": "high_risk_copy_pricing_legal_claim",
+    "legal_claim": "high_risk_copy_pricing_legal_claim",
+    "workflow_promotion": "workflow_promotion",
+    "promote_workflow": "workflow_promotion",
+}
+
+CUSTOMER_FACING_ACTION_TYPES = {
+    "campaign_launch",
+    "ad_budget_change",
+    "content_publish",
+    "email_send",
+    "landing_page_change",
+    "target_account_list_change",
+    "crisis_public_response",
+    "high_risk_copy_pricing_legal_claim",
+}
+
+
+def build_cmo_approval_review_projection(
+    approval_records: Iterable[Mapping[str, Any]] = (),
+    *,
+    connector_contracts: Iterable[Mapping[str, Any]] = (),
+    policy_projection: Mapping[str, Any] | None = None,
+    escalation_projection: Mapping[str, Any] | None = None,
+    decision_audit_projection: Mapping[str, Any] | None = None,
+    approval_timeout_risk: Mapping[str, Any] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build CMO approval-review cards from HITL/approval records."""
+
+    timestamp = _ensure_aware(now) or datetime.now(UTC)
+    timeout_by_id = _timeout_decisions_by_id(approval_timeout_risk)
+    contracts = _dicts(connector_contracts)
+    reviews = [
+        _build_approval_review(
+            record,
+            connector_contracts=contracts,
+            policy_projection=policy_projection,
+            escalation_projection=escalation_projection,
+            decision_audit_projection=decision_audit_projection,
+            timeout_decision=timeout_by_id.get(_approval_id(record)),
+            now=timestamp,
+        )
+        for record in _dicts(approval_records)
+    ]
+    reviews = sorted(
+        reviews,
+        key=lambda row: (
+            _status_sort(row["status"]),
+            _parse_datetime(row.get("due_at")) or datetime.max.replace(tzinfo=UTC),
+            row["approval_id"],
+        ),
+    )
+    return {
+        "cmo_approval_review_version": CMO_APPROVAL_REVIEW_VERSION,
+        "cmo_approval_reviews": reviews,
+        "cmo_approval_review_summary": summarize_cmo_approval_reviews(reviews),
+    }
+
+
+def summarize_cmo_approval_reviews(
+    reviews: Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    rows = _dicts(reviews)
+    counts = dict.fromkeys(APPROVAL_REVIEW_STATUSES, 0)
+    unsafe_write = 0
+    missing_audit = 0
+    ready = 0
+    for row in rows:
+        status = _normalize_key(row.get("status"))
+        if status in counts:
+            counts[status] += 1
+        write = row.get("external_write_readiness")
+        if isinstance(write, Mapping) and write.get("status") == "unsafe":
+            unsafe_write += 1
+        audit = row.get("audit_evidence")
+        if isinstance(audit, Mapping) and not audit.get("ready"):
+            missing_audit += 1
+        if "approve" in _string_list(row.get("allowed_reviewer_actions")):
+            ready += 1
+
+    first = rows[0] if rows else None
+    readiness = (
+        "blocked"
+        if counts["blocked"] or counts["timed_out"] or unsafe_write or missing_audit
+        else "pending"
+        if counts["pending"] or counts["escalated"]
+        else "ready"
+    )
+    return {
+        "schema_version": CMO_APPROVAL_REVIEW_VERSION,
+        "total": len(rows),
+        "readiness": readiness,
+        "approval_ready": ready,
+        "unsafe_write": unsafe_write,
+        "missing_audit": missing_audit,
+        "needs_action": sum(1 for row in rows if _review_needs_action(row)),
+        "first_approval_review_id": first.get("approval_review_id") if first else None,
+        "next_action_cta": first.get("next_action_cta") if first else _cta("none"),
+        **counts,
+    }
+
+
+def build_cmo_approval_decision_request(
+    review: Mapping[str, Any],
+    *,
+    decision: str,
+    actor_id: str,
+    actor_role: str,
+    reason: str | None = None,
+    replacement_action: Mapping[str, Any] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic request shape for the existing HITL endpoint.
+
+    This helper does not persist a decision. It validates that the requested
+    reviewer action is allowed by the current review projection and returns the
+    shape the approval endpoint or a future approval UI can submit.
+    """
+
+    row = dict(review)
+    normalized_decision = _normalize_key(decision)
+    allowed = set(_string_list(row.get("allowed_reviewer_actions")))
+    if normalized_decision not in REVIEWER_ACTIONS:
+        raise ValueError(f"Unsupported CMO approval decision: {decision}")
+    if normalized_decision not in allowed:
+        raise ValueError(
+            f"Decision {normalized_decision} is not allowed for approval "
+            f"{row.get('approval_id') or 'unknown'}"
+        )
+    if normalized_decision in {"reject", "override", "request_changes", "escalate", "pause"} and not reason:
+        raise ValueError(f"Decision {normalized_decision} requires a reason")
+    if normalized_decision == "override" and not isinstance(replacement_action, Mapping):
+        raise ValueError("Override requires a replacement_action payload")
+
+    timestamp = (_ensure_aware(now) or datetime.now(UTC)).isoformat()
+    request = {
+        "approval_id": row.get("approval_id"),
+        "approval_review_id": row.get("approval_review_id"),
+        "decision": normalized_decision,
+        "actor_type": "user",
+        "actor_id": actor_id,
+        "actor_role": actor_role,
+        "reason": reason,
+        "replacement_action": dict(replacement_action) if isinstance(replacement_action, Mapping) else None,
+        "decided_at": timestamp,
+        "policy_result_ref": row.get("policy_result_ref"),
+        "escalation_result_ref": row.get("escalation_result_ref"),
+        "timeout_result_ref": row.get("timeout_result_ref"),
+        "external_write_readiness_ref": row.get("external_write_readiness", {}).get("readiness_ref")
+        if isinstance(row.get("external_write_readiness"), Mapping)
+        else None,
+        "audit_refs": _unique_strings([*(_string_list(row.get("audit_refs"))), row.get("review_audit_ref")]),
+    }
+    audit = build_cmo_decision_audit_package(
+        {
+            "event_type": "override" if normalized_decision == "override" else row.get("action_type"),
+            "decision_type": normalized_decision,
+            "approval_result": request,
+            "workflow_id": row.get("workflow_id"),
+            "workflow_run_id": row.get("workflow_run_id"),
+            "step_id": row.get("step_id"),
+            "action": row.get("action"),
+            "actor_type": "user",
+            "actor_id": actor_id,
+            "actor_role": actor_role,
+            "rationale": reason,
+            "override": {
+                "actor_id": actor_id,
+                "actor_role": actor_role,
+                "reason": reason,
+                "replacement_action": normalized_decision == "override",
+                "replacement_action_ref": (replacement_action or {}).get("action_id")
+                if isinstance(replacement_action, Mapping)
+                else None,
+            }
+            if normalized_decision == "override"
+            else None,
+            "final_outcome": normalized_decision,
+        },
+        now=_ensure_aware(now),
+    )
+    request["decision_audit"] = audit
+    request["decision_audit_ref"] = audit["audit_reference"]
+    return request
+
+
+def _build_approval_review(
+    approval: Mapping[str, Any],
+    *,
+    connector_contracts: list[dict[str, Any]],
+    policy_projection: Mapping[str, Any] | None,
+    escalation_projection: Mapping[str, Any] | None,
+    decision_audit_projection: Mapping[str, Any] | None,
+    timeout_decision: Mapping[str, Any] | None,
+    now: datetime,
+) -> dict[str, Any]:
+    record = dict(approval)
+    approval_id = _approval_id(record) or _stable_hash("approval", record)
+    action = _normalize_key(
+        record.get("action")
+        or record.get("approval_action")
+        or record.get("blocked_action")
+        or record.get("trigger_type")
+    )
+    action_type = _approval_action_type(action, record)
+    workflow_mode = _normalize_key(record.get("workflow_mode") or record.get("mode") or "active")
+    customer_facing = _customer_facing(record, action, action_type)
+    external_required = _external_write_required(record, action, action_type)
+    policy_result = _policy_result(record, action, workflow_mode, customer_facing, external_required, policy_projection)
+    escalation_result = _escalation_result(record, action, policy_result, escalation_projection, now)
+    timeout_result = dict(timeout_decision) if isinstance(timeout_decision, Mapping) else _timeout_result(record, now)
+    write_readiness = _external_write_readiness(
+        record,
+        action,
+        action_type,
+        connector_contracts,
+        external_required,
+    )
+    audit_evidence = _audit_evidence(record, policy_result, decision_audit_projection, customer_facing)
+    blockers = _blockers(
+        policy_result=policy_result,
+        escalation_result=escalation_result,
+        timeout_result=timeout_result,
+        write_readiness=write_readiness,
+        audit_evidence=audit_evidence,
+        customer_facing=customer_facing,
+    )
+    status = _review_status(record, timeout_result, escalation_result, blockers)
+    allowed_actions = _allowed_actions(status, blockers, policy_result, escalation_result, audit_evidence)
+    review_id = _approval_review_id(approval_id, action, record.get("workflow_run_id"), record.get("step_id"))
+    review_audit = build_cmo_decision_audit_package(
+        {
+            "event_type": action_type,
+            "decision_type": status,
+            "workflow_id": record.get("workflow_id"),
+            "workflow_run_id": record.get("workflow_run_id") or record.get("run_id"),
+            "run_id": record.get("run_id"),
+            "step_id": record.get("step_id"),
+            "agent": record.get("agent_type") or record.get("agent_id"),
+            "action": action,
+            "actor_type": "system",
+            "source_refs": _source_refs(record),
+            "connector_refs": _connector_refs(record, connector_contracts),
+            "policy_result": policy_result,
+            "escalation_result": escalation_result,
+            "timeout_result": timeout_result,
+            "external_write_result": write_readiness,
+            "rationale": _agent_rationale(record),
+            "risk_flags": _risk_flags(record, policy_result, escalation_result, timeout_result, write_readiness),
+            "confidence": _float_or_none(record.get("confidence")),
+            "final_outcome": status,
+        },
+        now=now,
+    )
+    next_action = _next_action(status, blockers, policy_result, escalation_result, timeout_result, write_readiness)
+    return {
+        "approval_review_id": review_id,
+        "approval_id": approval_id,
+        "workflow_id": _string_or_none(record.get("workflow_id")),
+        "workflow_run_id": _string_or_none(record.get("workflow_run_id") or record.get("run_id")),
+        "run_id": _string_or_none(record.get("run_id")),
+        "step_id": _string_or_none(record.get("step_id")),
+        "action": action,
+        "action_type": action_type,
+        "status": status,
+        "requester": _string_or_none(record.get("requester") or record.get("requested_by")),
+        "agent_ref": _string_or_none(record.get("agent_ref") or record.get("agent_type") or record.get("agent_id")),
+        "actor_refs": {
+            "requester": _string_or_none(record.get("requester") or record.get("requested_by")),
+            "agent_id": _string_or_none(record.get("agent_id")),
+            "actor_id": _string_or_none(record.get("actor_id")),
+        },
+        "assigned_approver": _string_or_none(record.get("assigned_approver") or record.get("requested_approver")),
+        "assigned_approver_role": _string_or_none(
+            record.get("assigned_approver_role")
+            or record.get("requested_approver_role")
+            or record.get("assignee_role")
+        ),
+        "created_at": _datetime_string(record.get("created_at"), now),
+        "due_at": _datetime_string(record.get("due_at") or record.get("expires_at"), None),
+        "timeout_state": _timeout_state(timeout_result),
+        "preview_payload": _preview_payload(record),
+        "before_after_diff": _before_after_diff(record),
+        "budget_impact": _budget_impact(record),
+        "audience_impact": _audience_impact(record),
+        "risk_flags": _risk_flags(record, policy_result, escalation_result, timeout_result, write_readiness),
+        "source_refs": _source_refs(record),
+        "connector_refs": _connector_refs(record, connector_contracts),
+        "agent_rationale": _agent_rationale(record),
+        "policy_result": policy_result,
+        "policy_result_ref": _result_ref(policy_result, "policy"),
+        "escalation_result": escalation_result,
+        "escalation_result_ref": _result_ref(escalation_result, "escalation"),
+        "timeout_result": timeout_result,
+        "timeout_result_ref": _result_ref(timeout_result, "timeout"),
+        "external_write_readiness": write_readiness,
+        "external_write_result_ref": write_readiness.get("readiness_ref"),
+        "audit_evidence": audit_evidence,
+        "audit_refs": audit_evidence["audit_refs"],
+        "review_audit_ref": review_audit["audit_reference"],
+        "review_audit": review_audit,
+        "rollback_stop_plan": _rollback_stop_plan(record, action_type),
+        "allowed_reviewer_actions": allowed_actions,
+        "blocked_reasons": blockers,
+        "related_work_queue_item_ids": [_work_queue_item_id(approval_id)],
+        "next_action_cta": _cta(next_action),
+        "evaluated_at": now.isoformat(),
+    }
+
+
+def _policy_result(
+    record: Mapping[str, Any],
+    action: str,
+    workflow_mode: str,
+    customer_facing: bool,
+    external_required: bool,
+    policy_projection: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    existing = record.get("marketing_policy_decision") or record.get("policy_result") or record.get("policy_decision")
+    if isinstance(existing, Mapping):
+        return dict(existing)
+    manifest = None
+    if isinstance(policy_projection, Mapping):
+        candidate = policy_projection.get("marketing_policy_manifest")
+        if isinstance(candidate, Mapping):
+            manifest = candidate
+    return evaluate_marketing_policy(
+        {
+            **dict(record),
+            "action": action,
+            "workflow_mode": workflow_mode,
+            "workflow_id": record.get("workflow_id"),
+            "external_write_required": external_required,
+            "customer_facing": customer_facing,
+        },
+        manifest=manifest,
+        use_default=manifest is None,
+    )
+
+
+def _escalation_result(
+    record: Mapping[str, Any],
+    action: str,
+    policy_result: Mapping[str, Any],
+    escalation_projection: Mapping[str, Any] | None,
+    now: datetime,
+) -> dict[str, Any]:
+    existing = record.get("escalation_decision") or record.get("escalation_result")
+    if isinstance(existing, Mapping):
+        return dict(existing)
+    nested = policy_result.get("escalation_decision")
+    if isinstance(nested, Mapping) and nested.get("decision") != "no_escalation":
+        return dict(nested)
+    matrix = None
+    if isinstance(escalation_projection, Mapping):
+        candidate = escalation_projection.get("marketing_escalation_matrix")
+        if isinstance(candidate, Mapping):
+            matrix = candidate
+    return evaluate_marketing_escalation(
+        {
+            **dict(record),
+            "action": action,
+            "workflow_id": record.get("workflow_id"),
+            "workflow_run_id": record.get("workflow_run_id") or record.get("run_id"),
+            "step_id": record.get("step_id"),
+            "trigger_type": record.get("escalation_trigger_type") or record.get("trigger_type"),
+            "external_write_required": _truthy(record.get("external_write_required")),
+            "reason": policy_result.get("reason") or record.get("reason"),
+        },
+        matrix=matrix,
+        use_default=matrix is None,
+        now=now,
+    )
+
+
+def _timeout_result(record: Mapping[str, Any], now: datetime) -> dict[str, Any]:
+    existing = record.get("approval_timeout_decision") or record.get("timeout_result")
+    if isinstance(existing, Mapping):
+        return dict(existing)
+    return evaluate_approval_timeout(dict(record), policy_source=dict(record), now=now)
+
+
+def _external_write_readiness(
+    record: Mapping[str, Any],
+    action: str,
+    action_type: str,
+    connector_contracts: list[dict[str, Any]],
+    external_required: bool,
+) -> dict[str, Any]:
+    if not external_required:
+        return {
+            "status": "not_required",
+            "write_safe": True,
+            "reason": "Approval is not for an external/customer-facing write.",
+            "connector_keys": [],
+            "readiness_ref": _stable_ref("approval_write_readiness", action, "not_required"),
+            "next_action_cta": "none",
+        }
+
+    connector_keys = _connector_keys(record)
+    if not connector_keys:
+        return {
+            "status": "unsafe",
+            "write_safe": False,
+            "reason": "External/customer-facing approval has no connector key or connector ref.",
+            "connector_keys": [],
+            "readiness_ref": _stable_ref("approval_write_readiness", action, "missing_connector"),
+            "next_action_cta": "configure_connector_contract",
+        }
+
+    unsafe: list[str] = []
+    checked: list[dict[str, Any]] = []
+    for key in connector_keys:
+        row = _contract_for_key(connector_contracts, key)
+        if row is None:
+            unsafe.append(f"{key}: connector contract missing")
+            checked.append({"connector_key": key, "write_status": "missing"})
+            continue
+        write_safe = bool(row.get("write_safe", row.get("write_ready", False)))
+        write_status = _normalize_key(row.get("write_status") or row.get("contract_state"))
+        missing_scopes = _string_list(row.get("missing_write_scopes"))
+        blocks_write = bool(row.get("blocks_external_writes"))
+        mock_only = bool(row.get("mock_or_test_double"))
+        if (
+            not write_safe
+            or write_status not in {"ready", "write_confirmed", ""}
+            or missing_scopes
+            or blocks_write
+            or mock_only
+        ):
+            unsafe.append(
+                f"{key}: write status {write_status or 'unknown'}"
+                + (f", missing scopes {', '.join(missing_scopes)}" if missing_scopes else "")
+            )
+        checked.append(
+            {
+                "connector_key": key,
+                "write_status": write_status or "unknown",
+                "write_safe": write_safe,
+                "missing_write_scopes": missing_scopes,
+                "mock_or_test_double": mock_only,
+            }
+        )
+
+    if unsafe:
+        return {
+            "status": "unsafe",
+            "write_safe": False,
+            "reason": "; ".join(unsafe),
+            "connector_keys": connector_keys,
+            "checked_contracts": checked,
+            "readiness_ref": _stable_ref("approval_write_readiness", action_type, *unsafe),
+            "next_action_cta": "fix_connector_write_readiness",
+        }
+    return {
+        "status": "safe",
+        "write_safe": True,
+        "reason": (
+            "Required connector contracts are write-safe; final workflow "
+            "completion still requires CMO-5.3 write confirmation."
+        ),
+        "connector_keys": connector_keys,
+        "checked_contracts": checked,
+        "readiness_ref": _stable_ref("approval_write_readiness", action_type, *connector_keys),
+        "next_action_cta": "none",
+    }
+
+
+def _audit_evidence(
+    record: Mapping[str, Any],
+    policy_result: Mapping[str, Any],
+    decision_audit_projection: Mapping[str, Any] | None,
+    customer_facing: bool,
+) -> dict[str, Any]:
+    audit_refs = _audit_refs(record)
+    disabled = _truthy(record.get("decision_audit_disabled") or record.get("audit_package_disabled"))
+    projection_summary = (
+        decision_audit_projection.get("marketing_decision_audit_summary")
+        if isinstance(decision_audit_projection, Mapping)
+        else None
+    )
+    projection_ready = not (
+        isinstance(projection_summary, Mapping)
+        and _normalize_key(projection_summary.get("status")) == "missing_audit_evidence"
+    )
+    required = _string_list(policy_result.get("required_audit_evidence")) or (
+        ["approval_record", "policy_decision", "workflow_run", "actor"] if customer_facing else []
+    )
+    ready = bool(audit_refs) and projection_ready and not disabled
+    missing = [] if ready else required or ["audit_reference"]
+    return {
+        "ready": ready,
+        "required_evidence": required,
+        "missing_evidence": missing,
+        "audit_refs": audit_refs,
+        "projection_ready": projection_ready,
+        "reason": None if ready else "Required CMO decision-audit evidence is missing.",
+    }
+
+
+def _blockers(
+    *,
+    policy_result: Mapping[str, Any],
+    escalation_result: Mapping[str, Any],
+    timeout_result: Mapping[str, Any],
+    write_readiness: Mapping[str, Any],
+    audit_evidence: Mapping[str, Any],
+    customer_facing: bool,
+) -> list[str]:
+    blockers: list[str] = []
+    policy_decision = _normalize_key(policy_result.get("decision"))
+    if policy_decision == "missing_policy":
+        blockers.append("Marketing policy result is missing for this approval.")
+    elif policy_decision in {"blocked", "read_only_only"}:
+        blockers.append(str(policy_result.get("reason") or "Marketing policy blocks this approval."))
+
+    if policy_decision == "requires_escalation" and not _truthy(policy_result.get("escalation_satisfied")):
+        if not escalation_result.get("route_found"):
+            blockers.append("Required escalation route is missing for this approval.")
+        else:
+            blockers.append("Policy requires escalation before approval can proceed.")
+
+    if timeout_result.get("timed_out"):
+        outcome = _normalize_key(timeout_result.get("outcome"))
+        blockers.append(
+            "Approval timed out and requires manual resolution."
+            if outcome == "require_manual_resolution"
+            else "Approval timed out; reviewer must resolve timeout outcome before approving."
+        )
+
+    if customer_facing and write_readiness.get("write_safe") is False:
+        blockers.append(str(write_readiness.get("reason") or "Connector/write readiness is unsafe."))
+
+    if customer_facing and not audit_evidence.get("ready"):
+        blockers.append(str(audit_evidence.get("reason") or "Required audit evidence is missing."))
+
+    return _unique_strings(blockers)
+
+
+def _review_status(
+    record: Mapping[str, Any],
+    timeout_result: Mapping[str, Any],
+    escalation_result: Mapping[str, Any],
+    blockers: list[str],
+) -> str:
+    source_status = _normalize_key(record.get("status") or "pending")
+    decision = _normalize_key(record.get("decision"))
+    if source_status in {"approved", "rejected", "overridden", "timed_out", "escalated", "blocked"}:
+        return source_status
+    if source_status in {"decided", "completed"}:
+        if decision in {"reject", "rejected"}:
+            return "rejected"
+        if decision in {"override", "overridden"}:
+            return "overridden"
+        return "approved"
+    if timeout_result.get("timed_out"):
+        return "timed_out"
+    if blockers:
+        return "blocked"
+    return "pending"
+
+
+def _allowed_actions(
+    status: str,
+    blockers: list[str],
+    policy_result: Mapping[str, Any],
+    escalation_result: Mapping[str, Any],
+    audit_evidence: Mapping[str, Any],
+) -> list[str]:
+    if status in {"approved", "rejected", "overridden"}:
+        return []
+    if status == "timed_out":
+        actions = ["reject", "request_changes", "pause"]
+        if escalation_result.get("route_found"):
+            actions.insert(0, "escalate")
+        return actions
+    if blockers:
+        actions = ["reject", "request_changes", "pause"]
+        if escalation_result.get("route_found"):
+            actions.insert(0, "escalate")
+        if audit_evidence.get("ready") and _normalize_key(policy_result.get("decision")) not in {
+            "missing_policy",
+            "blocked",
+            "read_only_only",
+            "requires_escalation",
+        }:
+            actions.insert(0, "override")
+        return _unique_strings(actions)
+
+    actions = ["approve", "reject", "override", "request_changes", "pause"]
+    if _normalize_key(policy_result.get("decision")) == "requires_escalation":
+        actions = [action for action in actions if action != "approve"]
+    if escalation_result.get("route_found") and _normalize_key(escalation_result.get("decision")) != "no_escalation":
+        actions.insert(0, "escalate")
+    return _unique_strings(actions)
+
+
+def _next_action(
+    status: str,
+    blockers: list[str],
+    policy_result: Mapping[str, Any],
+    escalation_result: Mapping[str, Any],
+    timeout_result: Mapping[str, Any],
+    write_readiness: Mapping[str, Any],
+) -> str:
+    text = " ".join(blockers).lower()
+    if status == "timed_out" or timeout_result.get("timed_out"):
+        return str(timeout_result.get("next_action_cta") or "resolve_overdue_approvals")
+    if "policy" in text:
+        return str(policy_result.get("next_action_cta") or "configure_marketing_policy_manifest")
+    if "connector" in text or "write" in text:
+        return str(write_readiness.get("next_action_cta") or "fix_connector_write_readiness")
+    if "audit" in text:
+        return "configure_decision_audit_package"
+    if "escalation" in text:
+        return str(escalation_result.get("next_action_cta") or "review_escalation")
+    if status == "escalated":
+        return str(escalation_result.get("next_action_cta") or "review_escalation")
+    return "review_pending_approval"
+
+
+def _approval_action_type(action: str, record: Mapping[str, Any]) -> str:
+    explicit = _normalize_key(record.get("action_type") or record.get("approval_review_action_type"))
+    if explicit in APPROVAL_REVIEW_ACTION_TYPES:
+        return explicit
+    approval_type = _normalize_key(record.get("approval_type")) or approval_type_for_action(action, dict(record))
+    for value in (approval_type, action):
+        normalized = _normalize_key(value)
+        if normalized in ACTION_TYPE_ALIASES:
+            return ACTION_TYPE_ALIASES[normalized]
+    if _truthy(record.get("workflow_promotion")) or action == "promote_workflow":
+        return "workflow_promotion"
+    return ACTION_TYPE_ALIASES.get(action, "campaign_launch")
+
+
+def _customer_facing(record: Mapping[str, Any], action: str, action_type: str) -> bool:
+    if "customer_facing" in record:
+        return _truthy(record.get("customer_facing"))
+    return action in CUSTOMER_FACING_WRITE_ACTIONS or action_type in CUSTOMER_FACING_ACTION_TYPES
+
+
+def _external_write_required(record: Mapping[str, Any], action: str, action_type: str) -> bool:
+    if "external_write_required" in record or "requires_external_write" in record:
+        return _truthy(record.get("external_write_required") or record.get("requires_external_write"))
+    if action_type == "workflow_promotion":
+        return False
+    return action in CUSTOMER_FACING_WRITE_ACTIONS or action_type in CUSTOMER_FACING_ACTION_TYPES
+
+
+def _preview_payload(record: Mapping[str, Any]) -> dict[str, Any]:
+    for key in ("preview_payload", "preview", "proposed_payload", "payload"):
+        value = record.get(key)
+        if isinstance(value, Mapping):
+            return dict(value)
+    return {
+        "summary": (
+            _string_or_none(record.get("title") or record.get("summary"))
+            or "Approval preview was not supplied."
+        ),
+        "payload_status": "missing_preview_payload",
+    }
+
+
+def _before_after_diff(record: Mapping[str, Any]) -> dict[str, Any]:
+    for key in ("before_after_diff", "diff", "diff_summary", "change_summary"):
+        value = record.get(key)
+        if isinstance(value, Mapping):
+            return dict(value)
+        if _string_or_none(value):
+            return {"summary": str(value)}
+    return {"summary": "No before/after diff was supplied."}
+
+
+def _budget_impact(record: Mapping[str, Any]) -> dict[str, Any]:
+    value = record.get("budget_impact")
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {
+        "amount": _float_or_none(
+            record.get("budget_delta")
+            or record.get("budget_increase")
+            or record.get("budget_amount")
+            or record.get("daily_budget")
+        ),
+        "currency": _string_or_none(record.get("currency")) or "USD",
+        "summary": _string_or_none(record.get("budget_impact_summary")) or "No budget impact supplied.",
+    }
+
+
+def _audience_impact(record: Mapping[str, Any]) -> dict[str, Any]:
+    value = record.get("audience_impact") or record.get("list_impact")
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {
+        "estimated_recipients": _float_or_none(
+            record.get("audience_size")
+            or record.get("list_size")
+            or record.get("recipient_count")
+            or record.get("estimated_recipients")
+        ),
+        "summary": _string_or_none(record.get("audience_impact_summary")) or "No audience/list impact supplied.",
+    }
+
+
+def _risk_flags(
+    record: Mapping[str, Any],
+    policy_result: Mapping[str, Any],
+    escalation_result: Mapping[str, Any],
+    timeout_result: Mapping[str, Any],
+    write_readiness: Mapping[str, Any],
+) -> list[str]:
+    flags = _string_list(
+        record.get("brand_legal_risk_flags")
+        or record.get("risk_flags")
+        or record.get("risks")
+    )
+    for key in ("brand_risk", "legal_risk", "pricing_claim", "high_risk_copy", "crisis_response"):
+        if _truthy(record.get(key)):
+            flags.append(key)
+    for value in (
+        policy_result.get("decision"),
+        escalation_result.get("trigger_type"),
+        timeout_result.get("outcome") if timeout_result.get("timed_out") else None,
+        write_readiness.get("status") if write_readiness.get("status") == "unsafe" else None,
+    ):
+        if _string_or_none(value):
+            flags.append(str(value))
+    return _unique_strings(flags)
+
+
+def _source_refs(record: Mapping[str, Any]) -> list[dict[str, Any]]:
+    refs: list[dict[str, Any]] = []
+    for key in ("source_refs", "source_references", "sources"):
+        for item in _list_from_value(record.get(key)):
+            refs.append(dict(item) if isinstance(item, Mapping) else {"ref": str(item)})
+    return _unique_refs(refs)
+
+
+def _connector_refs(
+    record: Mapping[str, Any],
+    connector_contracts: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    refs: list[dict[str, Any]] = []
+    for item in _list_from_value(record.get("connector_refs") or record.get("connector_references")):
+        refs.append(dict(item) if isinstance(item, Mapping) else {"connector_key": str(item)})
+    for key in _connector_keys(record):
+        contract = _contract_for_key(connector_contracts, key)
+        refs.append(
+            {
+                "connector_key": key,
+                "type": "connector_contract",
+                "write_status": (contract or {}).get("write_status"),
+                "read_status": (contract or {}).get("read_status"),
+                "contract_state": (contract or {}).get("contract_state"),
+            }
+        )
+    return _unique_refs(refs)
+
+
+def _connector_keys(record: Mapping[str, Any]) -> list[str]:
+    keys = _string_list(
+        record.get("connector_keys")
+        or record.get("required_connector_keys")
+        or record.get("connector_key")
+        or record.get("connector")
+    )
+    for ref in _list_from_value(record.get("connector_refs") or record.get("connector_references")):
+        if isinstance(ref, Mapping):
+            keys.extend(_string_list(ref.get("connector_key") or ref.get("key")))
+    return _unique_strings(keys)
+
+
+def _contract_for_key(
+    connector_contracts: list[dict[str, Any]],
+    connector_key: str,
+) -> dict[str, Any] | None:
+    normalized = _normalize_key(connector_key)
+    for row in connector_contracts:
+        if _normalize_key(row.get("connector_key")) == normalized:
+            return row
+    return None
+
+
+def _agent_rationale(record: Mapping[str, Any]) -> str:
+    return _string_or_none(
+        record.get("agent_rationale")
+        or record.get("rationale")
+        or record.get("recommendation_reason")
+        or record.get("reason")
+    ) or "Agent rationale was not supplied."
+
+
+def _rollback_stop_plan(record: Mapping[str, Any], action_type: str) -> dict[str, Any]:
+    value = record.get("rollback_stop_plan") or record.get("rollback_plan") or record.get("stop_plan")
+    if isinstance(value, Mapping):
+        return dict(value)
+    defaults = {
+        "campaign_launch": "Pause campaigns, revert budget changes, archive launch assets, and notify Marketing Ops.",
+        "ad_budget_change": (
+            "Restore previous budget cap and pause further spend mutations "
+            "until reconciliation completes."
+        ),
+        "content_publish": "Unpublish or revert the CMS revision and keep the draft for legal/brand review.",
+        "email_send": "Cancel scheduled sends, suppress affected segment, and notify lifecycle marketing.",
+        "landing_page_change": "Rollback to the previous landing-page revision and invalidate published cache.",
+        "target_account_list_change": "Restore the previous target account list and halt downstream ABM activation.",
+        "crisis_public_response": (
+            "Pause public response, escalate to comms/legal/CEO, and keep "
+            "internal holding statement only."
+        ),
+        "high_risk_copy_pricing_legal_claim": "Block publish/send and route replacement copy to legal/compliance.",
+        "workflow_promotion": "Keep workflow in shadow or pause mode and revoke active external-write permissions.",
+    }
+    return {
+        "summary": defaults.get(action_type, "Pause workflow, stop external writes, and escalate to CMO."),
+        "provided_by": "default_cmo_safety_plan",
+    }
+
+
+def _timeout_state(timeout_result: Mapping[str, Any]) -> str:
+    if timeout_result.get("timed_out"):
+        return "timed_out"
+    return _normalize_key(timeout_result.get("status")) or "pending"
+
+
+def _audit_refs(record: Mapping[str, Any]) -> list[str]:
+    refs: list[Any] = [
+        record.get("audit_ref"),
+        record.get("audit_reference"),
+        record.get("decision_audit_ref"),
+        record.get("approval_audit_ref"),
+    ]
+    for key in ("audit_refs", "decision_audit_refs", "approval_audit_refs"):
+        refs.extend(_list_from_value(record.get(key)))
+    for key in ("audit_evidence", "decision_audit", "audit_package"):
+        value = record.get(key)
+        if isinstance(value, Mapping):
+            refs.extend([value.get("audit_reference"), value.get("decision_audit_ref"), value.get("audit_id")])
+    return _unique_strings(_strings(refs))
+
+
+def _timeout_decisions_by_id(
+    approval_timeout_risk: Mapping[str, Any] | None,
+) -> dict[str, dict[str, Any]]:
+    risk = approval_timeout_risk if isinstance(approval_timeout_risk, Mapping) else {}
+    result: dict[str, dict[str, Any]] = {}
+    for decision in _dicts(risk.get("approval_timeout_decisions")):
+        approval_id = _approval_id(decision)
+        if approval_id:
+            result[approval_id] = decision
+    return result
+
+
+def _result_ref(result: Mapping[str, Any] | None, prefix: str) -> str | None:
+    if not isinstance(result, Mapping) or not result:
+        return None
+    explicit = _string_or_none(
+        result.get("audit_reference")
+        or result.get("decision_audit_ref")
+        or result.get("audit_id")
+    )
+    if explicit:
+        return explicit
+    return _stable_ref(prefix, result)
+
+
+def _cta(action_key: Any) -> dict[str, str]:
+    key = _normalize_key(action_key) or "none"
+    return {
+        "action_key": key,
+        "label": CTA_LABELS.get(key, key.replace("_", " ").title()),
+        "path": CTA_PATHS.get(key, "/dashboard/approvals"),
+    }
+
+
+def _review_needs_action(row: Mapping[str, Any]) -> bool:
+    cta = row.get("next_action_cta")
+    if isinstance(cta, Mapping):
+        return _normalize_key(cta.get("action_key")) != "none"
+    return _normalize_key(cta) not in {"", "none"}
+
+
+CTA_LABELS = {
+    "none": "No Action",
+    "review_pending_approval": "Review Approval",
+    "resolve_overdue_approvals": "Resolve Approval",
+    "review_escalated_approval": "Review Escalation",
+    "review_escalation": "Review Escalation",
+    "configure_marketing_policy_manifest": "Configure Policy",
+    "configure_decision_audit_package": "Configure Audit",
+    "fix_connector_write_readiness": "Fix Write Readiness",
+    "configure_connector_contract": "Configure Connector",
+    "request_legal_or_compliance_review": "Request Legal Review",
+    "request_budget_approval": "Review Budget",
+    "request_marketing_approval": "Review Approval",
+}
+
+CTA_PATHS = {
+    "none": "/dashboard/cmo",
+    "review_pending_approval": "/dashboard/approvals",
+    "resolve_overdue_approvals": "/dashboard/approvals",
+    "review_escalated_approval": "/dashboard/approvals",
+    "review_escalation": "/dashboard/approvals",
+    "configure_marketing_policy_manifest": "/dashboard/settings",
+    "configure_decision_audit_package": "/dashboard/audit",
+    "fix_connector_write_readiness": "/dashboard/connectors",
+    "configure_connector_contract": "/dashboard/connectors",
+    "request_legal_or_compliance_review": "/dashboard/approvals",
+    "request_budget_approval": "/dashboard/approvals",
+    "request_marketing_approval": "/dashboard/approvals",
+}
+
+
+def _approval_id(record: Mapping[str, Any]) -> str | None:
+    return _string_or_none(record.get("approval_id") or record.get("id") or record.get("hitl_id"))
+
+
+def _approval_review_id(
+    approval_id: str,
+    action: str,
+    workflow_run_id: Any,
+    step_id: Any,
+) -> str:
+    source = "|".join(
+        str(part or "")
+        for part in (approval_id, action, workflow_run_id, step_id)
+    )
+    return f"cmo_approval_review_{hashlib.sha256(source.encode()).hexdigest()[:20]}"
+
+
+def _work_queue_item_id(approval_id: str) -> str:
+    return f"cmo_wq_{hashlib.sha256(f'approval:{approval_id}'.encode()).hexdigest()[:20]}"
+
+
+def _stable_ref(prefix: str, *parts: Any) -> str:
+    encoded = "|".join(str(part or "") for part in parts)
+    return f"{prefix}:{hashlib.sha256(encoded.encode()).hexdigest()[:20]}"
+
+
+def _stable_hash(prefix: str, value: Mapping[str, Any]) -> str:
+    return f"{prefix}_{hashlib.sha256(repr(sorted(value.items())).encode()).hexdigest()[:16]}"
+
+
+def _status_sort(status: str) -> int:
+    return {
+        "blocked": 0,
+        "timed_out": 1,
+        "escalated": 2,
+        "pending": 3,
+        "overridden": 4,
+        "rejected": 5,
+        "approved": 6,
+    }.get(status, 9)
+
+
+def _datetime_string(value: Any, fallback: datetime | None) -> str | None:
+    parsed = _parse_datetime(value)
+    if parsed is not None:
+        return parsed.isoformat()
+    return fallback.isoformat() if fallback is not None else None
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return _ensure_aware(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return _ensure_aware(datetime.fromisoformat(value.replace("Z", "+00:00")))
+        except ValueError:
+            return None
+    return None
+
+
+def _ensure_aware(value: Any) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value in {None, ""}:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _dicts(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, Mapping):
+        return [dict(value)]
+    if isinstance(value, str) or value is None:
+        return []
+    if isinstance(value, Iterable):
+        return [dict(item) for item in value if isinstance(item, Mapping)]
+    return []
+
+
+def _list_from_value(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, Iterable) and not isinstance(value, Mapping):
+        return list(value)
+    return [value]
+
+
+def _strings(values: Iterable[Any]) -> list[str]:
+    return [str(value) for value in values if _string_or_none(value)]
+
+
+def _string_list(value: Any) -> list[str]:
+    return _strings(_list_from_value(value))
+
+
+def _unique_strings(values: Iterable[Any]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in _strings(values):
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _unique_refs(values: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    result: list[dict[str, Any]] = []
+    for value in values:
+        encoded = repr(sorted(dict(value).items()))
+        if encoded in seen:
+            continue
+        seen.add(encoded)
+        result.append(dict(value))
+    return result
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _string_or_none(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)

--- a/core/marketing/approval_timeouts.py
+++ b/core/marketing/approval_timeouts.py
@@ -1,0 +1,1011 @@
+"""CMO approval timeout policy and audit projections.
+
+CMO-5.4 keeps approval-sensitive marketing work from hanging indefinitely or
+continuing unsafely after an approval SLA expires. The module is intentionally
+vendor-neutral: it evaluates approval records and workflow metadata, emits
+auditable timeout decisions, and lets callers fail closed before customer-
+facing writes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from core.marketing.decision_audit import build_approval_timeout_decision_audit
+from core.marketing.escalation_matrix import evaluate_marketing_escalation
+from core.marketing.policy_manifest import evaluate_marketing_policy
+
+APPROVAL_TIMEOUT_OUTCOMES = (
+    "auto_cancel",
+    "auto_escalate",
+    "continue_read_only",
+    "pause_workflow",
+    "require_manual_resolution",
+)
+
+APPROVAL_SENSITIVE_TYPES = (
+    "ad_campaign_launch",
+    "ad_budget_change",
+    "email_send",
+    "content_publish",
+    "landing_page_change",
+    "target_account_list_change",
+    "crisis_public_response",
+    "social_post_target_behavior",
+    "high_risk_copy_or_pricing_claims",
+    "crm_lifecycle_update",
+    "crm_segment_update",
+    "crm_bulk_update",
+)
+
+ACTION_APPROVAL_TYPES: dict[str, str] = {
+    "activate_campaign": "ad_campaign_launch",
+    "create_abm_campaign": "ad_campaign_launch",
+    "create_campaign": "ad_campaign_launch",
+    "create_linkedin_campaign": "ad_campaign_launch",
+    "launch_abm_campaign": "ad_campaign_launch",
+    "launch_campaign": "ad_campaign_launch",
+    "setup_google_campaign": "ad_campaign_launch",
+    "setup_meta_campaign": "ad_campaign_launch",
+    "mutate_ad_budget": "ad_budget_change",
+    "pause_campaign": "ad_budget_change",
+    "set_abm_budget": "ad_budget_change",
+    "spend": "ad_budget_change",
+    "update_ad_budget": "ad_budget_change",
+    "add_to_drip": "email_send",
+    "send": "email_send",
+    "send_email": "email_send",
+    "send_to_segment": "email_send",
+    "send_winner": "email_send",
+    "start_nurture_sequence": "email_send",
+    "publish": "content_publish",
+    "publish_seo_change": "landing_page_change",
+    "publish_post": "social_post_target_behavior",
+    "publish_to_wordpress": "content_publish",
+    "schedule_content": "content_publish",
+    "apply_redirect": "landing_page_change",
+    "submit_url_to_index": "landing_page_change",
+    "update_canonical_tag": "landing_page_change",
+    "update_landing_page": "landing_page_change",
+    "update_page_metadata": "landing_page_change",
+    "update_robots_txt": "landing_page_change",
+    "update_sitemap": "landing_page_change",
+    "publish_landing_page": "landing_page_change",
+    "landing_page_change": "landing_page_change",
+    "change_target_accounts": "target_account_list_change",
+    "query_target_accounts": "target_account_list_change",
+    "sync_target_accounts": "target_account_list_change",
+    "target_account_list_change": "target_account_list_change",
+    "update_target_accounts": "target_account_list_change",
+    "promote_lifecycle_stage": "crm_lifecycle_update",
+    "update_lifecycle_stage": "crm_lifecycle_update",
+    "update_lead_scores": "crm_lifecycle_update",
+    "change_segment_membership": "crm_segment_update",
+    "update_segment_membership": "crm_segment_update",
+    "bulk_crm_update": "crm_bulk_update",
+    "update_crm": "crm_bulk_update",
+    "crisis_response": "crisis_public_response",
+    "detect_crisis": "crisis_public_response",
+    "publish_brand_response": "crisis_public_response",
+    "publish_competitive_response": "crisis_public_response",
+    "public_response": "crisis_public_response",
+    "schedule_campaign_posts": "social_post_target_behavior",
+    "schedule_content_promotion": "social_post_target_behavior",
+    "schedule_post": "social_post_target_behavior",
+    "reply_to_mention": "social_post_target_behavior",
+    "social_post_target_behavior": "social_post_target_behavior",
+    "brand_claim": "high_risk_copy_or_pricing_claims",
+    "claims_review": "high_risk_copy_or_pricing_claims",
+    "comparative_claim": "high_risk_copy_or_pricing_claims",
+    "high_risk_copy": "high_risk_copy_or_pricing_claims",
+    "legal_claim": "high_risk_copy_or_pricing_claims",
+    "pricing_claim": "high_risk_copy_or_pricing_claims",
+    "launch_competitive_campaign": "ad_campaign_launch",
+}
+
+
+@dataclass(frozen=True)
+class ApprovalTimeoutPolicy:
+    approval_type: str
+    actions: tuple[str, ...]
+    default_sla: timedelta
+    escalation_role: str
+    timeout_outcome: str
+    external_writes_allowed_after_timeout: bool
+    notification_event_code: str
+    audit_event_code: str
+    safe_fallback_cta: str
+    safe_fallback_message: str
+    preapproved_after_timeout: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "approval_type": self.approval_type,
+            "actions": list(self.actions),
+            "default_sla_seconds": int(self.default_sla.total_seconds()),
+            "default_sla_hours": self.default_sla.total_seconds() / 3600,
+            "escalation_role": self.escalation_role,
+            "timeout_outcome": self.timeout_outcome,
+            "external_writes_allowed_after_timeout": self.external_writes_allowed_after_timeout,
+            "preapproved_after_timeout": self.preapproved_after_timeout,
+            "notification_event_code": self.notification_event_code,
+            "audit_event_code": self.audit_event_code,
+            "safe_fallback_cta": self.safe_fallback_cta,
+            "safe_fallback_message": self.safe_fallback_message,
+        }
+
+
+DEFAULT_APPROVAL_TIMEOUT_POLICIES: dict[str, ApprovalTimeoutPolicy] = {
+    "ad_campaign_launch": ApprovalTimeoutPolicy(
+        approval_type="ad_campaign_launch",
+        actions=(
+            "activate_campaign",
+            "create_abm_campaign",
+            "create_campaign",
+            "launch_abm_campaign",
+            "launch_campaign",
+            "launch_competitive_campaign",
+        ),
+        default_sla=timedelta(hours=4),
+        escalation_role="cmo",
+        timeout_outcome="auto_cancel",
+        external_writes_allowed_after_timeout=False,
+        notification_event_code="cmo_approval_timeout_campaign_launch",
+        audit_event_code="cmo_approval_timeout_auto_cancel",
+        safe_fallback_cta="restart_campaign_launch_approval",
+        safe_fallback_message="Campaign launch was cancelled because approval expired.",
+    ),
+    "ad_budget_change": ApprovalTimeoutPolicy(
+        approval_type="ad_budget_change",
+        actions=("mutate_ad_budget", "pause_campaign", "set_abm_budget", "update_ad_budget"),
+        default_sla=timedelta(hours=2),
+        escalation_role="cmo",
+        timeout_outcome="auto_escalate",
+        external_writes_allowed_after_timeout=False,
+        notification_event_code="cmo_approval_timeout_ad_budget_change",
+        audit_event_code="cmo_approval_timeout_auto_escalate",
+        safe_fallback_cta="review_budget_change_escalation",
+        safe_fallback_message="Budget change was escalated and external writes remain blocked.",
+    ),
+    "email_send": ApprovalTimeoutPolicy(
+        approval_type="email_send",
+        actions=("send", "send_email", "send_to_segment", "send_winner"),
+        default_sla=timedelta(hours=2),
+        escalation_role="cmo",
+        timeout_outcome="pause_workflow",
+        external_writes_allowed_after_timeout=False,
+        notification_event_code="cmo_approval_timeout_email_send",
+        audit_event_code="cmo_approval_timeout_pause_workflow",
+        safe_fallback_cta="reschedule_or_cancel_email",
+        safe_fallback_message="Email send was paused because approval expired.",
+    ),
+    "content_publish": ApprovalTimeoutPolicy(
+        approval_type="content_publish",
+        actions=("publish", "publish_to_wordpress", "schedule_content"),
+        default_sla=timedelta(hours=4),
+        escalation_role="content_lead",
+        timeout_outcome="pause_workflow",
+        external_writes_allowed_after_timeout=False,
+        notification_event_code="cmo_approval_timeout_content_publish",
+        audit_event_code="cmo_approval_timeout_pause_workflow",
+        safe_fallback_cta="review_content_publish_approval",
+        safe_fallback_message="Content publishing was paused because approval expired.",
+    ),
+    "landing_page_change": ApprovalTimeoutPolicy(
+        approval_type="landing_page_change",
+        actions=(
+            "apply_redirect",
+            "landing_page_change",
+            "publish_landing_page",
+            "publish_seo_change",
+            "submit_url_to_index",
+            "update_canonical_tag",
+            "update_landing_page",
+            "update_page_metadata",
+            "update_robots_txt",
+            "update_sitemap",
+        ),
+        default_sla=timedelta(hours=4),
+        escalation_role="growth_lead",
+        timeout_outcome="require_manual_resolution",
+        external_writes_allowed_after_timeout=False,
+        notification_event_code="cmo_approval_timeout_landing_page_change",
+        audit_event_code="cmo_approval_timeout_manual_resolution",
+        safe_fallback_cta="resolve_landing_page_change_manually",
+        safe_fallback_message="Landing-page change is blocked until a human resolves the approval.",
+    ),
+    "target_account_list_change": ApprovalTimeoutPolicy(
+        approval_type="target_account_list_change",
+        actions=(
+            "query_target_accounts",
+            "sync_target_accounts",
+            "target_account_list_change",
+            "update_target_accounts",
+        ),
+        default_sla=timedelta(hours=8),
+        escalation_role="revops_lead",
+        timeout_outcome="require_manual_resolution",
+        external_writes_allowed_after_timeout=False,
+        notification_event_code="cmo_approval_timeout_target_accounts",
+        audit_event_code="cmo_approval_timeout_manual_resolution",
+        safe_fallback_cta="resolve_target_account_list_change",
+        safe_fallback_message="Target account list change is blocked until a human resolves the approval.",
+    ),
+    "crisis_public_response": ApprovalTimeoutPolicy(
+        approval_type="crisis_public_response",
+        actions=(
+            "crisis_response",
+            "detect_crisis",
+            "public_response",
+            "publish_brand_response",
+            "publish_competitive_response",
+        ),
+        default_sla=timedelta(minutes=30),
+        escalation_role="ceo",
+        timeout_outcome="auto_escalate",
+        external_writes_allowed_after_timeout=False,
+        notification_event_code="cmo_approval_timeout_crisis_response",
+        audit_event_code="cmo_approval_timeout_auto_escalate",
+        safe_fallback_cta="escalate_crisis_response_to_exec",
+        safe_fallback_message="Public crisis response escalated; no external response is posted automatically.",
+    ),
+    "social_post_target_behavior": ApprovalTimeoutPolicy(
+        approval_type="social_post_target_behavior",
+        actions=(
+            "publish_post",
+            "reply_to_mention",
+            "schedule_campaign_posts",
+            "schedule_content_promotion",
+            "schedule_post",
+        ),
+        default_sla=timedelta(hours=1),
+        escalation_role="cmo",
+        timeout_outcome="pause_workflow",
+        external_writes_allowed_after_timeout=False,
+        notification_event_code="cmo_approval_timeout_social_post",
+        audit_event_code="cmo_approval_timeout_pause_workflow",
+        safe_fallback_cta="review_social_post_targeting",
+        safe_fallback_message="Social post targeting is paused until approval is resolved.",
+    ),
+    "high_risk_copy_or_pricing_claims": ApprovalTimeoutPolicy(
+        approval_type="high_risk_copy_or_pricing_claims",
+        actions=("brand_claim", "claims_review", "comparative_claim", "high_risk_copy", "pricing_claim"),
+        default_sla=timedelta(hours=2),
+        escalation_role="legal",
+        timeout_outcome="require_manual_resolution",
+        external_writes_allowed_after_timeout=False,
+        notification_event_code="cmo_approval_timeout_high_risk_claim",
+        audit_event_code="cmo_approval_timeout_manual_resolution",
+        safe_fallback_cta="resolve_high_risk_claim_review",
+        safe_fallback_message="High-risk copy, pricing, or legal claim is blocked until human resolution.",
+    ),
+    "crm_lifecycle_update": ApprovalTimeoutPolicy(
+        approval_type="crm_lifecycle_update",
+        actions=(
+            "promote_lifecycle_stage",
+            "update_lead_scores",
+            "update_lifecycle_stage",
+        ),
+        default_sla=timedelta(hours=8),
+        escalation_role="revops_lead",
+        timeout_outcome="pause_workflow",
+        external_writes_allowed_after_timeout=False,
+        notification_event_code="cmo_approval_timeout_crm_lifecycle_update",
+        audit_event_code="cmo_approval_timeout_pause_workflow",
+        safe_fallback_cta="review_crm_lifecycle_update_approval",
+        safe_fallback_message="CRM lifecycle/score update is paused until approval is resolved.",
+    ),
+    "crm_segment_update": ApprovalTimeoutPolicy(
+        approval_type="crm_segment_update",
+        actions=(
+            "change_segment_membership",
+            "update_segment_membership",
+        ),
+        default_sla=timedelta(hours=8),
+        escalation_role="revops_lead",
+        timeout_outcome="pause_workflow",
+        external_writes_allowed_after_timeout=False,
+        notification_event_code="cmo_approval_timeout_crm_segment_update",
+        audit_event_code="cmo_approval_timeout_pause_workflow",
+        safe_fallback_cta="review_crm_segment_update_approval",
+        safe_fallback_message="CRM segment/list change is paused until approval is resolved.",
+    ),
+    "crm_bulk_update": ApprovalTimeoutPolicy(
+        approval_type="crm_bulk_update",
+        actions=(
+            "bulk_crm_update",
+            "update_crm",
+        ),
+        default_sla=timedelta(hours=8),
+        escalation_role="revops_lead",
+        timeout_outcome="require_manual_resolution",
+        external_writes_allowed_after_timeout=False,
+        notification_event_code="cmo_approval_timeout_crm_bulk_update",
+        audit_event_code="cmo_approval_timeout_manual_resolution",
+        safe_fallback_cta="resolve_crm_bulk_update",
+        safe_fallback_message="Bulk CRM update is blocked until a human resolves the approval.",
+    ),
+}
+
+
+def approval_type_for_action(action: Any, context: dict[str, Any] | None = None) -> str | None:
+    """Return the approval type implied by a marketing action or flags."""
+
+    context = context if isinstance(context, dict) else {}
+    explicit = _normalize_key(
+        context.get("approval_type")
+        or context.get("approval_timeout_type")
+        or context.get("approval_timeout_policy_type")
+    )
+    if explicit:
+        return explicit
+
+    if any(
+        _truthy(context.get(field))
+        for field in (
+            "brand_claim",
+            "claims_review",
+            "claims_review_required",
+            "high_risk",
+            "high_risk_copy",
+            "legal_claim",
+            "legal_review_required",
+            "pricing_claim",
+        )
+    ):
+        return "high_risk_copy_or_pricing_claims"
+    if _truthy(context.get("crisis_response")) or _truthy(context.get("public_response")):
+        return "crisis_public_response"
+
+    normalized_action = _normalize_key(action)
+    return ACTION_APPROVAL_TYPES.get(normalized_action)
+
+
+def requires_approval_timeout_policy(action: Any, context: dict[str, Any] | None = None) -> bool:
+    """Return true when an action needs timeout policy before production use."""
+
+    context = context if isinstance(context, dict) else {}
+    if context.get("approval_sensitive") is False:
+        return False
+    if approval_type_for_action(action, context):
+        return True
+    return any(
+        _truthy(context.get(field))
+        for field in (
+            "approval_required",
+            "approval_sensitive",
+            "hitl_required",
+            "requires_approval",
+            "requires_human_approval",
+        )
+    )
+
+
+def timeout_policy_for_action(
+    action: Any,
+    source: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    approval_type = approval_type_for_action(action, source)
+    if not approval_type:
+        return None
+    return timeout_policy_for_approval_type(approval_type, source)
+
+
+def timeout_policy_for_approval_type(
+    approval_type: Any,
+    source: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    normalized_type = _normalize_key(approval_type)
+    if not normalized_type:
+        return None
+
+    source = source if isinstance(source, dict) else {}
+    if _truthy(source.get("approval_timeout_policy_disabled")):
+        return None
+
+    override = _policy_override(normalized_type, source)
+    if isinstance(override, dict) and _truthy(override.get("disabled")):
+        return None
+
+    base = DEFAULT_APPROVAL_TIMEOUT_POLICIES.get(normalized_type)
+    if base is None and not isinstance(override, dict):
+        return None
+
+    policy = base.to_dict() if base is not None else _minimal_policy(normalized_type)
+    if isinstance(override, dict):
+        policy = _merge_policy_override(policy, override)
+    return policy
+
+
+def has_timeout_policy_for_step(
+    step: dict[str, Any],
+    *,
+    workflow_definition: dict[str, Any] | None = None,
+) -> bool:
+    """Return true when a step has default or explicit timeout policy."""
+
+    action = step.get("action") or step.get("approval_action")
+    if not requires_approval_timeout_policy(action, step):
+        return True
+    source = {**(workflow_definition or {}), **step}
+    return timeout_policy_for_action(action, source) is not None
+
+
+def build_workflow_approval_timeout_status(
+    workflow_key: str,
+    actions: Iterable[Any],
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Project timeout-policy readiness for one CMO workflow."""
+
+    payload = payload if isinstance(payload, dict) else {}
+    required_actions = _unique(
+        [_normalize_key(action) for action in actions]
+        + [_normalize_key(action) for action in _list_from_value(payload.get("approval_sensitive_actions"))]
+    )
+    required_actions = [action for action in required_actions if requires_approval_timeout_policy(action, payload)]
+
+    policies: list[dict[str, Any]] = []
+    covered_actions: list[str] = []
+    missing_actions: list[str] = []
+    for action in required_actions:
+        policy = timeout_policy_for_action(action, payload)
+        if policy is None:
+            missing_actions.append(action)
+            continue
+        policies.append(policy)
+        covered_actions.append(action)
+
+    if not required_actions:
+        status = "not_required"
+        next_action = "none"
+    elif missing_actions:
+        status = "missing_policy"
+        next_action = "configure_approval_timeout_policy"
+    else:
+        status = "ready"
+        next_action = "none"
+
+    return {
+        "workflow_key": _normalize_key(workflow_key),
+        "status": status,
+        "required_actions": required_actions,
+        "covered_actions": covered_actions,
+        "missing_policy_actions": missing_actions,
+        "policies": _dedupe_policies(policies),
+        "external_writes_allowed_after_timeout": any(
+            bool(policy.get("external_writes_allowed_after_timeout"))
+            and bool(policy.get("preapproved_after_timeout"))
+            for policy in policies
+        ),
+        "next_action_cta": next_action,
+    }
+
+
+def evaluate_approval_timeout(
+    approval: dict[str, Any],
+    *,
+    policy_source: dict[str, Any] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Evaluate one pending approval against CMO timeout policy."""
+
+    now = _ensure_aware(now) or datetime.now(UTC)
+    source = {**(policy_source or {}), **(approval if isinstance(approval, dict) else {})}
+    action = source.get("action") or source.get("approval_action") or source.get("blocked_action")
+    approval_type = _normalize_key(source.get("approval_type")) or approval_type_for_action(action, source)
+    policy = timeout_policy_for_approval_type(approval_type, source) if approval_type else None
+    marketing_policy_decision = _marketing_policy_decision_for_approval(action, source)
+
+    approval_id = _string_or_none(source.get("approval_id") or source.get("id"))
+    created_at = _parse_datetime(source.get("created_at")) or now
+    due_at = _parse_datetime(source.get("due_at") or source.get("expires_at"))
+    if due_at is None and policy is not None:
+        due_at = created_at + timedelta(seconds=int(policy["default_sla_seconds"]))
+    if due_at is None:
+        due_at = created_at
+
+    status = _normalize_key(source.get("status") or "pending")
+    if status and status != "pending":
+        return {
+            "approval_id": approval_id,
+            "approval_type": approval_type,
+            "status": status,
+            "timed_out": False,
+            "created_at": created_at.isoformat(),
+            "due_at": due_at.isoformat(),
+            "timed_out_at": None,
+            "outcome": "already_resolved",
+            "workflow_state": "resolved",
+            "external_writes_allowed": False,
+            "progress_allowed": False,
+            "read_only_continuation_allowed": False,
+            "next_action_cta": "none",
+            "audit_evidence": None,
+        }
+
+    if policy is None:
+        return _timeout_decision(
+            approval=source,
+            policy=_missing_policy(approval_type),
+            created_at=created_at,
+            due_at=due_at,
+            timed_out_at=now if now > due_at else None,
+            action=action,
+            outcome="require_manual_resolution",
+            policy_missing=True,
+            marketing_policy_decision=marketing_policy_decision,
+        )
+
+    if now <= due_at:
+        return {
+            "approval_id": approval_id,
+            "approval_type": approval_type,
+            "status": "pending",
+            "timed_out": False,
+            "created_at": created_at.isoformat(),
+            "due_at": due_at.isoformat(),
+            "timed_out_at": None,
+            "outcome": None,
+            "workflow_state": "waiting_hitl",
+            "external_writes_allowed": False,
+            "progress_allowed": False,
+            "read_only_continuation_allowed": False,
+            "next_action_cta": "wait_for_approval",
+            "audit_evidence": None,
+        }
+
+    return _timeout_decision(
+        approval=source,
+        policy=policy,
+        created_at=created_at,
+        due_at=due_at,
+        timed_out_at=now,
+        action=action,
+        outcome=str(policy["timeout_outcome"]),
+        policy_missing=False,
+        marketing_policy_decision=marketing_policy_decision,
+    )
+
+
+def build_approval_timeout_risk(
+    approvals: Iterable[dict[str, Any]],
+    *,
+    policy_source: dict[str, Any] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build a dashboard/API projection for pending and overdue approvals."""
+
+    decisions = [
+        evaluate_approval_timeout(approval, policy_source=policy_source, now=now)
+        for approval in approvals
+    ]
+    counts = dict.fromkeys(APPROVAL_TIMEOUT_OUTCOMES, 0)
+    for decision in decisions:
+        outcome = str(decision.get("outcome") or "")
+        if outcome in counts:
+            counts[outcome] += 1
+
+    pending = sum(1 for decision in decisions if not decision.get("timed_out") and decision.get("status") == "pending")
+    timed_out = sum(1 for decision in decisions if decision.get("timed_out"))
+    blocked_external_writes = sum(
+        1
+        for decision in decisions
+        if decision.get("timed_out") and not decision.get("external_writes_allowed")
+    )
+    return {
+        "status": "blocked" if timed_out else "pending" if pending else "ready",
+        "total": len(decisions),
+        "pending": pending,
+        "overdue": timed_out,
+        "timed_out": timed_out,
+        "blocked_external_writes": blocked_external_writes,
+        **counts,
+        "next_action_cta": (
+            "resolve_overdue_approvals"
+            if timed_out
+            else "review_pending_approvals"
+            if pending
+            else "none"
+        ),
+        "approval_timeout_decisions": decisions,
+    }
+
+
+def approval_timeout_allows_external_write(decision: dict[str, Any] | None) -> bool:
+    """Return false when a timed-out approval blocks external writes."""
+
+    if not isinstance(decision, dict):
+        return True
+    if not decision.get("timed_out"):
+        return True
+    return bool(decision.get("external_writes_allowed"))
+
+
+def _timeout_decision(
+    *,
+    approval: dict[str, Any],
+    policy: dict[str, Any],
+    created_at: datetime,
+    due_at: datetime,
+    timed_out_at: datetime | None,
+    action: Any,
+    outcome: str,
+    policy_missing: bool,
+    marketing_policy_decision: dict[str, Any] | None,
+) -> dict[str, Any]:
+    timed_out = timed_out_at is not None
+    normalized_outcome = outcome if outcome in APPROVAL_TIMEOUT_OUTCOMES else "require_manual_resolution"
+    external_allowed = bool(
+        timed_out
+        and policy.get("external_writes_allowed_after_timeout")
+        and (
+            policy.get("preapproved_after_timeout")
+            or approval.get("preapproved_after_timeout")
+            or approval.get("external_writes_preapproved_after_timeout")
+        )
+    )
+    workflow_state = {
+        "auto_cancel": "cancelled",
+        "auto_escalate": "waiting_hitl",
+        "continue_read_only": "degraded",
+        "pause_workflow": "paused",
+        "require_manual_resolution": "blocked",
+    }[normalized_outcome]
+    next_action = _next_action_for_outcome(normalized_outcome, policy_missing, policy)
+    policy_required_role = _policy_required_role(marketing_policy_decision)
+    escalation_decision = _approval_escalation_decision(
+        approval,
+        policy,
+        action,
+        normalized_outcome,
+        timed_out_at or due_at,
+    )
+    audit_evidence = (
+        _audit_evidence(
+            approval,
+            policy,
+            created_at,
+            due_at,
+            timed_out_at,
+            action,
+            normalized_outcome,
+            external_allowed,
+            policy_missing,
+            policy_required_role,
+            escalation_decision,
+        )
+        if timed_out
+        else None
+    )
+    result = {
+        "approval_id": _string_or_none(approval.get("approval_id") or approval.get("id")),
+        "approval_type": policy.get("approval_type"),
+        "status": "timed_out" if timed_out else "pending",
+        "timed_out": timed_out,
+        "policy_missing": policy_missing,
+        "created_at": created_at.isoformat(),
+        "due_at": due_at.isoformat(),
+        "timed_out_at": timed_out_at.isoformat() if timed_out_at else None,
+        "outcome": normalized_outcome,
+        "workflow_state": workflow_state,
+        "step_status": _step_status_for_outcome(normalized_outcome),
+        "escalated": normalized_outcome == "auto_escalate",
+        "escalation_target": policy.get("escalation_role"),
+        "policy_required_role": policy_required_role,
+        "external_writes_allowed": external_allowed,
+        "progress_allowed": normalized_outcome == "continue_read_only",
+        "read_only_continuation_allowed": normalized_outcome == "continue_read_only",
+        "blocked_action": _normalize_key(action),
+        "next_action_cta": next_action,
+        "safe_fallback_message": policy.get("safe_fallback_message"),
+        "escalation_decision": escalation_decision,
+        "escalation_evidence": escalation_decision.get("evidence"),
+        "audit_evidence": audit_evidence,
+        "audit_reference": (audit_evidence or {}).get("audit_reference"),
+        "marketing_policy_decision": marketing_policy_decision,
+    }
+    if audit_evidence is not None:
+        audit_package = build_approval_timeout_decision_audit(result, now=timed_out_at or due_at)
+        result["decision_audit"] = audit_package
+        result["decision_audit_ref"] = audit_package["audit_reference"]
+        audit_evidence["decision_audit"] = audit_package
+        audit_evidence["decision_audit_ref"] = audit_package["audit_reference"]
+    return result
+
+
+def _audit_evidence(
+    approval: dict[str, Any],
+    policy: dict[str, Any],
+    created_at: datetime,
+    due_at: datetime,
+    timed_out_at: datetime,
+    action: Any,
+    outcome: str,
+    external_allowed: bool,
+    policy_missing: bool,
+    policy_required_role: str | None,
+    escalation_decision: dict[str, Any],
+) -> dict[str, Any]:
+    approval_id = _string_or_none(approval.get("approval_id") or approval.get("id"))
+    workflow_id = _string_or_none(approval.get("workflow_id"))
+    workflow_run_id = _string_or_none(
+        approval.get("workflow_run_id") or approval.get("run_id") or approval.get("engine_run_id")
+    )
+    step_id = _string_or_none(approval.get("step_id"))
+    blocked_action = _normalize_key(action)
+    audit_reference = _audit_reference(approval_id, workflow_id, workflow_run_id, step_id, blocked_action, outcome)
+    return {
+        "event_type": policy.get("audit_event_code"),
+        "notification_event_code": policy.get("notification_event_code"),
+        "approval_id": approval_id,
+        "workflow_id": workflow_id,
+        "workflow_run_id": workflow_run_id,
+        "run_id": _string_or_none(approval.get("run_id")),
+        "step_id": step_id,
+        "requested_approver": _string_or_none(
+            approval.get("requested_approver") or approval.get("approver") or approval.get("assignee")
+        ),
+        "requested_approver_role": _string_or_none(
+            approval.get("requested_approver_role")
+            or approval.get("assignee_role")
+            or approval.get("requested_role")
+        ),
+        "created_at": created_at.isoformat(),
+        "due_at": due_at.isoformat(),
+        "timed_out_at": timed_out_at.isoformat(),
+        "outcome": outcome,
+        "escalation_target": policy.get("escalation_role"),
+        "policy_required_role": policy_required_role,
+        "blocked_action": blocked_action,
+        "external_writes_allowed": external_allowed,
+        "policy_missing": policy_missing,
+        "escalation_decision": escalation_decision,
+        "escalation_evidence": escalation_decision.get("evidence"),
+        "notification_channels": escalation_decision.get("notification_channels") or [],
+        "audit_reference": audit_reference,
+    }
+
+
+def _approval_escalation_decision(
+    approval: dict[str, Any],
+    policy: dict[str, Any],
+    action: Any,
+    outcome: str,
+    now: datetime,
+) -> dict[str, Any]:
+    return evaluate_marketing_escalation(
+        {
+            **approval,
+            "trigger_type": "approval_timeout",
+            "severity": "high",
+            "action": action,
+            "blocked_action": action,
+            "workflow_id": approval.get("workflow_id"),
+            "workflow_run_id": approval.get("workflow_run_id") or approval.get("run_id"),
+            "step_id": approval.get("step_id"),
+            "fallback_outcome": outcome,
+            "reason": policy.get("safe_fallback_message"),
+        },
+        now=now,
+    )
+
+
+def _marketing_policy_decision_for_approval(
+    action: Any,
+    source: dict[str, Any],
+) -> dict[str, Any] | None:
+    existing = source.get("marketing_policy_decision") or source.get("cmo_marketing_policy_decision")
+    if isinstance(existing, dict):
+        return existing
+    if not action:
+        return None
+    context = {
+        **source,
+        "action": action,
+        "workflow_mode": source.get("workflow_mode") or source.get("mode") or "active",
+        "workflow_id": source.get("workflow_id"),
+        "external_write_required": source.get("external_write_required", True),
+        "customer_facing": source.get("customer_facing", True),
+    }
+    return evaluate_marketing_policy(context)
+
+
+def _policy_required_role(marketing_policy_decision: dict[str, Any] | None) -> str | None:
+    if not isinstance(marketing_policy_decision, dict):
+        return None
+    return _string_or_none(
+        marketing_policy_decision.get("required_escalation_role")
+        or marketing_policy_decision.get("required_approver_role")
+    )
+
+
+def _policy_override(approval_type: str, source: dict[str, Any]) -> dict[str, Any] | None:
+    candidates = (
+        source.get("approval_timeout_policies"),
+        source.get("approval_timeouts"),
+        source.get("timeout_policies"),
+    )
+    for candidate in candidates:
+        if isinstance(candidate, dict):
+            value = candidate.get(approval_type)
+            if isinstance(value, dict):
+                return value
+
+    single = source.get("approval_timeout_policy") or source.get("timeout_policy")
+    if isinstance(single, dict):
+        single_type = _normalize_key(single.get("approval_type") or single.get("type"))
+        if not single_type or single_type == approval_type:
+            return single
+    return None
+
+
+def _merge_policy_override(policy: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(policy)
+    if override.get("default_sla_seconds") is not None:
+        merged["default_sla_seconds"] = _int_or_default(
+            override.get("default_sla_seconds"),
+            merged["default_sla_seconds"],
+        )
+    elif override.get("sla_minutes") is not None or override.get("default_sla_minutes") is not None:
+        minutes = _int_or_default(override.get("sla_minutes") or override.get("default_sla_minutes"), 0)
+        merged["default_sla_seconds"] = max(minutes * 60, 0)
+    elif override.get("sla_hours") is not None or override.get("timeout_hours") is not None:
+        hours = _float_or_default(override.get("sla_hours") or override.get("timeout_hours"), 0.0)
+        merged["default_sla_seconds"] = int(max(hours, 0.0) * 3600)
+
+    merged["default_sla_hours"] = merged["default_sla_seconds"] / 3600
+    if override.get("escalation_owner_role") or override.get("escalation_role"):
+        merged["escalation_role"] = str(override.get("escalation_owner_role") or override.get("escalation_role"))
+    if override.get("timeout_outcome") or override.get("outcome"):
+        outcome = _normalize_key(override.get("timeout_outcome") or override.get("outcome"))
+        merged["timeout_outcome"] = outcome if outcome in APPROVAL_TIMEOUT_OUTCOMES else "require_manual_resolution"
+    for field in (
+        "external_writes_allowed_after_timeout",
+        "preapproved_after_timeout",
+        "notification_event_code",
+        "audit_event_code",
+        "safe_fallback_cta",
+        "safe_fallback_message",
+    ):
+        if field in override:
+            merged[field] = override[field]
+    return merged
+
+
+def _minimal_policy(approval_type: str) -> dict[str, Any]:
+    return {
+        "approval_type": approval_type,
+        "actions": [],
+        "default_sla_seconds": 0,
+        "default_sla_hours": 0,
+        "escalation_role": "cmo",
+        "timeout_outcome": "require_manual_resolution",
+        "external_writes_allowed_after_timeout": False,
+        "preapproved_after_timeout": False,
+        "notification_event_code": "cmo_approval_timeout_unknown",
+        "audit_event_code": "cmo_approval_timeout_manual_resolution",
+        "safe_fallback_cta": "configure_approval_timeout_policy",
+        "safe_fallback_message": "Approval timeout policy is missing; manual resolution is required.",
+    }
+
+
+def _missing_policy(approval_type: str | None) -> dict[str, Any]:
+    policy = _minimal_policy(approval_type or "unknown")
+    policy["notification_event_code"] = "cmo_approval_timeout_policy_missing"
+    policy["audit_event_code"] = "cmo_approval_timeout_policy_missing"
+    return policy
+
+
+def _next_action_for_outcome(
+    outcome: str,
+    policy_missing: bool,
+    policy: dict[str, Any],
+) -> str:
+    if policy_missing:
+        return "configure_approval_timeout_policy"
+    if outcome == "auto_cancel":
+        return "restart_approval"
+    if outcome == "auto_escalate":
+        return "review_escalated_approval"
+    if outcome == "continue_read_only":
+        return "continue_read_only"
+    if outcome == "pause_workflow":
+        return "resume_after_manual_approval"
+    return str(policy.get("safe_fallback_cta") or "manual_resolution_required")
+
+
+def _step_status_for_outcome(outcome: str) -> str:
+    if outcome == "auto_cancel":
+        return "cancelled"
+    if outcome == "continue_read_only":
+        return "completed"
+    return "waiting_hitl"
+
+
+def _dedupe_policies(policies: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    unique: list[dict[str, Any]] = []
+    for policy in policies:
+        key = str(policy.get("approval_type") or "")
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(policy)
+    return unique
+
+
+def _unique(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _list_from_value(value: Any) -> list[Any]:
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return []
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return _ensure_aware(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return _ensure_aware(parsed)
+    return None
+
+
+def _ensure_aware(value: datetime | None) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _audit_reference(*parts: Any) -> str:
+    source = "|".join(str(part or "") for part in parts)
+    return f"mkt_approval_timeout_{hashlib.sha256(source.encode()).hexdigest()[:20]}"
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _string_or_none(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _int_or_default(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _float_or_default(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default

--- a/core/marketing/connector_contracts.py
+++ b/core/marketing/connector_contracts.py
@@ -1,0 +1,1101 @@
+"""CMO marketing connector contract readiness projection.
+
+This module turns stored ConnectorConfig metadata into a machine-checkable
+connector contract for CMO agents and workflows. It separates read readiness
+from write readiness, represents retry/idempotency facts, and requires explicit
+external write confirmation before a write step can be considered complete.
+It does not call vendor APIs or treat test doubles as production proof.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from core.marketing.connector_retry_policy import (
+    build_degraded_mode_projection,
+    normalize_failure_class,
+    policy_projection,
+    summarize_degraded_modes,
+)
+from core.marketing.connector_setup import (
+    MARKETING_CONNECTOR_REQUIREMENTS,
+    STALE_SYNC_AFTER,
+)
+
+CONTRACT_STATES = (
+    "healthy",
+    "missing_scope",
+    "insufficient_scope",
+    "auth_expired",
+    "rate_limited",
+    "timeout",
+    "vendor_5xx",
+    "partial_data",
+    "stale_data",
+    "malformed_payload",
+    "quota_exhausted",
+    "connector_disabled",
+    "degraded",
+    "write_unconfirmed",
+    "write_confirmed",
+)
+WRITE_CONFIRMATION_STATES = (
+    "accepted",
+    "rejected",
+    "timeout_unknown",
+    "retry_scheduled",
+    "idempotent_recovered",
+    "write_confirmed",
+    "write_unconfirmed",
+    "draft_created",
+    "shadow_only",
+)
+
+AUTH_EXPIRED_MARKERS = ("expired", "invalid_grant", "reauthorize", "re-authorize", "401")
+MISSING_SCOPE_MARKERS = ("insufficient_scope", "missing_scope", "forbidden", "403")
+RATE_LIMIT_MARKERS = ("rate_limited", "rate limit", "429")
+TIMEOUT_MARKERS = ("timeout", "timed out", "deadline")
+VENDOR_5XX_MARKERS = ("5xx", "500", "502", "503", "504", "server error")
+PARTIAL_DATA_MARKERS = ("partial_data", "partial data", "partial")
+STALE_DATA_MARKERS = ("stale_data", "stale data", "stale")
+MALFORMED_PAYLOAD_MARKERS = ("malformed_payload", "malformed payload", "invalid_payload", "schema_error")
+QUOTA_EXHAUSTED_MARKERS = ("quota_exhausted", "quota exhausted", "quota", "limit exhausted")
+CONNECTOR_DISABLED_MARKERS = ("connector_disabled", "connector disabled", "disabled", "inactive")
+TEST_DOUBLE_PROOF_MARKERS = {"mock", "mock_only", "sample", "stub", "test", "test_double"}
+INTERNAL_ONLY_MODES = {"draft", "internal", "internal_only", "shadow"}
+
+
+@dataclass(frozen=True)
+class MarketingConnectorContractSpec:
+    connector_key: str
+    read_capabilities: tuple[str, ...]
+    write_capabilities: tuple[str, ...] = ()
+    required_read_scopes: tuple[str, ...] = ()
+    required_write_scopes: tuple[str, ...] = ()
+    ttl: timedelta = STALE_SYNC_AFTER
+
+
+CONTRACT_SPECS: dict[str, MarketingConnectorContractSpec] = {
+    "hubspot": MarketingConnectorContractSpec(
+        connector_key="hubspot",
+        read_capabilities=("contacts.read", "deals.read", "lists.read"),
+        write_capabilities=("contacts.write", "deals.write", "workflow.enroll"),
+        required_read_scopes=("crm.objects.contacts.read", "crm.objects.deals.read"),
+        required_write_scopes=("automation",),
+    ),
+    "salesforce": MarketingConnectorContractSpec(
+        connector_key="salesforce",
+        read_capabilities=("leads.read", "opportunities.read", "accounts.read"),
+        write_capabilities=("leads.write", "campaign_members.write"),
+        required_read_scopes=("api", "refresh_token", "offline_access"),
+        required_write_scopes=("api",),
+    ),
+    "google_ads": MarketingConnectorContractSpec(
+        connector_key="google_ads",
+        read_capabilities=("campaigns.read", "performance.read"),
+        write_capabilities=("campaigns.mutate", "budgets.mutate"),
+        required_read_scopes=("https://www.googleapis.com/auth/adwords",),
+        required_write_scopes=("https://www.googleapis.com/auth/adwords",),
+    ),
+    "meta_ads": MarketingConnectorContractSpec(
+        connector_key="meta_ads",
+        read_capabilities=("campaigns.read", "insights.read"),
+        write_capabilities=("campaigns.manage", "budgets.manage"),
+        required_read_scopes=("ads_read", "business_management"),
+        required_write_scopes=("ads_management",),
+    ),
+    "linkedin_ads": MarketingConnectorContractSpec(
+        connector_key="linkedin_ads",
+        read_capabilities=("campaigns.read", "analytics.read"),
+        write_capabilities=("campaigns.write",),
+        required_read_scopes=("r_ads_reporting",),
+        required_write_scopes=("rw_ads",),
+    ),
+    "ga4": MarketingConnectorContractSpec(
+        connector_key="ga4",
+        read_capabilities=("analytics.read", "events.read"),
+        required_read_scopes=("https://www.googleapis.com/auth/analytics.readonly",),
+    ),
+    "mixpanel": MarketingConnectorContractSpec(
+        connector_key="mixpanel",
+        read_capabilities=("events.read", "funnels.read"),
+    ),
+    "wordpress": MarketingConnectorContractSpec(
+        connector_key="wordpress",
+        read_capabilities=("posts.read", "pages.read"),
+        write_capabilities=("posts.create", "posts.update", "pages.update"),
+    ),
+    "mailchimp": MarketingConnectorContractSpec(
+        connector_key="mailchimp",
+        read_capabilities=("campaigns.read", "audiences.read", "reports.read"),
+        write_capabilities=("campaigns.create", "campaigns.send"),
+    ),
+    "sendgrid": MarketingConnectorContractSpec(
+        connector_key="sendgrid",
+        read_capabilities=("stats.read", "suppression.read"),
+        write_capabilities=("mail.send", "templates.update"),
+    ),
+    "buffer": MarketingConnectorContractSpec(
+        connector_key="buffer",
+        read_capabilities=("profiles.read", "analytics.read"),
+        write_capabilities=("updates.create",),
+        required_read_scopes=("profile:read",),
+        required_write_scopes=("updates:create",),
+    ),
+    "twitter": MarketingConnectorContractSpec(
+        connector_key="twitter",
+        read_capabilities=("tweets.read", "users.read"),
+        write_capabilities=("tweets.write",),
+        required_read_scopes=("tweet.read", "users.read", "offline.access"),
+        required_write_scopes=("tweet.write",),
+    ),
+    "youtube": MarketingConnectorContractSpec(
+        connector_key="youtube",
+        read_capabilities=("channel.read", "analytics.read"),
+        required_read_scopes=("https://www.googleapis.com/auth/youtube.readonly",),
+    ),
+    "ahrefs": MarketingConnectorContractSpec(
+        connector_key="ahrefs",
+        read_capabilities=("keywords.read", "backlinks.read", "site_audit.read"),
+    ),
+    "brandwatch": MarketingConnectorContractSpec(
+        connector_key="brandwatch",
+        read_capabilities=("mentions.read", "queries.read"),
+        required_read_scopes=("read_mentions", "read_queries"),
+    ),
+    "bombora": MarketingConnectorContractSpec(
+        connector_key="bombora",
+        read_capabilities=("intent.read", "accounts.read"),
+    ),
+    "g2": MarketingConnectorContractSpec(
+        connector_key="g2",
+        read_capabilities=("buyer_intent.read", "reviews.read"),
+    ),
+    "trustradius": MarketingConnectorContractSpec(
+        connector_key="trustradius",
+        read_capabilities=("intent.read", "reviews.read"),
+    ),
+    "stripe": MarketingConnectorContractSpec(
+        connector_key="stripe",
+        read_capabilities=("charges.read", "customers.read"),
+    ),
+    "tally": MarketingConnectorContractSpec(
+        connector_key="tally",
+        read_capabilities=("ledger.read", "reports.read"),
+    ),
+}
+
+
+def build_marketing_connector_contracts(
+    connector_setup: Iterable[dict[str, Any]],
+    connector_configs: Iterable[Any],
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Build connector contract rows for all marketing connector setup rows."""
+
+    now = _ensure_aware(now) or datetime.now(UTC)
+    configs_by_key = _configs_by_key(connector_configs)
+    rows: list[dict[str, Any]] = []
+    for setup_row in connector_setup:
+        key = str(setup_row.get("key") or "").strip().lower()
+        if not key:
+            continue
+        spec = CONTRACT_SPECS.get(key, _spec_from_setup(setup_row))
+        rows.append(_build_contract_row(spec, setup_row, configs_by_key.get(key), now))
+    return rows
+
+
+def summarize_marketing_connector_contracts(rows: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    items = list(rows)
+    configured_items = [
+        row for row in items if row.get("configured_status") != "unconfigured"
+    ]
+    blocked = [row for row in configured_items if row.get("read_status") == "blocked"]
+    degraded = [row for row in configured_items if row.get("read_status") == "degraded"]
+    missing_write_scope = [
+        row
+        for row in configured_items
+        if row.get("write_capabilities") and row.get("write_status") == "missing_scope"
+    ]
+    degraded_mode_summary = summarize_degraded_modes(configured_items)
+    return {
+        "total": len(items),
+        "configured": len(configured_items),
+        "read_ready": sum(1 for row in configured_items if row.get("read_ready")),
+        "write_ready": sum(1 for row in configured_items if row.get("write_ready")),
+        "write_safe": sum(1 for row in configured_items if row.get("write_safe")),
+        "blocked": len(blocked),
+        "degraded": len(degraded),
+        "missing_write_scope": len(missing_write_scope),
+        "failure_classes": sorted(
+            {
+                str(row.get("failure_class"))
+                for row in configured_items
+                if row.get("failure_class")
+            }
+        ),
+        "degraded_mode": degraded_mode_summary,
+        "write_unconfirmed": sum(
+            1
+            for row in configured_items
+            if row.get("external_write_confirmation_status") == "write_unconfirmed"
+        ),
+        "write_confirmed": sum(
+            1
+            for row in configured_items
+            if row.get("external_write_confirmation_status") == "write_confirmed"
+        ),
+        "mock_or_test_double": sum(1 for row in configured_items if row.get("mock_or_test_double")),
+        "readiness": "blocked" if blocked else "degraded" if degraded else "ready",
+    }
+
+
+def evaluate_marketing_write_completion(
+    connector_contracts: Iterable[dict[str, Any]],
+    connector_key: str,
+    action: str,
+    *,
+    workflow_mode: str = "active",
+    idempotency_key: str | None = None,
+) -> dict[str, Any]:
+    """Decide whether a marketing external-write step can be marked complete."""
+
+    normalized_key = _normalize_key(connector_key)
+    normalized_action = _normalize_key(action)
+    mode = _normalize_key(workflow_mode)
+    if mode in INTERNAL_ONLY_MODES:
+        return {
+            "can_mark_complete": True,
+            "connector_key": normalized_key,
+            "action": normalized_action,
+            "status": "internal_only",
+            "reason": "Draft, shadow, or internal-only workflow step does not require external write confirmation.",
+        }
+
+    row = _contract_by_key(connector_contracts, normalized_key)
+    if row is None:
+        return {
+            "can_mark_complete": False,
+            "connector_key": normalized_key,
+            "action": normalized_action,
+            "status": "write_unconfirmed",
+            "reason": "Connector contract is unavailable; external write cannot be confirmed.",
+        }
+
+    confirmation = _matching_confirmation(row, normalized_action, idempotency_key)
+    if confirmation and confirmation.get("status") in {"write_confirmed", "idempotent_recovered"}:
+        return {
+            "can_mark_complete": True,
+            "connector_key": normalized_key,
+            "action": normalized_action,
+            "status": confirmation.get("status"),
+            "external_object_id": confirmation.get("external_object_id"),
+            "source_url": confirmation.get("source_url"),
+            "idempotency_key": confirmation.get("idempotency_key"),
+            "request_fingerprint": confirmation.get("request_fingerprint"),
+            "audit_reference": confirmation.get("audit_reference"),
+            "confirmed_at": confirmation.get("confirmed_at"),
+            "reason": "External write confirmation is present.",
+        }
+
+    return {
+        "can_mark_complete": False,
+        "connector_key": normalized_key,
+        "action": normalized_action,
+        "status": "write_unconfirmed",
+        "idempotency_key": idempotency_key,
+        "reason": "External write confirmation is missing; do not mark this step complete.",
+    }
+
+
+def plan_marketing_write_retry(
+    connector_contracts: Iterable[dict[str, Any]],
+    connector_key: str,
+    action: str,
+    *,
+    idempotency_key: str | None = None,
+) -> dict[str, Any]:
+    """Project safe retry metadata for a marketing external write."""
+
+    normalized_key = _normalize_key(connector_key)
+    normalized_action = _normalize_key(action)
+    row = _contract_by_key(connector_contracts, normalized_key)
+    if row is None:
+        return {
+            "safe_to_retry": False,
+            "connector_key": normalized_key,
+            "action": normalized_action,
+            "reason": "Connector contract is unavailable.",
+        }
+
+    retry_budget = row.get("retry_budget") if isinstance(row.get("retry_budget"), dict) else {}
+    retry_policy = row.get("retry_policy") if isinstance(row.get("retry_policy"), dict) else {}
+    stored_key = _string_or_none(idempotency_key) or _string_or_none(retry_budget.get("idempotency_key"))
+    confirmation = _matching_confirmation(row, normalized_action, stored_key)
+
+    if confirmation and confirmation.get("status") in {"write_confirmed", "idempotent_recovered"}:
+        return {
+            "safe_to_retry": False,
+            "connector_key": normalized_key,
+            "action": normalized_action,
+            "idempotency_key": confirmation.get("idempotency_key"),
+            "reason": "External write is already confirmed; duplicate retry should not run.",
+            "duplicate_policy": "already_confirmed",
+        }
+
+    if row.get("failure_class") and not retry_policy.get("retryable"):
+        return {
+            "safe_to_retry": False,
+            "connector_key": normalized_key,
+            "action": normalized_action,
+            "idempotency_key": stored_key,
+            "reason": (
+                f"Connector failure class '{row.get('failure_class')}' is not retryable; "
+                "an operator action is required before retry."
+            ),
+            "duplicate_policy": "not_retryable",
+            "failure_class": row.get("failure_class"),
+            "audit_event_code": retry_policy.get("audit_event_code"),
+        }
+
+    requires_idempotency = bool(retry_policy.get("safe_retry_requires_idempotency")) or not row.get("failure_class")
+    if requires_idempotency and not row.get("idempotency_key_supported"):
+        return {
+            "safe_to_retry": False,
+            "connector_key": normalized_key,
+            "action": normalized_action,
+            "reason": "Connector contract does not prove idempotency-key support.",
+            "duplicate_policy": "blocked_without_idempotency",
+        }
+
+    if requires_idempotency and not stored_key:
+        return {
+            "safe_to_retry": False,
+            "connector_key": normalized_key,
+            "action": normalized_action,
+            "reason": "Safe retry requires a stable idempotency key.",
+            "duplicate_policy": "blocked_without_idempotency",
+            "failure_class": row.get("failure_class"),
+            "audit_event_code": retry_policy.get("audit_event_code"),
+        }
+
+    remaining = _int_or_zero(retry_budget.get("remaining_attempts"))
+    if remaining <= 0:
+        return {
+            "safe_to_retry": False,
+            "connector_key": normalized_key,
+            "action": normalized_action,
+            "idempotency_key": stored_key,
+            "reason": "Retry budget is exhausted.",
+            "duplicate_policy": "retry_budget_exhausted",
+        }
+
+    return {
+        "safe_to_retry": True,
+        "connector_key": normalized_key,
+        "action": normalized_action,
+        "idempotency_key": stored_key,
+        "remaining_attempts": remaining,
+        "next_retry_at": retry_budget.get("next_retry_at"),
+        "backoff_strategy": retry_budget.get("backoff_strategy"),
+        "failure_class": row.get("failure_class"),
+        "audit_event_code": retry_budget.get("audit_event_code"),
+        "reason": "Retry can reuse the same idempotency key within the recorded retry budget.",
+        "duplicate_policy": "reuse_idempotency_key",
+    }
+
+
+def _build_contract_row(
+    spec: MarketingConnectorContractSpec,
+    setup_row: dict[str, Any],
+    config: Any | None,
+    now: datetime,
+) -> dict[str, Any]:
+    config_dict = _config_dict(config)
+    contract = _contract_payload(config_dict)
+    configured = str(setup_row.get("configured_status") or "") != "unconfigured"
+    granted_scopes = _scopes_from_contract_or_config(contract, config_dict)
+    read_capabilities = _tuple_from_payload(contract, "read_capabilities", spec.read_capabilities)
+    write_capabilities = _tuple_from_payload(contract, "write_capabilities", spec.write_capabilities)
+    required_read_scopes = _tuple_from_payload(contract, "required_read_scopes", spec.required_read_scopes)
+    required_write_scopes = _tuple_from_payload(contract, "required_write_scopes", spec.required_write_scopes)
+    missing_read_scopes = _missing_scopes(required_read_scopes, granted_scopes)
+    missing_write_scopes = _missing_scopes(required_write_scopes, granted_scopes)
+    last_sync_at = _last_sync_at(config, contract)
+    ttl_seconds = _ttl_seconds(contract, spec.ttl)
+    freshness_status = _freshness_status(last_sync_at, ttl_seconds, now)
+    confirmations = _write_confirmations(contract)
+    confirmation_status = _external_write_confirmation_status(confirmations)
+    mock_or_test_double = _mock_or_test_double(contract, config_dict)
+    auth_status = _auth_status(contract, setup_row, config_dict)
+    contract_state = _contract_state(
+        contract,
+        setup_row,
+        auth_status,
+        freshness_status,
+        missing_read_scopes,
+        missing_write_scopes,
+        mock_or_test_double,
+    )
+    failure_class = _failure_class(
+        contract,
+        contract_state,
+        configured,
+        missing_read_scopes,
+        missing_write_scopes,
+        mock_or_test_double,
+    )
+    retry_policy = policy_projection(failure_class)
+    retry_budget = _retry_budget(contract, retry_policy)
+    production_ready = configured and not mock_or_test_double
+    read_status = _read_status(
+        configured,
+        production_ready,
+        contract_state,
+        missing_read_scopes,
+        missing_write_scopes,
+        read_capabilities,
+    )
+    write_status = _write_status(
+        read_status,
+        contract_state,
+        write_capabilities,
+        missing_write_scopes,
+        bool(retry_budget.get("idempotency_supported")),
+    )
+    degraded_reason = _degraded_reason(
+        contract,
+        contract_state,
+        mock_or_test_double,
+        missing_read_scopes,
+        missing_write_scopes,
+        retry_budget,
+    )
+    next_action_cta = _next_action_cta(contract_state, read_status, write_status, retry_policy)
+    row_blocks_kpi_confidence = bool(retry_policy.get("blocks_production_kpi_confidence")) and read_status != "ready"
+    blocks_external_writes = bool(write_capabilities) and (
+        bool(retry_policy.get("blocks_external_writes")) or write_status != "ready"
+    )
+    write_safe = write_status == "ready" and not blocks_external_writes
+    degraded_mode = build_degraded_mode_projection(
+        connector_key=spec.connector_key,
+        connector_name=_string_or_none(setup_row.get("name")),
+        category=_string_or_none(setup_row.get("category")),
+        failure_class=failure_class,
+        reason=degraded_reason,
+        policy={
+            **retry_policy,
+            "blocks_production_kpi_confidence": row_blocks_kpi_confidence,
+            "blocks_external_writes": blocks_external_writes,
+        },
+        read_status=read_status,
+        write_status=write_status,
+        next_action_cta=next_action_cta,
+    )
+
+    return {
+        "connector_key": spec.connector_key,
+        "name": setup_row.get("name"),
+        "category": setup_row.get("category"),
+        "configured_status": setup_row.get("configured_status"),
+        "vendor_account_id": _account_id_from_config(config_dict),
+        "workspace_id": _workspace_id_from_config(config_dict),
+        "read_capabilities": list(read_capabilities),
+        "write_capabilities": list(write_capabilities),
+        "required_read_scopes": list(required_read_scopes),
+        "required_write_scopes": list(required_write_scopes),
+        "required_scopes": sorted(set(required_read_scopes).union(required_write_scopes)),
+        "granted_scopes": granted_scopes,
+        "missing_read_scopes": missing_read_scopes,
+        "missing_write_scopes": missing_write_scopes,
+        "missing_scopes": sorted(set(missing_read_scopes).union(missing_write_scopes)),
+        "auth_status": auth_status,
+        "health_status": setup_row.get("health_status"),
+        "contract_state": contract_state,
+        "failure_class": failure_class,
+        "read_status": read_status,
+        "write_status": write_status,
+        "read_ready": read_status == "ready",
+        "write_ready": write_status == "ready",
+        "write_safe": write_safe,
+        "production_ready": production_ready,
+        "mock_or_test_double": mock_or_test_double,
+        "last_sync_at": _isoformat(last_sync_at),
+        "source_objects": _source_objects(contract, config_dict),
+        "data_freshness": {
+            "status": freshness_status,
+            "ttl_seconds": ttl_seconds,
+            "last_sync_at": _isoformat(last_sync_at),
+        },
+        "retry_budget": retry_budget,
+        "retry_policy": retry_policy,
+        "degraded_mode_reason": degraded_reason,
+        "degraded_mode": degraded_mode,
+        "confidence_impact": degraded_mode["confidence_impact"],
+        "blocks_external_writes": blocks_external_writes,
+        "blocks_production_kpi_confidence": row_blocks_kpi_confidence,
+        "idempotency_key_supported": bool(retry_budget.get("idempotency_supported")),
+        "external_write_confirmation_status": confirmation_status,
+        "external_write_confirmations": confirmations,
+        "next_action_cta": next_action_cta,
+    }
+
+
+def _spec_from_setup(setup_row: dict[str, Any]) -> MarketingConnectorContractSpec:
+    key = str(setup_row.get("key") or "").strip().lower()
+    requirement = next((item for item in MARKETING_CONNECTOR_REQUIREMENTS if item.key == key), None)
+    return MarketingConnectorContractSpec(
+        connector_key=key,
+        read_capabilities=(f"{key}.read",),
+        required_read_scopes=tuple(requirement.required_scopes if requirement else ()),
+    )
+
+
+def _contract_payload(config: dict[str, Any]) -> dict[str, Any]:
+    value = (
+        config.get("marketing_connector_contract")
+        or config.get("marketing_contract")
+        or config.get("connector_contract")
+        or {}
+    )
+    return value if isinstance(value, dict) else {}
+
+
+def _contract_state(
+    contract: dict[str, Any],
+    setup_row: dict[str, Any],
+    auth_status: str,
+    freshness_status: str,
+    missing_read_scopes: list[str],
+    missing_write_scopes: list[str],
+    mock_or_test_double: bool,
+) -> str:
+    raw = _normalize_key(
+        contract.get("state")
+        or contract.get("contract_state")
+        or contract.get("status")
+        or contract.get("health_status")
+        or setup_row.get("health_status")
+    )
+    status_text = " ".join(
+        str(part or "")
+        for part in (
+            raw,
+            contract.get("degraded_mode_reason"),
+            contract.get("last_error"),
+            setup_row.get("detail"),
+        )
+    ).lower()
+
+    if mock_or_test_double:
+        return "degraded"
+    if _contains_any(status_text, CONNECTOR_DISABLED_MARKERS):
+        return "connector_disabled"
+    if auth_status == "expired" or _contains_any(status_text, AUTH_EXPIRED_MARKERS):
+        return "auth_expired"
+    if missing_read_scopes or _contains_any(status_text, MISSING_SCOPE_MARKERS):
+        return "missing_scope"
+    if _contains_any(status_text, RATE_LIMIT_MARKERS):
+        return "rate_limited"
+    if _contains_any(status_text, TIMEOUT_MARKERS):
+        return "timeout"
+    if _contains_any(status_text, VENDOR_5XX_MARKERS):
+        return "vendor_5xx"
+    if _contains_any(status_text, MALFORMED_PAYLOAD_MARKERS):
+        return "malformed_payload"
+    if _contains_any(status_text, QUOTA_EXHAUSTED_MARKERS):
+        return "quota_exhausted"
+    if _contains_any(status_text, PARTIAL_DATA_MARKERS):
+        return "partial_data"
+    if freshness_status == "stale" or _contains_any(status_text, STALE_DATA_MARKERS):
+        return "stale_data"
+    if raw in CONTRACT_STATES:
+        return raw
+    if missing_write_scopes:
+        return "missing_scope"
+    if raw in {"healthy", "ok", "ready"}:
+        return "healthy"
+    return "degraded"
+
+
+def _failure_class(
+    contract: dict[str, Any],
+    contract_state: str,
+    configured: bool,
+    missing_read_scopes: list[str],
+    missing_write_scopes: list[str],
+    mock_or_test_double: bool,
+) -> str | None:
+    if not configured:
+        return None
+    explicit = normalize_failure_class(
+        contract.get("failure_class")
+        or contract.get("failure")
+        or contract.get("error_class")
+        or contract_state
+    )
+    if explicit:
+        return explicit
+    if missing_read_scopes or missing_write_scopes or contract_state == "missing_scope":
+        return "insufficient_scope"
+    if mock_or_test_double:
+        return None
+    return None
+
+
+def _read_status(
+    configured: bool,
+    production_ready: bool,
+    contract_state: str,
+    missing_read_scopes: list[str],
+    missing_write_scopes: list[str],
+    read_capabilities: tuple[str, ...],
+) -> str:
+    if not configured or not production_ready or not read_capabilities:
+        return "blocked"
+    unknown_scope_blocker = contract_state == "missing_scope" and not missing_write_scopes
+    hard_blocked_state = contract_state in {
+        "auth_expired",
+        "connector_disabled",
+        "malformed_payload",
+    }
+    if hard_blocked_state or missing_read_scopes or unknown_scope_blocker:
+        return "blocked"
+    if contract_state in {
+        "rate_limited",
+        "timeout",
+        "vendor_5xx",
+        "partial_data",
+        "stale_data",
+        "quota_exhausted",
+        "degraded",
+    }:
+        return "degraded"
+    return "ready"
+
+
+def _write_status(
+    read_status: str,
+    contract_state: str,
+    write_capabilities: tuple[str, ...],
+    missing_write_scopes: list[str],
+    idempotency_supported: bool,
+) -> str:
+    if not write_capabilities:
+        return "read_only"
+    if read_status == "blocked":
+        return "blocked"
+    if missing_write_scopes or contract_state == "missing_scope":
+        return "missing_scope"
+    if read_status == "degraded":
+        return "degraded"
+    if not idempotency_supported:
+        return "idempotency_missing"
+    return "ready"
+
+
+def _degraded_reason(
+    contract: dict[str, Any],
+    contract_state: str,
+    mock_or_test_double: bool,
+    missing_read_scopes: list[str],
+    missing_write_scopes: list[str],
+    retry_budget: dict[str, Any],
+) -> str | None:
+    explicit = _string_or_none(
+        contract.get("degraded_mode_reason")
+        or contract.get("blocking_reason")
+        or contract.get("last_error")
+    )
+    if explicit:
+        return explicit
+    if mock_or_test_double:
+        return "Connector contract is marked as test-double/mock-only and cannot prove production readiness."
+    if missing_read_scopes:
+        return f"Missing read scopes: {', '.join(missing_read_scopes)}."
+    if missing_write_scopes:
+        return f"Missing write scopes: {', '.join(missing_write_scopes)}."
+    if contract_state == "rate_limited":
+        return f"Connector is rate limited; next retry at {retry_budget.get('next_retry_at') or 'unknown'}."
+    if contract_state == "timeout":
+        return "Connector timed out; retry budget metadata is required before retrying."
+    if contract_state == "vendor_5xx":
+        return "Vendor returned a 5xx response; workflow should use degraded mode."
+    if contract_state == "malformed_payload":
+        return "Connector returned a malformed payload; fix the contract/parser before using production data."
+    if contract_state == "quota_exhausted":
+        return "Connector quota is exhausted; wait for the reset window before retrying."
+    if contract_state == "connector_disabled":
+        return "Connector is disabled and must be enabled before CMO workflows can use it."
+    if contract_state == "partial_data":
+        return "Connector returned partial data."
+    if contract_state == "stale_data":
+        return "Connector data is stale beyond its TTL."
+    if contract_state == "auth_expired":
+        return "Connector auth is expired and must be reauthorized."
+    if contract_state == "degraded":
+        return "Connector contract is degraded."
+    return None
+
+
+def _next_action_cta(
+    contract_state: str,
+    read_status: str,
+    write_status: str,
+    retry_policy: dict[str, Any] | None = None,
+) -> str:
+    if retry_policy and retry_policy.get("required_cta") not in {None, "", "none"}:
+        return str(retry_policy["required_cta"])
+    if contract_state == "auth_expired":
+        return "reconnect"
+    if contract_state == "missing_scope" or write_status == "missing_scope":
+        return "add_scope"
+    if contract_state in {"rate_limited", "timeout", "vendor_5xx"}:
+        return "review_retry_budget"
+    if contract_state == "malformed_payload":
+        return "fix_connector_payload"
+    if contract_state == "quota_exhausted":
+        return "wait_for_quota_reset"
+    if contract_state == "connector_disabled":
+        return "enable_connector"
+    if contract_state in {"partial_data", "stale_data", "degraded"}:
+        return "review_degraded"
+    if write_status == "idempotency_missing":
+        return "configure_idempotency"
+    if read_status == "blocked":
+        return "setup"
+    return "none"
+
+
+def _auth_status(
+    contract: dict[str, Any],
+    setup_row: dict[str, Any],
+    config: dict[str, Any],
+) -> str:
+    raw = str(
+        contract.get("auth_status")
+        or config.get("auth_state")
+        or setup_row.get("auth_status")
+        or ""
+    ).strip().lower()
+    health = str(setup_row.get("health_status") or "").strip().lower()
+    if raw in {"expired", "auth_expired", "token_expired"} or health == "expired_auth":
+        return "expired"
+    if raw in {"missing", "unconfigured"} or str(setup_row.get("configured_status") or "") == "unconfigured":
+        return "missing"
+    if raw in {"valid", "healthy", "ok", "ready"} or health in {"healthy", "stale", "degraded"}:
+        return "valid"
+    return raw or "unknown"
+
+
+def _retry_budget(contract: dict[str, Any], retry_policy: dict[str, Any] | None = None) -> dict[str, Any]:
+    value = contract.get("retry_budget") or contract.get("retry") or {}
+    raw = value if isinstance(value, dict) else {}
+    policy = retry_policy or {}
+    max_attempts = _int_or_zero(
+        raw.get("max_attempts")
+        or raw.get("budget")
+        or policy.get("max_attempts")
+        or 0
+    )
+    attempts_used = _int_or_zero(raw.get("attempts_used") or raw.get("used") or 0)
+    remaining = raw.get("remaining_attempts")
+    remaining_attempts = _int_or_zero(remaining) if remaining is not None else max(max_attempts - attempts_used, 0)
+    return {
+        "max_attempts": max_attempts,
+        "attempts_used": attempts_used,
+        "remaining_attempts": remaining_attempts,
+        "reset_at": _string_or_none(raw.get("reset_at")),
+        "next_retry_at": _string_or_none(raw.get("next_retry_at")),
+        "last_error": _string_or_none(raw.get("last_error")),
+        "idempotency_key": _string_or_none(
+            raw.get("idempotency_key")
+            or contract.get("idempotency_key")
+        ),
+        "idempotency_supported": bool(
+            raw.get("idempotency_supported")
+            or raw.get("supports_idempotency")
+            or contract.get("idempotency_supported")
+            or contract.get("supports_idempotency")
+        ),
+        "retryable": bool(policy.get("retryable")),
+        "backoff_strategy": policy.get("backoff_strategy") or {"type": "none"},
+        "safe_retry_requires_idempotency": bool(policy.get("safe_retry_requires_idempotency")),
+        "audit_event_code": _string_or_none(policy.get("audit_event_code")),
+    }
+
+
+def _write_confirmations(contract: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = (
+        contract.get("external_write_confirmations")
+        or contract.get("write_confirmations")
+        or contract.get("write_confirmation")
+        or {}
+    )
+    confirmations: list[dict[str, Any]] = []
+    if isinstance(raw, dict):
+        iterable = raw.items()
+    elif isinstance(raw, list):
+        iterable = [(item.get("action") if isinstance(item, dict) else None, item) for item in raw]
+    else:
+        iterable = []
+    for action, payload in iterable:
+        if not isinstance(payload, dict):
+            continue
+        status = _normalize_key(payload.get("status") or payload.get("confirmation_status") or "")
+        if status not in WRITE_CONFIRMATION_STATES:
+            status = "write_confirmed" if payload.get("confirmed") is True else "write_unconfirmed"
+        confirmations.append(
+            {
+                "action": _normalize_key(payload.get("action") or action),
+                "status": status,
+                "idempotency_key": _string_or_none(payload.get("idempotency_key")),
+                "external_object_id": _string_or_none(
+                    payload.get("external_object_id")
+                    or payload.get("source_object_id")
+                    or payload.get("id")
+                ),
+                "source_url": _string_or_none(payload.get("source_url") or payload.get("url")),
+                "confirmed_at": _string_or_none(payload.get("confirmed_at")),
+                "request_fingerprint": _string_or_none(
+                    payload.get("request_fingerprint")
+                    or payload.get("request_hash")
+                ),
+                "audit_reference": _string_or_none(
+                    payload.get("audit_reference")
+                    or payload.get("audit_ref")
+                ),
+                "actor_id": _string_or_none(payload.get("actor_id")),
+                "agent_id": _string_or_none(payload.get("agent_id")),
+                "workflow_id": _string_or_none(payload.get("workflow_id")),
+                "workflow_run_id": _string_or_none(payload.get("workflow_run_id")),
+                "run_id": _string_or_none(payload.get("run_id")),
+            }
+        )
+    return confirmations
+
+
+def _external_write_confirmation_status(confirmations: list[dict[str, Any]]) -> str:
+    if any(
+        row.get("status")
+        in {"accepted", "rejected", "timeout_unknown", "retry_scheduled", "write_unconfirmed"}
+        for row in confirmations
+    ):
+        return "write_unconfirmed"
+    if any(row.get("status") in {"write_confirmed", "idempotent_recovered"} for row in confirmations):
+        return "write_confirmed"
+    return "none"
+
+
+def _matching_confirmation(
+    contract_row: dict[str, Any],
+    action: str,
+    idempotency_key: str | None,
+) -> dict[str, Any] | None:
+    confirmations = contract_row.get("external_write_confirmations") or []
+    if not isinstance(confirmations, list):
+        return None
+    normalized_action = _normalize_key(action)
+    normalized_idempotency = _string_or_none(idempotency_key)
+    for confirmation in confirmations:
+        if not isinstance(confirmation, dict):
+            continue
+        if _normalize_key(confirmation.get("action")) != normalized_action:
+            continue
+        if normalized_idempotency and confirmation.get("idempotency_key") != normalized_idempotency:
+            continue
+        return confirmation
+    return None
+
+
+def _contract_by_key(
+    connector_contracts: Iterable[dict[str, Any]],
+    connector_key: str,
+) -> dict[str, Any] | None:
+    normalized_key = _normalize_key(connector_key)
+    for row in connector_contracts:
+        if _normalize_key(row.get("connector_key")) == normalized_key:
+            return row
+    return None
+
+
+def _source_objects(contract: dict[str, Any], config: dict[str, Any]) -> list[dict[str, str | None]]:
+    raw = contract.get("source_objects") or config.get("source_objects") or []
+    items: list[dict[str, str | None]] = []
+    if isinstance(raw, dict):
+        raw = [raw]
+    if isinstance(raw, list):
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            items.append(
+                {
+                    "source_object_id": _string_or_none(
+                        item.get("source_object_id") or item.get("id")
+                    ),
+                    "source_url": _string_or_none(item.get("source_url") or item.get("url")),
+                    "object_type": _string_or_none(item.get("object_type") or item.get("type")),
+                }
+            )
+    object_id = _string_or_none(config.get("source_object_id") or contract.get("source_object_id"))
+    object_url = _string_or_none(config.get("source_url") or contract.get("source_url"))
+    if object_id or object_url:
+        items.append(
+            {
+                "source_object_id": object_id,
+                "source_url": object_url,
+                "object_type": _string_or_none(config.get("source_object_type") or contract.get("source_object_type")),
+            }
+        )
+    return items
+
+
+def _freshness_status(last_sync_at: datetime | None, ttl_seconds: int, now: datetime) -> str:
+    if last_sync_at is None:
+        return "missing"
+    if ttl_seconds <= 0:
+        return "fresh"
+    return "stale" if now - last_sync_at > timedelta(seconds=ttl_seconds) else "fresh"
+
+
+def _ttl_seconds(contract: dict[str, Any], fallback: timedelta) -> int:
+    raw = contract.get("ttl_seconds") or contract.get("data_ttl_seconds")
+    if raw is None:
+        return int(fallback.total_seconds())
+    return _int_or_zero(raw)
+
+
+def _last_sync_at(config: Any | None, contract: dict[str, Any]) -> datetime | None:
+    return _parse_datetime(contract.get("last_sync_at") or contract.get("last_successful_sync_at")) or _ensure_aware(
+        getattr(config, "last_sync_at", None)
+    )
+
+
+def _mock_or_test_double(contract: dict[str, Any], config: dict[str, Any]) -> bool:
+    if any(bool(contract.get(key) or config.get(key)) for key in ("is_test_double", "mock_only", "stub_only")):
+        return True
+    proof = _normalize_key(contract.get("production_proof") or config.get("production_proof"))
+    environment = _normalize_key(contract.get("environment") or config.get("environment"))
+    return proof in TEST_DOUBLE_PROOF_MARKERS or environment in TEST_DOUBLE_PROOF_MARKERS
+
+
+def _tuple_from_payload(
+    contract: dict[str, Any],
+    key: str,
+    fallback: tuple[str, ...],
+) -> tuple[str, ...]:
+    value = contract.get(key)
+    if value is None:
+        return fallback
+    return tuple(str(item) for item in _list_from_value(value) if str(item).strip())
+
+
+def _scopes_from_contract_or_config(contract: dict[str, Any], config: dict[str, Any]) -> list[str]:
+    value = (
+        contract.get("granted_scopes")
+        or contract.get("validated_scopes")
+        or config.get("granted_scopes")
+        or config.get("validated_scopes")
+        or config.get("scopes")
+        or config.get("scope")
+    )
+    return [str(item) for item in _list_from_value(value) if str(item).strip()]
+
+
+def _missing_scopes(required: tuple[str, ...], granted: list[str]) -> list[str]:
+    granted_set = set(granted)
+    return [scope for scope in required if scope not in granted_set]
+
+
+def _configs_by_key(connector_configs: Iterable[Any]) -> dict[str, Any]:
+    return {
+        str(getattr(config, "connector_name", "") or "").strip().lower(): config
+        for config in connector_configs
+    }
+
+
+def _config_dict(config: Any | None) -> dict[str, Any]:
+    value = getattr(config, "config", None)
+    return value if isinstance(value, dict) else {}
+
+
+def _account_id_from_config(config: dict[str, Any]) -> str | None:
+    for key in (
+        "account_id",
+        "customer_id",
+        "ad_account_id",
+        "property_id",
+        "site_url",
+        "project_id",
+        "vendor_id",
+        "channel_id",
+        "company_name",
+    ):
+        value = _string_or_none(config.get(key))
+        if value:
+            return value
+    return None
+
+
+def _workspace_id_from_config(config: dict[str, Any]) -> str | None:
+    for key in ("workspace_id", "organization_id", "business_id", "account_id"):
+        value = _string_or_none(config.get(key))
+        if value:
+            return value
+    return None
+
+
+def _contains_any(value: str, markers: tuple[str, ...]) -> bool:
+    return any(marker in value for marker in markers)
+
+
+def _list_from_value(value: Any) -> list[Any]:
+    if isinstance(value, str):
+        return [part.strip() for part in value.replace(",", " ").split() if part.strip()]
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return []
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return _ensure_aware(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return _ensure_aware(parsed)
+    return None
+
+
+def _ensure_aware(value: Any) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _isoformat(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _string_or_none(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _int_or_zero(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")

--- a/core/marketing/connector_retry_policy.py
+++ b/core/marketing/connector_retry_policy.py
@@ -1,0 +1,392 @@
+"""CMO marketing connector retry and degraded-mode policy.
+
+This module is intentionally vendor-neutral. It gives connector setup,
+contracts, data readiness, workflow activation, write completion, and workflow
+linting the same failure-class vocabulary so production CMO paths do not treat
+partial, stale, or failed connector data as healthy.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+from core.marketing.decision_audit import build_connector_degraded_decision_audit
+from core.marketing.escalation_matrix import evaluate_marketing_escalation
+
+CONNECTOR_FAILURE_CLASSES = (
+    "timeout",
+    "rate_limited",
+    "vendor_5xx",
+    "auth_expired",
+    "insufficient_scope",
+    "partial_data",
+    "stale_data",
+    "malformed_payload",
+    "quota_exhausted",
+    "connector_disabled",
+)
+
+FAILURE_CLASS_ALIASES = {
+    "auth_expired": "auth_expired",
+    "expired_auth": "auth_expired",
+    "token_expired": "auth_expired",
+    "missing_scope": "insufficient_scope",
+    "insufficient_scope": "insufficient_scope",
+    "forbidden": "insufficient_scope",
+    "rate_limit": "rate_limited",
+    "rate_limited": "rate_limited",
+    "rate_limited_429": "rate_limited",
+    "timeout": "timeout",
+    "timed_out": "timeout",
+    "deadline_exceeded": "timeout",
+    "vendor_5xx": "vendor_5xx",
+    "server_error": "vendor_5xx",
+    "vendor_server_error": "vendor_5xx",
+    "partial": "partial_data",
+    "partial_data": "partial_data",
+    "stale": "stale_data",
+    "stale_data": "stale_data",
+    "malformed": "malformed_payload",
+    "malformed_payload": "malformed_payload",
+    "invalid_payload": "malformed_payload",
+    "schema_error": "malformed_payload",
+    "quota": "quota_exhausted",
+    "quota_exhausted": "quota_exhausted",
+    "disabled": "connector_disabled",
+    "connector_disabled": "connector_disabled",
+}
+
+
+@dataclass(frozen=True)
+class ConnectorFailurePolicy:
+    failure_class: str | None
+    retryable: bool
+    max_attempts: int
+    backoff_strategy: dict[str, Any]
+    safe_retry_requires_idempotency: bool
+    degraded_mode_allowed: bool
+    confidence_impact: float
+    blocks_external_writes: bool
+    blocks_production_kpi_confidence: bool
+    required_cta: str
+    audit_event_code: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "failure_class": self.failure_class,
+            "retryable": self.retryable,
+            "max_attempts": self.max_attempts,
+            "backoff_strategy": dict(self.backoff_strategy),
+            "safe_retry_requires_idempotency": self.safe_retry_requires_idempotency,
+            "degraded_mode_allowed": self.degraded_mode_allowed,
+            "confidence_impact": self.confidence_impact,
+            "blocks_external_writes": self.blocks_external_writes,
+            "blocks_production_kpi_confidence": self.blocks_production_kpi_confidence,
+            "required_cta": self.required_cta,
+            "audit_event_code": self.audit_event_code,
+        }
+
+
+NO_FAILURE_POLICY = ConnectorFailurePolicy(
+    failure_class=None,
+    retryable=False,
+    max_attempts=0,
+    backoff_strategy={"type": "none"},
+    safe_retry_requires_idempotency=False,
+    degraded_mode_allowed=False,
+    confidence_impact=0.0,
+    blocks_external_writes=False,
+    blocks_production_kpi_confidence=False,
+    required_cta="none",
+    audit_event_code="cmo_connector_healthy",
+)
+
+CONNECTOR_FAILURE_POLICIES: dict[str, ConnectorFailurePolicy] = {
+    "timeout": ConnectorFailurePolicy(
+        failure_class="timeout",
+        retryable=True,
+        max_attempts=3,
+        backoff_strategy={"type": "exponential_jitter", "initial_seconds": 30, "max_seconds": 900},
+        safe_retry_requires_idempotency=True,
+        degraded_mode_allowed=True,
+        confidence_impact=0.30,
+        blocks_external_writes=True,
+        blocks_production_kpi_confidence=False,
+        required_cta="review_retry_budget",
+        audit_event_code="cmo_connector_timeout",
+    ),
+    "rate_limited": ConnectorFailurePolicy(
+        failure_class="rate_limited",
+        retryable=True,
+        max_attempts=5,
+        backoff_strategy={"type": "retry_after_or_exponential", "initial_seconds": 60, "max_seconds": 3600},
+        safe_retry_requires_idempotency=True,
+        degraded_mode_allowed=True,
+        confidence_impact=0.25,
+        blocks_external_writes=True,
+        blocks_production_kpi_confidence=False,
+        required_cta="review_retry_budget",
+        audit_event_code="cmo_connector_rate_limited",
+    ),
+    "vendor_5xx": ConnectorFailurePolicy(
+        failure_class="vendor_5xx",
+        retryable=True,
+        max_attempts=3,
+        backoff_strategy={"type": "exponential_jitter", "initial_seconds": 120, "max_seconds": 1800},
+        safe_retry_requires_idempotency=True,
+        degraded_mode_allowed=True,
+        confidence_impact=0.35,
+        blocks_external_writes=True,
+        blocks_production_kpi_confidence=False,
+        required_cta="monitor_vendor_recovery",
+        audit_event_code="cmo_connector_vendor_5xx",
+    ),
+    "auth_expired": ConnectorFailurePolicy(
+        failure_class="auth_expired",
+        retryable=False,
+        max_attempts=0,
+        backoff_strategy={"type": "none"},
+        safe_retry_requires_idempotency=False,
+        degraded_mode_allowed=False,
+        confidence_impact=1.0,
+        blocks_external_writes=True,
+        blocks_production_kpi_confidence=True,
+        required_cta="reconnect",
+        audit_event_code="cmo_connector_auth_expired",
+    ),
+    "insufficient_scope": ConnectorFailurePolicy(
+        failure_class="insufficient_scope",
+        retryable=False,
+        max_attempts=0,
+        backoff_strategy={"type": "none"},
+        safe_retry_requires_idempotency=False,
+        degraded_mode_allowed=False,
+        confidence_impact=1.0,
+        blocks_external_writes=True,
+        blocks_production_kpi_confidence=True,
+        required_cta="add_scope",
+        audit_event_code="cmo_connector_insufficient_scope",
+    ),
+    "partial_data": ConnectorFailurePolicy(
+        failure_class="partial_data",
+        retryable=False,
+        max_attempts=0,
+        backoff_strategy={"type": "none"},
+        safe_retry_requires_idempotency=False,
+        degraded_mode_allowed=True,
+        confidence_impact=0.45,
+        blocks_external_writes=True,
+        blocks_production_kpi_confidence=False,
+        required_cta="review_degraded",
+        audit_event_code="cmo_connector_partial_data",
+    ),
+    "stale_data": ConnectorFailurePolicy(
+        failure_class="stale_data",
+        retryable=True,
+        max_attempts=2,
+        backoff_strategy={"type": "refresh_then_fixed", "initial_seconds": 300, "max_seconds": 1800},
+        safe_retry_requires_idempotency=False,
+        degraded_mode_allowed=True,
+        confidence_impact=0.40,
+        blocks_external_writes=True,
+        blocks_production_kpi_confidence=False,
+        required_cta="refresh_connector",
+        audit_event_code="cmo_connector_stale_data",
+    ),
+    "malformed_payload": ConnectorFailurePolicy(
+        failure_class="malformed_payload",
+        retryable=False,
+        max_attempts=0,
+        backoff_strategy={"type": "none"},
+        safe_retry_requires_idempotency=False,
+        degraded_mode_allowed=False,
+        confidence_impact=1.0,
+        blocks_external_writes=True,
+        blocks_production_kpi_confidence=True,
+        required_cta="fix_connector_payload",
+        audit_event_code="cmo_connector_malformed_payload",
+    ),
+    "quota_exhausted": ConnectorFailurePolicy(
+        failure_class="quota_exhausted",
+        retryable=True,
+        max_attempts=1,
+        backoff_strategy={"type": "quota_reset_window", "initial_seconds": 3600, "max_seconds": 86400},
+        safe_retry_requires_idempotency=True,
+        degraded_mode_allowed=True,
+        confidence_impact=0.35,
+        blocks_external_writes=True,
+        blocks_production_kpi_confidence=False,
+        required_cta="wait_for_quota_reset",
+        audit_event_code="cmo_connector_quota_exhausted",
+    ),
+    "connector_disabled": ConnectorFailurePolicy(
+        failure_class="connector_disabled",
+        retryable=False,
+        max_attempts=0,
+        backoff_strategy={"type": "none"},
+        safe_retry_requires_idempotency=False,
+        degraded_mode_allowed=False,
+        confidence_impact=1.0,
+        blocks_external_writes=True,
+        blocks_production_kpi_confidence=True,
+        required_cta="enable_connector",
+        audit_event_code="cmo_connector_disabled",
+    ),
+}
+
+KPI_BY_CONNECTOR_CATEGORY: dict[str, tuple[str, ...]] = {
+    "CRM": ("MQL", "SQL", "Pipeline contribution", "Lead nurture readiness"),
+    "Ads": ("ROAS", "CAC", "Attribution", "Spend optimization"),
+    "Analytics": ("Attribution", "Campaign performance", "Reporting freshness"),
+    "CMS": ("Content pipeline", "Attribution"),
+    "Email": ("Email performance", "Lead nurture readiness"),
+    "Social": ("Social engagement", "Campaign performance"),
+    "SEO": ("Organic pipeline", "Search visibility"),
+    "Brand": ("Brand sentiment", "Brand risk"),
+    "ABM": ("ABM readiness", "Pipeline contribution"),
+    "Finance": ("CAC", "ROAS", "Pipeline contribution"),
+}
+
+
+def normalize_failure_class(value: Any) -> str | None:
+    normalized = _normalize_key(value)
+    if not normalized or normalized in {"healthy", "ok", "ready", "write_confirmed"}:
+        return None
+    if normalized in CONNECTOR_FAILURE_CLASSES:
+        return normalized
+    return FAILURE_CLASS_ALIASES.get(normalized)
+
+
+def policy_for_failure(failure_class: Any) -> ConnectorFailurePolicy:
+    normalized = normalize_failure_class(failure_class)
+    if normalized is None:
+        return NO_FAILURE_POLICY
+    return CONNECTOR_FAILURE_POLICIES[normalized]
+
+
+def policy_projection(failure_class: Any) -> dict[str, Any]:
+    return policy_for_failure(failure_class).to_dict()
+
+
+def affected_kpis_for_category(category: Any) -> list[str]:
+    return list(KPI_BY_CONNECTOR_CATEGORY.get(str(category or "").strip(), ()))
+
+
+def build_degraded_mode_projection(
+    *,
+    connector_key: str,
+    connector_name: str | None,
+    category: str | None,
+    failure_class: str | None,
+    reason: str | None,
+    policy: dict[str, Any],
+    read_status: str,
+    write_status: str,
+    next_action_cta: str,
+    affected_workflows: Iterable[str] = (),
+) -> dict[str, Any]:
+    blocked = (
+        bool(failure_class)
+        and not bool(policy.get("degraded_mode_allowed"))
+        and (read_status == "blocked" or write_status in {"blocked", "missing_scope"})
+    )
+    active = bool(failure_class) and bool(policy.get("degraded_mode_allowed"))
+    active = active or read_status == "degraded" or write_status == "degraded"
+    status = "blocked" if blocked else "degraded" if active else "none"
+    escalation_decision = (
+        evaluate_marketing_escalation(
+            {
+                "trigger_type": (
+                    "connector_auth_expired"
+                    if failure_class == "auth_expired"
+                    else "connector_degraded"
+                ),
+                "connector_key": connector_key,
+                "connector_name": connector_name,
+                "failure_class": failure_class,
+                "severity": "high" if blocked else "medium",
+                "reason": reason,
+            }
+        )
+        if failure_class
+        else None
+    )
+    projection = {
+        "status": status,
+        "active": active,
+        "allowed": bool(policy.get("degraded_mode_allowed")),
+        "reason": reason,
+        "failure_class": failure_class,
+        "affected_connectors": [connector_key] if connector_key else [],
+        "affected_connector_names": [connector_name] if connector_name else [],
+        "affected_workflows": sorted({str(item) for item in affected_workflows if str(item).strip()}),
+        "affected_kpis": affected_kpis_for_category(category),
+        "affected_capability": category,
+        "confidence_impact": float(policy.get("confidence_impact") or 0.0),
+        "blocks_external_writes": bool(policy.get("blocks_external_writes")),
+        "blocks_production_kpi_confidence": bool(policy.get("blocks_production_kpi_confidence")),
+        "next_action_cta": next_action_cta,
+        "audit_event_code": str(policy.get("audit_event_code") or "cmo_connector_healthy"),
+        "escalation_decision": escalation_decision,
+        "escalation_evidence": escalation_decision.get("evidence") if escalation_decision else None,
+    }
+    if failure_class:
+        audit_package = build_connector_degraded_decision_audit(projection)
+        projection["decision_audit"] = audit_package
+        projection["decision_audit_ref"] = audit_package["audit_reference"]
+    return projection
+
+
+def summarize_degraded_modes(rows: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    degraded_modes = [
+        row.get("degraded_mode")
+        for row in rows
+        if isinstance(row.get("degraded_mode"), dict)
+        and row["degraded_mode"].get("status") in {"degraded", "blocked"}
+    ]
+    affected_connectors = {
+        connector
+        for mode in degraded_modes
+        for connector in mode.get("affected_connectors") or []
+        if connector
+    }
+    affected_workflows = {
+        workflow
+        for mode in degraded_modes
+        for workflow in mode.get("affected_workflows") or []
+        if workflow
+    }
+    affected_kpis = {
+        kpi
+        for mode in degraded_modes
+        for kpi in mode.get("affected_kpis") or []
+        if kpi
+    }
+    return {
+        "active": bool(degraded_modes),
+        "blocked": sum(1 for mode in degraded_modes if mode.get("status") == "blocked"),
+        "degraded": sum(1 for mode in degraded_modes if mode.get("status") == "degraded"),
+        "affected_connectors": sorted(affected_connectors),
+        "affected_workflows": sorted(affected_workflows),
+        "affected_kpis": sorted(affected_kpis),
+        "confidence_impact": max((float(mode.get("confidence_impact") or 0.0) for mode in degraded_modes), default=0.0),
+        "next_action_cta": next(
+            (
+                str(mode.get("next_action_cta"))
+                for mode in degraded_modes
+                if mode.get("next_action_cta") and mode.get("next_action_cta") != "none"
+            ),
+            "none",
+        ),
+        "reasons": [
+            str(mode.get("reason"))
+            for mode in degraded_modes
+            if mode.get("reason")
+        ],
+    }
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")

--- a/core/marketing/connector_setup.py
+++ b/core/marketing/connector_setup.py
@@ -1,0 +1,524 @@
+"""CMO marketing connector setup readiness projection.
+
+This module turns existing per-tenant ConnectorConfig rows into the
+operator-facing checklist the CMO dashboard needs. It does not call vendor
+APIs, decrypt credentials, or mark a connector healthy from registry metadata.
+Only stored setup, health, scope, and sync facts can make a row ready.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+STALE_SYNC_AFTER = timedelta(hours=48)
+
+CONFIGURED_STATUSES = {"active", "configured", "ready"}
+UNCONFIGURED_STATUSES = {"deleted", "disabled", "inactive", "unconfigured"}
+HEALTHY_STATUSES = {"healthy", "ok", "ready"}
+DEGRADED_STATUSES = {"degraded", "warning", "partial", "rate_limited"}
+EXPIRED_AUTH_MARKERS = ("expired", "invalid_grant", "reauthorize", "re-authorize", "401")
+INSUFFICIENT_SCOPE_MARKERS = ("insufficient_scope", "missing_scope", "forbidden", "403")
+MALFORMED_PAYLOAD_MARKERS = ("malformed_payload", "malformed payload", "invalid_payload", "schema_error")
+QUOTA_EXHAUSTED_MARKERS = ("quota_exhausted", "quota exhausted", "quota", "limit exhausted")
+CONNECTOR_DISABLED_MARKERS = ("connector_disabled", "connector disabled", "disabled", "inactive")
+
+
+@dataclass(frozen=True)
+class MarketingConnectorRequirement:
+    key: str
+    name: str
+    category: str
+    required_scopes: tuple[str, ...] = ()
+    required_credentials: tuple[str, ...] = ()
+
+
+MARKETING_CONNECTOR_REQUIREMENTS: tuple[MarketingConnectorRequirement, ...] = (
+    MarketingConnectorRequirement(
+        key="hubspot",
+        name="HubSpot",
+        category="CRM",
+        required_scopes=("crm.objects.contacts.read", "crm.objects.deals.read", "automation"),
+        required_credentials=("client_id", "client_secret", "refresh_token"),
+    ),
+    MarketingConnectorRequirement(
+        key="salesforce",
+        name="Salesforce",
+        category="CRM",
+        required_scopes=("api", "refresh_token", "offline_access"),
+        required_credentials=("client_id", "client_secret", "refresh_token", "instance_url"),
+    ),
+    MarketingConnectorRequirement(
+        key="google_ads",
+        name="Google Ads",
+        category="Ads",
+        required_scopes=("https://www.googleapis.com/auth/adwords",),
+        required_credentials=("client_id", "client_secret", "refresh_token", "developer_token", "customer_id"),
+    ),
+    MarketingConnectorRequirement(
+        key="meta_ads",
+        name="Meta Ads",
+        category="Ads",
+        required_scopes=("ads_read", "business_management"),
+        required_credentials=("access_token", "ad_account_id"),
+    ),
+    MarketingConnectorRequirement(
+        key="linkedin_ads",
+        name="LinkedIn Ads",
+        category="Ads",
+        required_scopes=("r_ads_reporting", "rw_ads"),
+        required_credentials=("client_id", "client_secret", "refresh_token", "account_id"),
+    ),
+    MarketingConnectorRequirement(
+        key="ga4",
+        name="Google Analytics 4",
+        category="Analytics",
+        required_scopes=("https://www.googleapis.com/auth/analytics.readonly",),
+        required_credentials=("client_id", "client_secret", "refresh_token", "property_id"),
+    ),
+    MarketingConnectorRequirement(
+        key="mixpanel",
+        name="Mixpanel",
+        category="Analytics",
+        required_credentials=("project_id", "service_account_username", "service_account_secret"),
+    ),
+    MarketingConnectorRequirement(
+        key="wordpress",
+        name="WordPress",
+        category="CMS",
+        required_credentials=("site_url", "username", "application_password"),
+    ),
+    MarketingConnectorRequirement(
+        key="mailchimp",
+        name="Mailchimp",
+        category="Email",
+        required_credentials=("api_key", "server_prefix", "audience_id"),
+    ),
+    MarketingConnectorRequirement(
+        key="sendgrid",
+        name="SendGrid",
+        category="Email",
+        required_credentials=("api_key", "sender_identity"),
+    ),
+    MarketingConnectorRequirement(
+        key="buffer",
+        name="Buffer",
+        category="Social",
+        required_scopes=("profile:read", "updates:create"),
+        required_credentials=("client_id", "client_secret", "refresh_token"),
+    ),
+    MarketingConnectorRequirement(
+        key="twitter",
+        name="X / Twitter",
+        category="Social",
+        required_scopes=("tweet.read", "tweet.write", "users.read", "offline.access"),
+        required_credentials=("client_id", "client_secret", "refresh_token"),
+    ),
+    MarketingConnectorRequirement(
+        key="youtube",
+        name="YouTube",
+        category="Social",
+        required_scopes=("https://www.googleapis.com/auth/youtube.readonly",),
+        required_credentials=("client_id", "client_secret", "refresh_token", "channel_id"),
+    ),
+    MarketingConnectorRequirement(
+        key="ahrefs",
+        name="Ahrefs",
+        category="SEO",
+        required_credentials=("api_token", "site_url"),
+    ),
+    MarketingConnectorRequirement(
+        key="brandwatch",
+        name="Brandwatch",
+        category="Brand",
+        required_scopes=("read_mentions", "read_queries"),
+        required_credentials=("client_id", "client_secret", "refresh_token", "project_id"),
+    ),
+    MarketingConnectorRequirement(
+        key="bombora",
+        name="Bombora",
+        category="ABM",
+        required_credentials=("api_key", "company_id"),
+    ),
+    MarketingConnectorRequirement(
+        key="g2",
+        name="G2",
+        category="ABM",
+        required_credentials=("api_key", "vendor_id"),
+    ),
+    MarketingConnectorRequirement(
+        key="trustradius",
+        name="TrustRadius",
+        category="ABM",
+        required_credentials=("api_key", "vendor_id"),
+    ),
+    MarketingConnectorRequirement(
+        key="stripe",
+        name="Stripe",
+        category="Finance",
+        required_credentials=("api_key", "account_id"),
+    ),
+    MarketingConnectorRequirement(
+        key="tally",
+        name="Tally",
+        category="Finance",
+        required_credentials=("company_name", "bridge_url"),
+    ),
+)
+
+
+def marketing_connector_keys() -> list[str]:
+    return [requirement.key for requirement in MARKETING_CONNECTOR_REQUIREMENTS]
+
+
+def build_marketing_connector_setup(
+    connector_configs: Iterable[Any],
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Build CMO setup rows from existing ConnectorConfig-like objects."""
+
+    now = _ensure_aware(now or datetime.now(UTC))
+    configs_by_name = {
+        str(getattr(config, "connector_name", "") or "").strip().lower(): config
+        for config in connector_configs
+    }
+
+    rows: list[dict[str, Any]] = []
+    for requirement in MARKETING_CONNECTOR_REQUIREMENTS:
+        config = configs_by_name.get(requirement.key)
+        rows.append(_build_row(requirement, config, now))
+    return rows
+
+
+def summarize_marketing_connector_setup(rows: Iterable[dict[str, Any]]) -> dict[str, int | bool | str]:
+    items = list(rows)
+    missing = sum(1 for row in items if row.get("health_status") == "missing")
+    healthy = sum(1 for row in items if row.get("health_status") == "healthy")
+    stale = sum(1 for row in items if row.get("health_status") == "stale")
+    degraded = sum(1 for row in items if row.get("health_status") == "degraded")
+    auth_actions = sum(
+        1
+        for row in items
+        if row.get("health_status") in {"expired_auth", "insufficient_scope"}
+    )
+    needs_action = sum(1 for row in items if row.get("cta_state") != "none")
+    return {
+        "total": len(items),
+        "healthy": healthy,
+        "missing": missing,
+        "stale": stale,
+        "degraded": degraded,
+        "auth_actions": auth_actions,
+        "needs_action": needs_action,
+        "readiness": "ready" if needs_action == 0 and items else "setup_required",
+    }
+
+
+def _build_row(
+    requirement: MarketingConnectorRequirement,
+    config: Any | None,
+    now: datetime,
+) -> dict[str, Any]:
+    if config is None:
+        return _missing_row(requirement)
+
+    config_payload = _dict_or_empty(getattr(config, "config", None))
+    status = str(getattr(config, "status", "") or "").strip().lower()
+    health_status_raw = str(getattr(config, "health_status", "") or "").strip().lower()
+    sync_error = str(getattr(config, "sync_error", "") or "")
+    last_sync_at = _ensure_aware(getattr(config, "last_sync_at", None))
+    credentials = getattr(config, "credentials_encrypted", None)
+    has_credentials = bool(credentials)
+    granted_scopes = _scopes_from_config(config_payload)
+    missing_scopes = _missing_scopes(requirement.required_scopes, granted_scopes)
+    contract_payload = _contract_payload(config_payload)
+    contract_state = _contract_state_from_payload(contract_payload, last_sync_at, now)
+
+    if status in UNCONFIGURED_STATUSES or not has_credentials:
+        return _missing_row(requirement)
+
+    configured_status = "configured" if status in CONFIGURED_STATUSES or status else status
+    status_text = " ".join(
+        str(part or "")
+        for part in (health_status_raw, sync_error, config_payload.get("auth_state"))
+    ).lower()
+
+    health_status = "degraded"
+    cta_state = "review"
+    data_coverage_status = "partial"
+    detail = sync_error or "Connector configured but no healthy sync has been proven yet."
+
+    if (
+        contract_state == "missing_scope"
+        or _contains_any(status_text, INSUFFICIENT_SCOPE_MARKERS)
+    ) and not missing_scopes:
+        missing_scopes = list(requirement.required_scopes)
+
+    if contract_state == "missing_scope" or _contains_any(status_text, INSUFFICIENT_SCOPE_MARKERS) or missing_scopes:
+        health_status = "insufficient_scope"
+        cta_state = "add_scope"
+        data_coverage_status = "blocked"
+        detail = "Connector is configured but required marketing scopes are missing."
+    elif contract_state == "auth_expired" or _contains_any(status_text, EXPIRED_AUTH_MARKERS) or health_status_raw in {
+        "expired_auth",
+        "auth_expired",
+        "token_expired",
+    }:
+        health_status = "expired_auth"
+        cta_state = "reconnect"
+        data_coverage_status = "blocked"
+        detail = sync_error or "Connector auth is expired and must be reauthorized."
+    elif contract_state == "connector_disabled" or _contains_any(status_text, CONNECTOR_DISABLED_MARKERS):
+        health_status = "degraded"
+        cta_state = "enable_connector"
+        data_coverage_status = "blocked"
+        detail = _contract_degraded_reason(contract_payload, "connector_disabled")
+    elif contract_state == "malformed_payload" or _contains_any(status_text, MALFORMED_PAYLOAD_MARKERS):
+        health_status = "degraded"
+        cta_state = "fix_connector_payload"
+        data_coverage_status = "blocked"
+        detail = _contract_degraded_reason(contract_payload, "malformed_payload")
+    elif contract_state == "quota_exhausted" or _contains_any(status_text, QUOTA_EXHAUSTED_MARKERS):
+        health_status = "degraded"
+        cta_state = "wait_for_quota_reset"
+        data_coverage_status = "partial"
+        detail = _contract_degraded_reason(contract_payload, "quota_exhausted")
+    elif contract_state in {"rate_limited", "timeout", "vendor_5xx", "partial_data", "degraded"}:
+        health_status = "degraded"
+        cta_state = "review"
+        data_coverage_status = "partial"
+        detail = _contract_degraded_reason(contract_payload, contract_state)
+    elif contract_state == "stale_data":
+        health_status = "stale"
+        cta_state = "refresh"
+        data_coverage_status = "stale"
+        detail = _contract_degraded_reason(contract_payload, contract_state)
+    elif last_sync_at is None:
+        health_status = "degraded"
+        cta_state = "refresh"
+        data_coverage_status = "missing"
+        detail = "Connector is configured but has no successful sync timestamp yet."
+    elif last_sync_at is not None and now - last_sync_at > STALE_SYNC_AFTER:
+        health_status = "stale"
+        cta_state = "refresh"
+        data_coverage_status = "stale"
+        detail = "Last successful sync is older than the CMO freshness threshold."
+    elif health_status_raw in HEALTHY_STATUSES:
+        health_status = "healthy"
+        cta_state = "none"
+        data_coverage_status = _coverage_from_config(config_payload, "ready")
+        detail = "Configured, healthy, and recently synced."
+    elif health_status_raw in DEGRADED_STATUSES:
+        health_status = "degraded"
+        cta_state = "review"
+        data_coverage_status = _coverage_from_config(config_payload, "partial")
+        detail = sync_error or "Connector is degraded; marketing data may be incomplete."
+
+    return {
+        "key": requirement.key,
+        "name": str(getattr(config, "display_name", None) or requirement.name),
+        "category": requirement.category,
+        "required_scopes": list(requirement.required_scopes),
+        "required_credentials": list(requirement.required_credentials),
+        "configured_status": configured_status,
+        "health_status": health_status,
+        "last_sync_at": _isoformat(last_sync_at),
+        "owner": _owner_from_config(config_payload),
+        "account_id": _account_id_from_config(config_payload),
+        "data_coverage_status": data_coverage_status,
+        "cta_state": cta_state,
+        "missing_scopes": missing_scopes,
+        "granted_scopes": granted_scopes,
+        "detail": detail,
+    }
+
+
+def _missing_row(requirement: MarketingConnectorRequirement) -> dict[str, Any]:
+    return {
+        "key": requirement.key,
+        "name": requirement.name,
+        "category": requirement.category,
+        "required_scopes": list(requirement.required_scopes),
+        "required_credentials": list(requirement.required_credentials),
+        "configured_status": "unconfigured",
+        "health_status": "missing",
+        "last_sync_at": None,
+        "owner": "Unassigned",
+        "account_id": None,
+        "data_coverage_status": "missing",
+        "cta_state": "setup",
+        "missing_scopes": list(requirement.required_scopes),
+        "granted_scopes": [],
+        "detail": "Connector is missing; configure it before treating CMO data as production-ready.",
+    }
+
+
+def _dict_or_empty(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _contract_payload(config: dict[str, Any]) -> dict[str, Any]:
+    value = (
+        config.get("marketing_connector_contract")
+        or config.get("marketing_contract")
+        or config.get("connector_contract")
+        or {}
+    )
+    return value if isinstance(value, dict) else {}
+
+
+def _contract_state_from_payload(
+    payload: dict[str, Any],
+    last_sync_at: datetime | None,
+    now: datetime,
+) -> str:
+    raw = str(
+        payload.get("state")
+        or payload.get("contract_state")
+        or payload.get("status")
+        or payload.get("health_status")
+        or ""
+    ).strip().lower()
+    normalized = raw.replace("-", "_").replace(" ", "_")
+    status_text = " ".join(
+        str(part or "")
+        for part in (
+            normalized,
+            payload.get("degraded_mode_reason"),
+            payload.get("blocking_reason"),
+            payload.get("last_error"),
+        )
+    ).lower()
+    ttl_seconds = _int_or_none(payload.get("ttl_seconds") or payload.get("data_ttl_seconds"))
+    contract_sync = _parse_datetime(payload.get("last_sync_at") or payload.get("last_successful_sync_at"))
+    effective_sync = contract_sync or last_sync_at
+    if (
+        normalized in {"", "healthy"}
+        and ttl_seconds
+        and effective_sync
+        and now - effective_sync > timedelta(seconds=ttl_seconds)
+    ):
+        return "stale_data"
+    if _contains_any(status_text, CONNECTOR_DISABLED_MARKERS):
+        return "connector_disabled"
+    if _contains_any(status_text, MALFORMED_PAYLOAD_MARKERS):
+        return "malformed_payload"
+    if _contains_any(status_text, QUOTA_EXHAUSTED_MARKERS):
+        return "quota_exhausted"
+    return normalized
+
+
+def _contract_degraded_reason(payload: dict[str, Any], state: str) -> str:
+    explicit = str(
+        payload.get("degraded_mode_reason")
+        or payload.get("blocking_reason")
+        or payload.get("last_error")
+        or ""
+    ).strip()
+    if explicit:
+        return explicit
+    return {
+        "rate_limited": "Connector is rate limited; retry budget controls when it can be retried.",
+        "timeout": "Connector timed out; use degraded mode until retry succeeds.",
+        "vendor_5xx": "Vendor returned a 5xx error; use degraded mode until vendor recovers.",
+        "partial_data": "Connector returned partial data; KPI confidence must be downgraded.",
+        "stale_data": "Connector data is stale beyond its TTL.",
+        "malformed_payload": "Connector returned malformed data; fix the connector payload before production use.",
+        "quota_exhausted": "Connector quota is exhausted; retry only after the reset window.",
+        "connector_disabled": "Connector is disabled and blocks dependent CMO workflows.",
+        "degraded": "Connector contract is degraded; marketing data may be incomplete.",
+    }.get(state, "Connector contract is degraded; marketing data may be incomplete.")
+
+
+def _coverage_from_config(config: dict[str, Any], fallback: str) -> str:
+    value = str(config.get("data_coverage_status") or config.get("data_coverage") or "").strip().lower()
+    return value if value in {"ready", "missing", "blocked", "stale", "partial", "unavailable"} else fallback
+
+
+def _owner_from_config(config: dict[str, Any]) -> str:
+    for key in ("owner", "owner_email", "admin_email", "marketing_owner"):
+        value = str(config.get(key) or "").strip()
+        if value:
+            return value
+    return "Unassigned"
+
+
+def _account_id_from_config(config: dict[str, Any]) -> str | None:
+    for key in (
+        "account_id",
+        "workspace_id",
+        "customer_id",
+        "ad_account_id",
+        "property_id",
+        "site_url",
+        "organization_id",
+        "project_id",
+        "vendor_id",
+        "channel_id",
+        "company_name",
+    ):
+        value = str(config.get(key) or "").strip()
+        if value:
+            return value
+    return None
+
+
+def _scopes_from_config(config: dict[str, Any]) -> list[str]:
+    raw = (
+        config.get("granted_scopes")
+        or config.get("validated_scopes")
+        or config.get("scopes")
+        or config.get("scope")
+    )
+    if isinstance(raw, str):
+        return [part for part in raw.replace(",", " ").split() if part]
+    if isinstance(raw, (list, tuple, set)):
+        return [str(part) for part in raw if str(part).strip()]
+    return []
+
+
+def _missing_scopes(required: tuple[str, ...], granted: list[str]) -> list[str]:
+    if not required or not granted:
+        return []
+    granted_set = set(granted)
+    return [scope for scope in required if scope not in granted_set]
+
+
+def _contains_any(value: str, markers: tuple[str, ...]) -> bool:
+    return any(marker in value for marker in markers)
+
+
+def _ensure_aware(value: Any) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return _ensure_aware(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return _ensure_aware(parsed)
+    return None
+
+
+def _isoformat(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/core/marketing/data_readiness.py
+++ b/core/marketing/data_readiness.py
@@ -1,0 +1,818 @@
+"""CMO marketing field mapping and historical backfill readiness.
+
+This module projects stored ConnectorConfig metadata into operator-facing
+CMO data readiness. It does not call vendor APIs or infer production
+readiness from connector registration. Field mappings and backfill facts must
+be explicitly present in connector config JSON before KPI paths can treat them
+as ready.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from core.marketing.connector_retry_policy import summarize_degraded_modes
+from core.marketing.decision_audit import build_cmo_decision_audit_package
+from core.marketing.escalation_matrix import evaluate_marketing_escalation
+
+MAPPING_STALE_AFTER = timedelta(days=90)
+
+FIELD_MAPPING_STATES = (
+    "unmapped",
+    "partially_mapped",
+    "valid",
+    "invalid",
+    "stale",
+    "blocked",
+)
+BACKFILL_STATES = (
+    "not_started",
+    "queued",
+    "running",
+    "completed",
+    "partial",
+    "failed",
+    "blocked",
+)
+ACTIVE_CONNECTOR_HEALTH = {"healthy", "stale", "degraded"}
+BLOCKED_CONNECTOR_HEALTH = {"missing", "expired_auth", "insufficient_scope"}
+VALID_CURRENCIES = {
+    "AED",
+    "AUD",
+    "CAD",
+    "EUR",
+    "GBP",
+    "INR",
+    "JPY",
+    "SGD",
+    "USD",
+}
+
+
+@dataclass(frozen=True)
+class FieldMappingRequirement:
+    key: str
+    name: str
+    source_categories: tuple[str, ...]
+    required_fields: tuple[str, ...]
+    affected_kpis: tuple[str, ...]
+    missing_blocks: bool = True
+
+
+FIELD_MAPPING_REQUIREMENTS: tuple[FieldMappingRequirement, ...] = (
+    FieldMappingRequirement(
+        key="lifecycle_stages",
+        name="Lifecycle stages",
+        source_categories=("CRM",),
+        required_fields=("source_field", "stage_map"),
+        affected_kpis=("MQL", "SQL", "Pipeline contribution", "Conversion rates"),
+    ),
+    FieldMappingRequirement(
+        key="opportunity_revenue",
+        name="Opportunity revenue fields",
+        source_categories=("CRM", "Finance"),
+        required_fields=("amount_field", "close_date_field", "currency_field"),
+        affected_kpis=("Pipeline contribution", "CAC", "ROAS"),
+    ),
+    FieldMappingRequirement(
+        key="campaign_ids",
+        name="Campaign IDs",
+        source_categories=("Ads", "Analytics", "Email", "CMS"),
+        required_fields=("campaign_id_field",),
+        affected_kpis=("ROAS", "Attribution", "Experiment velocity"),
+        missing_blocks=False,
+    ),
+    FieldMappingRequirement(
+        key="utm_fields",
+        name="UTM fields",
+        source_categories=("Ads", "Analytics", "Email", "CMS"),
+        required_fields=("source", "medium", "campaign"),
+        affected_kpis=("ROAS", "CAC", "Attribution"),
+        missing_blocks=False,
+    ),
+    FieldMappingRequirement(
+        key="account_domains",
+        name="Account domains",
+        source_categories=("CRM", "ABM"),
+        required_fields=("domain_field",),
+        affected_kpis=("ABM readiness", "Pipeline contribution"),
+        missing_blocks=False,
+    ),
+    FieldMappingRequirement(
+        key="consent_unsubscribe",
+        name="Consent and unsubscribe fields",
+        source_categories=("Email", "CRM"),
+        required_fields=("consent_field", "unsubscribe_field"),
+        affected_kpis=("Email performance", "Lead nurture readiness"),
+    ),
+    FieldMappingRequirement(
+        key="fiscal_calendar",
+        name="Fiscal calendar",
+        source_categories=(),
+        required_fields=("fiscal_year_start_month",),
+        affected_kpis=("CAC", "ROAS", "Pipeline contribution"),
+    ),
+    FieldMappingRequirement(
+        key="currency",
+        name="Currency",
+        source_categories=(),
+        required_fields=("currency",),
+        affected_kpis=("CAC", "ROAS", "Pipeline contribution"),
+    ),
+    FieldMappingRequirement(
+        key="timezone",
+        name="Timezone",
+        source_categories=(),
+        required_fields=("timezone",),
+        affected_kpis=("Campaign performance", "Email performance", "Reporting freshness"),
+    ),
+)
+
+
+def build_marketing_data_readiness(
+    connector_setup: Iterable[dict[str, Any]],
+    connector_configs: Iterable[Any],
+    *,
+    connector_contracts: Iterable[dict[str, Any]] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build mapping, backfill, and KPI-readiness projections."""
+
+    now = _ensure_aware(now) or datetime.now(UTC)
+    setup_rows = list(connector_setup)
+    config_rows = list(connector_configs)
+    field_mappings = build_marketing_field_mapping_status(
+        setup_rows,
+        config_rows,
+        now=now,
+    )
+    backfills = build_marketing_backfill_status(setup_rows, config_rows, now=now)
+    field_summary = summarize_field_mapping_status(field_mappings)
+    backfill_summary = summarize_backfill_status(backfills)
+    kpi_readiness = build_kpi_readiness(
+        field_mappings,
+        backfills,
+        field_summary,
+        backfill_summary,
+        setup_rows,
+        connector_contracts=connector_contracts or (),
+    )
+    return {
+        "field_mapping_status": field_mappings,
+        "field_mapping_summary": field_summary,
+        "backfill_status": backfills,
+        "backfill_summary": backfill_summary,
+        "kpi_readiness": kpi_readiness,
+    }
+
+
+def build_marketing_field_mapping_status(
+    connector_setup: Iterable[dict[str, Any]],
+    connector_configs: Iterable[Any],
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Validate canonical CMO field mappings from ConnectorConfig.config."""
+
+    now = _ensure_aware(now) or datetime.now(UTC)
+    setup_rows = list(connector_setup)
+    configs_by_key = _configs_by_key(connector_configs)
+    return [
+        _build_field_mapping_row(requirement, setup_rows, configs_by_key, now)
+        for requirement in FIELD_MAPPING_REQUIREMENTS
+    ]
+
+
+def build_marketing_backfill_status(
+    connector_setup: Iterable[dict[str, Any]],
+    connector_configs: Iterable[Any],
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Project historical backfill state for each configured marketing source."""
+
+    configs_by_key = _configs_by_key(connector_configs)
+    rows: list[dict[str, Any]] = []
+
+    for setup_row in connector_setup:
+        key = str(setup_row.get("key") or "").strip().lower()
+        if not key:
+            continue
+        if str(setup_row.get("configured_status") or "") == "unconfigured":
+            continue
+
+        payload = _backfill_payload(_config_dict(configs_by_key.get(key)))
+        health = str(setup_row.get("health_status") or "").strip().lower()
+        if health in BLOCKED_CONNECTOR_HEALTH:
+            rows.append(
+                _backfill_row(
+                    setup_row,
+                    "blocked",
+                    payload,
+                    blocking_reason=(
+                        setup_row.get("detail")
+                        or "Connector is not ready for historical CMO backfill."
+                    ),
+                )
+            )
+            continue
+
+        status = str(payload.get("status") or "").strip().lower()
+        if not payload:
+            rows.append(_backfill_row(setup_row, "not_started", payload))
+        elif status not in BACKFILL_STATES:
+            rows.append(
+                _backfill_row(
+                    setup_row,
+                    "blocked",
+                    payload,
+                    blocking_reason="Backfill status is missing or not recognized.",
+                )
+            )
+        else:
+            rows.append(_backfill_row(setup_row, status, payload))
+
+    return rows
+
+
+def summarize_field_mapping_status(rows: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    items = list(rows)
+    counts = dict.fromkeys(FIELD_MAPPING_STATES, 0)
+    for row in items:
+        status = str(row.get("status") or "")
+        if status in counts:
+            counts[status] += 1
+
+    blocking = [
+        row
+        for row in items
+        if row.get("missing_blocks") and row.get("status") in {"unmapped", "invalid", "blocked"}
+    ]
+    degraded = [
+        row
+        for row in items
+        if row.get("status") in {"partially_mapped", "stale"}
+        or (not row.get("missing_blocks") and row.get("status") in {"unmapped", "invalid", "blocked"})
+    ]
+    return {
+        "total": len(items),
+        **counts,
+        "needs_action": sum(1 for row in items if row.get("next_action_cta") != "none"),
+        "readiness": "blocked" if blocking else "degraded" if degraded else "ready",
+        "blocking": len(blocking),
+        "degraded": len(degraded),
+    }
+
+
+def summarize_backfill_status(rows: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    items = list(rows)
+    counts = dict.fromkeys(BACKFILL_STATES, 0)
+    for row in items:
+        status = str(row.get("status") or "")
+        if status in counts:
+            counts[status] += 1
+
+    if not items:
+        readiness = "blocked"
+    elif counts["blocked"] or counts["failed"]:
+        readiness = "blocked"
+    elif counts["completed"] == len(items):
+        readiness = "ready"
+    else:
+        readiness = "degraded"
+
+    return {
+        "total": len(items),
+        **counts,
+        "needs_action": sum(1 for row in items if row.get("next_action_cta") != "none"),
+        "readiness": readiness,
+    }
+
+
+def build_kpi_readiness(
+    field_mapping_rows: Iterable[dict[str, Any]],
+    backfill_rows: Iterable[dict[str, Any]],
+    field_summary: dict[str, Any],
+    backfill_summary: dict[str, Any],
+    connector_setup: Iterable[dict[str, Any]] = (),
+    connector_contracts: Iterable[dict[str, Any]] = (),
+) -> dict[str, Any]:
+    field_items = list(field_mapping_rows)
+    backfill_items = list(backfill_rows)
+    setup_items = list(connector_setup)
+    contract_items = list(connector_contracts)
+    blocked_reasons: list[str] = []
+    degraded_reasons: list[str] = []
+    affected_kpis: set[str] = set()
+
+    for row in field_items:
+        status = str(row.get("status") or "")
+        affected_kpis.update(str(kpi) for kpi in row.get("affected_kpis") or [])
+        if row.get("missing_blocks") and status in {"unmapped", "invalid", "blocked"}:
+            blocked_reasons.append(
+                f"{row.get('name')} mapping is {status.replace('_', ' ')}."
+            )
+        elif status in {"partially_mapped", "stale"}:
+            degraded_reasons.append(
+                f"{row.get('name')} mapping is {status.replace('_', ' ')}."
+            )
+        elif not row.get("missing_blocks") and status in {"unmapped", "invalid", "blocked"}:
+            degraded_reasons.append(
+                f"{row.get('name')} mapping is {status.replace('_', ' ')}."
+            )
+
+    if not backfill_items:
+        blocked_reasons.append("No connected marketing source has a historical backfill record.")
+    for row in backfill_items:
+        status = str(row.get("status") or "")
+        if status in {"blocked", "failed"}:
+            blocked_reasons.append(
+                f"{row.get('source_name')} backfill is {status}."
+            )
+        elif status in {"not_started", "queued", "running", "partial"}:
+            degraded_reasons.append(
+                f"{row.get('source_name')} backfill is {status.replace('_', ' ')}."
+            )
+    for row in setup_items:
+        if str(row.get("configured_status") or "") == "unconfigured":
+            continue
+        health = str(row.get("health_status") or "")
+        if health in {"stale", "degraded"}:
+            degraded_reasons.append(
+                f"{row.get('name')} connector is {health.replace('_', ' ')}."
+            )
+    for row in contract_items:
+        if str(row.get("configured_status") or "") == "unconfigured":
+            continue
+        degraded_mode = row.get("degraded_mode") if isinstance(row.get("degraded_mode"), dict) else {}
+        reason = degraded_mode.get("reason") or row.get("degraded_mode_reason")
+        connector_name = row.get("name") or row.get("connector_key")
+        affected_kpis.update(str(kpi) for kpi in degraded_mode.get("affected_kpis") or [])
+        if row.get("blocks_production_kpi_confidence"):
+            blocked_reasons.append(
+                f"{connector_name} connector blocks production KPI confidence: {reason or row.get('failure_class')}."
+            )
+        elif degraded_mode.get("status") == "degraded" or row.get("read_status") == "degraded":
+            degraded_reasons.append(
+                f"{connector_name} connector is degraded: {reason or row.get('failure_class')}."
+            )
+
+    if blocked_reasons:
+        status = "blocked"
+        next_action_cta = "resolve_data_readiness"
+    elif degraded_reasons or field_summary.get("readiness") != "ready" or backfill_summary.get("readiness") != "ready":
+        status = "degraded"
+        next_action_cta = "review_data_readiness"
+    else:
+        status = "ready"
+        next_action_cta = "none"
+
+    historical_status = "ready" if backfill_summary.get("readiness") == "ready" else "blocked"
+    return {
+        "status": status,
+        "historical_status": historical_status,
+        "field_mapping_readiness": field_summary.get("readiness"),
+        "backfill_readiness": backfill_summary.get("readiness"),
+        "blocked_reasons": blocked_reasons,
+        "degraded_reasons": degraded_reasons,
+        "affected_kpis": sorted(affected_kpis),
+        "degraded_mode": summarize_degraded_modes(contract_items),
+        "next_action_cta": next_action_cta,
+    }
+
+
+def _build_field_mapping_row(
+    requirement: FieldMappingRequirement,
+    setup_rows: list[dict[str, Any]],
+    configs_by_key: dict[str, Any],
+    now: datetime,
+) -> dict[str, Any]:
+    candidate_sources = _candidate_sources(requirement, setup_rows)
+    active_sources = [
+        row
+        for row in candidate_sources
+        if str(row.get("health_status") or "").strip().lower() in ACTIVE_CONNECTOR_HEALTH
+    ]
+    source_names = [str(row.get("name") or row.get("key")) for row in active_sources]
+
+    if requirement.source_categories and not active_sources:
+        return _field_mapping_row(
+            requirement,
+            "blocked",
+            [],
+            missing_fields=list(requirement.required_fields),
+            blocking_reason=(
+                "No configured source in "
+                f"{', '.join(requirement.source_categories)} is ready for mapping."
+            ),
+            next_action_cta="connect_source",
+        )
+
+    if requirement.source_categories:
+        payloads = [
+            (
+                str(source.get("key") or "").strip().lower(),
+                _mapping_payload(
+                    _config_dict(configs_by_key.get(str(source.get("key") or "").strip().lower())),
+                    requirement.key,
+                ),
+            )
+            for source in active_sources
+        ]
+    else:
+        payloads = [
+            (key, _mapping_payload(_config_dict(config), requirement.key))
+            for key, config in configs_by_key.items()
+        ]
+
+    payloads = [(key, payload) for key, payload in payloads if payload]
+    if not payloads:
+        return _field_mapping_row(
+            requirement,
+            "unmapped",
+            source_names,
+            missing_fields=list(requirement.required_fields),
+            next_action_cta="map_fields",
+        )
+
+    explicit_block = _first_blocking_reason(payload for _key, payload in payloads)
+    if explicit_block:
+        return _field_mapping_row(
+            requirement,
+            "blocked",
+            source_names,
+            missing_fields=list(requirement.required_fields),
+            blocking_reason=explicit_block,
+            next_action_cta="resolve_mapping_blocker",
+        )
+
+    combined = _merge_payloads(payload for _key, payload in payloads)
+    invalid_reason = _invalid_mapping_reason(requirement, combined)
+    if invalid_reason:
+        return _field_mapping_row(
+            requirement,
+            "invalid",
+            source_names,
+            missing_fields=[],
+            blocking_reason=invalid_reason,
+            next_action_cta="fix_mapping",
+            last_updated_at=_latest_updated_at(payloads),
+        )
+
+    missing_fields = _missing_required_fields(requirement.required_fields, combined)
+    missing_source_count = 0
+    if requirement.source_categories:
+        mapped_keys = {key for key, _payload in payloads}
+        missing_source_count = sum(
+            1
+            for source in active_sources
+            if str(source.get("key") or "").strip().lower() not in mapped_keys
+        )
+
+    if len(missing_fields) == len(requirement.required_fields):
+        status = "unmapped"
+        next_action = "map_fields"
+    elif missing_fields or missing_source_count:
+        status = "partially_mapped"
+        next_action = "complete_mapping"
+    elif _is_stale(payloads, now):
+        status = "stale"
+        next_action = "review_mapping"
+    else:
+        status = "valid"
+        next_action = "none"
+
+    return _field_mapping_row(
+        requirement,
+        status,
+        source_names,
+        missing_fields=missing_fields,
+        next_action_cta=next_action,
+        last_updated_at=_latest_updated_at(payloads),
+    )
+
+
+def _field_mapping_row(
+    requirement: FieldMappingRequirement,
+    status: str,
+    source_names: list[str],
+    *,
+    missing_fields: list[str],
+    next_action_cta: str,
+    blocking_reason: str | None = None,
+    last_updated_at: str | None = None,
+) -> dict[str, Any]:
+    normalized_status = status if status in FIELD_MAPPING_STATES else "blocked"
+    escalation_decision = (
+        evaluate_marketing_escalation(
+            {
+                "trigger_type": "data_mapping_blocked",
+                "mapping_status": normalized_status,
+                "action": "field_mapping",
+                "step_id": requirement.key,
+                "severity": "high",
+                "reason": blocking_reason or f"{requirement.name} mapping is {normalized_status}.",
+            }
+        )
+        if requirement.missing_blocks and normalized_status in {"unmapped", "invalid", "blocked"}
+        else None
+    )
+    row = {
+        "key": requirement.key,
+        "name": requirement.name,
+        "status": normalized_status,
+        "source_categories": list(requirement.source_categories),
+        "sources": source_names,
+        "required_fields": list(requirement.required_fields),
+        "missing_fields": missing_fields,
+        "affected_kpis": list(requirement.affected_kpis),
+        "missing_blocks": requirement.missing_blocks,
+        "last_updated_at": last_updated_at,
+        "blocking_reason": blocking_reason,
+        "next_action_cta": next_action_cta,
+        "escalation_decision": escalation_decision,
+        "escalation_evidence": escalation_decision.get("evidence") if escalation_decision else None,
+    }
+    if escalation_decision is not None:
+        audit_package = build_cmo_decision_audit_package(
+            {
+                "event_type": "connector_degraded_failure_decision",
+                "decision_type": normalized_status,
+                "action": "field_mapping",
+                "step_id": requirement.key,
+                "escalation_result": escalation_decision,
+                "rationale": blocking_reason or f"{requirement.name} mapping is {normalized_status}.",
+                "risk_flags": [normalized_status, "data_mapping_blocked"],
+                "final_outcome": normalized_status,
+                "actor_type": "system",
+            }
+        )
+        row["decision_audit"] = audit_package
+        row["decision_audit_ref"] = audit_package["audit_reference"]
+    return row
+
+
+def _backfill_row(
+    setup_row: dict[str, Any],
+    status: str,
+    payload: dict[str, Any],
+    *,
+    blocking_reason: str | None = None,
+) -> dict[str, Any]:
+    status = status if status in BACKFILL_STATES else "blocked"
+    reason = blocking_reason or str(payload.get("blocking_reason") or "").strip() or None
+    escalation_decision = (
+        evaluate_marketing_escalation(
+            {
+                "trigger_type": "backfill_failed",
+                "is_backfill": True,
+                "backfill_status": status,
+                "connector_key": setup_row.get("key"),
+                "workflow_id": payload.get("workflow_id"),
+                "severity": "high",
+                "reason": reason or f"{setup_row.get('name')} backfill is {status}.",
+            }
+        )
+        if status in {"failed", "blocked"}
+        else None
+    )
+    row = {
+        "source_connector_key": setup_row.get("key"),
+        "source_name": setup_row.get("name"),
+        "category": setup_row.get("category"),
+        "status": status,
+        "requested_start": _string_or_none(
+            payload.get("requested_start") or payload.get("date_range_start")
+        ),
+        "requested_end": _string_or_none(
+            payload.get("requested_end") or payload.get("date_range_end")
+        ),
+        "records_discovered": _int_or_none(payload.get("records_discovered")),
+        "records_imported": _int_or_none(payload.get("records_imported")),
+        "records_skipped": _int_or_none(payload.get("records_skipped")),
+        "records_failed": _int_or_none(payload.get("records_failed")),
+        "last_run_at": _iso_or_string(payload.get("last_run_at")),
+        "blocking_reason": reason,
+        "next_action_cta": _backfill_cta(status),
+        "escalation_decision": escalation_decision,
+        "escalation_evidence": escalation_decision.get("evidence") if escalation_decision else None,
+    }
+    if escalation_decision is not None:
+        audit_package = build_cmo_decision_audit_package(
+            {
+                "event_type": "connector_degraded_failure_decision",
+                "decision_type": status,
+                "connector_key": setup_row.get("key"),
+                "source_refs": [setup_row.get("key")],
+                "escalation_result": escalation_decision,
+                "rationale": reason or f"{setup_row.get('name')} backfill is {status}.",
+                "risk_flags": [status, "backfill_failed"],
+                "final_outcome": status,
+                "actor_type": "system",
+            }
+        )
+        row["decision_audit"] = audit_package
+        row["decision_audit_ref"] = audit_package["audit_reference"]
+    return row
+
+
+def _candidate_sources(
+    requirement: FieldMappingRequirement,
+    setup_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    if not requirement.source_categories:
+        return []
+    allowed = set(requirement.source_categories)
+    return [
+        row
+        for row in setup_rows
+        if str(row.get("category") or "").strip() in allowed
+    ]
+
+
+def _configs_by_key(connector_configs: Iterable[Any]) -> dict[str, Any]:
+    return {
+        str(getattr(config, "connector_name", "") or "").strip().lower(): config
+        for config in connector_configs
+    }
+
+
+def _config_dict(config: Any | None) -> dict[str, Any]:
+    value = getattr(config, "config", None)
+    return value if isinstance(value, dict) else {}
+
+
+def _mapping_payload(config: dict[str, Any], key: str) -> dict[str, Any]:
+    root = (
+        config.get("marketing_field_mapping")
+        or config.get("marketing_field_mappings")
+        or config.get("field_mapping")
+        or config.get("field_mappings")
+        or {}
+    )
+    if not isinstance(root, dict):
+        root = {}
+    value = root.get(key)
+    if isinstance(value, dict):
+        return value
+    if key == "currency":
+        value = root.get("currency") or config.get("currency") or config.get("default_currency")
+        if isinstance(value, str):
+            return {"currency": value, "updated_at": root.get("updated_at")}
+    if key == "timezone":
+        value = root.get("timezone") or config.get("timezone")
+        if isinstance(value, str):
+            return {"timezone": value, "updated_at": root.get("updated_at")}
+    if key == "fiscal_calendar":
+        value = (
+            root.get("fiscal_year_start_month")
+            or config.get("fiscal_year_start_month")
+            or config.get("fiscal_calendar_start_month")
+        )
+        if value is not None:
+            return {"fiscal_year_start_month": value, "updated_at": root.get("updated_at")}
+    return {}
+
+
+def _backfill_payload(config: dict[str, Any]) -> dict[str, Any]:
+    value = (
+        config.get("marketing_backfill")
+        or config.get("backfill")
+        or config.get("historical_backfill")
+        or {}
+    )
+    return value if isinstance(value, dict) else {}
+
+
+def _first_blocking_reason(payloads: Iterable[dict[str, Any]]) -> str | None:
+    for payload in payloads:
+        reason = str(payload.get("blocking_reason") or payload.get("blocked_reason") or "").strip()
+        status = str(payload.get("status") or payload.get("mapping_status") or "").strip().lower()
+        if reason:
+            return reason
+        if status == "blocked":
+            return "Mapping is explicitly blocked."
+    return None
+
+
+def _merge_payloads(payloads: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    merged: dict[str, Any] = {}
+    for payload in payloads:
+        for key, value in payload.items():
+            if value not in (None, "", [], {}):
+                merged[key] = value
+    return merged
+
+
+def _missing_required_fields(required_fields: tuple[str, ...], payload: dict[str, Any]) -> list[str]:
+    return [
+        field
+        for field in required_fields
+        if payload.get(field) in (None, "", [], {})
+    ]
+
+
+def _invalid_mapping_reason(
+    requirement: FieldMappingRequirement,
+    payload: dict[str, Any],
+) -> str | None:
+    if requirement.key == "currency":
+        currency = str(payload.get("currency") or "").strip().upper()
+        if currency and currency not in VALID_CURRENCIES:
+            return f"Currency '{currency}' is not in the supported ISO currency allowlist."
+    elif requirement.key == "timezone":
+        timezone = str(payload.get("timezone") or "").strip()
+        if timezone:
+            try:
+                ZoneInfo(timezone)
+            except ZoneInfoNotFoundError:
+                return f"Timezone '{timezone}' is not recognized."
+    elif requirement.key == "fiscal_calendar":
+        raw = payload.get("fiscal_year_start_month")
+        try:
+            month = int(raw)
+        except (TypeError, ValueError):
+            return "Fiscal year start month must be an integer between 1 and 12."
+        if month < 1 or month > 12:
+            return "Fiscal year start month must be between 1 and 12."
+    return None
+
+
+def _latest_updated_at(payloads: list[tuple[str, dict[str, Any]]]) -> str | None:
+    timestamps = [
+        value
+        for _key, payload in payloads
+        for value in (_iso_or_string(payload.get("updated_at") or payload.get("last_validated_at")),)
+        if value
+    ]
+    return max(timestamps) if timestamps else None
+
+
+def _is_stale(payloads: list[tuple[str, dict[str, Any]]], now: datetime) -> bool:
+    timestamps = [
+        parsed
+        for _key, payload in payloads
+        for parsed in (_parse_datetime(payload.get("updated_at") or payload.get("last_validated_at")),)
+        if parsed is not None
+    ]
+    return bool(timestamps) and all(now - timestamp > MAPPING_STALE_AFTER for timestamp in timestamps)
+
+
+def _backfill_cta(status: str) -> str:
+    return {
+        "not_started": "start_backfill",
+        "queued": "monitor_backfill",
+        "running": "monitor_backfill",
+        "completed": "none",
+        "partial": "review_failed_records",
+        "failed": "retry_backfill",
+        "blocked": "resolve_blocker",
+    }[status]
+
+
+def _ensure_aware(value: Any) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return _ensure_aware(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return _ensure_aware(parsed)
+    return None
+
+
+def _iso_or_string(value: Any) -> str | None:
+    if isinstance(value, datetime):
+        return (_ensure_aware(value) or value).isoformat()
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/core/marketing/decision_audit.py
+++ b/core/marketing/decision_audit.py
@@ -1,0 +1,785 @@
+"""Structured CMO decision audit packages.
+
+CMO-6.3 keeps marketing governance evidence portable until a persistent audit
+table is introduced. Callers receive deterministic, WORM-ready package objects
+and canonical JSON serialization that can later be stored unchanged.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+DECISION_AUDIT_SCHEMA_VERSION = "2026-05-23.cmo-6.3"
+
+CMO_DECISION_AUDIT_EVENT_TYPES = (
+    "campaign_launch",
+    "budget_change",
+    "content_publish",
+    "email_send",
+    "landing_page_change",
+    "target_account_list_change",
+    "crisis_public_response",
+    "high_risk_copy_pricing_legal_claim",
+    "workflow_promotion",
+    "approval_timeout",
+    "policy_decision",
+    "escalation_decision",
+    "connector_degraded_failure_decision",
+    "external_write_attempt",
+    "external_write_confirmation",
+    "external_write_rejection",
+    "external_write_timeout",
+    "external_write_idempotent_recovery",
+    "external_write_retry_scheduled",
+    "external_write_unconfirmed",
+    "draft_created",
+    "shadow_only",
+    "override",
+)
+
+MAJOR_CUSTOMER_FACING_EVENT_TYPES = {
+    "campaign_launch",
+    "budget_change",
+    "content_publish",
+    "email_send",
+    "landing_page_change",
+    "target_account_list_change",
+    "crisis_public_response",
+    "high_risk_copy_pricing_legal_claim",
+    "workflow_promotion",
+    "external_write_attempt",
+    "external_write_confirmation",
+    "external_write_rejection",
+    "external_write_timeout",
+    "external_write_idempotent_recovery",
+    "external_write_retry_scheduled",
+    "external_write_unconfirmed",
+}
+
+DEFAULT_REQUIRED_AUDIT_EVIDENCE_CLASSES = (
+    "actor_identity",
+    "input_snapshot_hash",
+    "policy_result",
+    "source_refs",
+    "workflow_context",
+    "final_outcome",
+)
+
+SECRET_KEY_MARKERS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "bearer",
+    "client_secret",
+    "cookie",
+    "credential",
+    "credentials",
+    "encrypted",
+    "password",
+    "private_key",
+    "refresh_token",
+    "secret",
+    "token",
+)
+
+ACTION_EVENT_TYPE_MAP = {  # enterprise-gate: process-local-ok reason=static-action-event-routing-map
+    "activate_campaign": "campaign_launch",
+    "create_campaign": "campaign_launch",
+    "create_linkedin_campaign": "campaign_launch",
+    "launch_campaign": "campaign_launch",
+    "setup_google_campaign": "campaign_launch",
+    "setup_meta_campaign": "campaign_launch",
+    "mutate_ad_budget": "budget_change",
+    "pause_campaign": "budget_change",
+    "spend": "budget_change",
+    "update_ad_budget": "budget_change",
+    "publish": "content_publish",
+    "publish_to_wordpress": "content_publish",
+    "schedule_content": "content_publish",
+    "add_to_drip": "email_send",
+    "send": "email_send",
+    "send_email": "email_send",
+    "send_to_segment": "email_send",
+    "send_winner": "email_send",
+    "start_nurture_sequence": "email_send",
+    "create_abm_campaign": "campaign_launch",
+    "launch_abm_campaign": "campaign_launch",
+    "launch_competitive_campaign": "campaign_launch",
+    "set_abm_budget": "budget_change",
+    "landing_page_change": "landing_page_change",
+    "apply_redirect": "landing_page_change",
+    "publish_landing_page": "landing_page_change",
+    "publish_seo_change": "landing_page_change",
+    "submit_url_to_index": "landing_page_change",
+    "update_canonical_tag": "landing_page_change",
+    "update_landing_page": "landing_page_change",
+    "update_page_metadata": "landing_page_change",
+    "update_robots_txt": "landing_page_change",
+    "update_sitemap": "landing_page_change",
+    "query_target_accounts": "target_account_list_change",
+    "sync_target_accounts": "target_account_list_change",
+    "target_account_list_change": "target_account_list_change",
+    "update_target_accounts": "target_account_list_change",
+    "crisis_response": "crisis_public_response",
+    "detect_crisis": "crisis_public_response",
+    "publish_brand_response": "crisis_public_response",
+    "publish_competitive_response": "crisis_public_response",
+    "public_response": "crisis_public_response",
+    "brand_claim": "high_risk_copy_pricing_legal_claim",
+    "claims_review": "high_risk_copy_pricing_legal_claim",
+    "comparative_claim": "high_risk_copy_pricing_legal_claim",
+    "high_risk_copy": "high_risk_copy_pricing_legal_claim",
+    "legal_claim": "high_risk_copy_pricing_legal_claim",
+    "pricing_claim": "high_risk_copy_pricing_legal_claim",
+}
+
+EXTERNAL_WRITE_FINAL_EVENT_TYPES = {
+    "write_confirmed": "external_write_confirmation",
+    "idempotent_recovered": "external_write_idempotent_recovery",
+    "rejected": "external_write_rejection",
+    "timeout_unknown": "external_write_timeout",
+    "retry_scheduled": "external_write_retry_scheduled",
+    "write_unconfirmed": "external_write_unconfirmed",
+    "accepted": "external_write_unconfirmed",
+    "draft_created": "draft_created",
+    "shadow_only": "shadow_only",
+}
+
+
+def build_cmo_decision_audit_package(
+    context: Mapping[str, Any] | None = None,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic, secret-redacted CMO decision audit package."""
+
+    ctx = context if isinstance(context, Mapping) else {}
+    timestamp = _timestamp(ctx, now)
+    action = _normalize_key(ctx.get("action") or ctx.get("blocked_action"))
+    event_type = _event_type(ctx, action)
+    policy_result = _clean_ref(ctx.get("policy_result") or ctx.get("marketing_policy_decision"))
+    escalation_result = _clean_ref(ctx.get("escalation_result") or ctx.get("escalation_decision"))
+    approval_result = _clean_ref(ctx.get("approval_result") or ctx.get("approval_decision"))
+    timeout_result = _clean_ref(ctx.get("timeout_result") or ctx.get("approval_timeout_decision"))
+    external_write_result = _clean_ref(
+        ctx.get("external_write_result") or ctx.get("external_write_decision")
+    )
+    input_snapshot = _input_snapshot(ctx, action, event_type)
+    package: dict[str, Any] = {
+        "schema_version": DECISION_AUDIT_SCHEMA_VERSION,
+        "audit_id": None,
+        "audit_reference": None,
+        "tenant_id": _string_or_none(ctx.get("tenant_id")),
+        "company_id": _string_or_none(ctx.get("company_id")),
+        "workflow_id": _string_or_none(ctx.get("workflow_id")),
+        "workflow_run_id": _string_or_none(ctx.get("workflow_run_id")),
+        "run_id": _string_or_none(ctx.get("run_id")),
+        "step_id": _string_or_none(ctx.get("step_id")),
+        "agent": _string_or_none(ctx.get("agent") or ctx.get("agent_type") or ctx.get("agent_id")),
+        "action": action or None,
+        "capability": _string_or_none(ctx.get("capability")),
+        "event_type": event_type,
+        "decision_type": _decision_type(ctx),
+        "actor_type": _actor_type(ctx.get("actor_type")),
+        "actor_id": _string_or_none(ctx.get("actor_id") or ctx.get("user_id") or ctx.get("agent_id")),
+        "actor_role": _string_or_none(ctx.get("actor_role") or ctx.get("user_role")),
+        "created_at": timestamp.isoformat(),
+        "decided_at": timestamp.isoformat(),
+        "input_snapshot_hash": _fingerprint(input_snapshot),
+        "input_snapshot": input_snapshot,
+        "source_refs": _source_refs(ctx),
+        "connector_refs": _connector_refs(ctx),
+        "policy_result_ref": _result_ref(policy_result, "policy"),
+        "policy_result": policy_result,
+        "escalation_result_ref": _result_ref(escalation_result, "escalation"),
+        "escalation_result": escalation_result,
+        "approval_result_ref": _result_ref(approval_result, "approval"),
+        "approval_result": approval_result,
+        "timeout_result_ref": _result_ref(timeout_result, "timeout"),
+        "timeout_result": timeout_result,
+        "external_write_result_ref": _result_ref(external_write_result, "external_write"),
+        "external_write_result": external_write_result,
+        "rationale": _string_or_none(ctx.get("rationale") or ctx.get("reason")) or "",
+        "alternatives_considered": _string_list(ctx.get("alternatives_considered") or ctx.get("alternatives")),
+        "risk_flags": _risk_flags(ctx),
+        "confidence": _float_or_none(ctx.get("confidence")),
+        "final_outcome": _string_or_none(ctx.get("final_outcome") or ctx.get("outcome")) or "unknown",
+        "override": _override(ctx),
+        "worm_ready": True,
+        "immutable": True,
+        "redaction": {
+            "status": "applied",
+            "redacted_markers": list(SECRET_KEY_MARKERS),
+        },
+        "serialization": {
+            "format": "canonical_json",
+            "sort_keys": True,
+            "schema_version": DECISION_AUDIT_SCHEMA_VERSION,
+        },
+    }
+    package["audit_id"] = _audit_id(package)
+    package["audit_reference"] = f"cmo_decision_audit:{package['audit_id']}"
+    package["serialization"]["sha256"] = _fingerprint(
+        {
+            key: value
+            for key, value in package.items()
+            if key != "serialization"
+        }
+    )
+    return package
+
+
+def serialize_cmo_decision_audit_package(package: Mapping[str, Any]) -> str:
+    """Return canonical WORM-ready JSON for a decision audit package."""
+
+    return _canonical_json(_redact(package))
+
+
+def build_policy_decision_audit(
+    decision: Mapping[str, Any],
+    context: Mapping[str, Any] | None = None,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    clean_decision = _without_audit(decision)
+    return build_cmo_decision_audit_package(
+        {
+            **(dict(context) if isinstance(context, Mapping) else {}),
+            "event_type": "policy_decision",
+            "decision_type": clean_decision.get("decision"),
+            "workflow_id": clean_decision.get("affected_workflow"),
+            "action": clean_decision.get("affected_action"),
+            "policy_result": clean_decision,
+            "source_refs": _policy_source_refs(clean_decision),
+            "rationale": clean_decision.get("reason"),
+            "final_outcome": clean_decision.get("decision"),
+            "actor_type": "system",
+        },
+        now=now,
+    )
+
+
+def build_escalation_decision_audit(
+    decision: Mapping[str, Any],
+    context: Mapping[str, Any] | None = None,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    clean_decision = _without_audit(decision)
+    return build_cmo_decision_audit_package(
+        {
+            **(dict(context) if isinstance(context, Mapping) else {}),
+            "event_type": "escalation_decision",
+            "decision_type": clean_decision.get("decision"),
+            "workflow_id": clean_decision.get("workflow_id"),
+            "workflow_run_id": clean_decision.get("workflow_run_id"),
+            "run_id": clean_decision.get("run_id"),
+            "step_id": clean_decision.get("step_id"),
+            "action": clean_decision.get("action"),
+            "escalation_result": clean_decision,
+            "rationale": clean_decision.get("reason"),
+            "risk_flags": [clean_decision.get("severity")],
+            "final_outcome": clean_decision.get("decision"),
+            "actor_type": "system",
+        },
+        now=now,
+    )
+
+
+def build_approval_timeout_decision_audit(
+    decision: Mapping[str, Any],
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    clean_decision = _without_audit(decision)
+    audit_evidence = clean_decision.get("audit_evidence")
+    audit_evidence = audit_evidence if isinstance(audit_evidence, Mapping) else {}
+    return build_cmo_decision_audit_package(
+        {
+            "event_type": "approval_timeout",
+            "decision_type": clean_decision.get("outcome"),
+            "workflow_id": clean_decision.get("workflow_id") or audit_evidence.get("workflow_id"),
+            "workflow_run_id": clean_decision.get("workflow_run_id") or audit_evidence.get("workflow_run_id"),
+            "run_id": clean_decision.get("run_id") or audit_evidence.get("run_id"),
+            "step_id": clean_decision.get("step_id") or audit_evidence.get("step_id"),
+            "action": clean_decision.get("blocked_action") or audit_evidence.get("blocked_action"),
+            "approval_result": clean_decision,
+            "timeout_result": audit_evidence or clean_decision,
+            "policy_result": clean_decision.get("marketing_policy_decision"),
+            "escalation_result": clean_decision.get("escalation_decision"),
+            "rationale": clean_decision.get("safe_fallback_message"),
+            "final_outcome": clean_decision.get("outcome"),
+            "actor_type": "system",
+        },
+        now=now,
+    )
+
+
+def build_external_write_decision_audit(
+    event: Mapping[str, Any],
+    *,
+    event_type: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    clean_event = _without_audit(event)
+    final_state = _normalize_key(clean_event.get("outcome") or clean_event.get("final_state"))
+    resolved_event_type = event_type or EXTERNAL_WRITE_FINAL_EVENT_TYPES.get(final_state, "external_write_attempt")
+    return build_cmo_decision_audit_package(
+        {
+            **clean_event,
+            "event_type": resolved_event_type,
+            "decision_type": clean_event.get("outcome") or clean_event.get("final_state") or "attempted",
+            "external_write_result": clean_event,
+            "action": clean_event.get("action"),
+            "connector_key": clean_event.get("connector_key"),
+            "rationale": clean_event.get("reason"),
+            "final_outcome": clean_event.get("outcome") or clean_event.get("final_state") or "attempted",
+            "actor_type": clean_event.get("actor_type") or "agent",
+        },
+        now=now,
+    )
+
+
+def build_connector_degraded_decision_audit(
+    degraded_mode: Mapping[str, Any],
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    clean_mode = _without_audit(degraded_mode)
+    return build_cmo_decision_audit_package(
+        {
+            "event_type": "connector_degraded_failure_decision",
+            "decision_type": clean_mode.get("status"),
+            "connector_key": next(iter(clean_mode.get("affected_connectors") or []), None),
+            "source_refs": clean_mode.get("affected_connectors"),
+            "risk_flags": [clean_mode.get("failure_class"), clean_mode.get("status")],
+            "confidence": 1.0 - float(clean_mode.get("confidence_impact") or 0.0),
+            "rationale": clean_mode.get("reason"),
+            "final_outcome": clean_mode.get("status"),
+            "escalation_result": clean_mode.get("escalation_decision"),
+            "actor_type": "system",
+        },
+        now=now,
+    )
+
+
+def build_workflow_promotion_audit_package(
+    workflow_row: Mapping[str, Any],
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    row = _without_audit(workflow_row)
+    return build_cmo_decision_audit_package(
+        {
+            "event_type": "workflow_promotion",
+            "decision_type": row.get("state"),
+            "workflow_id": row.get("workflow_key"),
+            "action": "workflow_promotion",
+            "policy_result": row.get("marketing_policy"),
+            "escalation_result": row.get("escalation_matrix"),
+            "approval_result": row.get("approval_timeout_policy"),
+            "rationale": "; ".join(str(item) for item in row.get("blocked_reasons") or [])
+            or "Workflow activation gate evaluated.",
+            "risk_flags": row.get("degraded_reasons") or row.get("blocked_reasons") or [],
+            "final_outcome": row.get("state"),
+            "actor_type": "system",
+        },
+        now=now,
+    )
+
+
+def build_workflow_decision_audit_status(
+    workflow_key: str,
+    actions: Iterable[Any],
+    payload: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload = payload if isinstance(payload, Mapping) else {}
+    required_actions = _unique(_normalize_key(action) for action in actions)
+    required_event_types = _unique(
+        action_event_type(action, payload)
+        for action in required_actions
+    )
+    if not required_actions:
+        status = "not_required"
+        next_action = "none"
+    elif _audit_disabled(payload):
+        status = "missing_audit_evidence"
+        next_action = "configure_decision_audit_package"
+    else:
+        status = "ready"
+        next_action = "none"
+    return {
+        "workflow_key": _normalize_key(workflow_key),
+        "status": status,
+        "required_actions": required_actions,
+        "required_event_types": required_event_types,
+        "required_evidence_classes": list(DEFAULT_REQUIRED_AUDIT_EVIDENCE_CLASSES),
+        "worm_ready": status == "ready",
+        "missing_audit_actions": required_actions if status == "missing_audit_evidence" else [],
+        "next_action_cta": next_action,
+        "schema_version": DECISION_AUDIT_SCHEMA_VERSION,
+    }
+
+
+def has_decision_audit_evidence_for_step(step: Mapping[str, Any] | None) -> bool:
+    if not isinstance(step, Mapping) or _audit_disabled(step):
+        return False
+    evidence_keys = (
+        "audit_evidence",
+        "audit_package",
+        "audit_reference",
+        "audit_refs",
+        "decision_audit",
+        "decision_audit_package",
+        "decision_audit_ref",
+        "decision_audit_required",
+        "audit_package_required",
+        "required_audit_evidence",
+    )
+    return any(_truthy(step.get(key)) for key in evidence_keys)
+
+
+def build_marketing_decision_audit_projection(
+    sources: Iterable[Any] | None = None,
+) -> dict[str, Any]:
+    disabled = False
+    for source in sources or []:
+        config = _config_dict(source)
+        if _audit_disabled(config):
+            disabled = True
+            break
+    summary = {
+        "status": "missing_audit_evidence" if disabled else "ready",
+        "schema_version": DECISION_AUDIT_SCHEMA_VERSION,
+        "event_type_count": len(CMO_DECISION_AUDIT_EVENT_TYPES),
+        "major_event_types": sorted(MAJOR_CUSTOMER_FACING_EVENT_TYPES),
+        "required_evidence_classes": list(DEFAULT_REQUIRED_AUDIT_EVIDENCE_CLASSES),
+        "secret_redaction": "applied",
+        "worm_ready": not disabled,
+        "next_action_cta": "configure_decision_audit_package" if disabled else "none",
+    }
+    return {
+        "marketing_decision_audit": {
+            "schema_version": DECISION_AUDIT_SCHEMA_VERSION,
+            "event_types": list(CMO_DECISION_AUDIT_EVENT_TYPES),
+            "required_evidence_classes": list(DEFAULT_REQUIRED_AUDIT_EVIDENCE_CLASSES),
+            "serialization": {
+                "format": "canonical_json",
+                "sort_keys": True,
+                "worm_ready": not disabled,
+            },
+        },
+        "marketing_decision_audit_summary": summary,
+    }
+
+
+def action_event_type(action: Any, context: Mapping[str, Any] | None = None) -> str:
+    ctx = context if isinstance(context, Mapping) else {}
+    explicit = _normalize_key(ctx.get("event_type") or ctx.get("audit_event_type"))
+    if explicit in CMO_DECISION_AUDIT_EVENT_TYPES:
+        return explicit
+    normalized_action = _normalize_key(action)
+    if _truthy(ctx.get("crisis_response")) or _truthy(ctx.get("public_response")):
+        return "crisis_public_response"
+    if _truthy(ctx.get("pricing_claim")) or _truthy(ctx.get("legal_claim")) or _truthy(ctx.get("high_risk_copy")):
+        return "high_risk_copy_pricing_legal_claim"
+    return ACTION_EVENT_TYPE_MAP.get(normalized_action, "policy_decision")
+
+
+def _event_type(ctx: Mapping[str, Any], action: str) -> str:
+    explicit = _normalize_key(ctx.get("event_type") or ctx.get("audit_event_type"))
+    if explicit in CMO_DECISION_AUDIT_EVENT_TYPES:
+        return explicit
+    return action_event_type(action, ctx)
+
+
+def _decision_type(ctx: Mapping[str, Any]) -> str:
+    return _normalize_key(
+        ctx.get("decision_type")
+        or ctx.get("decision")
+        or ctx.get("final_state")
+        or ctx.get("status")
+        or ctx.get("outcome")
+        or "decision"
+    )
+
+
+def _input_snapshot(ctx: Mapping[str, Any], action: str, event_type: str) -> dict[str, Any]:
+    for key in ("input_snapshot", "inputs", "request", "external_write_request", "write_request"):
+        value = ctx.get(key)
+        if isinstance(value, Mapping):
+            return _redact(value)
+    return _redact(
+        {
+            "event_type": event_type,
+            "action": action,
+            "workflow_id": ctx.get("workflow_id"),
+            "workflow_run_id": ctx.get("workflow_run_id") or ctx.get("run_id"),
+            "step_id": ctx.get("step_id"),
+            "source_refs": ctx.get("source_refs"),
+            "connector_key": ctx.get("connector_key"),
+        }
+    )
+
+
+def _source_refs(ctx: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw = ctx.get("source_refs") or ctx.get("source_references") or ctx.get("sources")
+    refs: list[dict[str, Any]] = []
+    for item in _list_from_value(raw):
+        if isinstance(item, Mapping):
+            refs.append(_redact(dict(item)))
+        else:
+            refs.append({"ref": str(item)})
+    return refs
+
+
+def _connector_refs(ctx: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw = ctx.get("connector_refs") or ctx.get("connector_references")
+    refs: list[dict[str, Any]] = []
+    for item in _list_from_value(raw):
+        if isinstance(item, Mapping):
+            refs.append(_redact(dict(item)))
+        else:
+            refs.append({"connector_key": str(item)})
+    connector_key = _string_or_none(ctx.get("connector_key"))
+    if connector_key and not any(ref.get("connector_key") == connector_key for ref in refs):
+        refs.append(
+            {
+                "connector_key": connector_key,
+                "external_object_id": _string_or_none(ctx.get("external_object_id")),
+                "source_url": _string_or_none(ctx.get("source_url")),
+            }
+        )
+    return refs
+
+
+def _policy_source_refs(decision: Mapping[str, Any]) -> list[dict[str, Any]]:
+    refs = []
+    for rule in decision.get("matched_rules") or []:
+        if isinstance(rule, Mapping):
+            refs.append(
+                {
+                    "type": "marketing_policy_rule",
+                    "policy_id": decision.get("policy_id"),
+                    "version": decision.get("version"),
+                    "rule_id": rule.get("rule_id"),
+                }
+            )
+    return refs
+
+
+def _result_ref(result: Mapping[str, Any] | None, prefix: str) -> str | None:
+    if not isinstance(result, Mapping) or not result:
+        return None
+    explicit = _string_or_none(
+        result.get("audit_reference")
+        or result.get("decision_audit_ref")
+        or result.get("audit_id")
+    )
+    if explicit:
+        return explicit
+    return f"{prefix}:{_fingerprint(_without_audit(result))[:20]}"
+
+
+def _override(ctx: Mapping[str, Any]) -> dict[str, Any] | None:
+    override = ctx.get("override")
+    if isinstance(override, Mapping):
+        source = override
+    elif any(ctx.get(key) for key in ("override_reason", "replacement_action", "overridden_by")):
+        source = ctx
+    else:
+        return None
+    return {
+        "overridden": True,
+        "actor_type": _actor_type(source.get("actor_type") or source.get("override_actor_type") or "user"),
+        "actor_id": _string_or_none(source.get("actor_id") or source.get("overridden_by")),
+        "actor_role": _string_or_none(source.get("actor_role") or source.get("override_actor_role")),
+        "reason": _string_or_none(source.get("reason") or source.get("override_reason")),
+        "replacement_action": _string_or_none(source.get("replacement_action")),
+        "replacement_action_ref": _string_or_none(source.get("replacement_action_ref")),
+    }
+
+
+def _audit_id(package: Mapping[str, Any]) -> str:
+    explicit = _string_or_none(package.get("audit_id"))
+    if explicit:
+        return explicit
+    source = {
+        key: value
+        for key, value in package.items()
+        if key not in {"audit_id", "audit_reference", "serialization"}
+    }
+    return f"cmo_audit_{_fingerprint(source)[:24]}"
+
+
+def _fingerprint(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode()).hexdigest()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(_redact(value), sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _without_audit(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            key: _without_audit(item)
+            for key, item in value.items()
+            if key
+            not in {
+                "decision_audit",
+                "decision_audit_package",
+                "audit_package",
+                "serialized_audit_package",
+            }
+        }
+    if isinstance(value, list):
+        return [_without_audit(item) for item in value]
+    return value
+
+
+def _clean_ref(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    return _redact(_without_audit(value))
+
+
+def _redact(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            text_key = str(key)
+            if _looks_secret_key(text_key):
+                result[text_key] = "[REDACTED]"
+            else:
+                result[text_key] = _redact(item)
+        return result
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact(item) for item in value]
+    return value
+
+
+def _looks_secret_key(key: str) -> bool:
+    normalized = key.lower().replace("-", "_")
+    return any(marker in normalized for marker in SECRET_KEY_MARKERS)
+
+
+def _timestamp(ctx: Mapping[str, Any], now: datetime | None) -> datetime:
+    for key in ("decided_at", "timestamp", "created_at", "attempted_at", "confirmed_at"):
+        parsed = _parse_datetime(ctx.get(key))
+        if parsed is not None:
+            return parsed
+    return _ensure_aware(now) or datetime.now(UTC)
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return _ensure_aware(value)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return _ensure_aware(parsed)
+
+
+def _ensure_aware(value: Any) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _actor_type(value: Any) -> str:
+    normalized = _normalize_key(value)
+    return normalized if normalized in {"agent", "user", "system"} else "system"
+
+
+def _risk_flags(ctx: Mapping[str, Any]) -> list[str]:
+    flags = _string_list(ctx.get("risk_flags") or ctx.get("risks"))
+    for field in (
+        "failure_class",
+        "severity",
+        "final_state",
+        "status",
+        "policy_missing",
+    ):
+        value = _string_or_none(ctx.get(field))
+        if value:
+            flags.append(value)
+    return _unique(flags)
+
+
+def _list_from_value(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
+
+
+def _string_list(value: Any) -> list[str]:
+    return [str(item) for item in _list_from_value(value) if str(item).strip()]
+
+
+def _unique(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _config_dict(config: Any | None) -> dict[str, Any]:
+    if isinstance(config, Mapping):
+        return dict(config)
+    value = getattr(config, "config", None)
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _audit_disabled(source: Mapping[str, Any]) -> bool:
+    return any(
+        _truthy(source.get(key))
+        for key in (
+            "decision_audit_disabled",
+            "marketing_decision_audit_disabled",
+            "cmo_decision_audit_disabled",
+            "audit_package_disabled",
+        )
+    )
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _string_or_none(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)

--- a/core/marketing/escalation_matrix.py
+++ b/core/marketing/escalation_matrix.py
@@ -1,0 +1,1097 @@
+"""CMO escalation matrix and evidence projection.
+
+CMO-6.2 makes escalation routes explicit and machine-checkable. The defaults
+are intentionally conservative: customer-facing failures, approval timeouts,
+missing policy, connector failures, data-quality blockers, crisis response, and
+high-risk claims route to accountable owners with SLA, fallback, notification,
+and audit metadata.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from core.marketing.decision_audit import build_escalation_decision_audit
+
+ESCALATION_TRIGGER_TYPES = (
+    "approval_timeout",
+    "crisis_public_response",
+    "budget_threshold_exceeded",
+    "connector_auth_expired",
+    "connector_degraded",
+    "data_mapping_blocked",
+    "backfill_failed",
+    "missing_policy",
+    "external_write_rejected",
+    "external_write_timeout_unknown",
+    "high_risk_copy",
+    "pricing_or_legal_claim",
+    "target_account_change",
+)
+
+ESCALATION_DECISIONS = (
+    "no_escalation",
+    "notify_owner",
+    "escalate",
+    "escalate_to_legal",
+    "escalate_to_finance",
+    "escalate_to_admin",
+    "pause_workflow",
+    "require_manual_resolution",
+)
+
+CONNECTOR_AUTH_FAILURES = {"auth_expired", "expired_auth", "token_expired"}
+CONNECTOR_DEGRADED_FAILURES = {
+    "connector_disabled",
+    "degraded",
+    "insufficient_scope",
+    "malformed_payload",
+    "missing_scope",
+    "partial_data",
+    "quota_exhausted",
+    "rate_limited",
+    "stale_data",
+    "timeout",
+    "vendor_5xx",
+}
+BUDGET_ACTIONS = {
+    "ad_budget_change",
+    "budget_change",
+    "create_abm_campaign",
+    "increase_budget",
+    "launch_abm_campaign",
+    "launch_competitive_campaign",
+    "mutate_ad_budget",
+    "set_abm_budget",
+    "spend",
+    "update_ad_budget",
+}
+CRISIS_ACTIONS = {
+    "crisis_response",
+    "detect_crisis",
+    "major_competitor_launch",
+    "public_response",
+    "publish_brand_response",
+    "publish_competitive_response",
+}
+HIGH_RISK_ACTIONS = {"brand_claim", "claims_review", "comparative_claim", "high_risk_copy"}
+PRICING_LEGAL_ACTIONS = {
+    "compliance_claim",
+    "legal_claim",
+    "pricing_claim",
+    "regulated_claim",
+}
+TARGET_ACCOUNT_ACTIONS = {
+    "query_target_accounts",
+    "sync_target_accounts",
+    "target_account_change",
+    "target_account_list_change",
+    "update_target_accounts",
+}
+CUSTOMER_WRITE_ACTION_HINTS = (
+    "activate",
+    "add_to_drip",
+    "launch",
+    "mutate",
+    "publish",
+    "schedule",
+    "send",
+    "spend",
+    "update_crm",
+    "write",
+)
+
+
+@dataclass(frozen=True)
+class MarketingEscalationRoute:
+    trigger_type: str
+    severity: str
+    primary_owner_role: str
+    backup_owner_role: str
+    escalation_chain: tuple[str, ...]
+    sla: timedelta
+    notification_channels: tuple[str, ...]
+    fallback_outcome: str
+    audit_event_code: str
+    next_action_cta: str
+    decision: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "trigger_type": self.trigger_type,
+            "severity": self.severity,
+            "primary_owner_role": self.primary_owner_role,
+            "backup_owner_role": self.backup_owner_role,
+            "escalation_chain": list(self.escalation_chain),
+            "sla_seconds": int(self.sla.total_seconds()),
+            "sla_duration": _duration_label(self.sla),
+            "notification_channels": list(self.notification_channels),
+            "fallback_outcome": self.fallback_outcome,
+            "audit_event_code": self.audit_event_code,
+            "next_action_cta": self.next_action_cta,
+            "decision": self.decision,
+        }
+
+
+@dataclass(frozen=True)
+class MarketingEscalationMatrix:
+    policy_id: str
+    version: str
+    routes: tuple[MarketingEscalationRoute, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "policy_id": self.policy_id,
+            "version": self.version,
+            "routes": [route.to_dict() for route in self.routes],
+        }
+
+
+DEFAULT_NOTIFICATION_CHANNELS = ("in_app", "email", "slack")
+DEFAULT_CHAIN = ("marketing_ops", "growth_lead", "cmo", "ceo")
+
+DEFAULT_MARKETING_ESCALATION_MATRIX = MarketingEscalationMatrix(
+    policy_id="cmo_default_escalation_matrix",
+    version="2026-05-23.cmo-6.2",
+    routes=(
+        MarketingEscalationRoute(
+            trigger_type="approval_timeout",
+            severity="high",
+            primary_owner_role="cmo",
+            backup_owner_role="ceo",
+            escalation_chain=DEFAULT_CHAIN,
+            sla=timedelta(hours=1),
+            notification_channels=DEFAULT_NOTIFICATION_CHANNELS,
+            fallback_outcome="pause_workflow",
+            audit_event_code="cmo_escalation_approval_timeout",
+            next_action_cta="review_overdue_approval",
+            decision="escalate",
+        ),
+        MarketingEscalationRoute(
+            trigger_type="crisis_public_response",
+            severity="critical",
+            primary_owner_role="cmo",
+            backup_owner_role="ceo",
+            escalation_chain=("brand_comms_lead", "cmo", "legal", "ceo"),
+            sla=timedelta(minutes=30),
+            notification_channels=("in_app", "email", "slack", "sms"),
+            fallback_outcome="pause_workflow",
+            audit_event_code="cmo_escalation_crisis_public_response",
+            next_action_cta="escalate_crisis_response_to_exec",
+            decision="escalate",
+        ),
+        MarketingEscalationRoute(
+            trigger_type="budget_threshold_exceeded",
+            severity="high",
+            primary_owner_role="growth_lead",
+            backup_owner_role="cmo",
+            escalation_chain=("growth_lead", "cmo", "cfo", "ceo"),
+            sla=timedelta(hours=2),
+            notification_channels=DEFAULT_NOTIFICATION_CHANNELS,
+            fallback_outcome="pause_workflow",
+            audit_event_code="cmo_escalation_budget_threshold_exceeded",
+            next_action_cta="request_finance_budget_review",
+            decision="escalate_to_finance",
+        ),
+        MarketingEscalationRoute(
+            trigger_type="connector_auth_expired",
+            severity="high",
+            primary_owner_role="admin_it_owner",
+            backup_owner_role="marketing_ops",
+            escalation_chain=("marketing_ops", "admin_it_owner", "cmo"),
+            sla=timedelta(hours=2),
+            notification_channels=DEFAULT_NOTIFICATION_CHANNELS,
+            fallback_outcome="require_manual_resolution",
+            audit_event_code="cmo_escalation_connector_auth_expired",
+            next_action_cta="reconnect_connector",
+            decision="escalate_to_admin",
+        ),
+        MarketingEscalationRoute(
+            trigger_type="connector_degraded",
+            severity="medium",
+            primary_owner_role="marketing_ops",
+            backup_owner_role="admin_it_owner",
+            escalation_chain=("marketing_ops", "admin_it_owner", "cmo"),
+            sla=timedelta(hours=4),
+            notification_channels=DEFAULT_NOTIFICATION_CHANNELS,
+            fallback_outcome="continue_read_only",
+            audit_event_code="cmo_escalation_connector_degraded",
+            next_action_cta="review_connector_degradation",
+            decision="notify_owner",
+        ),
+        MarketingEscalationRoute(
+            trigger_type="data_mapping_blocked",
+            severity="high",
+            primary_owner_role="marketing_ops",
+            backup_owner_role="revops_lead",
+            escalation_chain=("marketing_ops", "revops_lead", "cmo"),
+            sla=timedelta(hours=4),
+            notification_channels=DEFAULT_NOTIFICATION_CHANNELS,
+            fallback_outcome="require_manual_resolution",
+            audit_event_code="cmo_escalation_data_mapping_blocked",
+            next_action_cta="resolve_mapping_blocker",
+            decision="require_manual_resolution",
+        ),
+        MarketingEscalationRoute(
+            trigger_type="backfill_failed",
+            severity="high",
+            primary_owner_role="marketing_ops",
+            backup_owner_role="revops_lead",
+            escalation_chain=("marketing_ops", "revops_lead", "admin_it_owner", "cmo"),
+            sla=timedelta(hours=6),
+            notification_channels=DEFAULT_NOTIFICATION_CHANNELS,
+            fallback_outcome="require_manual_resolution",
+            audit_event_code="cmo_escalation_backfill_failed",
+            next_action_cta="retry_or_reconcile_backfill",
+            decision="require_manual_resolution",
+        ),
+        MarketingEscalationRoute(
+            trigger_type="missing_policy",
+            severity="critical",
+            primary_owner_role="policy_owner",
+            backup_owner_role="cmo",
+            escalation_chain=("policy_owner", "legal", "cmo", "ceo"),
+            sla=timedelta(hours=2),
+            notification_channels=DEFAULT_NOTIFICATION_CHANNELS,
+            fallback_outcome="require_manual_resolution",
+            audit_event_code="cmo_escalation_missing_policy",
+            next_action_cta="configure_marketing_policy_manifest",
+            decision="require_manual_resolution",
+        ),
+        MarketingEscalationRoute(
+            trigger_type="external_write_rejected",
+            severity="high",
+            primary_owner_role="workflow_owner",
+            backup_owner_role="cmo",
+            escalation_chain=("workflow_owner", "marketing_ops", "cmo"),
+            sla=timedelta(hours=1),
+            notification_channels=DEFAULT_NOTIFICATION_CHANNELS,
+            fallback_outcome="pause_workflow",
+            audit_event_code="cmo_escalation_external_write_rejected",
+            next_action_cta="fix_and_resubmit_write",
+            decision="escalate",
+        ),
+        MarketingEscalationRoute(
+            trigger_type="external_write_timeout_unknown",
+            severity="critical",
+            primary_owner_role="marketing_ops",
+            backup_owner_role="cmo",
+            escalation_chain=("marketing_ops", "admin_it_owner", "cmo", "ceo"),
+            sla=timedelta(minutes=30),
+            notification_channels=("in_app", "email", "slack", "sms"),
+            fallback_outcome="pause_workflow",
+            audit_event_code="cmo_escalation_external_write_timeout_unknown",
+            next_action_cta="manual_reconcile_before_retry",
+            decision="pause_workflow",
+        ),
+        MarketingEscalationRoute(
+            trigger_type="high_risk_copy",
+            severity="high",
+            primary_owner_role="legal",
+            backup_owner_role="cmo",
+            escalation_chain=("content_lead", "legal", "cmo"),
+            sla=timedelta(hours=2),
+            notification_channels=DEFAULT_NOTIFICATION_CHANNELS,
+            fallback_outcome="require_manual_resolution",
+            audit_event_code="cmo_escalation_high_risk_copy",
+            next_action_cta="request_legal_or_compliance_review",
+            decision="escalate_to_legal",
+        ),
+        MarketingEscalationRoute(
+            trigger_type="pricing_or_legal_claim",
+            severity="critical",
+            primary_owner_role="legal",
+            backup_owner_role="cmo",
+            escalation_chain=("content_lead", "legal", "compliance", "cmo", "ceo"),
+            sla=timedelta(hours=2),
+            notification_channels=DEFAULT_NOTIFICATION_CHANNELS,
+            fallback_outcome="require_manual_resolution",
+            audit_event_code="cmo_escalation_pricing_or_legal_claim",
+            next_action_cta="request_legal_or_compliance_review",
+            decision="escalate_to_legal",
+        ),
+        MarketingEscalationRoute(
+            trigger_type="target_account_change",
+            severity="high",
+            primary_owner_role="growth_lead",
+            backup_owner_role="cmo",
+            escalation_chain=("revops_lead", "growth_lead", "cmo"),
+            sla=timedelta(hours=4),
+            notification_channels=DEFAULT_NOTIFICATION_CHANNELS,
+            fallback_outcome="require_manual_resolution",
+            audit_event_code="cmo_escalation_target_account_change",
+            next_action_cta="review_target_account_change",
+            decision="escalate",
+        ),
+    ),
+)
+
+
+def default_marketing_escalation_matrix() -> dict[str, Any]:
+    """Return a serializable default escalation matrix."""
+
+    return DEFAULT_MARKETING_ESCALATION_MATRIX.to_dict()
+
+
+def load_marketing_escalation_matrix(
+    source: Mapping[str, Any] | None = None,
+    *,
+    use_default: bool = True,
+) -> dict[str, Any] | None:
+    """Load an escalation matrix from config or return conservative defaults."""
+
+    if _matrix_disabled(source):
+        return None
+    candidate = _matrix_candidate(source)
+    if candidate is None:
+        return default_marketing_escalation_matrix() if use_default else None
+    if not candidate or _truthy(candidate.get("disabled")):
+        return None
+    matrix = _normalize_matrix(candidate)
+    if not matrix.get("policy_id") or not matrix.get("version"):
+        return None
+    return matrix
+
+
+def evaluate_marketing_escalation(
+    context: Mapping[str, Any] | None = None,
+    *,
+    matrix: Mapping[str, Any] | None = None,
+    use_default: bool = True,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Evaluate one escalation event/context and return route evidence."""
+
+    ctx = context if isinstance(context, Mapping) else {}
+    now = _ensure_aware(now) or datetime.now(UTC)
+    trigger_type = _trigger_from_context(ctx)
+    if trigger_type is None:
+        return _no_escalation_decision(ctx, now)
+
+    matrix_source = matrix if matrix is not None else ctx
+    loaded = load_marketing_escalation_matrix(matrix_source, use_default=use_default)
+    if loaded is None:
+        return _missing_route_decision(ctx, trigger_type, now)
+
+    route = _route_by_trigger(loaded, trigger_type)
+    if route is None:
+        return _missing_route_decision(ctx, trigger_type, now, loaded)
+
+    sla_seconds = _int_or_default(route.get("sla_seconds"), 0)
+    due_at = _parse_datetime(ctx.get("escalation_due_at")) or (now + timedelta(seconds=sla_seconds))
+    event_id = _event_id(ctx, trigger_type)
+    audit_reference = _audit_reference(
+        event_id,
+        trigger_type,
+        ctx.get("workflow_id"),
+        ctx.get("workflow_run_id") or ctx.get("run_id"),
+        ctx.get("step_id"),
+    )
+    decision = str(route.get("decision") or "escalate")
+    if decision not in ESCALATION_DECISIONS:
+        decision = "escalate"
+    severity = _severity(ctx.get("severity"), route.get("severity"))
+    evidence = {
+        "event_id": event_id,
+        "event_type": trigger_type,
+        "workflow_id": _string_or_none(ctx.get("workflow_id")),
+        "workflow_run_id": _string_or_none(ctx.get("workflow_run_id")),
+        "run_id": _string_or_none(ctx.get("run_id")),
+        "step_id": _string_or_none(ctx.get("step_id")),
+        "severity": severity,
+        "owner_role": _string_or_none(route.get("primary_owner_role")),
+        "escalation_target": _string_or_none(route.get("primary_owner_role")),
+        "backup_owner_role": _string_or_none(route.get("backup_owner_role")),
+        "escalation_chain": _string_list(route.get("escalation_chain")),
+        "created_at": now.isoformat(),
+        "due_at": due_at.isoformat(),
+        "sla_seconds": sla_seconds,
+        "sla_duration": route.get("sla_duration") or _duration_label(timedelta(seconds=sla_seconds)),
+        "fallback_outcome": route.get("fallback_outcome"),
+        "notification_channels": _string_list(route.get("notification_channels")),
+        "audit_event_code": route.get("audit_event_code"),
+        "audit_reference": audit_reference,
+    }
+    result = {
+        "escalation_policy_id": loaded.get("policy_id"),
+        "policy_id": loaded.get("policy_id"),
+        "version": loaded.get("version"),
+        "route_found": True,
+        "trigger_type": trigger_type,
+        "event_id": event_id,
+        "event_type": trigger_type,
+        "severity": severity,
+        "decision": decision,
+        "reason": _string_or_none(ctx.get("reason")) or f"Escalation route matched trigger {trigger_type}.",
+        "primary_owner_role": route.get("primary_owner_role"),
+        "backup_owner_role": route.get("backup_owner_role"),
+        "owner_role": route.get("primary_owner_role"),
+        "escalation_target": route.get("primary_owner_role"),
+        "escalation_chain": _string_list(route.get("escalation_chain")),
+        "sla_seconds": sla_seconds,
+        "sla_duration": route.get("sla_duration") or _duration_label(timedelta(seconds=sla_seconds)),
+        "due_at": due_at.isoformat(),
+        "fallback_outcome": route.get("fallback_outcome"),
+        "notification_channels": _string_list(route.get("notification_channels")),
+        "audit_event_code": route.get("audit_event_code"),
+        "next_action_cta": route.get("next_action_cta") or "review_escalation",
+        "workflow_id": _string_or_none(ctx.get("workflow_id")),
+        "workflow_run_id": _string_or_none(ctx.get("workflow_run_id")),
+        "run_id": _string_or_none(ctx.get("run_id")),
+        "step_id": _string_or_none(ctx.get("step_id")),
+        "audit_reference": audit_reference,
+        "evidence": evidence,
+    }
+    audit_package = build_escalation_decision_audit(result, now=now)
+    result["decision_audit"] = audit_package
+    result["decision_audit_ref"] = audit_package["audit_reference"]
+    evidence["decision_audit_ref"] = audit_package["audit_reference"]
+    return result
+
+
+def escalation_triggers_for_action(
+    action: Any,
+    context: Mapping[str, Any] | None = None,
+    *,
+    external_write_required: bool = False,
+) -> list[str]:
+    """Infer escalation trigger types for a workflow/action context."""
+
+    ctx = context if isinstance(context, Mapping) else {}
+    explicit = _explicit_triggers(ctx)
+    if explicit:
+        return explicit
+
+    triggers: list[str] = []
+    normalized_action = _normalize_key(action)
+    policy_decision = ctx.get("marketing_policy_decision") or ctx.get("policy_decision")
+    if isinstance(policy_decision, Mapping):
+        decision = _normalize_key(policy_decision.get("decision"))
+        if decision == "missing_policy":
+            _append_unique(triggers, "missing_policy")
+        role = _normalize_key(
+            policy_decision.get("required_escalation_role")
+            or policy_decision.get("required_approver_role")
+        )
+        if role in {"legal", "compliance"}:
+            _append_unique(triggers, "pricing_or_legal_claim")
+        if decision == "requires_escalation" and not triggers:
+            _append_unique(triggers, "high_risk_copy")
+
+    failure_class = _normalize_key(ctx.get("failure_class") or ctx.get("connector_failure_class"))
+    if failure_class in CONNECTOR_AUTH_FAILURES:
+        _append_unique(triggers, "connector_auth_expired")
+    elif failure_class in CONNECTOR_DEGRADED_FAILURES:
+        _append_unique(triggers, "connector_degraded")
+
+    final_state = _normalize_key(
+        ctx.get("final_state")
+        or ctx.get("external_write_state")
+        or ctx.get("write_state")
+        or ctx.get("status")
+    )
+    if final_state == "rejected":
+        _append_unique(triggers, "external_write_rejected")
+    if final_state == "timeout_unknown":
+        _append_unique(triggers, "external_write_timeout_unknown")
+
+    mapping_status = _normalize_key(ctx.get("mapping_status") or ctx.get("field_mapping_status"))
+    if mapping_status in {"blocked", "invalid", "unmapped"} and ctx.get("missing_blocks") is not False:
+        _append_unique(triggers, "data_mapping_blocked")
+
+    backfill_status = _normalize_key(ctx.get("backfill_status") or ctx.get("status"))
+    if backfill_status in {"blocked", "failed"} and _truthy(ctx.get("is_backfill")):
+        _append_unique(triggers, "backfill_failed")
+
+    if _truthy(ctx.get("missing_policy")) or _truthy(ctx.get("marketing_policy_manifest_disabled")):
+        _append_unique(triggers, "missing_policy")
+    if (
+        normalized_action in CRISIS_ACTIONS
+        or _truthy(ctx.get("crisis_response"))
+        or _truthy(ctx.get("public_response"))
+    ):
+        _append_unique(triggers, "crisis_public_response")
+    if normalized_action in PRICING_LEGAL_ACTIONS or any(
+        _truthy(ctx.get(field))
+        for field in (
+            "comparative_claim",
+            "competitor_mention",
+            "compliance_claim",
+            "legal_claim",
+            "pricing_claim",
+            "regulated_claim",
+        )
+    ):
+        _append_unique(triggers, "pricing_or_legal_claim")
+    elif normalized_action in HIGH_RISK_ACTIONS or any(
+        _truthy(ctx.get(field))
+        for field in ("brand_claim", "claims_review", "high_risk", "high_risk_copy")
+    ):
+        _append_unique(triggers, "high_risk_copy")
+    if normalized_action in BUDGET_ACTIONS or _truthy(ctx.get("budget_threshold_exceeded")):
+        _append_unique(triggers, "budget_threshold_exceeded")
+    if normalized_action in TARGET_ACCOUNT_ACTIONS or _truthy(ctx.get("target_account_change")):
+        _append_unique(triggers, "target_account_change")
+
+    approval_sensitive = any(
+        _truthy(ctx.get(field))
+        for field in (
+            "approval_required",
+            "approval_sensitive",
+            "hitl_required",
+            "requires_approval",
+            "requires_human_approval",
+        )
+    )
+    if approval_sensitive or external_write_required or _action_looks_customer_write(normalized_action):
+        _append_unique(triggers, "approval_timeout")
+    if external_write_required or _action_looks_customer_write(normalized_action):
+        _append_unique(triggers, "external_write_rejected")
+        _append_unique(triggers, "external_write_timeout_unknown")
+
+    return triggers
+
+
+def has_escalation_route_for_step(
+    step: Mapping[str, Any],
+    *,
+    workflow_definition: Mapping[str, Any] | None = None,
+    action: Any = None,
+    matrix: Mapping[str, Any] | None = None,
+    external_write_required: bool = False,
+) -> bool:
+    """Return true when every inferred step trigger has an escalation route."""
+
+    return not missing_escalation_triggers_for_step(
+        step,
+        workflow_definition=workflow_definition,
+        action=action,
+        matrix=matrix,
+        external_write_required=external_write_required,
+    )
+
+
+def missing_escalation_triggers_for_step(
+    step: Mapping[str, Any],
+    *,
+    workflow_definition: Mapping[str, Any] | None = None,
+    action: Any = None,
+    matrix: Mapping[str, Any] | None = None,
+    external_write_required: bool = False,
+) -> list[str]:
+    """Return inferred escalation triggers that have no configured route."""
+
+    source: dict[str, Any] = {
+        **(dict(workflow_definition) if isinstance(workflow_definition, Mapping) else {}),
+        **(dict(step) if isinstance(step, Mapping) else {}),
+    }
+    action_value = action or source.get("action") or source.get("approval_action")
+    triggers = escalation_triggers_for_action(
+        action_value,
+        source,
+        external_write_required=external_write_required,
+    )
+    missing: list[str] = []
+    for trigger in triggers:
+        decision = evaluate_marketing_escalation(
+            {**source, "trigger_type": trigger},
+            matrix=matrix,
+            use_default=matrix is None,
+        )
+        if not decision.get("route_found"):
+            missing.append(trigger)
+    return missing
+
+
+def build_workflow_escalation_status(
+    workflow_key: str,
+    actions: Iterable[Any],
+    payload: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Project escalation-route readiness for one CMO workflow."""
+
+    payload = payload if isinstance(payload, Mapping) else {}
+    triggers: list[str] = []
+    for action in actions:
+        for trigger in escalation_triggers_for_action(
+            action,
+            payload,
+            external_write_required=True,
+        ):
+            _append_unique(triggers, trigger)
+    for trigger in _explicit_triggers(payload):
+        _append_unique(triggers, trigger)
+
+    decisions = [
+        evaluate_marketing_escalation(
+            {
+                **dict(payload),
+                "workflow_id": workflow_key,
+                "trigger_type": trigger,
+            },
+            use_default=True,
+        )
+        for trigger in triggers
+    ]
+    missing = [
+        str(decision.get("trigger_type"))
+        for decision in decisions
+        if not decision.get("route_found")
+    ]
+    if not triggers:
+        status = "not_required"
+        next_action = "none"
+    elif missing:
+        status = "missing_route"
+        next_action = "configure_escalation_matrix"
+    else:
+        status = "ready"
+        next_action = "none"
+
+    return {
+        "workflow_key": _normalize_key(workflow_key),
+        "status": status,
+        "required_triggers": triggers,
+        "covered_triggers": [
+            str(decision.get("trigger_type"))
+            for decision in decisions
+            if decision.get("route_found")
+        ],
+        "missing_route_triggers": missing,
+        "decisions": decisions,
+        "next_action_cta": next_action,
+    }
+
+
+def build_marketing_escalation_projection(
+    sources: Iterable[Any] | None = None,
+) -> dict[str, Any]:
+    """Build a KPI/API projection for the active escalation matrix."""
+
+    matrix = None
+    for source in sources or []:
+        config = _config_dict(source)
+        if _matrix_disabled(config):
+            return {
+                "marketing_escalation_matrix": None,
+                "marketing_escalation_summary": summarize_marketing_escalation_matrix(
+                    {"marketing_escalation_matrix_disabled": True}
+                ),
+            }
+        candidate = load_marketing_escalation_matrix(config, use_default=False)
+        if candidate is not None:
+            matrix = candidate
+            break
+    if matrix is None:
+        matrix = default_marketing_escalation_matrix()
+    return {
+        "marketing_escalation_matrix": matrix,
+        "marketing_escalation_summary": summarize_marketing_escalation_matrix(matrix),
+    }
+
+
+def summarize_marketing_escalation_matrix(
+    matrix: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    loaded = load_marketing_escalation_matrix(matrix, use_default=True)
+    if loaded is None:
+        return {
+            "status": "missing_route",
+            "policy_id": None,
+            "version": None,
+            "route_count": 0,
+            "missing_trigger_types": list(ESCALATION_TRIGGER_TYPES),
+            "next_action_cta": "configure_escalation_matrix",
+        }
+    routes = [
+        route
+        for route in loaded.get("routes") or []
+        if isinstance(route, Mapping)
+    ]
+    covered = {_normalize_key(route.get("trigger_type")) for route in routes}
+    missing = [trigger for trigger in ESCALATION_TRIGGER_TYPES if trigger not in covered]
+    decisions = dict.fromkeys(ESCALATION_DECISIONS, 0)
+    for route in routes:
+        decision = str(route.get("decision") or "")
+        if decision in decisions:
+            decisions[decision] += 1
+    return {
+        "status": "ready" if not missing else "missing_route",
+        "policy_id": loaded.get("policy_id"),
+        "version": loaded.get("version"),
+        "route_count": len(routes),
+        "covered_trigger_types": sorted(covered),
+        "missing_trigger_types": missing,
+        "next_action_cta": "none" if not missing else "configure_escalation_matrix",
+        **decisions,
+    }
+
+
+def _route_by_trigger(
+    matrix: Mapping[str, Any],
+    trigger_type: str,
+) -> dict[str, Any] | None:
+    normalized = _normalize_key(trigger_type)
+    for route in matrix.get("routes") or []:
+        if isinstance(route, Mapping) and _normalize_key(route.get("trigger_type")) == normalized:
+            return dict(route)
+    return None
+
+
+def _normalize_matrix(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    routes = candidate.get("routes") or candidate.get("escalation_routes") or []
+    normalized_routes: list[dict[str, Any]] = []
+    if isinstance(routes, Mapping):
+        iterable = []
+        for trigger_type, route in routes.items():
+            if isinstance(route, Mapping):
+                iterable.append({"trigger_type": trigger_type, **dict(route)})
+    elif isinstance(routes, (list, tuple)):
+        iterable = [route for route in routes if isinstance(route, Mapping)]
+    else:
+        iterable = []
+
+    for route in iterable:
+        trigger = _normalize_key(route.get("trigger_type"))
+        if trigger not in ESCALATION_TRIGGER_TYPES:
+            continue
+        sla = _sla_from_route(route)
+        decision = _normalize_key(route.get("decision") or "escalate")
+        if decision not in ESCALATION_DECISIONS:
+            decision = "escalate"
+        normalized_routes.append(
+            {
+                "trigger_type": trigger,
+                "severity": _severity(route.get("severity"), "high"),
+                "primary_owner_role": str(route.get("primary_owner_role") or "cmo"),
+                "backup_owner_role": str(route.get("backup_owner_role") or "ceo"),
+                "escalation_chain": _string_list(route.get("escalation_chain")) or list(DEFAULT_CHAIN),
+                "sla_seconds": int(sla.total_seconds()),
+                "sla_duration": _duration_label(sla),
+                "notification_channels": (
+                    _string_list(route.get("notification_channels"))
+                    or list(DEFAULT_NOTIFICATION_CHANNELS)
+                ),
+                "fallback_outcome": str(route.get("fallback_outcome") or "require_manual_resolution"),
+                "audit_event_code": str(route.get("audit_event_code") or f"cmo_escalation_{trigger}"),
+                "next_action_cta": str(route.get("next_action_cta") or "review_escalation"),
+                "decision": decision,
+            }
+        )
+    return {
+        "policy_id": str(candidate.get("policy_id") or "cmo_custom_escalation_matrix"),
+        "version": str(candidate.get("version") or "custom"),
+        "routes": normalized_routes,
+    }
+
+
+def _matrix_candidate(source: Mapping[str, Any] | None) -> Mapping[str, Any] | None:
+    if not isinstance(source, Mapping):
+        return None
+    for key in (
+        "marketing_escalation_matrix",
+        "cmo_escalation_matrix",
+        "escalation_matrix",
+    ):
+        value = source.get(key)
+        if isinstance(value, Mapping):
+            return value
+    if source.get("policy_id") and source.get("version") and isinstance(source.get("routes"), list):
+        return source
+    return None
+
+
+def _matrix_disabled(source: Mapping[str, Any] | None) -> bool:
+    if not isinstance(source, Mapping):
+        return False
+    return any(
+        _truthy(source.get(key))
+        for key in (
+            "marketing_escalation_matrix_disabled",
+            "cmo_escalation_matrix_disabled",
+            "escalation_matrix_disabled",
+        )
+    )
+
+
+def _explicit_triggers(context: Mapping[str, Any]) -> list[str]:
+    raw = (
+        context.get("trigger_type")
+        or context.get("escalation_trigger_type")
+        or context.get("escalation_triggers")
+        or context.get("escalation_trigger_types")
+    )
+    values = _string_list(raw)
+    return [value for value in values if value in ESCALATION_TRIGGER_TYPES]
+
+
+def _trigger_from_context(context: Mapping[str, Any]) -> str | None:
+    triggers = escalation_triggers_for_action(
+        context.get("action") or context.get("blocked_action"),
+        context,
+        external_write_required=_truthy(
+            context.get("external_write_required")
+            or context.get("requires_external_write")
+        ),
+    )
+    return triggers[0] if triggers else None
+
+
+def _missing_route_decision(
+    context: Mapping[str, Any],
+    trigger_type: str,
+    now: datetime,
+    matrix: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    event_id = _event_id(context, trigger_type)
+    audit_reference = _audit_reference(
+        event_id,
+        trigger_type,
+        context.get("workflow_id"),
+        context.get("workflow_run_id") or context.get("run_id"),
+        context.get("step_id"),
+    )
+    evidence = {
+        "event_id": event_id,
+        "event_type": trigger_type,
+        "workflow_id": _string_or_none(context.get("workflow_id")),
+        "workflow_run_id": _string_or_none(context.get("workflow_run_id")),
+        "run_id": _string_or_none(context.get("run_id")),
+        "step_id": _string_or_none(context.get("step_id")),
+        "severity": "critical",
+        "owner_role": "cmo",
+        "escalation_target": "cmo",
+        "backup_owner_role": "ceo",
+        "escalation_chain": ["cmo", "ceo"],
+        "created_at": now.isoformat(),
+        "due_at": now.isoformat(),
+        "sla_seconds": 0,
+        "sla_duration": "0s",
+        "fallback_outcome": "require_manual_resolution",
+        "notification_channels": [],
+        "audit_event_code": "cmo_escalation_route_missing",
+        "audit_reference": audit_reference,
+    }
+    result = {
+        "escalation_policy_id": (matrix or {}).get("policy_id"),
+        "policy_id": (matrix or {}).get("policy_id"),
+        "version": (matrix or {}).get("version"),
+        "route_found": False,
+        "trigger_type": trigger_type,
+        "event_id": event_id,
+        "event_type": trigger_type,
+        "severity": "critical",
+        "decision": "require_manual_resolution",
+        "reason": f"No CMO escalation route is configured for trigger {trigger_type}.",
+        "primary_owner_role": None,
+        "backup_owner_role": None,
+        "owner_role": "cmo",
+        "escalation_target": "cmo",
+        "escalation_chain": ["cmo", "ceo"],
+        "sla_seconds": 0,
+        "sla_duration": "0s",
+        "due_at": now.isoformat(),
+        "fallback_outcome": "require_manual_resolution",
+        "notification_channels": [],
+        "audit_event_code": "cmo_escalation_route_missing",
+        "next_action_cta": "configure_escalation_matrix",
+        "workflow_id": _string_or_none(context.get("workflow_id")),
+        "workflow_run_id": _string_or_none(context.get("workflow_run_id")),
+        "run_id": _string_or_none(context.get("run_id")),
+        "step_id": _string_or_none(context.get("step_id")),
+        "audit_reference": audit_reference,
+        "evidence": evidence,
+    }
+    audit_package = build_escalation_decision_audit(result, now=now)
+    result["decision_audit"] = audit_package
+    result["decision_audit_ref"] = audit_package["audit_reference"]
+    evidence["decision_audit_ref"] = audit_package["audit_reference"]
+    return result
+
+
+def _no_escalation_decision(
+    context: Mapping[str, Any],
+    now: datetime,
+) -> dict[str, Any]:
+    return {
+        "escalation_policy_id": None,
+        "policy_id": None,
+        "version": None,
+        "route_found": False,
+        "trigger_type": None,
+        "event_id": _event_id(context, "no_escalation"),
+        "event_type": "no_escalation",
+        "severity": "none",
+        "decision": "no_escalation",
+        "reason": "No escalation-sensitive trigger was found.",
+        "primary_owner_role": None,
+        "backup_owner_role": None,
+        "owner_role": None,
+        "escalation_target": None,
+        "escalation_chain": [],
+        "sla_seconds": 0,
+        "sla_duration": "0s",
+        "due_at": now.isoformat(),
+        "fallback_outcome": "none",
+        "notification_channels": [],
+        "audit_event_code": None,
+        "next_action_cta": "none",
+        "workflow_id": _string_or_none(context.get("workflow_id")),
+        "workflow_run_id": _string_or_none(context.get("workflow_run_id")),
+        "run_id": _string_or_none(context.get("run_id")),
+        "step_id": _string_or_none(context.get("step_id")),
+        "audit_reference": None,
+        "evidence": None,
+    }
+
+
+def _event_id(context: Mapping[str, Any], trigger_type: str) -> str:
+    explicit = _string_or_none(context.get("event_id") or context.get("escalation_event_id"))
+    if explicit:
+        return explicit
+    source = "|".join(
+        str(item or "")
+        for item in (
+            trigger_type,
+            context.get("workflow_id"),
+            context.get("workflow_run_id") or context.get("run_id"),
+            context.get("step_id"),
+            context.get("action") or context.get("blocked_action"),
+        )
+    )
+    return f"mkt_esc_evt_{hashlib.sha256(source.encode()).hexdigest()[:20]}"
+
+
+def _audit_reference(*parts: Any) -> str:
+    source = "|".join(str(part or "") for part in parts)
+    return f"mkt_escalation_{hashlib.sha256(source.encode()).hexdigest()[:20]}"
+
+
+def _sla_from_route(route: Mapping[str, Any]) -> timedelta:
+    if route.get("sla_seconds") is not None:
+        return timedelta(seconds=max(_int_or_default(route.get("sla_seconds"), 0), 0))
+    if route.get("sla_minutes") is not None:
+        return timedelta(minutes=max(_int_or_default(route.get("sla_minutes"), 0), 0))
+    if route.get("sla_hours") is not None:
+        return timedelta(hours=max(_float_or_default(route.get("sla_hours"), 0.0), 0.0))
+    return _parse_duration(route.get("sla_duration") or route.get("sla")) or timedelta(hours=1)
+
+
+def _parse_duration(value: Any) -> timedelta | None:
+    if isinstance(value, timedelta):
+        return value
+    text = str(value or "").strip().lower()
+    if not text:
+        return None
+    if text.endswith("minutes"):
+        return timedelta(minutes=_float_or_default(text[:-7].strip(), 0.0))
+    if text.endswith("minute"):
+        return timedelta(minutes=_float_or_default(text[:-6].strip(), 0.0))
+    if text.endswith("hours"):
+        return timedelta(hours=_float_or_default(text[:-5].strip(), 0.0))
+    if text.endswith("hour"):
+        return timedelta(hours=_float_or_default(text[:-4].strip(), 0.0))
+    suffix = text[-1]
+    amount = _float_or_default(text[:-1], -1.0)
+    if amount < 0:
+        return None
+    if suffix == "s":
+        return timedelta(seconds=amount)
+    if suffix == "m":
+        return timedelta(minutes=amount)
+    if suffix == "h":
+        return timedelta(hours=amount)
+    if suffix == "d":
+        return timedelta(days=amount)
+    return None
+
+
+def _duration_label(value: timedelta) -> str:
+    seconds = int(value.total_seconds())
+    if seconds % 3600 == 0 and seconds:
+        return f"{seconds // 3600}h"
+    if seconds % 60 == 0 and seconds:
+        return f"{seconds // 60}m"
+    return f"{seconds}s"
+
+
+def _config_dict(config: Any | None) -> dict[str, Any]:
+    value = getattr(config, "config", None)
+    return value if isinstance(value, dict) else {}
+
+
+def _action_looks_customer_write(action: str) -> bool:
+    return any(hint in action for hint in CUSTOMER_WRITE_ACTION_HINTS)
+
+
+def _append_unique(values: list[str], value: str) -> None:
+    if value and value not in values:
+        values.append(value)
+
+
+def _severity(requested: Any, fallback: Any) -> str:
+    value = _normalize_key(requested)
+    return value if value in {"low", "medium", "high", "critical"} else _normalize_key(fallback) or "high"
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [_normalize_key(item) for item in value.replace(",", " ").split() if _normalize_key(item)]
+    if isinstance(value, Iterable) and not isinstance(value, Mapping):
+        return [_normalize_key(item) for item in value if _normalize_key(item)]
+    return []
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return _ensure_aware(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return _ensure_aware(parsed)
+    return None
+
+
+def _ensure_aware(value: Any) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _string_or_none(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _int_or_default(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _float_or_default(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default

--- a/core/marketing/external_writes.py
+++ b/core/marketing/external_writes.py
@@ -1,0 +1,1069 @@
+"""Marketing external-write final-state policy.
+
+CMO-5.3 turns connector write confirmation from a dashboard contract into
+workflow-step behavior. This module does not call vendor APIs. It normalizes
+the result that a connector/agent reports after an attempted marketing write,
+checks idempotency and prior confirmations, and emits structured audit evidence
+that the workflow result can persist.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from typing import Any
+
+from core.marketing.approval_timeouts import approval_timeout_allows_external_write
+from core.marketing.connector_contracts import plan_marketing_write_retry
+from core.marketing.decision_audit import build_external_write_decision_audit
+from core.marketing.escalation_matrix import evaluate_marketing_escalation
+from core.marketing.policy_manifest import (
+    evaluate_marketing_policy,
+    marketing_policy_allows_external_write,
+)
+
+WRITE_FINAL_STATES = (
+    "accepted",
+    "rejected",
+    "timeout_unknown",
+    "retry_scheduled",
+    "idempotent_recovered",
+    "write_confirmed",
+    "write_unconfirmed",
+    "draft_created",
+    "shadow_only",
+)
+
+INTERNAL_ONLY_MODES = {"draft", "internal", "internal_only", "recommendation", "shadow", "simulation"}
+# enterprise-gate: process-local-ok reason=static-write-state-set
+EXTERNAL_SUCCESS_STATES = {"write_confirmed", "idempotent_recovered"}
+# enterprise-gate: process-local-ok reason=static-write-state-set
+INTERNAL_SUCCESS_STATES = {"draft_created", "shadow_only"}
+# enterprise-gate: process-local-ok reason=static-write-state-set
+UNCONFIRMED_STATES = {"accepted", "write_unconfirmed", "timeout_unknown"}
+EXTERNAL_CONFIRMATION_FIELDS = {
+    "external_object_id",
+    "source_object_id",
+    "external_id",
+    "connector_object_id",
+}
+EXTERNAL_CONFIRMATION_PAYLOAD_FIELDS = {
+    *EXTERNAL_CONFIRMATION_FIELDS,
+    "id",
+    "campaign_id",
+    "message_id",
+    "post_id",
+    "crm_record_id",
+}
+INTERNAL_SIGNAL_FIELDS = {
+    "approval_id",
+    "draft_id",
+    "draft_url",
+    "internal_record_id",
+    "recommendation",
+    "simulation",
+    "simulation_result",
+}
+
+
+def evaluate_marketing_external_write_result(
+    connector_contracts: Iterable[dict[str, Any]],
+    *,
+    connector_key: str | None,
+    action: str,
+    workflow_mode: str,
+    output: dict[str, Any],
+    step: dict[str, Any] | None = None,
+    state: dict[str, Any] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Evaluate whether a marketing write step can complete.
+
+    The returned ``step_status`` is one of the workflow engine's native step
+    statuses. ``completed`` means either a confirmed external write or a
+    clearly internal/draft/shadow result. ``waiting_delay`` means a safe
+    idempotent retry was scheduled. ``failed`` means the active workflow must
+    fail closed.
+    """
+
+    step = step or {}
+    state = state or {}
+    output = output if isinstance(output, dict) else {}
+    now = _ensure_aware(now) or datetime.now(UTC)
+    mode = _normalize_key(workflow_mode) or "active"
+    normalized_action = _normalize_key(action)
+    normalized_connector = _normalize_connector(connector_key, output, step)
+    attempt = _attempt_metadata(
+        normalized_connector,
+        normalized_action,
+        output,
+        step,
+        state,
+        now,
+    )
+    reported_state = _reported_write_state(output)
+    idempotency_key = attempt["idempotency_key"]
+    prior_confirmation = _prior_confirmation(
+        connector_contracts,
+        normalized_connector,
+        normalized_action,
+        idempotency_key,
+    )
+
+    if mode in INTERNAL_ONLY_MODES:
+        return _evaluate_internal_mode(
+            mode,
+            reported_state,
+            prior_confirmation,
+            attempt,
+            output,
+            now,
+        )
+
+    timeout_decision = _approval_timeout_decision(output, step, state)
+    if timeout_decision and not approval_timeout_allows_external_write(timeout_decision):
+        return _decision(
+            step_status="failed",
+            final_state="write_unconfirmed",
+            reason=(
+                "Approval timed out and policy does not allow customer-facing "
+                "external writes after timeout."
+            ),
+            next_action=str(timeout_decision.get("next_action_cta") or "resolve_overdue_approval"),
+            attempt=attempt,
+            confirmation=None,
+            now=now,
+            error_code="external_write_approval_timeout",
+        )
+
+    policy_decision = _marketing_policy_decision(
+        output,
+        step,
+        state,
+        normalized_action,
+        mode,
+    )
+    write_safety = _connector_write_safety(connector_contracts, normalized_connector)
+    if not write_safety["safe"]:
+        return _decision(
+            step_status="failed",
+            final_state="write_unconfirmed",
+            reason=str(write_safety["reason"]),
+            next_action=str(write_safety["next_action"]),
+            attempt=attempt,
+            confirmation=None,
+            now=now,
+            error_code="external_write_connector_not_write_safe",
+            policy_decision=policy_decision,
+        )
+
+    if not marketing_policy_allows_external_write(
+        policy_decision,
+        approval_satisfied=_approval_satisfied(output, step, state),
+    ):
+        return _decision(
+            step_status="failed",
+            final_state="write_unconfirmed",
+            reason=_policy_failure_reason(policy_decision),
+            next_action=str(policy_decision.get("next_action_cta") or "resolve_marketing_policy"),
+            attempt=attempt,
+            confirmation=None,
+            now=now,
+            error_code=_policy_error_code(policy_decision),
+            policy_decision=policy_decision,
+        )
+
+    if prior_confirmation:
+        confirmation = _confirmation_from_prior(prior_confirmation, attempt, now)
+        return _decision(
+            step_status="completed",
+            final_state="idempotent_recovered",
+            reason="Existing external write confirmation matched this idempotency key; no duplicate write is needed.",
+            next_action="none",
+            attempt=attempt,
+            confirmation=confirmation,
+            now=now,
+            policy_decision=policy_decision,
+        )
+
+    if reported_state == "rejected":
+        return _decision(
+            step_status="failed",
+            final_state="rejected",
+            reason=_rejection_reason(output),
+            next_action=_next_action(output, "fix_and_resubmit"),
+            attempt=attempt,
+            confirmation=None,
+            now=now,
+            policy_decision=policy_decision,
+        )
+
+    if reported_state == "timeout_unknown":
+        retry_plan = _retry_plan(connector_contracts, normalized_connector, normalized_action, idempotency_key)
+        if retry_plan.get("safe_to_retry"):
+            retry_at = _string_or_none(retry_plan.get("next_retry_at"))
+            return _decision(
+                step_status="waiting_delay",
+                final_state="retry_scheduled",
+                reason=(
+                    "Connector timed out with unknown write state; retry is scheduled "
+                    "with the same idempotency key."
+                ),
+                next_action="wait_for_idempotent_retry",
+                attempt=attempt,
+                confirmation=None,
+                retry_plan=retry_plan,
+                resume_at=retry_at,
+                now=now,
+                policy_decision=policy_decision,
+            )
+        return _decision(
+            step_status="failed",
+            final_state="timeout_unknown",
+            reason=str(retry_plan.get("reason") or "Connector timed out and safe retry metadata is missing."),
+            next_action="manual_reconcile_before_retry",
+            attempt=attempt,
+            confirmation=None,
+            retry_plan=retry_plan,
+            now=now,
+            policy_decision=policy_decision,
+        )
+
+    if reported_state == "retry_scheduled":
+        retry_plan = _retry_plan(connector_contracts, normalized_connector, normalized_action, idempotency_key)
+        if retry_plan.get("safe_to_retry"):
+            retry_at = _string_or_none(output.get("next_retry_at") or retry_plan.get("next_retry_at"))
+            return _decision(
+                step_status="waiting_delay",
+                final_state="retry_scheduled",
+                reason="Connector scheduled a safe retry with idempotency metadata.",
+                next_action="wait_for_idempotent_retry",
+                attempt=attempt,
+                confirmation=None,
+                retry_plan=retry_plan,
+                resume_at=retry_at,
+                now=now,
+                policy_decision=policy_decision,
+            )
+        return _decision(
+            step_status="failed",
+            final_state="write_unconfirmed",
+            reason=str(retry_plan.get("reason") or "Retry was requested without safe idempotency metadata."),
+            next_action="manual_reconcile_before_retry",
+            attempt=attempt,
+            confirmation=None,
+            retry_plan=retry_plan,
+            now=now,
+            error_code="external_write_retry_blocked",
+            policy_decision=policy_decision,
+        )
+
+    if reported_state == "draft_created":
+        return _decision(
+            step_status="failed",
+            final_state="draft_created",
+            reason=(
+                "Active external-write step created only a draft; it cannot be reported "
+                "as published, sent, launched, or updated."
+            ),
+            next_action="promote_draft_or_mark_step_internal",
+            attempt=attempt,
+            confirmation=None,
+            now=now,
+            policy_decision=policy_decision,
+        )
+
+    if reported_state == "write_confirmed" or (
+        reported_state == "accepted" and _has_external_object_id(output)
+    ):
+        confirmation = _confirmation_from_output(output, attempt, now)
+        if confirmation.get("external_object_id"):
+            return _decision(
+                step_status="completed",
+                final_state="write_confirmed",
+                reason="Connector accepted and confirmed the external write.",
+                next_action="none",
+                attempt=attempt,
+                confirmation=confirmation,
+                now=now,
+                policy_decision=policy_decision,
+            )
+
+    return _decision(
+        step_status="failed",
+        final_state="write_unconfirmed",
+        reason="Active external-write step did not include connector confirmation with an external object ID.",
+        next_action="confirm_write_or_reconcile",
+        attempt=attempt,
+        confirmation=None,
+        now=now,
+        policy_decision=policy_decision,
+    )
+
+
+def _evaluate_internal_mode(
+    mode: str,
+    reported_state: str,
+    prior_confirmation: dict[str, Any] | None,
+    attempt: dict[str, Any],
+    output: dict[str, Any],
+    now: datetime,
+) -> dict[str, Any]:
+    if prior_confirmation or reported_state in {"accepted", "write_confirmed"} or _has_external_object_id(output):
+        return _decision(
+            step_status="failed",
+            final_state="write_unconfirmed",
+            reason="Draft, shadow, and internal-only workflows must not execute external marketing writes.",
+            next_action="remove_external_write_from_shadow_step",
+            attempt=attempt,
+            confirmation=None,
+            now=now,
+            error_code="external_write_shadow_violation" if mode == "shadow" else "external_write_internal_violation",
+        )
+
+    if mode == "shadow":
+        final_state = "shadow_only"
+        reason = (
+            "Shadow workflow produced a recommendation, draft, simulation, or approval "
+            "record without an external write."
+        )
+    elif _is_clearly_internal(output, reported_state):
+        final_state = (
+            "draft_created"
+            if reported_state == "draft_created" or _has_any(output, {"draft_id", "draft_url"})
+            else "shadow_only"
+        )
+        reason = "Draft/internal-only workflow step is clearly labeled as non-external."
+    else:
+        return _decision(
+            step_status="failed",
+            final_state="write_unconfirmed",
+            reason=(
+                "Draft/internal-only step is not clearly labeled as draft, simulation, "
+                "recommendation, or internal approval."
+            ),
+            next_action="label_step_as_draft_or_internal",
+            attempt=attempt,
+            confirmation=None,
+            now=now,
+            error_code="external_write_draft_label_missing",
+        )
+
+    return _decision(
+        step_status="completed",
+        final_state=final_state,
+        reason=reason,
+        next_action="none",
+        attempt=attempt,
+        confirmation=None,
+        now=now,
+    )
+
+
+def _decision(
+    *,
+    step_status: str,
+    final_state: str,
+    reason: str,
+    next_action: str,
+    attempt: dict[str, Any],
+    confirmation: dict[str, Any] | None,
+    now: datetime,
+    retry_plan: dict[str, Any] | None = None,
+    resume_at: str | None = None,
+    error_code: str | None = None,
+    policy_decision: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    audit_events = _audit_events(final_state, attempt, confirmation, reason, now, retry_plan)
+    resolved_error_code = error_code or _error_code_for(final_state, step_status)
+    escalation_decision = _write_escalation_decision(
+        resolved_error_code,
+        final_state,
+        step_status,
+        reason,
+        attempt,
+        policy_decision,
+        now,
+    )
+    decision = {
+        "step_status": step_status,
+        "final_state": final_state,
+        "can_mark_complete": step_status == "completed",
+        "reason": reason,
+        "next_action": next_action,
+        "attempt": attempt,
+        "confirmation": confirmation,
+        "retry_plan": retry_plan,
+        "resume_at": resume_at,
+        "audit_events": audit_events,
+        "audit_reference": audit_events[-1]["audit_reference"],
+        "error_code": resolved_error_code,
+        "marketing_policy_decision": policy_decision,
+        "escalation_decision": escalation_decision,
+        "escalation_evidence": escalation_decision.get("evidence") if escalation_decision else None,
+    }
+    decision["decision_audit"] = audit_events[-1].get("decision_audit")
+    decision["decision_audit_ref"] = audit_events[-1].get("decision_audit_ref")
+    return decision
+
+
+def _write_escalation_decision(
+    error_code: str | None,
+    final_state: str,
+    step_status: str,
+    reason: str,
+    attempt: dict[str, Any],
+    policy_decision: dict[str, Any] | None,
+    now: datetime,
+) -> dict[str, Any] | None:
+    trigger_type = _write_escalation_trigger(error_code, final_state, step_status)
+    if trigger_type is None:
+        return None
+    if (
+        trigger_type in {"approval_timeout", "missing_policy"}
+        or str(error_code or "").startswith("external_write_marketing_policy")
+    ) and isinstance(policy_decision, dict):
+        existing = policy_decision.get("escalation_decision")
+        if isinstance(existing, dict) and existing.get("decision") != "no_escalation":
+            return existing
+    return evaluate_marketing_escalation(
+        {
+            "trigger_type": trigger_type,
+            "connector_key": attempt.get("connector_key"),
+            "action": attempt.get("action"),
+            "workflow_id": attempt.get("workflow_id"),
+            "workflow_run_id": attempt.get("workflow_run_id"),
+            "run_id": attempt.get("run_id"),
+            "step_id": attempt.get("step_id"),
+            "severity": "critical" if trigger_type == "external_write_timeout_unknown" else "high",
+            "reason": reason,
+        },
+        now=now,
+    )
+
+
+def _write_escalation_trigger(
+    error_code: str | None,
+    final_state: str,
+    step_status: str,
+) -> str | None:
+    if step_status != "failed" and final_state != "retry_scheduled":
+        return None
+    if error_code == "external_write_approval_timeout":
+        return "approval_timeout"
+    if error_code == "external_write_marketing_policy_missing":
+        return "missing_policy"
+    if error_code == "external_write_connector_not_write_safe":
+        return "connector_degraded"
+    if final_state == "rejected" or error_code == "external_write_rejected":
+        return "external_write_rejected"
+    if final_state == "timeout_unknown" or error_code == "external_write_timeout_unknown":
+        return "external_write_timeout_unknown"
+    if final_state == "write_unconfirmed":
+        return "external_write_timeout_unknown"
+    return None
+
+
+def _attempt_metadata(
+    connector_key: str | None,
+    action: str,
+    output: dict[str, Any],
+    step: dict[str, Any],
+    state: dict[str, Any],
+    now: datetime,
+) -> dict[str, Any]:
+    idempotency_key = _idempotency_key(output, step)
+    fingerprint = _request_fingerprint(output, step, connector_key, action, idempotency_key)
+    workflow_run_id = _string_or_none(
+        state.get("workflow_run_id")
+        or state.get("db_workflow_run_id")
+        or state.get("database_workflow_run_id")
+        or state.get("id")
+    )
+    agent_id = _string_or_none(output.get("agent_id") or step.get("agent_id") or step.get("agent"))
+    actor_id = _string_or_none(output.get("actor_id") or agent_id or workflow_run_id)
+    audit_reference = _audit_reference("attempt", connector_key, action, fingerprint, idempotency_key)
+    return {
+        "connector_key": connector_key,
+        "action": action,
+        "idempotency_key": idempotency_key,
+        "request_fingerprint": fingerprint,
+        "attempted_at": now.isoformat(),
+        "actor_id": actor_id,
+        "actor_type": _string_or_none(output.get("actor_type")) or "agent",
+        "agent_id": agent_id,
+        "workflow_id": _string_or_none(state.get("workflow_id") or state.get("definition_id")),
+        "workflow_run_id": workflow_run_id,
+        "run_id": _string_or_none(state.get("id")),
+        "tenant_id": _string_or_none(state.get("tenant_id")),
+        "step_id": _string_or_none(step.get("id")),
+        "audit_reference": audit_reference,
+    }
+
+
+def _confirmation_from_output(
+    output: dict[str, Any],
+    attempt: dict[str, Any],
+    now: datetime,
+) -> dict[str, Any]:
+    confirmation_payload = _confirmation_payload(output)
+    confirmed_at = _string_or_none(
+        confirmation_payload.get("confirmed_at")
+        or output.get("confirmed_at")
+        or output.get("external_write_confirmed_at")
+    ) or now.isoformat()
+    external_object_id = _external_object_id(output)
+    source_url = _string_or_none(
+        confirmation_payload.get("source_url")
+        or confirmation_payload.get("url")
+        or output.get("source_url")
+        or output.get("external_object_url")
+    )
+    return {
+        "connector_key": attempt.get("connector_key"),
+        "action": attempt.get("action"),
+        "status": "write_confirmed",
+        "external_object_id": external_object_id,
+        "source_url": source_url,
+        "idempotency_key": attempt.get("idempotency_key"),
+        "request_fingerprint": attempt.get("request_fingerprint"),
+        "confirmed_at": confirmed_at,
+        "actor_id": attempt.get("actor_id"),
+        "actor_type": attempt.get("actor_type"),
+        "agent_id": attempt.get("agent_id"),
+        "workflow_id": attempt.get("workflow_id"),
+        "workflow_run_id": attempt.get("workflow_run_id"),
+        "run_id": attempt.get("run_id"),
+        "audit_reference": _audit_reference(
+            "confirmed",
+            attempt.get("connector_key"),
+            attempt.get("action"),
+            attempt.get("request_fingerprint"),
+            attempt.get("idempotency_key"),
+        ),
+    }
+
+
+def _confirmation_from_prior(
+    prior: dict[str, Any],
+    attempt: dict[str, Any],
+    now: datetime,
+) -> dict[str, Any]:
+    return {
+        "connector_key": attempt.get("connector_key"),
+        "action": attempt.get("action"),
+        "status": "idempotent_recovered",
+        "external_object_id": prior.get("external_object_id"),
+        "source_url": prior.get("source_url"),
+        "idempotency_key": prior.get("idempotency_key") or attempt.get("idempotency_key"),
+        "request_fingerprint": prior.get("request_fingerprint") or attempt.get("request_fingerprint"),
+        "confirmed_at": prior.get("confirmed_at") or now.isoformat(),
+        "actor_id": attempt.get("actor_id"),
+        "actor_type": attempt.get("actor_type"),
+        "agent_id": attempt.get("agent_id"),
+        "workflow_id": attempt.get("workflow_id"),
+        "workflow_run_id": attempt.get("workflow_run_id"),
+        "run_id": attempt.get("run_id"),
+        "audit_reference": _audit_reference(
+            "idempotent_recovered",
+            attempt.get("connector_key"),
+            attempt.get("action"),
+            attempt.get("request_fingerprint"),
+            prior.get("idempotency_key") or attempt.get("idempotency_key"),
+        ),
+    }
+
+
+def _audit_events(
+    final_state: str,
+    attempt: dict[str, Any],
+    confirmation: dict[str, Any] | None,
+    reason: str,
+    now: datetime,
+    retry_plan: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    attempted = {
+        "event_type": "marketing_external_write_attempted",
+        "outcome": "attempted",
+        "audit_reference": attempt["audit_reference"],
+        "connector_key": attempt.get("connector_key"),
+        "action": attempt.get("action"),
+        "idempotency_key": attempt.get("idempotency_key"),
+        "request_fingerprint": attempt.get("request_fingerprint"),
+        "actor_id": attempt.get("actor_id"),
+        "agent_id": attempt.get("agent_id"),
+        "workflow_run_id": attempt.get("workflow_run_id"),
+        "workflow_id": attempt.get("workflow_id"),
+        "run_id": attempt.get("run_id"),
+        "step_id": attempt.get("step_id"),
+        "created_at": attempt.get("attempted_at"),
+    }
+    attempted_package = build_external_write_decision_audit(
+        attempted,
+        event_type="external_write_attempt",
+        now=_ensure_aware(now),
+    )
+    attempted["decision_audit"] = attempted_package
+    attempted["decision_audit_ref"] = attempted_package["audit_reference"]
+    final = {
+        "event_type": f"marketing_external_write_{final_state}",
+        "outcome": final_state,
+        "audit_reference": _audit_reference(
+            final_state,
+            attempt.get("connector_key"),
+            attempt.get("action"),
+            attempt.get("request_fingerprint"),
+            attempt.get("idempotency_key"),
+        ),
+        "connector_key": attempt.get("connector_key"),
+        "action": attempt.get("action"),
+        "idempotency_key": attempt.get("idempotency_key"),
+        "request_fingerprint": attempt.get("request_fingerprint"),
+        "reason": reason,
+        "next_retry_at": (retry_plan or {}).get("next_retry_at"),
+        "external_object_id": (confirmation or {}).get("external_object_id"),
+        "source_url": (confirmation or {}).get("source_url"),
+        "actor_id": attempt.get("actor_id"),
+        "actor_type": attempt.get("actor_type"),
+        "agent_id": attempt.get("agent_id"),
+        "workflow_run_id": attempt.get("workflow_run_id"),
+        "workflow_id": attempt.get("workflow_id"),
+        "run_id": attempt.get("run_id"),
+        "step_id": attempt.get("step_id"),
+        "created_at": now.isoformat(),
+    }
+    final_package = build_external_write_decision_audit(final, now=_ensure_aware(now))
+    final["decision_audit"] = final_package
+    final["decision_audit_ref"] = final_package["audit_reference"]
+    return [attempted, final]
+
+
+def _prior_confirmation(
+    connector_contracts: Iterable[dict[str, Any]],
+    connector_key: str | None,
+    action: str,
+    idempotency_key: str | None,
+) -> dict[str, Any] | None:
+    if not connector_key or not idempotency_key:
+        return None
+    normalized_connector = _normalize_key(connector_key)
+    normalized_action = _normalize_key(action)
+    for row in connector_contracts:
+        if _normalize_key(row.get("connector_key")) != normalized_connector:
+            continue
+        confirmations = row.get("external_write_confirmations") or []
+        if not isinstance(confirmations, list):
+            continue
+        for confirmation in confirmations:
+            if not isinstance(confirmation, dict):
+                continue
+            if _normalize_key(confirmation.get("action")) != normalized_action:
+                continue
+            if idempotency_key and confirmation.get("idempotency_key") != idempotency_key:
+                continue
+            if confirmation.get("status") == "write_confirmed":
+                return confirmation
+    return None
+
+
+def _retry_plan(
+    connector_contracts: Iterable[dict[str, Any]],
+    connector_key: str | None,
+    action: str,
+    idempotency_key: str | None,
+) -> dict[str, Any]:
+    if not connector_key:
+        return {
+            "safe_to_retry": False,
+            "reason": "Connector key is missing; retry cannot be tied to idempotency metadata.",
+            "duplicate_policy": "blocked_without_connector",
+        }
+    return plan_marketing_write_retry(
+        connector_contracts,
+        connector_key,
+        action,
+        idempotency_key=idempotency_key,
+    )
+
+
+def _connector_write_safety(
+    connector_contracts: Iterable[dict[str, Any]],
+    connector_key: str | None,
+) -> dict[str, Any]:
+    if not connector_key:
+        return {
+            "safe": False,
+            "reason": "Connector key is missing; active external write cannot prove write safety.",
+            "next_action": "configure_connector_contract",
+        }
+    normalized_connector = _normalize_key(connector_key)
+    saw_contract = False
+    for row in connector_contracts:
+        saw_contract = True
+        if _normalize_key(row.get("connector_key")) != normalized_connector:
+            continue
+        degraded_mode = row.get("degraded_mode") if isinstance(row.get("degraded_mode"), dict) else {}
+        retry_policy = row.get("retry_policy") if isinstance(row.get("retry_policy"), dict) else {}
+        if row.get("blocks_external_writes") or retry_policy.get("blocks_external_writes"):
+            return {
+                "safe": False,
+                "reason": (
+                    degraded_mode.get("reason")
+                    or row.get("degraded_mode_reason")
+                    or f"Connector failure class {row.get('failure_class') or 'unknown'} blocks external writes."
+                ),
+                "next_action": degraded_mode.get("next_action_cta") or row.get("next_action_cta") or "fix_connector",
+            }
+        if "write_safe" in row:
+            safe = bool(row.get("write_safe"))
+        elif "write_ready" in row:
+            safe = bool(row.get("write_ready"))
+        else:
+            safe = True
+        return {
+            "safe": safe,
+            "reason": (
+                "Connector contract is write-safe."
+                if safe
+                else row.get("degraded_mode_reason") or "Connector contract is not write-ready."
+            ),
+            "next_action": row.get("next_action_cta") or "fix_connector",
+        }
+    if not saw_contract:
+        return {
+            "safe": True,
+            "reason": (
+                "No connector contract context was supplied; write completion "
+                "still requires explicit confirmation."
+            ),
+            "next_action": "confirm_write_or_reconcile",
+        }
+    return {
+        "safe": False,
+        "reason": "Connector contract is unavailable; active external write cannot prove write safety.",
+        "next_action": "configure_connector_contract",
+    }
+
+
+def _approval_timeout_decision(
+    output: dict[str, Any],
+    step: dict[str, Any],
+    state: dict[str, Any],
+) -> dict[str, Any] | None:
+    for container in (
+        output,
+        step,
+        state,
+        state.get("context") if isinstance(state.get("context"), dict) else {},
+        state.get("trigger_payload") if isinstance(state.get("trigger_payload"), dict) else {},
+    ):
+        if not isinstance(container, dict):
+            continue
+        value = container.get("approval_timeout_decision") or container.get("cmo_approval_timeout_decision")
+        if isinstance(value, dict):
+            return value
+    return None
+
+
+def _marketing_policy_decision(
+    output: dict[str, Any],
+    step: dict[str, Any],
+    state: dict[str, Any],
+    action: str,
+    mode: str,
+) -> dict[str, Any]:
+    for container in _policy_containers(output, step, state):
+        value = (
+            container.get("marketing_policy_decision")
+            or container.get("cmo_marketing_policy_decision")
+        )
+        if isinstance(value, dict):
+            return value
+
+    manifest = _marketing_policy_manifest(output, step, state)
+    context: dict[str, Any] = {}
+    for container in reversed(_policy_containers(output, step, state)):
+        context.update(container)
+    context.update(
+        {
+            "action": action,
+            "workflow_mode": mode,
+            "workflow_id": (
+                state.get("workflow_id")
+                or state.get("definition_id")
+                or step.get("workflow_id")
+                or output.get("workflow_id")
+            ),
+            "external_write_required": True,
+            "customer_facing": True,
+            "connector_key": (
+                output.get("connector_key")
+                or step.get("connector_key")
+                or output.get("connector")
+                or step.get("connector")
+            ),
+        }
+    )
+    return evaluate_marketing_policy(context, manifest=manifest, use_default=manifest is None)
+
+
+def _marketing_policy_manifest(
+    output: dict[str, Any],
+    step: dict[str, Any],
+    state: dict[str, Any],
+) -> dict[str, Any] | None:
+    for container in _policy_containers(output, step, state):
+        for key in (
+            "marketing_policy_manifest",
+            "cmo_marketing_policy_manifest",
+            "policy_manifest",
+        ):
+            value = container.get(key)
+            if isinstance(value, dict):
+                return value
+    return None
+
+
+def _policy_containers(
+    output: dict[str, Any],
+    step: dict[str, Any],
+    state: dict[str, Any],
+) -> list[dict[str, Any]]:
+    return [
+        container
+        for container in (
+            output,
+            step,
+            state,
+            state.get("context") if isinstance(state.get("context"), dict) else {},
+            state.get("trigger_payload") if isinstance(state.get("trigger_payload"), dict) else {},
+        )
+        if isinstance(container, dict)
+    ]
+
+
+def _approval_satisfied(
+    output: dict[str, Any],
+    step: dict[str, Any],
+    state: dict[str, Any],
+) -> bool:
+    for container in _policy_containers(output, step, state):
+        if container.get("marketing_policy_approval_satisfied") is True:
+            return True
+        if container.get("approval_satisfied") is True or container.get("approved") is True:
+            return True
+        timeout_decision = container.get("approval_timeout_decision") or container.get("cmo_approval_timeout_decision")
+        if isinstance(timeout_decision, dict) and timeout_decision.get("external_writes_allowed") is True:
+            return True
+        status = _normalize_key(container.get("approval_status") or container.get("policy_approval_status"))
+        if status in {"approved", "accepted"}:
+            return True
+        for key in ("approval_decision", "human_approval", "policy_approval"):
+            value = container.get(key)
+            if not isinstance(value, dict):
+                continue
+            nested_status = _normalize_key(value.get("status") or value.get("decision"))
+            if nested_status in {"approved", "accepted"}:
+                return True
+            if _string_or_none(value.get("approved_by") or value.get("decision_by")):
+                return True
+    return False
+
+
+def _policy_failure_reason(policy_decision: dict[str, Any]) -> str:
+    decision = str(policy_decision.get("decision") or "")
+    if decision == "missing_policy":
+        return "Active customer-facing marketing write has no matching policy manifest rule."
+    if decision == "blocked":
+        return str(policy_decision.get("reason") or "Marketing policy blocks this external write.")
+    if decision == "read_only_only":
+        return "Marketing policy permits this workflow only as read-only/shadow output."
+    if decision in {"requires_approval", "requires_escalation"}:
+        return (
+            "Marketing policy requires approval or escalation before this "
+            "customer-facing external write can complete."
+        )
+    return "Marketing policy does not allow this external write."
+
+
+def _policy_error_code(policy_decision: dict[str, Any]) -> str:
+    decision = str(policy_decision.get("decision") or "")
+    if decision == "missing_policy":
+        return "external_write_marketing_policy_missing"
+    if decision == "blocked":
+        return "external_write_marketing_policy_blocked"
+    if decision == "read_only_only":
+        return "external_write_marketing_policy_read_only"
+    if decision in {"requires_approval", "requires_escalation"}:
+        return "external_write_marketing_policy_approval_required"
+    return "external_write_marketing_policy_denied"
+
+
+def _reported_write_state(output: dict[str, Any]) -> str:
+    value = _normalize_key(
+        output.get("external_write_state")
+        or output.get("write_state")
+        or output.get("external_write_confirmation_status")
+        or output.get("write_confirmation_status")
+        or output.get("connector_write_status")
+        or output.get("status")
+    )
+    if value in WRITE_FINAL_STATES:
+        return value
+    if value in {"confirmed", "success", "succeeded"}:
+        return "write_confirmed"
+    if value in {"accepted_pending_confirmation", "accepted_pending"}:
+        return "accepted"
+    if value in {"timed_out", "timeout", "unknown"}:
+        return "timeout_unknown"
+    if value in {"failed", "denied"}:
+        return "rejected"
+    if _has_external_object_id(output):
+        return "accepted"
+    return "write_unconfirmed"
+
+
+def _confirmation_payload(output: dict[str, Any]) -> dict[str, Any]:
+    raw = (
+        output.get("external_write_confirmation")
+        or output.get("write_confirmation")
+        or output.get("connector_write_confirmation")
+        or {}
+    )
+    return raw if isinstance(raw, dict) else {}
+
+
+def _external_object_id(output: dict[str, Any]) -> str | None:
+    confirmation = _confirmation_payload(output)
+    for field in EXTERNAL_CONFIRMATION_PAYLOAD_FIELDS:
+        value = _string_or_none(confirmation.get(field))
+        if value:
+            return value
+    for field in EXTERNAL_CONFIRMATION_FIELDS:
+        value = _string_or_none(output.get(field))
+        if value:
+            return value
+    return None
+
+
+def _has_external_object_id(output: dict[str, Any]) -> bool:
+    return _external_object_id(output) is not None
+
+
+def _has_any(output: dict[str, Any], fields: set[str]) -> bool:
+    return any(_string_or_none(output.get(field)) for field in fields)
+
+
+def _is_clearly_internal(output: dict[str, Any], reported_state: str) -> bool:
+    return (
+        reported_state in INTERNAL_SUCCESS_STATES
+        or _has_any(output, INTERNAL_SIGNAL_FIELDS)
+        or bool(output.get("internal_only") is True or output.get("shadow_only") is True)
+    )
+
+
+def _idempotency_key(output: dict[str, Any], step: dict[str, Any]) -> str | None:
+    confirmation = _confirmation_payload(output)
+    return _string_or_none(
+        output.get("idempotency_key")
+        or output.get("external_write_idempotency_key")
+        or confirmation.get("idempotency_key")
+        or step.get("idempotency_key")
+    )
+
+
+def _request_fingerprint(
+    output: dict[str, Any],
+    step: dict[str, Any],
+    connector_key: str | None,
+    action: str,
+    idempotency_key: str | None,
+) -> str:
+    explicit = _string_or_none(
+        output.get("request_fingerprint")
+        or output.get("request_hash")
+        or output.get("external_write_request_fingerprint")
+    )
+    if explicit:
+        return explicit
+    payload = {
+        "action": action,
+        "connector_key": connector_key,
+        "idempotency_key": idempotency_key,
+        "inputs": step.get("inputs") or {},
+        "request": output.get("external_write_request") or output.get("write_request") or {},
+    }
+    encoded = json.dumps(payload, sort_keys=True, default=str)
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def _audit_reference(
+    label: str,
+    connector_key: str | None,
+    action: str | None,
+    request_fingerprint: str | None,
+    idempotency_key: str | None,
+) -> str:
+    source = "|".join(
+        str(item or "")
+        for item in (label, connector_key, action, request_fingerprint, idempotency_key)
+    )
+    return f"mkt_write_{hashlib.sha256(source.encode()).hexdigest()[:20]}"
+
+
+def _rejection_reason(output: dict[str, Any]) -> str:
+    return _string_or_none(
+        output.get("rejection_reason")
+        or output.get("error")
+        or output.get("reason")
+        or output.get("message")
+    ) or "Connector rejected the external write."
+
+
+def _next_action(output: dict[str, Any], default: str) -> str:
+    return _normalize_key(output.get("next_action") or output.get("next_action_cta") or default)
+
+
+def _error_code_for(final_state: str, step_status: str) -> str | None:
+    if step_status != "failed":
+        return None
+    if final_state == "rejected":
+        return "external_write_rejected"
+    if final_state == "timeout_unknown":
+        return "external_write_timeout_unknown"
+    if final_state == "draft_created":
+        return "external_write_draft_only"
+    return "external_write_confirmation_missing"
+
+
+def _normalize_connector(
+    connector_key: str | None,
+    output: dict[str, Any],
+    step: dict[str, Any],
+) -> str | None:
+    return _string_or_none(
+        connector_key
+        or output.get("connector_key")
+        or output.get("connector")
+        or step.get("connector_key")
+        or step.get("connector")
+    )
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _string_or_none(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _ensure_aware(value: Any) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value

--- a/core/marketing/kpi_drilldown.py
+++ b/core/marketing/kpi_drilldown.py
@@ -1,0 +1,660 @@
+"""CMO KPI drill-down and data-lineage projections.
+
+CMO-8.2 turns unified KPI results into operator-facing explanations. The
+projection is deterministic and intentionally lightweight: it does not persist
+KPI history or infer production lineage from demo, sample, mock, or stub data.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from core.marketing.kpi_schema import default_cmo_kpi_schema
+
+CMO_KPI_DRILLDOWN_VERSION = "2026-05-23.cmo-8.2"
+
+DRILLDOWN_STATUSES = ("ready", "degraded", "blocked", "unavailable")
+DEMO_SOURCE_MARKERS = {"demo", "sample", "mock", "stub", "hardcoded", "fallback", "test_double"}
+
+FORMULA_INPUT_ALIASES: dict[str, tuple[str, ...]] = {
+    "total_marketing_spend": ("total_marketing_spend", "marketing_spend", "total_spend", "ad_spend"),
+    "new_customers": ("new_customers", "new_customer_count", "customers_acquired"),
+    "mql_count": ("mql_count", "mql"),
+    "sql_count": ("sql_count", "sql"),
+    "attributed_revenue": ("attributed_revenue", "marketing_attributed_revenue"),
+    "ad_spend": ("ad_spend", "total_marketing_spend", "marketing_spend", "total_spend"),
+    "pipeline_contribution": ("pipeline_contribution", "marketing_pipeline", "pipeline_value", "opportunities"),
+    "customer_ltv": ("customer_ltv", "ltv", "average_ltv"),
+    "cac": ("cac",),
+    "completed_experiments": ("completed_experiments", "experiments_completed"),
+    "period_days": ("period_days", "experiment_period_days"),
+    "content_conversions": ("content_conversions", "conversions"),
+    "content_sessions": ("content_sessions", "sessions", "pageviews"),
+    "emails_sent": ("emails_sent", "email_sent", "sent"),
+    "emails_opened": ("emails_opened", "email_opens", "opens"),
+    "emails_clicked": ("emails_clicked", "email_clicks", "clicks"),
+    "emails_unsubscribed": ("emails_unsubscribed", "unsubscribes"),
+    "brand_sentiment_score": ("brand_sentiment_score", "sentiment_score"),
+    "brand_positive_mentions": ("brand_positive_mentions", "positive_mentions"),
+    "brand_negative_mentions": ("brand_negative_mentions", "negative_mentions"),
+    "brand_neutral_mentions": ("brand_neutral_mentions", "neutral_mentions"),
+    "intent_ready_accounts": ("intent_ready_accounts", "abm_intent_accounts"),
+    "target_accounts": ("target_accounts", "target_account_count"),
+    "funnel_stage_counts": ("funnel_stage_counts", "lifecycle_stage_counts"),
+}
+
+CTA_LABELS = {
+    "none": "No Action",
+    "configure_required_connector": "Configure Connector",
+    "fix_required_mapping": "Fix Mapping",
+    "complete_backfill": "Complete Backfill",
+    "provide_kpi_source_data": "Provide Source Data",
+    "refresh_source_data": "Refresh Source Data",
+    "review_degraded_kpi_inputs": "Review KPI Inputs",
+    "resolve_spend_reconciliation": "Resolve Spend Reconciliation",
+    "review_campaign_attribution_mapping": "Review Attribution Mapping",
+    "review_web_to_crm_lead_mapping": "Review Web-to-CRM Mapping",
+    "resolve_reconciliation": "Resolve Reconciliation",
+    "review_kpi_readiness": "Review KPI Readiness",
+    "connect_ltv_source": "Connect LTV Source",
+    "connect_real_marketing_sources": "Connect Real Sources",
+}
+
+CTA_PATHS = {
+    "none": "/dashboard/cmo",
+    "configure_required_connector": "/dashboard/connectors",
+    "fix_required_mapping": "/dashboard/connectors",
+    "complete_backfill": "/dashboard/connectors",
+    "provide_kpi_source_data": "/dashboard/connectors",
+    "refresh_source_data": "/dashboard/connectors",
+    "review_degraded_kpi_inputs": "/dashboard/cmo?panel=kpi-lineage",
+    "resolve_spend_reconciliation": "/dashboard/cmo?panel=reconciliation",
+    "review_campaign_attribution_mapping": "/dashboard/cmo?panel=reconciliation",
+    "review_web_to_crm_lead_mapping": "/dashboard/cmo?panel=reconciliation",
+    "resolve_reconciliation": "/dashboard/cmo?panel=reconciliation",
+    "review_kpi_readiness": "/dashboard/cmo?panel=kpi-lineage",
+    "connect_ltv_source": "/dashboard/connectors",
+    "connect_real_marketing_sources": "/dashboard/connectors",
+}
+
+
+def build_cmo_kpi_drilldown_projection(
+    *,
+    kpi_schema: Mapping[str, Any] | None = None,
+    kpi_results: Iterable[Mapping[str, Any]] = (),
+    reconciliation_checks: Iterable[Mapping[str, Any]] = (),
+    connector_setup: Iterable[Mapping[str, Any]] = (),
+    data_readiness: Mapping[str, Any] | None = None,
+    connector_contracts: Iterable[Mapping[str, Any]] = (),
+    work_queue: Iterable[Mapping[str, Any]] = (),
+    report_quality_gates: Iterable[Mapping[str, Any]] = (),
+    source_data: Mapping[str, Any] | None = None,
+    source_context: Mapping[str, Any] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build KPI drill-down rows and summary counts."""
+
+    timestamp = _ensure_aware(now) or datetime.now(UTC)
+    schema = kpi_schema if isinstance(kpi_schema, Mapping) else default_cmo_kpi_schema()
+    definitions = _definitions_by_key(schema)
+    results = _results_by_key(kpi_results)
+    checks = _dicts(reconciliation_checks)
+    setup_rows = _dicts(connector_setup)
+    contract_rows = _dicts(connector_contracts)
+    readiness = data_readiness if isinstance(data_readiness, Mapping) else {}
+    queue_rows = _dicts(work_queue)
+    report_rows = _dicts(report_quality_gates)
+    facts = _facts(source_data)
+    source = source_context if isinstance(source_context, Mapping) else {}
+    demo_or_sample = (
+        _demo_or_sample_source(source)
+        or _demo_or_sample_source(facts)
+        or _has_mock_contract(contract_rows)
+    )
+
+    drilldowns = [
+        _build_drilldown(
+            definition,
+            results.get(key),
+            checks,
+            setup_rows,
+            readiness,
+            contract_rows,
+            queue_rows,
+            report_rows,
+            facts,
+            timestamp,
+            demo_or_sample=demo_or_sample,
+        )
+        for key, definition in definitions.items()
+    ]
+
+    return {
+        "cmo_kpi_drilldown_version": CMO_KPI_DRILLDOWN_VERSION,
+        "cmo_kpi_drilldowns": drilldowns,
+        "cmo_kpi_drilldown_summary": summarize_cmo_kpi_drilldowns(drilldowns),
+    }
+
+
+def summarize_cmo_kpi_drilldowns(drilldowns: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    items = [dict(item) for item in drilldowns if isinstance(item, Mapping)]
+    counts = dict.fromkeys(DRILLDOWN_STATUSES, 0)
+    lineage_blocked = 0
+    for item in items:
+        status = str(item.get("status") or "unavailable")
+        if status in counts:
+            counts[status] += 1
+        if item.get("production_lineage_status") == "blocked":
+            lineage_blocked += 1
+    readiness = "blocked" if counts["blocked"] or lineage_blocked else "degraded" if counts["degraded"] else "ready"
+    return {
+        "schema_version": CMO_KPI_DRILLDOWN_VERSION,
+        "total": len(items),
+        **counts,
+        "lineage_blocked": lineage_blocked,
+        "readiness": readiness,
+        "needs_action": sum(1 for item in items if _cta_key(item.get("next_action_cta")) != "none"),
+        "next_action_cta": next(
+            (
+                item.get("next_action_cta")
+                for item in items
+                if _cta_key(item.get("next_action_cta")) != "none"
+            ),
+            _cta("none"),
+        ),
+    }
+
+
+def _build_drilldown(
+    definition: Mapping[str, Any],
+    result: Mapping[str, Any] | None,
+    reconciliation_checks: list[dict[str, Any]],
+    connector_setup: list[dict[str, Any]],
+    data_readiness: Mapping[str, Any],
+    connector_contracts: list[dict[str, Any]],
+    work_queue: list[dict[str, Any]],
+    report_quality_gates: list[dict[str, Any]],
+    facts: Mapping[str, Any],
+    timestamp: datetime,
+    *,
+    demo_or_sample: bool,
+) -> dict[str, Any]:
+    key = _normalize_key(definition.get("key"))
+    row = result if isinstance(result, Mapping) else {}
+    current_status = _status(row.get("status"))
+    missing_requirements = _missing_requirements(row.get("missing_requirements"))
+    blocked_reasons = _string_list(row.get("blocked_reasons"))
+    degraded_reasons = _string_list(row.get("degraded_reasons"))
+    source_refs = _source_refs(row.get("source_refs")) if not demo_or_sample else []
+    connector_refs = _connector_refs(definition, connector_setup, connector_contracts)
+    reconciliation = _reconciliation_for_kpi(key, reconciliation_checks)
+    report_refs = _report_gate_refs(key, report_quality_gates)
+    work_item_ids = _work_item_ids(key, work_queue)
+    audit_refs = _unique(
+        [
+            *_string_list(row.get("audit_refs") or row.get("decision_audit_refs")),
+            *_string_list(row.get("reconciliation_refs")),
+            *[
+                str(check.get("decision_audit_ref"))
+                for check in reconciliation
+                if check.get("decision_audit_ref")
+            ],
+            *[
+                str(gate.get("decision_audit_ref"))
+                for gate in report_quality_gates
+                if key in _kpi_refs_from_report_gate(gate) and gate.get("decision_audit_ref")
+            ],
+        ]
+    )
+    if demo_or_sample:
+        missing_requirements.setdefault("source_data", [])
+        missing_requirements["source_data"].append("real_production_lineage")
+        blocked_reasons.append("Demo, mock, stub, hardcoded, or sample KPI inputs are not production lineage proof.")
+    next_action_key = _next_action(row, missing_requirements, demo_or_sample)
+
+    return {
+        "drilldown_id": f"cmo_kpi_drilldown:{key}",
+        "kpi_key": key,
+        "display_name": str(definition.get("display_name") or row.get("display_name") or key),
+        "description": str(definition.get("description") or ""),
+        "status": current_status,
+        "value": row.get("value"),
+        "unit": row.get("unit") or definition.get("unit"),
+        "confidence": float(row.get("confidence") or 0.0),
+        "formula": row.get("formula") or definition.get("formula"),
+        "formula_refs": row.get("formula_refs") or _formula_refs(definition),
+        "formula_inputs": _formula_inputs(row, facts),
+        "required_source_domains": list(definition.get("required_source_domains") or []),
+        "required_connector_categories": list(definition.get("required_connector_categories") or []),
+        "required_field_mappings": list(definition.get("required_field_mappings") or []),
+        "required_backfill_categories": list(definition.get("required_backfill_categories") or []),
+        "source_refs": source_refs,
+        "connector_refs": connector_refs,
+        "field_mappings_used": _field_mapping_rows(definition, data_readiness),
+        "backfill_state": _backfill_rows(definition, data_readiness),
+        "reconciliation_checks": reconciliation,
+        "freshness_status": row.get("freshness_status") or "unknown",
+        "freshness": row.get("freshness") or {},
+        "confidence_rules": list(definition.get("confidence_rules") or []),
+        "confidence_impact_reasons": _confidence_reasons(row, reconciliation, demo_or_sample),
+        "missing_requirements": {name: _unique(values) for name, values in missing_requirements.items()},
+        "blocked_reasons": _unique(blocked_reasons),
+        "degraded_reasons": _unique(degraded_reasons),
+        "related_work_queue_item_ids": work_item_ids,
+        "related_report_gate_ids": report_refs,
+        "policy_refs": _policy_refs(report_quality_gates, key),
+        "audit_refs": audit_refs,
+        "owner_role": row.get("owner_role") or definition.get("owner_role") or "marketing_ops",
+        "next_action_cta": _cta(next_action_key),
+        "production_lineage_status": "blocked" if demo_or_sample else "ready",
+        "production_lineage_ready": not demo_or_sample,
+        "last_computed_at": row.get("last_computed_at") or timestamp.isoformat(),
+    }
+
+
+def _definitions_by_key(schema: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    definitions = {}
+    for item in _dicts(schema.get("kpis")):
+        key = _normalize_key(item.get("key"))
+        if key:
+            definitions[key] = item
+    return definitions
+
+
+def _results_by_key(results: Iterable[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    rows = {}
+    for item in _dicts(results):
+        key = _normalize_key(item.get("kpi_key") or item.get("key"))
+        if key:
+            rows[key] = item
+    return rows
+
+
+def _formula_inputs(result: Mapping[str, Any], facts: Mapping[str, Any]) -> list[dict[str, Any]]:
+    refs = result.get("formula_refs") if isinstance(result.get("formula_refs"), Mapping) else {}
+    input_names = _string_list(refs.get("formula_inputs"))
+    if not input_names:
+        input_names = _string_list(result.get("required_formula_inputs"))
+    return [_resolved_formula_input(name, facts, result) for name in input_names]
+
+
+def _resolved_formula_input(name: str, facts: Mapping[str, Any], result: Mapping[str, Any]) -> dict[str, Any]:
+    aliases = FORMULA_INPUT_ALIASES.get(name, (name,))
+    for alias in aliases:
+        value = _resolve_fact(alias, facts, result)
+        if value is not None:
+            return {"name": name, "source_key": alias, "value": value, "resolved": True}
+    return {"name": name, "source_key": aliases[0] if aliases else name, "value": None, "resolved": False}
+
+
+def _resolve_fact(alias: str, facts: Mapping[str, Any], result: Mapping[str, Any]) -> Any:
+    if alias in {"mql_count", "mql"}:
+        return _stage_count(facts, "mql")
+    if alias in {"sql_count", "sql"}:
+        return _stage_count(facts, "sql")
+    if alias == "opportunities":
+        opportunities = _dicts(facts.get("opportunities") or facts.get("pipeline_opportunities"))
+        if opportunities:
+            return sum(float(item.get("amount") or 0.0) for item in opportunities)
+    if alias == "cac" and result.get("kpi_key") == "ltv_cac":
+        return None
+    if alias in facts:
+        return facts[alias]
+    return None
+
+
+def _stage_count(facts: Mapping[str, Any], stage: str) -> float | None:
+    explicit = facts.get(f"{stage}_count") or facts.get(stage)
+    if explicit is not None:
+        return _number(explicit)
+    counts = facts.get("lifecycle_stage_counts")
+    if isinstance(counts, Mapping):
+        return _number(counts.get(stage))
+    return None
+
+
+def _connector_refs(
+    definition: Mapping[str, Any],
+    connector_setup: list[dict[str, Any]],
+    connector_contracts: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    categories = {str(item) for item in definition.get("required_connector_categories") or []}
+    refs = []
+    for row in connector_setup:
+        if str(row.get("category") or "") in categories:
+            refs.append(
+                {
+                    "type": "connector_setup",
+                    "connector_key": row.get("key") or row.get("connector_key"),
+                    "connector_name": row.get("name"),
+                    "category": row.get("category"),
+                    "configured_status": row.get("configured_status"),
+                    "health_status": row.get("health_status"),
+                    "last_sync_at": row.get("last_sync_at"),
+                    "account_id": row.get("account_id") or row.get("workspace_id"),
+                }
+            )
+    for row in connector_contracts:
+        if str(row.get("category") or "") in categories:
+            refs.append(
+                {
+                    "type": "connector_contract",
+                    "connector_key": row.get("connector_key") or row.get("key"),
+                    "category": row.get("category"),
+                    "read_status": row.get("read_status"),
+                    "write_status": row.get("write_status"),
+                    "health_status": row.get("health_status"),
+                    "contract_state": row.get("contract_state"),
+                    "mock_or_test_double": bool(row.get("mock_or_test_double")),
+                }
+            )
+    return _unique_refs(refs)
+
+
+def _field_mapping_rows(
+    definition: Mapping[str, Any],
+    data_readiness: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    required = {str(item) for item in definition.get("required_field_mappings") or []}
+    rows = []
+    for row in _dicts(data_readiness.get("field_mapping_status")):
+        key = str(row.get("key") or "")
+        if key not in required:
+            continue
+        rows.append(
+            {
+                "key": key,
+                "name": row.get("name") or key,
+                "status": row.get("status") or "unmapped",
+                "sources": row.get("sources") or row.get("source_categories") or [],
+                "missing_fields": row.get("missing_fields") or [],
+                "blocking_reason": row.get("blocking_reason"),
+                "audit_ref": row.get("decision_audit_ref") or row.get("audit_reference"),
+            }
+        )
+    return rows
+
+
+def _backfill_rows(
+    definition: Mapping[str, Any],
+    data_readiness: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    required = {str(item) for item in definition.get("required_backfill_categories") or []}
+    rows = []
+    for row in _dicts(data_readiness.get("backfill_status")):
+        category = str(row.get("category") or "")
+        if category not in required:
+            continue
+        rows.append(
+            {
+                "source_connector_key": row.get("source_connector_key"),
+                "source_name": row.get("source_name"),
+                "category": category,
+                "status": row.get("status") or "not_started",
+                "requested_start": row.get("requested_start"),
+                "requested_end": row.get("requested_end"),
+                "last_run_at": row.get("last_run_at"),
+                "blocking_reason": row.get("blocking_reason"),
+                "audit_ref": row.get("decision_audit_ref") or row.get("audit_reference"),
+            }
+        )
+    return rows
+
+
+def _reconciliation_for_kpi(kpi_key: str, checks: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    rows = []
+    for check in _dicts(checks):
+        affected = {_normalize_key(item) for item in check.get("affected_kpi_keys") or []}
+        if kpi_key not in affected:
+            continue
+        rows.append(
+            {
+                "reconciliation_key": check.get("reconciliation_key"),
+                "status": check.get("status"),
+                "severity": check.get("severity"),
+                "sources_compared": check.get("sources_compared") or [],
+                "expected_value": check.get("expected_value"),
+                "observed_value": check.get("observed_value"),
+                "delta_absolute": check.get("delta_absolute"),
+                "delta_percentage": check.get("delta_percentage"),
+                "tolerance": check.get("tolerance") or {},
+                "confidence_impact": float(check.get("confidence_impact") or 0.0),
+                "freshness_impact": float(check.get("freshness_impact") or 0.0),
+                "source_refs": _source_refs(check.get("source_refs")),
+                "missing_requirements": check.get("missing_requirements") or {},
+                "next_action_cta": _cta(str(check.get("next_action_cta") or "none")),
+                "decision_audit_ref": check.get("decision_audit_ref"),
+            }
+        )
+    return rows
+
+
+def _report_gate_refs(kpi_key: str, gates: Iterable[Mapping[str, Any]]) -> list[str]:
+    refs = []
+    for gate in _dicts(gates):
+        if kpi_key in _kpi_refs_from_report_gate(gate):
+            ref = str(gate.get("report_key") or gate.get("report_type") or "")
+            if ref:
+                refs.append(ref)
+    return _unique(refs)
+
+
+def _kpi_refs_from_report_gate(gate: Mapping[str, Any]) -> set[str]:
+    refs: set[str] = set()
+    for key in (
+        "required_kpi_keys",
+        "optional_kpi_keys",
+        "blocked_kpi_keys",
+        "degraded_kpi_keys",
+    ):
+        refs.update(_normalize_key(item) for item in gate.get(key) or [])
+    return refs
+
+
+def _work_item_ids(kpi_key: str, work_queue: Iterable[Mapping[str, Any]]) -> list[str]:
+    ids = []
+    for item in _dicts(work_queue):
+        affected = _normalize_key(item.get("affected_kpi"))
+        affected_parts = {_normalize_key(part) for part in str(item.get("affected_kpi") or "").split(",")}
+        if affected == kpi_key or kpi_key in affected_parts:
+            item_id = str(item.get("item_id") or "")
+            if item_id:
+                ids.append(item_id)
+    return _unique(ids)
+
+
+def _policy_refs(gates: Iterable[Mapping[str, Any]], kpi_key: str) -> list[str]:
+    refs = []
+    for gate in _dicts(gates):
+        if kpi_key not in _kpi_refs_from_report_gate(gate):
+            continue
+        refs.extend(_string_list(gate.get("required_approval_refs")))
+        refs.extend(_string_list(gate.get("required_escalation_refs")))
+    return _unique(refs)
+
+
+def _confidence_reasons(
+    result: Mapping[str, Any],
+    reconciliation: Iterable[Mapping[str, Any]],
+    demo_or_sample: bool,
+) -> list[str]:
+    reasons = [
+        *_string_list(result.get("blocked_reasons")),
+        *_string_list(result.get("degraded_reasons")),
+    ]
+    freshness = result.get("freshness") if isinstance(result.get("freshness"), Mapping) else {}
+    reasons.extend(_string_list(freshness.get("degraded_reasons")))
+    for check in reconciliation:
+        status = str(check.get("status") or "")
+        if status not in {"passed", "info"}:
+            reasons.append(f"Reconciliation {check.get('reconciliation_key')} is {status}.")
+    if demo_or_sample:
+        reasons.append("Demo/mock/sample lineage blocks production confidence.")
+    return _unique(reasons)
+
+
+def _next_action(
+    result: Mapping[str, Any],
+    missing_requirements: Mapping[str, list[str]],
+    demo_or_sample: bool,
+) -> str:
+    if demo_or_sample:
+        return "connect_real_marketing_sources"
+    action = str(result.get("next_action_cta") or "none")
+    if action != "none":
+        return action
+    if missing_requirements.get("connectors"):
+        return "configure_required_connector"
+    if missing_requirements.get("field_mappings"):
+        return "fix_required_mapping"
+    if missing_requirements.get("backfills"):
+        return "complete_backfill"
+    if missing_requirements.get("fields"):
+        return "provide_kpi_source_data"
+    return "none"
+
+
+def _formula_refs(definition: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": str(definition.get("schema_version") or ""),
+        "definition_key": definition.get("key"),
+        "formula": definition.get("formula"),
+        "formula_inputs": [],
+    }
+
+
+def _missing_requirements(value: Any) -> dict[str, list[str]]:
+    result: dict[str, list[str]] = {}
+    if not isinstance(value, Mapping):
+        return result
+    for key, values in value.items():
+        result[str(key)] = _string_list(values)
+    return result
+
+
+def _cta(value: Any) -> dict[str, str]:
+    key = _cta_key(value)
+    return {
+        "action_key": key,
+        "label": CTA_LABELS.get(key, key.replace("_", " ").title()),
+        "path": CTA_PATHS.get(key, "/dashboard/cmo"),
+    }
+
+
+def _cta_key(value: Any) -> str:
+    if isinstance(value, Mapping):
+        return str(value.get("action_key") or value.get("key") or "none")
+    return str(value or "none")
+
+
+def _facts(source_data: Mapping[str, Any] | None) -> dict[str, Any]:
+    source = source_data if isinstance(source_data, Mapping) else {}
+    facts: dict[str, Any] = {}
+    for key in ("metrics", "facts", "kpi_inputs", "marketing_kpi_inputs", "cmo_kpi_inputs"):
+        value = source.get(key)
+        if isinstance(value, Mapping):
+            facts.update(dict(value))
+    facts.update(dict(source))
+    return facts
+
+
+def _source_refs(value: Any) -> list[dict[str, Any]]:
+    refs = []
+    for item in _list_from_value(value):
+        if isinstance(item, Mapping):
+            refs.append(dict(item))
+        elif str(item).strip():
+            refs.append({"ref": str(item)})
+    return _unique_refs(refs)
+
+
+def _demo_or_sample_source(source: Mapping[str, Any]) -> bool:
+    if not isinstance(source, Mapping):
+        return False
+    if source.get("demo") or source.get("production_data_blocked"):
+        return True
+    marker_values = [
+        source.get("source"),
+        source.get("data_source"),
+        source.get("lineage_source"),
+        source.get("kpi_source"),
+    ]
+    return any(_normalize_key(value) in DEMO_SOURCE_MARKERS for value in marker_values)
+
+
+def _has_mock_contract(rows: Iterable[Mapping[str, Any]]) -> bool:
+    return any(bool(row.get("mock_or_test_double")) for row in rows)
+
+
+def _status(value: Any) -> str:
+    normalized = _normalize_key(value)
+    return normalized if normalized in DRILLDOWN_STATUSES else "unavailable"
+
+
+def _number(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _dicts(value: Any) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if isinstance(value, Mapping):
+        return [dict(value)]
+    if isinstance(value, Iterable) and not isinstance(value, str):
+        return [dict(item) for item in value if isinstance(item, Mapping)]
+    return []
+
+
+def _list_from_value(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, list | tuple | set):
+        return list(value)
+    return [value]
+
+
+def _string_list(value: Any) -> list[str]:
+    return _unique(str(item) for item in _list_from_value(value) if str(item).strip())
+
+
+def _unique(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _unique_refs(values: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    result = []
+    for value in values:
+        marker = repr(sorted(value.items()))
+        if marker in seen:
+            continue
+        seen.add(marker)
+        result.append(value)
+    return result
+
+
+def _ensure_aware(value: Any) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")

--- a/core/marketing/kpi_reconciliation.py
+++ b/core/marketing/kpi_reconciliation.py
@@ -1,0 +1,984 @@
+"""CMO KPI reconciliation checks.
+
+CMO-7.2 cross-checks source totals before canonical marketing KPIs are treated
+as trusted production output. The checks are deterministic projections over
+structured source facts and connector readiness. They do not invent source
+values or call vendor APIs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from core.marketing.decision_audit import build_cmo_decision_audit_package
+
+CMO_KPI_RECONCILIATION_VERSION = "2026-05-23.cmo-7.2"
+
+RECONCILIATION_STATUSES = ("passed", "warning", "failed", "blocked", "unavailable")
+
+FINANCIAL_KPIS = ("cac", "roas", "pipeline_contribution", "ltv_cac")
+ATTRIBUTION_KPIS = (
+    "mql",
+    "sql",
+    "mql_to_sql_conversion_rate",
+    "roas",
+    "pipeline_contribution",
+    "conversion_rates_by_funnel_stage",
+)
+TIME_BASED_KPIS = (
+    "cac",
+    "mql",
+    "sql",
+    "mql_to_sql_conversion_rate",
+    "roas",
+    "pipeline_contribution",
+    "conversion_rates_by_funnel_stage",
+    "experiment_velocity",
+    "content_performance",
+    "email_performance",
+    "brand_sentiment",
+    "abm_intent_account_readiness",
+)
+
+CATEGORY_KPI_KEYS = {
+    "Ads": ("cac", "roas", "experiment_velocity", "ltv_cac"),
+    "CRM": (
+        "cac",
+        "mql",
+        "sql",
+        "mql_to_sql_conversion_rate",
+        "roas",
+        "pipeline_contribution",
+        "conversion_rates_by_funnel_stage",
+        "ltv_cac",
+        "email_performance",
+        "abm_intent_account_readiness",
+    ),
+    "Analytics": (
+        "roas",
+        "conversion_rates_by_funnel_stage",
+        "experiment_velocity",
+        "content_performance",
+    ),
+    "CMS": ("content_performance", "experiment_velocity"),
+    "Email": ("email_performance", "experiment_velocity"),
+    "Brand": ("brand_sentiment",),
+    "ABM": ("abm_intent_account_readiness",),
+    "Finance": ("cac", "roas", "pipeline_contribution", "ltv_cac"),
+}
+
+
+def build_cmo_kpi_reconciliation_projection(
+    *,
+    connector_setup: Iterable[dict[str, Any]] = (),
+    data_readiness: Mapping[str, Any] | None = None,
+    connector_contracts: Iterable[dict[str, Any]] = (),
+    connector_configs: Iterable[Any] = (),
+    source_data: Mapping[str, Any] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build all CMO KPI reconciliation checks and a compact summary."""
+
+    timestamp = _ensure_aware(now) or datetime.now(UTC)
+    facts = _collect_reconciliation_facts(source_data, connector_configs)
+    setup_rows = list(connector_setup)
+    contract_rows = list(connector_contracts)
+    checks = [
+        _paid_spend_totals_check(facts),
+        _ad_conversion_crm_attribution_check(facts),
+        _ga4_web_crm_lead_check(facts),
+        _email_engagement_check(facts),
+        _content_traffic_check(facts),
+        _abm_account_domain_check(facts),
+        _currency_consistency_check(facts),
+        _timezone_consistency_check(facts),
+        _freshness_and_partial_data_check(setup_rows, contract_rows, timestamp),
+    ]
+    return {
+        "cmo_kpi_reconciliation_version": CMO_KPI_RECONCILIATION_VERSION,
+        "cmo_kpi_reconciliation_checks": checks,
+        "cmo_kpi_reconciliation_summary": summarize_cmo_kpi_reconciliation(checks),
+    }
+
+
+def summarize_cmo_kpi_reconciliation(checks: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    items = list(checks)
+    counts = dict.fromkeys(RECONCILIATION_STATUSES, 0)
+    for item in items:
+        status = str(item.get("status") or "")
+        if status in counts:
+            counts[status] += 1
+
+    if counts["failed"] or counts["blocked"]:
+        readiness = "blocked"
+    elif counts["warning"] or counts["unavailable"]:
+        readiness = "degraded"
+    else:
+        readiness = "ready"
+
+    affected = sorted(
+        {
+            str(kpi)
+            for item in items
+            if item.get("status") in {"failed", "blocked", "warning", "unavailable"}
+            for kpi in item.get("affected_kpi_keys") or []
+            if str(kpi).strip()
+        }
+    )
+    return {
+        "schema_version": CMO_KPI_RECONCILIATION_VERSION,
+        "total": len(items),
+        **counts,
+        "readiness": readiness,
+        "affected_kpi_keys": affected,
+        "confidence_impact": round(
+            min(sum(float(item.get("confidence_impact") or 0.0) for item in items), 0.75),
+            3,
+        ),
+        "freshness_impact": round(
+            min(sum(float(item.get("freshness_impact") or 0.0) for item in items), 0.75),
+            3,
+        ),
+        "next_action_cta": next(
+            (
+                str(item.get("next_action_cta"))
+                for item in items
+                if item.get("next_action_cta") not in {None, "", "none"}
+            ),
+            "none",
+        ),
+    }
+
+
+def _paid_spend_totals_check(facts: Mapping[str, Any]) -> dict[str, Any]:
+    expected = _number_from(
+        facts,
+        "ad_platform_spend_total",
+        "paid_spend_total",
+        "total_marketing_spend",
+        "ad_spend",
+    )
+    observed = _number_from(facts, "campaign_level_spend_total", "campaign_spend_total")
+    if observed is None:
+        observed = _sum_amounts(
+            facts.get("campaign_spend_by_channel")
+            or facts.get("campaign_spend")
+            or facts.get("campaign_level_spend")
+        )
+    return _numeric_check(
+        key="paid_spend_totals_by_channel",
+        severity="high",
+        affected_kpi_keys=("cac", "roas", "ltv_cac"),
+        sources_compared=("ad_platform_spend_total", "campaign_level_spend"),
+        expected=expected,
+        observed=observed,
+        expected_field="ad_platform_spend_total",
+        observed_field="campaign_level_spend",
+        tolerance_percentage=2.0,
+        tolerance_absolute=1.0,
+        next_action_cta="resolve_spend_reconciliation",
+        failure_blocks=True,
+        facts=facts,
+    )
+
+
+def _ad_conversion_crm_attribution_check(facts: Mapping[str, Any]) -> dict[str, Any]:
+    expected = _number_from(facts, "ad_platform_conversions", "ad_conversions", "platform_conversions")
+    observed = _number_from(
+        facts,
+        "crm_campaign_attributed_mqls",
+        "crm_attributed_mqls",
+        "crm_campaign_attributed_conversions",
+    )
+    if observed is None:
+        observed = _stage_count(facts, "mql")
+    return _numeric_check(
+        key="ad_conversions_vs_crm_attribution",
+        severity="medium",
+        affected_kpi_keys=ATTRIBUTION_KPIS,
+        sources_compared=("ad_platform_conversions", "crm_campaign_attributed_mqls"),
+        expected=expected,
+        observed=observed,
+        expected_field="ad_platform_conversions",
+        observed_field="crm_campaign_attributed_mqls",
+        tolerance_percentage=20.0,
+        tolerance_absolute=5.0,
+        next_action_cta="review_campaign_attribution_mapping",
+        failure_blocks=False,
+        facts=facts,
+    )
+
+
+def _ga4_web_crm_lead_check(facts: Mapping[str, Any]) -> dict[str, Any]:
+    expected = _number_from(facts, "ga4_conversion_events", "web_conversion_events", "analytics_conversion_events")
+    observed = _number_from(facts, "crm_leads_created", "crm_lead_creations", "lead_count")
+    if observed is None:
+        observed = _stage_count(facts, "lead")
+    return _numeric_check(
+        key="ga4_web_conversions_vs_crm_leads",
+        severity="medium",
+        affected_kpi_keys=(
+            "mql",
+            "sql",
+            "mql_to_sql_conversion_rate",
+            "conversion_rates_by_funnel_stage",
+            "roas",
+        ),
+        sources_compared=("ga4_conversion_events", "crm_leads_created"),
+        expected=expected,
+        observed=observed,
+        expected_field="ga4_conversion_events",
+        observed_field="crm_leads_created",
+        tolerance_percentage=15.0,
+        tolerance_absolute=5.0,
+        next_action_cta="review_web_to_crm_lead_mapping",
+        failure_blocks=False,
+        facts=facts,
+    )
+
+
+def _email_engagement_check(facts: Mapping[str, Any]) -> dict[str, Any]:
+    pairs = (
+        ("emails_sent", "crm_email_sends"),
+        ("emails_clicked", "crm_email_clicks"),
+        ("emails_unsubscribed", "crm_unsubscribed_contacts"),
+    )
+    return _multi_numeric_check(
+        key="email_engagement_vs_crm_list",
+        severity="medium",
+        affected_kpi_keys=("email_performance",),
+        sources_compared=("email_platform_metrics", "crm_or_list_engagement"),
+        field_pairs=pairs,
+        facts=facts,
+        tolerance_percentage=5.0,
+        tolerance_absolute=2.0,
+        next_action_cta="review_email_crm_engagement_sync",
+        failure_blocks=False,
+    )
+
+
+def _content_traffic_check(facts: Mapping[str, Any]) -> dict[str, Any]:
+    expected = _number_from(facts, "wordpress_content_sessions", "cms_content_sessions", "content_cms_sessions")
+    observed = _number_from(facts, "ga4_content_sessions", "content_sessions", "analytics_content_sessions")
+    return _numeric_check(
+        key="content_traffic_vs_ga4",
+        severity="medium",
+        affected_kpi_keys=("content_performance",),
+        sources_compared=("wordpress_content_sessions", "ga4_content_sessions"),
+        expected=expected,
+        observed=observed,
+        expected_field="wordpress_content_sessions",
+        observed_field="ga4_content_sessions",
+        tolerance_percentage=10.0,
+        tolerance_absolute=10.0,
+        next_action_cta="review_content_analytics_mapping",
+        failure_blocks=False,
+        facts=facts,
+    )
+
+
+def _abm_account_domain_check(facts: Mapping[str, Any]) -> dict[str, Any]:
+    targets = _domain_set(
+        facts.get("abm_target_account_domains")
+        or facts.get("target_account_domains")
+        or facts.get("target_accounts_domains")
+    )
+    crm_domains = _domain_set(facts.get("crm_account_domains") or facts.get("account_domains"))
+    intent_domains = _domain_set(facts.get("intent_account_domains") or facts.get("abm_intent_account_domains"))
+
+    missing = []
+    if not targets:
+        missing.append("abm_target_account_domains")
+    if not crm_domains:
+        missing.append("crm_account_domains")
+    if not intent_domains:
+        missing.append("intent_account_domains")
+    if missing:
+        return _blocked_check(
+            key="abm_account_domain_consistency",
+            severity="high",
+            affected_kpi_keys=("abm_intent_account_readiness",),
+            sources_compared=("abm_target_accounts", "crm_account_domains", "intent_account_domains"),
+            missing_fields=missing,
+            next_action_cta="map_abm_and_crm_account_domains",
+            facts=facts,
+        )
+
+    reconciled = targets & crm_domains & intent_domains
+    missing_domains = sorted(targets - reconciled)
+    expected = float(len(targets))
+    observed = float(len(reconciled))
+    result = _numeric_check(
+        key="abm_account_domain_consistency",
+        severity="high",
+        affected_kpi_keys=("abm_intent_account_readiness",),
+        sources_compared=("abm_target_accounts", "crm_account_domains", "intent_account_domains"),
+        expected=expected,
+        observed=observed,
+        expected_field="abm_target_account_domains",
+        observed_field="crm_and_intent_domain_overlap",
+        tolerance_percentage=5.0,
+        tolerance_absolute=0.0,
+        next_action_cta="resolve_abm_account_domain_mapping",
+        failure_blocks=True,
+        facts=facts,
+    )
+    result["missing_requirements"]["domains"] = missing_domains
+    if missing_domains and result["status"] == "passed":
+        result["status"] = "warning"
+        result["severity"] = "medium"
+        result["confidence_impact"] = 0.1
+    return _attach_audit_ref(result)
+
+
+def _currency_consistency_check(facts: Mapping[str, Any]) -> dict[str, Any]:
+    currencies = _source_values(
+        facts,
+        aggregate_key="source_currencies",
+        explicit_keys=("ads_currency", "crm_currency", "finance_currency", "currency"),
+    )
+    return _consistency_check(
+        key="currency_consistency",
+        severity="high",
+        affected_kpi_keys=FINANCIAL_KPIS,
+        sources_compared=("ads_currency", "crm_currency", "finance_currency"),
+        values=currencies,
+        missing_field="source_currencies",
+        next_action_cta="align_source_currency_mapping",
+        failure_blocks=True,
+        facts=facts,
+    )
+
+
+def _timezone_consistency_check(facts: Mapping[str, Any]) -> dict[str, Any]:
+    timezones = _source_values(
+        facts,
+        aggregate_key="source_timezones",
+        explicit_keys=("ads_timezone", "crm_timezone", "analytics_timezone", "email_timezone", "timezone"),
+    )
+    return _consistency_check(
+        key="timezone_consistency",
+        severity="medium",
+        affected_kpi_keys=TIME_BASED_KPIS,
+        sources_compared=("ads_timezone", "crm_timezone", "analytics_timezone", "email_timezone"),
+        values=timezones,
+        missing_field="source_timezones",
+        next_action_cta="align_source_timezone_mapping",
+        failure_blocks=False,
+        facts=facts,
+    )
+
+
+def _freshness_and_partial_data_check(
+    connector_setup: list[dict[str, Any]],
+    connector_contracts: list[dict[str, Any]],
+    now: datetime,
+) -> dict[str, Any]:
+    configured_setup = [
+        row
+        for row in connector_setup
+        if str(row.get("configured_status") or "") != "unconfigured"
+    ]
+    if not configured_setup and not connector_contracts:
+        return _base_check(
+            key="source_freshness_and_partial_data",
+            status="unavailable",
+            severity="info",
+            affected_kpi_keys=(),
+            sources_compared=("connector_setup", "connector_contracts"),
+            expected_value="configured fresh sources",
+            observed_value="no configured source evidence",
+            next_action_cta="configure_marketing_connectors",
+            missing_requirements={"connectors": ["configured_marketing_source"]},
+            confidence_impact=0.0,
+            freshness_impact=0.0,
+            source_refs=[],
+        )
+
+    stale_sources: list[str] = []
+    partial_sources: list[str] = []
+    affected: set[str] = set()
+    refs: list[dict[str, Any]] = []
+
+    for row in configured_setup:
+        category = str(row.get("category") or "").strip()
+        health = _normalize_key(row.get("health_status"))
+        if category in CATEGORY_KPI_KEYS:
+            affected.update(CATEGORY_KPI_KEYS[category])
+        refs.append(
+            {
+                "connector_key": row.get("key"),
+                "category": category,
+                "health_status": row.get("health_status"),
+                "last_sync_at": row.get("last_sync_at"),
+            }
+        )
+        if health == "stale":
+            stale_sources.append(str(row.get("key") or row.get("name") or category))
+        elif health in {"degraded", "partial_data"}:
+            partial_sources.append(str(row.get("key") or row.get("name") or category))
+
+    for row in connector_contracts:
+        if str(row.get("configured_status") or "") == "unconfigured":
+            continue
+        category = str(row.get("category") or "").strip()
+        if category in CATEGORY_KPI_KEYS:
+            affected.update(CATEGORY_KPI_KEYS[category])
+        failure_class = _normalize_key(row.get("failure_class"))
+        degraded = row.get("degraded_mode") if isinstance(row.get("degraded_mode"), Mapping) else {}
+        if failure_class == "stale_data" or row.get("read_status") == "stale":
+            stale_sources.append(str(row.get("connector_key") or category))
+        if failure_class == "partial_data" or degraded.get("status") == "degraded":
+            partial_sources.append(str(row.get("connector_key") or category))
+
+    if stale_sources or partial_sources:
+        observed = {
+            "stale_sources": sorted(set(stale_sources)),
+            "partial_sources": sorted(set(partial_sources)),
+            "evaluated_at": now.isoformat(),
+        }
+        result = _base_check(
+            key="source_freshness_and_partial_data",
+            status="warning",
+            severity="medium",
+            affected_kpi_keys=tuple(sorted(affected)),
+            sources_compared=("connector_setup", "connector_contracts"),
+            expected_value="fresh complete source data",
+            observed_value=observed,
+            next_action_cta="review_stale_or_partial_sources",
+            confidence_impact=0.15 if partial_sources else 0.1,
+            freshness_impact=0.2 if stale_sources else 0.0,
+            source_refs=refs,
+        )
+        return _attach_audit_ref(result)
+
+    return _base_check(
+        key="source_freshness_and_partial_data",
+        status="passed",
+        severity="info",
+        affected_kpi_keys=tuple(sorted(affected)),
+        sources_compared=("connector_setup", "connector_contracts"),
+        expected_value="fresh complete source data",
+        observed_value="fresh",
+        next_action_cta="none",
+        source_refs=refs,
+    )
+
+
+def _numeric_check(
+    *,
+    key: str,
+    severity: str,
+    affected_kpi_keys: tuple[str, ...],
+    sources_compared: tuple[str, ...],
+    expected: float | None,
+    observed: float | None,
+    expected_field: str,
+    observed_field: str,
+    tolerance_percentage: float,
+    tolerance_absolute: float,
+    next_action_cta: str,
+    failure_blocks: bool,
+    facts: Mapping[str, Any],
+) -> dict[str, Any]:
+    missing = []
+    if expected is None:
+        missing.append(expected_field)
+    if observed is None:
+        missing.append(observed_field)
+    if missing:
+        return _blocked_check(
+            key=key,
+            severity=severity,
+            affected_kpi_keys=affected_kpi_keys,
+            sources_compared=sources_compared,
+            missing_fields=missing,
+            next_action_cta=next_action_cta,
+            facts=facts,
+        )
+
+    assert expected is not None
+    assert observed is not None
+    delta_absolute = abs(observed - expected)
+    delta_percentage = 0.0 if expected == 0 and observed == 0 else _safe_pct(delta_absolute, abs(expected))
+    allowed_delta = max(tolerance_absolute, abs(expected) * (tolerance_percentage / 100.0))
+    passed = delta_absolute <= allowed_delta
+    status = "passed" if passed else "failed"
+    result = _base_check(
+        key=key,
+        status=status,
+        severity="info" if passed else severity,
+        affected_kpi_keys=affected_kpi_keys,
+        sources_compared=sources_compared,
+        expected_value=_round(expected),
+        observed_value=_round(observed),
+        delta_absolute=_round(delta_absolute),
+        delta_percentage=_round(delta_percentage),
+        tolerance={
+            "percentage": tolerance_percentage,
+            "absolute": tolerance_absolute,
+            "allowed_delta": _round(allowed_delta),
+        },
+        next_action_cta="none" if passed else next_action_cta,
+        confidence_impact=0.0 if passed else _confidence_impact(severity),
+        blocks_kpi_readiness=bool(failure_blocks and not passed),
+        source_refs=_source_refs(facts, sources_compared),
+    )
+    return _attach_audit_ref(result)
+
+
+def _multi_numeric_check(
+    *,
+    key: str,
+    severity: str,
+    affected_kpi_keys: tuple[str, ...],
+    sources_compared: tuple[str, ...],
+    field_pairs: tuple[tuple[str, str], ...],
+    facts: Mapping[str, Any],
+    tolerance_percentage: float,
+    tolerance_absolute: float,
+    next_action_cta: str,
+    failure_blocks: bool,
+) -> dict[str, Any]:
+    expected_values: dict[str, float] = {}
+    observed_values: dict[str, float] = {}
+    missing: list[str] = []
+    max_delta_absolute = 0.0
+    max_delta_percentage = 0.0
+    failed_pair = False
+    max_allowed_delta = 0.0
+
+    for expected_field, observed_field in field_pairs:
+        expected = _number_from(facts, expected_field)
+        observed = _number_from(facts, observed_field)
+        if expected is None and observed is None:
+            continue
+        if expected is None:
+            missing.append(expected_field)
+            continue
+        if observed is None:
+            missing.append(observed_field)
+            continue
+        expected_values[expected_field] = _round(expected)
+        observed_values[observed_field] = _round(observed)
+        delta_absolute = abs(observed - expected)
+        allowed_delta = max(tolerance_absolute, abs(expected) * (tolerance_percentage / 100.0))
+        failed_pair = failed_pair or delta_absolute > allowed_delta
+        max_allowed_delta = max(max_allowed_delta, allowed_delta)
+        max_delta_absolute = max(max_delta_absolute, delta_absolute)
+        max_delta_percentage = max(max_delta_percentage, _safe_pct(delta_absolute, abs(expected)))
+
+    if missing or not expected_values:
+        if not expected_values:
+            missing.extend([expected_field for expected_field, _observed_field in field_pairs])
+        return _blocked_check(
+            key=key,
+            severity=severity,
+            affected_kpi_keys=affected_kpi_keys,
+            sources_compared=sources_compared,
+            missing_fields=missing,
+            next_action_cta=next_action_cta,
+            facts=facts,
+        )
+
+    passed = not failed_pair
+    result = _base_check(
+        key=key,
+        status="passed" if passed else "failed",
+        severity="info" if passed else severity,
+        affected_kpi_keys=affected_kpi_keys,
+        sources_compared=sources_compared,
+        expected_value=expected_values,
+        observed_value=observed_values,
+        delta_absolute=_round(max_delta_absolute),
+        delta_percentage=_round(max_delta_percentage),
+        tolerance={
+            "percentage": tolerance_percentage,
+            "absolute": tolerance_absolute,
+            "allowed_delta": _round(max_allowed_delta),
+        },
+        next_action_cta="none" if passed else next_action_cta,
+        confidence_impact=0.0 if passed else _confidence_impact(severity),
+        blocks_kpi_readiness=bool(failure_blocks and not passed),
+        source_refs=_source_refs(facts, sources_compared),
+    )
+    return _attach_audit_ref(result)
+
+
+def _consistency_check(
+    *,
+    key: str,
+    severity: str,
+    affected_kpi_keys: tuple[str, ...],
+    sources_compared: tuple[str, ...],
+    values: dict[str, str],
+    missing_field: str,
+    next_action_cta: str,
+    failure_blocks: bool,
+    facts: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not values:
+        return _blocked_check(
+            key=key,
+            severity=severity,
+            affected_kpi_keys=affected_kpi_keys,
+            sources_compared=sources_compared,
+            missing_fields=[missing_field],
+            next_action_cta=next_action_cta,
+            facts=facts,
+        )
+
+    normalized_values = sorted(set(values.values()))
+    passed = len(normalized_values) == 1
+    status = "passed" if passed else "failed"
+    if not passed and not failure_blocks:
+        status = "warning"
+    result = _base_check(
+        key=key,
+        status=status,
+        severity="info" if passed else severity,
+        affected_kpi_keys=affected_kpi_keys,
+        sources_compared=sources_compared,
+        expected_value=normalized_values[0] if normalized_values else None,
+        observed_value=values,
+        delta_absolute=None,
+        delta_percentage=None,
+        tolerance={"match": "all_sources_same"},
+        next_action_cta="none" if passed else next_action_cta,
+        confidence_impact=0.0 if passed else _confidence_impact(severity),
+        blocks_kpi_readiness=bool(failure_blocks and not passed),
+        source_refs=_source_refs(facts, sources_compared),
+    )
+    return _attach_audit_ref(result)
+
+
+def _blocked_check(
+    *,
+    key: str,
+    severity: str,
+    affected_kpi_keys: tuple[str, ...],
+    sources_compared: tuple[str, ...],
+    missing_fields: list[str],
+    next_action_cta: str,
+    facts: Mapping[str, Any],
+) -> dict[str, Any]:
+    result = _base_check(
+        key=key,
+        status="blocked",
+        severity=severity,
+        affected_kpi_keys=affected_kpi_keys,
+        sources_compared=sources_compared,
+        expected_value=None,
+        observed_value=None,
+        next_action_cta=next_action_cta,
+        missing_requirements={"fields": _unique(missing_fields)},
+        confidence_impact=_confidence_impact(severity),
+        blocks_kpi_readiness=True,
+        source_refs=_source_refs(facts, sources_compared),
+    )
+    return _attach_audit_ref(result)
+
+
+def _base_check(
+    *,
+    key: str,
+    status: str,
+    severity: str,
+    affected_kpi_keys: tuple[str, ...],
+    sources_compared: tuple[str, ...],
+    expected_value: Any,
+    observed_value: Any,
+    next_action_cta: str,
+    delta_absolute: float | None = None,
+    delta_percentage: float | None = None,
+    tolerance: Mapping[str, Any] | None = None,
+    confidence_impact: float = 0.0,
+    freshness_impact: float = 0.0,
+    missing_requirements: Mapping[str, list[str]] | None = None,
+    blocks_kpi_readiness: bool = False,
+    source_refs: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "reconciliation_key": key,
+        "status": status,
+        "severity": severity,
+        "affected_kpi_keys": list(affected_kpi_keys),
+        "sources_compared": list(sources_compared),
+        "expected_value": expected_value,
+        "observed_value": observed_value,
+        "delta_absolute": delta_absolute,
+        "delta_percentage": delta_percentage,
+        "tolerance": dict(tolerance or {}),
+        "confidence_impact": round(float(confidence_impact), 3),
+        "freshness_impact": round(float(freshness_impact), 3),
+        "source_refs": source_refs or [],
+        "missing_requirements": {
+            key: _unique(values)
+            for key, values in dict(missing_requirements or {}).items()
+        },
+        "next_action_cta": next_action_cta,
+        "decision_audit_ref": None,
+        "blocks_kpi_readiness": blocks_kpi_readiness,
+    }
+
+
+def _attach_audit_ref(result: dict[str, Any]) -> dict[str, Any]:
+    if result.get("status") == "passed":
+        return result
+    audit = build_cmo_decision_audit_package(
+        {
+            "event_type": "policy_decision",
+            "decision_type": "kpi_reconciliation",
+            "action": result.get("reconciliation_key"),
+            "capability": "cmo_kpi_reconciliation",
+            "source_refs": result.get("source_refs") or [],
+            "rationale": (
+                f"KPI reconciliation {result.get('reconciliation_key')} "
+                f"returned {result.get('status')}."
+            ),
+            "risk_flags": [
+                str(result.get("status")),
+                str(result.get("severity")),
+                "kpi_reconciliation",
+            ],
+            "confidence": max(1.0 - float(result.get("confidence_impact") or 0.0), 0.0),
+            "final_outcome": result.get("status"),
+            "actor_type": "system",
+            "input_snapshot": {
+                "expected_value": result.get("expected_value"),
+                "observed_value": result.get("observed_value"),
+                "delta_absolute": result.get("delta_absolute"),
+                "delta_percentage": result.get("delta_percentage"),
+                "tolerance": result.get("tolerance"),
+            },
+        }
+    )
+    result["decision_audit_ref"] = audit["audit_reference"]
+    return result
+
+
+def _collect_reconciliation_facts(
+    source_data: Mapping[str, Any] | None,
+    connector_configs: Iterable[Any],
+) -> dict[str, Any]:
+    facts: dict[str, Any] = {}
+    for config in connector_configs:
+        payload = _config_dict(config)
+        for key in (
+            "marketing_kpi_inputs",
+            "cmo_kpi_inputs",
+            "marketing_kpi_facts",
+            "cmo_kpi_facts",
+            "kpi_inputs",
+            "marketing_reconciliation",
+            "cmo_kpi_reconciliation",
+            "reconciliation_inputs",
+        ):
+            value = payload.get(key)
+            if isinstance(value, Mapping):
+                _merge_facts(facts, value)
+    source = source_data if isinstance(source_data, Mapping) else {}
+    for key in (
+        "metrics",
+        "facts",
+        "kpi_inputs",
+        "marketing_kpi_inputs",
+        "cmo_kpi_inputs",
+        "marketing_reconciliation",
+        "cmo_kpi_reconciliation",
+        "reconciliation_inputs",
+    ):
+        value = source.get(key)
+        if isinstance(value, Mapping):
+            _merge_facts(facts, value)
+    _merge_facts(facts, source)
+    return facts
+
+
+def _merge_facts(target: dict[str, Any], source: Mapping[str, Any]) -> None:
+    for key, value in source.items():
+        if key in {"source_refs", "source_lineage_refs", "audit_refs", "decision_audit_refs"}:
+            target.setdefault(key, [])
+            target[key] = [*list(_list_from_value(target[key])), *list(_list_from_value(value))]
+        elif key in {"lifecycle_stage_counts", "funnel_stage_counts"} and isinstance(value, Mapping):
+            existing = _dict_from_value(target.get(key))
+            for stage, count in value.items():
+                normalized_stage = _normalize_key(stage)
+                existing[normalized_stage] = (
+                    (_number(existing.get(normalized_stage)) or 0.0)
+                    + (_number(count) or 0.0)
+                )
+            target[key] = existing
+        elif isinstance(value, (int, float)) and isinstance(target.get(key), (int, float)):
+            target[key] = float(target[key]) + float(value)
+        elif key not in target or target.get(key) in (None, "", [], {}):
+            target[key] = value
+
+
+def _sum_amounts(value: Any) -> float | None:
+    if isinstance(value, Mapping):
+        amounts = [_number(item) for item in value.values()]
+        amounts = [item for item in amounts if item is not None]
+        return sum(amounts) if amounts else None
+    items = _list_from_value(value)
+    if not items:
+        return None
+    amounts = []
+    for item in items:
+        if isinstance(item, Mapping):
+            amount = _number(
+                item.get("amount")
+                or item.get("spend")
+                or item.get("cost")
+                or item.get("value")
+            )
+        else:
+            amount = _number(item)
+        if amount is not None:
+            amounts.append(amount)
+    return sum(amounts) if amounts else None
+
+
+def _stage_count(facts: Mapping[str, Any], stage: str) -> float | None:
+    explicit = _number_from(facts, f"{stage}_count", stage)
+    if explicit is not None:
+        return explicit
+    counts = _dict_from_value(facts.get("lifecycle_stage_counts"))
+    return _number(counts.get(stage))
+
+
+def _source_values(
+    facts: Mapping[str, Any],
+    *,
+    aggregate_key: str,
+    explicit_keys: tuple[str, ...],
+) -> dict[str, str]:
+    values: dict[str, str] = {}
+    aggregate = facts.get(aggregate_key)
+    if isinstance(aggregate, Mapping):
+        for source, value in aggregate.items():
+            text = str(value or "").strip()
+            if text:
+                values[str(source)] = text.upper() if "currencies" in aggregate_key else text
+    elif isinstance(aggregate, (list, tuple, set)):
+        for index, value in enumerate(aggregate):
+            text = str(value or "").strip()
+            if text:
+                values[f"{aggregate_key}_{index}"] = text.upper() if "currencies" in aggregate_key else text
+    for key in explicit_keys:
+        text = str(facts.get(key) or "").strip()
+        if text:
+            values[key] = text.upper() if "currency" in key else text
+    return values
+
+
+def _domain_set(value: Any) -> set[str]:
+    domains: set[str] = set()
+    for item in _list_from_value(value):
+        if isinstance(item, Mapping):
+            raw = (
+                item.get("domain")
+                or item.get("account_domain")
+                or item.get("website")
+                or item.get("value")
+            )
+        else:
+            raw = item
+        domain = str(raw or "").strip().lower()
+        if domain:
+            domains.add(domain.removeprefix("https://").removeprefix("http://").strip("/"))
+    return domains
+
+
+def _source_refs(facts: Mapping[str, Any], sources_compared: tuple[str, ...]) -> list[dict[str, Any]]:
+    refs = []
+    for item in _list_from_value(facts.get("source_refs") or facts.get("source_lineage_refs")):
+        if isinstance(item, Mapping):
+            refs.append(dict(item))
+        else:
+            refs.append({"ref": str(item)})
+    for source in sources_compared:
+        refs.append({"source": source})
+    return refs
+
+
+def _confidence_impact(severity: str) -> float:
+    return {
+        "critical": 0.35,
+        "high": 0.25,
+        "medium": 0.15,
+        "low": 0.08,
+        "info": 0.0,
+    }.get(severity, 0.1)
+
+
+def _safe_pct(numerator: float, denominator: float) -> float:
+    if denominator == 0:
+        return 0.0 if numerator == 0 else 100.0
+    return (numerator / denominator) * 100.0
+
+
+def _number_from(facts: Mapping[str, Any], *keys: str) -> float | None:
+    for key in keys:
+        value = _number(facts.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _number(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _round(value: float) -> float:
+    return round(float(value), 4)
+
+
+def _dict_from_value(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list_from_value(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
+
+
+def _unique(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _config_dict(config: Any | None) -> dict[str, Any]:
+    if isinstance(config, Mapping):
+        return dict(config)
+    value = getattr(config, "config", None)
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _ensure_aware(value: Any) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")

--- a/core/marketing/kpi_schema.py
+++ b/core/marketing/kpi_schema.py
@@ -1,0 +1,1309 @@
+"""Unified CMO KPI schema and deterministic formula helpers.
+
+CMO-7.1 defines canonical marketing KPI definitions and a small evaluation
+engine. It consumes the existing connector setup, connector contract, field
+mapping, backfill, retry/degraded, and decision-audit projections; it does not
+invent production values when real mapped source facts are missing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from core.marketing.kpi_reconciliation import build_cmo_kpi_reconciliation_projection
+
+CMO_KPI_SCHEMA_VERSION = "2026-05-23.cmo-7.1"
+
+KPI_STATUSES = ("ready", "degraded", "blocked", "unavailable")
+
+COUNT_UNIT = "count"
+CURRENCY_UNIT = "currency"
+PERCENT_UNIT = "percentage"
+RATIO_UNIT = "ratio"
+INDEX_UNIT = "index"
+
+
+@dataclass(frozen=True)
+class CmoKpiDefinition:
+    key: str
+    display_name: str
+    description: str
+    formula: str
+    required_source_domains: tuple[str, ...]
+    required_connector_categories: tuple[str, ...]
+    required_field_mappings: tuple[str, ...]
+    required_backfill_categories: tuple[str, ...]
+    refresh_ttl_seconds: int
+    unit: str
+    owner_role: str
+    confidence_rules: tuple[str, ...]
+    freshness_rules: tuple[str, ...]
+    missing_data_behavior: str
+    source_lineage_refs: tuple[str, ...]
+    audit_evidence_classes: tuple[str, ...] = (
+        "input_snapshot_hash",
+        "source_refs",
+        "field_mapping_status",
+        "backfill_status",
+        "connector_contract_status",
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "display_name": self.display_name,
+            "description": self.description,
+            "formula": self.formula,
+            "required_source_domains": list(self.required_source_domains),
+            "required_connector_categories": list(self.required_connector_categories),
+            "required_field_mappings": list(self.required_field_mappings),
+            "required_backfill_categories": list(self.required_backfill_categories),
+            "refresh_cadence_ttl_seconds": self.refresh_ttl_seconds,
+            "unit": self.unit,
+            "owner_role": self.owner_role,
+            "confidence_rules": list(self.confidence_rules),
+            "freshness_rules": list(self.freshness_rules),
+            "missing_data_behavior": self.missing_data_behavior,
+            "source_lineage_refs": list(self.source_lineage_refs),
+            "audit_evidence_classes": list(self.audit_evidence_classes),
+        }
+
+
+CMO_KPI_DEFINITIONS: tuple[CmoKpiDefinition, ...] = (
+    CmoKpiDefinition(
+        key="cac",
+        display_name="CAC",
+        description="Customer acquisition cost for the evaluated period.",
+        formula="total_marketing_spend / new_customers",
+        required_source_domains=("Ads", "CRM", "Finance"),
+        required_connector_categories=("Ads", "CRM"),
+        required_field_mappings=("opportunity_revenue", "campaign_ids", "utm_fields", "currency"),
+        required_backfill_categories=("Ads", "CRM"),
+        refresh_ttl_seconds=24 * 3600,
+        unit=CURRENCY_UNIT,
+        owner_role="growth_lead",
+        confidence_rules=(
+            "Requires mapped spend and new-customer facts.",
+            "Connector degraded-mode confidence impact is applied.",
+        ),
+        freshness_rules=("Spend and CRM facts should be refreshed daily.",),
+        missing_data_behavior="blocked",
+        source_lineage_refs=("ads.spend", "crm.new_customers", "finance.currency"),
+    ),
+    CmoKpiDefinition(
+        key="mql",
+        display_name="MQL",
+        description="Marketing qualified leads from mapped lifecycle stages.",
+        formula="count(lifecycle_stage == mql)",
+        required_source_domains=("CRM",),
+        required_connector_categories=("CRM",),
+        required_field_mappings=("lifecycle_stages",),
+        required_backfill_categories=("CRM",),
+        refresh_ttl_seconds=6 * 3600,
+        unit=COUNT_UNIT,
+        owner_role="revops_lead",
+        confidence_rules=("Requires mapped CRM lifecycle stages.",),
+        freshness_rules=("CRM lifecycle data should refresh within 6 hours.",),
+        missing_data_behavior="blocked",
+        source_lineage_refs=("crm.lifecycle_stages",),
+    ),
+    CmoKpiDefinition(
+        key="sql",
+        display_name="SQL",
+        description="Sales qualified leads from mapped lifecycle stages.",
+        formula="count(lifecycle_stage == sql)",
+        required_source_domains=("CRM",),
+        required_connector_categories=("CRM",),
+        required_field_mappings=("lifecycle_stages",),
+        required_backfill_categories=("CRM",),
+        refresh_ttl_seconds=6 * 3600,
+        unit=COUNT_UNIT,
+        owner_role="revops_lead",
+        confidence_rules=("Requires mapped CRM lifecycle stages.",),
+        freshness_rules=("CRM lifecycle data should refresh within 6 hours.",),
+        missing_data_behavior="blocked",
+        source_lineage_refs=("crm.lifecycle_stages",),
+    ),
+    CmoKpiDefinition(
+        key="mql_to_sql_conversion_rate",
+        display_name="MQL-to-SQL conversion rate",
+        description="Share of MQLs that became SQLs in the evaluated period.",
+        formula="sql_count / mql_count * 100",
+        required_source_domains=("CRM",),
+        required_connector_categories=("CRM",),
+        required_field_mappings=("lifecycle_stages",),
+        required_backfill_categories=("CRM",),
+        refresh_ttl_seconds=6 * 3600,
+        unit=PERCENT_UNIT,
+        owner_role="revops_lead",
+        confidence_rules=("Zero MQL denominator returns 0 safely and marks denominator context.",),
+        freshness_rules=("CRM lifecycle data should refresh within 6 hours.",),
+        missing_data_behavior="blocked",
+        source_lineage_refs=("crm.lifecycle_stages",),
+    ),
+    CmoKpiDefinition(
+        key="roas",
+        display_name="ROAS",
+        description="Return on ad spend from attributed revenue and ad spend.",
+        formula="attributed_revenue / ad_spend",
+        required_source_domains=("Ads", "CRM", "Analytics"),
+        required_connector_categories=("Ads", "CRM", "Analytics"),
+        required_field_mappings=("opportunity_revenue", "campaign_ids", "utm_fields", "currency"),
+        required_backfill_categories=("Ads", "CRM", "Analytics"),
+        refresh_ttl_seconds=6 * 3600,
+        unit=RATIO_UNIT,
+        owner_role="growth_lead",
+        confidence_rules=("Attribution gaps degrade confidence.",),
+        freshness_rules=("Ads, CRM, and analytics facts should refresh within 6 hours.",),
+        missing_data_behavior="blocked",
+        source_lineage_refs=("ads.spend", "crm.attributed_revenue", "analytics.attribution"),
+    ),
+    CmoKpiDefinition(
+        key="pipeline_contribution",
+        display_name="Pipeline contribution",
+        description="Marketing-sourced open pipeline value.",
+        formula="sum(marketing_sourced_opportunity.amount)",
+        required_source_domains=("CRM", "Finance"),
+        required_connector_categories=("CRM",),
+        required_field_mappings=("opportunity_revenue", "campaign_ids", "currency"),
+        required_backfill_categories=("CRM",),
+        refresh_ttl_seconds=6 * 3600,
+        unit=CURRENCY_UNIT,
+        owner_role="revops_lead",
+        confidence_rules=("Requires mapped opportunity amounts and marketing source attribution.",),
+        freshness_rules=("CRM opportunity data should refresh within 6 hours.",),
+        missing_data_behavior="blocked",
+        source_lineage_refs=("crm.opportunities", "crm.campaign_ids"),
+    ),
+    CmoKpiDefinition(
+        key="conversion_rates_by_funnel_stage",
+        display_name="Conversion rates by funnel stage",
+        description="Stage-to-stage conversion rates across the marketing funnel.",
+        formula="next_stage_count / current_stage_count * 100 by ordered funnel stage",
+        required_source_domains=("CRM", "Analytics"),
+        required_connector_categories=("CRM", "Analytics"),
+        required_field_mappings=("lifecycle_stages", "utm_fields"),
+        required_backfill_categories=("CRM", "Analytics"),
+        refresh_ttl_seconds=6 * 3600,
+        unit=PERCENT_UNIT,
+        owner_role="revops_lead",
+        confidence_rules=("Zero denominators return 0 safely for that stage transition.",),
+        freshness_rules=("Funnel data should refresh within 6 hours.",),
+        missing_data_behavior="blocked",
+        source_lineage_refs=("crm.lifecycle_stages", "analytics.funnel_events"),
+    ),
+    CmoKpiDefinition(
+        key="ltv_cac",
+        display_name="LTV/CAC",
+        description="Customer lifetime value divided by customer acquisition cost, when LTV is mapped.",
+        formula="customer_ltv / cac",
+        required_source_domains=("CRM", "Finance", "Ads"),
+        required_connector_categories=("CRM", "Ads", "Finance"),
+        required_field_mappings=("opportunity_revenue", "currency"),
+        required_backfill_categories=("CRM", "Ads"),
+        refresh_ttl_seconds=24 * 3600,
+        unit=RATIO_UNIT,
+        owner_role="growth_lead",
+        confidence_rules=("Unavailable until mapped LTV/customer revenue facts exist.",),
+        freshness_rules=("Finance and CRM facts should refresh daily.",),
+        missing_data_behavior="unavailable_if_ltv_missing",
+        source_lineage_refs=("finance.customer_ltv", "ads.spend", "crm.new_customers"),
+    ),
+    CmoKpiDefinition(
+        key="experiment_velocity",
+        display_name="Experiment velocity",
+        description="Completed experiments normalized to a 30-day period.",
+        formula="completed_experiments / period_days * 30",
+        required_source_domains=("Ads", "Analytics", "CMS", "Email"),
+        required_connector_categories=("Ads", "Analytics"),
+        required_field_mappings=("campaign_ids",),
+        required_backfill_categories=("Ads", "Analytics"),
+        refresh_ttl_seconds=24 * 3600,
+        unit=COUNT_UNIT,
+        owner_role="growth_lead",
+        confidence_rules=("Partial experiment tracking degrades confidence.",),
+        freshness_rules=("Experiment registry should refresh daily.",),
+        missing_data_behavior="blocked",
+        source_lineage_refs=("experiments.completed", "experiments.active"),
+    ),
+    CmoKpiDefinition(
+        key="content_performance",
+        display_name="Content performance",
+        description="Content conversion and engagement performance.",
+        formula="content_conversions / content_sessions * 100 with engagement context",
+        required_source_domains=("CMS", "Analytics"),
+        required_connector_categories=("CMS", "Analytics"),
+        required_field_mappings=("campaign_ids", "utm_fields", "timezone"),
+        required_backfill_categories=("CMS", "Analytics"),
+        refresh_ttl_seconds=12 * 3600,
+        unit=PERCENT_UNIT,
+        owner_role="content_lead",
+        confidence_rules=("Missing content attribution degrades confidence.",),
+        freshness_rules=("Content analytics should refresh within 12 hours.",),
+        missing_data_behavior="blocked",
+        source_lineage_refs=("cms.content_ids", "analytics.content_events"),
+    ),
+    CmoKpiDefinition(
+        key="email_performance",
+        display_name="Email performance",
+        description="Email open, click, unsubscribe, and deliverability performance.",
+        formula="opens/sent, clicks/sent, unsubscribes/sent",
+        required_source_domains=("Email", "CRM"),
+        required_connector_categories=("Email",),
+        required_field_mappings=("campaign_ids", "consent_unsubscribe", "timezone"),
+        required_backfill_categories=("Email",),
+        refresh_ttl_seconds=6 * 3600,
+        unit=PERCENT_UNIT,
+        owner_role="demand_gen_lead",
+        confidence_rules=("Consent/unsubscribe mapping is required for trusted email KPIs.",),
+        freshness_rules=("Email platform metrics should refresh within 6 hours.",),
+        missing_data_behavior="blocked",
+        source_lineage_refs=("email.campaign_metrics", "email.unsubscribe_status"),
+    ),
+    CmoKpiDefinition(
+        key="brand_sentiment",
+        display_name="Brand sentiment",
+        description="Normalized positive/negative/neutral brand sentiment score.",
+        formula="(positive_mentions - negative_mentions) / total_mentions",
+        required_source_domains=("Brand", "Social"),
+        required_connector_categories=("Brand",),
+        required_field_mappings=("timezone",),
+        required_backfill_categories=("Brand",),
+        refresh_ttl_seconds=3 * 3600,
+        unit=INDEX_UNIT,
+        owner_role="brand_lead",
+        confidence_rules=("Low mention volume or degraded brand connector lowers confidence.",),
+        freshness_rules=("Brand mentions should refresh within 3 hours.",),
+        missing_data_behavior="blocked",
+        source_lineage_refs=("brand.mentions", "brand.sentiment"),
+    ),
+    CmoKpiDefinition(
+        key="abm_intent_account_readiness",
+        display_name="ABM intent/account readiness",
+        description="Share of target accounts with usable intent or readiness signal.",
+        formula="intent_ready_accounts / target_accounts * 100",
+        required_source_domains=("ABM", "CRM"),
+        required_connector_categories=("ABM", "CRM"),
+        required_field_mappings=("account_domains", "lifecycle_stages"),
+        required_backfill_categories=("ABM", "CRM"),
+        refresh_ttl_seconds=24 * 3600,
+        unit=PERCENT_UNIT,
+        owner_role="growth_lead",
+        confidence_rules=("Unavailable ABM connector blocks this KPI until real intent data is configured.",),
+        freshness_rules=("ABM intent and CRM accounts should refresh daily.",),
+        missing_data_behavior="blocked",
+        source_lineage_refs=("abm.intent_accounts", "crm.account_domains"),
+    ),
+)
+
+
+def default_cmo_kpi_schema() -> dict[str, Any]:
+    return {
+        "schema_version": CMO_KPI_SCHEMA_VERSION,
+        "kpis": [definition.to_dict() for definition in CMO_KPI_DEFINITIONS],
+    }
+
+
+def cmo_kpi_definition_by_key(key: str) -> dict[str, Any] | None:
+    normalized = _normalize_key(key)
+    for definition in CMO_KPI_DEFINITIONS:
+        if definition.key == normalized:
+            return definition.to_dict()
+    return None
+
+
+def evaluate_cmo_kpi(
+    kpi_key: str,
+    source_data: Mapping[str, Any] | None = None,
+    *,
+    connector_setup: Iterable[dict[str, Any]] = (),
+    data_readiness: Mapping[str, Any] | None = None,
+    connector_contracts: Iterable[dict[str, Any]] = (),
+    reconciliation_checks: Iterable[dict[str, Any]] = (),
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    definition = _definition(kpi_key)
+    if definition is None:
+        return _unavailable_result(kpi_key, now)
+    return _evaluate_definition(
+        definition,
+        _facts(source_data),
+        list(connector_setup),
+        data_readiness if isinstance(data_readiness, Mapping) else {},
+        list(connector_contracts),
+        list(reconciliation_checks),
+        _ensure_aware(now) or datetime.now(UTC),
+    )
+
+
+def evaluate_cmo_kpis(
+    source_data: Mapping[str, Any] | None = None,
+    *,
+    connector_setup: Iterable[dict[str, Any]] = (),
+    data_readiness: Mapping[str, Any] | None = None,
+    connector_contracts: Iterable[dict[str, Any]] = (),
+    reconciliation_checks: Iterable[dict[str, Any]] = (),
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    timestamp = _ensure_aware(now) or datetime.now(UTC)
+    facts = _facts(source_data)
+    setup_rows = list(connector_setup)
+    readiness = data_readiness if isinstance(data_readiness, Mapping) else {}
+    contract_rows = list(connector_contracts)
+    check_rows = list(reconciliation_checks)
+    return [
+        _evaluate_definition(
+            definition,
+            facts,
+            setup_rows,
+            readiness,
+            contract_rows,
+            check_rows,
+            timestamp,
+        )
+        for definition in CMO_KPI_DEFINITIONS
+    ]
+
+
+def build_unified_cmo_kpi_projection(
+    *,
+    connector_setup: Iterable[dict[str, Any]],
+    data_readiness: Mapping[str, Any],
+    connector_contracts: Iterable[dict[str, Any]],
+    connector_configs: Iterable[Any] = (),
+    source_data: Mapping[str, Any] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    setup_rows = list(connector_setup)
+    contract_rows = list(connector_contracts)
+    config_rows = list(connector_configs)
+    facts = collect_cmo_kpi_facts(source_data, config_rows)
+    reconciliation_projection = build_cmo_kpi_reconciliation_projection(
+        connector_setup=setup_rows,
+        data_readiness=data_readiness,
+        connector_contracts=contract_rows,
+        source_data=facts,
+        now=now,
+    )
+    results = evaluate_cmo_kpis(
+        facts,
+        connector_setup=setup_rows,
+        data_readiness=data_readiness,
+        connector_contracts=contract_rows,
+        reconciliation_checks=reconciliation_projection["cmo_kpi_reconciliation_checks"],
+        now=now,
+    )
+    return {
+        "unified_cmo_kpi_schema": default_cmo_kpi_schema(),
+        "unified_cmo_kpi_results": results,
+        "unified_cmo_kpi_summary": summarize_cmo_kpi_results(results),
+        **reconciliation_projection,
+    }
+
+
+def collect_cmo_kpi_facts(
+    source_data: Mapping[str, Any] | None = None,
+    connector_configs: Iterable[Any] = (),
+) -> dict[str, Any]:
+    facts = _kpi_facts_from_configs(connector_configs)
+    _merge_facts(facts, _facts(source_data))
+    return facts
+
+
+def summarize_cmo_kpi_results(results: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    items = list(results)
+    counts = dict.fromkeys(KPI_STATUSES, 0)
+    for item in items:
+        status = str(item.get("status") or "")
+        if status in counts:
+            counts[status] += 1
+    readiness = (
+        "blocked"
+        if counts["blocked"]
+        else "degraded"
+        if counts["degraded"] or counts["unavailable"]
+        else "ready"
+    )
+    return {
+        "schema_version": CMO_KPI_SCHEMA_VERSION,
+        "total": len(items),
+        **counts,
+        "readiness": readiness,
+        "needs_action": sum(1 for item in items if item.get("next_action_cta") != "none"),
+        "next_action_cta": next(
+            (
+                str(item.get("next_action_cta"))
+                for item in items
+                if item.get("next_action_cta") and item.get("next_action_cta") != "none"
+            ),
+            "none",
+        ),
+    }
+
+
+def _evaluate_definition(
+    definition: CmoKpiDefinition,
+    facts: dict[str, Any],
+    connector_setup: list[dict[str, Any]],
+    data_readiness: Mapping[str, Any],
+    connector_contracts: list[dict[str, Any]],
+    reconciliation_checks: list[dict[str, Any]],
+    now: datetime,
+) -> dict[str, Any]:
+    requirements = _requirements_status(
+        definition,
+        connector_setup,
+        data_readiness,
+        connector_contracts,
+    )
+    formula = _compute_formula(definition.key, facts)
+    freshness = _freshness_status(definition, facts, now)
+    reconciliation = _reconciliation_impact(definition.key, reconciliation_checks)
+    missing_requirements = {
+        **requirements["missing_requirements"],
+        "fields": formula["missing_fields"],
+        "reconciliation": reconciliation["missing_requirements"],
+    }
+
+    blocked = bool(
+        requirements["blocked_reasons"]
+        or reconciliation["blocked_reasons"]
+        or (
+            formula["missing_fields"]
+            and definition.missing_data_behavior != "unavailable_if_ltv_missing"
+        )
+    )
+    unavailable = bool(
+        formula["missing_fields"]
+        and definition.missing_data_behavior == "unavailable_if_ltv_missing"
+    )
+    degraded_reasons = [
+        *requirements["degraded_reasons"],
+        *formula["degraded_reasons"],
+        *freshness["degraded_reasons"],
+        *reconciliation["degraded_reasons"],
+    ]
+
+    if blocked:
+        status = "blocked"
+        value = None
+        confidence = 0.0
+        next_action = _next_action(
+            missing_requirements,
+            freshness,
+            reconciliation_cta=reconciliation["next_action_cta"],
+        )
+    elif unavailable:
+        status = "unavailable"
+        value = None
+        confidence = 0.0
+        next_action = "connect_ltv_source"
+    elif degraded_reasons:
+        status = "degraded"
+        value = formula["value"]
+        confidence = _confidence(
+            requirements,
+            freshness,
+            formula,
+            reconciliation,
+            degraded=True,
+        )
+        next_action = (
+            reconciliation["next_action_cta"]
+            if reconciliation["next_action_cta"] != "none"
+            else _next_action(missing_requirements, freshness, degraded=True)
+        )
+    else:
+        status = "ready"
+        value = formula["value"]
+        confidence = _confidence(
+            requirements,
+            freshness,
+            formula,
+            reconciliation,
+            degraded=False,
+        )
+        next_action = "none"
+
+    source_refs = _source_refs(definition, facts, connector_setup)
+    return {
+        "kpi_key": definition.key,
+        "display_name": definition.display_name,
+        "status": status,
+        "value": value,
+        "unit": definition.unit,
+        "confidence": confidence,
+        "formula": definition.formula,
+        "formula_refs": {
+            "schema_version": CMO_KPI_SCHEMA_VERSION,
+            "definition_key": definition.key,
+            "formula": definition.formula,
+            "formula_inputs": formula["input_fields"],
+        },
+        "source_refs": source_refs,
+        "source_lineage_refs": list(definition.source_lineage_refs),
+        "audit_refs": _audit_refs(facts, data_readiness),
+        "missing_requirements": missing_requirements,
+        "blocked_reasons": requirements["blocked_reasons"]
+        + reconciliation["blocked_reasons"]
+        + (
+            [f"Missing source field: {field}" for field in formula["missing_fields"]]
+            if blocked
+            else []
+        ),
+        "degraded_reasons": degraded_reasons,
+        "reconciliation_status": reconciliation["status"],
+        "reconciliation_refs": reconciliation["refs"],
+        "reconciliation_confidence_impact": reconciliation["confidence_impact"],
+        "freshness_status": freshness["status"],
+        "freshness": freshness,
+        "last_computed_at": _iso_or_none(facts.get("last_computed_at")) or now.isoformat(),
+        "next_action_cta": next_action,
+        "owner_role": definition.owner_role,
+        "required_field_mappings": list(definition.required_field_mappings),
+        "required_connector_categories": list(definition.required_connector_categories),
+        "required_backfill_categories": list(definition.required_backfill_categories),
+        "missing_data_behavior": definition.missing_data_behavior,
+        "zero_denominator": bool(formula.get("zero_denominator")),
+    }
+
+
+def _requirements_status(
+    definition: CmoKpiDefinition,
+    connector_setup: list[dict[str, Any]],
+    data_readiness: Mapping[str, Any],
+    connector_contracts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    blocked: list[str] = []
+    degraded: list[str] = []
+    missing: dict[str, list[str]] = {"connectors": [], "field_mappings": [], "backfills": []}
+
+    for category in definition.required_connector_categories:
+        rows = _setup_rows_for_category(connector_setup, category)
+        healthy_rows = [row for row in rows if _health(row) == "healthy"]
+        if not rows:
+            missing["connectors"].append(category)
+            blocked.append(f"Required {category} connector is not configured.")
+        elif not healthy_rows:
+            health_states = sorted({_health(row) for row in rows})
+            if any(state in {"stale", "degraded"} for state in health_states):
+                degraded.append(f"Required {category} connector is {', '.join(health_states)}.")
+            else:
+                missing["connectors"].append(category)
+                blocked.append(f"Required {category} connector is not healthy ({', '.join(health_states)}).")
+
+        contract_rows = _contract_rows_for_category(connector_contracts, category)
+        if not contract_rows:
+            missing["connectors"].append(f"{category}:contract")
+            blocked.append(f"Required {category} connector contract is missing.")
+        elif any(row.get("blocks_production_kpi_confidence") for row in contract_rows):
+            blocked.append(f"Required {category} connector blocks production KPI confidence.")
+        elif any(_contract_degraded(row) for row in contract_rows):
+            degraded.append(f"Required {category} connector contract is degraded.")
+        elif not any(row.get("read_ready") for row in contract_rows):
+            missing["connectors"].append(f"{category}:readiness")
+            blocked.append(f"Required {category} connector contract is not read-ready.")
+
+    mappings = {
+        str(row.get("key") or ""): row
+        for row in data_readiness.get("field_mapping_status") or []
+        if isinstance(row, Mapping)
+    }
+    for mapping_key in definition.required_field_mappings:
+        row = mappings.get(mapping_key)
+        status = str((row or {}).get("status") or "unmapped")
+        if status in {"unmapped", "invalid", "blocked"}:
+            missing["field_mappings"].append(mapping_key)
+            blocked.append(f"Required mapping {mapping_key} is {status.replace('_', ' ')}.")
+        elif status in {"partially_mapped", "stale"}:
+            degraded.append(f"Required mapping {mapping_key} is {status.replace('_', ' ')}.")
+
+    backfills = [
+        row
+        for row in data_readiness.get("backfill_status") or []
+        if isinstance(row, Mapping)
+    ]
+    for category in definition.required_backfill_categories:
+        configured_sources = _setup_rows_for_category(connector_setup, category)
+        category_backfills = [
+            row
+            for row in backfills
+            if str(row.get("category") or "").strip() == category
+        ]
+        if not configured_sources:
+            continue
+        if not category_backfills:
+            missing["backfills"].append(category)
+            blocked.append(f"Required {category} backfill is missing.")
+            continue
+        statuses = {str(row.get("status") or "") for row in category_backfills}
+        if "completed" in statuses:
+            continue
+        if statuses & {"blocked", "failed"}:
+            missing["backfills"].append(category)
+            blocked.append(f"Required {category} backfill is blocked or failed.")
+        else:
+            degraded.append(f"Required {category} backfill is incomplete ({', '.join(sorted(statuses))}).")
+
+    return {
+        "blocked_reasons": _unique(blocked),
+        "degraded_reasons": _unique(degraded),
+        "missing_requirements": {key: _unique(values) for key, values in missing.items()},
+        "confidence_impact": _max_confidence_impact(connector_contracts, definition.required_connector_categories),
+    }
+
+
+def _compute_formula(kpi_key: str, facts: dict[str, Any]) -> dict[str, Any]:
+    if kpi_key == "cac":
+        spend = _number_from(facts, "total_marketing_spend", "marketing_spend", "total_spend", "ad_spend")
+        customers = _number_from(facts, "new_customers", "new_customer_count", "customers_acquired")
+        return _divide(spend, customers, input_fields=["total_marketing_spend", "new_customers"])
+    if kpi_key == "mql":
+        return _count_result(_stage_count(facts, "mql"), "mql_count")
+    if kpi_key == "sql":
+        return _count_result(_stage_count(facts, "sql"), "sql_count")
+    if kpi_key == "mql_to_sql_conversion_rate":
+        mql = _stage_count(facts, "mql")
+        sql = _stage_count(facts, "sql")
+        return _percentage(sql, mql, input_fields=["sql_count", "mql_count"], zero_is_zero=True)
+    if kpi_key == "roas":
+        revenue = _number_from(facts, "attributed_revenue", "marketing_attributed_revenue")
+        spend = _number_from(facts, "ad_spend", "total_marketing_spend", "marketing_spend", "total_spend")
+        result = _divide(revenue, spend, input_fields=["attributed_revenue", "ad_spend"])
+        if _partial_attribution(facts):
+            result["degraded_reasons"].append("Attribution coverage is partial.")
+        return result
+    if kpi_key == "pipeline_contribution":
+        value = _number_from(facts, "pipeline_contribution", "marketing_pipeline", "pipeline_value")
+        if value is None:
+            opportunities = _list_from_value(facts.get("opportunities") or facts.get("pipeline_opportunities"))
+            if opportunities:
+                value = sum(
+                    (_number(item.get("amount")) or 0.0)
+                    for item in opportunities
+                    if isinstance(item, Mapping)
+                )
+        return _numeric_result(value, "pipeline_contribution")
+    if kpi_key == "conversion_rates_by_funnel_stage":
+        return _conversion_rates(facts)
+    if kpi_key == "ltv_cac":
+        ltv = _number_from(facts, "customer_ltv", "ltv", "average_ltv")
+        cac = _number_from(facts, "cac")
+        if cac is None:
+            cac_result = _compute_formula("cac", facts)
+            cac = _number(cac_result.get("value"))
+        return _divide(ltv, cac, input_fields=["customer_ltv", "cac"])
+    if kpi_key == "experiment_velocity":
+        completed = _number_from(facts, "completed_experiments", "experiments_completed")
+        period_days = _number_from(facts, "period_days", "experiment_period_days") or 30.0
+        if completed is None:
+            return _missing_result(["completed_experiments"], ["completed_experiments", "period_days"])
+        return _numeric_result((completed / max(period_days, 1.0)) * 30.0, "experiment_velocity")
+    if kpi_key == "content_performance":
+        sessions = _number_from(facts, "content_sessions", "sessions", "pageviews")
+        conversions = _number_from(facts, "content_conversions", "conversions")
+        result = _percentage(conversions, sessions, input_fields=["content_conversions", "content_sessions"])
+        if result["value"] is not None:
+            result["value"] = {
+                "conversion_rate": result["value"],
+                "sessions": sessions,
+                "conversions": conversions,
+                "avg_engagement_seconds": _number_from(
+                    facts,
+                    "content_avg_engagement_seconds",
+                    "avg_engagement_seconds",
+                ),
+            }
+        return result
+    if kpi_key == "email_performance":
+        sent = _number_from(facts, "emails_sent", "email_sent", "sent")
+        opened = _number_from(facts, "emails_opened", "email_opens", "opens")
+        clicked = _number_from(facts, "emails_clicked", "email_clicks", "clicks")
+        unsubscribed = _number_from(facts, "emails_unsubscribed", "unsubscribes")
+        missing = [
+            name
+            for name, value in (
+                ("emails_sent", sent),
+                ("emails_opened", opened),
+                ("emails_clicked", clicked),
+            )
+            if value is None
+        ]
+        if missing:
+            return _missing_result(
+                missing,
+                ["emails_sent", "emails_opened", "emails_clicked", "emails_unsubscribed"],
+            )
+        return {
+            "value": {
+                "open_rate": _safe_percentage(opened, sent),
+                "click_rate": _safe_percentage(clicked, sent),
+                "unsubscribe_rate": _safe_percentage(unsubscribed or 0.0, sent),
+            },
+            "missing_fields": [],
+            "degraded_reasons": [],
+            "input_fields": ["emails_sent", "emails_opened", "emails_clicked", "emails_unsubscribed"],
+            "zero_denominator": sent == 0,
+        }
+    if kpi_key == "brand_sentiment":
+        score = _number_from(facts, "brand_sentiment_score", "sentiment_score")
+        if score is not None:
+            return _numeric_result(score, "brand_sentiment_score")
+        positive = _number_from(facts, "brand_positive_mentions", "positive_mentions")
+        negative = _number_from(facts, "brand_negative_mentions", "negative_mentions")
+        neutral = _number_from(facts, "brand_neutral_mentions", "neutral_mentions") or 0.0
+        missing = [
+            name
+            for name, value in (
+                ("brand_positive_mentions", positive),
+                ("brand_negative_mentions", negative),
+            )
+            if value is None
+        ]
+        if missing:
+            return _missing_result(
+                missing,
+                [
+                    "brand_positive_mentions",
+                    "brand_negative_mentions",
+                    "brand_neutral_mentions",
+                ],
+            )
+        assert positive is not None
+        assert negative is not None
+        total = positive + negative + neutral
+        return _divide(
+            positive - negative,
+            total,
+            input_fields=[
+                "brand_positive_mentions",
+                "brand_negative_mentions",
+                "brand_neutral_mentions",
+            ],
+            zero_is_zero=True,
+        )
+    if kpi_key == "abm_intent_account_readiness":
+        ready = _number_from(facts, "intent_ready_accounts", "abm_intent_accounts")
+        targets = _number_from(facts, "target_accounts", "target_account_count")
+        return _percentage(ready, targets, input_fields=["intent_ready_accounts", "target_accounts"], zero_is_zero=True)
+    return _missing_result(["formula"], ["formula"])
+
+
+def _count_result(value: float | None, field_name: str) -> dict[str, Any]:
+    return _numeric_result(value, field_name)
+
+
+def _numeric_result(value: float | None, field_name: str) -> dict[str, Any]:
+    if value is None:
+        return _missing_result([field_name], [field_name])
+    return {
+        "value": _round(value),
+        "missing_fields": [],
+        "degraded_reasons": [],
+        "input_fields": [field_name],
+        "zero_denominator": False,
+    }
+
+
+def _divide(
+    numerator: float | None,
+    denominator: float | None,
+    *,
+    input_fields: list[str],
+    zero_is_zero: bool = False,
+) -> dict[str, Any]:
+    missing: list[str] = []
+    if numerator is None:
+        missing.append(input_fields[0])
+    if denominator is None:
+        missing.append(input_fields[1])
+    if missing:
+        return _missing_result(missing, input_fields)
+    assert numerator is not None
+    assert denominator is not None
+    if denominator == 0:
+        if zero_is_zero:
+            return {
+                "value": 0.0,
+                "missing_fields": [],
+                "degraded_reasons": [f"Zero denominator for {input_fields[1]}."],
+                "input_fields": input_fields,
+                "zero_denominator": True,
+            }
+        return _missing_result([input_fields[1]], input_fields)
+    return {
+        "value": _round(numerator / denominator),
+        "missing_fields": [],
+        "degraded_reasons": [],
+        "input_fields": input_fields,
+        "zero_denominator": False,
+    }
+
+
+def _percentage(
+    numerator: float | None,
+    denominator: float | None,
+    *,
+    input_fields: list[str],
+    zero_is_zero: bool = False,
+) -> dict[str, Any]:
+    result = _divide(numerator, denominator, input_fields=input_fields, zero_is_zero=zero_is_zero)
+    if result["value"] is not None:
+        result["value"] = _round(float(result["value"]) * 100)
+    return result
+
+
+def _conversion_rates(facts: dict[str, Any]) -> dict[str, Any]:
+    counts = _dict_from_value(facts.get("funnel_stage_counts") or facts.get("lifecycle_stage_counts"))
+    if not counts:
+        return _missing_result(["funnel_stage_counts"], ["funnel_stage_counts"])
+    stages = ["visitor", "lead", "mql", "sql", "opportunity", "customer"]
+    rates: dict[str, float] = {}
+    zero_denominator = False
+    for current, next_stage in zip(stages, stages[1:], strict=False):
+        current_count = _number(counts.get(current))
+        next_count = _number(counts.get(next_stage))
+        if current_count is None or next_count is None:
+            continue
+        if current_count == 0:
+            rates[f"{current}_to_{next_stage}"] = 0.0
+            zero_denominator = True
+        else:
+            rates[f"{current}_to_{next_stage}"] = _round((next_count / current_count) * 100)
+    if not rates:
+        return _missing_result(["funnel_stage_counts"], ["funnel_stage_counts"])
+    return {
+        "value": rates,
+        "missing_fields": [],
+        "degraded_reasons": ["One or more funnel stages had a zero denominator."] if zero_denominator else [],
+        "input_fields": ["funnel_stage_counts"],
+        "zero_denominator": zero_denominator,
+    }
+
+
+def _missing_result(missing_fields: list[str], input_fields: list[str]) -> dict[str, Any]:
+    return {
+        "value": None,
+        "missing_fields": _unique(missing_fields),
+        "degraded_reasons": [],
+        "input_fields": input_fields,
+        "zero_denominator": False,
+    }
+
+
+def _freshness_status(
+    definition: CmoKpiDefinition,
+    facts: dict[str, Any],
+    now: datetime,
+) -> dict[str, Any]:
+    last_updated = _parse_datetime(
+        facts.get(f"{definition.key}_last_updated_at")
+        or facts.get("last_updated_at")
+        or facts.get("last_sync_at")
+        or facts.get("computed_at")
+    )
+    if last_updated is None:
+        return {
+            "status": "unknown",
+            "last_updated_at": None,
+            "ttl_seconds": definition.refresh_ttl_seconds,
+            "age_seconds": None,
+            "degraded_reasons": ["Source freshness timestamp is missing."],
+        }
+    age_seconds = max(int((now - last_updated).total_seconds()), 0)
+    if age_seconds > definition.refresh_ttl_seconds:
+        return {
+            "status": "stale",
+            "last_updated_at": last_updated.isoformat(),
+            "ttl_seconds": definition.refresh_ttl_seconds,
+            "age_seconds": age_seconds,
+            "degraded_reasons": ["Source data is stale for this KPI TTL."],
+        }
+    return {
+        "status": "fresh",
+        "last_updated_at": last_updated.isoformat(),
+        "ttl_seconds": definition.refresh_ttl_seconds,
+        "age_seconds": age_seconds,
+        "degraded_reasons": [],
+    }
+
+
+def _confidence(
+    requirements: dict[str, Any],
+    freshness: dict[str, Any],
+    formula: dict[str, Any],
+    reconciliation: dict[str, Any],
+    *,
+    degraded: bool,
+) -> float:
+    confidence = 0.95
+    confidence -= float(requirements.get("confidence_impact") or 0.0)
+    confidence -= float(reconciliation.get("confidence_impact") or 0.0)
+    if degraded:
+        confidence -= 0.15
+    if freshness["status"] == "stale":
+        confidence -= 0.20
+    elif freshness["status"] == "unknown":
+        confidence -= 0.10
+    if formula.get("zero_denominator"):
+        confidence -= 0.10
+    return max(round(confidence, 3), 0.0)
+
+
+def _next_action(
+    missing_requirements: dict[str, list[str]],
+    freshness: dict[str, Any],
+    *,
+    reconciliation_cta: str = "none",
+    degraded: bool = False,
+) -> str:
+    if reconciliation_cta not in {"", "none"}:
+        return reconciliation_cta
+    if missing_requirements.get("connectors"):
+        return "configure_required_connector"
+    if missing_requirements.get("field_mappings"):
+        return "fix_required_mapping"
+    if missing_requirements.get("backfills"):
+        return "complete_backfill"
+    if missing_requirements.get("fields"):
+        return "provide_kpi_source_data"
+    if freshness["status"] == "stale":
+        return "refresh_source_data"
+    if degraded:
+        return "review_degraded_kpi_inputs"
+    return "none"
+
+
+def _reconciliation_impact(
+    kpi_key: str,
+    reconciliation_checks: Iterable[dict[str, Any]],
+) -> dict[str, Any]:
+    key = _normalize_key(kpi_key)
+    relevant = [
+        check
+        for check in reconciliation_checks
+        if key in {_normalize_key(item) for item in check.get("affected_kpi_keys") or []}
+    ]
+    blocked: list[str] = []
+    degraded: list[str] = []
+    refs: list[str] = []
+    missing: list[str] = []
+    next_action = "none"
+    confidence_impact = 0.0
+    rank = {"passed": 0, "warning": 1, "unavailable": 1, "failed": 2, "blocked": 3}
+    worst_status = "passed"
+
+    for check in relevant:
+        status = str(check.get("status") or "unavailable")
+        severity = str(check.get("severity") or "")
+        check_key = str(check.get("reconciliation_key") or "unknown_reconciliation")
+        worst_status = status if rank.get(status, 1) > rank.get(worst_status, 0) else worst_status
+        if check.get("decision_audit_ref"):
+            refs.append(str(check["decision_audit_ref"]))
+        confidence_impact += float(check.get("confidence_impact") or 0.0)
+        missing.extend(
+            str(item)
+            for values in (check.get("missing_requirements") or {}).values()
+            for item in values
+        )
+        if next_action == "none" and check.get("next_action_cta") not in {None, "", "none"}:
+            next_action = str(check["next_action_cta"])
+
+        reason = f"KPI reconciliation {check_key} is {status}."
+        if status == "blocked" or bool(check.get("blocks_kpi_readiness")):
+            blocked.append(reason)
+        elif status == "failed" and severity in {"critical", "high"}:
+            blocked.append(reason)
+        elif status in {"failed", "warning", "unavailable"}:
+            degraded.append(reason)
+
+    return {
+        "status": worst_status,
+        "blocked_reasons": _unique(blocked),
+        "degraded_reasons": _unique(degraded),
+        "missing_requirements": _unique(missing),
+        "refs": _unique(refs),
+        "confidence_impact": round(min(confidence_impact, 0.75), 3),
+        "next_action_cta": next_action,
+    }
+
+
+def _source_refs(
+    definition: CmoKpiDefinition,
+    facts: dict[str, Any],
+    connector_setup: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    refs = []
+    for item in _list_from_value(facts.get("source_refs") or facts.get("source_lineage_refs")):
+        if isinstance(item, Mapping):
+            refs.append(dict(item))
+        else:
+            refs.append({"ref": str(item)})
+    categories = set(definition.required_connector_categories)
+    for row in connector_setup:
+        if str(row.get("category") or "").strip() in categories:
+            refs.append(
+                {
+                    "connector_key": row.get("key"),
+                    "connector_name": row.get("name"),
+                    "category": row.get("category"),
+                    "last_sync_at": row.get("last_sync_at"),
+                    "health_status": row.get("health_status"),
+                }
+            )
+    return refs
+
+
+def _audit_refs(facts: dict[str, Any], data_readiness: Mapping[str, Any]) -> list[str]:
+    refs = _string_list(facts.get("audit_refs") or facts.get("decision_audit_refs"))
+    readiness_rows = [
+        *list(data_readiness.get("field_mapping_status") or []),
+        *list(data_readiness.get("backfill_status") or []),
+    ]
+    for row in readiness_rows:
+        if isinstance(row, Mapping) and row.get("decision_audit_ref"):
+            refs.append(str(row["decision_audit_ref"]))
+    return _unique(refs)
+
+
+def _kpi_facts_from_configs(connector_configs: Iterable[Any]) -> dict[str, Any]:
+    facts: dict[str, Any] = {}
+    for config in connector_configs:
+        payload = _config_dict(config)
+        for key in (
+            "marketing_kpi_inputs",
+            "cmo_kpi_inputs",
+            "marketing_kpi_facts",
+            "cmo_kpi_facts",
+            "kpi_inputs",
+        ):
+            value = payload.get(key)
+            if isinstance(value, Mapping):
+                _merge_facts(facts, value)
+    return facts
+
+
+def _merge_facts(target: dict[str, Any], source: Mapping[str, Any]) -> None:
+    for key, value in source.items():
+        if key in {"source_refs", "source_lineage_refs", "audit_refs", "decision_audit_refs"}:
+            target.setdefault(key, [])
+            target[key] = [*list(_list_from_value(target[key])), *list(_list_from_value(value))]
+        elif key in {"lifecycle_stage_counts", "funnel_stage_counts"} and isinstance(value, Mapping):
+            existing = _dict_from_value(target.get(key))
+            for stage, count in value.items():
+                normalized_stage = _normalize_key(stage)
+                existing[normalized_stage] = (
+                    (_number(existing.get(normalized_stage)) or 0.0)
+                    + (_number(count) or 0.0)
+                )
+            target[key] = existing
+        elif key in {"opportunities", "pipeline_opportunities"}:
+            target.setdefault(key, [])
+            target[key] = [*list(_list_from_value(target[key])), *list(_list_from_value(value))]
+        elif isinstance(value, (int, float)) and isinstance(target.get(key), (int, float)):
+            target[key] = float(target[key]) + float(value)
+        elif key not in target or target.get(key) in (None, "", [], {}):
+            target[key] = value
+
+
+def _facts(source_data: Mapping[str, Any] | None) -> dict[str, Any]:
+    source = source_data if isinstance(source_data, Mapping) else {}
+    facts: dict[str, Any] = {}
+    for key in ("metrics", "facts", "kpi_inputs", "marketing_kpi_inputs", "cmo_kpi_inputs"):
+        value = source.get(key)
+        if isinstance(value, Mapping):
+            _merge_facts(facts, value)
+    _merge_facts(facts, source)
+    if "lifecycle_stage_counts" in facts:
+        facts["lifecycle_stage_counts"] = {
+            _normalize_key(key): _number(value)
+            for key, value in _dict_from_value(facts["lifecycle_stage_counts"]).items()
+        }
+    if "funnel_stage_counts" in facts:
+        facts["funnel_stage_counts"] = {
+            _normalize_key(key): _number(value)
+            for key, value in _dict_from_value(facts["funnel_stage_counts"]).items()
+        }
+    return facts
+
+
+def _definition(key: str) -> CmoKpiDefinition | None:
+    normalized = _normalize_key(key)
+    for definition in CMO_KPI_DEFINITIONS:
+        if definition.key == normalized:
+            return definition
+    return None
+
+
+def _unavailable_result(kpi_key: str, now: datetime | None) -> dict[str, Any]:
+    timestamp = (_ensure_aware(now) or datetime.now(UTC)).isoformat()
+    return {
+        "kpi_key": _normalize_key(kpi_key),
+        "display_name": str(kpi_key),
+        "status": "unavailable",
+        "value": None,
+        "unit": None,
+        "confidence": 0.0,
+        "formula": None,
+        "formula_refs": {},
+        "source_refs": [],
+        "missing_requirements": {"definition": [_normalize_key(kpi_key)]},
+        "freshness_status": "unknown",
+        "last_computed_at": timestamp,
+        "next_action_cta": "define_kpi",
+    }
+
+
+def _setup_rows_for_category(rows: Iterable[dict[str, Any]], category: str) -> list[dict[str, Any]]:
+    return [
+        row
+        for row in rows
+        if str(row.get("category") or "").strip() == category
+        and str(row.get("configured_status") or "") != "unconfigured"
+    ]
+
+
+def _contract_rows_for_category(rows: Iterable[dict[str, Any]], category: str) -> list[dict[str, Any]]:
+    return [
+        row
+        for row in rows
+        if str(row.get("category") or "").strip() == category
+        and str(row.get("configured_status") or "") != "unconfigured"
+    ]
+
+
+def _contract_degraded(row: Mapping[str, Any]) -> bool:
+    degraded_mode = row.get("degraded_mode") if isinstance(row.get("degraded_mode"), Mapping) else {}
+    return (
+        row.get("read_status") == "degraded"
+        or str(degraded_mode.get("status") or "") in {"degraded", "blocked"}
+        or bool(degraded_mode.get("active"))
+    )
+
+
+def _max_confidence_impact(rows: Iterable[dict[str, Any]], categories: Iterable[str]) -> float:
+    category_set = set(categories)
+    impacts = []
+    for row in rows:
+        if str(row.get("category") or "").strip() not in category_set:
+            continue
+        degraded_mode = row.get("degraded_mode") if isinstance(row.get("degraded_mode"), Mapping) else {}
+        impacts.append(float(row.get("confidence_impact") or degraded_mode.get("confidence_impact") or 0.0))
+    return max(impacts, default=0.0)
+
+
+def _stage_count(facts: Mapping[str, Any], stage: str) -> float | None:
+    explicit = _number_from(facts, f"{stage}_count", stage)
+    if explicit is not None:
+        return explicit
+    counts = _dict_from_value(facts.get("lifecycle_stage_counts"))
+    return _number(counts.get(stage))
+
+
+def _partial_attribution(facts: Mapping[str, Any]) -> bool:
+    status = _normalize_key(facts.get("attribution_status"))
+    if status in {"partial", "degraded", "incomplete"}:
+        return True
+    coverage = _number(facts.get("attribution_coverage"))
+    return coverage is not None and coverage < 1.0
+
+
+def _number_from(facts: Mapping[str, Any], *keys: str) -> float | None:
+    for key in keys:
+        value = _number(facts.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _number(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_percentage(numerator: float | None, denominator: float | None) -> float:
+    if numerator is None or denominator is None or denominator == 0:
+        return 0.0
+    return _round((numerator / denominator) * 100)
+
+
+def _round(value: float) -> float:
+    return round(float(value), 4)
+
+
+def _dict_from_value(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list_from_value(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
+
+
+def _string_list(value: Any) -> list[str]:
+    return [str(item) for item in _list_from_value(value) if str(item).strip()]
+
+
+def _unique(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _config_dict(config: Any | None) -> dict[str, Any]:
+    if isinstance(config, Mapping):
+        return dict(config)
+    value = getattr(config, "config", None)
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _health(row: Mapping[str, Any]) -> str:
+    return str(row.get("health_status") or "missing").strip().lower()
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return _ensure_aware(value)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return _ensure_aware(parsed)
+
+
+def _ensure_aware(value: Any) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _iso_or_none(value: Any) -> str | None:
+    parsed = _parse_datetime(value)
+    if parsed is not None:
+        return parsed.isoformat()
+    text = str(value or "").strip()
+    return text or None
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")

--- a/core/marketing/pilot_proof.py
+++ b/core/marketing/pilot_proof.py
@@ -1,0 +1,1453 @@
+"""CMO pilot tenant proof projection.
+
+CMO-9.4 does not make live vendor claims by itself. It packages evidence from
+existing CMO readiness, governance, KPI, report, workbench, approval, agent
+contract, scenario, and chaos projections so a pilot tenant can be evaluated
+without treating demo data, mocks, stubs, or test doubles as production proof.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from core.marketing.agent_contracts import marketing_agent_contract_specs
+
+CMO_PILOT_PROOF_VERSION = "2026-05-24.cmo-9.4"
+
+ENVIRONMENT_TYPES = {"real_vendor", "vendor_sandbox", "demo", "test_double", "unknown"}
+PROOF_STATUSES = {"passed", "partial", "blocked", "demo_only", "test_only", "unavailable"}
+DEMO_SOURCE_MARKERS = {"demo", "sample", "mock", "stub", "hardcoded", "fallback"}
+TEST_SOURCE_MARKERS = {"test", "test_double", "fake", "fixture", "contract_test_double"}
+SECRET_KEY_MARKERS = (
+    "secret",
+    "token",
+    "password",
+    "api_key",
+    "apikey",
+    "authorization",
+    "credential",
+    "private_key",
+)
+
+FIRST_CLASS_UNPROVEN_AGENT_KEYS: dict[str, str] = {}
+
+
+def build_cmo_pilot_proof_projection(
+    *,
+    tenant_id: str | None = None,
+    company_id: str | None = None,
+    environment_type: str | None = None,
+    source_context: Mapping[str, Any] | None = None,
+    connector_setup: Iterable[Mapping[str, Any]] | None = None,
+    connector_contracts: Iterable[Mapping[str, Any]] | None = None,
+    data_readiness: Mapping[str, Any] | None = None,
+    workflow_activation: Mapping[str, Any] | None = None,
+    workflow_lint_results: Iterable[Any] | None = None,
+    policy_projection: Mapping[str, Any] | None = None,
+    escalation_projection: Mapping[str, Any] | None = None,
+    approval_timeout_risk: Mapping[str, Any] | None = None,
+    external_write_results: Iterable[Mapping[str, Any]] | None = None,
+    decision_audit_projection: Mapping[str, Any] | None = None,
+    kpi_schema: Iterable[Mapping[str, Any]] | None = None,
+    kpi_results: Iterable[Mapping[str, Any]] | None = None,
+    reconciliation_checks: Iterable[Mapping[str, Any]] | None = None,
+    report_quality_gates: Iterable[Mapping[str, Any]] | None = None,
+    work_queue: Iterable[Mapping[str, Any]] | None = None,
+    kpi_drilldowns: Iterable[Mapping[str, Any]] | None = None,
+    approval_review_projection: Mapping[str, Any] | None = None,
+    agent_contracts: Iterable[Mapping[str, Any]] | None = None,
+    scenario_evidence: Iterable[Mapping[str, Any]] | None = None,
+    chaos_evidence: Iterable[Mapping[str, Any]] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic pilot proof package and compact summary."""
+
+    generated_at = _iso(now or datetime.now(UTC))
+    source = source_context if isinstance(source_context, Mapping) else {}
+    setup_rows = _dicts(connector_setup)
+    contract_rows = _dicts(connector_contracts)
+    data = data_readiness if isinstance(data_readiness, Mapping) else {}
+    workflows = workflow_activation if isinstance(workflow_activation, Mapping) else {}
+    policy = policy_projection if isinstance(policy_projection, Mapping) else {}
+    escalation = escalation_projection if isinstance(escalation_projection, Mapping) else {}
+    approval_timeout = approval_timeout_risk if isinstance(approval_timeout_risk, Mapping) else {}
+    audit = decision_audit_projection if isinstance(decision_audit_projection, Mapping) else {}
+    approvals = approval_review_projection if isinstance(approval_review_projection, Mapping) else {}
+    kpi_defs = _dicts(kpi_schema)
+    kpis = _dicts(kpi_results)
+    reconciliations = _dicts(reconciliation_checks)
+    reports = _dicts(report_quality_gates)
+    queue = _dicts(work_queue)
+    drilldowns = _dicts(kpi_drilldowns)
+    writes = _dicts(external_write_results)
+    scenarios = _dicts(scenario_evidence)
+    chaos = _dicts(chaos_evidence)
+    agents = _dicts(agent_contracts) or marketing_agent_contract_specs()
+
+    env = _resolve_environment_type(environment_type, source, contract_rows)
+    blockers: list[dict[str, Any]] = []
+    risks: list[dict[str, Any]] = []
+    proven: list[dict[str, Any]] = []
+    unproven: list[dict[str, Any]] = []
+    evidence_refs: list[dict[str, Any]] = []
+    test_evidence_refs: list[dict[str, Any]] = []
+    next_actions: list[dict[str, Any]] = []
+
+    _evaluate_environment(env, source, contract_rows, blockers, risks, next_actions)
+    _evaluate_connector_setup(setup_rows, blockers, proven, evidence_refs, next_actions)
+    _evaluate_connector_contracts(contract_rows, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_data_readiness(data, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_workflow_activation(workflows, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_workflow_lint(workflow_lint_results, blockers, risks, proven, test_evidence_refs, next_actions)
+    _evaluate_summary_projection(
+        policy,
+        summary_key="marketing_policy_summary",
+        capability_key="marketing_policy_manifest",
+        blocker_status="missing_policy",
+        blocker_category="policy",
+        blocker_message="Marketing policy manifest is missing or not ready.",
+        blockers=blockers,
+        proven=proven,
+        evidence_refs=evidence_refs,
+        next_actions=next_actions,
+    )
+    _evaluate_summary_projection(
+        escalation,
+        summary_key="marketing_escalation_summary",
+        capability_key="marketing_escalation_matrix",
+        blocker_status="missing_route",
+        blocker_category="escalation",
+        blocker_message="Marketing escalation matrix has no route for required pilot events.",
+        blockers=blockers,
+        proven=proven,
+        evidence_refs=evidence_refs,
+        next_actions=next_actions,
+    )
+    _evaluate_approval_timeout(approval_timeout, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_external_writes(writes, contract_rows, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_summary_projection(
+        audit,
+        summary_key="marketing_decision_audit_summary",
+        capability_key="decision_audit_package",
+        blocker_status="missing_audit_evidence",
+        blocker_category="audit",
+        blocker_message="CMO decision audit package or required evidence is missing.",
+        blockers=blockers,
+        proven=proven,
+        evidence_refs=evidence_refs,
+        next_actions=next_actions,
+    )
+    _evaluate_kpis(kpi_defs, kpis, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_reconciliation(reconciliations, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_report_gates(reports, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_work_queue(queue, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_drilldowns(drilldowns, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_approval_reviews(approvals, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_agent_contracts(agents, proven, unproven, evidence_refs)
+    _evaluate_test_evidence("scenario", scenarios, risks, proven, test_evidence_refs)
+    _evaluate_test_evidence("chaos", chaos, risks, proven, test_evidence_refs)
+
+    source_refs = _connector_source_refs(contract_rows, drilldowns, kpis)
+    report_refs = _report_refs(reports)
+    audit_refs = _audit_refs(audit, approvals, writes, reports, kpis)
+    if not source_refs:
+        _add_issue(
+            risks if env == "vendor_sandbox" else blockers,
+            category="source_lineage",
+            message="Pilot proof has no real connector/source lineage refs.",
+            severity="medium" if env == "vendor_sandbox" else "high",
+            next_action="connect_real_or_sandbox_sources",
+        )
+        next_actions.append(_next_action("connect_real_or_sandbox_sources", "Connect Real/Sandbox Sources"))
+
+    _apply_environment_specific_rules(env, blockers, risks, proven, source_refs, report_refs, audit_refs, next_actions)
+    blockers = _dedupe_issues(blockers)
+    risks = _dedupe_issues(risks)
+    proven = _dedupe_capabilities(proven)
+    unproven = _dedupe_capabilities(unproven)
+    evidence_refs = _dedupe_refs(evidence_refs)
+    test_evidence_refs = _dedupe_refs(test_evidence_refs)
+    next_actions = _dedupe_actions(next_actions)
+
+    status = _proof_status(env, blockers, risks)
+    score = _readiness_score(env, blockers, risks, proven)
+    proof: dict[str, Any] = {
+        "proof_id": _proof_id(tenant_id, company_id, env, blockers, risks, proven, source_refs, report_refs),
+        "schema_version": CMO_PILOT_PROOF_VERSION,
+        "tenant_id": tenant_id,
+        "company_id": company_id,
+        "environment_type": env,
+        "proof_scope": "sandbox" if env == "vendor_sandbox" else env,
+        "proof_status": status,
+        "production_claim_allowed": env == "real_vendor" and status == "passed",
+        "real_vendor_claim_allowed": env == "real_vendor" and status == "passed",
+        "full_cmo_autonomy_claim_allowed": False,
+        "readiness_score": score,
+        "proven_capabilities": proven,
+        "unproven_capabilities": unproven,
+        "blockers": blockers,
+        "risks": risks,
+        "evidence_refs": evidence_refs,
+        "test_evidence_refs": test_evidence_refs,
+        "connector_source_refs": source_refs,
+        "report_proof_refs": report_refs,
+        "audit_refs": audit_refs,
+        "next_actions": next_actions,
+        "generated_at": generated_at,
+    }
+    return {
+        "cmo_pilot_proof_version": CMO_PILOT_PROOF_VERSION,
+        "cmo_pilot_proof": _redact(proof),
+        "cmo_pilot_proof_summary": summarize_cmo_pilot_proof(proof),
+        "cmo_pilot_evidence_bundle": build_cmo_pilot_evidence_bundle(proof),
+    }
+
+
+def build_cmo_pilot_proof_projection_from_kpi_payload(
+    payload: Mapping[str, Any] | None,
+    *,
+    environment_type: str | None = None,
+    scenario_evidence: Iterable[Mapping[str, Any]] | None = None,
+    chaos_evidence: Iterable[Mapping[str, Any]] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build pilot proof from an existing `/kpis/cmo` response payload."""
+
+    data = payload if isinstance(payload, Mapping) else {}
+    return build_cmo_pilot_proof_projection(
+        tenant_id=_string_or_none(data.get("tenant_id")),
+        company_id=_string_or_none(data.get("company_id")),
+        environment_type=environment_type,
+        source_context=data,
+        connector_setup=_dicts(data.get("connector_setup")),
+        connector_contracts=_dicts(data.get("connector_contracts")),
+        data_readiness={
+            "field_mapping_status": _dicts(data.get("field_mapping_status")),
+            "backfill_status": _dicts(data.get("backfill_status")),
+            "kpi_readiness": data.get("kpi_readiness") or {},
+        },
+        workflow_activation={
+            "workflow_activation_status": _dicts(data.get("workflow_activation_status")),
+            "workflow_activation_summary": data.get("workflow_activation_summary") or {},
+        },
+        workflow_lint_results=data.get("workflow_lint_results") or data.get("marketing_workflow_lint_results") or [],
+        policy_projection={
+            "marketing_policy_manifest": data.get("marketing_policy_manifest"),
+            "marketing_policy_summary": data.get("marketing_policy_summary") or {},
+        },
+        escalation_projection={
+            "marketing_escalation_matrix": data.get("marketing_escalation_matrix"),
+            "marketing_escalation_summary": data.get("marketing_escalation_summary") or {},
+        },
+        approval_timeout_risk=data.get("approval_timeout_risk") or {},
+        external_write_results=data.get("external_write_results") or data.get("marketing_external_write_results") or [],
+        decision_audit_projection={
+            "marketing_decision_audit": data.get("marketing_decision_audit"),
+            "marketing_decision_audit_summary": data.get("marketing_decision_audit_summary") or {},
+        },
+        kpi_schema=_dicts(data.get("unified_cmo_kpi_schema")),
+        kpi_results=_dicts(data.get("unified_cmo_kpi_results")),
+        reconciliation_checks=_dicts(data.get("cmo_kpi_reconciliation_checks")),
+        report_quality_gates=_dicts(data.get("report_quality_gates")),
+        work_queue=_dicts(data.get("cmo_work_queue")),
+        kpi_drilldowns=_dicts(data.get("cmo_kpi_drilldowns")),
+        approval_review_projection={
+            "cmo_approval_reviews": _dicts(data.get("cmo_approval_reviews")),
+            "cmo_approval_review_summary": data.get("cmo_approval_review_summary") or {},
+        },
+        agent_contracts=data.get("marketing_agent_contracts") or data.get("agent_contracts") or [],
+        scenario_evidence=scenario_evidence or data.get("cmo_scenario_evidence") or [],
+        chaos_evidence=chaos_evidence or data.get("cmo_chaos_evidence") or [],
+        now=now,
+    )
+
+
+def summarize_cmo_pilot_proof(proof: Mapping[str, Any]) -> dict[str, Any]:
+    status = str(proof.get("proof_status") or "unavailable")
+    blockers = _dicts(proof.get("blockers"))
+    risks = _dicts(proof.get("risks"))
+    return {
+        "schema_version": CMO_PILOT_PROOF_VERSION,
+        "proof_id": proof.get("proof_id"),
+        "environment_type": proof.get("environment_type") or "unknown",
+        "proof_status": status,
+        "readiness_score": proof.get("readiness_score") or 0,
+        "production_claim_allowed": bool(proof.get("production_claim_allowed")),
+        "real_vendor_claim_allowed": bool(proof.get("real_vendor_claim_allowed")),
+        "full_cmo_autonomy_claim_allowed": False,
+        "proven_capabilities": len(_dicts(proof.get("proven_capabilities"))),
+        "unproven_capabilities": len(_dicts(proof.get("unproven_capabilities"))),
+        "blockers": len(blockers),
+        "risks": len(risks),
+        "next_action_cta": _summary_next_action(status, blockers, risks),
+    }
+
+
+def build_cmo_pilot_evidence_bundle(proof: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a lightweight, secret-redacted evidence bundle for docs/future UI."""
+
+    redacted = _redact(dict(proof))
+    return {
+        "bundle_version": CMO_PILOT_PROOF_VERSION,
+        "bundle_type": "cmo_pilot_proof",
+        "proof_id": redacted.get("proof_id"),
+        "environment_type": redacted.get("environment_type"),
+        "proof_status": redacted.get("proof_status"),
+        "generated_at": redacted.get("generated_at"),
+        "summary": summarize_cmo_pilot_proof(redacted),
+        "evidence": {
+            "proven_capabilities": redacted.get("proven_capabilities") or [],
+            "unproven_capabilities": redacted.get("unproven_capabilities") or [],
+            "blockers": redacted.get("blockers") or [],
+            "risks": redacted.get("risks") or [],
+            "evidence_refs": redacted.get("evidence_refs") or [],
+            "test_evidence_refs": redacted.get("test_evidence_refs") or [],
+            "connector_source_refs": redacted.get("connector_source_refs") or [],
+            "report_proof_refs": redacted.get("report_proof_refs") or [],
+            "audit_refs": redacted.get("audit_refs") or [],
+            "next_actions": redacted.get("next_actions") or [],
+        },
+    }
+
+
+def serialize_cmo_pilot_evidence_bundle(bundle: Mapping[str, Any]) -> str:
+    return _canonical_json(_redact(bundle))
+
+
+def _evaluate_environment(
+    env: str,
+    source: Mapping[str, Any],
+    contracts: list[dict[str, Any]],
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    if env == "demo":
+        _add_issue(
+            blockers,
+            category="environment",
+            message="Demo/sample environments cannot produce production pilot proof.",
+            severity="critical",
+            next_action="connect_real_or_sandbox_sources",
+        )
+    elif env == "test_double":
+        _add_issue(
+            blockers,
+            category="environment",
+            message="Test-double/mock connector proof cannot produce production pilot proof.",
+            severity="critical",
+            next_action="replace_test_doubles_with_vendor_sandbox",
+        )
+    elif env == "unknown":
+        _add_issue(
+            risks,
+            category="environment",
+            message="Pilot environment type is unknown; proof cannot be treated as real-vendor evidence.",
+            severity="medium",
+            next_action="label_pilot_environment",
+        )
+    if source.get("production_data_blocked"):
+        _add_issue(
+            blockers,
+            category="environment",
+            message="Production data policy blocks KPI/report confidence for this tenant.",
+            severity="critical",
+            next_action="resolve_production_data_blocker",
+        )
+    if any(row.get("mock_or_test_double") for row in contracts):
+        _add_issue(
+            blockers,
+            category="environment",
+            message="At least one connector contract is marked mock/test-double proof.",
+            severity="critical",
+            next_action="replace_test_doubles_with_vendor_sandbox",
+        )
+    next_actions.append(_next_action("label_pilot_environment", "Label Pilot Environment"))
+
+
+def _evaluate_connector_setup(
+    rows: list[dict[str, Any]],
+    blockers: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    configured = [row for row in rows if row.get("configured_status") == "configured"]
+    if not configured:
+        _add_issue(
+            blockers,
+            category="connector_setup",
+            message="No configured marketing connectors are available for pilot proof.",
+            severity="critical",
+            next_action="connect_marketing_systems",
+        )
+        next_actions.append(_next_action("connect_marketing_systems", "Connect Marketing Systems"))
+        return
+    needs_action = [
+        row
+        for row in rows
+        if row.get("configured_status") != "configured"
+        or row.get("health_status") in {"unhealthy", "expired_auth", "degraded"}
+        or row.get("data_coverage_status") in {"missing", "blocked", "unavailable"}
+        or row.get("cta_state") not in {None, "", "none", "connected"}
+    ]
+    if needs_action:
+        _add_issue(
+            blockers,
+            category="connector_setup",
+            message="One or more marketing connectors need setup, reconnect, scope, or health action.",
+            severity="high",
+            next_action=str(needs_action[0].get("cta_state") or "resolve_connector_setup"),
+        )
+    else:
+        proven.append(_capability("connector_setup", "Configured marketing connectors are healthy."))
+    for row in configured:
+        refs.append(_ref("connector_setup", row.get("key") or row.get("connector_key"), row))
+
+
+def _evaluate_connector_contracts(
+    rows: list[dict[str, Any]],
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    if not rows:
+        _add_issue(
+            blockers,
+            category="connector_contracts",
+            message="Connector contract/read-write readiness evidence is missing.",
+            severity="critical",
+            next_action="configure_connector_contracts",
+        )
+        return
+    blocked = [
+        row
+        for row in rows
+        if row.get("read_status") == "blocked"
+        or row.get("write_status") in {"blocked", "missing_scope", "idempotency_missing"}
+        or row.get("blocks_external_writes")
+        or row.get("mock_or_test_double")
+    ]
+    degraded = [row for row in rows if row.get("read_status") == "degraded" or row.get("write_status") == "degraded"]
+    if blocked:
+        _add_issue(
+            blockers,
+            category="connector_contracts",
+            message="Connector contract evidence blocks read/write production readiness.",
+            severity="critical",
+            affected=[str(row.get("connector_key")) for row in blocked],
+            next_action=str(blocked[0].get("next_action_cta") or "fix_connector_contract"),
+        )
+        next_actions.append(
+            _next_action(
+                str(blocked[0].get("next_action_cta") or "fix_connector_contract"),
+                "Fix Connector Contract",
+            )
+        )
+    elif degraded:
+        _add_issue(
+            risks,
+            category="connector_contracts",
+            message="Connector contract evidence is degraded and lowers pilot confidence.",
+            severity="medium",
+            affected=[str(row.get("connector_key")) for row in degraded],
+            next_action="review_degraded_connectors",
+        )
+    else:
+        proven.append(_capability("connector_contracts", "Connector read/write contracts are ready."))
+    for row in rows:
+        refs.append(_ref("connector_contract", row.get("connector_key"), row))
+
+
+def _evaluate_data_readiness(
+    data: Mapping[str, Any],
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    kpi_readiness = data.get("kpi_readiness") if isinstance(data.get("kpi_readiness"), Mapping) else {}
+    status = _normalize(kpi_readiness.get("status") or kpi_readiness.get("readiness"))
+    if not data or status in {"", "missing", "blocked"}:
+        _add_issue(
+            blockers,
+            category="data_readiness",
+            message="Field mapping or historical backfill readiness blocks pilot proof.",
+            severity="critical",
+            next_action=str(kpi_readiness.get("next_action_cta") or "resolve_data_readiness"),
+        )
+        next_actions.append(
+            _next_action(
+                str(kpi_readiness.get("next_action_cta") or "resolve_data_readiness"),
+                "Resolve Data Readiness",
+            )
+        )
+    elif status == "degraded":
+        _add_issue(
+            risks,
+            category="data_readiness",
+            message="Field mapping or backfill readiness is degraded.",
+            severity="medium",
+            next_action=str(kpi_readiness.get("next_action_cta") or "review_data_readiness"),
+        )
+    else:
+        proven.append(_capability("data_mapping_backfill", "Mappings and historical backfills are ready."))
+    for row in _dicts(data.get("field_mapping_status")):
+        refs.append(_ref("field_mapping", row.get("connector_key"), row))
+    for row in _dicts(data.get("backfill_status")):
+        refs.append(_ref("backfill", row.get("connector_key"), row))
+
+
+def _evaluate_workflow_activation(
+    projection: Mapping[str, Any],
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    rows = _dicts(projection.get("workflow_activation_status"))
+    if not rows:
+        _add_issue(
+            blockers,
+            category="workflow_activation",
+            message="Workflow activation evidence is missing.",
+            severity="high",
+            next_action="configure_workflow_activation",
+        )
+        return
+    blocked = [row for row in rows if row.get("state") in {"promotion_blocked", "unavailable"}]
+    degraded = [row for row in rows if row.get("state") in {"shadow", "degraded", "paused"}]
+    if blocked:
+        _add_issue(
+            blockers,
+            category="workflow_activation",
+            message="One or more CMO workflows are blocked or unavailable.",
+            severity="high",
+            affected=[str(row.get("workflow_key")) for row in blocked],
+            next_action=str(blocked[0].get("next_action_cta") or "resolve_workflow_activation"),
+        )
+    elif degraded:
+        _add_issue(
+            risks,
+            category="workflow_activation",
+            message="One or more CMO workflows remain shadow, degraded, or paused.",
+            severity="medium",
+            affected=[str(row.get("workflow_key")) for row in degraded],
+            next_action="review_workflow_modes",
+        )
+    else:
+        proven.append(_capability("workflow_activation", "Pilot workflows have activation evidence."))
+    for row in rows:
+        refs.append(_ref("workflow_activation", row.get("workflow_key"), row))
+
+
+def _evaluate_workflow_lint(
+    lint_results: Iterable[Any] | None,
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    rows = list(lint_results or [])
+    if not rows:
+        _add_issue(
+            risks,
+            category="workflow_linter",
+            message="Workflow linter evidence is not attached to this pilot proof.",
+            severity="medium",
+            next_action="attach_workflow_lint_evidence",
+        )
+        return
+    errors = []
+    warnings = []
+    for row in rows:
+        result = _lint_result_dict(row)
+        errors.extend(_dicts(result.get("errors")))
+        warnings.extend(_dicts(result.get("warnings")))
+        refs.append(_ref("workflow_lint", result.get("workflow_file") or result.get("workflow_id"), result))
+    if errors:
+        _add_issue(
+            blockers,
+            category="workflow_linter",
+            message="Marketing workflow linter has production-blocking errors.",
+            severity="high",
+            affected=[str(item.get("code")) for item in errors],
+            next_action="fix_workflow_lint_errors",
+        )
+    elif warnings:
+        _add_issue(
+            risks,
+            category="workflow_linter",
+            message="Marketing workflow linter has warnings.",
+            severity="low",
+            affected=[str(item.get("code")) for item in warnings],
+            next_action="review_workflow_lint_warnings",
+        )
+    else:
+        proven.append(_capability("workflow_linter", "Workflow lint evidence has no production-blocking errors."))
+
+
+def _evaluate_summary_projection(
+    projection: Mapping[str, Any],
+    *,
+    summary_key: str,
+    capability_key: str,
+    blocker_status: str,
+    blocker_category: str,
+    blocker_message: str,
+    blockers: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    evidence_refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    summary = projection.get(summary_key) if isinstance(projection, Mapping) else None
+    summary_status = _normalize((summary or {}).get("status") or (summary or {}).get("readiness"))
+    if not isinstance(summary, Mapping) or summary_status == blocker_status:
+        _add_issue(
+            blockers,
+            category=blocker_category,
+            message=blocker_message,
+            severity="high",
+            next_action=str((summary or {}).get("next_action_cta") or f"configure_{capability_key}"),
+        )
+        next_actions.append(
+            _next_action(
+                str((summary or {}).get("next_action_cta") or f"configure_{capability_key}"),
+                "Configure Governance",
+            )
+        )
+    else:
+        proven.append(_capability(capability_key, f"{capability_key.replace('_', ' ').title()} is ready."))
+    if isinstance(summary, Mapping):
+        evidence_refs.append(_ref(capability_key, summary.get("policy_id") or summary.get("schema_version"), summary))
+
+
+def _evaluate_approval_timeout(
+    risk: Mapping[str, Any],
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    decisions = _dicts(risk.get("approval_timeout_decisions"))
+    overdue = _int(risk.get("overdue"))
+    timed_out = [
+        row
+        for row in decisions
+        if row.get("timed_out")
+        or row.get("outcome") in {"auto_cancel", "require_manual_resolution", "pause_workflow"}
+    ]
+    if overdue or timed_out:
+        _add_issue(
+            blockers,
+            category="approval_timeout",
+            message="Approval timeout evidence contains overdue or fail-closed approvals.",
+            severity="high",
+            next_action="resolve_approval_timeout",
+        )
+    else:
+        proven.append(_capability("approval_timeout_policy", "Approval timeout state has no overdue blockers."))
+    if not risk:
+        _add_issue(
+            risks,
+            category="approval_timeout",
+            message="No approval timeout evidence is attached.",
+            severity="low",
+            next_action="attach_approval_timeout_evidence",
+        )
+    for row in decisions:
+        refs.append(_ref("approval_timeout", row.get("approval_id") or row.get("event_id"), row))
+
+
+def _evaluate_external_writes(
+    writes: list[dict[str, Any]],
+    contracts: list[dict[str, Any]],
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    confirmed = [
+        row
+        for row in writes
+        if row.get("final_state") in {"write_confirmed", "idempotent_recovered"}
+        or row.get("step_status") == "completed"
+        or row.get("status") in {"write_confirmed", "idempotent_recovered"}
+    ]
+    confirmed.extend(
+        confirmation
+        for contract in contracts
+        for confirmation in _dicts(contract.get("external_write_confirmations"))
+        if confirmation.get("status") in {"write_confirmed", "idempotent_recovered"}
+    )
+    unsafe = [
+        row
+        for row in writes
+        if row.get("step_status") == "failed"
+        or row.get("final_state") in {"rejected", "timeout_unknown", "write_unconfirmed"}
+        or row.get("status") in {"rejected", "timeout_unknown", "write_unconfirmed"}
+    ]
+    if unsafe:
+        _add_issue(
+            blockers,
+            category="external_write",
+            message="External write evidence includes rejected, timeout/unknown, failed, or unconfirmed writes.",
+            severity="critical",
+            next_action="resolve_external_write_failure",
+        )
+    elif confirmed:
+        proven.append(
+            _capability(
+                "external_write_confirmation",
+                "At least one external write is confirmed or idempotently recovered.",
+            )
+        )
+    else:
+        _add_issue(
+            risks,
+            category="external_write",
+            message="No confirmed external write evidence is attached; read-only pilot proof can only be partial.",
+            severity="medium",
+            next_action="attach_confirmed_external_write_evidence",
+        )
+    for row in writes:
+        refs.append(
+            _ref(
+                "external_write",
+                row.get("audit_reference") or row.get("final_state") or row.get("status"),
+                row,
+            )
+        )
+    for row in confirmed:
+        refs.append(
+            _ref(
+                "external_write_confirmation",
+                row.get("audit_reference") or row.get("external_object_id"),
+                row,
+            )
+        )
+
+
+def _evaluate_kpis(
+    definitions: list[dict[str, Any]],
+    results: list[dict[str, Any]],
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    if not definitions or not results:
+        _add_issue(
+            blockers,
+            category="kpi_schema",
+            message="Unified CMO KPI schema or KPI result evidence is missing.",
+            severity="high",
+            next_action="attach_kpi_schema_evidence",
+        )
+        return
+    blocked = [row for row in results if row.get("status") in {"blocked", "unavailable"}]
+    degraded = [row for row in results if row.get("status") == "degraded"]
+    if blocked:
+        _add_issue(
+            blockers,
+            category="kpi_schema",
+            message="One or more critical CMO KPIs are blocked or unavailable.",
+            severity="high",
+            affected=[str(row.get("kpi_key")) for row in blocked],
+            next_action="resolve_kpi_blockers",
+        )
+    elif degraded:
+        _add_issue(
+            risks,
+            category="kpi_schema",
+            message="One or more CMO KPIs are degraded.",
+            severity="medium",
+            affected=[str(row.get("kpi_key")) for row in degraded],
+            next_action="review_degraded_kpis",
+        )
+    else:
+        proven.append(_capability("unified_kpi_schema", "Unified CMO KPI schema/results are ready."))
+    for row in results:
+        refs.append(_ref("kpi_result", row.get("kpi_key"), row))
+
+
+def _evaluate_reconciliation(
+    checks: list[dict[str, Any]],
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    if not checks:
+        _add_issue(
+            blockers,
+            category="kpi_reconciliation",
+            message="KPI reconciliation evidence is missing.",
+            severity="high",
+            next_action="run_kpi_reconciliation",
+        )
+        return
+    failed = [row for row in checks if row.get("status") in {"failed", "blocked"}]
+    warnings = [row for row in checks if row.get("status") == "warning"]
+    if failed:
+        _add_issue(
+            blockers,
+            category="kpi_reconciliation",
+            message="One or more KPI reconciliation checks failed or are blocked.",
+            severity="high",
+            affected=[str(row.get("reconciliation_key")) for row in failed],
+            next_action="resolve_reconciliation_failure",
+        )
+    elif warnings:
+        _add_issue(
+            risks,
+            category="kpi_reconciliation",
+            message="One or more KPI reconciliation checks warn.",
+            severity="medium",
+            affected=[str(row.get("reconciliation_key")) for row in warnings],
+            next_action="review_reconciliation_warnings",
+        )
+    else:
+        proven.append(_capability("kpi_reconciliation", "KPI reconciliation checks pass."))
+    for row in checks:
+        refs.append(_ref("kpi_reconciliation", row.get("reconciliation_key"), row))
+
+
+def _evaluate_report_gates(
+    gates: list[dict[str, Any]],
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    if not gates:
+        _add_issue(
+            blockers,
+            category="report_quality",
+            message="Report quality gate evidence is missing.",
+            severity="high",
+            next_action="run_report_quality_gates",
+        )
+        return
+    blocked = [
+        row
+        for row in gates
+        if row.get("status") in {"blocked", "unavailable"}
+        or row.get("safe_report_mode") in {"draft_only", "internal_only"}
+        or row.get("trusted_delivery_allowed") is False
+    ]
+    warnings = [row for row in gates if row.get("status") == "warning"]
+    if blocked:
+        _add_issue(
+            blockers,
+            category="report_quality",
+            message="One or more CMO report quality gates block trusted delivery.",
+            severity="high",
+            affected=[str(row.get("report_key")) for row in blocked],
+            next_action="resolve_report_quality_gate",
+        )
+    elif warnings:
+        _add_issue(
+            risks,
+            category="report_quality",
+            message="One or more CMO report quality gates warn.",
+            severity="medium",
+            affected=[str(row.get("report_key")) for row in warnings],
+            next_action="review_report_warnings",
+        )
+    else:
+        proven.append(_capability("report_quality_gates", "CMO report quality gates allow trusted delivery."))
+    for row in gates:
+        refs.append(_ref("report_quality_gate", row.get("report_key"), row))
+
+
+def _evaluate_work_queue(
+    queue: list[dict[str, Any]],
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    critical = [
+        row
+        for row in queue
+        if row.get("status") in {"open", "blocked", "waiting"}
+        and row.get("severity") in {"critical", "high"}
+    ]
+    lower = [
+        row
+        for row in queue
+        if row.get("status") in {"open", "blocked", "waiting"}
+        and row.get("severity") in {"medium", "low", "info"}
+    ]
+    if critical:
+        _add_issue(
+            blockers,
+            category="work_queue",
+            message="Critical or high CMO work queue items prevent passed pilot proof.",
+            severity="critical",
+            affected=[str(row.get("item_id")) for row in critical],
+            next_action=str(critical[0].get("next_action_key") or "resolve_work_queue"),
+        )
+    elif lower:
+        _add_issue(
+            risks,
+            category="work_queue",
+            message="Open CMO work queue warnings remain.",
+            severity="medium",
+            affected=[str(row.get("item_id")) for row in lower],
+            next_action="review_work_queue",
+        )
+    else:
+        proven.append(_capability("work_queue_clear", "No critical/high CMO work queue blockers remain."))
+    for row in queue:
+        refs.append(_ref("work_queue", row.get("item_id"), row))
+
+
+def _evaluate_drilldowns(
+    drilldowns: list[dict[str, Any]],
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    if not drilldowns:
+        _add_issue(
+            blockers,
+            category="kpi_lineage",
+            message="KPI drill-down/data-lineage evidence is missing.",
+            severity="high",
+            next_action="attach_kpi_lineage",
+        )
+        return
+    blocked = [
+        row
+        for row in drilldowns
+        if row.get("production_lineage_ready") is False
+        or row.get("production_lineage_status") == "blocked"
+        or row.get("status") in {"blocked", "unavailable"}
+    ]
+    degraded = [row for row in drilldowns if row.get("status") == "degraded"]
+    if blocked:
+        _add_issue(
+            blockers,
+            category="kpi_lineage",
+            message="KPI drill-down lineage blocks production proof.",
+            severity="high",
+            affected=[str(row.get("kpi_key")) for row in blocked],
+            next_action="resolve_kpi_lineage",
+        )
+    elif degraded:
+        _add_issue(
+            risks,
+            category="kpi_lineage",
+            message="KPI drill-down lineage is degraded.",
+            severity="medium",
+            affected=[str(row.get("kpi_key")) for row in degraded],
+            next_action="review_kpi_lineage",
+        )
+    else:
+        proven.append(_capability("kpi_drilldown_lineage", "KPI drill-down lineage is production-ready."))
+    for row in drilldowns:
+        refs.append(_ref("kpi_drilldown", row.get("kpi_key"), row))
+
+
+def _evaluate_approval_reviews(
+    projection: Mapping[str, Any],
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    reviews = _dicts(projection.get("cmo_approval_reviews"))
+    if not reviews:
+        _add_issue(
+            risks,
+            category="approval_review",
+            message="No approval-review evidence is attached; read-only proof may still be partial.",
+            severity="low",
+            next_action="attach_approval_review_evidence",
+        )
+        return
+    blocked = [row for row in reviews if row.get("status") in {"blocked", "timed_out"}]
+    if blocked:
+        _add_issue(
+            blockers,
+            category="approval_review",
+            message="Approval review evidence blocks approval-sensitive pilot actions.",
+            severity="high",
+            affected=[str(row.get("approval_id")) for row in blocked],
+            next_action="resolve_approval_review",
+        )
+    else:
+        proven.append(_capability("approval_review", "Approval review evidence is actionable."))
+    for row in reviews:
+        refs.append(_ref("approval_review", row.get("approval_id"), row))
+
+
+def _evaluate_agent_contracts(
+    agents: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    unproven: list[dict[str, Any]],
+    refs: list[dict[str, Any]],
+) -> None:
+    if not agents:
+        agents = marketing_agent_contract_specs()
+    for spec in agents:
+        agent_type = _normalize(spec.get("agent_type") or spec.get("agent"))
+        production_ready = bool(spec.get("production_ready"))
+        maturity = _normalize(spec.get("maturity") or spec.get("status"))
+        if production_ready:
+            proven.append(_capability(f"agent:{agent_type}", f"{agent_type} contract is production-capable."))
+        else:
+            unproven.append(
+                _capability(
+                    f"agent:{agent_type}",
+                    str(spec.get("blocker") or f"{agent_type} is {maturity or 'not production-ready'}."),
+                    status=maturity or "not_production_ready",
+                )
+            )
+        refs.append(_ref("agent_contract", agent_type, spec))
+    present = {_normalize(spec.get("agent_type") or spec.get("agent")) for spec in agents}
+    for key, reason in FIRST_CLASS_UNPROVEN_AGENT_KEYS.items():
+        if key not in present:
+            unproven.append(_capability(f"agent:{key}", reason, status="unavailable"))
+
+
+def _evaluate_test_evidence(
+    kind: str,
+    evidence: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    refs: list[dict[str, Any]],
+) -> None:
+    if not evidence:
+        _add_issue(
+            risks,
+            category=f"{kind}_evidence",
+            message=f"No CMO {kind} test evidence refs are attached to the pilot proof.",
+            severity="low",
+            next_action=f"attach_{kind}_test_evidence",
+        )
+        return
+    failures = [row for row in evidence if row.get("status") not in {"passed", "pass", "ok"}]
+    if failures:
+        _add_issue(
+            risks,
+            category=f"{kind}_evidence",
+            message=f"CMO {kind} test evidence includes non-passing cases.",
+            severity="medium",
+            affected=[str(row.get("scenario") or row.get("test") or row.get("ref")) for row in failures],
+            next_action=f"review_{kind}_test_evidence",
+        )
+    else:
+        proven.append(_capability(f"{kind}_test_evidence", f"CMO {kind} test evidence is passing."))
+    for row in evidence:
+        refs.append(_ref(f"{kind}_test", row.get("ref") or row.get("scenario") or row.get("test"), row))
+
+
+def _apply_environment_specific_rules(
+    env: str,
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    source_refs: list[dict[str, Any]],
+    report_refs: list[dict[str, Any]],
+    audit_refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    has_confirmed_write = any(item.get("capability_key") == "external_write_confirmation" for item in proven)
+    has_report = bool(report_refs)
+    has_audit = bool(audit_refs)
+    has_sources = bool(source_refs)
+    if env == "vendor_sandbox":
+        missing = []
+        if not has_confirmed_write:
+            missing.append("confirmed_external_write")
+        if not has_sources:
+            missing.append("source_refs")
+        if not has_report:
+            missing.append("report_proof")
+        if not has_audit:
+            missing.append("audit_refs")
+        if missing:
+            _add_issue(
+                risks,
+                category="sandbox_criteria",
+                message="Vendor-sandbox proof is partial until write, source, report, and audit evidence are attached.",
+                severity="medium",
+                affected=missing,
+                next_action="attach_sandbox_completion_evidence",
+            )
+        next_actions.append(_next_action("attach_sandbox_completion_evidence", "Attach Sandbox Completion Evidence"))
+    elif env == "real_vendor":
+        missing = []
+        if not has_confirmed_write:
+            missing.append("confirmed_external_write")
+        if not has_sources:
+            missing.append("source_refs")
+        if not has_report:
+            missing.append("report_proof")
+        if not has_audit:
+            missing.append("audit_refs")
+        if missing:
+            _add_issue(
+                blockers,
+                category="real_vendor_criteria",
+                message=(
+                    "Real-vendor proof is blocked until critical write, source, "
+                    "report, and audit evidence is present."
+                ),
+                severity="critical",
+                affected=missing,
+                next_action="attach_real_vendor_completion_evidence",
+            )
+        next_actions.append(_next_action("attach_real_vendor_completion_evidence", "Attach Real-Vendor Evidence"))
+
+
+def _proof_status(env: str, blockers: list[dict[str, Any]], risks: list[dict[str, Any]]) -> str:
+    if env == "demo":
+        return "demo_only"
+    if env == "test_double":
+        return "test_only"
+    if env == "unknown" and not blockers:
+        return "unavailable"
+    if blockers:
+        return "blocked"
+    if risks and env == "vendor_sandbox":
+        return "partial"
+    if risks and env != "real_vendor":
+        return "partial"
+    if risks and env == "real_vendor":
+        low_only = all(row.get("severity") in {"low", "info"} for row in risks)
+        return "passed" if low_only else "partial"
+    return "passed"
+
+
+def _readiness_score(
+    env: str,
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+) -> int:
+    score = 100
+    score -= min(len(blockers) * 12, 84)
+    score -= min(sum(4 if row.get("severity") in {"low", "info"} else 7 for row in risks), 35)
+    score += min(len(proven), 8)
+    if env == "demo":
+        score = min(score, 30)
+    elif env == "test_double":
+        score = min(score, 35)
+    elif env == "unknown":
+        score = min(score, 60)
+    elif env == "vendor_sandbox":
+        score = min(score, 92)
+    return max(min(score, 100), 0)
+
+
+def _resolve_environment_type(
+    explicit: str | None,
+    source_context: Mapping[str, Any],
+    contracts: list[dict[str, Any]],
+) -> str:
+    candidates = [
+        explicit,
+        source_context.get("cmo_pilot_environment_type"),
+        source_context.get("pilot_environment_type"),
+        source_context.get("environment_type"),
+        source_context.get("environment"),
+    ]
+    for candidate in candidates:
+        normalized = _normalize(candidate)
+        if normalized in ENVIRONMENT_TYPES:
+            return normalized
+        if normalized in {"sandbox", "vendor_test", "vendor_sandbox"}:
+            return "vendor_sandbox"
+        if normalized in {"real", "production_vendor", "live_vendor"}:
+            return "real_vendor"
+    source = _normalize(source_context.get("source"))
+    if source_context.get("demo") or source in DEMO_SOURCE_MARKERS:
+        return "demo"
+    if source in TEST_SOURCE_MARKERS or any(row.get("mock_or_test_double") for row in contracts):
+        return "test_double"
+    return "unknown"
+
+
+def _connector_source_refs(
+    contracts: list[dict[str, Any]],
+    drilldowns: list[dict[str, Any]],
+    kpis: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    refs: list[dict[str, Any]] = []
+    for row in contracts:
+        for source in _dicts(row.get("source_objects")):
+            refs.append(_ref("connector_source", row.get("connector_key"), source))
+    for row in drilldowns:
+        for source in _dicts(row.get("source_refs")):
+            refs.append(_ref("kpi_drilldown_source", row.get("kpi_key"), source))
+    for row in kpis:
+        for source in _dicts(row.get("source_refs")):
+            refs.append(_ref("kpi_source", row.get("kpi_key"), source))
+    return _dedupe_refs(refs)
+
+
+def _report_refs(gates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        _ref("report_quality_gate", row.get("report_key"), row)
+        for row in gates
+        if row.get("status") in {"pass", "passed"} or row.get("safe_report_mode") == "deliverable"
+    ]
+
+
+def _audit_refs(
+    audit: Mapping[str, Any],
+    approvals: Mapping[str, Any],
+    writes: list[dict[str, Any]],
+    reports: list[dict[str, Any]],
+    kpis: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    refs: list[dict[str, Any]] = []
+    for key in ("audit_ref", "audit_reference", "audit_id"):
+        if audit.get(key):
+            refs.append(_ref("decision_audit", audit.get(key), {key: audit.get(key)}))
+    summary = audit.get("marketing_decision_audit_summary")
+    if isinstance(summary, Mapping) and summary.get("status") == "ready":
+        refs.append(_ref("decision_audit_summary", summary.get("schema_version"), summary))
+    for row in _dicts(approvals.get("cmo_approval_reviews")):
+        for value in _string_list(row.get("audit_refs")):
+            refs.append(_ref("approval_audit", value, row))
+    for row in writes:
+        for key in ("audit_reference", "audit_ref"):
+            if row.get(key):
+                refs.append(_ref("external_write_audit", row.get(key), row))
+    for row in reports:
+        for value in _string_list(row.get("required_approval_audit_refs") or row.get("audit_refs")):
+            refs.append(_ref("report_audit", value, row))
+    for row in kpis:
+        for value in _string_list(row.get("audit_refs") or row.get("audit_ref")):
+            refs.append(_ref("kpi_audit", value, row))
+    return _dedupe_refs(refs)
+
+
+def _summary_next_action(status: str, blockers: list[dict[str, Any]], risks: list[dict[str, Any]]) -> str:
+    if status in {"demo_only", "test_only"}:
+        return "connect_real_or_vendor_sandbox"
+    if blockers:
+        return str(blockers[0].get("next_action") or "resolve_pilot_blockers")
+    if risks:
+        return str(risks[0].get("next_action") or "review_pilot_risks")
+    return "none"
+
+
+def _proof_id(
+    tenant_id: str | None,
+    company_id: str | None,
+    env: str,
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    source_refs: list[dict[str, Any]],
+    report_refs: list[dict[str, Any]],
+) -> str:
+    payload = {
+        "tenant_id": tenant_id,
+        "company_id": company_id,
+        "environment_type": env,
+        "blockers": blockers,
+        "risks": risks,
+        "proven": proven,
+        "source_refs": source_refs,
+        "report_refs": report_refs,
+    }
+    digest = hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:20]
+    return f"cmo_pilot_proof_{digest}"
+
+
+def _lint_result_dict(row: Any) -> dict[str, Any]:
+    if isinstance(row, Mapping):
+        result = dict(row)
+    else:
+        result = {
+            "has_errors": bool(getattr(row, "has_errors", False)),
+            "errors": [getattr(item, "__dict__", item) for item in getattr(row, "errors", [])],
+            "warnings": [getattr(item, "__dict__", item) for item in getattr(row, "warnings", [])],
+            "workflow_file": getattr(row, "workflow_file", None),
+            "workflow_id": getattr(row, "workflow_id", None),
+        }
+    return _redact(result)
+
+
+def _add_issue(
+    target: list[dict[str, Any]],
+    *,
+    category: str,
+    message: str,
+    severity: str,
+    next_action: str,
+    affected: Iterable[str] | None = None,
+) -> None:
+    target.append(
+        {
+            "category": category,
+            "severity": severity,
+            "message": message,
+            "affected": sorted({str(item) for item in affected or [] if item}),
+            "next_action": next_action,
+        }
+    )
+
+
+def _capability(key: str, description: str, *, status: str = "proven") -> dict[str, Any]:
+    return {"capability_key": key, "status": status, "description": description}
+
+
+def _ref(ref_type: str, ref_id: Any, source: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    return _redact(
+        {
+            "type": ref_type,
+            "ref_id": _string_or_none(ref_id) or _stable_ref(ref_type, source or {}),
+            "connector_key": (source or {}).get("connector_key"),
+            "status": (source or {}).get("status") or (source or {}).get("readiness"),
+            "source_url": (source or {}).get("source_url") or (source or {}).get("url"),
+            "audit_reference": (source or {}).get("audit_reference") or (source or {}).get("audit_ref"),
+        }
+    )
+
+
+def _next_action(action_key: str, label: str) -> dict[str, str]:
+    return {"action_key": action_key, "label": label}
+
+
+def _stable_ref(ref_type: str, source: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(_canonical_json(source).encode("utf-8")).hexdigest()[:12]
+    return f"{ref_type}_{digest}"
+
+
+def _dedupe_issues(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    output: list[dict[str, Any]] = []
+    for row in rows:
+        key = f"{row.get('category')}|{row.get('message')}|{','.join(row.get('affected') or [])}"
+        if key in seen:
+            continue
+        seen.add(key)
+        output.append(row)
+    return output
+
+
+def _dedupe_capabilities(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    output: list[dict[str, Any]] = []
+    for row in rows:
+        key = str(row.get("capability_key") or row.get("description"))
+        if key in seen:
+            continue
+        seen.add(key)
+        output.append(row)
+    return output
+
+
+def _dedupe_refs(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    output: list[dict[str, Any]] = []
+    for row in rows:
+        key = f"{row.get('type')}|{row.get('ref_id')}"
+        if key in seen:
+            continue
+        seen.add(key)
+        output.append(row)
+    return output
+
+
+def _dedupe_actions(rows: list[dict[str, str]]) -> list[dict[str, str]]:
+    seen: set[str] = set()
+    output: list[dict[str, str]] = []
+    for row in rows:
+        key = str(row.get("action_key") or row.get("label"))
+        if key in seen or key in {"", "none"}:
+            continue
+        seen.add(key)
+        output.append(row)
+    return output
+
+
+def _dicts(value: Any) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if isinstance(value, Mapping):
+        return [dict(value)]
+    if isinstance(value, list | tuple | set):
+        return [dict(item) for item in value if isinstance(item, Mapping)]
+    return []
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value else []
+    if isinstance(value, list | tuple | set):
+        return [str(item) for item in value if item not in {None, ""}]
+    return []
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _iso(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.isoformat()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(_redact(value), sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _redact(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            text_key = str(key)
+            if any(marker in text_key.lower() for marker in SECRET_KEY_MARKERS):
+                redacted[text_key] = "[REDACTED]"
+            else:
+                redacted[text_key] = _redact(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    if isinstance(value, tuple | set):
+        return [_redact(item) for item in value]
+    return value

--- a/core/marketing/policy_manifest.py
+++ b/core/marketing/policy_manifest.py
@@ -1,0 +1,1074 @@
+"""Machine-checkable CMO marketing policy manifest.
+
+CMO-6.1 makes marketing autonomy policy explicit. The default manifest is
+conservative for real companies: customer-facing writes require approval,
+crisis/legal/comparative claims escalate, destructive actions are blocked, and
+shadow mode remains read-only.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from core.marketing.decision_audit import build_policy_decision_audit
+from core.marketing.escalation_matrix import evaluate_marketing_escalation
+
+POLICY_DECISIONS = (
+    "allowed",
+    "blocked",
+    "requires_approval",
+    "requires_escalation",
+    "read_only_only",
+    "missing_policy",
+)
+
+ACTIVE_MODES = {"active", "prod", "production"}
+SHADOW_MODES = {"shadow", "draft", "internal", "internal_only", "recommendation", "simulation"}
+
+READ_ONLY_ACTIONS = {
+    "account_deal_health_summary",
+    "account_health_summary",
+    "aggregate_engagement",
+    "aggregate_intent",
+    "aggregate_weekly_metrics",
+    "analyze",
+    "analyze_pipeline_velocity",
+    "churn_risk_signal_extraction",
+    "compile_weekly_digest",
+    "create_approval",
+    "create_draft",
+    "create_internal_approval",
+    "create_plan",
+    "detect_crisis",
+    "detect_negative_spike",
+    "draft",
+    "draft_social_post",
+    "extract_churn_signals",
+    "funnel_conversion_analysis",
+    "generate_content_calendar",
+    "generate",
+    "generate_campaign_assets",
+    "generate_content",
+    "generate_weekly_calendar",
+    "generate_weekly_report",
+    "get_keyword_rankings",
+    "get_sentiment",
+    "lead_scoring_refresh",
+    "mention_aggregation",
+    "get_weekly_metrics",
+    "get_weekly_engagement",
+    "identify_content_gaps",
+    "keyword_gap_analysis",
+    "monitor_mentions",
+    "optimize_content",
+    "pipeline_velocity_analysis",
+    "promote_to_sql",
+    "recommend_response_playbook",
+    "recommend_segments",
+    "optimize_posting_schedule",
+    "prioritize_technical_issues",
+    "query_target_accounts",
+    "recommend",
+    "recommend_next_best_action",
+    "refresh_lead_scores",
+    "ranking_delta_computation",
+    "recommendation_bundling",
+    "score_accounts",
+    "score_icp_fit",
+    "score_intent_heat",
+    "segment_recommendation",
+    "seo_sprint_planning",
+    "score_lead",
+    "segment_list",
+    "simulate",
+    "sql_promotion_criteria",
+    "validate_account_csv",
+    "triage_engagement",
+    "classify_reply_risk",
+    "change_confidence_score",
+    "duplicate_change_suppression",
+    "evaluate_alert_thresholds",
+    "extract_win_loss_signals",
+    "feature_capability_diffing",
+    "technical_issue_prioritization",
+    "weekly_benchmark",
+    "weekly_market_snapshot",
+    "normalize_competitor_profiles",
+    "positioning_recommendation",
+    "pricing_change_detection",
+}
+
+CUSTOMER_FACING_WRITE_ACTIONS = {
+    "activate_campaign",
+    "add_to_drip",
+    "apply_redirect",
+    "bulk_crm_update",
+    "change_segment_membership",
+    "change_target_accounts",
+    "create_abm_campaign",
+    "create_campaign",
+    "create_linkedin_campaign",
+    "launch_abm_campaign",
+    "launch_campaign",
+    "launch_competitive_campaign",
+    "manage_campaign",
+    "mutate_ad_budget",
+    "pause_campaign",
+    "promote_lifecycle_stage",
+    "publish",
+    "publish_brand_response",
+    "publish_competitive_response",
+    "publish_landing_page",
+    "publish_post",
+    "publish_seo_change",
+    "publish_to_wordpress",
+    "public_response",
+    "reply_to_mention",
+    "schedule_campaign_posts",
+    "schedule_content",
+    "schedule_content_promotion",
+    "schedule_post",
+    "send",
+    "send_email",
+    "send_to_segment",
+    "send_winner",
+    "setup",
+    "setup_google_campaign",
+    "setup_meta_campaign",
+    "spend",
+    "start_nurture_sequence",
+    "sync_target_accounts",
+    "target_account_list_change",
+    "submit_url_to_index",
+    "update_ad_budget",
+    "update_canonical_tag",
+    "update_crm",
+    "update_landing_page",
+    "update_lead_scores",
+    "update_lifecycle_stage",
+    "update_page_metadata",
+    "update_robots_txt",
+    "update_segment_membership",
+    "update_sitemap",
+    "update_target_accounts",
+    "write_external",
+}
+
+BUDGET_ACTIONS = {
+    "activate_campaign",
+    "create_abm_campaign",
+    "create_campaign",
+    "create_linkedin_campaign",
+    "launch_abm_campaign",
+    "launch_campaign",
+    "launch_competitive_campaign",
+    "mutate_ad_budget",
+    "set_abm_budget",
+    "setup_google_campaign",
+    "setup_meta_campaign",
+    "spend",
+    "update_ad_budget",
+}
+
+CRISIS_ACTIONS = {
+    "crisis_response",
+    "detect_crisis",
+    "publish_brand_response",
+    "public_response",
+}
+
+HIGH_RISK_CLAIM_ACTIONS = {
+    "brand_claim",
+    "claims_review",
+    "comparative_claim",
+    "compliance_claim",
+    "high_risk_copy",
+    "legal_claim",
+    "pricing_claim",
+    "regulated_claim",
+    "sensitive_claim",
+}
+
+TARGET_ACCOUNT_ACTIONS = {
+    "change_target_accounts",
+    "query_target_accounts",
+    "sync_target_accounts",
+    "target_account_list_change",
+    "update_target_accounts",
+}
+
+DISALLOWED_ACTIONS = {
+    "bulk_delete_audience",
+    "bulk_unsubscribe",
+    "delete_audience",
+    "delete_campaign",
+    "delete_contact_list",
+    "delete_crm_records",
+    "disable_tracking",
+    "purge_list",
+    "remove_all_budget_caps",
+    "write_external_without_confirmation",
+}
+
+DEFAULT_REQUIRED_AUDIT = {
+    "approval": ("approval_record", "policy_decision", "workflow_run", "actor"),
+    "escalation": (
+        "approval_record",
+        "escalation_record",
+        "policy_decision",
+        "workflow_run",
+        "actor",
+    ),
+    "blocked": ("policy_decision", "workflow_run", "actor"),
+    "allowed": ("policy_decision", "workflow_run", "actor"),
+}
+
+
+@dataclass(frozen=True)
+class MarketingPolicyRule:
+    rule_id: str
+    description: str
+    decision: str
+    actions: tuple[str, ...] = ()
+    required_approver_role: str | None = None
+    required_escalation_role: str | None = None
+    required_audit_evidence: tuple[str, ...] = ()
+    next_action_cta: str = "none"
+    reason: str = ""
+    threshold: int | float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rule_id": self.rule_id,
+            "description": self.description,
+            "decision": self.decision,
+            "actions": list(self.actions),
+            "required_approver_role": self.required_approver_role,
+            "required_escalation_role": self.required_escalation_role,
+            "required_audit_evidence": list(self.required_audit_evidence),
+            "next_action_cta": self.next_action_cta,
+            "reason": self.reason,
+            "threshold": self.threshold,
+        }
+
+
+@dataclass(frozen=True)
+class MarketingPolicyManifest:
+    policy_id: str
+    version: str
+    rules: tuple[MarketingPolicyRule, ...]
+    allowed_autonomous_actions: tuple[str, ...]
+    disallowed_autonomous_actions: tuple[str, ...]
+    budget_thresholds: dict[str, int]
+    audience_size_threshold: int
+    target_account_change_threshold: int
+    high_risk_copy_categories: tuple[str, ...]
+    region_legal_constraints: dict[str, tuple[str, ...]]
+    required_approval_roles: tuple[str, ...]
+    required_audit_evidence_classes: tuple[str, ...]
+    shadow_mode_allowances: tuple[str, ...]
+    active_mode_allowances: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "policy_id": self.policy_id,
+            "version": self.version,
+            "rules": [rule.to_dict() for rule in self.rules],
+            "allowed_autonomous_actions": list(self.allowed_autonomous_actions),
+            "disallowed_autonomous_actions": list(self.disallowed_autonomous_actions),
+            "budget_thresholds": dict(self.budget_thresholds),
+            "audience_size_threshold": self.audience_size_threshold,
+            "target_account_change_threshold": self.target_account_change_threshold,
+            "high_risk_copy_categories": list(self.high_risk_copy_categories),
+            "region_legal_constraints": {
+                key: list(values)
+                for key, values in self.region_legal_constraints.items()
+            },
+            "required_approval_roles": list(self.required_approval_roles),
+            "required_audit_evidence_classes": list(self.required_audit_evidence_classes),
+            "shadow_mode_allowances": list(self.shadow_mode_allowances),
+            "active_mode_allowances": list(self.active_mode_allowances),
+        }
+
+
+DEFAULT_MARKETING_POLICY_MANIFEST = MarketingPolicyManifest(
+    policy_id="cmo_default_marketing_policy",
+    version="2026-05-23.cmo-6.1",
+    rules=(
+        MarketingPolicyRule(
+            rule_id="cmo_forbidden_destructive_actions",
+            description="Destructive or irreversible external marketing actions are blocked by default.",
+            decision="blocked",
+            actions=tuple(sorted(DISALLOWED_ACTIONS)),
+            required_audit_evidence=DEFAULT_REQUIRED_AUDIT["blocked"],
+            next_action_cta="remove_destructive_action",
+            reason="Destructive or irreversible marketing action is disallowed by policy.",
+        ),
+        MarketingPolicyRule(
+            rule_id="cmo_crisis_public_response_escalation",
+            description="Crisis and public-response actions require executive escalation.",
+            decision="requires_escalation",
+            actions=tuple(sorted(CRISIS_ACTIONS)),
+            required_escalation_role="ceo",
+            required_audit_evidence=DEFAULT_REQUIRED_AUDIT["escalation"],
+            next_action_cta="escalate_crisis_response_to_exec",
+            reason="Crisis or public response requires executive escalation.",
+        ),
+        MarketingPolicyRule(
+            rule_id="cmo_high_risk_claims_review",
+            description="Pricing, legal, compliance, comparative, and sensitive claims require review.",
+            decision="requires_escalation",
+            required_escalation_role="legal",
+            required_audit_evidence=DEFAULT_REQUIRED_AUDIT["escalation"],
+            next_action_cta="request_legal_or_compliance_review",
+            reason="High-risk marketing copy or claim requires legal/compliance review.",
+        ),
+        MarketingPolicyRule(
+            rule_id="cmo_budget_threshold_approval",
+            description="Budget increases above channel threshold require approval.",
+            decision="requires_approval",
+            actions=tuple(sorted(BUDGET_ACTIONS)),
+            required_approver_role="cmo",
+            required_audit_evidence=DEFAULT_REQUIRED_AUDIT["approval"],
+            next_action_cta="request_budget_approval",
+            reason="Budget change exceeds the configured approval threshold.",
+        ),
+        MarketingPolicyRule(
+            rule_id="cmo_audience_threshold_approval",
+            description="Large audience or list-size changes require approval.",
+            decision="requires_approval",
+            required_approver_role="cmo",
+            required_audit_evidence=DEFAULT_REQUIRED_AUDIT["approval"],
+            next_action_cta="request_audience_approval",
+            reason="Audience/list size exceeds the configured approval threshold.",
+        ),
+        MarketingPolicyRule(
+            rule_id="cmo_target_account_threshold_approval",
+            description="Target account list changes above threshold require approval.",
+            decision="requires_approval",
+            actions=tuple(sorted(TARGET_ACCOUNT_ACTIONS)),
+            required_approver_role="revops_lead",
+            required_audit_evidence=DEFAULT_REQUIRED_AUDIT["approval"],
+            next_action_cta="request_target_account_approval",
+            reason="Target account list change exceeds the configured threshold.",
+        ),
+        MarketingPolicyRule(
+            rule_id="cmo_publish_send_launch_approval",
+            description="Customer-facing publish, send, launch, spend, and update actions require approval.",
+            decision="requires_approval",
+            actions=tuple(sorted(CUSTOMER_FACING_WRITE_ACTIONS)),
+            required_approver_role="cmo",
+            required_audit_evidence=DEFAULT_REQUIRED_AUDIT["approval"],
+            next_action_cta="request_marketing_approval",
+            reason="Customer-facing marketing write requires approval.",
+        ),
+        MarketingPolicyRule(
+            rule_id="cmo_read_only_autonomy",
+            description="Read-only analysis, recommendation, drafting, and simulation can run autonomously.",
+            decision="allowed",
+            actions=tuple(sorted(READ_ONLY_ACTIONS)),
+            required_audit_evidence=DEFAULT_REQUIRED_AUDIT["allowed"],
+            next_action_cta="none",
+            reason="Read-only marketing action is allowed by policy.",
+        ),
+    ),
+    allowed_autonomous_actions=tuple(sorted(READ_ONLY_ACTIONS)),
+    disallowed_autonomous_actions=tuple(sorted(DISALLOWED_ACTIONS)),
+    budget_thresholds={
+        "default": 500,
+        "google_ads": 1000,
+        "meta_ads": 1000,
+        "linkedin_ads": 1500,
+        "email": 250,
+        "cms": 0,
+        "social": 250,
+    },
+    audience_size_threshold=50000,
+    target_account_change_threshold=25,
+    high_risk_copy_categories=(
+        "pricing",
+        "legal",
+        "compliance",
+        "comparative",
+        "competitor",
+        "regulated_industry",
+        "sensitive_claim",
+    ),
+    region_legal_constraints={
+        "eu": ("privacy", "gdpr", "regulated_claims"),
+        "in": ("privacy", "regulated_claims"),
+        "us": ("pricing", "regulated_claims"),
+    },
+    required_approval_roles=("cmo", "content_lead", "legal", "revops_lead", "ceo"),
+    required_audit_evidence_classes=(
+        "approval_record",
+        "audit_reference",
+        "connector_confirmation",
+        "escalation_record",
+        "external_object_id",
+        "policy_decision",
+        "workflow_run",
+    ),
+    shadow_mode_allowances=("recommend", "draft", "simulate", "create_internal_approval"),
+    active_mode_allowances=("approved_external_write", "confirmed_external_write"),
+)
+
+
+def default_marketing_policy_manifest() -> dict[str, Any]:
+    """Return a serializable copy of the default marketing policy manifest."""
+
+    return DEFAULT_MARKETING_POLICY_MANIFEST.to_dict()
+
+
+def load_marketing_policy_manifest(
+    source: Mapping[str, Any] | None = None,
+    *,
+    use_default: bool = True,
+) -> dict[str, Any] | None:
+    """Load a manifest from workflow/config source or return the default.
+
+    Passing an explicit disabled flag or an empty explicit manifest returns
+    ``None`` so callers can test fail-closed missing-policy behavior.
+    """
+
+    if _manifest_disabled(source):
+        return None
+    candidate = _manifest_candidate(source)
+    if candidate is None:
+        return default_marketing_policy_manifest() if use_default else None
+    if not candidate:
+        return None
+    manifest = _normalize_manifest(candidate)
+    if not manifest.get("policy_id") or not manifest.get("version"):
+        return None
+    return manifest
+
+
+def evaluate_marketing_policy(
+    context: Mapping[str, Any] | None = None,
+    manifest: Mapping[str, Any] | None = None,
+    *,
+    use_default: bool = True,
+) -> dict[str, Any]:
+    """Evaluate a marketing workflow/action context against the manifest."""
+
+    ctx = _normalize_context(context)
+    manifest_source = manifest if manifest is not None else ctx
+    loaded = load_marketing_policy_manifest(manifest_source, use_default=use_default)
+    if loaded is None:
+        return _missing_policy_decision(ctx)
+
+    policy_id = str(loaded.get("policy_id"))
+    version = str(loaded.get("version"))
+    action = ctx["action"]
+    mode = ctx["workflow_mode"]
+
+    if mode in SHADOW_MODES and (ctx["external_write_required"] or action in CUSTOMER_FACING_WRITE_ACTIONS):
+        return _decision(
+            policy_id=policy_id,
+            version=version,
+            matched_rules=[_rule_dict(loaded, "cmo_shadow_read_only")],
+            decision="read_only_only",
+            reason="Shadow, draft, and internal marketing workflows cannot execute external writes.",
+            required_approver_role=None,
+            required_escalation_role=None,
+            required_audit_evidence=DEFAULT_REQUIRED_AUDIT["blocked"],
+            affected_workflow=ctx["workflow_id"],
+            affected_action=action,
+            next_action_cta="convert_to_recommendation_or_draft",
+        )
+
+    blocked_rule = _manifest_rule(loaded, "cmo_forbidden_destructive_actions")
+    if action in _string_set(loaded.get("disallowed_autonomous_actions")) or action in DISALLOWED_ACTIONS:
+        return _decision_from_rule(loaded, blocked_rule, ctx)
+
+    crisis_rule = _manifest_rule(loaded, "cmo_crisis_public_response_escalation")
+    if action in CRISIS_ACTIONS or ctx["crisis_response"] or ctx["public_response"]:
+        return _decision_from_rule(loaded, crisis_rule, ctx)
+
+    high_risk_rule = _manifest_rule(loaded, "cmo_high_risk_claims_review")
+    if _has_high_risk_claim(ctx):
+        return _decision_from_rule(loaded, high_risk_rule, ctx)
+
+    region_rule = high_risk_rule
+    if _matches_region_constraint(ctx, loaded):
+        return _decision_from_rule(
+            loaded,
+            {
+                **region_rule,
+                "rule_id": "cmo_region_legal_constraints",
+                "reason": "Regional legal constraints require legal/compliance review.",
+                "next_action_cta": "request_regional_legal_review",
+            },
+            ctx,
+        )
+
+    budget_rule = _manifest_rule(loaded, "cmo_budget_threshold_approval")
+    if _budget_change_requires_approval(ctx, loaded):
+        return _decision_from_rule(loaded, budget_rule, ctx)
+
+    audience_rule = _manifest_rule(loaded, "cmo_audience_threshold_approval")
+    if _audience_requires_approval(ctx, loaded):
+        return _decision_from_rule(loaded, audience_rule, ctx)
+
+    target_rule = _manifest_rule(loaded, "cmo_target_account_threshold_approval")
+    if _target_accounts_require_approval(ctx, loaded):
+        return _decision_from_rule(loaded, target_rule, ctx)
+
+    write_rule = _manifest_rule(loaded, "cmo_publish_send_launch_approval")
+    if action in CUSTOMER_FACING_WRITE_ACTIONS or ctx["customer_facing"] or ctx["external_write_required"]:
+        return _decision_from_rule(loaded, write_rule, ctx)
+
+    read_only_rule = _manifest_rule(loaded, "cmo_read_only_autonomy")
+    allowed_actions = _string_set(loaded.get("allowed_autonomous_actions")) | READ_ONLY_ACTIONS
+    if action in allowed_actions:
+        return _decision_from_rule(loaded, read_only_rule, ctx)
+
+    if mode in ACTIVE_MODES:
+        return _decision(
+            policy_id=policy_id,
+            version=version,
+            matched_rules=[],
+            decision="missing_policy",
+            reason="No marketing policy rule covers this active workflow action.",
+            required_approver_role=None,
+            required_escalation_role=None,
+            required_audit_evidence=DEFAULT_REQUIRED_AUDIT["blocked"],
+            affected_workflow=ctx["workflow_id"],
+            affected_action=action,
+            next_action_cta="add_marketing_policy_rule",
+        )
+
+    return _decision(
+        policy_id=policy_id,
+        version=version,
+        matched_rules=[read_only_rule],
+        decision="read_only_only",
+        reason="Non-production action may continue only as read-only or shadow output.",
+        required_approver_role=None,
+        required_escalation_role=None,
+        required_audit_evidence=DEFAULT_REQUIRED_AUDIT["allowed"],
+        affected_workflow=ctx["workflow_id"],
+        affected_action=action,
+        next_action_cta="label_as_read_only_recommendation",
+    )
+
+
+def build_workflow_marketing_policy_status(
+    workflow_key: str,
+    actions: Iterable[Any],
+    payload: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Project policy coverage for one CMO workflow activation row."""
+
+    payload = payload if isinstance(payload, Mapping) else {}
+    required_actions = _unique(_normalize_key(action) for action in actions)
+    evaluations = [
+        evaluate_marketing_policy(
+            {
+                **dict(payload),
+                "workflow_id": workflow_key,
+                "workflow_mode": "active",
+                "action": action,
+                "external_write_required": True,
+                "customer_facing": True,
+            },
+            use_default=True,
+        )
+        for action in required_actions
+    ]
+
+    if not required_actions:
+        status = "not_required"
+        next_action = "none"
+    elif any(item["decision"] == "missing_policy" for item in evaluations):
+        status = "missing_policy"
+        next_action = "configure_marketing_policy_manifest"
+    elif any(item["decision"] in {"blocked", "read_only_only"} for item in evaluations):
+        status = "blocked"
+        next_action = "revise_workflow_or_policy"
+    else:
+        status = "ready"
+        next_action = "none"
+
+    return {
+        "workflow_key": _normalize_key(workflow_key),
+        "status": status,
+        "required_actions": required_actions,
+        "covered_actions": [
+            item["affected_action"]
+            for item in evaluations
+            if item["decision"] in {"allowed", "requires_approval", "requires_escalation"}
+        ],
+        "missing_policy_actions": [
+            item["affected_action"]
+            for item in evaluations
+            if item["decision"] == "missing_policy"
+        ],
+        "blocked_actions": [
+            item["affected_action"]
+            for item in evaluations
+            if item["decision"] in {"blocked", "read_only_only"}
+        ],
+        "evaluations": evaluations,
+        "next_action_cta": next_action,
+    }
+
+
+def build_marketing_policy_projection(
+    sources: Iterable[Any] | None = None,
+) -> dict[str, Any]:
+    """Build a KPI/API projection for the active marketing policy manifest."""
+
+    manifest = None
+    for source in sources or []:
+        config = _config_dict(source)
+        if _manifest_disabled(config):
+            return {
+                "marketing_policy_manifest": None,
+                "marketing_policy_summary": summarize_marketing_policy_manifest(
+                    {"marketing_policy_manifest_disabled": True}
+                ),
+            }
+        candidate = load_marketing_policy_manifest(config, use_default=False)
+        if candidate is not None:
+            manifest = candidate
+            break
+    if manifest is None:
+        manifest = default_marketing_policy_manifest()
+    return {
+        "marketing_policy_manifest": manifest,
+        "marketing_policy_summary": summarize_marketing_policy_manifest(manifest),
+    }
+
+
+def summarize_marketing_policy_manifest(manifest: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    loaded = load_marketing_policy_manifest(manifest, use_default=True)
+    if loaded is None:
+        return {
+            "status": "missing_policy",
+            "policy_id": None,
+            "version": None,
+            "rule_count": 0,
+            "next_action_cta": "configure_marketing_policy_manifest",
+        }
+    rules = list(loaded.get("rules") or [])
+    decisions = dict.fromkeys(POLICY_DECISIONS, 0)
+    for rule in rules:
+        decision = str(rule.get("decision") or "")
+        if decision in decisions:
+            decisions[decision] += 1
+    return {
+        "status": "ready",
+        "policy_id": loaded.get("policy_id"),
+        "version": loaded.get("version"),
+        "rule_count": len(rules),
+        "allowed_autonomous_actions": len(loaded.get("allowed_autonomous_actions") or []),
+        "disallowed_autonomous_actions": len(loaded.get("disallowed_autonomous_actions") or []),
+        "next_action_cta": "none",
+        **decisions,
+    }
+
+
+def marketing_policy_allows_external_write(
+    decision: Mapping[str, Any] | None,
+    *,
+    approval_satisfied: bool = False,
+) -> bool:
+    """Return true only when policy permits the active external write."""
+
+    if not isinstance(decision, Mapping):
+        return False
+    outcome = str(decision.get("decision") or "")
+    if outcome == "allowed":
+        return True
+    if outcome in {"requires_approval", "requires_escalation"}:
+        return approval_satisfied
+    return False
+
+
+def _decision_from_rule(
+    manifest: Mapping[str, Any],
+    rule: Mapping[str, Any],
+    ctx: Mapping[str, Any],
+) -> dict[str, Any]:
+    return _decision(
+        policy_id=str(manifest.get("policy_id")),
+        version=str(manifest.get("version")),
+        matched_rules=[dict(rule)],
+        decision=str(rule.get("decision") or "missing_policy"),
+        reason=str(rule.get("reason") or rule.get("description") or ""),
+        required_approver_role=_string_or_none(rule.get("required_approver_role")),
+        required_escalation_role=_string_or_none(rule.get("required_escalation_role")),
+        required_audit_evidence=_string_list(rule.get("required_audit_evidence")),
+        affected_workflow=str(ctx.get("workflow_id") or ""),
+        affected_action=str(ctx.get("action") or ""),
+        next_action_cta=str(rule.get("next_action_cta") or "none"),
+    )
+
+
+def _decision(
+    *,
+    policy_id: str | None,
+    version: str | None,
+    matched_rules: list[Mapping[str, Any]],
+    decision: str,
+    reason: str,
+    required_approver_role: str | None,
+    required_escalation_role: str | None,
+    required_audit_evidence: Iterable[str],
+    affected_workflow: str,
+    affected_action: str,
+    next_action_cta: str,
+) -> dict[str, Any]:
+    normalized_decision = decision if decision in POLICY_DECISIONS else "missing_policy"
+    matched = [dict(rule) for rule in matched_rules]
+    escalation_decision = _escalation_for_policy_decision(
+        normalized_decision,
+        affected_workflow,
+        affected_action,
+        matched,
+        required_escalation_role,
+        required_approver_role,
+        reason,
+    )
+    result = {
+        "policy_id": policy_id,
+        "version": version,
+        "matched_rules": matched,
+        "decision": normalized_decision,
+        "reason": reason,
+        "required_approver_role": required_approver_role,
+        "required_escalation_role": required_escalation_role,
+        "required_audit_evidence": list(required_audit_evidence),
+        "affected_workflow": affected_workflow,
+        "affected_action": affected_action,
+        "next_action_cta": next_action_cta,
+        "escalation_decision": escalation_decision,
+        "escalation_evidence": escalation_decision.get("evidence") if escalation_decision else None,
+    }
+    audit_package = build_policy_decision_audit(result)
+    result["decision_audit"] = audit_package
+    result["decision_audit_ref"] = audit_package["audit_reference"]
+    result["audit_reference"] = audit_package["audit_reference"]
+    return result
+
+
+def _escalation_for_policy_decision(
+    decision: str,
+    workflow_id: str,
+    action: str,
+    matched_rules: list[Mapping[str, Any]],
+    required_escalation_role: str | None,
+    required_approver_role: str | None,
+    reason: str,
+) -> dict[str, Any] | None:
+    trigger_type = _policy_escalation_trigger(
+        decision,
+        action,
+        matched_rules,
+        required_escalation_role,
+        required_approver_role,
+    )
+    if trigger_type is None:
+        return None
+    return evaluate_marketing_escalation(
+        {
+            "trigger_type": trigger_type,
+            "workflow_id": workflow_id,
+            "action": action,
+            "reason": reason,
+        }
+    )
+
+
+def _policy_escalation_trigger(
+    decision: str,
+    action: str,
+    matched_rules: list[Mapping[str, Any]],
+    required_escalation_role: str | None,
+    required_approver_role: str | None,
+) -> str | None:
+    rule_ids = {_normalize_key(rule.get("rule_id")) for rule in matched_rules}
+    if decision == "missing_policy":
+        return "missing_policy"
+    if "cmo_crisis_public_response_escalation" in rule_ids:
+        return "crisis_public_response"
+    if "cmo_high_risk_claims_review" in rule_ids or "cmo_region_legal_constraints" in rule_ids:
+        if _normalize_key(required_escalation_role) in {"legal", "compliance"}:
+            return "pricing_or_legal_claim"
+        return "high_risk_copy"
+    if "cmo_budget_threshold_approval" in rule_ids:
+        return "budget_threshold_exceeded"
+    if "cmo_target_account_threshold_approval" in rule_ids:
+        return "target_account_change"
+    if decision == "requires_escalation":
+        if _normalize_key(required_escalation_role) in {"legal", "compliance"}:
+            return "pricing_or_legal_claim"
+        return "high_risk_copy"
+    if decision == "requires_approval" and required_approver_role:
+        return "approval_timeout"
+    if action in DISALLOWED_ACTIONS:
+        return "missing_policy"
+    return None
+
+
+def _missing_policy_decision(ctx: Mapping[str, Any]) -> dict[str, Any]:
+    read_only_shadow = (
+        str(ctx.get("workflow_mode") or "") in SHADOW_MODES
+        and str(ctx.get("action") or "") in READ_ONLY_ACTIONS
+        and not bool(ctx.get("external_write_required"))
+    )
+    return _decision(
+        policy_id=None,
+        version=None,
+        matched_rules=[],
+        decision="read_only_only" if read_only_shadow else "missing_policy",
+        reason=(
+            "Marketing policy manifest is missing; this can continue only as a "
+            "read-only shadow recommendation."
+            if read_only_shadow
+            else "Marketing policy manifest is missing for this active/customer-facing action."
+        ),
+        required_approver_role=None,
+        required_escalation_role=None,
+        required_audit_evidence=DEFAULT_REQUIRED_AUDIT["blocked"],
+        affected_workflow=str(ctx.get("workflow_id") or ""),
+        affected_action=str(ctx.get("action") or ""),
+        next_action_cta=(
+            "label_as_read_only_recommendation"
+            if read_only_shadow
+            else "configure_marketing_policy_manifest"
+        ),
+    )
+
+
+def _normalize_context(context: Mapping[str, Any] | None) -> dict[str, Any]:
+    context = context if isinstance(context, Mapping) else {}
+    action = _normalize_key(
+        context.get("action")
+        or context.get("approval_action")
+        or context.get("blocked_action")
+        or "unknown_action"
+    )
+    mode = _normalize_key(
+        context.get("workflow_mode")
+        or context.get("mode")
+        or context.get("configured_mode")
+        or "active"
+    )
+    return {
+        **dict(context),
+        "action": action,
+        "workflow_mode": mode,
+        "workflow_id": _normalize_key(
+            context.get("workflow_id")
+            or context.get("workflow_key")
+            or context.get("workflow")
+        ),
+        "channel": _normalize_key(context.get("channel") or context.get("connector_key") or "default"),
+        "external_write_required": _truthy(
+            context.get("external_write_required") or context.get("requires_external_write")
+        ),
+        "customer_facing": _truthy(context.get("customer_facing") or context.get("external")),
+        "crisis_response": _truthy(context.get("crisis_response")),
+        "public_response": _truthy(context.get("public_response")),
+    }
+
+
+def _normalize_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = dict(manifest)
+    normalized["rules"] = [
+        dict(rule)
+        for rule in normalized.get("rules", [])
+        if isinstance(rule, Mapping)
+    ]
+    normalized.setdefault("allowed_autonomous_actions", list(READ_ONLY_ACTIONS))
+    normalized.setdefault("disallowed_autonomous_actions", list(DISALLOWED_ACTIONS))
+    normalized.setdefault("budget_thresholds", {"default": 500})
+    normalized.setdefault("audience_size_threshold", 50000)
+    normalized.setdefault("target_account_change_threshold", 25)
+    normalized.setdefault("high_risk_copy_categories", [])
+    normalized.setdefault("region_legal_constraints", {})
+    return normalized
+
+
+def _manifest_candidate(source: Mapping[str, Any] | None) -> Mapping[str, Any] | None:
+    if not isinstance(source, Mapping):
+        return None
+    for key in (
+        "marketing_policy_manifest",
+        "cmo_marketing_policy_manifest",
+        "marketing_policy",
+        "policy_manifest",
+    ):
+        value = source.get(key)
+        if isinstance(value, Mapping):
+            return value
+    if source.get("policy_id") and source.get("version") and isinstance(source.get("rules"), list):
+        return source
+    return None
+
+
+def _manifest_disabled(source: Mapping[str, Any] | None) -> bool:
+    if not isinstance(source, Mapping):
+        return False
+    return any(
+        _truthy(source.get(key))
+        for key in (
+            "marketing_policy_manifest_disabled",
+            "cmo_marketing_policy_manifest_disabled",
+            "policy_manifest_disabled",
+        )
+    )
+
+
+def _manifest_rule(manifest: Mapping[str, Any], rule_id: str) -> dict[str, Any]:
+    for rule in manifest.get("rules") or []:
+        if isinstance(rule, Mapping) and str(rule.get("rule_id") or "") == rule_id:
+            return dict(rule)
+    return _rule_dict(manifest, rule_id)
+
+
+def _rule_dict(manifest: Mapping[str, Any], rule_id: str) -> dict[str, Any]:
+    return {
+        "rule_id": rule_id,
+        "description": f"Implicit rule in {manifest.get('policy_id') or 'missing policy'}.",
+        "decision": "missing_policy",
+        "required_audit_evidence": list(DEFAULT_REQUIRED_AUDIT["blocked"]),
+        "next_action_cta": "configure_marketing_policy_manifest",
+        "reason": "Policy rule is missing.",
+    }
+
+
+def _has_high_risk_claim(ctx: Mapping[str, Any]) -> bool:
+    if str(ctx.get("action") or "") in HIGH_RISK_CLAIM_ACTIONS:
+        return True
+    return any(
+        _truthy(ctx.get(field))
+        for field in (
+            "brand_claim",
+            "claims_review",
+            "claims_review_required",
+            "comparative_claim",
+            "competitor_mention",
+            "compliance_claim",
+            "compliance_review_required",
+            "high_risk",
+            "high_risk_copy",
+            "legal_claim",
+            "legal_review_required",
+            "pricing_claim",
+            "regulated_claim",
+            "sensitive_claim",
+        )
+    ) or bool(_string_set(ctx.get("high_risk_copy_categories")))
+
+
+def _matches_region_constraint(ctx: Mapping[str, Any], manifest: Mapping[str, Any]) -> bool:
+    region = _normalize_key(ctx.get("region") or ctx.get("country") or ctx.get("market"))
+    if not region:
+        return False
+    constraints = manifest.get("region_legal_constraints")
+    if not isinstance(constraints, Mapping):
+        return False
+    region_constraints = _string_set(constraints.get(region))
+    if not region_constraints:
+        return False
+    if ctx.get("legal_claim") or ctx.get("regulated_claim") or ctx.get("compliance_claim"):
+        return True
+    categories = _string_set(ctx.get("high_risk_copy_categories"))
+    return bool(categories & region_constraints)
+
+
+def _budget_change_requires_approval(ctx: Mapping[str, Any], manifest: Mapping[str, Any]) -> bool:
+    action = str(ctx.get("action") or "")
+    budget_value = _number(
+        ctx.get("budget_delta")
+        or ctx.get("budget_increase")
+        or ctx.get("spend_delta")
+        or ctx.get("budget_amount")
+        or ctx.get("daily_budget")
+    )
+    if budget_value <= 0 and action not in BUDGET_ACTIONS:
+        return False
+    thresholds = manifest.get("budget_thresholds")
+    thresholds = thresholds if isinstance(thresholds, Mapping) else {}
+    channel = str(ctx.get("channel") or "default")
+    threshold = _number(thresholds.get(channel) or thresholds.get("default") or 0)
+    return budget_value > threshold
+
+
+def _audience_requires_approval(ctx: Mapping[str, Any], manifest: Mapping[str, Any]) -> bool:
+    size = _number(
+        ctx.get("audience_size")
+        or ctx.get("list_size")
+        or ctx.get("recipient_count")
+        or ctx.get("estimated_recipients")
+    )
+    threshold = _number(manifest.get("audience_size_threshold") or 0)
+    return bool(size and threshold and size > threshold)
+
+
+def _target_accounts_require_approval(ctx: Mapping[str, Any], manifest: Mapping[str, Any]) -> bool:
+    action = str(ctx.get("action") or "")
+    delta = _number(
+        ctx.get("target_account_delta")
+        or ctx.get("target_account_change_count")
+        or ctx.get("account_list_change_count")
+    )
+    threshold = _number(manifest.get("target_account_change_threshold") or 0)
+    return action in TARGET_ACCOUNT_ACTIONS and bool(delta and threshold and delta > threshold)
+
+
+def _config_dict(config: Any | None) -> dict[str, Any]:
+    if isinstance(config, Mapping):
+        return dict(config)
+    value = getattr(config, "config", None)
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _string_set(value: Any) -> set[str]:
+    if isinstance(value, str):
+        return {_normalize_key(part) for part in value.split(",") if _normalize_key(part)}
+    if isinstance(value, Iterable):
+        return {_normalize_key(item) for item in value if _normalize_key(item)}
+    return set()
+
+
+def _string_list(value: Any) -> list[str]:
+    return sorted(_string_set(value))
+
+
+def _unique(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _number(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _string_or_none(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)

--- a/core/marketing/report_quality.py
+++ b/core/marketing/report_quality.py
@@ -1,0 +1,1208 @@
+"""CMO report quality gates.
+
+CMO-7.3 turns KPI readiness and reconciliation into report-level decisions.
+The gates are deterministic projections over already-computed CMO readiness
+state; they do not render reports, persist report history, or invent values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from core.marketing.decision_audit import build_cmo_decision_audit_package
+from core.marketing.escalation_matrix import evaluate_marketing_escalation
+from core.marketing.policy_manifest import evaluate_marketing_policy
+
+CMO_REPORT_QUALITY_VERSION = "2026-05-23.cmo-7.3"
+
+REPORT_GATE_STATUSES = ("pass", "warning", "blocked", "unavailable")
+SAFE_REPORT_MODES = ("draft_only", "internal_only", "deliverable")
+
+REPORT_TYPE_ALIASES = {
+    "cmo_weekly": "weekly_marketing_report",
+    "campaign_report": "campaign_performance_ad_hoc",
+    "campaign_performance_report": "campaign_performance_ad_hoc",
+    "board_summary": "executive_board_summary",
+}
+
+# enterprise-gate: process-local-ok reason=static-workflow-state-set
+ACTIVE_WORKFLOW_STATES = {"active"}
+# enterprise-gate: process-local-ok reason=static-workflow-state-set
+INTERNAL_WORKFLOW_STATES = {"promotion_ready", "degraded"}
+BLOCKING_WORKFLOW_STATES = {  # enterprise-gate: process-local-ok reason=static-workflow-state-set
+    "promotion_blocked",
+    "shadow",
+    "paused",
+    "unavailable",
+}
+
+BLOCKING_KPI_STATUSES = {"blocked", "unavailable"}
+DEGRADED_KPI_STATUSES = {"degraded"}
+BLOCKING_RECONCILIATION_STATUSES = {"blocked", "failed"}
+WARNING_RECONCILIATION_STATUSES = {"warning", "unavailable"}
+STALE_FRESHNESS_STATUSES = {"stale"}
+UNKNOWN_FRESHNESS_STATUSES = {"unknown", "missing"}
+DEMO_SOURCES = {
+    "demo",
+    "hardcoded",
+    "sample",
+    "mock",
+    "report_generator_fallback",
+    "fallback",
+}
+
+
+@dataclass(frozen=True)
+class CmoReportQualitySpec:
+    key: str
+    display_name: str
+    required_kpi_keys: tuple[str, ...]
+    optional_kpi_keys: tuple[str, ...]
+    critical_connector_categories: tuple[str, ...]
+    workflow_key: str
+    policy_action: str
+    confidence_floor: float
+    stale_required_sources_block: bool = True
+    sensitive_by_default: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "report_key": self.key,
+            "display_name": self.display_name,
+            "required_kpi_keys": list(self.required_kpi_keys),
+            "optional_kpi_keys": list(self.optional_kpi_keys),
+            "critical_connector_categories": list(self.critical_connector_categories),
+            "workflow_key": self.workflow_key,
+            "policy_action": self.policy_action,
+            "confidence_floor": self.confidence_floor,
+            "stale_required_sources_block": self.stale_required_sources_block,
+            "sensitive_by_default": self.sensitive_by_default,
+        }
+
+
+CMO_REPORT_QUALITY_SPECS: tuple[CmoReportQualitySpec, ...] = (
+    CmoReportQualitySpec(
+        key="weekly_marketing_report",
+        display_name="Weekly Marketing Report",
+        required_kpi_keys=(
+            "cac",
+            "mql",
+            "sql",
+            "mql_to_sql_conversion_rate",
+            "roas",
+            "pipeline_contribution",
+            "conversion_rates_by_funnel_stage",
+            "email_performance",
+        ),
+        optional_kpi_keys=("content_performance", "brand_sentiment"),
+        critical_connector_categories=("CRM", "Ads", "Analytics", "Email"),
+        workflow_key="weekly_marketing_report",
+        policy_action="generate_weekly_report",
+        confidence_floor=0.75,
+    ),
+    CmoReportQualitySpec(
+        key="daily_ad_performance",
+        display_name="Daily Ad Performance",
+        required_kpi_keys=("cac", "roas", "mql", "conversion_rates_by_funnel_stage"),
+        optional_kpi_keys=("experiment_velocity",),
+        critical_connector_categories=("Ads", "CRM", "Analytics"),
+        workflow_key="daily_spend_optimization",
+        policy_action="generate_weekly_report",
+        confidence_floor=0.80,
+    ),
+    CmoReportQualitySpec(
+        key="monthly_marketing_roi",
+        display_name="Monthly Marketing ROI",
+        required_kpi_keys=("cac", "roas", "pipeline_contribution", "ltv_cac"),
+        optional_kpi_keys=("content_performance", "email_performance", "brand_sentiment"),
+        critical_connector_categories=("CRM", "Ads", "Analytics", "Finance"),
+        workflow_key="weekly_marketing_report",
+        policy_action="generate_weekly_report",
+        confidence_floor=0.82,
+    ),
+    CmoReportQualitySpec(
+        key="campaign_performance_ad_hoc",
+        display_name="Campaign Performance Ad Hoc",
+        required_kpi_keys=("roas", "mql", "sql", "conversion_rates_by_funnel_stage"),
+        optional_kpi_keys=("content_performance", "email_performance"),
+        critical_connector_categories=("CRM", "Ads", "Analytics"),
+        workflow_key="weekly_marketing_report",
+        policy_action="generate_weekly_report",
+        confidence_floor=0.65,
+        stale_required_sources_block=False,
+    ),
+    CmoReportQualitySpec(
+        key="executive_board_summary",
+        display_name="Executive Board Summary",
+        required_kpi_keys=(
+            "cac",
+            "mql_to_sql_conversion_rate",
+            "roas",
+            "pipeline_contribution",
+            "brand_sentiment",
+        ),
+        optional_kpi_keys=("ltv_cac", "content_performance", "email_performance"),
+        critical_connector_categories=("CRM", "Ads", "Analytics", "Brand"),
+        workflow_key="weekly_marketing_report",
+        policy_action="generate_weekly_report",
+        confidence_floor=0.85,
+        sensitive_by_default=True,
+    ),
+)
+
+
+def default_cmo_report_quality_specs() -> dict[str, Any]:
+    return {
+        "schema_version": CMO_REPORT_QUALITY_VERSION,
+        "reports": [spec.to_dict() for spec in CMO_REPORT_QUALITY_SPECS],
+    }
+
+
+def build_cmo_report_quality_projection(
+    *,
+    kpi_results: Iterable[dict[str, Any]],
+    reconciliation_checks: Iterable[dict[str, Any]],
+    connector_setup: Iterable[dict[str, Any]] = (),
+    data_readiness: Mapping[str, Any] | None = None,
+    connector_contracts: Iterable[dict[str, Any]] = (),
+    workflow_activation: Mapping[str, Any] | None = None,
+    policy_projection: Mapping[str, Any] | None = None,
+    escalation_projection: Mapping[str, Any] | None = None,
+    decision_audit_projection: Mapping[str, Any] | None = None,
+    source_context: Mapping[str, Any] | None = None,
+    report_context: Mapping[str, Any] | None = None,
+    report_types: Iterable[str] | None = None,
+    production_tenant: bool = False,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build report-level quality gates and a compact summary."""
+
+    requested = {_normalize_key(report_type) for report_type in report_types or []}
+    specs = [
+        spec
+        for spec in CMO_REPORT_QUALITY_SPECS
+        if not requested or spec.key in {_canonical_report_key(item) for item in requested}
+    ]
+    gates = [
+        evaluate_cmo_report_quality_gate(
+            spec.key,
+            kpi_results=kpi_results,
+            reconciliation_checks=reconciliation_checks,
+            connector_setup=connector_setup,
+            data_readiness=data_readiness,
+            connector_contracts=connector_contracts,
+            workflow_activation=workflow_activation,
+            policy_projection=policy_projection,
+            escalation_projection=escalation_projection,
+            decision_audit_projection=decision_audit_projection,
+            source_context=source_context,
+            report_context=_context_for_report(report_context, spec.key),
+            production_tenant=production_tenant,
+            now=now,
+        )
+        for spec in specs
+    ]
+    return {
+        "cmo_report_quality_version": CMO_REPORT_QUALITY_VERSION,
+        "report_quality_spec": default_cmo_report_quality_specs(),
+        "report_quality_gates": gates,
+        "report_quality_summary": summarize_cmo_report_quality_gates(gates),
+    }
+
+
+def build_cmo_report_quality_projection_from_kpi_payload(
+    payload: Mapping[str, Any] | None,
+    *,
+    report_context: Mapping[str, Any] | None = None,
+    report_types: Iterable[str] | None = None,
+    production_tenant: bool = False,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Evaluate report quality using the `/kpis/cmo` response shape."""
+
+    data = payload if isinstance(payload, Mapping) else {}
+    workflow_activation = {
+        "workflow_activation_status": _list_from_value(data.get("workflow_activation_status")),
+        "workflow_activation_summary": data.get("workflow_activation_summary") or {},
+    }
+    policy_projection = {
+        "marketing_policy_manifest": data.get("marketing_policy_manifest"),
+        "marketing_policy_summary": data.get("marketing_policy_summary") or {},
+    }
+    escalation_projection = {
+        "marketing_escalation_matrix": data.get("marketing_escalation_matrix"),
+        "marketing_escalation_summary": data.get("marketing_escalation_summary") or {},
+    }
+    decision_audit_projection = {
+        "marketing_decision_audit": data.get("marketing_decision_audit"),
+        "marketing_decision_audit_summary": data.get("marketing_decision_audit_summary") or {},
+    }
+    return build_cmo_report_quality_projection(
+        kpi_results=_list_from_value(data.get("unified_cmo_kpi_results")),
+        reconciliation_checks=_list_from_value(data.get("cmo_kpi_reconciliation_checks")),
+        connector_setup=_list_from_value(data.get("connector_setup")),
+        data_readiness={
+            "field_mapping_status": _list_from_value(data.get("field_mapping_status")),
+            "backfill_status": _list_from_value(data.get("backfill_status")),
+            "kpi_readiness": data.get("kpi_readiness") or {},
+        },
+        connector_contracts=_list_from_value(data.get("connector_contracts")),
+        workflow_activation=workflow_activation,
+        policy_projection=policy_projection,
+        escalation_projection=escalation_projection,
+        decision_audit_projection=decision_audit_projection,
+        source_context=data,
+        report_context=report_context,
+        report_types=report_types,
+        production_tenant=production_tenant,
+        now=now,
+    )
+
+
+def evaluate_cmo_report_quality_gate(
+    report_key: str,
+    *,
+    kpi_results: Iterable[dict[str, Any]],
+    reconciliation_checks: Iterable[dict[str, Any]],
+    connector_setup: Iterable[dict[str, Any]] = (),
+    data_readiness: Mapping[str, Any] | None = None,
+    connector_contracts: Iterable[dict[str, Any]] = (),
+    workflow_activation: Mapping[str, Any] | None = None,
+    policy_projection: Mapping[str, Any] | None = None,
+    escalation_projection: Mapping[str, Any] | None = None,
+    decision_audit_projection: Mapping[str, Any] | None = None,
+    source_context: Mapping[str, Any] | None = None,
+    report_context: Mapping[str, Any] | None = None,
+    production_tenant: bool = False,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Evaluate one CMO report quality gate."""
+
+    spec = _spec_for_report(report_key)
+    timestamp = _ensure_aware(now) or datetime.now(UTC)
+    if spec is None:
+        return _unavailable_gate(report_key, timestamp)
+
+    kpis = _kpis_by_key(kpi_results)
+    checks = [dict(item) for item in reconciliation_checks if isinstance(item, Mapping)]
+    setup_rows = [dict(item) for item in connector_setup if isinstance(item, Mapping)]
+    contract_rows = [dict(item) for item in connector_contracts if isinstance(item, Mapping)]
+    workflow_rows = _workflow_rows(workflow_activation)
+    source = source_context if isinstance(source_context, Mapping) else {}
+    context = report_context if isinstance(report_context, Mapping) else {}
+
+    blockers: list[str] = []
+    warnings: list[str] = []
+    missing_requirements: dict[str, list[str]] = {
+        "kpis": [],
+        "connectors": [],
+        "field_mappings": [],
+        "backfills": [],
+        "reconciliation": [],
+        "workflow": [],
+        "policy": [],
+        "approval": [],
+        "escalation": [],
+        "audit": [],
+        "source_data": [],
+    }
+    stale_missing_source_refs: list[dict[str, Any]] = []
+    failed_reconciliation_keys: list[str] = []
+    required_approval_refs: list[str] = []
+    required_escalation_refs: list[str] = []
+    required_audit_refs: list[str] = []
+
+    required_results = [kpis.get(key) for key in spec.required_kpi_keys]
+    optional_results = [kpis.get(key) for key in spec.optional_kpi_keys]
+    blocked_kpis: list[str] = []
+    degraded_kpis: list[str] = []
+    confidences: list[float] = []
+
+    for key, result in zip(spec.required_kpi_keys, required_results, strict=False):
+        if not result:
+            blocked_kpis.append(key)
+            missing_requirements["kpis"].append(key)
+            blockers.append(f"Required KPI {key} is missing from the unified KPI projection.")
+            confidences.append(0.0)
+            continue
+        status = str(result.get("status") or "unavailable")
+        confidences.append(float(result.get("confidence") or 0.0))
+        _collect_missing_from_kpi(result, missing_requirements)
+        if status in BLOCKING_KPI_STATUSES:
+            blocked_kpis.append(key)
+            blockers.append(f"Required KPI {key} is {status}.")
+        elif status in DEGRADED_KPI_STATUSES:
+            degraded_kpis.append(key)
+            warnings.append(f"Required KPI {key} is degraded.")
+        freshness_status = str(result.get("freshness_status") or "")
+        if freshness_status in STALE_FRESHNESS_STATUSES | UNKNOWN_FRESHNESS_STATUSES:
+            stale_missing_source_refs.extend(_kpi_source_refs(result, key, freshness_status))
+            if freshness_status in STALE_FRESHNESS_STATUSES and spec.stale_required_sources_block:
+                blocked_kpis.append(key)
+                blockers.append(f"Required KPI {key} has stale source data.")
+            else:
+                degraded_kpis.append(key)
+                warnings.append(f"Required KPI {key} freshness is {freshness_status}.")
+
+    for key, result in zip(spec.optional_kpi_keys, optional_results, strict=False):
+        if not result:
+            continue
+        status = str(result.get("status") or "")
+        freshness_status = str(result.get("freshness_status") or "")
+        if status in BLOCKING_KPI_STATUSES | DEGRADED_KPI_STATUSES:
+            degraded_kpis.append(key)
+            warnings.append(f"Optional KPI {key} is {status}.")
+        if freshness_status in STALE_FRESHNESS_STATUSES | UNKNOWN_FRESHNESS_STATUSES:
+            stale_missing_source_refs.extend(_kpi_source_refs(result, key, freshness_status))
+            degraded_kpis.append(key)
+            warnings.append(f"Optional KPI {key} freshness is {freshness_status}.")
+
+    actual_confidence = round(min(confidences), 3) if confidences else 0.0
+    if actual_confidence < spec.confidence_floor:
+        blockers.append(
+            f"Required KPI confidence {actual_confidence:.3f} is below floor {spec.confidence_floor:.3f}."
+        )
+        missing_requirements["source_data"].append("confidence_floor")
+
+    reconciliation = _evaluate_reconciliation(spec, checks)
+    blockers.extend(reconciliation["blockers"])
+    warnings.extend(reconciliation["warnings"])
+    failed_reconciliation_keys.extend(reconciliation["failed_keys"])
+    missing_requirements["reconciliation"].extend(reconciliation["missing"])
+    stale_missing_source_refs.extend(reconciliation["source_refs"])
+
+    connector_quality = _evaluate_connector_quality(spec, setup_rows, contract_rows)
+    blockers.extend(connector_quality["blockers"])
+    warnings.extend(connector_quality["warnings"])
+    stale_missing_source_refs.extend(connector_quality["source_refs"])
+    missing_requirements["connectors"].extend(connector_quality["missing"])
+
+    readiness_quality = _evaluate_data_readiness_quality(spec, data_readiness, spec.required_kpi_keys)
+    blockers.extend(readiness_quality["blockers"])
+    warnings.extend(readiness_quality["warnings"])
+    missing_requirements["field_mappings"].extend(readiness_quality["field_mappings"])
+    missing_requirements["backfills"].extend(readiness_quality["backfills"])
+
+    workflow_quality = _evaluate_workflow_quality(spec, workflow_rows)
+    blockers.extend(workflow_quality["blockers"])
+    warnings.extend(workflow_quality["warnings"])
+    missing_requirements["workflow"].extend(workflow_quality["missing"])
+
+    governance = _evaluate_governance_quality(
+        spec,
+        policy_projection,
+        escalation_projection,
+        decision_audit_projection,
+        context,
+        timestamp,
+    )
+    blockers.extend(governance["blockers"])
+    warnings.extend(governance["warnings"])
+    required_approval_refs.extend(governance["approval_refs"])
+    required_escalation_refs.extend(governance["escalation_refs"])
+    required_audit_refs.extend(governance["audit_refs"])
+    for key, values in governance["missing"].items():
+        missing_requirements[key].extend(values)
+
+    source_quality = _evaluate_source_context(source, production_tenant)
+    blockers.extend(source_quality["blockers"])
+    missing_requirements["source_data"].extend(source_quality["missing"])
+
+    blocked_kpis = _unique(blocked_kpis)
+    degraded_kpis = [key for key in _unique(degraded_kpis) if key not in set(blocked_kpis)]
+    blockers = _unique(blockers)
+    warnings = _unique(warnings)
+    failed_reconciliation_keys = _unique(failed_reconciliation_keys)
+    stale_missing_source_refs = _unique_refs(stale_missing_source_refs)
+    missing_requirements = {
+        key: _unique(values)
+        for key, values in missing_requirements.items()
+        if _unique(values)
+    }
+
+    if blockers:
+        status = "blocked"
+        safe_mode = "draft_only"
+        severity = "critical" if source_quality["blockers"] else "high"
+    elif warnings:
+        status = "warning"
+        safe_mode = "internal_only"
+        severity = "medium"
+    else:
+        status = "pass"
+        safe_mode = "deliverable"
+        severity = "low"
+
+    next_action = _next_action(
+        missing_requirements,
+        failed_reconciliation_keys,
+        stale_missing_source_refs,
+        warnings,
+    )
+    gate = {
+        "report_key": spec.key,
+        "report_type": spec.key,
+        "display_name": spec.display_name,
+        "status": status,
+        "severity": severity,
+        "required_kpi_keys": list(spec.required_kpi_keys),
+        "optional_kpi_keys": list(spec.optional_kpi_keys),
+        "blocked_kpi_keys": blocked_kpis,
+        "degraded_kpi_keys": degraded_kpis,
+        "failed_reconciliation_keys": failed_reconciliation_keys,
+        "stale_missing_source_refs": stale_missing_source_refs,
+        "confidence_floor": spec.confidence_floor,
+        "actual_confidence": actual_confidence,
+        "required_approval_refs": _unique(required_approval_refs),
+        "required_escalation_refs": _unique(required_escalation_refs),
+        "required_audit_refs": _unique(required_audit_refs),
+        "missing_requirements": missing_requirements,
+        "blocked_reasons": blockers,
+        "warning_reasons": warnings,
+        "next_action_cta": next_action,
+        "safe_report_mode": safe_mode,
+        "trusted_delivery_allowed": safe_mode == "deliverable",
+        "evaluated_at": timestamp.isoformat(),
+    }
+    audit_package = build_cmo_decision_audit_package(
+        {
+            "event_type": "policy_decision",
+            "decision_type": "report_quality_gate",
+            "workflow_id": spec.workflow_key,
+            "action": spec.key,
+            "capability": "cmo_report_quality",
+            "source_refs": stale_missing_source_refs,
+            "confidence": actual_confidence,
+            "status": status,
+            "reason": "; ".join(blockers or warnings or ["Report quality gate passed."]),
+            "final_outcome": safe_mode,
+            "input_snapshot": {
+                "required_kpi_keys": list(spec.required_kpi_keys),
+                "blocked_kpi_keys": blocked_kpis,
+                "failed_reconciliation_keys": failed_reconciliation_keys,
+                "missing_requirements": missing_requirements,
+            },
+        },
+        now=timestamp,
+    )
+    gate["decision_audit_ref"] = audit_package["audit_reference"]
+    return gate
+
+
+def summarize_cmo_report_quality_gates(gates: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    items = list(gates)
+    counts = dict.fromkeys(REPORT_GATE_STATUSES, 0)
+    modes = dict.fromkeys(SAFE_REPORT_MODES, 0)
+    for item in items:
+        status = str(item.get("status") or "")
+        mode = str(item.get("safe_report_mode") or "")
+        if status in counts:
+            counts[status] += 1
+        if mode in modes:
+            modes[mode] += 1
+
+    readiness = (
+        "blocked"
+        if counts["blocked"] or counts["unavailable"]
+        else "degraded"
+        if counts["warning"]
+        else "ready"
+    )
+    return {
+        "schema_version": CMO_REPORT_QUALITY_VERSION,
+        "total": len(items),
+        **counts,
+        **{f"{key}_reports": value for key, value in modes.items()},
+        "readiness": readiness,
+        "deliverable_report_keys": [
+            str(item.get("report_key"))
+            for item in items
+            if item.get("safe_report_mode") == "deliverable"
+        ],
+        "blocked_report_keys": [
+            str(item.get("report_key"))
+            for item in items
+            if item.get("status") in {"blocked", "unavailable"}
+        ],
+        "needs_action": sum(1 for item in items if item.get("next_action_cta") != "none"),
+        "next_action_cta": next(
+            (
+                str(item.get("next_action_cta"))
+                for item in items
+                if item.get("next_action_cta") not in {None, "", "none"}
+            ),
+            "none",
+        ),
+    }
+
+
+def cmo_report_gate_for_type(
+    report_type: str,
+    payload: Mapping[str, Any] | None,
+    *,
+    production_tenant: bool = False,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Return a gate for a CMO report type from a KPI payload."""
+
+    key = _canonical_report_key(report_type)
+    if _spec_for_report(key) is None:
+        return None
+    data = payload if isinstance(payload, Mapping) else {}
+    for gate in data.get("report_quality_gates") or []:
+        if isinstance(gate, Mapping) and _canonical_report_key(gate.get("report_key")) == key:
+            return dict(gate)
+    projection = build_cmo_report_quality_projection_from_kpi_payload(
+        data,
+        report_types=(key,),
+        production_tenant=production_tenant,
+        now=now,
+    )
+    gates = projection["report_quality_gates"]
+    return dict(gates[0]) if gates else None
+
+
+def cmo_report_trusted_delivery_allowed(gate: Mapping[str, Any] | None) -> bool:
+    """Return true only when a report gate permits trusted external delivery."""
+
+    if not isinstance(gate, Mapping):
+        return False
+    return str(gate.get("safe_report_mode") or "") == "deliverable" and str(gate.get("status") or "") == "pass"
+
+
+def _evaluate_reconciliation(
+    spec: CmoReportQualitySpec,
+    checks: list[dict[str, Any]],
+) -> dict[str, Any]:
+    required = set(spec.required_kpi_keys)
+    optional = set(spec.optional_kpi_keys)
+    blockers: list[str] = []
+    warnings: list[str] = []
+    failed_keys: list[str] = []
+    missing: list[str] = []
+    source_refs: list[dict[str, Any]] = []
+
+    for check in checks:
+        affected = {_normalize_key(key) for key in check.get("affected_kpi_keys") or []}
+        if not affected & (required | optional):
+            continue
+        status = str(check.get("status") or "unavailable")
+        check_key = str(check.get("reconciliation_key") or "unknown_reconciliation")
+        affects_required = bool(affected & required)
+        if status in BLOCKING_RECONCILIATION_STATUSES:
+            failed_keys.append(check_key)
+            source_refs.extend(_refs_from_check(check, check_key))
+            if affects_required or check.get("blocks_kpi_readiness"):
+                blockers.append(f"Reconciliation {check_key} is {status}.")
+            else:
+                warnings.append(f"Optional reconciliation {check_key} is {status}.")
+        elif status in WARNING_RECONCILIATION_STATUSES:
+            warnings.append(f"Reconciliation {check_key} is {status}.")
+            source_refs.extend(_refs_from_check(check, check_key))
+        for values in (check.get("missing_requirements") or {}).values():
+            for value in values:
+                missing.append(f"{check_key}:{value}")
+
+    return {
+        "blockers": blockers,
+        "warnings": warnings,
+        "failed_keys": failed_keys,
+        "missing": missing,
+        "source_refs": source_refs,
+    }
+
+
+def _evaluate_connector_quality(
+    spec: CmoReportQualitySpec,
+    setup_rows: list[dict[str, Any]],
+    contract_rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    blockers: list[str] = []
+    warnings: list[str] = []
+    missing: list[str] = []
+    source_refs: list[dict[str, Any]] = []
+
+    for category in spec.critical_connector_categories:
+        setup = _rows_for_category(setup_rows, category)
+        contracts = _rows_for_category(contract_rows, category)
+        if not setup:
+            missing.append(category)
+            source_refs.append({"type": "connector_category", "category": category, "status": "missing"})
+            blockers.append(f"Critical {category} connector setup is missing.")
+        elif not any(_connector_configured(row) for row in setup):
+            missing.append(category)
+            source_refs.extend(_setup_refs(setup, category))
+            blockers.append(f"Critical {category} connector is not configured.")
+        else:
+            health_states = {_health(row) for row in setup}
+            if health_states & {"missing", "unconfigured", "auth_expired", "insufficient_scope", "unhealthy"}:
+                source_refs.extend(_setup_refs(setup, category))
+                blockers.append(f"Critical {category} connector health is {', '.join(sorted(health_states))}.")
+            elif health_states & {"stale", "degraded", "partial"}:
+                source_refs.extend(_setup_refs(setup, category))
+                if spec.stale_required_sources_block:
+                    blockers.append(f"Critical {category} connector health is {', '.join(sorted(health_states))}.")
+                else:
+                    warnings.append(f"Critical {category} connector health is {', '.join(sorted(health_states))}.")
+
+        if not contracts:
+            missing.append(f"{category}:contract")
+            source_refs.append({"type": "connector_contract", "category": category, "status": "missing"})
+            blockers.append(f"Critical {category} connector contract is missing.")
+            continue
+        if any(row.get("blocks_production_kpi_confidence") for row in contracts):
+            source_refs.extend(_contract_refs(contracts, category))
+            blockers.append(f"Critical {category} connector contract blocks production KPI confidence.")
+        elif any(not row.get("read_ready", True) for row in contracts):
+            source_refs.extend(_contract_refs(contracts, category))
+            blockers.append(f"Critical {category} connector contract is not read-ready.")
+        elif any(_contract_degraded(row) for row in contracts):
+            source_refs.extend(_contract_refs(contracts, category))
+            warnings.append(f"Critical {category} connector contract is degraded.")
+
+    return {
+        "blockers": blockers,
+        "warnings": warnings,
+        "missing": missing,
+        "source_refs": source_refs,
+    }
+
+
+def _evaluate_data_readiness_quality(
+    spec: CmoReportQualitySpec,
+    data_readiness: Mapping[str, Any] | None,
+    required_kpi_keys: tuple[str, ...],
+) -> dict[str, Any]:
+    readiness = data_readiness if isinstance(data_readiness, Mapping) else {}
+    blockers: list[str] = []
+    warnings: list[str] = []
+    missing_mappings: list[str] = []
+    missing_backfills: list[str] = []
+
+    kpi_readiness = readiness.get("kpi_readiness") if isinstance(readiness.get("kpi_readiness"), Mapping) else {}
+    for key in required_kpi_keys:
+        row = kpi_readiness.get(key) if isinstance(kpi_readiness, Mapping) else None
+        if not isinstance(row, Mapping):
+            continue
+        status = str(row.get("status") or row.get("readiness") or "")
+        if status in {"blocked", "unavailable"}:
+            blockers.append(f"KPI readiness for {key} is {status}.")
+        elif status in {"degraded", "warning"}:
+            warnings.append(f"KPI readiness for {key} is {status}.")
+
+    for row in readiness.get("field_mapping_status") or []:
+        if not isinstance(row, Mapping):
+            continue
+        status = str(row.get("status") or "")
+        if status in {"unmapped", "invalid", "blocked"}:
+            missing_mappings.append(str(row.get("key") or "unknown_mapping"))
+    for row in readiness.get("backfill_status") or []:
+        if not isinstance(row, Mapping):
+            continue
+        status = str(row.get("status") or "")
+        category = str(row.get("category") or row.get("source_connector_key") or "unknown_source")
+        if status in {"failed", "blocked"}:
+            missing_backfills.append(category)
+
+    if missing_mappings:
+        blockers.append("One or more field mappings are invalid, blocked, or unmapped.")
+    if missing_backfills:
+        blockers.append("One or more source backfills are failed or blocked.")
+
+    return {
+        "blockers": blockers,
+        "warnings": warnings,
+        "field_mappings": missing_mappings,
+        "backfills": missing_backfills,
+    }
+
+
+def _evaluate_workflow_quality(
+    spec: CmoReportQualitySpec,
+    workflow_rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    row = _workflow_row(workflow_rows, spec.workflow_key)
+    if row is None:
+        return {
+            "blockers": [f"Workflow activation state for {spec.workflow_key} is missing."],
+            "warnings": [],
+            "missing": [spec.workflow_key],
+        }
+    state = str(row.get("state") or row.get("mode") or "unavailable")
+    if state in ACTIVE_WORKFLOW_STATES:
+        return {"blockers": [], "warnings": [], "missing": []}
+    if state in INTERNAL_WORKFLOW_STATES:
+        return {
+            "blockers": [],
+            "warnings": [f"Workflow {spec.workflow_key} is {state}; report may be internal only."],
+            "missing": [],
+        }
+    if state in BLOCKING_WORKFLOW_STATES:
+        return {
+            "blockers": [f"Workflow {spec.workflow_key} is {state}."],
+            "warnings": [],
+            "missing": [spec.workflow_key],
+        }
+    return {
+        "blockers": [f"Workflow {spec.workflow_key} state {state} is not deliverable."],
+        "warnings": [],
+        "missing": [spec.workflow_key],
+    }
+
+
+def _evaluate_governance_quality(
+    spec: CmoReportQualitySpec,
+    policy_projection: Mapping[str, Any] | None,
+    escalation_projection: Mapping[str, Any] | None,
+    decision_audit_projection: Mapping[str, Any] | None,
+    context: Mapping[str, Any],
+    now: datetime,
+) -> dict[str, Any]:
+    blockers: list[str] = []
+    warnings: list[str] = []
+    missing: dict[str, list[str]] = {"policy": [], "approval": [], "escalation": [], "audit": []}
+    approval_refs = _string_list(
+        context.get("approval_refs")
+        or context.get("approval_ref")
+        or context.get("delivery_approval_ref")
+    )
+    escalation_refs = _string_list(
+        context.get("escalation_refs")
+        or context.get("escalation_ref")
+        or context.get("delivery_escalation_ref")
+    )
+    audit_refs = _string_list(
+        context.get("audit_refs")
+        or context.get("decision_audit_refs")
+        or context.get("delivery_audit_ref")
+    )
+    external_delivery = _truthy(context.get("external_delivery_requested") or context.get("deliver_externally"))
+    sensitive = bool(spec.sensitive_by_default) or _truthy(
+        context.get("contains_sensitive_claims")
+        or context.get("sensitive_claims")
+        or context.get("pricing_claim")
+        or context.get("legal_claim")
+        or context.get("high_risk_copy")
+    )
+
+    policy_missing = _projection_missing(policy_projection, "marketing_policy_summary", "missing_policy")
+    audit_missing = _projection_missing(
+        decision_audit_projection,
+        "marketing_decision_audit_summary",
+        "missing_audit_evidence",
+    )
+    escalation_missing = _projection_missing(
+        escalation_projection,
+        "marketing_escalation_summary",
+        "missing_escalation_route",
+    )
+
+    if policy_missing:
+        blockers.append("Marketing policy manifest is missing for report delivery.")
+        missing["policy"].append("marketing_policy_manifest")
+        policy_decision = None
+    else:
+        manifest = None
+        if isinstance(policy_projection, Mapping):
+            manifest = policy_projection.get("marketing_policy_manifest")
+        policy_decision = evaluate_marketing_policy(
+            {
+                "workflow_id": spec.workflow_key,
+                "workflow_mode": "active",
+                "action": spec.policy_action,
+                "customer_facing": external_delivery,
+                "external_write_required": external_delivery,
+                "pricing_claim": _truthy(context.get("pricing_claim")),
+                "legal_claim": _truthy(context.get("legal_claim")),
+                "high_risk_copy": _truthy(context.get("high_risk_copy")),
+                "crisis_response": _truthy(context.get("crisis_response")),
+                "public_response": _truthy(context.get("public_response")),
+            },
+            manifest=manifest if isinstance(manifest, Mapping) else None,
+            use_default=True,
+        )
+        decision = str(policy_decision.get("decision") or "")
+        if decision in {"blocked", "missing_policy", "read_only_only"}:
+            blockers.append(f"Marketing policy decision for report delivery is {decision}.")
+            missing["policy"].append(spec.policy_action)
+        elif decision in {"requires_approval", "requires_escalation"}:
+            if external_delivery or sensitive:
+                if not approval_refs:
+                    blockers.append("Report delivery requires approval evidence.")
+                    missing["approval"].append("delivery_approval_ref")
+                if decision == "requires_escalation" and not escalation_refs:
+                    blockers.append("Report delivery requires escalation evidence.")
+                    missing["escalation"].append("delivery_escalation_ref")
+            else:
+                warnings.append(f"Policy decision for report is {decision}.")
+        if policy_decision.get("decision_audit_ref"):
+            audit_refs.append(str(policy_decision["decision_audit_ref"]))
+
+    if external_delivery or sensitive:
+        if audit_missing:
+            blockers.append("Decision audit package readiness is missing for report delivery.")
+            missing["audit"].append("marketing_decision_audit")
+        if escalation_missing and sensitive:
+            blockers.append("Escalation route readiness is missing for sensitive report delivery.")
+            missing["escalation"].append("marketing_escalation_matrix")
+
+    if sensitive and not escalation_refs:
+        escalation = evaluate_marketing_escalation(
+            {
+                "trigger_type": "pricing_or_legal_claim"
+                if _truthy(context.get("pricing_claim") or context.get("legal_claim"))
+                else "high_risk_copy",
+                "workflow_id": spec.workflow_key,
+                "action": spec.policy_action,
+                "severity": "high",
+            },
+            now=now,
+        )
+        if escalation.get("audit_reference"):
+            escalation_refs.append(str(escalation["audit_reference"]))
+
+    return {
+        "blockers": blockers,
+        "warnings": warnings,
+        "approval_refs": approval_refs,
+        "escalation_refs": escalation_refs,
+        "audit_refs": audit_refs,
+        "missing": missing,
+    }
+
+
+def _evaluate_source_context(
+    source: Mapping[str, Any],
+    production_tenant: bool,
+) -> dict[str, Any]:
+    blockers: list[str] = []
+    missing: list[str] = []
+    demo = _truthy(source.get("demo"))
+    production_blocked = _truthy(source.get("production_data_blocked"))
+    source_label = _normalize_key(source.get("source"))
+    if production_blocked:
+        blockers.append("Production CMO data policy blocked real-data readiness.")
+        missing.append("production_data_blocked")
+    if production_tenant and (demo or source_label in DEMO_SOURCES):
+        blockers.append("Production report cannot use demo, sample, hardcoded, mock, or fallback KPI data.")
+        missing.append("real_tenant_kpi_data")
+    return {"blockers": blockers, "missing": missing}
+
+
+def _unavailable_gate(report_key: str, timestamp: datetime) -> dict[str, Any]:
+    key = _canonical_report_key(report_key)
+    return {
+        "report_key": key,
+        "report_type": key,
+        "display_name": key.replace("_", " ").title(),
+        "status": "unavailable",
+        "severity": "high",
+        "required_kpi_keys": [],
+        "blocked_kpi_keys": [],
+        "degraded_kpi_keys": [],
+        "failed_reconciliation_keys": [],
+        "stale_missing_source_refs": [],
+        "confidence_floor": None,
+        "actual_confidence": 0.0,
+        "required_approval_refs": [],
+        "required_escalation_refs": [],
+        "required_audit_refs": [],
+        "missing_requirements": {"report": [key]},
+        "blocked_reasons": ["Report type is not covered by CMO report quality gates."],
+        "warning_reasons": [],
+        "next_action_cta": "add_report_quality_spec",
+        "safe_report_mode": "draft_only",
+        "trusted_delivery_allowed": False,
+        "evaluated_at": timestamp.isoformat(),
+    }
+
+
+def _next_action(
+    missing_requirements: Mapping[str, list[str]],
+    failed_reconciliation_keys: list[str],
+    stale_missing_source_refs: list[dict[str, Any]],
+    warnings: list[str],
+) -> str:
+    if missing_requirements.get("connectors"):
+        return "fix_report_connectors"
+    if missing_requirements.get("field_mappings"):
+        return "fix_required_mapping"
+    if missing_requirements.get("backfills"):
+        return "complete_backfill"
+    if missing_requirements.get("kpis"):
+        return "restore_required_kpis"
+    if failed_reconciliation_keys or missing_requirements.get("reconciliation"):
+        return "resolve_report_reconciliation"
+    if stale_missing_source_refs:
+        return "refresh_report_sources"
+    if missing_requirements.get("source_data"):
+        return "connect_real_kpi_sources"
+    if missing_requirements.get("workflow"):
+        return "activate_report_workflow"
+    if missing_requirements.get("policy"):
+        return "configure_marketing_policy_manifest"
+    if missing_requirements.get("approval"):
+        return "capture_report_delivery_approval"
+    if missing_requirements.get("escalation"):
+        return "configure_report_escalation_route"
+    if missing_requirements.get("audit"):
+        return "configure_decision_audit_package"
+    if warnings:
+        return "review_report_quality_warnings"
+    return "none"
+
+
+def _collect_missing_from_kpi(result: Mapping[str, Any], missing: dict[str, list[str]]) -> None:
+    requirements = result.get("missing_requirements") if isinstance(result.get("missing_requirements"), Mapping) else {}
+    for key, target in (
+        ("connectors", "connectors"),
+        ("field_mappings", "field_mappings"),
+        ("backfills", "backfills"),
+        ("reconciliation", "reconciliation"),
+        ("fields", "source_data"),
+    ):
+        for value in requirements.get(key) or []:
+            missing[target].append(str(value))
+
+
+def _evaluate_report_gate_from_payload(
+    report_type: str,
+    payload: Mapping[str, Any],
+    *,
+    production_tenant: bool = False,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    return cmo_report_gate_for_type(
+        report_type,
+        payload,
+        production_tenant=production_tenant,
+        now=now,
+    )
+
+
+def _spec_for_report(report_key: Any) -> CmoReportQualitySpec | None:
+    key = _canonical_report_key(report_key)
+    for spec in CMO_REPORT_QUALITY_SPECS:
+        if spec.key == key:
+            return spec
+    return None
+
+
+def _canonical_report_key(value: Any) -> str:
+    key = _normalize_key(value)
+    return REPORT_TYPE_ALIASES.get(key, key)
+
+
+def _kpis_by_key(kpi_results: Iterable[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {
+        _normalize_key(row.get("kpi_key")): dict(row)
+        for row in kpi_results
+        if isinstance(row, Mapping) and row.get("kpi_key")
+    }
+
+
+def _workflow_rows(workflow_activation: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(workflow_activation, Mapping):
+        return []
+    return [
+        dict(row)
+        for row in workflow_activation.get("workflow_activation_status") or []
+        if isinstance(row, Mapping)
+    ]
+
+
+def _workflow_row(rows: list[dict[str, Any]], workflow_key: str) -> dict[str, Any] | None:
+    key = _normalize_key(workflow_key)
+    for row in rows:
+        if _normalize_key(row.get("workflow_key") or row.get("key")) == key:
+            return row
+    return None
+
+
+def _rows_for_category(rows: list[dict[str, Any]], category: str) -> list[dict[str, Any]]:
+    target = _normalize_key(category)
+    return [
+        row
+        for row in rows
+        if _normalize_key(row.get("category") or row.get("connector_category")) == target
+    ]
+
+
+def _connector_configured(row: Mapping[str, Any]) -> bool:
+    status = _normalize_key(row.get("status") or row.get("configured_status") or row.get("setup_status"))
+    if status in {"unconfigured", "missing", "not_configured"}:
+        return False
+    if row.get("configured") is False:
+        return False
+    return True
+
+
+def _health(row: Mapping[str, Any]) -> str:
+    return _normalize_key(
+        row.get("health_status")
+        or row.get("health")
+        or row.get("status")
+        or row.get("read_status")
+        or "missing"
+    )
+
+
+def _contract_degraded(row: Mapping[str, Any]) -> bool:
+    state = _normalize_key(
+        row.get("read_status")
+        or row.get("health_status")
+        or row.get("contract_state")
+        or row.get("status")
+    )
+    failure_class = _normalize_key(row.get("failure_class"))
+    if state in {"degraded", "partial_data", "stale_data", "rate_limited", "timeout", "vendor_5xx"}:
+        return True
+    if failure_class in {"partial_data", "stale_data", "rate_limited", "timeout", "vendor_5xx"}:
+        return True
+    degraded_mode = row.get("degraded_mode")
+    return isinstance(degraded_mode, Mapping) and bool(degraded_mode.get("allowed"))
+
+
+def _setup_refs(rows: list[dict[str, Any]], category: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "connector_setup",
+            "category": category,
+            "connector_key": row.get("connector_key") or row.get("key"),
+            "status": row.get("status") or row.get("configured_status"),
+            "health_status": row.get("health_status") or row.get("health"),
+            "last_sync_at": row.get("last_sync_at"),
+        }
+        for row in rows
+    ]
+
+
+def _contract_refs(rows: list[dict[str, Any]], category: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "connector_contract",
+            "category": category,
+            "connector_key": row.get("connector_key") or row.get("key"),
+            "read_status": row.get("read_status"),
+            "health_status": row.get("health_status"),
+            "failure_class": row.get("failure_class"),
+        }
+        for row in rows
+    ]
+
+
+def _refs_from_check(check: Mapping[str, Any], check_key: str) -> list[dict[str, Any]]:
+    refs = []
+    for ref in check.get("source_refs") or []:
+        if isinstance(ref, Mapping):
+            refs.append({"type": "reconciliation", "reconciliation_key": check_key, **dict(ref)})
+        else:
+            refs.append({"type": "reconciliation", "reconciliation_key": check_key, "ref": str(ref)})
+    if not refs:
+        refs.append({"type": "reconciliation", "reconciliation_key": check_key})
+    return refs
+
+
+def _kpi_source_refs(result: Mapping[str, Any], key: str, freshness_status: str) -> list[dict[str, Any]]:
+    refs = []
+    for ref in result.get("source_refs") or []:
+        if isinstance(ref, Mapping):
+            refs.append({"type": "kpi_source", "kpi_key": key, "freshness_status": freshness_status, **dict(ref)})
+        else:
+            refs.append({"type": "kpi_source", "kpi_key": key, "freshness_status": freshness_status, "ref": str(ref)})
+    if not refs:
+        refs.append({"type": "kpi_source", "kpi_key": key, "freshness_status": freshness_status})
+    return refs
+
+
+def _projection_missing(
+    projection: Mapping[str, Any] | None,
+    summary_key: str,
+    missing_status: str,
+) -> bool:
+    if not isinstance(projection, Mapping):
+        return False
+    summary = projection.get(summary_key)
+    if not isinstance(summary, Mapping):
+        return False
+    return _normalize_key(summary.get("status") or summary.get("readiness")) == _normalize_key(missing_status)
+
+
+def _context_for_report(
+    report_context: Mapping[str, Any] | None,
+    report_key: str,
+) -> dict[str, Any]:
+    if not isinstance(report_context, Mapping):
+        return {}
+    base = dict(report_context.get("*") or {}) if isinstance(report_context.get("*"), Mapping) else {}
+    specific = report_context.get(report_key)
+    if isinstance(specific, Mapping):
+        base.update(specific)
+        return base
+    if not base:
+        return dict(report_context)
+    return base
+
+
+def _list_from_value(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple | set):
+        return list(value)
+    return [value]
+
+
+def _string_list(value: Any) -> list[str]:
+    result = []
+    for item in _list_from_value(value):
+        text = str(item).strip()
+        if text:
+            result.append(text)
+    return _unique(result)
+
+
+def _unique(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _unique_refs(values: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    result: list[dict[str, Any]] = []
+    for value in values:
+        key = repr(sorted(value.items()))
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(value)
+    return result
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+    return bool(value)
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _ensure_aware(value: Any) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value

--- a/core/marketing/weekly_report_pilot_persistence.py
+++ b/core/marketing/weekly_report_pilot_persistence.py
@@ -1,0 +1,384 @@
+"""Persistence helper for weekly-marketing-report pilot proof (CMO-PROD-2).
+
+This module is the only path that should write rows into the
+``weekly_report_pilot_proofs`` table. It:
+
+  1. accepts a ``WeeklyReportPilotEvidence`` instance or an evidence-bundle
+     -shaped dict;
+  2. invokes the authoritative CMO-PROD-1 validator
+     (``evaluate_weekly_marketing_report_proof``) to produce the verdict;
+  3. redacts secret/token-shaped keys from both the evidence bundle and
+     the verdict before persistence;
+  4. writes a new ``WeeklyReportPilotProof`` row;
+  5. exposes a "latest by tenant + company" retrieval used by ``/kpis/cmo``.
+
+It never re-implements the validator. CMO-PROD-1 remains the authority
+for what counts as production-claim-allowed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.marketing.weekly_report_pilot_proof import (
+    SECRET_KEY_MARKERS,
+    WeeklyReportPilotEvidence,
+    build_weekly_marketing_report_evidence_bundle,
+    evaluate_weekly_marketing_report_proof,
+    evidence_from_mapping,
+    summarize_weekly_marketing_report_proof,
+)
+from core.models.weekly_report_pilot_proof import WeeklyReportPilotProof
+
+logger = logging.getLogger(__name__)
+
+
+async def persist_weekly_report_pilot_proof(
+    session: AsyncSession,
+    *,
+    tenant_id: str | uuid.UUID,
+    company_id: str | uuid.UUID | None = None,
+    evidence: Mapping[str, Any] | WeeklyReportPilotEvidence,
+    now: datetime | None = None,
+) -> WeeklyReportPilotProof:
+    """Evaluate ``evidence`` and persist the verdict.
+
+    Returns the inserted ORM row. Does **not** commit — the caller decides
+    transaction boundaries (matches the existing repo conventions for
+    ``get_tenant_session`` / ``get_session``).
+    """
+
+    evaluated_at = (now or datetime.now(UTC))
+    bundle = evidence_from_mapping(evidence)
+    if not bundle.tenant_id:
+        bundle.tenant_id = str(tenant_id)
+    if not bundle.company_id and company_id is not None:
+        bundle.company_id = str(company_id)
+
+    proof = evaluate_weekly_marketing_report_proof(bundle, now=evaluated_at)
+    evidence_bundle = build_weekly_marketing_report_evidence_bundle(proof)
+
+    row = WeeklyReportPilotProof(
+        tenant_id=_coerce_uuid(tenant_id, allow_none=False),
+        company_id=_coerce_uuid(company_id, allow_none=True),
+        proof_id=str(proof.get("proof_id") or ""),
+        environment_type=str(proof.get("environment_type") or "unknown"),
+        proof_status=str(proof.get("proof_status") or "unavailable"),
+        production_claim_allowed=bool(proof.get("production_claim_allowed")),
+        real_vendor_claim_allowed=bool(proof.get("real_vendor_claim_allowed")),
+        readiness_score=int(proof.get("readiness_score") or 0),
+        evaluated_at=evaluated_at,
+        evidence_bundle=_redact(evidence_bundle),
+        verdict=_redact(_strip_internal_evidence(proof)),
+        blockers=_redact(list(proof.get("blockers") or [])),
+        next_actions=_redact(list(proof.get("next_actions") or [])),
+        report_artifact_refs=_redact(list(bundle.report_artifact_refs)),
+        decision_audit_refs=_redact(list(bundle.decision_audit_refs)),
+    )
+    session.add(row)
+    await session.flush()
+    return row
+
+
+async def latest_weekly_report_pilot_proof(
+    session: AsyncSession,
+    *,
+    tenant_id: str | uuid.UUID,
+    company_id: str | uuid.UUID | None = None,
+) -> WeeklyReportPilotProof | None:
+    """Return the newest persisted verdict for ``tenant_id`` / ``company_id``."""
+
+    stmt = select(WeeklyReportPilotProof).where(
+        WeeklyReportPilotProof.tenant_id == _coerce_uuid(tenant_id, allow_none=False)
+    )
+    if company_id is not None:
+        stmt = stmt.where(
+            WeeklyReportPilotProof.company_id == _coerce_uuid(company_id, allow_none=True)
+        )
+    stmt = stmt.order_by(desc(WeeklyReportPilotProof.evaluated_at)).limit(1)
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+def serialize_persisted_proof(row: WeeklyReportPilotProof | None) -> dict[str, Any] | None:
+    """Project a persisted row into a JSON-friendly dict for the API layer."""
+
+    if row is None:
+        return None
+    return {
+        "proof_id": row.proof_id,
+        "tenant_id": str(row.tenant_id) if row.tenant_id else None,
+        "company_id": str(row.company_id) if row.company_id else None,
+        "environment_type": row.environment_type,
+        "proof_status": row.proof_status,
+        "production_claim_allowed": bool(row.production_claim_allowed),
+        "real_vendor_claim_allowed": bool(row.real_vendor_claim_allowed),
+        "readiness_score": int(row.readiness_score or 0),
+        "evaluated_at": row.evaluated_at.isoformat() if row.evaluated_at else None,
+        "evidence_bundle": row.evidence_bundle,
+        "verdict": row.verdict,
+        "blockers": row.blockers,
+        "next_actions": row.next_actions,
+        "report_artifact_refs": row.report_artifact_refs,
+        "decision_audit_refs": row.decision_audit_refs,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+    }
+
+
+def summarize_persisted_proof(row: WeeklyReportPilotProof | None) -> dict[str, Any] | None:
+    """Compact summary for the CMO dashboard."""
+
+    if row is None:
+        return None
+    summary = {}
+    if isinstance(row.verdict, Mapping):
+        summary = summarize_weekly_marketing_report_proof(row.verdict)
+    return {
+        "proof_id": row.proof_id,
+        "environment_type": row.environment_type,
+        "proof_status": row.proof_status,
+        "production_claim_allowed": bool(row.production_claim_allowed),
+        "real_vendor_claim_allowed": bool(row.real_vendor_claim_allowed),
+        "readiness_score": int(row.readiness_score or 0),
+        "evaluated_at": row.evaluated_at.isoformat() if row.evaluated_at else None,
+        "blockers": len(row.blockers or []),
+        "next_action_cta": summary.get("next_action_cta", "none"),
+    }
+
+
+def build_weekly_report_evidence_from_report_output(
+    *,
+    tenant_id: str | None,
+    company_id: str | None,
+    report_id: str,
+    report_data: Mapping[str, Any] | None,
+    rendered_paths: Iterable[str] | None = None,
+    environment_type: str | None = None,
+    now: datetime | None = None,
+) -> WeeklyReportPilotEvidence:
+    """Hydrate a ``WeeklyReportPilotEvidence`` from a successful weekly report run.
+
+    The CMO weekly report generator runs against ``/kpis/cmo`` (or its
+    fallback). When the response is real, ``report_data`` already
+    carries the CMO-PROD-1 evidence we need: connector setup, mapping +
+    backfill status, unified KPI results, reconciliation checks, and
+    report quality gates. This function shapes those projections into
+    the evidence model so the persistence helper can write a verdict.
+    """
+
+    data = dict(report_data or {})
+    generated_at = (now or datetime.now(UTC)).isoformat()
+    rendered = [path for path in (rendered_paths or []) if path]
+    artifact_refs: list[dict[str, Any]] = [
+        {
+            "artifact_id": report_id,
+            "path": path,
+            "format": _format_from_path(path),
+            "delivered_at": generated_at,
+        }
+        for path in rendered
+    ]
+    audit_refs: list[dict[str, Any]] = []
+    quality_gate = data.get("report_quality_gate")
+    if isinstance(quality_gate, Mapping):
+        for ref in quality_gate.get("required_approval_audit_refs") or []:
+            audit_refs.append({"audit_id": str(ref), "event_type": "report_quality_gate"})
+    if rendered:
+        audit_refs.append(
+            {
+                "audit_id": f"weekly_report:{report_id}",
+                "event_type": "weekly_report_delivered",
+                "generated_at": generated_at,
+            }
+        )
+    if isinstance(data.get("demo"), bool) and data["demo"] and environment_type is None:
+        environment_type = "demo"
+    resolved_env = environment_type or data.get("environment_type") or "unknown"
+    return WeeklyReportPilotEvidence(
+        tenant_id=tenant_id,
+        company_id=company_id,
+        environment_type=str(resolved_env),
+        connector_evidence=_dicts(data.get("connector_setup")),
+        mapping_evidence=_dicts(data.get("field_mapping_status")),
+        backfill_evidence=_dicts(data.get("backfill_status")),
+        kpi_results=_dicts(data.get("unified_cmo_kpi_results")),
+        reconciliation_checks=_dicts(data.get("cmo_kpi_reconciliation_checks")),
+        report_quality_gates=_dicts(data.get("report_quality_gates")),
+        report_artifact_refs=artifact_refs,
+        decision_audit_refs=audit_refs,
+        source_refs=_dicts(data.get("weekly_report_source_refs")),
+        generated_at=generated_at,
+        source_context={"source": data.get("source")} if data.get("source") else {},
+    )
+
+
+async def evaluate_and_persist_weekly_report_pilot_proof_from_report_output(
+    *,
+    tenant_id: str | uuid.UUID,
+    company_id: str | uuid.UUID | None,
+    report_id: str,
+    report_data: Mapping[str, Any] | None,
+    rendered_paths: Iterable[str] | None = None,
+    environment_type: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Async convenience helper: hydrate evidence, evaluate, persist, summarise.
+
+    Used by the weekly-report Celery path. Returns the verdict summary so
+    the caller can log it without needing to re-query the DB.
+    """
+
+    from core.database import get_tenant_session  # local import keeps unit tests light
+
+    evidence = build_weekly_report_evidence_from_report_output(
+        tenant_id=str(tenant_id) if tenant_id is not None else None,
+        company_id=str(company_id) if company_id is not None else None,
+        report_id=report_id,
+        report_data=report_data,
+        rendered_paths=rendered_paths,
+        environment_type=environment_type,
+        now=now,
+    )
+    async with get_tenant_session(_coerce_uuid(tenant_id, allow_none=False)) as session:
+        row = await persist_weekly_report_pilot_proof(
+            session,
+            tenant_id=tenant_id,
+            company_id=company_id,
+            evidence=evidence,
+            now=now,
+        )
+        return summarize_persisted_proof(row) or {}
+
+
+def persist_weekly_report_pilot_proof_from_report_output_sync(
+    *,
+    tenant_id: str,
+    company_id: str | None,
+    report_id: str,
+    report_data: Mapping[str, Any] | None,
+    rendered_paths: Iterable[str] | None = None,
+    environment_type: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Sync wrapper for the Celery report task.
+
+    Returns the verdict summary or ``None`` if persistence was skipped
+    (DB unavailable, invalid UUID, no event loop available, etc.).
+    Errors are logged and swallowed so the report task itself does not
+    fail because pilot-proof persistence couldn't run.
+    """
+
+    try:
+        _coerce_uuid(tenant_id, allow_none=False)
+    except ValueError:
+        logger.info(
+            "weekly_report_pilot_proof_skipped",
+            extra={"reason": "non_uuid_tenant_id", "tenant_id": str(tenant_id)},
+        )
+        return None
+    try:
+        company_uuid = _coerce_uuid(company_id, allow_none=True)
+    except ValueError:
+        company_uuid = None
+    try:
+        return asyncio.run(
+            evaluate_and_persist_weekly_report_pilot_proof_from_report_output(
+                tenant_id=tenant_id,
+                company_id=str(company_uuid) if company_uuid else None,
+                report_id=report_id,
+                report_data=report_data,
+                rendered_paths=rendered_paths,
+                environment_type=environment_type,
+                now=now,
+            )
+        )
+    # enterprise-gate: broad-except-ok reason=pilot-proof-persistence-must-not-fail-report-delivery
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "weekly_report_pilot_proof_persist_failed",
+            extra={"error": str(exc), "report_id": report_id},
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_from_path(path: str) -> str:
+    lowered = path.lower()
+    if lowered.endswith(".pdf"):
+        return "pdf"
+    if lowered.endswith(".xlsx") or lowered.endswith(".xls"):
+        return "excel"
+    if lowered.endswith(".html") or lowered.endswith(".htm"):
+        return "html"
+    return "binary"
+
+
+def _dicts(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, Mapping):
+        return [dict(value)]
+    if isinstance(value, list | tuple | set):
+        return [dict(item) for item in value if isinstance(item, Mapping)]
+    return []
+
+
+def _coerce_uuid(value: Any, *, allow_none: bool) -> uuid.UUID | None:
+    if value in (None, ""):
+        if allow_none:
+            return None
+        raise ValueError("tenant_id is required for weekly-report pilot proof persistence")
+    if isinstance(value, uuid.UUID):
+        return value
+    try:
+        return uuid.UUID(str(value))
+    except (ValueError, AttributeError) as exc:
+        raise ValueError(f"invalid UUID for weekly-report pilot proof: {value!r}") from exc
+
+
+def _strip_internal_evidence(proof: Mapping[str, Any]) -> dict[str, Any]:
+    """Drop the verbose ``evidence_input`` from the persisted verdict.
+
+    ``evidence_input`` is already represented in the redacted bundle stored
+    alongside the verdict; keeping it in both columns just inflates row
+    size and risks leaking unredacted nested dicts.
+    """
+
+    out = dict(proof)
+    out.pop("evidence_input", None)
+    return out
+
+
+def _redact(value: Any) -> Any:
+    """Belt-and-braces redaction mirroring the validator's redactor.
+
+    The validator already redacts before returning. This pass guarantees
+    that anything the caller added to the persisted row (e.g. directly
+    constructed dicts) is also redacted before it lands in JSONB.
+    """
+
+    if isinstance(value, Mapping):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            text_key = str(key).lower()
+            if any(marker in text_key for marker in SECRET_KEY_MARKERS):
+                redacted[str(key)] = "[REDACTED]"
+            else:
+                redacted[str(key)] = _redact(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    if isinstance(value, tuple | set):
+        return [_redact(item) for item in value]
+    return value

--- a/core/marketing/weekly_report_pilot_proof.py
+++ b/core/marketing/weekly_report_pilot_proof.py
@@ -1,0 +1,1027 @@
+"""CMO-PROD-1 weekly marketing report pilot proof.
+
+This module turns a structured evidence bundle into a strict pilot-proof
+verdict for the **read-only weekly marketing report**. It is the production-
+proof gate that complements the CMO-9.4 broader pilot-proof projection.
+
+It is intentionally narrow and fail-closed:
+
+  * Demo / test-double / unknown environments cannot produce a real-vendor
+    production claim.
+  * Vendor-sandbox evidence can only produce a *sandbox* / *partial* proof
+    label and must never be described as real-vendor production proof.
+  * Real-vendor evidence passes only when CRM + Ads + Analytics + Email
+    connectors are configured/read-ready, all required field mappings are
+    valid, the historical backfill is complete for each required category,
+    every required weekly-report KPI is present and not blocked, every
+    reconciliation check passes, the weekly-report quality gate is `pass`
+    or `passed`, and the report artifact + decision-audit refs are present.
+  * Mock / test-double connector evidence and demo / sample / fallback
+    source markers always block the proof.
+
+The module is storage-free: it operates on JSON-serialisable evidence
+dictionaries (or `WeeklyReportPilotEvidence` instances). Callers that want
+to evaluate runtime state should hydrate the evidence dict from their own
+projections before calling :func:`evaluate_weekly_marketing_report_proof`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from core.marketing.pilot_proof import (
+    DEMO_SOURCE_MARKERS,
+    ENVIRONMENT_TYPES,
+    SECRET_KEY_MARKERS,
+    TEST_SOURCE_MARKERS,
+)
+
+WEEKLY_REPORT_PROOF_VERSION = "2026-05-24.cmo-prod-1"
+
+PROOF_STATUSES = (
+    "passed",
+    "sandbox_proven",
+    "partial",
+    "blocked",
+    "demo_only",
+    "test_only",
+    "unavailable",
+)
+
+REQUIRED_CONNECTOR_CATEGORIES: tuple[str, ...] = ("CRM", "Ads", "Analytics", "Email")
+REQUIRED_MAPPINGS: tuple[str, ...] = (
+    "lifecycle_stages",
+    "opportunity_revenue",
+    "campaign_ids",
+    "utm_fields",
+    "consent_unsubscribe",
+    "fiscal_calendar",
+    "currency",
+    "timezone",
+)
+REQUIRED_BACKFILL_CATEGORIES: tuple[str, ...] = ("CRM", "Ads", "Analytics", "Email")
+REQUIRED_KPI_KEYS: tuple[str, ...] = (
+    "cac",
+    "mql",
+    "sql",
+    "mql_to_sql_conversion_rate",
+    "roas",
+    "pipeline_contribution",
+    "conversion_rates_by_funnel_stage",
+    "email_performance",
+)
+
+# Statuses we treat as "ok" for connector/mapping/backfill/KPI/reconciliation/report rows.
+# enterprise-gate: process-local-ok reason=static-proof-state-set
+HEALTHY_CONNECTOR_STATES = {"healthy", "ok", "ready"}
+# enterprise-gate: process-local-ok reason=static-proof-state-set
+VALID_MAPPING_STATES = {"valid", "ready", "configured", "ok"}
+# enterprise-gate: process-local-ok reason=static-proof-state-set
+COMPLETED_BACKFILL_STATES = {"completed", "ready", "ok"}
+# enterprise-gate: process-local-ok reason=static-proof-state-set
+HEALTHY_KPI_STATES = {"ready", "passed", "pass", "ok", "warning"}
+# enterprise-gate: process-local-ok reason=static-proof-state-set
+BLOCKING_KPI_STATES = {"blocked", "unavailable", "missing"}
+# enterprise-gate: process-local-ok reason=static-proof-state-set
+PASSED_RECON_STATES = {"pass", "passed", "ok"}
+# enterprise-gate: process-local-ok reason=static-proof-state-set
+WARNING_RECON_STATES = {"warning", "warn"}
+# enterprise-gate: process-local-ok reason=static-proof-state-set
+BLOCKING_RECON_STATES = {"blocked", "failed", "missing", "unavailable"}
+# enterprise-gate: process-local-ok reason=static-proof-state-set
+PASSED_REPORT_STATES = {"pass", "passed"}
+# enterprise-gate: process-local-ok reason=static-proof-state-set
+WARNING_REPORT_STATES = {"warning", "warn"}
+# enterprise-gate: process-local-ok reason=static-proof-state-set
+BLOCKING_REPORT_STATES = {"blocked", "unavailable", "missing", "failed"}
+
+
+# ---------------------------------------------------------------------------
+# Evidence model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WeeklyReportPilotEvidence:
+    """Structured evidence bundle for the weekly-report pilot proof.
+
+    Every field is optional in the dataclass so a caller can supply only
+    what they have; the validator enforces what is *required* per
+    environment type.
+    """
+
+    tenant_id: str | None = None
+    company_id: str | None = None
+    environment_type: str = "unknown"
+    connector_evidence: list[dict[str, Any]] = field(default_factory=list)
+    mapping_evidence: list[dict[str, Any]] = field(default_factory=list)
+    backfill_evidence: list[dict[str, Any]] = field(default_factory=list)
+    kpi_results: list[dict[str, Any]] = field(default_factory=list)
+    reconciliation_checks: list[dict[str, Any]] = field(default_factory=list)
+    report_quality_gates: list[dict[str, Any]] = field(default_factory=list)
+    report_artifact_refs: list[dict[str, Any]] = field(default_factory=list)
+    decision_audit_refs: list[dict[str, Any]] = field(default_factory=list)
+    source_refs: list[dict[str, Any]] = field(default_factory=list)
+    generated_at: str | None = None
+    source_context: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tenant_id": self.tenant_id,
+            "company_id": self.company_id,
+            "environment_type": self.environment_type,
+            "connector_evidence": list(self.connector_evidence),
+            "mapping_evidence": list(self.mapping_evidence),
+            "backfill_evidence": list(self.backfill_evidence),
+            "kpi_results": list(self.kpi_results),
+            "reconciliation_checks": list(self.reconciliation_checks),
+            "report_quality_gates": list(self.report_quality_gates),
+            "report_artifact_refs": list(self.report_artifact_refs),
+            "decision_audit_refs": list(self.decision_audit_refs),
+            "source_refs": list(self.source_refs),
+            "generated_at": self.generated_at,
+            "source_context": dict(self.source_context),
+        }
+
+
+def evidence_from_mapping(value: Mapping[str, Any] | WeeklyReportPilotEvidence | None) -> WeeklyReportPilotEvidence:
+    """Normalise either a dict or a dataclass into ``WeeklyReportPilotEvidence``."""
+
+    if isinstance(value, WeeklyReportPilotEvidence):
+        return value
+    data = value if isinstance(value, Mapping) else {}
+    return WeeklyReportPilotEvidence(
+        tenant_id=_string_or_none(data.get("tenant_id")),
+        company_id=_string_or_none(data.get("company_id")),
+        environment_type=_normalize(data.get("environment_type") or "unknown") or "unknown",
+        connector_evidence=_dicts(data.get("connector_evidence")),
+        mapping_evidence=_dicts(data.get("mapping_evidence") or data.get("field_mapping_status")),
+        backfill_evidence=_dicts(data.get("backfill_evidence") or data.get("backfill_status")),
+        kpi_results=_dicts(data.get("kpi_results") or data.get("unified_cmo_kpi_results")),
+        reconciliation_checks=_dicts(data.get("reconciliation_checks") or data.get("cmo_kpi_reconciliation_checks")),
+        report_quality_gates=_dicts(data.get("report_quality_gates")),
+        report_artifact_refs=_dicts(data.get("report_artifact_refs") or data.get("report_artifacts")),
+        decision_audit_refs=_dicts(data.get("decision_audit_refs") or data.get("audit_refs")),
+        source_refs=_dicts(data.get("source_refs")),
+        generated_at=_string_or_none(data.get("generated_at")),
+        source_context=(
+            dict(data["source_context"])
+            if isinstance(data.get("source_context"), Mapping)
+            else {}
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def evaluate_weekly_marketing_report_proof(
+    evidence: Mapping[str, Any] | WeeklyReportPilotEvidence | None,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Return a strict, deterministic weekly-report pilot-proof verdict.
+
+    Output keys mirror the broader ``cmo_pilot_proof`` projection so the
+    redacted bundle can be embedded in the same /kpis/cmo response.
+    """
+
+    bundle = evidence_from_mapping(evidence)
+    generated_at = _iso(now or datetime.now(UTC))
+    env = _resolve_environment(bundle)
+
+    blockers: list[dict[str, Any]] = []
+    risks: list[dict[str, Any]] = []
+    proven: list[dict[str, Any]] = []
+    next_actions: list[dict[str, Any]] = []
+    evidence_refs: list[dict[str, Any]] = []
+
+    _evaluate_environment(env, bundle, blockers, risks, next_actions)
+    _evaluate_connectors(bundle, env, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_mappings(bundle, env, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_backfills(bundle, env, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_kpis(bundle, env, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_reconciliations(bundle, env, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_report_quality(bundle, env, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_report_artifacts(bundle, env, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_decision_audit(bundle, env, blockers, risks, proven, evidence_refs, next_actions)
+    _evaluate_source_lineage(bundle, env, blockers, risks, proven, evidence_refs, next_actions)
+
+    blockers = _dedupe_issues(blockers)
+    risks = _dedupe_issues(risks)
+    proven = _dedupe(proven, key=lambda row: row.get("capability_key", ""))
+    evidence_refs = _dedupe(evidence_refs, key=lambda row: (row.get("type", ""), str(row.get("ref_id") or "")))
+    next_actions = _dedupe(next_actions, key=lambda row: row.get("action_key", ""))
+
+    status = _proof_status(env, blockers, risks)
+    real_vendor_allowed = env == "real_vendor" and status == "passed"
+    production_claim_allowed = real_vendor_allowed
+    proof: dict[str, Any] = {
+        "schema_version": WEEKLY_REPORT_PROOF_VERSION,
+        "proof_id": _proof_id(bundle, env, blockers, proven, evidence_refs),
+        "tenant_id": bundle.tenant_id,
+        "company_id": bundle.company_id,
+        "environment_type": env,
+        "proof_scope": "sandbox" if env == "vendor_sandbox" else env,
+        "proof_status": status,
+        "production_claim_allowed": production_claim_allowed,
+        "real_vendor_claim_allowed": real_vendor_allowed,
+        "readiness_score": _readiness_score(env, blockers, risks, proven),
+        "blockers": blockers,
+        "risks": risks,
+        "proven_capabilities": proven,
+        "evidence_refs": evidence_refs,
+        "next_actions": next_actions,
+        "generated_at": generated_at,
+        "evidence_input": bundle.to_dict(),
+    }
+    return _redact(proof)
+
+
+def summarize_weekly_marketing_report_proof(proof: Mapping[str, Any]) -> dict[str, Any]:
+    status = str(proof.get("proof_status") or "unavailable")
+    blockers = _dicts(proof.get("blockers"))
+    risks = _dicts(proof.get("risks"))
+    return {
+        "schema_version": WEEKLY_REPORT_PROOF_VERSION,
+        "proof_id": proof.get("proof_id"),
+        "environment_type": proof.get("environment_type") or "unknown",
+        "proof_status": status,
+        "readiness_score": proof.get("readiness_score") or 0,
+        "production_claim_allowed": bool(proof.get("production_claim_allowed")),
+        "real_vendor_claim_allowed": bool(proof.get("real_vendor_claim_allowed")),
+        "proven_capabilities": len(_dicts(proof.get("proven_capabilities"))),
+        "blockers": len(blockers),
+        "risks": len(risks),
+        "next_action_cta": _summary_next_action(status, blockers, risks),
+    }
+
+
+def build_weekly_marketing_report_evidence_bundle(proof: Mapping[str, Any]) -> dict[str, Any]:
+    redacted = _redact(dict(proof))
+    return {
+        "bundle_version": WEEKLY_REPORT_PROOF_VERSION,
+        "bundle_type": "weekly_marketing_report_pilot_proof",
+        "proof_id": redacted.get("proof_id"),
+        "environment_type": redacted.get("environment_type"),
+        "proof_status": redacted.get("proof_status"),
+        "generated_at": redacted.get("generated_at"),
+        "summary": summarize_weekly_marketing_report_proof(redacted),
+        "evidence": {
+            "proven_capabilities": redacted.get("proven_capabilities") or [],
+            "blockers": redacted.get("blockers") or [],
+            "risks": redacted.get("risks") or [],
+            "evidence_refs": redacted.get("evidence_refs") or [],
+            "next_actions": redacted.get("next_actions") or [],
+        },
+    }
+
+
+def serialize_weekly_marketing_report_evidence_bundle(bundle: Mapping[str, Any]) -> str:
+    return json.dumps(_redact(bundle), sort_keys=True, separators=(",", ":"), default=str)
+
+
+def build_weekly_marketing_report_proof_projection(
+    evidence: Mapping[str, Any] | WeeklyReportPilotEvidence | None,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Return the /kpis/cmo-shaped projection for the weekly report proof."""
+
+    proof = evaluate_weekly_marketing_report_proof(evidence, now=now)
+    return {
+        "weekly_report_pilot_proof_version": WEEKLY_REPORT_PROOF_VERSION,
+        "weekly_report_pilot_proof": proof,
+        "weekly_report_pilot_proof_summary": summarize_weekly_marketing_report_proof(proof),
+        "weekly_report_pilot_evidence_bundle": build_weekly_marketing_report_evidence_bundle(proof),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Evaluators
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_environment(
+    env: str,
+    bundle: WeeklyReportPilotEvidence,
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    if env == "demo":
+        _add_issue(
+            blockers,
+            category="environment",
+            message="Demo/sample evidence cannot produce a weekly-report production proof.",
+            severity="critical",
+            next_action="connect_real_or_sandbox_sources",
+        )
+        next_actions.append(_next_action("connect_real_or_sandbox_sources", "Connect Real or Sandbox Sources"))
+    elif env == "test_double":
+        _add_issue(
+            blockers,
+            category="environment",
+            message="Test-double / mock evidence cannot produce a weekly-report production proof.",
+            severity="critical",
+            next_action="replace_test_doubles_with_vendor_sandbox",
+        )
+        next_actions.append(
+            _next_action("replace_test_doubles_with_vendor_sandbox", "Replace Test Doubles With Vendor Sandbox")
+        )
+    elif env == "unknown":
+        _add_issue(
+            risks,
+            category="environment",
+            message="Weekly-report pilot environment type is unknown.",
+            severity="medium",
+            next_action="label_pilot_environment",
+        )
+        next_actions.append(_next_action("label_pilot_environment", "Label Pilot Environment"))
+
+    for row in bundle.connector_evidence:
+        if row.get("mock_or_test_double") or row.get("stub_only"):
+            _add_issue(
+                blockers,
+                category="environment",
+                message="At least one connector evidence row is marked mock/test-double.",
+                severity="critical",
+                next_action="replace_test_doubles_with_vendor_sandbox",
+            )
+            break
+
+
+def _evaluate_connectors(
+    bundle: WeeklyReportPilotEvidence,
+    env: str,
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    evidence_refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    rows = bundle.connector_evidence
+    by_category: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        category = _category(row)
+        if category:
+            by_category.setdefault(category, []).append(row)
+
+    missing: list[str] = []
+    not_ready: list[str] = []
+    for required in REQUIRED_CONNECTOR_CATEGORIES:
+        configured = by_category.get(required, [])
+        if not configured:
+            missing.append(required)
+            continue
+        ready_rows = [
+            row
+            for row in configured
+            if _normalize(row.get("health_status") or row.get("status")) in HEALTHY_CONNECTOR_STATES
+            and bool(row.get("read_ready", row.get("configured", True)))
+            and not (row.get("mock_or_test_double") or row.get("stub_only"))
+        ]
+        if not ready_rows:
+            not_ready.append(required)
+        for row in configured:
+            evidence_refs.append(_ref("connector", row.get("connector_key") or row.get("key"), row))
+
+    if missing:
+        _add_issue(
+            blockers,
+            category="connector",
+            message=(
+                f"Required connector categor{'ies' if len(missing) > 1 else 'y'} "
+                f"{', '.join(missing)} not present in pilot evidence."
+            ),
+            severity="critical",
+            affected=missing,
+            next_action="connect_real_or_sandbox_sources",
+        )
+        next_actions.append(_next_action("connect_real_or_sandbox_sources", "Connect Real or Sandbox Sources"))
+    if not_ready:
+        _add_issue(
+            blockers,
+            category="connector",
+            message=(
+                f"Required connector categor{'ies' if len(not_ready) > 1 else 'y'} "
+                f"{', '.join(not_ready)} are configured but not read-ready."
+            ),
+            severity="high",
+            affected=not_ready,
+            next_action="resolve_connector_readiness",
+        )
+    if not missing and not not_ready:
+        proven.append(
+            _capability(
+                "weekly_report_connectors",
+                "CRM, Ads, Analytics, and Email connectors are present and read-ready.",
+            )
+        )
+
+
+def _evaluate_mappings(
+    bundle: WeeklyReportPilotEvidence,
+    env: str,
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    evidence_refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    by_key: dict[str, dict[str, Any]] = {}
+    for row in bundle.mapping_evidence:
+        key = _normalize(row.get("key") or row.get("mapping_key"))
+        if key:
+            by_key[key] = row
+        evidence_refs.append(_ref("mapping", key or row.get("name"), row))
+
+    missing: list[str] = []
+    invalid: list[str] = []
+    for required in REQUIRED_MAPPINGS:
+        row = by_key.get(required)
+        if row is None:
+            missing.append(required)
+            continue
+        status = _normalize(row.get("status") or row.get("state"))
+        if status not in VALID_MAPPING_STATES:
+            invalid.append(required)
+
+    if missing:
+        _add_issue(
+            blockers,
+            category="mapping",
+            message=f"Required field mapping(s) missing: {', '.join(missing)}.",
+            severity="critical",
+            affected=missing,
+            next_action="configure_field_mapping",
+        )
+        next_actions.append(_next_action("configure_field_mapping", "Configure Required Field Mappings"))
+    if invalid:
+        _add_issue(
+            blockers,
+            category="mapping",
+            message=f"Required field mapping(s) not valid: {', '.join(invalid)}.",
+            severity="high",
+            affected=invalid,
+            next_action="repair_field_mapping",
+        )
+    if not missing and not invalid:
+        proven.append(_capability("weekly_report_mappings", "All required field mappings are valid."))
+
+
+def _evaluate_backfills(
+    bundle: WeeklyReportPilotEvidence,
+    env: str,
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    evidence_refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    by_category: dict[str, list[dict[str, Any]]] = {}
+    for row in bundle.backfill_evidence:
+        category = _category(row)
+        if category:
+            by_category.setdefault(category, []).append(row)
+        backfill_ref = (
+            row.get("source_connector_key")
+            or row.get("connector_key")
+            or category
+        )
+        evidence_refs.append(_ref("backfill", backfill_ref, row))
+
+    missing: list[str] = []
+    incomplete: list[str] = []
+    for required in REQUIRED_BACKFILL_CATEGORIES:
+        rows = by_category.get(required, [])
+        if not rows:
+            missing.append(required)
+            continue
+        completed = [row for row in rows if _normalize(row.get("status")) in COMPLETED_BACKFILL_STATES]
+        if not completed:
+            incomplete.append(required)
+
+    if missing:
+        _add_issue(
+            blockers,
+            category="backfill",
+            message=f"Historical backfill evidence missing for: {', '.join(missing)}.",
+            severity="critical",
+            affected=missing,
+            next_action="complete_required_backfill",
+        )
+        next_actions.append(_next_action("complete_required_backfill", "Complete Required Backfill"))
+    if incomplete:
+        _add_issue(
+            blockers,
+            category="backfill",
+            message=f"Historical backfill not complete for: {', '.join(incomplete)}.",
+            severity="high",
+            affected=incomplete,
+            next_action="complete_required_backfill",
+        )
+    if not missing and not incomplete:
+        proven.append(_capability("weekly_report_backfill", "Required CRM/Ads/Analytics/Email backfill complete."))
+
+
+def _evaluate_kpis(
+    bundle: WeeklyReportPilotEvidence,
+    env: str,
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    evidence_refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    by_key: dict[str, dict[str, Any]] = {}
+    for row in bundle.kpi_results:
+        key = _normalize(row.get("kpi_key") or row.get("key"))
+        if key:
+            by_key[key] = row
+        evidence_refs.append(_ref("kpi", key or row.get("name"), row))
+
+    missing: list[str] = []
+    blocked: list[str] = []
+    degraded: list[str] = []
+    for required in REQUIRED_KPI_KEYS:
+        row = by_key.get(required)
+        if row is None:
+            missing.append(required)
+            continue
+        status = _normalize(row.get("status") or row.get("readiness"))
+        if status in BLOCKING_KPI_STATES:
+            blocked.append(required)
+        elif status not in HEALTHY_KPI_STATES:
+            degraded.append(required)
+
+    if missing:
+        _add_issue(
+            blockers,
+            category="kpi",
+            message=f"Required weekly-report KPI(s) missing: {', '.join(missing)}.",
+            severity="critical",
+            affected=missing,
+            next_action="compute_required_weekly_report_kpis",
+        )
+        next_actions.append(
+            _next_action("compute_required_weekly_report_kpis", "Compute Required Weekly Report KPIs")
+        )
+    if blocked:
+        _add_issue(
+            blockers,
+            category="kpi",
+            message=f"Required weekly-report KPI(s) blocked: {', '.join(blocked)}.",
+            severity="high",
+            affected=blocked,
+            next_action="resolve_blocked_weekly_report_kpis",
+        )
+    if degraded:
+        _add_issue(
+            risks,
+            category="kpi",
+            message=f"Required weekly-report KPI(s) degraded: {', '.join(degraded)}.",
+            severity="medium",
+            affected=degraded,
+            next_action="review_degraded_weekly_report_kpis",
+        )
+    if not missing and not blocked:
+        proven.append(_capability("weekly_report_kpis", "Required weekly-report KPIs are present and not blocked."))
+
+
+def _evaluate_reconciliations(
+    bundle: WeeklyReportPilotEvidence,
+    env: str,
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    evidence_refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    rows = bundle.reconciliation_checks
+    if not rows:
+        _add_issue(
+            blockers,
+            category="reconciliation",
+            message="No KPI reconciliation check evidence attached.",
+            severity="high",
+            next_action="attach_reconciliation_checks",
+        )
+        next_actions.append(_next_action("attach_reconciliation_checks", "Attach Reconciliation Checks"))
+        return
+    failed: list[str] = []
+    warning: list[str] = []
+    passed: list[str] = []
+    for row in rows:
+        status = _normalize(row.get("status"))
+        key = str(row.get("check_key") or row.get("key") or row.get("name") or "")
+        evidence_refs.append(_ref("reconciliation", key or row.get("kpi_key"), row))
+        if status in BLOCKING_RECON_STATES:
+            failed.append(key or "unknown_check")
+        elif status in WARNING_RECON_STATES:
+            warning.append(key or "unknown_check")
+        elif status in PASSED_RECON_STATES:
+            passed.append(key)
+    if failed:
+        _add_issue(
+            blockers,
+            category="reconciliation",
+            message=f"KPI reconciliation failed for: {', '.join(failed)}.",
+            severity="critical",
+            affected=failed,
+            next_action="resolve_failed_reconciliations",
+        )
+        next_actions.append(_next_action("resolve_failed_reconciliations", "Resolve Failed Reconciliations"))
+    if warning:
+        _add_issue(
+            risks,
+            category="reconciliation",
+            message=f"KPI reconciliation warnings for: {', '.join(warning)}.",
+            severity="medium",
+            affected=warning,
+            next_action="review_reconciliation_warnings",
+        )
+    if passed and not failed:
+        proven.append(_capability("weekly_report_reconciliation", "All KPI reconciliation checks pass."))
+
+
+def _evaluate_report_quality(
+    bundle: WeeklyReportPilotEvidence,
+    env: str,
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    evidence_refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    rows = bundle.report_quality_gates
+    if not rows:
+        _add_issue(
+            blockers,
+            category="report_quality",
+            message="Report quality gate evidence is missing for weekly_marketing_report.",
+            severity="critical",
+            next_action="attach_report_quality_gate",
+        )
+        next_actions.append(_next_action("attach_report_quality_gate", "Attach Report Quality Gate"))
+        return
+    relevant = [
+        row
+        for row in rows
+        if _normalize(row.get("report_key") or row.get("key")) == "weekly_marketing_report"
+    ]
+    if not relevant:
+        relevant = rows
+    pass_rows = [row for row in relevant if _normalize(row.get("status")) in PASSED_REPORT_STATES]
+    warning_rows = [row for row in relevant if _normalize(row.get("status")) in WARNING_REPORT_STATES]
+    blocked_rows = [row for row in relevant if _normalize(row.get("status")) in BLOCKING_REPORT_STATES]
+    for row in relevant:
+        evidence_refs.append(_ref("report_quality_gate", row.get("report_key") or row.get("key"), row))
+    if blocked_rows:
+        _add_issue(
+            blockers,
+            category="report_quality",
+            message="Weekly marketing report quality gate is blocked.",
+            severity="critical",
+            next_action=str(blocked_rows[0].get("next_action_cta") or "fix_weekly_report_quality_gate"),
+        )
+        next_actions.append(_next_action("fix_weekly_report_quality_gate", "Fix Weekly Report Quality Gate"))
+    elif not pass_rows:
+        _add_issue(
+            blockers,
+            category="report_quality",
+            message="Weekly marketing report quality gate has no passing evidence.",
+            severity="high",
+            next_action="run_weekly_report_quality_gate",
+        )
+    elif warning_rows:
+        _add_issue(
+            risks,
+            category="report_quality",
+            message="Weekly marketing report quality gate has warnings.",
+            severity="medium",
+            next_action="review_weekly_report_warnings",
+        )
+        proven.append(_capability("weekly_report_quality_gate", "Weekly report quality gate has passing evidence."))
+    else:
+        proven.append(_capability("weekly_report_quality_gate", "Weekly report quality gate passes."))
+
+
+def _evaluate_report_artifacts(
+    bundle: WeeklyReportPilotEvidence,
+    env: str,
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    evidence_refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    rows = bundle.report_artifact_refs
+    if not rows:
+        category = blockers if env == "real_vendor" else risks
+        _add_issue(
+            category,
+            category="report_artifact",
+            message="No weekly-report artifact reference attached to pilot evidence.",
+            severity="high" if env == "real_vendor" else "medium",
+            next_action="attach_weekly_report_artifact",
+        )
+        next_actions.append(_next_action("attach_weekly_report_artifact", "Attach Weekly Report Artifact"))
+        return
+    for row in rows:
+        evidence_refs.append(_ref("report_artifact", row.get("artifact_id") or row.get("id"), row))
+    proven.append(_capability("weekly_report_artifact", "Weekly-report artifact reference attached."))
+
+
+def _evaluate_decision_audit(
+    bundle: WeeklyReportPilotEvidence,
+    env: str,
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    evidence_refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    rows = bundle.decision_audit_refs
+    if not rows:
+        category = blockers if env == "real_vendor" else risks
+        _add_issue(
+            category,
+            category="decision_audit",
+            message="No decision-audit reference attached to weekly-report pilot evidence.",
+            severity="high" if env == "real_vendor" else "medium",
+            next_action="attach_decision_audit_ref",
+        )
+        next_actions.append(_next_action("attach_decision_audit_ref", "Attach Decision Audit Reference"))
+        return
+    for row in rows:
+        audit_ref_id = (
+            row.get("audit_id") or row.get("audit_reference") or row.get("id")
+        )
+        evidence_refs.append(_ref("decision_audit", audit_ref_id, row))
+    proven.append(_capability("weekly_report_audit", "Decision-audit references attached."))
+
+
+def _evaluate_source_lineage(
+    bundle: WeeklyReportPilotEvidence,
+    env: str,
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    evidence_refs: list[dict[str, Any]],
+    next_actions: list[dict[str, Any]],
+) -> None:
+    rows = bundle.source_refs
+    if not rows:
+        category = blockers if env == "real_vendor" else risks
+        _add_issue(
+            category,
+            category="source_lineage",
+            message="Weekly-report pilot evidence has no real connector / source lineage refs.",
+            severity="high" if env == "real_vendor" else "medium",
+            next_action="connect_real_or_sandbox_sources",
+        )
+        return
+    for row in rows:
+        source = _normalize(row.get("source") or row.get("connector_key"))
+        if source in DEMO_SOURCE_MARKERS:
+            _add_issue(
+                blockers,
+                category="source_lineage",
+                message="Demo/sample/mock source markers cannot back a production pilot proof.",
+                severity="critical",
+                next_action="connect_real_or_sandbox_sources",
+            )
+            return
+        if source in TEST_SOURCE_MARKERS:
+            _add_issue(
+                blockers,
+                category="source_lineage",
+                message="Test-double source markers cannot back a production pilot proof.",
+                severity="critical",
+                next_action="replace_test_doubles_with_vendor_sandbox",
+            )
+            return
+        evidence_refs.append(_ref("source", row.get("ref_id") or row.get("type"), row))
+    proven.append(_capability("weekly_report_source_lineage", "Real source lineage refs attached."))
+
+
+# ---------------------------------------------------------------------------
+# Status / scoring
+# ---------------------------------------------------------------------------
+
+
+def _proof_status(env: str, blockers: list[dict[str, Any]], risks: list[dict[str, Any]]) -> str:
+    if env == "demo":
+        return "demo_only"
+    if env == "test_double":
+        return "test_only"
+    if env == "unknown" and not blockers:
+        return "unavailable"
+    if blockers:
+        return "blocked"
+    if env == "vendor_sandbox":
+        return "sandbox_proven" if not risks else "partial"
+    if env == "real_vendor":
+        if risks and any(row.get("severity") in {"high", "critical"} for row in risks):
+            return "partial"
+        return "passed"
+    return "partial"
+
+
+def _readiness_score(
+    env: str,
+    blockers: list[dict[str, Any]],
+    risks: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+) -> int:
+    score = 100
+    score -= min(len(blockers) * 12, 84)
+    score -= min(
+        sum(7 if row.get("severity") in {"high", "critical"} else 4 for row in risks),
+        35,
+    )
+    score += min(len(proven), 8)
+    if env == "demo":
+        score = min(score, 25)
+    elif env == "test_double":
+        score = min(score, 30)
+    elif env == "unknown":
+        score = min(score, 55)
+    elif env == "vendor_sandbox":
+        score = min(score, 90)
+    return max(min(score, 100), 0)
+
+
+def _resolve_environment(bundle: WeeklyReportPilotEvidence) -> str:
+    explicit = _normalize(bundle.environment_type)
+    if explicit in ENVIRONMENT_TYPES:
+        return explicit
+    if explicit in {"sandbox", "vendor_test"}:
+        return "vendor_sandbox"
+    if explicit in {"real", "production_vendor", "live_vendor"}:
+        return "real_vendor"
+    source = _normalize(bundle.source_context.get("source"))
+    if bundle.source_context.get("demo") or source in DEMO_SOURCE_MARKERS:
+        return "demo"
+    if source in TEST_SOURCE_MARKERS:
+        return "test_double"
+    return "unknown"
+
+
+def _summary_next_action(status: str, blockers: list[dict[str, Any]], risks: list[dict[str, Any]]) -> str:
+    if status in {"demo_only", "test_only"}:
+        return "connect_real_or_sandbox_sources"
+    if blockers:
+        return str(blockers[0].get("next_action") or "resolve_weekly_report_blockers")
+    if risks:
+        return str(risks[0].get("next_action") or "review_weekly_report_risks")
+    return "none"
+
+
+def _proof_id(
+    bundle: WeeklyReportPilotEvidence,
+    env: str,
+    blockers: list[dict[str, Any]],
+    proven: list[dict[str, Any]],
+    evidence_refs: list[dict[str, Any]],
+) -> str:
+    payload = {
+        "tenant_id": bundle.tenant_id,
+        "company_id": bundle.company_id,
+        "environment_type": env,
+        "blockers": [row.get("category") for row in blockers],
+        "proven": [row.get("capability_key") for row in proven],
+        "evidence_refs": [(row.get("type"), row.get("ref_id")) for row in evidence_refs],
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"wkly_report_proof_{digest}"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _add_issue(
+    bucket: list[dict[str, Any]],
+    *,
+    category: str,
+    message: str,
+    severity: str,
+    next_action: str,
+    affected: Iterable[str] | None = None,
+) -> None:
+    bucket.append(
+        {
+            "category": category,
+            "message": message,
+            "severity": severity,
+            "next_action": next_action,
+            "affected": sorted({str(item) for item in (affected or [])}),
+        }
+    )
+
+
+def _capability(key: str, description: str) -> dict[str, Any]:
+    return {"capability_key": key, "description": description, "status": "proven"}
+
+
+def _ref(ref_type: str, ref_id: Any, source: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "type": ref_type,
+        "ref_id": str(ref_id) if ref_id is not None else None,
+        "source": dict(source) if isinstance(source, Mapping) else {},
+    }
+
+
+def _next_action(action_key: str, label: str) -> dict[str, str]:
+    return {"action_key": action_key, "label": label}
+
+
+def _category(row: Mapping[str, Any]) -> str:
+    raw = (
+        row.get("category")
+        or row.get("connector_category")
+        or row.get("source_category")
+    )
+    return str(raw or "").strip()
+
+
+def _dedupe(rows: list[dict[str, Any]], *, key) -> list[dict[str, Any]]:
+    seen: set[Any] = set()
+    result: list[dict[str, Any]] = []
+    for row in rows:
+        marker = key(row)
+        if marker in seen:
+            continue
+        seen.add(marker)
+        result.append(row)
+    return result
+
+
+def _dedupe_issues(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[tuple[str, str, str]] = set()
+    result: list[dict[str, Any]] = []
+    for row in rows:
+        marker = (
+            str(row.get("category") or ""),
+            str(row.get("message") or ""),
+            str(row.get("severity") or ""),
+        )
+        if marker in seen:
+            continue
+        seen.add(marker)
+        result.append(row)
+    return result
+
+
+def _dicts(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, Mapping):
+        return [dict(value)]
+    if isinstance(value, list | tuple | set):
+        return [dict(item) for item in value if isinstance(item, Mapping)]
+    return []
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _iso(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.isoformat()
+
+
+def _redact(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            text_key = str(key)
+            if any(marker in text_key.lower() for marker in SECRET_KEY_MARKERS):
+                redacted[text_key] = "[REDACTED]"
+            else:
+                redacted[text_key] = _redact(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    if isinstance(value, tuple | set):
+        return [_redact(item) for item in value]
+    return value

--- a/core/marketing/weekly_report_sandbox_pilot.py
+++ b/core/marketing/weekly_report_sandbox_pilot.py
@@ -1,0 +1,736 @@
+"""CMO-PROD-3 sandbox walk-through orchestration.
+
+This module orchestrates a fail-closed sandbox-pilot run for the weekly
+marketing report. It does **not** invent data: when sandbox credentials or
+config are missing, it returns a structured `blocked` envelope listing
+exactly which env vars / DB / migration / connector configs / mappings
+are absent, so the caller can populate them. When everything is present,
+it delegates to the existing CMO-PROD-2 persistence helper through the
+real report-task path, so the same code that runs in production runs in
+the sandbox.
+
+Critically:
+
+* This module never marks a verdict as ``passed`` for ``real_vendor``.
+* It refuses to insert any proof row when preflight fails.
+* All log / output dictionaries are redacted via the same key-marker
+  redactor used by ``core.marketing.weekly_report_pilot_proof``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from core.marketing.weekly_report_pilot_proof import SECRET_KEY_MARKERS
+
+logger = logging.getLogger(__name__)
+
+
+CMO_PROD_3_VERSION = "2026-05-24.cmo-prod-3"
+
+
+SANDBOX_ENV_PREFIX = "AGENTICORG_CMO_SANDBOX_"
+CATEGORY_ORDER = ("CRM", "Ads", "Analytics", "Email")
+READY_STATUSES = {"active", "configured", "connected", "healthy", "ok", "ready"}
+READY_HEALTH = {"", "active", "configured", "connected", "healthy", "ok", "ready", "unknown"}
+VENDOR_SANDBOX_SCOPES = {
+    "qa_sandbox",
+    "sandbox",
+    "vendor-sandbox",
+    "vendor_sandbox",
+    "vendor_sandbox_proof",
+}
+LOCAL_PREFLIGHT_SCOPES = {"local_preflight_only", "preflight_only"}
+TRUTHY = {"1", "true", "yes", "y", "on"}
+CATEGORY_ALIASES = {
+    "CRM": {"crm", "hubspot", "hubspot_crm", "salesforce", "salesforce_crm"},
+    "Ads": {"ad", "ads", "google_ads", "linkedin_ads", "meta_ads"},
+    "Analytics": {"analytics", "ga4", "google_analytics", "google_analytics_4", "gsc"},
+    "Email": {"email", "mailchimp", "sendgrid", "hubspot_email"},
+}
+
+
+# Per category, the env-var groups that constitute a usable sandbox
+# connector. The runner picks the first group whose required env vars
+# are all populated. A category is *missing* only if no group can be
+# satisfied.
+SANDBOX_CONNECTOR_OPTIONS: dict[str, tuple[dict[str, Any], ...]] = {
+    "CRM": (
+        {
+            "connector_key": "hubspot",
+            "required_envs": (f"{SANDBOX_ENV_PREFIX}HUBSPOT_ACCESS_TOKEN",),
+            "credential_env_map": {"access_token": f"{SANDBOX_ENV_PREFIX}HUBSPOT_ACCESS_TOKEN"},
+        },
+        {
+            "connector_key": "salesforce",
+            "required_envs": (
+                f"{SANDBOX_ENV_PREFIX}SALESFORCE_INSTANCE_URL",
+                f"{SANDBOX_ENV_PREFIX}SALESFORCE_REFRESH_TOKEN",
+                f"{SANDBOX_ENV_PREFIX}SALESFORCE_CLIENT_ID",
+                f"{SANDBOX_ENV_PREFIX}SALESFORCE_CLIENT_SECRET",
+            ),
+            "credential_env_map": {
+                "instance_url": f"{SANDBOX_ENV_PREFIX}SALESFORCE_INSTANCE_URL",
+                "refresh_token": f"{SANDBOX_ENV_PREFIX}SALESFORCE_REFRESH_TOKEN",
+                "client_id": f"{SANDBOX_ENV_PREFIX}SALESFORCE_CLIENT_ID",
+                "client_secret": f"{SANDBOX_ENV_PREFIX}SALESFORCE_CLIENT_SECRET",
+            },
+        },
+    ),
+    "Ads": (
+        {
+            "connector_key": "google_ads",
+            "required_envs": (
+                f"{SANDBOX_ENV_PREFIX}GOOGLE_ADS_DEVELOPER_TOKEN",
+                f"{SANDBOX_ENV_PREFIX}GOOGLE_ADS_REFRESH_TOKEN",
+                f"{SANDBOX_ENV_PREFIX}GOOGLE_ADS_CUSTOMER_ID",
+                f"{SANDBOX_ENV_PREFIX}GOOGLE_ADS_CLIENT_ID",
+                f"{SANDBOX_ENV_PREFIX}GOOGLE_ADS_CLIENT_SECRET",
+            ),
+            "credential_env_map": {
+                "developer_token": f"{SANDBOX_ENV_PREFIX}GOOGLE_ADS_DEVELOPER_TOKEN",
+                "refresh_token": f"{SANDBOX_ENV_PREFIX}GOOGLE_ADS_REFRESH_TOKEN",
+                "customer_id": f"{SANDBOX_ENV_PREFIX}GOOGLE_ADS_CUSTOMER_ID",
+                "client_id": f"{SANDBOX_ENV_PREFIX}GOOGLE_ADS_CLIENT_ID",
+                "client_secret": f"{SANDBOX_ENV_PREFIX}GOOGLE_ADS_CLIENT_SECRET",
+            },
+        },
+        {
+            "connector_key": "meta_ads",
+            "required_envs": (
+                f"{SANDBOX_ENV_PREFIX}META_ADS_ACCESS_TOKEN",
+                f"{SANDBOX_ENV_PREFIX}META_ADS_AD_ACCOUNT_ID",
+            ),
+            "credential_env_map": {
+                "access_token": f"{SANDBOX_ENV_PREFIX}META_ADS_ACCESS_TOKEN",
+                "ad_account_id": f"{SANDBOX_ENV_PREFIX}META_ADS_AD_ACCOUNT_ID",
+            },
+        },
+        {
+            "connector_key": "linkedin_ads",
+            "required_envs": (
+                f"{SANDBOX_ENV_PREFIX}LINKEDIN_ADS_REFRESH_TOKEN",
+                f"{SANDBOX_ENV_PREFIX}LINKEDIN_ADS_ACCOUNT_ID",
+                f"{SANDBOX_ENV_PREFIX}LINKEDIN_ADS_CLIENT_ID",
+                f"{SANDBOX_ENV_PREFIX}LINKEDIN_ADS_CLIENT_SECRET",
+            ),
+            "credential_env_map": {
+                "refresh_token": f"{SANDBOX_ENV_PREFIX}LINKEDIN_ADS_REFRESH_TOKEN",
+                "account_id": f"{SANDBOX_ENV_PREFIX}LINKEDIN_ADS_ACCOUNT_ID",
+                "client_id": f"{SANDBOX_ENV_PREFIX}LINKEDIN_ADS_CLIENT_ID",
+                "client_secret": f"{SANDBOX_ENV_PREFIX}LINKEDIN_ADS_CLIENT_SECRET",
+            },
+        },
+    ),
+    "Analytics": (
+        {
+            "connector_key": "ga4",
+            "required_envs": (
+                f"{SANDBOX_ENV_PREFIX}GA4_PROPERTY_ID",
+                f"{SANDBOX_ENV_PREFIX}GA4_REFRESH_TOKEN",
+                f"{SANDBOX_ENV_PREFIX}GA4_CLIENT_ID",
+                f"{SANDBOX_ENV_PREFIX}GA4_CLIENT_SECRET",
+            ),
+            "credential_env_map": {
+                "property_id": f"{SANDBOX_ENV_PREFIX}GA4_PROPERTY_ID",
+                "refresh_token": f"{SANDBOX_ENV_PREFIX}GA4_REFRESH_TOKEN",
+                "client_id": f"{SANDBOX_ENV_PREFIX}GA4_CLIENT_ID",
+                "client_secret": f"{SANDBOX_ENV_PREFIX}GA4_CLIENT_SECRET",
+            },
+        },
+    ),
+    "Email": (
+        {
+            "connector_key": "sendgrid",
+            "required_envs": (
+                f"{SANDBOX_ENV_PREFIX}SENDGRID_API_KEY",
+                f"{SANDBOX_ENV_PREFIX}SENDGRID_SENDER",
+            ),
+            "credential_env_map": {
+                "api_key": f"{SANDBOX_ENV_PREFIX}SENDGRID_API_KEY",
+                "sender_identity": f"{SANDBOX_ENV_PREFIX}SENDGRID_SENDER",
+            },
+        },
+        {
+            "connector_key": "mailchimp",
+            "required_envs": (
+                f"{SANDBOX_ENV_PREFIX}MAILCHIMP_API_KEY",
+                f"{SANDBOX_ENV_PREFIX}MAILCHIMP_SERVER_PREFIX",
+                f"{SANDBOX_ENV_PREFIX}MAILCHIMP_AUDIENCE_ID",
+            ),
+            "credential_env_map": {
+                "api_key": f"{SANDBOX_ENV_PREFIX}MAILCHIMP_API_KEY",
+                "server_prefix": f"{SANDBOX_ENV_PREFIX}MAILCHIMP_SERVER_PREFIX",
+                "audience_id": f"{SANDBOX_ENV_PREFIX}MAILCHIMP_AUDIENCE_ID",
+            },
+        },
+    ),
+}
+
+REQUIRED_BASE_ENVS: tuple[str, ...] = (
+    "AGENTICORG_DB_URL",
+    f"{SANDBOX_ENV_PREFIX}TENANT_ID",
+)
+OPTIONAL_BASE_ENVS: tuple[str, ...] = (f"{SANDBOX_ENV_PREFIX}COMPANY_ID",)
+
+
+@dataclass
+class SandboxPilotConfig:
+    db_url: str | None = None
+    tenant_id: str | None = None
+    company_id: str | None = None
+    chosen_connectors: dict[str, dict[str, Any]] = field(default_factory=dict)
+    missing_envs: list[str] = field(default_factory=list)
+    missing_categories: list[str] = field(default_factory=list)
+    db_discovery_state: str = "not_checked"
+    local_preflight_only: bool = False
+
+
+@dataclass
+class SandboxPilotPreflight:
+    preflight_status: str  # "ready" or "blocked"
+    config: SandboxPilotConfig
+    blockers: list[dict[str, Any]]
+    next_actions: list[dict[str, Any]]
+    proof_status: str = "unavailable"
+
+
+def discover_sandbox_pilot_config(
+    env: Mapping[str, str] | None = None,
+    *,
+    connector_rows: Sequence[Any] | None = None,
+) -> SandboxPilotPreflight:
+    """Inspect tenant ConnectorConfig rows/env vars and return a preflight verdict.
+
+    Tenant-scoped ConnectorConfig rows are the preferred source because that
+    matches the product connector setup path. Env vars remain a local/dev
+    fallback for missing categories or DB-discovery outages. The function never
+    returns credential values.
+    """
+
+    env = env if env is not None else os.environ
+    blockers: list[dict[str, Any]] = []
+    next_actions: list[dict[str, Any]] = []
+    config = SandboxPilotConfig()
+
+    db_url = env.get("AGENTICORG_DB_URL") or None
+    config.db_url = db_url
+    if not db_url:
+        blockers.append(
+            {
+                "category": "database",
+                "missing_env": "AGENTICORG_DB_URL",
+                "severity": "critical",
+                "message": "DB URL is not configured; cannot run migration or persist sandbox proof.",
+                "next_action": "configure_db_url",
+            }
+        )
+        next_actions.append(
+            {
+                "action_key": "configure_db_url",
+                "label": "Set AGENTICORG_DB_URL to a Postgres URL with the v4917 migration applied.",
+            }
+        )
+
+    tenant_id = env.get(f"{SANDBOX_ENV_PREFIX}TENANT_ID") or None
+    config.tenant_id = tenant_id
+    if not tenant_id:
+        blockers.append(
+            {
+                "category": "tenant",
+                "missing_env": f"{SANDBOX_ENV_PREFIX}TENANT_ID",
+                "severity": "critical",
+                "message": "Sandbox tenant id is not configured.",
+                "next_action": "configure_sandbox_tenant",
+            }
+        )
+        next_actions.append(
+            {
+                "action_key": "configure_sandbox_tenant",
+                "label": (
+                    f"Create or pick a sandbox tenant and export its UUID as "
+                    f"{SANDBOX_ENV_PREFIX}TENANT_ID."
+                ),
+            }
+        )
+    else:
+        try:
+            uuid.UUID(tenant_id)
+        except ValueError:
+            blockers.append(
+                {
+                    "category": "tenant",
+                    "severity": "critical",
+                    "message": f"{SANDBOX_ENV_PREFIX}TENANT_ID is not a valid UUID.",
+                    "next_action": "configure_sandbox_tenant",
+                }
+            )
+
+    company_id = env.get(f"{SANDBOX_ENV_PREFIX}COMPANY_ID") or None
+    config.company_id = company_id
+
+    db_result = _discover_connector_config_categories(
+        env=env,
+        tenant_id=tenant_id,
+        db_url=db_url,
+        connector_rows=connector_rows,
+    )
+    config.db_discovery_state = db_result["state"]
+    db_categories: dict[str, dict[str, Any]] = db_result["categories"]
+    if db_result["state"] == "blocked":
+        blockers.append(
+            {
+                "category": "connector_config",
+                "severity": "critical",
+                "message": db_result["message"],
+                "next_action": "configure_sandbox_tenant",
+            }
+        )
+
+    for category, options in SANDBOX_CONNECTOR_OPTIONS.items():
+        db_choice = db_categories.get(category)
+        if db_choice is not None:
+            config.chosen_connectors[category] = db_choice
+            if db_choice.get("local_preflight_only"):
+                config.local_preflight_only = True
+            if db_choice.get("readiness_state") != "ready":
+                config.missing_categories.append(category)
+                blockers.append(
+                    {
+                        "category": "connector",
+                        "connector_category": category,
+                        "severity": "critical",
+                        "message": str(
+                            db_choice.get("missing_reason")
+                            or f"Tenant ConnectorConfig for {category} is not usable."
+                        ),
+                        "next_action": f"configure_{category.lower()}_sandbox_connector",
+                    }
+                )
+                next_actions.append(
+                    {
+                        "action_key": f"configure_{category.lower()}_sandbox_connector",
+                        "label": (
+                            f"Update the tenant ConnectorConfig for {category} to a real "
+                            "vendor-sandbox connector with usable status/health and "
+                            "proof_scope=vendor_sandbox."
+                        ),
+                    }
+                )
+            continue
+
+        chosen: dict[str, Any] | None = None
+        category_missing_envs: list[str] = []
+        for option in options:
+            envs = option["required_envs"]
+            missing = [name for name in envs if not env.get(name)]
+            if not missing:
+                chosen = {
+                    "connector_key": option["connector_key"],
+                    "connector_name": option["connector_key"],
+                    "source": "env",
+                    "readiness_state": "ready",
+                    "proof_scope": "local_env_fallback",
+                    "local_test_only": False,
+                    "credential_envs": dict(option["credential_env_map"]),
+                }
+                break
+            # Track first option's missing envs so we can suggest exactly
+            # which set of vars to populate.
+            if not category_missing_envs:
+                category_missing_envs = missing
+        if chosen is None:
+            config.missing_categories.append(category)
+            for env_name in category_missing_envs:
+                if env_name not in config.missing_envs:
+                    config.missing_envs.append(env_name)
+            blockers.append(
+                {
+                    "category": "connector",
+                    "connector_category": category,
+                    "severity": "critical",
+                    "missing_envs": category_missing_envs,
+                    "message": (
+                        f"No sandbox connector option for category {category} is fully "
+                        f"configured. Populate one of: "
+                        f"{', '.join(opt['connector_key'] for opt in options)}."
+                    ),
+                    "next_action": f"configure_{category.lower()}_sandbox_connector",
+                }
+            )
+            next_actions.append(
+                {
+                    "action_key": f"configure_{category.lower()}_sandbox_connector",
+                    "label": (
+                        f"Pick one {category} sandbox connector and export the env vars "
+                        f"listed in SANDBOX_CONNECTOR_OPTIONS[{category!r}]."
+                    ),
+                }
+            )
+        else:
+            config.chosen_connectors[category] = chosen
+
+    status = "ready" if not blockers else "blocked"
+    proof_status = "unavailable"
+    if status == "ready":
+        proof_status = "local_preflight_only" if config.local_preflight_only else "preflight_ready"
+    return SandboxPilotPreflight(
+        preflight_status=status,
+        config=config,
+        blockers=blockers,
+        next_actions=next_actions,
+        proof_status=proof_status,
+    )
+
+
+def build_blocked_preflight_envelope(preflight: SandboxPilotPreflight) -> dict[str, Any]:
+    """Return a stable, redacted envelope describing why preflight failed.
+
+    The envelope intentionally mirrors the persisted-proof summary shape
+    used by ``/kpis/cmo`` so dashboards can render either an actual
+    ``weekly_report_pilot_proof_summary`` row or this preflight result
+    with the same component.
+    """
+
+    return _redact(
+        {
+            "schema_version": CMO_PROD_3_VERSION,
+            "preflight_status": preflight.preflight_status,
+            "environment_type": "vendor_sandbox",
+            "proof_status": preflight.proof_status,
+            "production_claim_allowed": False,
+            "real_vendor_claim_allowed": False,
+            "tenant_id": preflight.config.tenant_id,
+            "company_id": preflight.config.company_id,
+            "db_discovery_state": preflight.config.db_discovery_state,
+            "chosen_connectors": preflight.config.chosen_connectors,
+            "missing_envs": preflight.config.missing_envs,
+            "missing_categories": preflight.config.missing_categories,
+            "blockers": preflight.blockers,
+            "next_actions": preflight.next_actions,
+            "generated_at": datetime.now(UTC).isoformat(),
+            "note": (
+                "CMO-PROD-3 cannot synthesize sandbox proof. No row will be inserted "
+                "into weekly_report_pilot_proofs while preflight is blocked. Resolve "
+                "the listed env vars / DB / migration prerequisites and re-run."
+            ),
+        }
+    )
+
+
+async def run_sandbox_pilot(
+    *,
+    env: Mapping[str, str] | None = None,
+    connector_rows: Sequence[Any] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Execute the sandbox walk-through when preflight is ready.
+
+    Drives the real weekly-report path:
+
+      1. Resolve config from env vars (no fixtures).
+      2. If preflight fails, return the blocked envelope unchanged.
+      3. Otherwise, call the real ``generate_report`` Celery task entry
+         point. The CMO-PROD-2 hook persists the verdict via the same
+         path production uses.
+      4. Read the latest persisted verdict back so the caller sees what
+         landed in the DB (proof_id, proof_status, blockers count).
+
+    Returns a redacted summary dict.
+    """
+
+    preflight = discover_sandbox_pilot_config(env, connector_rows=connector_rows)
+    if preflight.preflight_status != "ready":
+        return build_blocked_preflight_envelope(preflight)
+    if preflight.proof_status == "local_preflight_only":
+        return _redact(
+            {
+                "schema_version": CMO_PROD_3_VERSION,
+                "preflight_status": "ready",
+                "environment_type": "vendor_sandbox",
+                "proof_status": "local_preflight_only",
+                "production_claim_allowed": False,
+                "real_vendor_claim_allowed": False,
+                "proof_inserted": False,
+                "tenant_id": preflight.config.tenant_id,
+                "company_id": preflight.config.company_id,
+                "db_discovery_state": preflight.config.db_discovery_state,
+                "chosen_connectors": preflight.config.chosen_connectors,
+                "generated_at": (now or datetime.now(UTC)).isoformat(),
+                "note": (
+                    "Tenant ConnectorConfig rows are local/preflight-only. This can "
+                    "prove DB discovery but cannot create sandbox_proven or production proof."
+                ),
+            }
+        )
+
+    # Local imports keep test/runner light and avoid Celery/DB import in
+    # the blocked path.
+    from core.marketing.weekly_report_pilot_persistence import (
+        latest_weekly_report_pilot_proof,
+        summarize_persisted_proof,
+    )
+    from core.tasks import report_tasks
+
+    config = preflight.config
+    report_config = {
+        "report_type": "cmo_weekly",
+        "params": {"pilot_environment_type": "vendor_sandbox"},
+        "tenant_id": str(config.tenant_id),
+        "company_id": str(config.company_id) if config.company_id else "default",
+        "format": "pdf",
+        "delivery_channels": [],
+    }
+    task_result = report_tasks.generate_report.run(report_config)
+
+    # Verify the verdict landed in DB by re-reading it.
+    persisted_summary: dict[str, Any] | None = None
+    try:
+        from core.database import get_tenant_session
+
+        async with get_tenant_session(uuid.UUID(str(config.tenant_id))) as session:
+            row = await latest_weekly_report_pilot_proof(
+                session,
+                tenant_id=str(config.tenant_id),
+                company_id=str(config.company_id) if config.company_id else None,
+            )
+        persisted_summary = summarize_persisted_proof(row)
+    # enterprise-gate: broad-except-ok reason=sandbox-runner-tolerates-db-readback-failure
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "sandbox_pilot_db_readback_failed",
+            extra={"error": str(exc)},
+        )
+
+    summary_from_task = (
+        task_result.get("weekly_report_pilot_proof") if isinstance(task_result, dict) else None
+    )
+    return _redact(
+        {
+            "schema_version": CMO_PROD_3_VERSION,
+            "preflight_status": "ready",
+            "environment_type": "vendor_sandbox",
+            "tenant_id": config.tenant_id,
+            "company_id": config.company_id,
+            "report_task_result": _strip_paths(task_result),
+            "weekly_report_pilot_proof": summary_from_task,
+            "latest_weekly_report_pilot_proof": persisted_summary,
+            "generated_at": (now or datetime.now(UTC)).isoformat(),
+        }
+    )
+
+
+def _strip_paths(result: Any) -> Any:
+    """Drop filesystem paths from a task result to keep the runbook output safe."""
+
+    if not isinstance(result, Mapping):
+        return result
+    stripped = dict(result)
+    paths = stripped.get("paths")
+    if isinstance(paths, list):
+        stripped["paths"] = [
+            f"<{len(paths)} report artifact(s) written>" if paths else "<no artifacts>"
+        ]
+    return stripped
+
+
+def _discover_connector_config_categories(
+    *,
+    env: Mapping[str, str],
+    tenant_id: str | None,
+    db_url: str | None,
+    connector_rows: Sequence[Any] | None,
+) -> dict[str, Any]:
+    if not tenant_id:
+        return {"state": "not_checked", "message": "Sandbox tenant id is missing.", "categories": {}}
+    try:
+        parsed_tenant_id = uuid.UUID(str(tenant_id))
+    except ValueError:
+        return {
+            "state": "blocked",
+            "message": f"{SANDBOX_ENV_PREFIX}TENANT_ID must be a valid UUID.",
+            "categories": {},
+        }
+
+    try:
+        rows = list(connector_rows) if connector_rows is not None else _load_connector_config_rows(
+            parsed_tenant_id,
+            db_url,
+        )
+    # enterprise-gate: broad-except-ok reason=sandbox-preflight-must-fail-closed-on-db-discovery-errors
+    except Exception:
+        return {
+            "state": "unavailable",
+            "message": "Tenant ConnectorConfig discovery is unavailable; env fallback may be used.",
+            "categories": {},
+        }
+
+    categories: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        category = _category_for_connector_row(row)
+        if category is None:
+            continue
+        entry = _safe_connector_entry(category, row)
+        existing = categories.get(category)
+        if existing is None or (entry["readiness_state"] == "ready" and existing["readiness_state"] != "ready"):
+            categories[category] = entry
+    return {"state": "ready", "message": "Tenant ConnectorConfig discovery completed.", "categories": categories}
+
+
+def _load_connector_config_rows(tenant_id: uuid.UUID, db_url: str | None) -> list[dict[str, Any]]:
+    if not db_url:
+        return []
+    from sqlalchemy import create_engine, text
+
+    engine = create_engine(_sync_db_url(db_url), connect_args={"connect_timeout": 2}, pool_pre_ping=True)
+    try:
+        with engine.connect() as conn:
+            result = conn.execute(
+                text(
+                    """
+                    SELECT
+                        connector_name,
+                        display_name,
+                        status,
+                        health_status,
+                        config,
+                        credentials_encrypted
+                    FROM connector_configs
+                    WHERE tenant_id = CAST(:tenant_id AS UUID)
+                    """
+                ),
+                {"tenant_id": str(tenant_id)},
+            )
+            return [dict(row._mapping) for row in result.fetchall()]
+    finally:
+        engine.dispose()
+
+
+def _safe_connector_entry(category: str, row: Any) -> dict[str, Any]:
+    config = _dict_or_empty(_row_value(row, "config"))
+    proof_scope = _clean_public_text(
+        config.get("proof_scope")
+        or config.get("environment_type")
+        or config.get("environment")
+        or config.get("source_context")
+    )
+    local_test_only = _truthy(config.get("local_test_only"))
+    mock_or_test_double = _truthy(config.get("mock_or_test_double") or config.get("test_double") or config.get("mock"))
+    status = str(_row_value(row, "status") or "").strip().lower()
+    health = str(_row_value(row, "health_status") or "").strip().lower()
+
+    missing_reason = None
+    if status not in READY_STATUSES:
+        missing_reason = f"ConnectorConfig status is not usable ({status or 'missing'})."
+    elif health not in READY_HEALTH:
+        missing_reason = f"ConnectorConfig health is not usable ({health or 'missing'})."
+    elif mock_or_test_double:
+        missing_reason = "ConnectorConfig is marked mock_or_test_double/test_double."
+    elif local_test_only or _normalize_token(proof_scope) in LOCAL_PREFLIGHT_SCOPES:
+        missing_reason = None
+    elif _normalize_token(proof_scope) not in VENDOR_SANDBOX_SCOPES:
+        missing_reason = "ConnectorConfig proof_scope/environment is not vendor_sandbox."
+
+    local_preflight_only = bool(
+        missing_reason is None
+        and (local_test_only or _normalize_token(proof_scope) in LOCAL_PREFLIGHT_SCOPES)
+    )
+    return {
+        "connector_key": _clean_public_text(_row_value(row, "connector_name")),
+        "connector_name": _clean_public_text(_row_value(row, "display_name"))
+        or _clean_public_text(_row_value(row, "connector_name")),
+        "source": "db",
+        "readiness_state": "blocked" if missing_reason else "ready",
+        "missing_reason": missing_reason,
+        "proof_scope": proof_scope,
+        "local_test_only": local_test_only,
+        "local_preflight_only": local_preflight_only,
+        "mock_or_test_double": mock_or_test_double,
+        "category": category,
+    }
+
+
+def _category_for_connector_row(row: Any) -> str | None:
+    config = _dict_or_empty(_row_value(row, "config"))
+    explicit = (
+        config.get("cmo_category")
+        or config.get("connector_category")
+        or config.get("category")
+        or config.get("source_domain")
+    )
+    category = _normalize_category(explicit)
+    if category:
+        return category
+    return _category_from_name(str(_row_value(row, "connector_name") or ""))
+
+
+def _normalize_category(value: Any) -> str | None:
+    normalized = _normalize_token(value)
+    for category, aliases in CATEGORY_ALIASES.items():
+        if normalized == _normalize_token(category) or normalized in aliases:
+            return category
+    return None
+
+
+def _category_from_name(value: str) -> str | None:
+    normalized = _normalize_token(value)
+    for category, aliases in CATEGORY_ALIASES.items():
+        if normalized in aliases or any(alias in normalized for alias in aliases if len(alias) > 3):
+            return category
+    return None
+
+
+def _sync_db_url(db_url: str) -> str:
+    return db_url.replace("postgresql+asyncpg", "postgresql").replace("+asyncpg", "")
+
+
+def _row_value(row: Any, key: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(key)
+    return getattr(row, key, None)
+
+
+def _dict_or_empty(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _truthy(value: Any) -> bool:
+    return str(value or "").strip().lower() in TRUTHY
+
+
+def _normalize_token(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _clean_public_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if any(marker in text.lower() for marker in SECRET_KEY_MARKERS):
+        return "[REDACTED]"
+    return text
+
+
+def _redact(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            text_key = str(key).lower()
+            if any(marker in text_key for marker in SECRET_KEY_MARKERS):
+                redacted[str(key)] = "[REDACTED]"
+            else:
+                redacted[str(key)] = _redact(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    if isinstance(value, tuple | set):
+        return [_redact(item) for item in value]
+    return value

--- a/core/marketing/work_queue.py
+++ b/core/marketing/work_queue.py
@@ -1,0 +1,1440 @@
+"""CMO operator work queue projection.
+
+CMO-8.1 turns the readiness, governance, KPI, reconciliation, and report-gate
+projections into prioritized operator-visible work items. The queue is
+deterministic and storage-free by design; it can later be persisted without
+changing the API shape.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+CMO_WORK_QUEUE_VERSION = "2026-05-23.cmo-8.1"
+
+SEVERITIES = ("critical", "high", "medium", "low", "info")
+ITEM_STATUSES = ("open", "blocked", "waiting", "resolved", "dismissed")
+
+SEVERITY_SCORE = {
+    "critical": 1000,
+    "high": 800,
+    "medium": 500,
+    "low": 250,
+    "info": 50,
+}
+CATEGORY_SCORE = {
+    "crisis_risk": 120,
+    "external_write": 110,
+    "approval": 100,
+    "escalation": 95,
+    "connector": 85,
+    "policy": 82,
+    "audit": 80,
+    "report": 75,
+    "workflow": 70,
+    "kpi": 62,
+    "reconciliation": 60,
+    "data_readiness": 55,
+    "source_data": 50,
+}
+
+BLOCKING_CONNECTOR_STATES = {  # enterprise-gate: process-local-ok reason=static-work-queue-state-set
+    "missing",
+    "unconfigured",
+    "expired_auth",
+    "auth_expired",
+    "insufficient_scope",
+    "missing_scope",
+    "connector_disabled",
+    "malformed_payload",
+    "quota_exhausted",
+}
+DEGRADED_CONNECTOR_STATES = {  # enterprise-gate: process-local-ok reason=static-work-queue-state-set
+    "stale",
+    "stale_data",
+    "degraded",
+    "partial",
+    "partial_data",
+    "rate_limited",
+    "timeout",
+    "vendor_5xx",
+}
+# enterprise-gate: process-local-ok reason=static-work-queue-state-set
+BAD_MAPPING_STATES = {"unmapped", "invalid", "blocked", "partially_mapped", "stale"}
+# enterprise-gate: process-local-ok reason=static-work-queue-state-set
+BAD_BACKFILL_STATES = {"not_started", "partial", "failed", "blocked", "queued", "running"}
+# enterprise-gate: process-local-ok reason=static-work-queue-state-set
+BAD_WORKFLOW_STATES = {"promotion_blocked", "unavailable", "degraded", "paused", "shadow", "promotion_ready"}
+# enterprise-gate: process-local-ok reason=static-work-queue-state-set
+BAD_KPI_STATES = {"blocked", "unavailable", "degraded"}
+# enterprise-gate: process-local-ok reason=static-work-queue-state-set
+BAD_RECONCILIATION_STATES = {"failed", "blocked", "warning", "unavailable"}
+# enterprise-gate: process-local-ok reason=static-work-queue-state-set
+BAD_REPORT_STATES = {"blocked", "unavailable", "warning"}
+# enterprise-gate: process-local-ok reason=static-work-queue-state-set
+BAD_WRITE_STATES = {"rejected", "timeout_unknown", "write_unconfirmed", "retry_scheduled", "accepted"}
+
+
+def build_cmo_work_queue_projection(
+    *,
+    approval_timeout_risk: Mapping[str, Any] | None = None,
+    escalation_projection: Mapping[str, Any] | None = None,
+    connector_setup: Iterable[Mapping[str, Any]] = (),
+    connector_contracts: Iterable[Mapping[str, Any]] = (),
+    data_readiness: Mapping[str, Any] | None = None,
+    workflow_activation: Mapping[str, Any] | None = None,
+    policy_projection: Mapping[str, Any] | None = None,
+    decision_audit_projection: Mapping[str, Any] | None = None,
+    kpi_results: Iterable[Mapping[str, Any]] = (),
+    reconciliation_checks: Iterable[Mapping[str, Any]] = (),
+    report_quality_gates: Iterable[Mapping[str, Any]] = (),
+    external_write_results: Iterable[Mapping[str, Any]] = (),
+    source_context: Mapping[str, Any] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build prioritized CMO work items from current CMO projections."""
+
+    timestamp = _ensure_aware(now) or datetime.now(UTC)
+    source = source_context if isinstance(source_context, Mapping) else {}
+    data = data_readiness if isinstance(data_readiness, Mapping) else {}
+    workflow = workflow_activation if isinstance(workflow_activation, Mapping) else {}
+
+    items: dict[str, dict[str, Any]] = {}
+    _collect_approval_items(items, approval_timeout_risk, timestamp)
+    _collect_escalation_items(items, approval_timeout_risk, escalation_projection, source, timestamp)
+    _collect_connector_setup_items(items, connector_setup, timestamp)
+    _collect_connector_contract_items(items, connector_contracts, timestamp)
+    _collect_data_readiness_items(items, data, timestamp)
+    _collect_workflow_items(items, workflow, timestamp)
+    _collect_policy_and_audit_items(
+        items,
+        policy_projection,
+        decision_audit_projection,
+        workflow,
+        source,
+        timestamp,
+    )
+    _collect_external_write_items(
+        items,
+        [*list(external_write_results), *_external_write_results_from_source(source)],
+        timestamp,
+    )
+    _collect_kpi_items(items, kpi_results, timestamp)
+    _collect_reconciliation_items(items, reconciliation_checks, timestamp)
+    _collect_report_quality_items(items, report_quality_gates, timestamp)
+    _collect_source_context_items(items, source, timestamp)
+    _collect_crisis_risk_items(items, source, timestamp)
+
+    queue = _sort_items(items.values())
+    return {
+        "cmo_work_queue_version": CMO_WORK_QUEUE_VERSION,
+        "cmo_work_queue": queue,
+        "cmo_work_queue_summary": summarize_cmo_work_queue(queue),
+    }
+
+
+def build_cmo_work_queue_projection_from_kpi_payload(
+    payload: Mapping[str, Any] | None,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build the work queue from a `/kpis/cmo` response payload."""
+
+    data = payload if isinstance(payload, Mapping) else {}
+    workflow_activation = {
+        "workflow_activation_status": _dicts(data.get("workflow_activation_status")),
+        "workflow_activation_summary": data.get("workflow_activation_summary") or {},
+    }
+    policy_projection = {
+        "marketing_policy_manifest": data.get("marketing_policy_manifest"),
+        "marketing_policy_summary": data.get("marketing_policy_summary") or {},
+    }
+    escalation_projection = {
+        "marketing_escalation_matrix": data.get("marketing_escalation_matrix"),
+        "marketing_escalation_summary": data.get("marketing_escalation_summary") or {},
+    }
+    decision_audit_projection = {
+        "marketing_decision_audit": data.get("marketing_decision_audit"),
+        "marketing_decision_audit_summary": data.get("marketing_decision_audit_summary") or {},
+    }
+    approval_timeout_risk = data.get("approval_timeout_risk")
+    return build_cmo_work_queue_projection(
+        approval_timeout_risk=approval_timeout_risk if isinstance(approval_timeout_risk, Mapping) else {},
+        escalation_projection=escalation_projection,
+        connector_setup=_dicts(data.get("connector_setup")),
+        connector_contracts=_dicts(data.get("connector_contracts")),
+        data_readiness={
+            "field_mapping_status": _dicts(data.get("field_mapping_status")),
+            "backfill_status": _dicts(data.get("backfill_status")),
+            "kpi_readiness": data.get("kpi_readiness") or {},
+        },
+        workflow_activation=workflow_activation,
+        policy_projection=policy_projection,
+        decision_audit_projection=decision_audit_projection,
+        kpi_results=_dicts(data.get("unified_cmo_kpi_results")),
+        reconciliation_checks=_dicts(data.get("cmo_kpi_reconciliation_checks")),
+        report_quality_gates=_dicts(data.get("report_quality_gates")),
+        external_write_results=_external_write_results_from_source(data),
+        source_context=data,
+        now=now,
+    )
+
+
+def summarize_cmo_work_queue(items: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    queue = [dict(item) for item in items if isinstance(item, Mapping)]
+    severity_counts = dict.fromkeys(SEVERITIES, 0)
+    status_counts = dict.fromkeys(ITEM_STATUSES, 0)
+    category_counts: dict[str, int] = {}
+    for item in queue:
+        severity = str(item.get("severity") or "info")
+        status = str(item.get("status") or "open")
+        category = str(item.get("category") or "unknown")
+        if severity in severity_counts:
+            severity_counts[severity] += 1
+        if status in status_counts:
+            status_counts[status] += 1
+        category_counts[category] = category_counts.get(category, 0) + 1
+
+    first = queue[0] if queue else None
+    readiness = (
+        "blocked"
+        if severity_counts["critical"] or severity_counts["high"] or status_counts["blocked"]
+        else "degraded"
+        if queue
+        else "ready"
+    )
+    return {
+        "schema_version": CMO_WORK_QUEUE_VERSION,
+        "total": len(queue),
+        "readiness": readiness,
+        "critical_or_high": severity_counts["critical"] + severity_counts["high"],
+        "needs_action": sum(1 for item in queue if item.get("next_action_key") not in {None, "", "none"}),
+        "top_priority_score": int(first.get("priority_score") or 0) if first else 0,
+        "first_item_id": first.get("item_id") if first else None,
+        "next_action_cta": first.get("next_action_cta") if first else _cta("none"),
+        "by_severity": severity_counts,
+        "by_status": status_counts,
+        "by_category": dict(sorted(category_counts.items())),
+        "empty_state": (
+            "No open CMO work queue items. This does not upgrade stub, unavailable, or demo capabilities."
+            if not queue
+            else None
+        ),
+    }
+
+
+def _collect_approval_items(
+    items: dict[str, dict[str, Any]],
+    approval_timeout_risk: Mapping[str, Any] | None,
+    now: datetime,
+) -> None:
+    risk = approval_timeout_risk if isinstance(approval_timeout_risk, Mapping) else {}
+    for decision in _dicts(risk.get("approval_timeout_decisions")):
+        approval_id = _string_or_none(decision.get("approval_id")) or "unknown_approval"
+        timed_out = bool(decision.get("timed_out"))
+        due_at = _string_or_none(decision.get("due_at"))
+        approval_type = _string_or_none(decision.get("approval_type")) or "approval"
+        owner = _string_or_none(
+            decision.get("escalation_target")
+            or decision.get("requested_approver_role")
+            or decision.get("policy_required_role")
+        ) or "cmo"
+        if timed_out:
+            severity = "critical" if decision.get("external_writes_allowed") is False else "high"
+            _add_item(
+                items,
+                dedupe_key=f"approval:{approval_id}",
+                category="approval",
+                item_type="approval_timeout",
+                severity=severity,
+                status="blocked",
+                title=f"Overdue CMO approval: {approval_type.replace('_', ' ')}",
+                message=str(
+                    decision.get("safe_fallback_message")
+                    or "Approval is overdue; customer-facing marketing action must stay blocked until resolved."
+                ),
+                owner_role=owner,
+                due_at=due_at,
+                action_key=str(decision.get("next_action_cta") or "resolve_overdue_approvals"),
+                affected_workflow=_string_or_none(decision.get("workflow_id")),
+                source_refs=[_approval_ref(decision)],
+                audit_refs=_audit_refs(decision),
+                created_at=_string_or_none(decision.get("created_at")),
+                now=now,
+                customer_facing=True,
+            )
+        elif decision.get("status") == "pending":
+            due = _parse_datetime(due_at)
+            severity = "high" if due is not None and due <= now + timedelta(hours=2) else "medium"
+            _add_item(
+                items,
+                dedupe_key=f"approval:{approval_id}",
+                category="approval",
+                item_type="pending_approval",
+                severity=severity,
+                status="waiting",
+                title=f"Pending CMO approval: {approval_type.replace('_', ' ')}",
+                message="Human approval is waiting; external/customer-facing action remains blocked until approval.",
+                owner_role=owner,
+                due_at=due_at,
+                action_key="review_pending_approvals",
+                affected_workflow=_string_or_none(decision.get("workflow_id")),
+                source_refs=[_approval_ref(decision)],
+                created_at=_string_or_none(decision.get("created_at")),
+                now=now,
+                customer_facing=True,
+            )
+
+
+def _collect_escalation_items(
+    items: dict[str, dict[str, Any]],
+    approval_timeout_risk: Mapping[str, Any] | None,
+    escalation_projection: Mapping[str, Any] | None,
+    source: Mapping[str, Any],
+    now: datetime,
+) -> None:
+    decisions: list[dict[str, Any]] = []
+    risk = approval_timeout_risk if isinstance(approval_timeout_risk, Mapping) else {}
+    for approval in _dicts(risk.get("approval_timeout_decisions")):
+        decisions.extend(_dicts([approval.get("escalation_decision")]))
+    decisions.extend(_dicts(source.get("marketing_escalation_decisions")))
+    decisions.extend(_dicts(source.get("escalation_decisions")))
+    decisions.extend(_dicts(source.get("recent_escalations")))
+
+    summary = (
+        escalation_projection.get("marketing_escalation_summary")
+        if isinstance(escalation_projection, Mapping)
+        else None
+    )
+    if isinstance(summary, Mapping) and summary.get("status") == "missing_route":
+        _add_item(
+            items,
+            dedupe_key="escalation:missing_routes",
+            category="escalation",
+            item_type="missing_escalation_route",
+            severity="high",
+            status="blocked",
+            title="CMO escalation matrix is missing routes",
+            message="Production workflows with escalation-sensitive actions cannot proceed without a configured route.",
+            owner_role="cmo",
+            action_key=str(summary.get("next_action_cta") or "configure_escalation_matrix"),
+            source_refs=[{"type": "marketing_escalation_summary", "status": summary.get("status")}],
+            now=now,
+        )
+
+    for decision in decisions:
+        if not decision or str(decision.get("decision") or "") == "no_escalation":
+            continue
+        event_id = _string_or_none(decision.get("event_id")) or _stable_key("escalation", decision)
+        trigger = _string_or_none(decision.get("trigger_type") or decision.get("event_type")) or "escalation"
+        severity = _severity(decision.get("severity"), default="high")
+        _add_item(
+            items,
+            dedupe_key=f"escalation:{event_id}:{trigger}",
+            category="escalation",
+            item_type="escalation",
+            severity=severity,
+            status="open",
+            title=f"CMO escalation: {trigger.replace('_', ' ')}",
+            message=str(decision.get("reason") or "Escalation route requires owner attention."),
+            owner_role=_string_or_none(decision.get("escalation_target")) or "cmo",
+            due_at=_string_or_none(decision.get("due_at") or decision.get("sla_due_at")),
+            action_key=str(decision.get("next_action_cta") or "review_escalation"),
+            affected_workflow=_string_or_none(decision.get("workflow_id")),
+            source_refs=[{"type": "escalation_decision", "event_id": event_id, "trigger_type": trigger}],
+            audit_refs=_audit_refs(decision),
+            now=now,
+            customer_facing=trigger in {"crisis_public_response", "external_write_timeout_unknown"},
+        )
+
+
+def _collect_connector_setup_items(
+    items: dict[str, dict[str, Any]],
+    connector_setup: Iterable[Mapping[str, Any]],
+    now: datetime,
+) -> None:
+    for row in _dicts(connector_setup):
+        key = _string_or_none(row.get("key") or row.get("connector_key"))
+        if not key:
+            continue
+        health = _normalize_key(row.get("health_status") or row.get("status"))
+        configured = _normalize_key(row.get("configured_status") or row.get("setup_status"))
+        cta = _normalize_key(row.get("cta_state") or row.get("next_action_cta"))
+        coverage = _normalize_key(row.get("data_coverage_status"))
+        if (
+            health in {"healthy", "ready"}
+            and configured not in {"unconfigured", "missing"}
+            and cta in {"", "none"}
+            and coverage in {"", "ready"}
+        ):
+            continue
+        state = health or configured or coverage or "unknown"
+        severity = _connector_severity(state, bool(row.get("write_capabilities")))
+        _add_item(
+            items,
+            dedupe_key=f"connector:{key}",
+            category="connector",
+            item_type="connector_issue",
+            severity=severity,
+            status="blocked" if severity in {"critical", "high"} else "open",
+            title=f"{row.get('name') or key} connector needs attention",
+            message=str(row.get("detail") or f"Connector state is {state.replace('_', ' ')}."),
+            owner_role=_string_or_none(row.get("owner")) or "marketing_ops",
+            due_at=_string_or_none(row.get("due_at")),
+            action_key=cta or _connector_action(state),
+            affected_connector=key,
+            source_refs=[_connector_setup_ref(row, state)],
+            now=now,
+        )
+
+
+def _collect_connector_contract_items(
+    items: dict[str, dict[str, Any]],
+    connector_contracts: Iterable[Mapping[str, Any]],
+    now: datetime,
+) -> None:
+    for row in _dicts(connector_contracts):
+        key = _string_or_none(row.get("connector_key"))
+        if not key:
+            continue
+        contract_state = _normalize_key(row.get("contract_state"))
+        read_status = _normalize_key(row.get("read_status"))
+        write_status = _normalize_key(row.get("write_status"))
+        confirmation_status = _normalize_key(row.get("external_write_confirmation_status"))
+        failure_class = _normalize_key(row.get("failure_class"))
+        blocks_write = bool(row.get("blocks_external_writes"))
+        blocks_kpi = bool(row.get("blocks_production_kpi_confidence"))
+        has_write_capability = bool(_list_from_value(row.get("write_capabilities")))
+        bad = (
+            contract_state in BLOCKING_CONNECTOR_STATES | DEGRADED_CONNECTOR_STATES
+            or read_status in {"blocked", "degraded"}
+            or (has_write_capability and write_status not in {"ready", ""})
+            or confirmation_status == "write_unconfirmed"
+            or failure_class
+            or blocks_write
+            or blocks_kpi
+            or bool(row.get("mock_or_test_double"))
+        )
+        if not bad:
+            continue
+        severity = _connector_severity(
+            contract_state or read_status or write_status,
+            has_write_capability or blocks_write,
+        )
+        if confirmation_status == "write_unconfirmed" or blocks_write:
+            severity = "high"
+        if bool(row.get("mock_or_test_double")):
+            severity = "high"
+        _add_item(
+            items,
+            dedupe_key=f"connector:{key}",
+            category="connector",
+            item_type="connector_contract_issue",
+            severity=severity,
+            status="blocked" if severity in {"critical", "high"} else "open",
+            title=f"{row.get('name') or key} connector contract is not production-ready",
+            message=str(
+                row.get("degraded_mode_reason")
+                or row.get("reason")
+                or f"Read status {read_status or 'unknown'}, write status {write_status or 'unknown'}."
+            ),
+            owner_role="marketing_ops",
+            action_key=str(row.get("next_action_cta") or _connector_action(contract_state or write_status)),
+            affected_connector=key,
+            source_refs=[_connector_contract_ref(row)],
+            audit_refs=_audit_refs(row),
+            now=now,
+            customer_facing=blocks_write,
+        )
+
+
+def _collect_data_readiness_items(
+    items: dict[str, dict[str, Any]],
+    data_readiness: Mapping[str, Any],
+    now: datetime,
+) -> None:
+    for row in _dicts(data_readiness.get("field_mapping_status")):
+        status = _normalize_key(row.get("status"))
+        if status not in BAD_MAPPING_STATES:
+            continue
+        key = _string_or_none(row.get("key")) or "unknown_mapping"
+        severity = "high" if status in {"invalid", "blocked", "unmapped"} else "medium"
+        _add_item(
+            items,
+            dedupe_key=f"mapping:{key}",
+            category="data_readiness",
+            item_type="mapping_blocker",
+            severity=severity,
+            status="blocked" if severity == "high" else "open",
+            title=f"Field mapping needs action: {row.get('name') or key}",
+            message=str(row.get("blocking_reason") or f"Mapping status is {status.replace('_', ' ')}."),
+            owner_role="revops",
+            due_at=_string_or_none(row.get("due_at")),
+            action_key=str(row.get("next_action_cta") or "map_fields"),
+            affected_kpi=", ".join(_string_list(row.get("affected_kpis"))) or None,
+            source_refs=[{"type": "field_mapping", "key": key, "status": status}],
+            audit_refs=_audit_refs(row),
+            created_at=_string_or_none(row.get("created_at") or row.get("last_updated_at")),
+            now=now,
+        )
+
+    for row in _dicts(data_readiness.get("backfill_status")):
+        status = _normalize_key(row.get("status"))
+        if status not in BAD_BACKFILL_STATES:
+            continue
+        key = (
+            _string_or_none(row.get("source_connector_key"))
+            or _string_or_none(row.get("category"))
+            or "unknown_source"
+        )
+        severity = "high" if status in {"failed", "blocked", "not_started"} else "medium"
+        _add_item(
+            items,
+            dedupe_key=f"backfill:{key}",
+            category="data_readiness",
+            item_type="backfill_blocker",
+            severity=severity,
+            status="blocked" if severity == "high" else "waiting" if status in {"queued", "running"} else "open",
+            title=f"Historical backfill needs action: {row.get('source_name') or key}",
+            message=str(row.get("blocking_reason") or f"Backfill status is {status.replace('_', ' ')}."),
+            owner_role="revops",
+            action_key=str(row.get("next_action_cta") or "complete_backfill"),
+            affected_connector=key,
+            source_refs=[{"type": "backfill", "source_connector_key": key, "status": status}],
+            audit_refs=_audit_refs(row),
+            created_at=_string_or_none(row.get("created_at") or row.get("last_run_at")),
+            now=now,
+        )
+
+
+def _collect_workflow_items(
+    items: dict[str, dict[str, Any]],
+    workflow_activation: Mapping[str, Any],
+    now: datetime,
+) -> None:
+    for row in _dicts(workflow_activation.get("workflow_activation_status")):
+        state = _normalize_key(row.get("state"))
+        if state not in BAD_WORKFLOW_STATES:
+            continue
+        key = _string_or_none(row.get("workflow_key") or row.get("key")) or "unknown_workflow"
+        if state == "promotion_ready":
+            severity = "medium"
+            status = "open"
+            title = f"{row.get('name') or key} is ready for promotion review"
+            message = "Workflow prerequisites pass; CMO/admin must explicitly promote it before active writes."
+        elif state in {"promotion_blocked", "unavailable", "paused"}:
+            severity = "high"
+            status = "blocked"
+            title = f"{row.get('name') or key} workflow is blocked"
+            message = _first_text(row.get("blocked_reasons")) or f"Workflow state is {state.replace('_', ' ')}."
+        else:
+            severity = "medium"
+            status = "open"
+            title = f"{row.get('name') or key} workflow needs review"
+            message = _first_text(row.get("degraded_reasons")) or _first_text(row.get("blocked_reasons")) or (
+                f"Workflow state is {state.replace('_', ' ')}."
+            )
+        _add_item(
+            items,
+            dedupe_key=f"workflow:{key}:{state}",
+            category="workflow",
+            item_type="workflow_activation",
+            severity=severity,
+            status=status,
+            title=title,
+            message=message,
+            owner_role=_string_or_none(row.get("approval_owner") or row.get("policy_owner")) or "cmo",
+            action_key=str(row.get("next_action_cta") or "resolve_promotion_blocker"),
+            affected_workflow=key,
+            affected_capability=key,
+            source_refs=[{"type": "workflow_activation", "workflow_key": key, "state": state}],
+            audit_refs=_audit_refs(row),
+            created_at=_string_or_none(row.get("evaluated_at")),
+            now=now,
+        )
+
+
+def _collect_policy_and_audit_items(
+    items: dict[str, dict[str, Any]],
+    policy_projection: Mapping[str, Any] | None,
+    decision_audit_projection: Mapping[str, Any] | None,
+    workflow_activation: Mapping[str, Any],
+    source: Mapping[str, Any],
+    now: datetime,
+) -> None:
+    policy_summary = (
+        policy_projection.get("marketing_policy_summary")
+        if isinstance(policy_projection, Mapping)
+        else None
+    )
+    if isinstance(policy_summary, Mapping) and policy_summary.get("status") == "missing_policy":
+        _add_policy_item(
+            items,
+            dedupe_key="policy:manifest",
+            title="Marketing policy manifest is missing",
+            message="Active customer-facing CMO actions must fail closed until policy coverage is configured.",
+            action_key=str(policy_summary.get("next_action_cta") or "configure_marketing_policy_manifest"),
+            workflow_key=None,
+            now=now,
+        )
+
+    audit_summary = (
+        decision_audit_projection.get("marketing_decision_audit_summary")
+        if isinstance(decision_audit_projection, Mapping)
+        else None
+    )
+    if isinstance(audit_summary, Mapping) and audit_summary.get("status") == "missing_audit_evidence":
+        _add_audit_item(
+            items,
+            dedupe_key="audit:package",
+            title="CMO decision audit package is missing evidence",
+            message=(
+                "Production customer-facing actions cannot pass readiness without required "
+                "decision-audit evidence."
+            ),
+            action_key=str(audit_summary.get("next_action_cta") or "configure_decision_audit_package"),
+            workflow_key=None,
+            now=now,
+        )
+
+    for row in _dicts(workflow_activation.get("workflow_activation_status")):
+        workflow_key = _string_or_none(row.get("workflow_key")) or "unknown_workflow"
+        policy = row.get("marketing_policy") if isinstance(row.get("marketing_policy"), Mapping) else {}
+        if policy and _normalize_key(policy.get("status")) in {"missing_policy", "blocked"}:
+            _add_policy_item(
+                items,
+                dedupe_key=f"policy:{workflow_key}",
+                title=f"{row.get('name') or workflow_key} has a marketing policy blocker",
+                message=_first_text(policy.get("missing_policy_actions") or policy.get("blocked_actions"))
+                or "Workflow has missing or blocking marketing policy coverage.",
+                action_key=str(policy.get("next_action_cta") or "configure_marketing_policy_manifest"),
+                workflow_key=workflow_key,
+                audit_refs=_audit_refs(policy),
+                now=now,
+            )
+        audit = row.get("decision_audit") if isinstance(row.get("decision_audit"), Mapping) else {}
+        if audit and _normalize_key(audit.get("status")) == "missing_audit_evidence":
+            _add_audit_item(
+                items,
+                dedupe_key=f"audit:{workflow_key}",
+                title=f"{row.get('name') or workflow_key} lacks decision-audit evidence",
+                message=_first_text(audit.get("missing_audit_actions"))
+                or "Workflow needs CMO decision audit evidence before production use.",
+                action_key=str(audit.get("next_action_cta") or "configure_decision_audit_package"),
+                workflow_key=workflow_key,
+                audit_refs=_audit_refs(audit),
+                now=now,
+            )
+
+    for decision in _dicts(source.get("marketing_policy_decisions") or source.get("policy_decisions")):
+        outcome = _normalize_key(decision.get("decision"))
+        if outcome not in {"missing_policy", "blocked", "read_only_only"}:
+            continue
+        workflow_key = _string_or_none(decision.get("affected_workflow") or decision.get("workflow_id"))
+        _add_policy_item(
+            items,
+            dedupe_key=f"policy_decision:{workflow_key or 'global'}:{decision.get('affected_action')}",
+            title="CMO policy decision blocks execution",
+            message=str(decision.get("reason") or f"Policy decision is {outcome}."),
+            action_key=str(decision.get("next_action_cta") or "configure_marketing_policy_manifest"),
+            workflow_key=workflow_key,
+            audit_refs=_audit_refs(decision),
+            now=now,
+        )
+
+
+def _collect_external_write_items(
+    items: dict[str, dict[str, Any]],
+    external_write_results: Iterable[Mapping[str, Any]],
+    now: datetime,
+) -> None:
+    for row in _dicts(external_write_results):
+        state = _normalize_key(
+            row.get("final_state")
+            or row.get("external_write_state")
+            or row.get("write_state")
+            or row.get("status")
+        )
+        if state not in BAD_WRITE_STATES:
+            continue
+        workflow_key = _string_or_none(row.get("workflow_id") or row.get("workflow_key"))
+        step_id = _string_or_none(row.get("step_id"))
+        connector_key = _string_or_none(row.get("connector_key") or row.get("connector"))
+        severity = "critical" if state in {"rejected", "timeout_unknown", "write_unconfirmed", "accepted"} else "high"
+        status = "waiting" if state == "retry_scheduled" else "blocked"
+        _add_item(
+            items,
+            dedupe_key=f"external_write:{workflow_key}:{step_id}:{connector_key}:{state}",
+            category="external_write",
+            item_type="external_write_failure",
+            severity=severity,
+            status=status,
+            title=f"External marketing write is {state.replace('_', ' ')}",
+            message=str(row.get("reason") or row.get("message") or "External write cannot be treated as complete."),
+            owner_role=_string_or_none(row.get("owner_role")) or "marketing_ops",
+            due_at=_string_or_none(row.get("due_at") or row.get("resume_at")),
+            action_key=str(row.get("next_action") or row.get("next_action_cta") or "resolve_external_write_failure"),
+            affected_workflow=workflow_key,
+            affected_connector=connector_key,
+            source_refs=[{"type": "external_write", "state": state, "workflow_id": workflow_key, "step_id": step_id}],
+            audit_refs=_audit_refs(row),
+            created_at=_string_or_none(row.get("created_at") or row.get("attempted_at")),
+            now=now,
+            customer_facing=True,
+        )
+        for escalation in _dicts([row.get("escalation_decision")]):
+            _add_item(
+                items,
+                dedupe_key=f"escalation:{row.get('audit_reference') or _stable_key('write', row)}",
+                category="escalation",
+                item_type="external_write_escalation",
+                severity=_severity(escalation.get("severity"), default="high"),
+                status="open",
+                title="External-write failure escalation",
+                message=str(escalation.get("reason") or "External write failure needs escalation handling."),
+                owner_role=_string_or_none(escalation.get("escalation_target")) or "cmo",
+                due_at=_string_or_none(escalation.get("due_at")),
+                action_key=str(escalation.get("next_action_cta") or "review_escalation"),
+                affected_workflow=workflow_key,
+                affected_connector=connector_key,
+                source_refs=[{"type": "external_write_escalation", "state": state}],
+                audit_refs=_audit_refs(escalation),
+                now=now,
+                customer_facing=True,
+            )
+
+
+def _collect_kpi_items(
+    items: dict[str, dict[str, Any]],
+    kpi_results: Iterable[Mapping[str, Any]],
+    now: datetime,
+) -> None:
+    for row in _dicts(kpi_results):
+        status = _normalize_key(row.get("status"))
+        if status not in BAD_KPI_STATES:
+            continue
+        key = _string_or_none(row.get("kpi_key")) or "unknown_kpi"
+        severity = "high" if status in {"blocked", "unavailable"} else "medium"
+        message = _first_text(row.get("blocked_reasons") or row.get("missing_requirements"))
+        if not message:
+            message = f"KPI status is {status}; confidence {row.get('confidence', 'unknown')}."
+        _add_item(
+            items,
+            dedupe_key=f"kpi:{key}",
+            category="kpi",
+            item_type="kpi_readiness",
+            severity=severity,
+            status="blocked" if severity == "high" else "open",
+            title=f"KPI needs attention: {key.replace('_', ' ')}",
+            message=message,
+            owner_role=_string_or_none(row.get("owner_role")) or "marketing_ops",
+            action_key=str(row.get("next_action_cta") or "review_kpi_readiness"),
+            affected_kpi=key,
+            source_refs=_source_refs(row, default_type="kpi_result"),
+            audit_refs=_audit_refs(row),
+            created_at=_string_or_none(row.get("last_computed_at")),
+            now=now,
+        )
+
+
+def _collect_reconciliation_items(
+    items: dict[str, dict[str, Any]],
+    reconciliation_checks: Iterable[Mapping[str, Any]],
+    now: datetime,
+) -> None:
+    for row in _dicts(reconciliation_checks):
+        status = _normalize_key(row.get("status"))
+        if status not in BAD_RECONCILIATION_STATES:
+            continue
+        key = _string_or_none(row.get("reconciliation_key")) or "unknown_reconciliation"
+        severity = _reconciliation_severity(row, status)
+        _add_item(
+            items,
+            dedupe_key=f"reconciliation:{key}",
+            category="reconciliation",
+            item_type="reconciliation_issue",
+            severity=severity,
+            status="blocked" if severity in {"critical", "high"} else "open",
+            title=f"Reconciliation needs attention: {key.replace('_', ' ')}",
+            message=str(row.get("message") or row.get("reason") or f"Reconciliation status is {status}."),
+            owner_role="marketing_ops",
+            action_key=str(row.get("next_action_cta") or "resolve_reconciliation"),
+            affected_kpi=", ".join(_string_list(row.get("affected_kpi_keys"))) or None,
+            source_refs=_source_refs(row, default_type="reconciliation_check"),
+            audit_refs=_audit_refs(row),
+            now=now,
+        )
+
+
+def _collect_report_quality_items(
+    items: dict[str, dict[str, Any]],
+    report_quality_gates: Iterable[Mapping[str, Any]],
+    now: datetime,
+) -> None:
+    for row in _dicts(report_quality_gates):
+        status = _normalize_key(row.get("status"))
+        safe_mode = _normalize_key(row.get("safe_report_mode"))
+        if status not in BAD_REPORT_STATES and safe_mode in {"", "deliverable"}:
+            continue
+        key = _string_or_none(row.get("report_key") or row.get("report_type")) or "unknown_report"
+        if status in {"blocked", "unavailable"}:
+            severity = _severity(row.get("severity"), default="high")
+            if severity in {"low", "info", "medium"}:
+                severity = "high"
+        else:
+            severity = "medium" if safe_mode in {"internal_only", "draft_only"} else "low"
+        _add_item(
+            items,
+            dedupe_key=f"report:{key}",
+            category="report",
+            item_type="report_quality_gate",
+            severity=severity,
+            status="blocked" if status in {"blocked", "unavailable"} else "open",
+            title=f"Report quality gate needs attention: {row.get('display_name') or key}",
+            message=_first_text(row.get("blocked_reasons") or row.get("warning_reasons"))
+            or f"Report gate status is {status}; safe mode is {safe_mode or 'unknown'}.",
+            owner_role="marketing_ops",
+            action_key=str(row.get("next_action_cta") or "review_report_quality"),
+            affected_report=key,
+            affected_kpi=", ".join(_string_list(row.get("blocked_kpi_keys") or row.get("degraded_kpi_keys"))) or None,
+            source_refs=_source_refs(row, default_type="report_quality_gate"),
+            audit_refs=_audit_refs(row),
+            created_at=_string_or_none(row.get("evaluated_at")),
+            now=now,
+        )
+
+
+def _collect_source_context_items(
+    items: dict[str, dict[str, Any]],
+    source: Mapping[str, Any],
+    now: datetime,
+) -> None:
+    if source.get("production_data_blocked"):
+        _add_item(
+            items,
+            dedupe_key="source:production_data_blocked",
+            category="source_data",
+            item_type="production_data_blocked",
+            severity="high",
+            status="blocked",
+            title="Production CMO data is blocked",
+            message=str(
+                source.get("message")
+                or "Real connector, mapping, and backfill evidence is required before production KPI/report readiness."
+            ),
+            owner_role="marketing_ops",
+            action_key="connect_real_kpi_sources",
+            source_refs=[{"type": "source_context", "production_data_blocked": True}],
+            now=now,
+        )
+    elif source.get("demo") or source.get("demo_suppressed"):
+        _add_item(
+            items,
+            dedupe_key="source:demo_data",
+            category="source_data",
+            item_type="demo_data",
+            severity="medium",
+            status="open",
+            title="CMO dashboard is using demo/sample data",
+            message="Demo/sample values are not production readiness proof for CMO workflows or reports.",
+            owner_role="marketing_ops",
+            action_key="connect_real_kpi_sources",
+            source_refs=[{"type": "source_context", "demo": bool(source.get("demo"))}],
+            now=now,
+        )
+
+
+def _collect_crisis_risk_items(
+    items: dict[str, dict[str, Any]],
+    source: Mapping[str, Any],
+    now: datetime,
+) -> None:
+    risks = _dicts(source.get("crisis_risks") or source.get("brand_crisis_risks"))
+    single = source.get("crisis_risk") or source.get("brand_crisis_risk")
+    risks.extend(_dicts([single]))
+    for risk in risks:
+        if not risk:
+            continue
+        severity = _severity(
+            risk.get("severity"),
+            default="critical" if risk.get("public_response_required") else "high",
+        )
+        risk_id = _string_or_none(risk.get("risk_id") or risk.get("id")) or _stable_key("crisis", risk)
+        _add_item(
+            items,
+            dedupe_key=f"crisis:{risk_id}",
+            category="crisis_risk",
+            item_type="crisis_public_response_risk",
+            severity=severity,
+            status="blocked" if risk.get("public_response_required") else "open",
+            title=str(risk.get("title") or "Brand/crisis response risk"),
+            message=str(risk.get("message") or risk.get("reason") or "Crisis/public-response risk needs CMO review."),
+            owner_role=_string_or_none(risk.get("owner_role")) or "cmo",
+            due_at=_string_or_none(risk.get("due_at")),
+            action_key=str(risk.get("next_action_cta") or "open_incident_room"),
+            affected_workflow="brand_crisis_response",
+            affected_capability="brand_crisis_response",
+            source_refs=_source_refs(risk, default_type="crisis_risk"),
+            audit_refs=_audit_refs(risk),
+            created_at=_string_or_none(risk.get("created_at")),
+            now=now,
+            customer_facing=True,
+        )
+
+
+def _add_policy_item(
+    items: dict[str, dict[str, Any]],
+    *,
+    dedupe_key: str,
+    title: str,
+    message: str,
+    action_key: str,
+    workflow_key: str | None,
+    audit_refs: Iterable[Any] = (),
+    now: datetime,
+) -> None:
+    _add_item(
+        items,
+        dedupe_key=dedupe_key,
+        category="policy",
+        item_type="policy_gap",
+        severity="high",
+        status="blocked",
+        title=title,
+        message=message,
+        owner_role="policy_owner",
+        action_key=action_key,
+        affected_workflow=workflow_key,
+        source_refs=[{"type": "marketing_policy", "workflow_key": workflow_key}],
+        audit_refs=audit_refs,
+        now=now,
+        customer_facing=True,
+    )
+
+
+def _add_audit_item(
+    items: dict[str, dict[str, Any]],
+    *,
+    dedupe_key: str,
+    title: str,
+    message: str,
+    action_key: str,
+    workflow_key: str | None,
+    audit_refs: Iterable[Any] = (),
+    now: datetime,
+) -> None:
+    _add_item(
+        items,
+        dedupe_key=dedupe_key,
+        category="audit",
+        item_type="audit_gap",
+        severity="high",
+        status="blocked",
+        title=title,
+        message=message,
+        owner_role="marketing_ops",
+        action_key=action_key,
+        affected_workflow=workflow_key,
+        source_refs=[{"type": "decision_audit", "workflow_key": workflow_key}],
+        audit_refs=audit_refs,
+        now=now,
+        customer_facing=True,
+    )
+
+
+def _add_item(
+    items: dict[str, dict[str, Any]],
+    *,
+    dedupe_key: str,
+    category: str,
+    item_type: str,
+    severity: str,
+    status: str,
+    title: str,
+    message: str,
+    owner_role: str,
+    action_key: str,
+    now: datetime,
+    affected_workflow: str | None = None,
+    affected_capability: str | None = None,
+    affected_kpi: str | None = None,
+    affected_report: str | None = None,
+    affected_connector: str | None = None,
+    due_at: str | None = None,
+    source_refs: Iterable[Any] = (),
+    audit_refs: Iterable[Any] = (),
+    created_at: str | None = None,
+    customer_facing: bool = False,
+) -> None:
+    severity = _severity(severity)
+    status = status if status in ITEM_STATUSES else "open"
+    cta = _cta(action_key)
+    normalized_key = _normalize_key(dedupe_key)
+    priority = _priority_score(
+        severity=severity,
+        category=category,
+        status=status,
+        due_at=due_at,
+        customer_facing=customer_facing,
+        now=now,
+    )
+    item = {
+        "item_id": _item_id(normalized_key),
+        "type": item_type,
+        "category": category,
+        "severity": severity,
+        "priority_score": priority,
+        "title": title,
+        "message": message,
+        "affected_workflow": affected_workflow,
+        "affected_capability": affected_capability,
+        "affected_kpi": affected_kpi,
+        "affected_report": affected_report,
+        "affected_connector": affected_connector,
+        "owner_role": owner_role,
+        "due_at": due_at,
+        "source_refs": _refs(source_refs),
+        "audit_refs": _strings(audit_refs),
+        "next_action_cta": cta,
+        "next_action_label": cta["label"],
+        "next_action_path": cta["path"],
+        "next_action_key": cta["action_key"],
+        "status": status,
+        "created_at": created_at or now.isoformat(),
+        "updated_at": now.isoformat(),
+    }
+    existing = items.get(normalized_key)
+    if existing is None:
+        items[normalized_key] = item
+        return
+
+    if item["priority_score"] > existing["priority_score"]:
+        for key in (
+            "type",
+            "category",
+            "severity",
+            "priority_score",
+            "title",
+            "owner_role",
+            "due_at",
+            "next_action_cta",
+            "next_action_label",
+            "next_action_path",
+            "next_action_key",
+            "status",
+        ):
+            existing[key] = item[key]
+    if item["message"] and item["message"] not in existing["message"]:
+        existing["message"] = f"{existing['message']} {item['message']}"
+    for field in (
+        "affected_workflow",
+        "affected_capability",
+        "affected_kpi",
+        "affected_report",
+        "affected_connector",
+    ):
+        existing[field] = existing.get(field) or item.get(field)
+    existing["source_refs"] = _unique_refs([*existing["source_refs"], *item["source_refs"]])
+    existing["audit_refs"] = _unique_strings([*existing["audit_refs"], *item["audit_refs"]])
+    existing["updated_at"] = now.isoformat()
+
+
+def _sort_items(items: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        [dict(item) for item in items],
+        key=lambda item: (
+            -int(item.get("priority_score") or 0),
+            _due_sort_key(item.get("due_at")),
+            str(item.get("title") or ""),
+        ),
+    )
+
+
+def _priority_score(
+    *,
+    severity: str,
+    category: str,
+    status: str,
+    due_at: str | None,
+    customer_facing: bool,
+    now: datetime,
+) -> int:
+    score = SEVERITY_SCORE[severity] + CATEGORY_SCORE.get(category, 0)
+    if status == "blocked":
+        score += 40
+    elif status == "waiting":
+        score += 20
+    if customer_facing:
+        score += 60
+    due = _parse_datetime(due_at)
+    if due is not None:
+        if due <= now:
+            score += 80
+        elif due <= now + timedelta(hours=4):
+            score += 45
+        elif due <= now + timedelta(days=1):
+            score += 20
+    return int(score)
+
+
+def _connector_severity(state: str, write_related: bool = False) -> str:
+    normalized = _normalize_key(state)
+    if normalized in {"expired_auth", "auth_expired", "connector_disabled", "malformed_payload"}:
+        return "high"
+    if normalized in {"missing", "unconfigured", "insufficient_scope", "missing_scope"}:
+        return "high" if write_related else "medium"
+    if normalized in {"timeout", "vendor_5xx", "quota_exhausted"}:
+        return "high" if write_related else "medium"
+    if normalized in {"stale", "stale_data", "degraded", "partial", "partial_data", "rate_limited"}:
+        return "medium"
+    return "low"
+
+
+def _connector_action(state: str) -> str:
+    normalized = _normalize_key(state)
+    if normalized in {"expired_auth", "auth_expired"}:
+        return "reconnect"
+    if normalized in {"missing", "unconfigured"}:
+        return "setup"
+    if normalized in {"insufficient_scope", "missing_scope"}:
+        return "add_scope"
+    if normalized in {"stale", "stale_data"}:
+        return "refresh"
+    if normalized in {"timeout", "vendor_5xx", "rate_limited"}:
+        return "review_retry_budget"
+    if normalized == "connector_disabled":
+        return "enable_connector"
+    if normalized == "malformed_payload":
+        return "fix_connector_payload"
+    return "review"
+
+
+def _reconciliation_severity(row: Mapping[str, Any], status: str) -> str:
+    explicit = _severity(row.get("severity"), default="")
+    if explicit:
+        return explicit
+    if status in {"failed", "blocked"}:
+        return "high"
+    if status == "warning":
+        return "medium"
+    return "low"
+
+
+def _severity(value: Any, *, default: str = "medium") -> str:
+    normalized = _normalize_key(value)
+    if normalized in SEVERITIES:
+        return normalized
+    return default
+
+
+def _cta(action_key: Any) -> dict[str, str]:
+    key = _normalize_key(action_key) or "none"
+    return {
+        "action_key": key,
+        "label": CTA_LABELS.get(key, key.replace("_", " ").title()),
+        "path": CTA_PATHS.get(key, "/dashboard/cmo"),
+    }
+
+
+CTA_LABELS = {
+    "none": "No Action",
+    "setup": "Set Up",
+    "reconnect": "Reconnect",
+    "add_scope": "Add Scope",
+    "refresh": "Refresh Sync",
+    "review": "Review",
+    "review_retry_budget": "Review Retry Budget",
+    "review_degraded": "Review Degraded",
+    "configure_idempotency": "Configure Idempotency",
+    "fix_connector_payload": "Fix Connector Payload",
+    "wait_for_quota_reset": "Wait For Quota Reset",
+    "enable_connector": "Enable Connector",
+    "map_fields": "Map Fields",
+    "complete_mapping": "Complete Mapping",
+    "fix_required_mapping": "Fix Mapping",
+    "complete_backfill": "Complete Backfill",
+    "retry_backfill": "Retry Backfill",
+    "resolve_blocker": "Resolve Blocker",
+    "resolve_overdue_approvals": "Resolve Approval",
+    "review_pending_approvals": "Review Approval",
+    "review_escalated_approval": "Review Escalation",
+    "configure_escalation_matrix": "Configure Escalation",
+    "review_escalation": "Review Escalation",
+    "configure_marketing_policy_manifest": "Configure Policy",
+    "configure_decision_audit_package": "Configure Audit",
+    "resolve_marketing_policy": "Resolve Policy",
+    "resolve_external_write_failure": "Resolve Write Failure",
+    "manual_reconcile_before_retry": "Reconcile Before Retry",
+    "wait_for_idempotent_retry": "Wait For Retry",
+    "confirm_write_or_reconcile": "Confirm Or Reconcile",
+    "restore_required_kpis": "Restore KPI",
+    "review_kpi_readiness": "Review KPI",
+    "resolve_reconciliation": "Resolve Reconciliation",
+    "resolve_report_reconciliation": "Resolve Reconciliation",
+    "review_report_quality": "Review Report",
+    "review_report_quality_warnings": "Review Report Warnings",
+    "fix_report_connectors": "Fix Report Connectors",
+    "refresh_report_sources": "Refresh Report Sources",
+    "connect_real_kpi_sources": "Connect Real Sources",
+    "activate_report_workflow": "Activate Workflow",
+    "promote_workflow": "Promote",
+    "resolve_promotion_blocker": "Resolve Blocker",
+    "fix_required_connector": "Fix Connector",
+    "run_shadow_quality": "Run Shadow QA",
+    "review_degraded_dependency": "Review Degraded",
+    "resume_workflow": "Resume",
+    "implement_first_class_agent": "Implement Agent",
+    "open_incident_room": "Open Incident Room",
+}
+
+CTA_PATHS = {
+    "none": "/dashboard/cmo",
+    "setup": "/dashboard/connectors",
+    "reconnect": "/dashboard/connectors",
+    "add_scope": "/dashboard/connectors",
+    "refresh": "/dashboard/connectors",
+    "review": "/dashboard/connectors",
+    "review_retry_budget": "/dashboard/connectors",
+    "review_degraded": "/dashboard/connectors",
+    "configure_idempotency": "/dashboard/connectors",
+    "fix_connector_payload": "/dashboard/connectors",
+    "wait_for_quota_reset": "/dashboard/connectors",
+    "enable_connector": "/dashboard/connectors",
+    "map_fields": "/dashboard/cmo?panel=data-readiness",
+    "complete_mapping": "/dashboard/cmo?panel=data-readiness",
+    "fix_required_mapping": "/dashboard/cmo?panel=data-readiness",
+    "complete_backfill": "/dashboard/cmo?panel=data-readiness",
+    "retry_backfill": "/dashboard/cmo?panel=data-readiness",
+    "resolve_blocker": "/dashboard/cmo?panel=data-readiness",
+    "resolve_overdue_approvals": "/dashboard/approvals",
+    "review_pending_approvals": "/dashboard/approvals",
+    "review_escalated_approval": "/dashboard/approvals",
+    "configure_escalation_matrix": "/dashboard/settings",
+    "review_escalation": "/dashboard/approvals",
+    "configure_marketing_policy_manifest": "/dashboard/settings",
+    "configure_decision_audit_package": "/dashboard/audit",
+    "resolve_marketing_policy": "/dashboard/settings",
+    "resolve_external_write_failure": "/dashboard/approvals",
+    "manual_reconcile_before_retry": "/dashboard/approvals",
+    "wait_for_idempotent_retry": "/dashboard/approvals",
+    "confirm_write_or_reconcile": "/dashboard/approvals",
+    "restore_required_kpis": "/dashboard/cmo?kpi=all",
+    "review_kpi_readiness": "/dashboard/cmo?kpi=all",
+    "resolve_reconciliation": "/dashboard/cmo?panel=reconciliation",
+    "resolve_report_reconciliation": "/dashboard/cmo?panel=reconciliation",
+    "review_report_quality": "/dashboard/reports",
+    "review_report_quality_warnings": "/dashboard/reports",
+    "fix_report_connectors": "/dashboard/connectors",
+    "refresh_report_sources": "/dashboard/connectors",
+    "connect_real_kpi_sources": "/dashboard/connectors",
+    "activate_report_workflow": "/dashboard/workflows",
+    "promote_workflow": "/dashboard/workflows",
+    "resolve_promotion_blocker": "/dashboard/workflows",
+    "fix_required_connector": "/dashboard/connectors",
+    "run_shadow_quality": "/dashboard/workflows",
+    "review_degraded_dependency": "/dashboard/workflows",
+    "resume_workflow": "/dashboard/workflows",
+    "implement_first_class_agent": "/dashboard/agents",
+    "open_incident_room": "/dashboard/approvals",
+}
+
+
+def _external_write_results_from_source(source: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for key in (
+        "external_write_results",
+        "marketing_external_write_results",
+        "external_write_failures",
+        "marketing_external_write_failures",
+    ):
+        rows.extend(_dicts(source.get(key)))
+    return rows
+
+
+def _connector_setup_ref(row: Mapping[str, Any], state: str) -> dict[str, Any]:
+    return {
+        "type": "connector_setup",
+        "connector_key": row.get("key") or row.get("connector_key"),
+        "category": row.get("category"),
+        "status": row.get("configured_status"),
+        "health_status": row.get("health_status"),
+        "state": state,
+        "last_sync_at": row.get("last_sync_at"),
+    }
+
+
+def _connector_contract_ref(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "connector_contract",
+        "connector_key": row.get("connector_key"),
+        "category": row.get("category"),
+        "contract_state": row.get("contract_state"),
+        "read_status": row.get("read_status"),
+        "write_status": row.get("write_status"),
+        "failure_class": row.get("failure_class"),
+    }
+
+
+def _approval_ref(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "approval",
+        "approval_id": row.get("approval_id"),
+        "approval_review_id": row.get("approval_review_id"),
+        "approval_review_status": row.get("approval_review_status"),
+        "approval_type": row.get("approval_type"),
+        "workflow_id": row.get("workflow_id"),
+        "step_id": row.get("step_id"),
+    }
+
+
+def _source_refs(row: Mapping[str, Any], *, default_type: str) -> list[dict[str, Any]]:
+    refs = []
+    for key in ("source_refs", "source_references", "sources_compared", "sources"):
+        for value in _list_from_value(row.get(key)):
+            if isinstance(value, Mapping):
+                refs.append(dict(value))
+            else:
+                refs.append({"type": default_type, "ref": str(value)})
+    if not refs:
+        refs.append({"type": default_type})
+    return _unique_refs(refs)
+
+
+def _audit_refs(row: Mapping[str, Any] | None) -> list[str]:
+    if not isinstance(row, Mapping):
+        return []
+    refs: list[Any] = [
+        row.get("audit_ref"),
+        row.get("audit_reference"),
+        row.get("decision_audit_ref"),
+    ]
+    for key in ("audit_refs", "decision_audit_refs"):
+        refs.extend(_list_from_value(row.get(key)))
+    evidence = row.get("audit_evidence")
+    if isinstance(evidence, Mapping):
+        refs.extend([evidence.get("audit_reference"), evidence.get("decision_audit_ref")])
+    for event in _dicts(row.get("audit_events")):
+        refs.extend([event.get("audit_reference"), event.get("decision_audit_ref")])
+    return _unique_strings(_strings(refs))
+
+
+def _refs(values: Iterable[Any]) -> list[dict[str, Any]]:
+    refs = []
+    for value in values:
+        if isinstance(value, Mapping):
+            refs.append(dict(value))
+        elif value not in {None, ""}:
+            refs.append({"ref": str(value)})
+    return _unique_refs(refs)
+
+
+def _unique_refs(values: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    result: list[dict[str, Any]] = []
+    for value in values:
+        encoded = repr(sorted(dict(value).items()))
+        if encoded in seen:
+            continue
+        seen.add(encoded)
+        result.append(dict(value))
+    return result
+
+
+def _strings(values: Iterable[Any]) -> list[str]:
+    return [str(value) for value in values if _string_or_none(value)]
+
+
+def _unique_strings(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _dicts(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, Mapping):
+        return [dict(value)]
+    if isinstance(value, str) or value is None:
+        return []
+    if isinstance(value, Iterable):
+        return [dict(item) for item in value if isinstance(item, Mapping)]
+    return []
+
+
+def _list_from_value(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, Iterable):
+        return list(value)
+    return [value]
+
+
+def _string_list(value: Any) -> list[str]:
+    return [str(item) for item in _list_from_value(value) if _string_or_none(item)]
+
+
+def _first_text(value: Any) -> str | None:
+    if isinstance(value, Mapping):
+        for nested in value.values():
+            text = _first_text(nested)
+            if text:
+                return text
+        return None
+    for item in _list_from_value(value):
+        if isinstance(item, Mapping):
+            text = _first_text(item)
+            if text:
+                return text
+        elif _string_or_none(item):
+            return str(item)
+    return None
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return _ensure_aware(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return _ensure_aware(datetime.fromisoformat(value.replace("Z", "+00:00")))
+        except ValueError:
+            return None
+    return None
+
+
+def _ensure_aware(value: datetime | None) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _due_sort_key(value: Any) -> str:
+    due = _parse_datetime(value)
+    return due.isoformat() if due else "9999-12-31T23:59:59+00:00"
+
+
+def _item_id(dedupe_key: str) -> str:
+    return f"cmo_wq_{hashlib.sha256(dedupe_key.encode()).hexdigest()[:20]}"
+
+
+def _stable_key(prefix: str, value: Mapping[str, Any]) -> str:
+    return f"{prefix}_{hashlib.sha256(repr(sorted(value.items())).encode()).hexdigest()[:16]}"
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _string_or_none(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None

--- a/core/marketing/workflow_activation.py
+++ b/core/marketing/workflow_activation.py
@@ -1,0 +1,1076 @@
+"""CMO workflow shadow-mode and promotion readiness projection.
+
+This module projects stored marketing connector metadata into per-workflow
+activation gates. It does not promote workflows by itself, call vendor APIs, or
+trust demo/sample data as proof. A workflow can write to external marketing
+systems only when its own row is explicitly active and every prerequisite still
+passes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from core.marketing.approval_timeouts import build_workflow_approval_timeout_status
+from core.marketing.connector_contracts import build_marketing_connector_contracts
+from core.marketing.connector_retry_policy import summarize_degraded_modes
+from core.marketing.decision_audit import (
+    build_workflow_decision_audit_status,
+    build_workflow_promotion_audit_package,
+)
+from core.marketing.escalation_matrix import build_workflow_escalation_status
+from core.marketing.policy_manifest import build_workflow_marketing_policy_status
+
+WORKFLOW_STATES = (
+    "unavailable",
+    "shadow",
+    "promotion_blocked",
+    "promotion_ready",
+    "active",
+    "degraded",
+    "paused",
+)
+
+PROMOTABLE_MODES = {"shadow", "promotion_ready", "active", "paused"}
+READ_ONLY_ACTIONS = {
+    "account_deal_health_summary",
+    "account_health_summary",
+    "analyze",
+    "analyze_pipeline_velocity",
+    "change_confidence_score",
+    "churn_risk_signal_extraction",
+    "classify_crisis_severity",
+    "classify_sentiment",
+    "create_approval",
+    "create_internal_approval",
+    "draft",
+    "aggregate_mentions",
+    "aggregate_engagement",
+    "aggregate_intent",
+    "competitor_brand_grouping",
+    "duplicate_change_suppression",
+    "detect_crisis",
+    "detect_negative_spike",
+    "evaluate_alert_thresholds",
+    "extract_churn_signals",
+    "extract_win_loss_signals",
+    "false_positive_suppression",
+    "feature_capability_diffing",
+    "funnel_conversion_analysis",
+    "get_sentiment",
+    "get_keyword_rankings",
+    "group_mentions",
+    "identify_content_gaps",
+    "keyword_gap_analysis",
+    "lead_scoring_refresh",
+    "mention_aggregation",
+    "monitor_mentions",
+    "normalize_competitor_profiles",
+    "optimize_content",
+    "pipeline_velocity_analysis",
+    "positioning_recommendation",
+    "pricing_change_detection",
+    "prioritize_technical_issues",
+    "promote_to_sql",
+    "query_target_accounts",
+    "recommend",
+    "recommend_next_best_action",
+    "recommend_response_playbook",
+    "recommend_segments",
+    "refresh_lead_scores",
+    "ranking_delta_computation",
+    "recommendation_bundling",
+    "score_accounts",
+    "score_icp_fit",
+    "score_intent_heat",
+    "score_lead",
+    "segment_recommendation",
+    "seo_sprint_planning",
+    "sentiment_trend",
+    "simulate",
+    "sql_promotion_criteria",
+    "technical_issue_prioritization",
+    "validate_account_csv",
+    "weekly_benchmark",
+    "weekly_market_snapshot",
+}
+EXTERNAL_WRITE_ACTIONS = {
+    "bulk_crm_update",
+    "change_segment_membership",
+    "change_target_accounts",
+    "comparative_claim",
+    "apply_redirect",
+    "create_abm_campaign",
+    "create_campaign",
+    "crisis_response",
+    "launch_campaign",
+    "launch_abm_campaign",
+    "launch_competitive_campaign",
+    "mutate_ad_budget",
+    "pause_campaign",
+    "pricing_claim",
+    "promote_lifecycle_stage",
+    "public_response",
+    "publish",
+    "publish_brand_response",
+    "publish_competitive_response",
+    "publish_landing_page",
+    "publish_post",
+    "publish_seo_change",
+    "publish_to_wordpress",
+    "reply_to_mention",
+    "schedule_campaign_posts",
+    "schedule_content_promotion",
+    "schedule_post",
+    "send",
+    "send_email",
+    "spend",
+    "sync_target_accounts",
+    "target_account_list_change",
+    "update_canonical_tag",
+    "update_ad_budget",
+    "update_crm",
+    "update_landing_page",
+    "update_lead_scores",
+    "update_lifecycle_stage",
+    "update_page_metadata",
+    "update_robots_txt",
+    "update_segment_membership",
+    "update_sitemap",
+    "update_target_accounts",
+    "write_external",
+}
+
+
+@dataclass(frozen=True)
+class WorkflowActivationSpec:
+    key: str
+    name: str
+    required_connector_categories: tuple[str, ...]
+    required_mappings: tuple[str, ...]
+    required_backfill_categories: tuple[str, ...]
+    write_connector_categories: tuple[str, ...] = ()
+    write_actions: tuple[str, ...] = ()
+    optional_connector_categories: tuple[str, ...] = ()
+    optional_mappings: tuple[str, ...] = ()
+    optional_backfill_categories: tuple[str, ...] = ()
+    production_available: bool = True
+    unavailable_reason: str | None = None
+    min_shadow_runs: int = 3
+    min_shadow_success_rate: float = 0.8
+
+
+CMO_WORKFLOW_SPECS: tuple[WorkflowActivationSpec, ...] = (
+    WorkflowActivationSpec(
+        key="weekly_marketing_report",
+        name="Weekly Marketing Report",
+        required_connector_categories=("CRM", "Ads", "Analytics", "Email"),
+        required_mappings=(
+            "lifecycle_stages",
+            "opportunity_revenue",
+            "campaign_ids",
+            "utm_fields",
+            "consent_unsubscribe",
+            "fiscal_calendar",
+            "currency",
+            "timezone",
+        ),
+        required_backfill_categories=("CRM", "Ads", "Analytics", "Email"),
+        optional_connector_categories=("SEO", "Brand", "Finance"),
+        optional_backfill_categories=("SEO", "Brand", "Finance"),
+    ),
+    WorkflowActivationSpec(
+        key="campaign_launch",
+        name="Campaign Launch",
+        required_connector_categories=("CRM", "Ads", "Analytics", "Email"),
+        required_mappings=(
+            "campaign_ids",
+            "utm_fields",
+            "consent_unsubscribe",
+            "currency",
+            "timezone",
+        ),
+        required_backfill_categories=("CRM", "Ads", "Analytics", "Email"),
+        write_connector_categories=("Ads", "Email"),
+        write_actions=("launch_campaign", "send_email"),
+        optional_connector_categories=("CMS", "Social"),
+        optional_mappings=("account_domains",),
+        optional_backfill_categories=("CMS", "Social"),
+    ),
+    WorkflowActivationSpec(
+        key="daily_spend_optimization",
+        name="Daily Spend Optimization",
+        required_connector_categories=("CRM", "Ads", "Analytics"),
+        required_mappings=(
+            "opportunity_revenue",
+            "campaign_ids",
+            "utm_fields",
+            "currency",
+            "timezone",
+        ),
+        required_backfill_categories=("CRM", "Ads", "Analytics"),
+        write_connector_categories=("Ads",),
+        write_actions=("mutate_ad_budget",),
+        optional_connector_categories=("Finance",),
+        optional_backfill_categories=("Finance",),
+        min_shadow_runs=5,
+        min_shadow_success_rate=0.85,
+    ),
+    WorkflowActivationSpec(
+        key="content_pipeline",
+        name="Content Pipeline",
+        required_connector_categories=("CMS",),
+        required_mappings=("campaign_ids", "utm_fields", "timezone"),
+        required_backfill_categories=("CMS",),
+        write_connector_categories=("CMS",),
+        write_actions=("publish",),
+        optional_connector_categories=("Analytics", "SEO", "Social"),
+        optional_backfill_categories=("Analytics", "SEO", "Social"),
+    ),
+    WorkflowActivationSpec(
+        key="lead_nurture",
+        name="Lead Nurture",
+        required_connector_categories=("CRM", "Email"),
+        required_mappings=("lifecycle_stages", "consent_unsubscribe", "timezone"),
+        required_backfill_categories=("CRM", "Email"),
+        write_connector_categories=("CRM", "Email"),
+        write_actions=("update_crm", "send_email"),
+        optional_connector_categories=("ABM",),
+        optional_mappings=("account_domains",),
+        optional_backfill_categories=("ABM",),
+    ),
+    WorkflowActivationSpec(
+        key="social_publishing",
+        name="Social Publishing",
+        required_connector_categories=("Social",),
+        required_mappings=("campaign_ids", "utm_fields", "timezone"),
+        required_backfill_categories=("Social",),
+        write_connector_categories=("Social",),
+        write_actions=("schedule_post", "publish_post", "reply_to_mention"),
+        optional_connector_categories=("Analytics", "Brand"),
+        optional_backfill_categories=("Analytics", "Brand"),
+    ),
+    WorkflowActivationSpec(
+        key="abm_sprint",
+        name="ABM Sprint",
+        required_connector_categories=("CRM", "ABM"),
+        required_mappings=("account_domains", "lifecycle_stages", "timezone"),
+        required_backfill_categories=("CRM", "ABM"),
+        write_connector_categories=("CRM", "Ads"),
+        write_actions=("update_target_accounts", "launch_abm_campaign"),
+    ),
+    WorkflowActivationSpec(
+        key="competitive_intel_monitoring",
+        name="Competitive Intel Monitoring",
+        required_connector_categories=("Brand", "SEO"),
+        required_mappings=("timezone",),
+        required_backfill_categories=("Brand", "SEO"),
+        write_connector_categories=("Social", "Ads"),
+        write_actions=("publish_competitive_response", "launch_competitive_campaign"),
+        optional_connector_categories=("ABM", "CRM"),
+        optional_backfill_categories=("ABM", "CRM"),
+    ),
+    WorkflowActivationSpec(
+        key="brand_crisis_response",
+        name="Brand Crisis Response",
+        required_connector_categories=("Brand",),
+        required_mappings=("timezone",),
+        required_backfill_categories=("Brand",),
+        write_connector_categories=("Social",),
+        write_actions=("public_response", "crisis_response", "publish_brand_response"),
+        optional_connector_categories=("Social",),
+        optional_backfill_categories=("Social",),
+    ),
+    WorkflowActivationSpec(
+        key="seo_sprint",
+        name="SEO Sprint",
+        required_connector_categories=("SEO", "Analytics", "CMS"),
+        required_mappings=("campaign_ids", "utm_fields", "timezone"),
+        required_backfill_categories=("SEO", "Analytics", "CMS"),
+        write_connector_categories=("CMS",),
+        write_actions=("update_page_metadata", "update_canonical_tag", "apply_redirect", "publish_seo_change"),
+    ),
+    WorkflowActivationSpec(
+        key="crm_pipeline_intelligence",
+        name="CRM Pipeline Intelligence",
+        required_connector_categories=("CRM",),
+        required_mappings=("lifecycle_stages", "opportunity_revenue", "timezone"),
+        required_backfill_categories=("CRM",),
+        write_connector_categories=("CRM",),
+        write_actions=(
+            "update_lead_scores",
+            "update_lifecycle_stage",
+            "change_segment_membership",
+            "change_target_accounts",
+            "bulk_crm_update",
+        ),
+        optional_connector_categories=("Analytics", "ABM"),
+        optional_mappings=("account_domains",),
+        optional_backfill_categories=("Analytics", "ABM"),
+    ),
+)
+
+
+def build_cmo_workflow_activation(
+    connector_setup: Iterable[dict[str, Any]],
+    data_readiness: dict[str, Any],
+    connector_configs: Iterable[Any],
+    *,
+    connector_contracts: Iterable[dict[str, Any]] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build per-workflow activation gates for the CMO dashboard/API."""
+
+    now = _ensure_aware(now) or datetime.now(UTC)
+    setup_rows = list(connector_setup)
+    config_rows = list(connector_configs)
+    mapping_rows = list(data_readiness.get("field_mapping_status") or [])
+    backfill_rows = list(data_readiness.get("backfill_status") or [])
+    contract_rows = list(
+        connector_contracts
+        if connector_contracts is not None
+        else build_marketing_connector_contracts(setup_rows, config_rows, now=now)
+    )
+    workflow_payloads = _workflow_payloads(config_rows)
+
+    rows = [
+        _build_workflow_row(
+            spec,
+            setup_rows,
+            mapping_rows,
+            backfill_rows,
+            contract_rows,
+            workflow_payloads.get(spec.key, {}),
+            now,
+        )
+        for spec in CMO_WORKFLOW_SPECS
+    ]
+    return {
+        "workflow_activation_status": rows,
+        "workflow_activation_summary": summarize_cmo_workflow_activation(rows),
+    }
+
+
+def summarize_cmo_workflow_activation(rows: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    items = list(rows)
+    counts = dict.fromkeys(WORKFLOW_STATES, 0)
+    for row in items:
+        state = str(row.get("state") or "")
+        if state in counts:
+            counts[state] += 1
+
+    external_writes_allowed = sum(1 for row in items if row.get("external_writes_allowed"))
+    return {
+        "total": len(items),
+        **counts,
+        "external_writes_allowed": external_writes_allowed,
+        "needs_action": sum(1 for row in items if row.get("next_action_cta") != "none"),
+        "readiness": (
+            "blocked"
+            if counts["promotion_blocked"] or counts["unavailable"]
+            else "degraded"
+            if counts["shadow"] or counts["degraded"] or counts["paused"]
+            else "ready"
+        ),
+    }
+
+
+def evaluate_cmo_workflow_external_write(
+    workflow_rows: Iterable[dict[str, Any]],
+    workflow_key: str,
+    action: str,
+) -> dict[str, Any]:
+    """Return an allow/deny decision for a workflow action.
+
+    Unknown non-read-only actions are treated as external writes. This is a
+    fail-closed policy for marketing actions that could publish, send, spend,
+    update CRM, or mutate vendor systems.
+    """
+
+    normalized_action = _normalize_key(action)
+    row = _workflow_row_by_key(workflow_rows, workflow_key)
+    if row is None:
+        return {
+            "allowed": False,
+            "workflow_key": workflow_key,
+            "action": normalized_action,
+            "state": "unavailable",
+            "reason": "Workflow is not known to the CMO activation gate.",
+            "next_action_cta": "implement_workflow",
+        }
+
+    state = str(row.get("state") or "unavailable")
+    if normalized_action in READ_ONLY_ACTIONS:
+        return {
+            "allowed": True,
+            "workflow_key": row.get("workflow_key"),
+            "action": normalized_action,
+            "state": state,
+            "reason": "Read-only shadow action is allowed.",
+            "next_action_cta": "none",
+        }
+
+    is_write = normalized_action in EXTERNAL_WRITE_ACTIONS or normalized_action not in READ_ONLY_ACTIONS
+    if is_write and state != "active":
+        return {
+            "allowed": False,
+            "workflow_key": row.get("workflow_key"),
+            "action": normalized_action,
+            "state": state,
+            "reason": (
+                "External marketing writes require this workflow to be "
+                "explicitly promoted to active mode."
+            ),
+            "next_action_cta": row.get("next_action_cta") or "promote_workflow",
+        }
+
+    return {
+        "allowed": True,
+        "workflow_key": row.get("workflow_key"),
+        "action": normalized_action,
+        "state": state,
+        "reason": (
+            "Workflow is active; downstream connector confirmation and audit "
+            "still apply before marking an external write complete."
+        ),
+        "next_action_cta": "none",
+    }
+
+
+def _build_workflow_row(
+    spec: WorkflowActivationSpec,
+    setup_rows: list[dict[str, Any]],
+    mapping_rows: list[dict[str, Any]],
+    backfill_rows: list[dict[str, Any]],
+    contract_rows: list[dict[str, Any]],
+    payload: dict[str, Any],
+    now: datetime,
+) -> dict[str, Any]:
+    mode = _workflow_mode(payload)
+    approval_owner = _string_or_none(payload.get("approval_owner"))
+    policy_owner = _string_or_none(payload.get("policy_owner"))
+    accepted_partials = _accepted_partial_backfills(payload)
+    approval_timeout_policy = build_workflow_approval_timeout_status(
+        spec.key,
+        spec.write_actions,
+        payload,
+    )
+    marketing_policy = build_workflow_marketing_policy_status(
+        spec.key,
+        spec.write_actions,
+        payload,
+    )
+    escalation_matrix = build_workflow_escalation_status(
+        spec.key,
+        spec.write_actions,
+        payload,
+    )
+    decision_audit = build_workflow_decision_audit_status(
+        spec.key,
+        spec.write_actions,
+        payload,
+    )
+
+    blockers: list[str] = []
+    degraded: list[str] = []
+
+    if not spec.production_available:
+        reason = spec.unavailable_reason or "Workflow is not production-available yet."
+        blockers.append(reason)
+        state = "unavailable"
+        next_action_cta = "implement_first_class_agent"
+    else:
+        blockers.extend(_required_connector_blockers(spec, setup_rows, contract_rows))
+        blockers.extend(_required_write_contract_blockers(spec, contract_rows))
+        blockers.extend(_required_mapping_blockers(spec, mapping_rows))
+        blockers.extend(_required_backfill_blockers(spec, setup_rows, backfill_rows, accepted_partials))
+        blockers.extend(_policy_blockers(approval_owner, policy_owner))
+        blockers.extend(_marketing_policy_blockers(marketing_policy))
+        blockers.extend(_approval_timeout_policy_blockers(approval_timeout_policy))
+        blockers.extend(_escalation_matrix_blockers(escalation_matrix))
+        blockers.extend(_decision_audit_blockers(decision_audit))
+        degraded.extend(_required_connector_degraded(spec, setup_rows, contract_rows))
+        degraded.extend(_optional_connector_degraded(spec, setup_rows, contract_rows))
+        degraded.extend(_optional_mapping_degraded(spec, mapping_rows))
+        degraded.extend(_optional_backfill_degraded(spec, setup_rows, backfill_rows))
+        degraded.extend(_accepted_partial_degraded(spec, setup_rows, backfill_rows, accepted_partials))
+
+        shadow_quality = _shadow_quality(payload, spec, now)
+        if blockers:
+            state = "promotion_blocked"
+            next_action_cta = _blocked_cta(blockers)
+        elif shadow_quality["status"] != "passed":
+            blockers.append(str(shadow_quality["blocking_reason"]))
+            state = "shadow"
+            next_action_cta = "run_shadow_quality"
+        elif mode == "paused":
+            state = "paused"
+            next_action_cta = "resume_workflow"
+        elif degraded:
+            state = "degraded"
+            next_action_cta = "review_degraded_dependency"
+        elif _is_promoted(payload, mode):
+            state = "active"
+            next_action_cta = "none"
+        else:
+            state = "promotion_ready"
+            next_action_cta = "promote_workflow"
+
+    if not spec.production_available:
+        shadow_quality = _shadow_quality(payload, spec, now)
+
+    row = {
+        "workflow_key": spec.key,
+        "name": spec.name,
+        "state": state,
+        "configured_mode": mode,
+        "required_connectors": list(spec.required_connector_categories),
+        "optional_connectors": list(spec.optional_connector_categories),
+        "required_mappings": list(spec.required_mappings),
+        "optional_mappings": list(spec.optional_mappings),
+        "required_backfill_categories": list(spec.required_backfill_categories),
+        "optional_backfill_categories": list(spec.optional_backfill_categories),
+        "write_connector_categories": list(spec.write_connector_categories),
+        "write_actions": list(spec.write_actions),
+        "approval_owner": approval_owner,
+        "policy_owner": policy_owner,
+        "marketing_policy": marketing_policy,
+        "approval_timeout_policy": approval_timeout_policy,
+        "escalation_matrix": escalation_matrix,
+        "decision_audit": decision_audit,
+        "shadow_quality": shadow_quality,
+        "blocked_reasons": blockers,
+        "degraded_reasons": degraded,
+        "degraded_mode": _workflow_degraded_mode(spec, contract_rows, degraded),
+        "next_action_cta": next_action_cta,
+        "external_writes_allowed": state == "active",
+        "read_only_actions": sorted(READ_ONLY_ACTIONS),
+        "blocked_write_actions": sorted(EXTERNAL_WRITE_ACTIONS),
+        "evaluated_at": now.isoformat(),
+    }
+    audit_package = build_workflow_promotion_audit_package(row, now=now)
+    row["workflow_promotion_audit"] = audit_package
+    row["workflow_promotion_audit_ref"] = audit_package["audit_reference"]
+    return row
+
+
+def _required_connector_blockers(
+    spec: WorkflowActivationSpec,
+    setup_rows: list[dict[str, Any]],
+    contract_rows: list[dict[str, Any]],
+) -> list[str]:
+    blockers: list[str] = []
+    for category in spec.required_connector_categories:
+        rows = _configured_rows_for_category(setup_rows, category)
+        healthy = [row for row in rows if _health(row) == "healthy"]
+        contracts = _contracts_for_category(contract_rows, category)
+        degraded_allowed = [
+            row
+            for row in contracts
+            if row.get("read_status") == "degraded"
+            and isinstance(row.get("degraded_mode"), dict)
+            and row["degraded_mode"].get("allowed")
+        ]
+        if not rows:
+            blockers.append(f"Required {category} connector is not configured.")
+        elif not healthy:
+            if degraded_allowed:
+                continue
+            states = ", ".join(sorted({_health(row) for row in rows}))
+            blockers.append(f"Required {category} connector is not healthy ({states}).")
+        else:
+            read_ready = [row for row in contracts if row.get("read_ready")]
+            if not read_ready:
+                if degraded_allowed:
+                    continue
+                states = ", ".join(
+                    sorted(
+                        {
+                            str(row.get("read_status") or row.get("contract_state") or "unknown")
+                            for row in _contracts_for_category(contract_rows, category)
+                        }
+                    )
+                )
+                blockers.append(f"Required {category} connector contract is not read-ready ({states or 'missing'}).")
+    return blockers
+
+
+def _required_write_contract_blockers(
+    spec: WorkflowActivationSpec,
+    contract_rows: list[dict[str, Any]],
+) -> list[str]:
+    blockers: list[str] = []
+    for category in spec.write_connector_categories:
+        rows = _contracts_for_category(contract_rows, category)
+        write_ready = [row for row in rows if row.get("write_safe", row.get("write_ready"))]
+        if write_ready:
+            continue
+        if not rows:
+            blockers.append(f"Required {category} connector contract is missing for external writes.")
+            continue
+        details = []
+        for row in rows:
+            status = str(row.get("write_status") or row.get("contract_state") or "unknown")
+            failure_class = str(row.get("failure_class") or "")
+            missing = row.get("missing_write_scopes") or []
+            if missing:
+                status = f"{status}: missing {', '.join(str(scope) for scope in missing)}"
+            if failure_class:
+                status = f"{status}: {failure_class}"
+            details.append(f"{row.get('connector_key')}={status}")
+        actions = ", ".join(spec.write_actions) or "external writes"
+        blockers.append(
+            f"Required {category} connector is not write-ready for "
+            f"{actions} ({'; '.join(details)})."
+        )
+    return blockers
+
+
+def _required_connector_degraded(
+    spec: WorkflowActivationSpec,
+    setup_rows: list[dict[str, Any]],
+    contract_rows: list[dict[str, Any]],
+) -> list[str]:
+    reasons: list[str] = []
+    for category in spec.required_connector_categories:
+        if not _configured_rows_for_category(setup_rows, category):
+            continue
+        for contract in _contracts_for_category(contract_rows, category):
+            degraded_mode = contract.get("degraded_mode") if isinstance(contract.get("degraded_mode"), dict) else {}
+            if contract.get("read_status") == "degraded" and degraded_mode.get("allowed"):
+                reason = (
+                    degraded_mode.get("reason")
+                    or contract.get("degraded_mode_reason")
+                    or contract.get("failure_class")
+                    or "degraded connector contract"
+                )
+                impact = degraded_mode.get("confidence_impact")
+                impact_text = f"; confidence impact {impact}" if impact not in (None, "", 0, 0.0) else ""
+                reasons.append(
+                    f"Required {category} connector {contract.get('connector_key')} "
+                    f"is degraded ({reason}{impact_text})."
+                )
+    return reasons
+
+
+def _optional_connector_degraded(
+    spec: WorkflowActivationSpec,
+    setup_rows: list[dict[str, Any]],
+    contract_rows: list[dict[str, Any]],
+) -> list[str]:
+    reasons: list[str] = []
+    for category in spec.optional_connector_categories:
+        rows = _configured_rows_for_category(setup_rows, category)
+        for row in rows:
+            health = _health(row)
+            if health in {"stale", "degraded"}:
+                reasons.append(f"Optional {category} connector {row.get('name')} is {health}.")
+        for contract in _contracts_for_category(contract_rows, category):
+            if contract.get("read_status") == "degraded":
+                reasons.append(
+                    f"Optional {category} connector contract {contract.get('connector_key')} is degraded."
+                )
+    return reasons
+
+
+def _workflow_degraded_mode(
+    spec: WorkflowActivationSpec,
+    contract_rows: list[dict[str, Any]],
+    degraded_reasons: list[str],
+) -> dict[str, Any]:
+    relevant_categories = set(spec.required_connector_categories).union(spec.optional_connector_categories)
+    relevant_rows: list[dict[str, Any]] = []
+    for row in contract_rows:
+        if str(row.get("category") or "").strip() not in relevant_categories:
+            continue
+        degraded_mode = row.get("degraded_mode")
+        if isinstance(degraded_mode, dict):
+            affected_workflows = set(degraded_mode.get("affected_workflows") or [])
+            affected_workflows.add(spec.key)
+            relevant_rows.append(
+                {
+                    **row,
+                    "degraded_mode": {
+                        **degraded_mode,
+                        "affected_workflows": sorted(affected_workflows),
+                    },
+                }
+            )
+        else:
+            relevant_rows.append(row)
+    summary = summarize_degraded_modes(relevant_rows)
+    return {
+        **summary,
+        "active": bool(degraded_reasons) or bool(summary.get("active")),
+        "affected_workflows": sorted(
+            set(summary.get("affected_workflows") or [])
+            | ({spec.key} if degraded_reasons else set())
+        ),
+    }
+
+
+def _required_mapping_blockers(
+    spec: WorkflowActivationSpec,
+    mapping_rows: list[dict[str, Any]],
+) -> list[str]:
+    by_key = {str(row.get("key") or ""): row for row in mapping_rows}
+    blockers: list[str] = []
+    for key in spec.required_mappings:
+        row = by_key.get(key)
+        status = str((row or {}).get("status") or "unmapped")
+        if status != "valid":
+            name = str((row or {}).get("name") or key)
+            blockers.append(f"Required mapping {name} is {status.replace('_', ' ')}.")
+    return blockers
+
+
+def _optional_mapping_degraded(
+    spec: WorkflowActivationSpec,
+    mapping_rows: list[dict[str, Any]],
+) -> list[str]:
+    by_key = {str(row.get("key") or ""): row for row in mapping_rows}
+    reasons: list[str] = []
+    for key in spec.optional_mappings:
+        row = by_key.get(key)
+        status = str((row or {}).get("status") or "unmapped")
+        if status in {"partially_mapped", "stale", "invalid", "blocked"}:
+            name = str((row or {}).get("name") or key)
+            reasons.append(f"Optional mapping {name} is {status.replace('_', ' ')}.")
+    return reasons
+
+
+def _required_backfill_blockers(
+    spec: WorkflowActivationSpec,
+    setup_rows: list[dict[str, Any]],
+    backfill_rows: list[dict[str, Any]],
+    accepted_partials: set[str],
+) -> list[str]:
+    blockers: list[str] = []
+    backfills_by_key = {
+        str(row.get("source_connector_key") or "").strip().lower(): row
+        for row in backfill_rows
+    }
+    for category in spec.required_backfill_categories:
+        sources = [
+            row
+            for row in _configured_rows_for_category(setup_rows, category)
+            if _health(row) == "healthy"
+        ]
+        if not sources:
+            continue
+
+        statuses = []
+        for source in sources:
+            key = str(source.get("key") or "").strip().lower()
+            status = str((backfills_by_key.get(key) or {}).get("status") or "not_started")
+            statuses.append((key, status))
+        if any(status == "completed" for _key, status in statuses):
+            continue
+        if any(status == "partial" and _partial_accepted(key, category, accepted_partials) for key, status in statuses):
+            continue
+        status_text = ", ".join(f"{key}:{status}" for key, status in statuses)
+        blockers.append(f"Required {category} backfill is not complete ({status_text}).")
+    return blockers
+
+
+def _accepted_partial_degraded(
+    spec: WorkflowActivationSpec,
+    setup_rows: list[dict[str, Any]],
+    backfill_rows: list[dict[str, Any]],
+    accepted_partials: set[str],
+) -> list[str]:
+    reasons: list[str] = []
+    backfills_by_key = {
+        str(row.get("source_connector_key") or "").strip().lower(): row
+        for row in backfill_rows
+    }
+    for category in spec.required_backfill_categories:
+        for source in _configured_rows_for_category(setup_rows, category):
+            key = str(source.get("key") or "").strip().lower()
+            status = str((backfills_by_key.get(key) or {}).get("status") or "")
+            if status == "partial" and _partial_accepted(key, category, accepted_partials):
+                reasons.append(
+                    f"Required {category} source {source.get('name')} has accepted partial backfill."
+                )
+    return reasons
+
+
+def _optional_backfill_degraded(
+    spec: WorkflowActivationSpec,
+    setup_rows: list[dict[str, Any]],
+    backfill_rows: list[dict[str, Any]],
+) -> list[str]:
+    reasons: list[str] = []
+    backfills_by_key = {
+        str(row.get("source_connector_key") or "").strip().lower(): row
+        for row in backfill_rows
+    }
+    for category in spec.optional_backfill_categories:
+        for source in _configured_rows_for_category(setup_rows, category):
+            key = str(source.get("key") or "").strip().lower()
+            row = backfills_by_key.get(key)
+            status = str((row or {}).get("status") or "")
+            if status and status != "completed":
+                reasons.append(f"Optional {category} source {source.get('name')} backfill is {status}.")
+    return reasons
+
+
+def _policy_blockers(approval_owner: str | None, policy_owner: str | None) -> list[str]:
+    blockers: list[str] = []
+    if not approval_owner:
+        blockers.append("Approval owner is not configured.")
+    if not policy_owner:
+        blockers.append("Policy owner is not configured.")
+    return blockers
+
+
+def _approval_timeout_policy_blockers(timeout_policy: dict[str, Any]) -> list[str]:
+    if timeout_policy.get("status") != "missing_policy":
+        return []
+    missing = timeout_policy.get("missing_policy_actions") or []
+    action_text = ", ".join(str(action) for action in missing) or "approval-sensitive action"
+    return [f"Approval timeout policy is missing for {action_text}."]
+
+
+def _escalation_matrix_blockers(escalation_matrix: dict[str, Any]) -> list[str]:
+    if escalation_matrix.get("status") != "missing_route":
+        return []
+    missing = escalation_matrix.get("missing_route_triggers") or []
+    trigger_text = ", ".join(str(trigger) for trigger in missing) or "escalation-sensitive action"
+    return [f"Escalation route is missing for {trigger_text}."]
+
+
+def _decision_audit_blockers(decision_audit: dict[str, Any]) -> list[str]:
+    if decision_audit.get("status") != "missing_audit_evidence":
+        return []
+    missing = decision_audit.get("missing_audit_actions") or []
+    action_text = ", ".join(str(action) for action in missing) or "customer-facing action"
+    return [f"Decision audit evidence is missing for {action_text}."]
+
+
+def _marketing_policy_blockers(marketing_policy: dict[str, Any]) -> list[str]:
+    status = str(marketing_policy.get("status") or "")
+    if status == "missing_policy":
+        missing = marketing_policy.get("missing_policy_actions") or []
+        action_text = ", ".join(str(action) for action in missing) or "external marketing action"
+        return [f"Marketing policy manifest is missing for {action_text}."]
+    if status == "blocked":
+        blocked = marketing_policy.get("blocked_actions") or []
+        action_text = ", ".join(str(action) for action in blocked) or "external marketing action"
+        return [f"Marketing policy manifest blocks {action_text}."]
+    return []
+
+
+def _shadow_quality(
+    payload: dict[str, Any],
+    spec: WorkflowActivationSpec,
+    now: datetime,
+) -> dict[str, Any]:
+    raw = payload.get("shadow_quality") or payload.get("shadow_run_quality") or {}
+    raw = raw if isinstance(raw, dict) else {}
+    status = str(raw.get("status") or "").strip().lower()
+    sample_count = _int_or_zero(raw.get("sample_count") or raw.get("runs"))
+    success_rate = _float_or_zero(raw.get("success_rate") or raw.get("pass_rate"))
+    last_run_at = _string_or_none(raw.get("last_run_at"))
+
+    if status == "passed" and sample_count >= spec.min_shadow_runs and success_rate >= spec.min_shadow_success_rate:
+        normalized = "passed"
+        blocking_reason = None
+        next_action_cta = "none"
+    else:
+        normalized = status if status in {"failed", "running", "not_measured"} else "not_measured"
+        if normalized == "failed":
+            blocking_reason = "Recent shadow-run quality gate failed."
+        elif normalized == "running":
+            blocking_reason = "Recent shadow-run quality gate is still running."
+        elif sample_count < spec.min_shadow_runs:
+            blocking_reason = (
+                "Recent shadow-run quality gate has not collected enough runs "
+                f"({sample_count}/{spec.min_shadow_runs})."
+            )
+        else:
+            blocking_reason = (
+                "Recent shadow-run success rate is below the workflow threshold "
+                f"({success_rate:.2f}/{spec.min_shadow_success_rate:.2f})."
+            )
+        next_action_cta = "run_shadow_quality"
+
+    return {
+        "status": normalized,
+        "sample_count": sample_count,
+        "success_rate": success_rate,
+        "required_sample_count": spec.min_shadow_runs,
+        "required_success_rate": spec.min_shadow_success_rate,
+        "last_run_at": last_run_at,
+        "blocking_reason": blocking_reason,
+        "next_action_cta": next_action_cta,
+        "evaluated_at": now.isoformat(),
+    }
+
+
+def _workflow_payloads(connector_configs: Iterable[Any]) -> dict[str, dict[str, Any]]:
+    payloads: dict[str, dict[str, Any]] = {}
+    for config in connector_configs:
+        root = _config_dict(config)
+        for key in (
+            "marketing_workflows",
+            "cmo_workflows",
+            "workflow_activation",
+            "cmo_workflow_activation",
+        ):
+            value = root.get(key)
+            if isinstance(value, dict):
+                source = value.get("workflows") if isinstance(value.get("workflows"), dict) else value
+                for workflow_key, workflow_payload in source.items():
+                    normalized_key = _normalize_key(workflow_key)
+                    if isinstance(workflow_payload, dict) and normalized_key:
+                        payloads[normalized_key] = {
+                            **payloads.get(normalized_key, {}),
+                            **workflow_payload,
+                        }
+    return payloads
+
+
+def _workflow_mode(payload: dict[str, Any]) -> str:
+    raw = _normalize_key(payload.get("mode") or payload.get("configured_mode") or "shadow")
+    return raw if raw in PROMOTABLE_MODES else "shadow"
+
+
+def _is_promoted(payload: dict[str, Any], mode: str) -> bool:
+    return bool(
+        mode == "active"
+        or payload.get("promoted") is True
+        or _string_or_none(payload.get("promoted_at"))
+        or _string_or_none(payload.get("promoted_by"))
+    )
+
+
+def _accepted_partial_backfills(payload: dict[str, Any]) -> set[str]:
+    raw = (
+        payload.get("accepted_partial_backfills")
+        or payload.get("accepted_partial_backfill_sources")
+        or []
+    )
+    categories = payload.get("accepted_partial_backfill_categories") or []
+    values: set[str] = set()
+    for item in _list_from_value(raw):
+        values.add(_normalize_key(item))
+    for item in _list_from_value(categories):
+        values.add(str(item).strip())
+    return {item for item in values if item}
+
+
+def _partial_accepted(key: str, category: str, accepted_partials: set[str]) -> bool:
+    return (
+        "all" in accepted_partials
+        or key in accepted_partials
+        or category in accepted_partials
+        or _normalize_key(category) in accepted_partials
+    )
+
+
+def _blocked_cta(blockers: list[str]) -> str:
+    text = " ".join(blockers).lower()
+    if "escalation route" in text:
+        return "configure_escalation_matrix"
+    if "marketing policy manifest" in text:
+        return "configure_marketing_policy_manifest"
+    if "timeout" in text:
+        return "configure_approval_timeout_policy"
+    if "audit" in text:
+        return "configure_decision_audit_package"
+    if "connector" in text:
+        return "fix_required_connector"
+    if "mapping" in text:
+        return "fix_required_mapping"
+    if "backfill" in text:
+        return "complete_backfill"
+    if "owner" in text or "policy" in text:
+        return "configure_policy_owner"
+    return "resolve_promotion_blocker"
+
+
+def _configured_rows_for_category(
+    setup_rows: list[dict[str, Any]],
+    category: str,
+) -> list[dict[str, Any]]:
+    return [
+        row
+        for row in setup_rows
+        if str(row.get("category") or "").strip() == category
+        and str(row.get("configured_status") or "").strip() != "unconfigured"
+    ]
+
+
+def _health(row: dict[str, Any]) -> str:
+    return str(row.get("health_status") or "missing").strip().lower()
+
+
+def _contracts_for_category(
+    contract_rows: list[dict[str, Any]],
+    category: str,
+) -> list[dict[str, Any]]:
+    return [
+        row
+        for row in contract_rows
+        if str(row.get("category") or "").strip() == category
+        and str(row.get("configured_status") or "") != "unconfigured"
+    ]
+
+
+def _workflow_row_by_key(
+    workflow_rows: Iterable[dict[str, Any]],
+    workflow_key: str,
+) -> dict[str, Any] | None:
+    normalized = _normalize_key(workflow_key)
+    for row in workflow_rows:
+        if _normalize_key(row.get("workflow_key")) == normalized:
+            return row
+    return None
+
+
+def _config_dict(config: Any | None) -> dict[str, Any]:
+    value = getattr(config, "config", None)
+    return value if isinstance(value, dict) else {}
+
+
+def _list_from_value(value: Any) -> list[Any]:
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return []
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _string_or_none(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _int_or_zero(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float_or_zero(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _ensure_aware(value: Any) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value

--- a/core/marketing/workflow_linter.py
+++ b/core/marketing/workflow_linter.py
@@ -1,0 +1,1803 @@
+"""Marketing workflow linter for CMO production-readiness gates.
+
+CMO-5.1 validates marketing workflow definitions before execution. The linter
+does not implement missing agents or vendor adapters; it reports whether a
+workflow is safe to treat as production, target/demo/shadow, or out of scope.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from core.marketing.approval_timeouts import (
+    has_timeout_policy_for_step,
+    requires_approval_timeout_policy,
+)
+from core.marketing.decision_audit import (
+    action_event_type,
+    has_decision_audit_evidence_for_step,
+)
+from core.marketing.escalation_matrix import (
+    escalation_triggers_for_action,
+    missing_escalation_triggers_for_step,
+)
+from core.marketing.policy_manifest import evaluate_marketing_policy
+from core.marketing.workflow_activation import EXTERNAL_WRITE_ACTIONS
+
+SEVERITIES = ("error", "warning", "info")
+
+PRODUCTION_MODES = {"active", "prod", "production"}
+SHADOW_MODES = {"shadow"}
+NON_PRODUCTION_MODES = {
+    "demo",
+    "draft",
+    "internal",
+    "internal_only",
+    "recommendation",
+    "simulation",
+    "target",
+}
+READINESS_MODE_FIELDS = (
+    "workflow_mode",
+    "mode",
+    "deployment_mode",
+    "readiness",
+    "capability_state",
+    "maturity",
+    "status",
+)
+MARKETING_WRITE_ACTION_HINTS = (
+    "activate",
+    "add_to_drip",
+    "launch",
+    "mutate",
+    "publish",
+    "schedule",
+    "send",
+    "setup",
+    "spend",
+    "start_nurture",
+    "update_crm",
+)
+
+MARKETING_AGENT_STATES: dict[str, str] = {  # enterprise-gate: process-local-ok reason=static-marketing-agent-state-map
+    "campaign_pilot": "production",
+    "content_factory": "beta",
+    "email_agent": "beta",
+    "email_marketing": "beta",
+    "brand_monitor": "beta",
+    "seo_strategist": "beta",
+    "crm_intelligence": "beta",
+    "social_media": "beta",
+    "abm": "beta",
+    "abm_agent": "beta",
+    "competitive_intel": "beta",
+}
+
+MARKETING_AGENT_ACTIONS: dict[str, set[str] | None] = {
+    "campaign_pilot": {
+        "activate_campaign",
+        "aggregate_weekly_metrics",
+        "compile_weekly_digest",
+        "create",
+        "create_campaign",
+        "create_linkedin_campaign",
+        "create_plan",
+        "generate_weekly_report",
+        "get_weekly_metrics",
+        "launch_campaign",
+        "manage_campaign",
+        "mutate_ad_budget",
+        "pause_campaign",
+        "setup",
+        "setup_google_campaign",
+        "setup_meta_campaign",
+        "update_ad_budget",
+    },
+    "content_factory": {
+        "create_draft",
+        "generate",
+        "generate_campaign_assets",
+        "generate_content",
+        "generate_weekly_calendar",
+        "publish",
+        "publish_to_wordpress",
+        "schedule_content",
+    },
+    "email_marketing": {
+        "add_to_drip",
+        "check_winner",
+        "create_ab_test",
+        "segment_list",
+        "send_email",
+        "send_to_segment",
+        "send_winner",
+        "start_nurture_sequence",
+    },
+    "email_agent": {
+        "draft_email",
+        "read_email",
+        "search_email",
+        "send_email",
+    },
+    "brand_monitor": {
+        "aggregate_mentions",
+        "brand_claim",
+        "classify_crisis_severity",
+        "classify_sentiment",
+        "comparative_claim",
+        "competitor_brand_grouping",
+        "crisis_response",
+        "detect_crisis",
+        "detect_negative_spike",
+        "false_positive_suppression",
+        "get_sentiment",
+        "group_mentions",
+        "mention_aggregation",
+        "monitor_mentions",
+        "pricing_claim",
+        "public_response",
+        "publish_brand_response",
+        "recommend_response_playbook",
+        "sentiment_trend",
+    },
+    "seo_strategist": {
+        "apply_redirect",
+        "analyze_keyword_gaps",
+        "bundle_recommendations",
+        "compute_ranking_deltas",
+        "content_optimization_recommendation",
+        "get_keyword_rankings",
+        "identify_content_gaps",
+        "keyword_gap_analysis",
+        "optimize_content",
+        "plan_seo_sprint",
+        "prioritize_technical_issues",
+        "publish_landing_page",
+        "publish_seo_change",
+        "publish_to_wordpress",
+        "ranking_delta_computation",
+        "recommendation_bundling",
+        "seo_sprint_planning",
+        "submit_url_to_index",
+        "technical_issue_prioritization",
+        "update_canonical_tag",
+        "update_landing_page",
+        "update_page_metadata",
+        "update_robots_txt",
+        "update_sitemap",
+    },
+    "crm_intelligence": {
+        "account_deal_health_summary",
+        "account_health_summary",
+        "analyze_pipeline_velocity",
+        "bulk_crm_update",
+        "change_segment_membership",
+        "change_target_accounts",
+        "churn_risk_signal_extraction",
+        "extract_churn_signals",
+        "funnel_conversion_analysis",
+        "lead_scoring_refresh",
+        "pipeline_velocity_analysis",
+        "promote_lifecycle_stage",
+        "promote_to_sql",
+        "recommend_segments",
+        "refresh_lead_scores",
+        "score_lead",
+        "segment_recommendation",
+        "sql_promotion_criteria",
+        "update_crm",
+        "update_lead_scores",
+        "update_lifecycle_stage",
+        "update_segment_membership",
+    },
+    "social_media": {
+        "classify_reply_risk",
+        "draft_social_post",
+        "generate_content_calendar",
+        "get_weekly_engagement",
+        "optimize_posting_schedule",
+        "publish_post",
+        "reply_to_mention",
+        "schedule_campaign_posts",
+        "schedule_content_promotion",
+        "schedule_post",
+        "triage_engagement",
+    },
+    "abm": {
+        "aggregate_engagement",
+        "aggregate_intent",
+        "create_abm_campaign",
+        "launch_abm_campaign",
+        "query_target_accounts",
+        "recommend_next_best_action",
+        "score_accounts",
+        "score_icp_fit",
+        "score_intent_heat",
+        "set_abm_budget",
+        "sync_target_accounts",
+        "target_account_list_change",
+        "update_target_accounts",
+        "validate_account_csv",
+    },
+    "abm_agent": {
+        "aggregate_engagement",
+        "aggregate_intent",
+        "create_abm_campaign",
+        "launch_abm_campaign",
+        "query_target_accounts",
+        "recommend_next_best_action",
+        "score_accounts",
+        "score_icp_fit",
+        "score_intent_heat",
+        "set_abm_budget",
+        "sync_target_accounts",
+        "target_account_list_change",
+        "update_target_accounts",
+        "validate_account_csv",
+    },
+    "competitive_intel": {
+        "change_confidence_score",
+        "comparative_claim",
+        "duplicate_change_suppression",
+        "evaluate_alert_thresholds",
+        "extract_win_loss_signals",
+        "feature_capability_diffing",
+        "launch_competitive_campaign",
+        "normalize_competitor_profiles",
+        "positioning_recommendation",
+        "pricing_change_detection",
+        "pricing_claim",
+        "public_response",
+        "publish_competitive_response",
+        "weekly_benchmark",
+        "weekly_market_snapshot",
+    },
+}
+
+ACTION_CONNECTOR_REQUIREMENTS: dict[tuple[str, str], dict[str, tuple[str, ...]]] = {
+    ("campaign_pilot", "activate_campaign"): {
+        "categories": ("Ads",),
+        "keys": (),
+    },
+    ("campaign_pilot", "create_campaign"): {
+        "categories": ("Ads",),
+        "keys": (),
+    },
+    ("campaign_pilot", "create_linkedin_campaign"): {
+        "categories": (),
+        "keys": ("linkedin_ads",),
+    },
+    ("campaign_pilot", "launch_campaign"): {
+        "categories": ("Ads",),
+        "keys": (),
+    },
+    ("campaign_pilot", "mutate_ad_budget"): {
+        "categories": ("Ads",),
+        "keys": (),
+    },
+    ("campaign_pilot", "pause_campaign"): {
+        "categories": ("Ads",),
+        "keys": (),
+    },
+    ("campaign_pilot", "setup_google_campaign"): {
+        "categories": (),
+        "keys": ("google_ads",),
+    },
+    ("campaign_pilot", "setup_meta_campaign"): {
+        "categories": (),
+        "keys": ("meta_ads",),
+    },
+    ("campaign_pilot", "update_ad_budget"): {
+        "categories": ("Ads",),
+        "keys": (),
+    },
+    ("content_factory", "publish"): {
+        "categories": ("CMS",),
+        "keys": (),
+    },
+    ("content_factory", "publish_to_wordpress"): {
+        "categories": (),
+        "keys": ("wordpress",),
+    },
+    ("content_factory", "schedule_content"): {
+        "categories": ("CMS",),
+        "keys": (),
+    },
+    ("email_marketing", "add_to_drip"): {
+        "categories": ("Email",),
+        "keys": (),
+    },
+    ("email_marketing", "send_email"): {
+        "categories": ("Email",),
+        "keys": (),
+    },
+    ("email_marketing", "send_to_segment"): {
+        "categories": ("Email",),
+        "keys": (),
+    },
+    ("email_marketing", "send_winner"): {
+        "categories": ("Email",),
+        "keys": (),
+    },
+    ("email_marketing", "start_nurture_sequence"): {
+        "categories": ("Email",),
+        "keys": (),
+    },
+    ("crm_intelligence", "score_lead"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "analyze_pipeline_velocity"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "pipeline_velocity_analysis"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "funnel_conversion_analysis"): {
+        "categories": ("CRM", "Analytics"),
+        "keys": (),
+    },
+    ("crm_intelligence", "lead_scoring_refresh"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "refresh_lead_scores"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "extract_churn_signals"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "churn_risk_signal_extraction"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "recommend_segments"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "segment_recommendation"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "sql_promotion_criteria"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "promote_to_sql"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "account_health_summary"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "account_deal_health_summary"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "update_lead_scores"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "update_lifecycle_stage"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "promote_lifecycle_stage"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "change_segment_membership"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "update_segment_membership"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "change_target_accounts"): {
+        "categories": ("CRM", "ABM"),
+        "keys": (),
+    },
+    ("crm_intelligence", "bulk_crm_update"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("crm_intelligence", "update_crm"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("social_media", "schedule_campaign_posts"): {
+        "categories": ("Social",),
+        "keys": (),
+    },
+    ("social_media", "schedule_content_promotion"): {
+        "categories": ("Social",),
+        "keys": (),
+    },
+    ("social_media", "schedule_post"): {
+        "categories": ("Social",),
+        "keys": (),
+    },
+    ("social_media", "publish_post"): {
+        "categories": ("Social",),
+        "keys": (),
+    },
+    ("social_media", "reply_to_mention"): {
+        "categories": ("Social",),
+        "keys": (),
+    },
+    ("abm", "query_target_accounts"): {
+        "categories": ("CRM", "ABM"),
+        "keys": (),
+    },
+    ("abm", "score_accounts"): {
+        "categories": ("CRM", "ABM"),
+        "keys": (),
+    },
+    ("abm", "aggregate_intent"): {
+        "categories": ("ABM",),
+        "keys": (),
+    },
+    ("abm", "aggregate_engagement"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("abm", "sync_target_accounts"): {
+        "categories": ("CRM", "ABM"),
+        "keys": (),
+    },
+    ("abm", "target_account_list_change"): {
+        "categories": ("CRM", "ABM"),
+        "keys": (),
+    },
+    ("abm", "update_target_accounts"): {
+        "categories": ("CRM", "ABM"),
+        "keys": (),
+    },
+    ("abm", "launch_abm_campaign"): {
+        "categories": ("Ads", "ABM"),
+        "keys": (),
+    },
+    ("abm", "create_abm_campaign"): {
+        "categories": ("Ads", "ABM"),
+        "keys": (),
+    },
+    ("abm", "set_abm_budget"): {
+        "categories": ("Ads", "ABM"),
+        "keys": (),
+    },
+    ("abm_agent", "query_target_accounts"): {
+        "categories": ("CRM", "ABM"),
+        "keys": (),
+    },
+    ("abm_agent", "score_accounts"): {
+        "categories": ("CRM", "ABM"),
+        "keys": (),
+    },
+    ("abm_agent", "aggregate_intent"): {
+        "categories": ("ABM",),
+        "keys": (),
+    },
+    ("abm_agent", "aggregate_engagement"): {
+        "categories": ("CRM",),
+        "keys": (),
+    },
+    ("abm_agent", "sync_target_accounts"): {
+        "categories": ("CRM", "ABM"),
+        "keys": (),
+    },
+    ("abm_agent", "target_account_list_change"): {
+        "categories": ("CRM", "ABM"),
+        "keys": (),
+    },
+    ("abm_agent", "update_target_accounts"): {
+        "categories": ("CRM", "ABM"),
+        "keys": (),
+    },
+    ("abm_agent", "launch_abm_campaign"): {
+        "categories": ("Ads", "ABM"),
+        "keys": (),
+    },
+    ("abm_agent", "create_abm_campaign"): {
+        "categories": ("Ads", "ABM"),
+        "keys": (),
+    },
+    ("abm_agent", "set_abm_budget"): {
+        "categories": ("Ads", "ABM"),
+        "keys": (),
+    },
+    ("competitive_intel", "weekly_market_snapshot"): {
+        "categories": ("Brand", "SEO"),
+        "keys": (),
+    },
+    ("competitive_intel", "weekly_benchmark"): {
+        "categories": ("Brand", "SEO"),
+        "keys": (),
+    },
+    ("competitive_intel", "pricing_change_detection"): {
+        "categories": ("Brand",),
+        "keys": (),
+    },
+    ("competitive_intel", "feature_capability_diffing"): {
+        "categories": ("Brand", "SEO"),
+        "keys": (),
+    },
+    ("competitive_intel", "publish_competitive_response"): {
+        "categories": ("Social",),
+        "keys": (),
+    },
+    ("competitive_intel", "public_response"): {
+        "categories": ("Social",),
+        "keys": (),
+    },
+    ("competitive_intel", "launch_competitive_campaign"): {
+        "categories": ("Ads",),
+        "keys": (),
+    },
+    ("brand_monitor", "aggregate_mentions"): {
+        "categories": ("Brand",),
+        "keys": (),
+    },
+    ("brand_monitor", "detect_crisis"): {
+        "categories": ("Brand",),
+        "keys": (),
+    },
+    ("brand_monitor", "get_sentiment"): {
+        "categories": ("Brand",),
+        "keys": (),
+    },
+    ("brand_monitor", "mention_aggregation"): {
+        "categories": ("Brand",),
+        "keys": (),
+    },
+    ("brand_monitor", "monitor_mentions"): {
+        "categories": ("Brand",),
+        "keys": (),
+    },
+    ("brand_monitor", "sentiment_trend"): {
+        "categories": ("Brand",),
+        "keys": (),
+    },
+    ("brand_monitor", "crisis_response"): {
+        "categories": ("Social",),
+        "keys": (),
+    },
+    ("brand_monitor", "public_response"): {
+        "categories": ("Social",),
+        "keys": (),
+    },
+    ("brand_monitor", "publish_brand_response"): {
+        "categories": ("Social",),
+        "keys": (),
+    },
+    ("seo_strategist", "analyze_keyword_gaps"): {
+        "categories": ("SEO",),
+        "keys": (),
+    },
+    ("seo_strategist", "get_keyword_rankings"): {
+        "categories": ("SEO",),
+        "keys": (),
+    },
+    ("seo_strategist", "identify_content_gaps"): {
+        "categories": ("SEO", "Analytics"),
+        "keys": (),
+    },
+    ("seo_strategist", "keyword_gap_analysis"): {
+        "categories": ("SEO",),
+        "keys": (),
+    },
+    ("seo_strategist", "ranking_delta_computation"): {
+        "categories": ("SEO",),
+        "keys": (),
+    },
+    ("seo_strategist", "technical_issue_prioritization"): {
+        "categories": ("SEO", "CMS"),
+        "keys": (),
+    },
+    ("seo_strategist", "content_optimization_recommendation"): {
+        "categories": ("SEO", "CMS"),
+        "keys": (),
+    },
+    ("seo_strategist", "seo_sprint_planning"): {
+        "categories": ("SEO", "Analytics", "CMS"),
+        "keys": (),
+    },
+    ("seo_strategist", "apply_redirect"): {
+        "categories": ("CMS",),
+        "keys": (),
+    },
+    ("seo_strategist", "publish_landing_page"): {
+        "categories": ("CMS",),
+        "keys": (),
+    },
+    ("seo_strategist", "publish_seo_change"): {
+        "categories": ("CMS",),
+        "keys": (),
+    },
+    ("seo_strategist", "publish_to_wordpress"): {
+        "categories": (),
+        "keys": ("wordpress",),
+    },
+    ("seo_strategist", "submit_url_to_index"): {
+        "categories": (),
+        "keys": ("google_search_console",),
+    },
+    ("seo_strategist", "update_canonical_tag"): {
+        "categories": ("CMS",),
+        "keys": (),
+    },
+    ("seo_strategist", "update_landing_page"): {
+        "categories": ("CMS",),
+        "keys": (),
+    },
+    ("seo_strategist", "update_page_metadata"): {
+        "categories": ("CMS",),
+        "keys": (),
+    },
+    ("seo_strategist", "update_robots_txt"): {
+        "categories": ("CMS",),
+        "keys": (),
+    },
+    ("seo_strategist", "update_sitemap"): {
+        "categories": ("CMS",),
+        "keys": (),
+    },
+}
+
+
+@dataclass(frozen=True)
+class MarketingWorkflowLintFinding:
+    workflow_file: str | None
+    workflow_id: str
+    workflow_name: str
+    step_id: str | None
+    step_name: str | None
+    severity: str
+    code: str
+    message: str
+    suggested_fix: str
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {
+            "workflow_file": self.workflow_file,
+            "workflow_id": self.workflow_id,
+            "workflow_name": self.workflow_name,
+            "step_id": self.step_id,
+            "step_name": self.step_name,
+            "severity": self.severity,
+            "code": self.code,
+            "message": self.message,
+            "suggested_fix": self.suggested_fix,
+        }
+
+
+@dataclass(frozen=True)
+class MarketingWorkflowLintResult:
+    workflow_file: str | None
+    workflow_id: str
+    workflow_name: str
+    in_scope: bool
+    findings: tuple[MarketingWorkflowLintFinding, ...]
+
+    @property
+    def has_errors(self) -> bool:
+        return any(finding.severity == "error" for finding in self.findings)
+
+    @property
+    def errors(self) -> tuple[MarketingWorkflowLintFinding, ...]:
+        return tuple(finding for finding in self.findings if finding.severity == "error")
+
+    @property
+    def warnings(self) -> tuple[MarketingWorkflowLintFinding, ...]:
+        return tuple(finding for finding in self.findings if finding.severity == "warning")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "workflow_file": self.workflow_file,
+            "workflow_id": self.workflow_id,
+            "workflow_name": self.workflow_name,
+            "in_scope": self.in_scope,
+            "has_errors": self.has_errors,
+            "findings": [finding.to_dict() for finding in self.findings],
+        }
+
+
+def lint_marketing_workflow_file(
+    path: str | Path,
+    *,
+    connector_contracts: Iterable[dict[str, Any]] | None = None,
+    marketing_policy_manifest: dict[str, Any] | None = None,
+    marketing_escalation_matrix: dict[str, Any] | None = None,
+) -> MarketingWorkflowLintResult:
+    """Load and lint one workflow YAML file."""
+
+    workflow_path = Path(path)
+    with workflow_path.open(encoding="utf-8") as handle:
+        definition = yaml.safe_load(handle)
+    return lint_marketing_workflow(
+        definition,
+        workflow_file=str(workflow_path),
+        connector_contracts=connector_contracts,
+        marketing_policy_manifest=marketing_policy_manifest,
+        marketing_escalation_matrix=marketing_escalation_matrix,
+    )
+
+
+def lint_marketing_workflow_paths(
+    paths: Iterable[str | Path],
+    *,
+    connector_contracts: Iterable[dict[str, Any]] | None = None,
+    marketing_policy_manifest: dict[str, Any] | None = None,
+    marketing_escalation_matrix: dict[str, Any] | None = None,
+) -> list[MarketingWorkflowLintResult]:
+    """Lint a list of workflow YAML files."""
+
+    return [
+        lint_marketing_workflow_file(
+            path,
+            connector_contracts=connector_contracts,
+            marketing_policy_manifest=marketing_policy_manifest,
+            marketing_escalation_matrix=marketing_escalation_matrix,
+        )
+        for path in paths
+    ]
+
+
+def lint_marketing_workflow(
+    definition: dict[str, Any] | str,
+    *,
+    workflow_file: str | None = None,
+    connector_contracts: Iterable[dict[str, Any]] | None = None,
+    marketing_policy_manifest: dict[str, Any] | None = None,
+    marketing_escalation_matrix: dict[str, Any] | None = None,
+) -> MarketingWorkflowLintResult:
+    """Lint a parsed workflow definition or YAML string."""
+
+    if isinstance(definition, str):
+        definition = yaml.safe_load(definition)
+    if not isinstance(definition, dict):
+        definition = {}
+
+    workflow_id = _workflow_id(definition, workflow_file)
+    workflow_name = _string_or_none(definition.get("name")) or workflow_id
+    workflow_mode = _workflow_mode(definition)
+    contracts = tuple(connector_contracts or ())
+    findings: list[MarketingWorkflowLintFinding] = []
+
+    steps = list(_iter_steps(definition.get("steps") or []))
+    in_scope = _is_marketing_workflow(definition, steps)
+    if not in_scope:
+        findings.append(
+            _finding(
+                workflow_file,
+                workflow_id,
+                workflow_name,
+                None,
+                None,
+                "info",
+                "marketing_workflow_out_of_scope",
+                "Workflow is not a marketing workflow; marketing lint rules were not applied.",
+                "Run the relevant domain linter for this workflow.",
+            )
+        )
+        return MarketingWorkflowLintResult(
+            workflow_file=workflow_file,
+            workflow_id=workflow_id,
+            workflow_name=workflow_name,
+            in_scope=False,
+            findings=tuple(findings),
+        )
+
+    for step, parent_id in steps:
+        if step.get("type", "agent") != "agent":
+            continue
+        findings.extend(
+            _lint_agent_step(
+                step,
+                parent_id=parent_id,
+                workflow_file=workflow_file,
+                workflow_id=workflow_id,
+                workflow_name=workflow_name,
+                workflow_mode=workflow_mode,
+                connector_contracts=contracts,
+                marketing_policy_manifest=marketing_policy_manifest,
+                marketing_escalation_matrix=marketing_escalation_matrix,
+            )
+        )
+
+    return MarketingWorkflowLintResult(
+        workflow_file=workflow_file,
+        workflow_id=workflow_id,
+        workflow_name=workflow_name,
+        in_scope=True,
+        findings=tuple(findings),
+    )
+
+
+def _lint_agent_step(
+    step: dict[str, Any],
+    *,
+    parent_id: str | None,
+    workflow_file: str | None,
+    workflow_id: str,
+    workflow_name: str,
+    workflow_mode: str,
+    connector_contracts: tuple[dict[str, Any], ...],
+    marketing_policy_manifest: dict[str, Any] | None,
+    marketing_escalation_matrix: dict[str, Any] | None,
+) -> list[MarketingWorkflowLintFinding]:
+    step_id = _string_or_none(step.get("id")) or "unknown_step"
+    step_name = _string_or_none(step.get("name")) or step_id
+    agent_type = _normalize_key(step.get("agent_type") or step.get("agent"))
+    action = _normalize_key(step.get("action") or "process")
+    step_mode = _workflow_mode(step, default=workflow_mode)
+    findings: list[MarketingWorkflowLintFinding] = []
+
+    if not agent_type:
+        findings.append(
+            _step_finding(
+                workflow_file,
+                workflow_id,
+                workflow_name,
+                step_id,
+                step_name,
+                "error",
+                "marketing_agent_type_missing",
+                "Marketing agent step is missing agent_type.",
+                "Set agent_type to a known marketing agent or convert this step to a non-agent step.",
+                parent_id=parent_id,
+            )
+        )
+        return findings
+
+    agent_state = MARKETING_AGENT_STATES.get(agent_type)
+    if agent_state is None:
+        findings.append(
+            _step_finding(
+                workflow_file,
+                workflow_id,
+                workflow_name,
+                step_id,
+                step_name,
+                "error",
+                "marketing_agent_type_unknown",
+                f"Unknown marketing agent_type '{agent_type}'.",
+                "Use a registered marketing agent type or implement and register this agent before referencing it.",
+                parent_id=parent_id,
+            )
+        )
+        return findings
+
+    allowed_actions = MARKETING_AGENT_ACTIONS.get(agent_type)
+    if allowed_actions is not None and action not in allowed_actions:
+        findings.append(
+            _step_finding(
+                workflow_file,
+                workflow_id,
+                workflow_name,
+                step_id,
+                step_name,
+                "error",
+                "marketing_action_unknown",
+                f"Action '{action}' is not declared for marketing agent '{agent_type}'.",
+                "Use a declared action or add explicit action metadata and tests for this agent.",
+                parent_id=parent_id,
+            )
+        )
+
+    if agent_state in {"stub", "unavailable"}:
+        severity = "error" if _is_production_mode(step_mode) else "warning"
+        code = (
+            "marketing_agent_unavailable_for_production"
+            if agent_state == "unavailable"
+            else "marketing_agent_stub_for_production"
+        )
+        non_prod_code = (
+            "marketing_agent_unavailable_target_only"
+            if agent_state == "unavailable"
+            else "marketing_agent_stub_target_only"
+        )
+        findings.append(
+            _step_finding(
+                workflow_file,
+                workflow_id,
+                workflow_name,
+                step_id,
+                step_name,
+                severity,
+                code if severity == "error" else non_prod_code,
+                (
+                    f"Agent '{agent_type}' is {agent_state}; this cannot be treated "
+                    f"as production/active CMO behavior."
+                ),
+                (
+                    "Implement a first-class production marketing agent or mark the "
+                    "workflow explicitly as target, demo, or shadow."
+                ),
+                parent_id=parent_id,
+            )
+        )
+    elif agent_state == "beta" and _is_production_mode(step_mode):
+        findings.append(
+            _step_finding(
+                workflow_file,
+                workflow_id,
+                workflow_name,
+                step_id,
+                step_name,
+                "warning",
+                "marketing_agent_beta_in_production",
+                f"Agent '{agent_type}' is beta; production workflows should treat this as degraded.",
+                "Keep the workflow shadow/degraded or add production evidence before claiming full readiness.",
+                parent_id=parent_id,
+            )
+        )
+
+    required_keys, required_categories = _connector_requirements(agent_type, action, step)
+    findings.extend(
+        _lint_declared_connector_readiness(
+            required_keys,
+            required_categories,
+            connector_contracts,
+            workflow_file=workflow_file,
+            workflow_id=workflow_id,
+            workflow_name=workflow_name,
+            step_id=step_id,
+            step_name=step_name,
+            step_mode=step_mode,
+            parent_id=parent_id,
+        )
+    )
+
+    if _is_external_write_step(agent_type, action, step):
+        findings.extend(
+            _lint_marketing_policy(
+                action,
+                step,
+                workflow_file=workflow_file,
+                workflow_id=workflow_id,
+                workflow_name=workflow_name,
+                step_id=step_id,
+                step_name=step_name,
+                step_mode=step_mode,
+                parent_id=parent_id,
+                marketing_policy_manifest=marketing_policy_manifest,
+                external_write_required=True,
+            )
+        )
+        findings.extend(
+            _lint_external_write_step(
+                required_keys,
+                required_categories,
+                connector_contracts,
+                step,
+                workflow_file=workflow_file,
+                workflow_id=workflow_id,
+                workflow_name=workflow_name,
+                step_id=step_id,
+                step_name=step_name,
+                step_mode=step_mode,
+                parent_id=parent_id,
+            )
+        )
+    else:
+        findings.extend(
+            _lint_marketing_policy(
+                action,
+                step,
+                workflow_file=workflow_file,
+                workflow_id=workflow_id,
+                workflow_name=workflow_name,
+                step_id=step_id,
+                step_name=step_name,
+                step_mode=step_mode,
+                parent_id=parent_id,
+                marketing_policy_manifest=marketing_policy_manifest,
+                external_write_required=False,
+            )
+        )
+
+    findings.extend(
+        _lint_approval_timeout_policy(
+            action,
+            step,
+            workflow_file=workflow_file,
+            workflow_id=workflow_id,
+            workflow_name=workflow_name,
+            step_id=step_id,
+            step_name=step_name,
+            step_mode=step_mode,
+            parent_id=parent_id,
+        )
+    )
+    findings.extend(
+        _lint_escalation_route(
+            action,
+            step,
+            workflow_file=workflow_file,
+            workflow_id=workflow_id,
+            workflow_name=workflow_name,
+            step_id=step_id,
+            step_name=step_name,
+            step_mode=step_mode,
+            parent_id=parent_id,
+            marketing_escalation_matrix=marketing_escalation_matrix,
+            external_write_required=_is_external_write_step(agent_type, action, step),
+        )
+    )
+    findings.extend(
+        _lint_decision_audit_evidence(
+            action,
+            step,
+            workflow_file=workflow_file,
+            workflow_id=workflow_id,
+            workflow_name=workflow_name,
+            step_id=step_id,
+            step_name=step_name,
+            step_mode=step_mode,
+            parent_id=parent_id,
+            external_write_required=_is_external_write_step(agent_type, action, step),
+        )
+    )
+
+    return findings
+
+
+def _lint_marketing_policy(
+    action: str,
+    step: dict[str, Any],
+    *,
+    workflow_file: str | None,
+    workflow_id: str,
+    workflow_name: str,
+    step_id: str,
+    step_name: str,
+    step_mode: str,
+    parent_id: str | None,
+    marketing_policy_manifest: dict[str, Any] | None,
+    external_write_required: bool,
+) -> list[MarketingWorkflowLintFinding]:
+    manifest = marketing_policy_manifest
+    if manifest is None:
+        for key in ("marketing_policy_manifest", "cmo_marketing_policy_manifest", "policy_manifest"):
+            value = step.get(key)
+            if isinstance(value, dict):
+                manifest = value
+                break
+    context = {
+        **step,
+        "workflow_id": workflow_id,
+        "workflow_mode": step_mode,
+        "action": action,
+        "external_write_required": external_write_required,
+        "customer_facing": step.get("customer_facing", external_write_required),
+    }
+    decision = evaluate_marketing_policy(context, manifest=manifest, use_default=manifest is None)
+    outcome = str(decision.get("decision") or "")
+
+    if _is_production_mode(step_mode):
+        if outcome == "missing_policy":
+            return [
+                _step_finding(
+                    workflow_file,
+                    workflow_id,
+                    workflow_name,
+                    step_id,
+                    step_name,
+                    "error",
+                    "marketing_policy_missing",
+                    "Production marketing step has no matching marketing policy manifest rule.",
+                    "Add a CMO marketing policy manifest rule or keep this workflow out of production.",
+                    parent_id=parent_id,
+                )
+            ]
+        if outcome == "blocked":
+            return [
+                _step_finding(
+                    workflow_file,
+                    workflow_id,
+                    workflow_name,
+                    step_id,
+                    step_name,
+                    "error",
+                    "marketing_policy_blocked",
+                    str(decision.get("reason") or "Marketing policy blocks this production step."),
+                    "Remove the blocked action or change the policy only after governance review.",
+                    parent_id=parent_id,
+                )
+            ]
+        if outcome == "read_only_only" and external_write_required:
+            return [
+                _step_finding(
+                    workflow_file,
+                    workflow_id,
+                    workflow_name,
+                    step_id,
+                    step_name,
+                    "error",
+                    "marketing_policy_read_only_only",
+                    "Marketing policy permits this step only as read-only/shadow behavior.",
+                    "Replace the external write with a recommendation/draft or add a governed active policy.",
+                    parent_id=parent_id,
+                )
+            ]
+
+    if outcome == "read_only_only" and _is_shadow_mode(step_mode):
+        return [
+            _step_finding(
+                workflow_file,
+                workflow_id,
+                workflow_name,
+                step_id,
+                step_name,
+                "warning",
+                "marketing_policy_shadow_read_only",
+                "Marketing policy allows this only as read-only/shadow output.",
+                "Keep the step labeled as a recommendation, draft, simulation, or internal approval.",
+                parent_id=parent_id,
+            )
+        ]
+    return []
+
+
+def _lint_declared_connector_readiness(
+    required_keys: tuple[str, ...],
+    required_categories: tuple[str, ...],
+    connector_contracts: tuple[dict[str, Any], ...],
+    *,
+    workflow_file: str | None,
+    workflow_id: str,
+    workflow_name: str,
+    step_id: str,
+    step_name: str,
+    step_mode: str,
+    parent_id: str | None,
+) -> list[MarketingWorkflowLintFinding]:
+    if not _is_production_mode(step_mode):
+        return []
+    if not required_keys and not required_categories:
+        return []
+    if not connector_contracts:
+        return [
+            _step_finding(
+                workflow_file,
+                workflow_id,
+                workflow_name,
+                step_id,
+                step_name,
+                "error",
+                "marketing_connector_contracts_missing",
+                "Production marketing step declares connector requirements but no connector contracts were supplied.",
+                "Pass CMO connector contract rows into the linter or keep this workflow out of production.",
+                parent_id=parent_id,
+            )
+        ]
+    findings: list[MarketingWorkflowLintFinding] = []
+    for key in required_keys:
+        row = _contract_by_key(connector_contracts, key)
+        if row is not None and _contract_is_degraded_only(row):
+            findings.append(
+                _step_finding(
+                    workflow_file,
+                    workflow_id,
+                    workflow_name,
+                    step_id,
+                    step_name,
+                    "error",
+                    "marketing_connector_degraded_only",
+                    f"Required connector '{key}' is only available in degraded mode for this production step.",
+                    (
+                        "Restore fresh/complete connector data or keep this workflow "
+                        "shadow/degraded with visible confidence impact."
+                    ),
+                    parent_id=parent_id,
+                )
+            )
+        elif row is None or not row.get("read_ready"):
+            findings.append(
+                _step_finding(
+                    workflow_file,
+                    workflow_id,
+                    workflow_name,
+                    step_id,
+                    step_name,
+                    "error",
+                    "marketing_connector_readiness_missing",
+                    f"Required connector '{key}' is not read-ready for this production step.",
+                    "Configure the connector, scopes, auth, health, and freshness before production lint can pass.",
+                    parent_id=parent_id,
+                )
+            )
+    for category in required_categories:
+        rows = _contracts_by_category(connector_contracts, category)
+        degraded_only = (
+            rows
+            and not any(row.get("read_ready") for row in rows)
+            and any(_contract_is_degraded_only(row) for row in rows)
+        )
+        if degraded_only:
+            findings.append(
+                _step_finding(
+                    workflow_file,
+                    workflow_id,
+                    workflow_name,
+                    step_id,
+                    step_name,
+                    "error",
+                    "marketing_connector_degraded_only",
+                    (
+                        f"Required connector category '{category}' is only available "
+                        "in degraded mode for this production step."
+                    ),
+                    (
+                        "Restore fresh/complete connector data or keep this workflow "
+                        "shadow/degraded with visible confidence impact."
+                    ),
+                    parent_id=parent_id,
+                )
+            )
+        elif not rows or not any(row.get("read_ready") for row in rows):
+            findings.append(
+                _step_finding(
+                    workflow_file,
+                    workflow_id,
+                    workflow_name,
+                    step_id,
+                    step_name,
+                    "error",
+                    "marketing_connector_category_readiness_missing",
+                    f"Required connector category '{category}' has no read-ready connector contract.",
+                    "Connect at least one healthy connector in this category before production lint can pass.",
+                    parent_id=parent_id,
+                )
+            )
+    return findings
+
+
+def _lint_external_write_step(
+    required_keys: tuple[str, ...],
+    required_categories: tuple[str, ...],
+    connector_contracts: tuple[dict[str, Any], ...],
+    step: dict[str, Any],
+    *,
+    workflow_file: str | None,
+    workflow_id: str,
+    workflow_name: str,
+    step_id: str,
+    step_name: str,
+    step_mode: str,
+    parent_id: str | None,
+) -> list[MarketingWorkflowLintFinding]:
+    if _is_shadow_mode(step_mode):
+        return [
+            _step_finding(
+                workflow_file,
+                workflow_id,
+                workflow_name,
+                step_id,
+                step_name,
+                "error",
+                "marketing_shadow_external_write",
+                "Shadow marketing workflows must stay read-only and cannot execute external-write steps.",
+                "Replace this with a recommendation, simulation, draft, or internal approval record.",
+                parent_id=parent_id,
+            )
+        ]
+
+    if not _is_production_mode(step_mode):
+        return [
+            _step_finding(
+                workflow_file,
+                workflow_id,
+                workflow_name,
+                step_id,
+                step_name,
+                "warning",
+                "marketing_external_write_target_only",
+                "External-write step is present only in target/demo/internal mode.",
+                "Keep this workflow out of production until connector write readiness and confirmation metadata pass.",
+                parent_id=parent_id,
+            )
+        ]
+
+    findings: list[MarketingWorkflowLintFinding] = []
+    if not required_keys and not required_categories:
+        findings.append(
+            _step_finding(
+                workflow_file,
+                workflow_id,
+                workflow_name,
+                step_id,
+                step_name,
+                "error",
+                "marketing_external_write_connector_missing",
+                "Production external-write step does not declare a connector key or category.",
+                "Declare connector_key, connector_category, or action metadata that maps the write to a connector.",
+                parent_id=parent_id,
+            )
+        )
+
+    if not _has_write_confirmation_metadata(step):
+        findings.append(
+            _step_finding(
+                workflow_file,
+                workflow_id,
+                workflow_name,
+                step_id,
+                step_name,
+                "error",
+                "marketing_external_write_confirmation_metadata_missing",
+                "Production external-write step lacks CMO-5.3 write-confirmation metadata.",
+                "Set external_write_confirmation_required and expected confirmation fields for the write.",
+                parent_id=parent_id,
+            )
+        )
+
+    if not _has_idempotency_metadata(step):
+        findings.append(
+            _step_finding(
+                workflow_file,
+                workflow_id,
+                workflow_name,
+                step_id,
+                step_name,
+                "error",
+                "marketing_external_write_idempotency_metadata_missing",
+                "Production external-write step lacks idempotency metadata.",
+                "Add idempotency_key, idempotency_key_template, or request_fingerprint for safe retry reasoning.",
+                parent_id=parent_id,
+            )
+        )
+
+    if not connector_contracts:
+        findings.append(
+            _step_finding(
+                workflow_file,
+                workflow_id,
+                workflow_name,
+                step_id,
+                step_name,
+                "error",
+                "marketing_external_write_contracts_missing",
+                "Production external-write step cannot prove connector write readiness without connector contracts.",
+                "Pass CMO connector contract rows into the linter before promoting this workflow.",
+                parent_id=parent_id,
+            )
+        )
+        return findings
+
+    write_ready_rows = _matching_write_contracts(required_keys, required_categories, connector_contracts)
+    if not write_ready_rows:
+        findings.append(
+            _step_finding(
+                workflow_file,
+                workflow_id,
+                workflow_name,
+                step_id,
+                step_name,
+                "error",
+                "marketing_external_write_connector_not_ready",
+                "No matching connector contract is write-ready for this production external-write step.",
+                "Configure write scopes, auth, health, freshness, and idempotency support for the required connector.",
+                parent_id=parent_id,
+            )
+        )
+        return findings
+
+    if not any(row.get("idempotency_key_supported") for row in write_ready_rows):
+        findings.append(
+            _step_finding(
+                workflow_file,
+                workflow_id,
+                workflow_name,
+                step_id,
+                step_name,
+                "error",
+                "marketing_external_write_contract_idempotency_missing",
+                "Matching write-ready connector contract does not prove idempotency-key support.",
+                "Harden the connector contract retry metadata before this active write can pass lint.",
+                parent_id=parent_id,
+            )
+        )
+
+    return findings
+
+
+def _lint_approval_timeout_policy(
+    action: str,
+    step: dict[str, Any],
+    *,
+    workflow_file: str | None,
+    workflow_id: str,
+    workflow_name: str,
+    step_id: str,
+    step_name: str,
+    step_mode: str,
+    parent_id: str | None,
+) -> list[MarketingWorkflowLintFinding]:
+    if not _is_production_mode(step_mode):
+        return []
+    if not requires_approval_timeout_policy(action, step):
+        return []
+    if has_timeout_policy_for_step(step):
+        return []
+    return [
+        _step_finding(
+            workflow_file,
+            workflow_id,
+            workflow_name,
+            step_id,
+            step_name,
+            "error",
+            "marketing_approval_timeout_policy_missing",
+            "Production approval-sensitive marketing step has no approval timeout policy.",
+            (
+                "Attach a CMO approval timeout policy or use a supported "
+                "approval-sensitive action with a default timeout policy."
+            ),
+            parent_id=parent_id,
+        )
+    ]
+
+
+def _lint_escalation_route(
+    action: str,
+    step: dict[str, Any],
+    *,
+    workflow_file: str | None,
+    workflow_id: str,
+    workflow_name: str,
+    step_id: str,
+    step_name: str,
+    step_mode: str,
+    parent_id: str | None,
+    marketing_escalation_matrix: dict[str, Any] | None,
+    external_write_required: bool,
+) -> list[MarketingWorkflowLintFinding]:
+    if not _is_production_mode(step_mode):
+        return []
+    triggers = escalation_triggers_for_action(
+        action,
+        {**step, "workflow_id": workflow_id},
+        external_write_required=external_write_required,
+    )
+    if not triggers:
+        return []
+    missing = missing_escalation_triggers_for_step(
+        {**step, "workflow_id": workflow_id},
+        action=action,
+        matrix=marketing_escalation_matrix,
+        external_write_required=external_write_required,
+    )
+    if not missing:
+        return []
+    return [
+        _step_finding(
+            workflow_file,
+            workflow_id,
+            workflow_name,
+            step_id,
+            step_name,
+            "error",
+            "marketing_escalation_route_missing",
+            (
+                "Production escalation-sensitive marketing step has no CMO "
+                f"escalation route for {', '.join(missing)}."
+            ),
+            "Configure the CMO escalation matrix route or keep this workflow out of production.",
+            parent_id=parent_id,
+        )
+    ]
+
+
+def _lint_decision_audit_evidence(
+    action: str,
+    step: dict[str, Any],
+    *,
+    workflow_file: str | None,
+    workflow_id: str,
+    workflow_name: str,
+    step_id: str,
+    step_name: str,
+    step_mode: str,
+    parent_id: str | None,
+    external_write_required: bool,
+) -> list[MarketingWorkflowLintFinding]:
+    if not _is_production_mode(step_mode):
+        return []
+    event_type = action_event_type(action, step)
+    major_customer_action = external_write_required or event_type not in {
+        "policy_decision",
+        "shadow_only",
+    }
+    if not major_customer_action:
+        return []
+    if has_decision_audit_evidence_for_step(step):
+        return []
+    return [
+        _step_finding(
+            workflow_file,
+            workflow_id,
+            workflow_name,
+            step_id,
+            step_name,
+            "error",
+            "marketing_decision_audit_evidence_missing",
+            (
+                "Production customer-facing marketing step lacks CMO-6.3 "
+                "decision-audit evidence metadata."
+            ),
+            (
+                "Set decision_audit_required/audit_package_required or attach "
+                "a decision audit package/ref before production promotion."
+            ),
+            parent_id=parent_id,
+        )
+    ]
+
+
+def _is_marketing_workflow(
+    definition: dict[str, Any],
+    steps: list[tuple[dict[str, Any], str | None]],
+) -> bool:
+    if _normalize_key(definition.get("domain")) == "marketing":
+        return True
+    return any(
+        _normalize_key(step.get("agent_type") or step.get("agent")) in MARKETING_AGENT_STATES
+        for step, _parent_id in steps
+    )
+
+
+def _iter_steps(
+    steps: Iterable[Any],
+    *,
+    parent_id: str | None = None,
+) -> Iterable[tuple[dict[str, Any], str | None]]:
+    for raw_step in steps:
+        if not isinstance(raw_step, dict):
+            continue
+        yield raw_step, parent_id
+        step_id = _string_or_none(raw_step.get("id")) or parent_id
+        for child_key in ("sub_steps", "steps"):
+            child_steps = raw_step.get(child_key)
+            if isinstance(child_steps, list):
+                yield from _iter_steps(child_steps, parent_id=step_id)
+
+
+def _connector_requirements(
+    agent_type: str,
+    action: str,
+    step: dict[str, Any],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    metadata = ACTION_CONNECTOR_REQUIREMENTS.get((agent_type, action), {})
+    keys = set(_string_list(metadata.get("keys")))
+    categories = set(_string_list(metadata.get("categories")))
+    keys.update(
+        _string_list(
+            step.get("connector_key")
+            or step.get("connector")
+            or step.get("required_connector_key")
+            or step.get("required_connector_keys")
+            or step.get("required_connectors")
+            or step.get("connectors")
+        )
+    )
+    categories.update(
+        _string_list(
+            step.get("connector_category")
+            or step.get("required_connector_category")
+            or step.get("connector_categories")
+            or step.get("required_connector_categories")
+        )
+    )
+    return tuple(sorted(keys)), tuple(sorted(categories))
+
+
+def _is_external_write_step(agent_type: str, action: str, step: dict[str, Any]) -> bool:
+    if step.get("external_write_required") is False or step.get("requires_external_write") is False:
+        return False
+    if step.get("external_write_required") is True or step.get("requires_external_write") is True:
+        return True
+    if action in EXTERNAL_WRITE_ACTIONS:
+        return True
+    if (agent_type, action) in ACTION_CONNECTOR_REQUIREMENTS and _action_looks_write(action):
+        return True
+    return _action_looks_write(action)
+
+
+def _action_looks_write(action: str) -> bool:
+    return any(hint in action for hint in MARKETING_WRITE_ACTION_HINTS)
+
+
+def _has_write_confirmation_metadata(step: dict[str, Any]) -> bool:
+    if step.get("external_write_confirmation_required") is True:
+        return True
+    if step.get("requires_write_confirmation") is True:
+        return True
+    if step.get("write_confirmation_required") is True:
+        return True
+    if step.get("expected_external_object_id_field"):
+        return True
+    fields = step.get("expected_confirmation_fields")
+    return isinstance(fields, list) and bool(fields)
+
+
+def _has_idempotency_metadata(step: dict[str, Any]) -> bool:
+    return any(
+        step.get(field)
+        for field in (
+            "idempotency_key",
+            "idempotency_key_template",
+            "request_fingerprint",
+            "request_fingerprint_template",
+        )
+    )
+
+
+def _matching_write_contracts(
+    required_keys: tuple[str, ...],
+    required_categories: tuple[str, ...],
+    connector_contracts: tuple[dict[str, Any], ...],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for key in required_keys:
+        row = _contract_by_key(connector_contracts, key)
+        if row is not None and _contract_write_safe(row):
+            rows.append(row)
+    for category in required_categories:
+        rows.extend(row for row in _contracts_by_category(connector_contracts, category) if _contract_write_safe(row))
+    return rows
+
+
+def _contract_is_degraded_only(row: dict[str, Any]) -> bool:
+    degraded_mode = row.get("degraded_mode") if isinstance(row.get("degraded_mode"), dict) else {}
+    return (
+        not row.get("read_ready")
+        and (
+            row.get("read_status") == "degraded"
+            or degraded_mode.get("status") == "degraded"
+            or bool(degraded_mode.get("allowed"))
+        )
+    )
+
+
+def _contract_write_safe(row: dict[str, Any]) -> bool:
+    if "write_safe" in row:
+        return bool(row.get("write_safe"))
+    return bool(row.get("write_ready"))
+
+
+def _contract_by_key(
+    connector_contracts: tuple[dict[str, Any], ...],
+    key: str,
+) -> dict[str, Any] | None:
+    normalized_key = _normalize_key(key)
+    for row in connector_contracts:
+        if _normalize_key(row.get("connector_key") or row.get("key")) == normalized_key:
+            return row
+    return None
+
+
+def _contracts_by_category(
+    connector_contracts: tuple[dict[str, Any], ...],
+    category: str,
+) -> list[dict[str, Any]]:
+    normalized_category = _normalize_key(category)
+    return [
+        row
+        for row in connector_contracts
+        if _normalize_key(row.get("category")) == normalized_category
+    ]
+
+
+def _workflow_id(definition: dict[str, Any], workflow_file: str | None) -> str:
+    explicit = definition.get("id") or definition.get("workflow_id") or definition.get("key")
+    if explicit:
+        return _normalize_key(explicit)
+    if workflow_file:
+        return Path(workflow_file).stem
+    return _normalize_key(definition.get("name")) or "unknown_workflow"
+
+
+def _workflow_mode(definition: dict[str, Any], *, default: str = "production") -> str:
+    for field in READINESS_MODE_FIELDS:
+        value = _normalize_key(definition.get(field))
+        if value:
+            return value
+    if definition.get("production_ready") is False:
+        return "target"
+    return default
+
+
+def _is_production_mode(mode: str) -> bool:
+    return _normalize_key(mode) in PRODUCTION_MODES
+
+
+def _is_shadow_mode(mode: str) -> bool:
+    return _normalize_key(mode) in SHADOW_MODES
+
+
+def _step_finding(
+    workflow_file: str | None,
+    workflow_id: str,
+    workflow_name: str,
+    step_id: str,
+    step_name: str,
+    severity: str,
+    code: str,
+    message: str,
+    suggested_fix: str,
+    *,
+    parent_id: str | None,
+) -> MarketingWorkflowLintFinding:
+    if parent_id:
+        message = f"{message} Parent step: {parent_id}."
+    return _finding(
+        workflow_file,
+        workflow_id,
+        workflow_name,
+        step_id,
+        step_name,
+        severity,
+        code,
+        message,
+        suggested_fix,
+    )
+
+
+def _finding(
+    workflow_file: str | None,
+    workflow_id: str,
+    workflow_name: str,
+    step_id: str | None,
+    step_name: str | None,
+    severity: str,
+    code: str,
+    message: str,
+    suggested_fix: str,
+) -> MarketingWorkflowLintFinding:
+    if severity not in SEVERITIES:
+        raise ValueError(f"Invalid lint severity: {severity}")
+    return MarketingWorkflowLintFinding(
+        workflow_file=workflow_file,
+        workflow_id=workflow_id,
+        workflow_name=workflow_name,
+        step_id=step_id,
+        step_name=step_name,
+        severity=severity,
+        code=code,
+        message=message,
+        suggested_fix=suggested_fix,
+    )
+
+
+def _string_list(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (_normalize_key(value),) if value.strip() else ()
+    if isinstance(value, (list, tuple, set)):
+        return tuple(_normalize_key(item) for item in value if _normalize_key(item))
+    return ()
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -64,6 +64,9 @@ from core.models.tenant_ai_credential import TenantAICredential as TenantAICrede
 from core.models.tenant_ai_setting import TenantAISetting as TenantAISetting
 from core.models.tool_call import ToolCall as ToolCall
 from core.models.user import User as User
+from core.models.weekly_report_pilot_proof import (
+    WeeklyReportPilotProof as WeeklyReportPilotProof,
+)
 from core.models.workflow import StepExecution as StepExecution
 from core.models.workflow import WorkflowDefinition as WorkflowDefinition
 from core.models.workflow import WorkflowEventWait as WorkflowEventWait

--- a/core/models/weekly_report_pilot_proof.py
+++ b/core/models/weekly_report_pilot_proof.py
@@ -1,0 +1,59 @@
+"""Weekly Marketing Report pilot-proof ORM model (CMO-PROD-2).
+
+Stores the strict CMO-PROD-1 verdict alongside the redacted evidence bundle
+that produced it. Rows are append-only by convention (the persistence helper
+inserts a new row per evaluation) so the table is effectively a verdict log
+keyed by ``proof_id`` with newest-first lookup by tenant/company.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, Index, Integer, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.models.base import BaseModel, TenantMixin, TimestampMixin
+
+
+class WeeklyReportPilotProof(BaseModel, TenantMixin, TimestampMixin):
+    """Durable record of one weekly-marketing-report pilot-proof evaluation."""
+
+    __tablename__ = "weekly_report_pilot_proofs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    proof_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    # tenant_id comes from TenantMixin; company_id is optional like
+    # ReportSchedule because a tenant may run weekly reports per company.
+    company_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True, index=True
+    )
+    environment_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    proof_status: Mapped[str] = mapped_column(String(32), nullable=False)
+    production_claim_allowed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False
+    )
+    real_vendor_claim_allowed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False
+    )
+    readiness_score: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    evaluated_at: Mapped[datetime] = mapped_column(nullable=False)
+    evidence_bundle: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    verdict: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    blockers: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    next_actions: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    report_artifact_refs: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    decision_audit_refs: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+
+    __table_args__ = (
+        Index(
+            "ix_weekly_report_pilot_proofs_tenant_evaluated",
+            "tenant_id",
+            "company_id",
+            "evaluated_at",
+        ),
+    )

--- a/core/reports/generator.py
+++ b/core/reports/generator.py
@@ -112,6 +112,57 @@ def _inr(amount: int | float) -> str:
     return f"INR {s}"
 
 
+def _with_cmo_report_quality_gate(
+    data: dict[str, Any],
+    report_type: str,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Attach CMO report quality gate metadata to report data."""
+
+    payload = dict(data)
+    allow_demo_report = bool(params.get("allow_demo_report") or params.get("demo"))
+    try:
+        from core.marketing.report_quality import cmo_report_gate_for_type
+
+        gate = cmo_report_gate_for_type(
+            report_type,
+            payload,
+            production_tenant=not allow_demo_report,
+        )
+    # enterprise-gate: broad-except-ok reason=report-quality-gate-failure-marks-cmo-report-draft-only
+    except Exception as exc:
+        gate = {
+            "report_key": report_type,
+            "status": "blocked",
+            "severity": "high",
+            "safe_report_mode": "draft_only",
+            "trusted_delivery_allowed": False,
+            "next_action_cta": "repair_report_quality_gate",
+            "blocked_reasons": [f"Report quality gate evaluation failed: {exc!s}"],
+        }
+    if gate is not None:
+        payload["report_quality_gate"] = gate
+        payload["safe_report_mode"] = gate.get("safe_report_mode")
+        payload["trusted_delivery_allowed"] = bool(gate.get("trusted_delivery_allowed"))
+    return payload
+
+
+def _quality_gate_banner(data: dict[str, Any]) -> str:
+    gate = data.get("report_quality_gate")
+    if not isinstance(gate, dict) or gate.get("status") == "pass":
+        return ""
+    status = html.escape(str(gate.get("status") or "blocked"))
+    mode = html.escape(str(gate.get("safe_report_mode") or "draft_only"))
+    action = html.escape(str(gate.get("next_action_cta") or "review_report_quality"))
+    reasons = gate.get("blocked_reasons") or gate.get("warning_reasons") or []
+    reason_text = "; ".join(str(item) for item in reasons[:3]) if isinstance(reasons, list) else str(reasons)
+    return (
+        "<p><strong>Report quality gate:</strong> "
+        f"{status}. Safe mode: {mode}. Next action: {action}. "
+        f"{html.escape(reason_text)}</p>"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Generator class
 # ---------------------------------------------------------------------------
@@ -214,6 +265,7 @@ class ReportGenerator:
         tenant_id: str = "default",
     ) -> ReportOutput:
         data = self._fetch_cmo_kpis(company_id)
+        data = _with_cmo_report_quality_gate(data, "cmo_weekly", params)
         now_str = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
 
         kpis = "".join([
@@ -239,6 +291,7 @@ class ReportGenerator:
         ) if domain_rows else "<p>No marketing activity in the last 30 days.</p>"
 
         body = (
+            f"{_quality_gate_banner(data)}"
             f"{kpis}"
             f"<h3>Domain Breakdown</h3>{domain_table}"
         )
@@ -379,6 +432,7 @@ class ReportGenerator:
         tenant_id: str = "default",
     ) -> ReportOutput:
         data = self._fetch_cmo_kpis(company_id)
+        data = _with_cmo_report_quality_gate(data, "campaign_report", params)
         now_str = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
 
         kpis = "".join([
@@ -404,6 +458,7 @@ class ReportGenerator:
         ) if domain_rows else "<p>No campaign data available. Connect marketing integrations to populate metrics.</p>"
 
         body = (
+            f"{_quality_gate_banner(data)}"
             f"{kpis}"
             f"<h3>Domain Breakdown</h3>{domain_table}"
         )

--- a/core/tasks/report_tasks.py
+++ b/core/tasks/report_tasks.py
@@ -182,6 +182,29 @@ def generate_report(self: Any, report_config: dict[str, Any]) -> dict[str, Any]:
             company_id=company_id,
             tenant_id=tenant_id,
         )
+        gate = output.content_data.get("report_quality_gate")
+        if channels and gate is not None:
+            from core.marketing.report_quality import cmo_report_trusted_delivery_allowed
+
+            if not cmo_report_trusted_delivery_allowed(gate):
+                log.warning(
+                    "report_delivery_blocked_by_quality_gate",
+                    report_id=report_id,
+                    report_type=report_type,
+                    safe_report_mode=gate.get("safe_report_mode"),
+                    status=gate.get("status"),
+                    next_action_cta=gate.get("next_action_cta"),
+                )
+                return {
+                    "report_id": report_id,
+                    "report_type": report_type,
+                    "paths": [],
+                    "elapsed_sec": round(time.monotonic() - start_ts, 2),
+                    "status": "blocked",
+                    "safe_report_mode": gate.get("safe_report_mode", "draft_only"),
+                    "next_action_cta": gate.get("next_action_cta", "review_report_quality"),
+                    "blocked_reasons": gate.get("blocked_reasons", []),
+                }
 
         # 2. Render to requested format(s)
         from core.reports.renderer import render_excel, render_pdf
@@ -221,13 +244,42 @@ def generate_report(self: Any, report_config: dict[str, Any]) -> dict[str, Any]:
             elapsed_sec=elapsed,
         )
 
-        return {
+        pilot_proof_summary: dict[str, Any] | None = None
+        if report_type in {"cmo_weekly", "weekly_marketing_report"}:
+            from core.marketing.weekly_report_pilot_persistence import (
+                persist_weekly_report_pilot_proof_from_report_output_sync,
+            )
+
+            pilot_proof_summary = persist_weekly_report_pilot_proof_from_report_output_sync(
+                tenant_id=tenant_id,
+                company_id=company_id,
+                report_id=report_id,
+                report_data=output.content_data,
+                rendered_paths=rendered_paths,
+            )
+            if pilot_proof_summary is not None:
+                log.info(
+                    "weekly_report_pilot_proof_persisted",
+                    report_id=report_id,
+                    tenant_id=tenant_id,
+                    company_id=company_id,
+                    proof_status=pilot_proof_summary.get("proof_status"),
+                    production_claim_allowed=pilot_proof_summary.get(
+                        "production_claim_allowed"
+                    ),
+                    readiness_score=pilot_proof_summary.get("readiness_score"),
+                )
+
+        result: dict[str, Any] = {
             "report_id": report_id,
             "report_type": report_type,
             "paths": rendered_paths,
             "elapsed_sec": elapsed,
             "status": "completed",
         }
+        if pilot_proof_summary is not None:
+            result["weekly_report_pilot_proof"] = pilot_proof_summary
+        return result
 
     # enterprise-gate: broad-except-ok reason=report-generation-task-retries-failed-pipeline
     except Exception as exc:

--- a/docs/CMO_VENDOR_SANDBOX_QA_FLOW.md
+++ b/docs/CMO_VENDOR_SANDBOX_QA_FLOW.md
@@ -1,0 +1,140 @@
+# CMO Vendor-Sandbox QA Flow
+
+Use this runbook to QA the CMO vendor-sandbox connector flow end to end. Do not paste real credentials into tickets, chat, docs, screenshots, or commit history.
+
+## 1. Login And Open Setup
+
+1. Login to the target tenant as an admin user.
+2. Open `/dashboard/connectors`.
+3. Click `CMO Sandbox Setup`.
+4. Confirm the page shows four required categories: `CRM`, `Ads`, `Analytics`, and `Email`.
+5. Confirm any existing DB rows show only safe metadata: provider name, DB readiness, proof scope, environment type, and boolean flags. Credential values must not appear.
+
+## 2. Configure One Provider Per Category
+
+Use real QA-owned sandbox credentials only.
+
+1. CRM: choose `HubSpot Sandbox` or `Salesforce Sandbox`.
+2. Ads: choose `Google Ads Test Customer`, `Meta Ads Sandbox`, or `LinkedIn Ads Sandbox`.
+3. Analytics: choose `GA4 Sandbox Property`.
+4. Email: choose `SendGrid Sandbox` or `Mailchimp Test Account`.
+5. Fill every required field for the selected provider.
+6. Click `Save CMO Sandbox Connectors`.
+
+Expected UI result:
+
+- Success message appears.
+- All four current DB preflight cards show `DB ready`.
+- Each row shows `vendor_sandbox | vendor_sandbox`.
+- Each row shows `local=false mock=false`.
+- No credential values are displayed after save.
+
+## 3. Verify Stored DB Shape Locally
+
+In PowerShell:
+
+```powershell
+Set-Location C:\tmp\agenticorg-cmo-1-1
+$env:AGENTICORG_DB_URL = "postgresql+asyncpg://agenticorg:agenticorg_dev_password@localhost:5433/agenticorg"
+$env:AGENTICORG_CMO_SANDBOX_TENANT_ID = "d3f0d84c-836f-4cda-8896-ce2f1623213d"
+python scripts/run_weekly_report_sandbox_pilot.py --preflight-only --json
+```
+
+Required result:
+
+- `preflight_status` is `ready`.
+- `chosen_connectors.CRM.source` is `db`.
+- `chosen_connectors.Ads.source` is `db`.
+- `chosen_connectors.Analytics.source` is `db`.
+- `chosen_connectors.Email.source` is `db`.
+- Each category has `readiness_state=ready`.
+- Each category has `proof_scope=vendor_sandbox`.
+- Each category has `local_test_only=false`.
+- Each category has `mock_or_test_double=false`.
+- No category uses `source=env`.
+
+If preflight is blocked, stop. Do not run the full proof.
+
+## 4. Run Full Vendor-Sandbox Proof
+
+Only run this after preflight is clean:
+
+```powershell
+python scripts/run_weekly_report_sandbox_pilot.py --format json > sandbox-proof.json
+```
+
+Inspect `sandbox-proof.json`:
+
+- `preflight_status` is `ready`.
+- `environment_type` is `vendor_sandbox`.
+- `production_claim_allowed` is `false`.
+- `real_vendor_claim_allowed` is `false`.
+- A sandbox pass is not production proof.
+
+Then inspect the latest DB row:
+
+```powershell
+@'
+import asyncio, os
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+async def main():
+    engine = create_async_engine(os.environ["AGENTICORG_DB_URL"])
+    async with engine.connect() as conn:
+        result = await conn.execute(text("""
+            SELECT proof_id, environment_type, proof_status,
+                   production_claim_allowed, real_vendor_claim_allowed,
+                   readiness_score, evaluated_at
+              FROM weekly_report_pilot_proofs
+             WHERE tenant_id = :tenant_id
+             ORDER BY evaluated_at DESC
+             LIMIT 1
+        """), {"tenant_id": os.environ["AGENTICORG_CMO_SANDBOX_TENANT_ID"]})
+        print(result.mappings().first())
+    await engine.dispose()
+
+asyncio.run(main())
+'@ | python -
+```
+
+Required DB result:
+
+- `environment_type=vendor_sandbox`.
+- `production_claim_allowed=false`.
+- `real_vendor_claim_allowed=false`.
+- `proof_status` is `sandbox_proven`, `partial`, or `blocked` according to evidence quality. It must not silently imply real-vendor production readiness.
+
+## 5. QA The CMO Dashboard
+
+1. Open `/dashboard/cmo`.
+2. Confirm `Marketing Connector Setup` lists CRM, Ads, Analytics, and Email.
+3. Confirm configured sandbox rows show healthy or actionable status without demo-only claims.
+4. Confirm any remaining field mapping, backfill, reconciliation, report-quality, approval, or workflow blockers are visible as blockers or work queue items.
+5. Click connector setup CTAs. Missing connector setup should route to `/dashboard/connectors/cmo-vendor-sandbox`.
+6. Confirm the dashboard never claims full autonomous CMO production readiness from vendor-sandbox proof alone.
+
+## 6. Regression Checks
+
+Run:
+
+```powershell
+python -m pytest tests/unit/test_cmo_vendor_sandbox_connector_config.py tests/unit/test_cmo_weekly_report_sandbox_runner.py tests/unit/test_cmo_weekly_report_pilot_persistence.py tests/unit/test_cmo_weekly_report_pilot_proof.py --no-cov -q
+python -m ruff check api/v1/connectors.py core/marketing/weekly_report_sandbox_pilot.py core/marketing/weekly_report_pilot_persistence.py scripts/run_weekly_report_sandbox_pilot.py scripts/configure_cmo_vendor_sandbox_connectors.py tests/unit/test_cmo_vendor_sandbox_connector_config.py
+npm --prefix ui test -- CMOVendorSandboxConnectors
+npm --prefix ui test -- CMODashboard
+npm --prefix ui run typecheck
+python -m compileall api/v1/connectors.py core/marketing/weekly_report_sandbox_pilot.py core/marketing/weekly_report_pilot_persistence.py scripts/run_weekly_report_sandbox_pilot.py scripts/configure_cmo_vendor_sandbox_connectors.py
+git diff --check
+```
+
+## 7. Production Acceptance
+
+CMO-PROD-3F is complete only when:
+
+- The tenant has four DB-discovered ConnectorConfig rows from the UI or helper path.
+- The rows are real vendor-sandbox credentials, not placeholders.
+- Preflight discovers all four categories from DB.
+- No env fallback is used.
+- A full proof row is inserted only after clean preflight.
+- `production_claim_allowed=false` and `real_vendor_claim_allowed=false` remain false for vendor-sandbox evidence.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -81,11 +81,73 @@ AgenticOrg is an **AI virtual employee platform** for enterprises. Instead of hi
 |--------|--------|------------|
 | **Finance** (6) | AP Processor, AR Collections, Reconciliation, Tax Compliance, Month-End Close, FP&A | 99.7% recon match, ₹69,800/mo saved |
 | **HR** (6) | Onboarding, Payroll Engine, Talent Acquisition, Performance Coach, L&D, Offboarding | Zero payroll errors, 4-hour onboarding |
-| **Marketing** (5) | Campaign Pilot, Content Factory, SEO Strategist, CRM Intelligence, Brand Monitor | 3.2x campaign ROI |
+| **Marketing** (current: 9 core agents plus email path; target: 9 production CMO pillars) | Production-strength today: Campaign Pilot. Beta: Content Factory, Email Marketing, Social Media, ABM, Competitive Intel, Brand Monitor, SEO Strategist, and CRM Intelligence (deepened by CMO-4.3 with deterministic pipeline / funnel / scoring / churn / segments / SQL promotion / account health and policy/approval/audit/write-confirmation gates). Beta agents are not production-ready without real-vendor proof. | ROI claims must come from connected tenant data, not demo values |
 | **Operations** (5) | Support Triage, IT Operations, Compliance Guard, Contract Intelligence, Vendor Manager | 88% auto-classify, zero mis-routes |
 | **Backoffice** (3) | Legal Ops, Risk Sentinel, Facilities Agent | |
 | **Sales** (1) | Sales Agent (Aarav) — lead qualification, email outreach, pipeline management | |
 | **Custom** (user-created) | Any type — admin creates via wizard with custom prompt | |
+
+### 3.1a CMO Production Replan: Real Marketing Department Requirements
+
+The CMO product must be usable by real companies and their marketing teams, not just demo tenants. A CMO capability is not production-ready until it works against real tenant data, real connector configuration, real approvals, real audit trails, and a real operator UX.
+
+**Product rule:** mocks and stubs are allowed only inside automated tests and local development harnesses. They must never be used as proof that a customer-facing CMO feature is production-ready.
+
+| Area | Production requirement |
+|------|------------------------|
+| Data | KPIs must come from configured tenant systems such as Google Ads, Meta Ads, LinkedIn Ads, HubSpot, Salesforce, GA4, WordPress, Mailchimp, SendGrid, Buffer, Brandwatch, Ahrefs, Bombora, G2, and TrustRadius where enabled. Canonical CMO KPIs must use the unified KPI schema and return formula refs, source lineage, freshness, confidence, reconciliation status, and blocked/degraded status when required source facts are missing or cross-source totals do not reconcile. |
+| Connectors | Each connector needs setup UI, credential validation, read/write permission separation, health checks, last-sync metadata, data freshness/TTL, policy-backed retry/degraded-mode behavior, idempotency metadata, external write confirmation, audit evidence, and clear reconnect actions. The CMO KPI API exposes real-company `connector_setup` and `connector_contracts` projections so missing, stale, expired-auth, insufficient-scope, timeout, rate-limit, vendor-error, partial-data, malformed-payload, quota-exhausted, disabled, read-ready, write-safe, write-unconfirmed, healthy, and degraded states are visible before production readiness is claimed. |
+| Agents | Every marketing agent must have domain-specific execution logic, canonical input/output schemas, policy checks, confidence scoring, per-agent contract tests for happy path, invalid input, degraded connector input, HITL/policy behavior, audit refs, source refs, external-write safety, and truthful production/beta/stub/unavailable status. |
+| Governance | All spend, publishing, audience, pricing, claim-making, crisis, and externally visible actions require a machine-checkable marketing policy manifest, explicit approval policy, approval timeout outcomes, escalation matrix routes, per-workflow promotion, structured decision-audit packages, and audit logging. |
+| UX | The CMO dashboard must be a working marketing cockpit: KPI drill-downs, work queue, approvals, campaign timeline, data freshness, confidence, connector health, and next-best actions. |
+| Onboarding | A company must be able to connect systems, import historical data, configure brand/legal/budget policies, run agents in shadow mode, then promote workflows to production one workflow at a time. |
+| Reporting | Weekly and monthly reports must include formulas, data lineage, reconciliation status, freshness, exceptions, confidence, policy/audit/approval state, and a report quality gate. Missing critical fields or failed quality gates should block trusted report generation/delivery instead of silently producing weak output. |
+| Pilot proof | `/kpis/cmo` must expose a code-backed pilot proof package that distinguishes real-vendor, vendor-sandbox, demo, test-double, and unknown evidence. Demo or test-double proof must never count as production readiness. Social Media, ABM, Competitive Intel, and Brand Monitor beta capabilities must remain unproven for production without real-vendor or pilot proof. |
+
+#### Real-Company CMO Activation Journey
+
+1. Admin selects company size, region, primary CRM, ad platforms, email platform, web analytics, CMS, and social/listening stack.
+2. Admin connects each system through OAuth or approved API-key flow. The product validates scopes and runs a read-only health check.
+3. Marketing Ops maps source fields: lifecycle stage, campaign IDs, UTM conventions, opportunity stages, revenue fields, account ownership, and consent fields.
+4. CMO configures brand voice, blocked claims, legal review categories, budget thresholds, approval owners, SLA timers, and escalation paths.
+5. Agents run in shadow mode for at least one full reporting cycle. The product compares recommendations against actual historical decisions and records precision/recall where measurable.
+6. CMO promotes individual workflows from shadow to active. Promotion is per workflow, not a blanket switch for the whole marketing department.
+7. The dashboard shows only real connected data in production tenants. Demo data is allowed only in explicitly labeled demo tenants.
+
+#### CMO User Experience Bar
+
+The CMO experience should feel like an operations console for a serious marketing team:
+
+- One screen answers: what changed, what needs approval, what is at risk, what should we do next, and which data is stale.
+- Every KPI card has drill-down, source, formula, last sync, confidence, owner, and affected campaigns/accounts.
+- Approval screens show before/after previews, budget impact, audience impact, brand/legal/policy risk flags, source refs, agent rationale, policy/escalation/timeout/write/audit state, allowed reviewer actions, and rollback or stop plan.
+- No empty decorative cards. If a connector is missing, the UI shows the missing system, why it matters, and the exact setup path.
+- The dashboard supports saved views for Demand Gen, Content, ABM, Brand, and Executive Review.
+- Tables support sorting, filtering, export, and row-level action history.
+- Charts always have text equivalents and usable empty/error states.
+
+#### CMO Production Readiness Gate
+
+The CMO product is production-ready only when:
+
+- zero customer-facing endpoints return hardcoded or demo KPI values for production tenants;
+- CAC, MQL, SQL, MQL-to-SQL conversion, ROAS, pipeline contribution, conversion rates, LTV/CAC, experiment velocity, content, email, brand, and ABM KPI outputs use the unified CMO KPI schema and formula helpers before being treated as production-ready;
+- canonical CMO KPI drill-downs expose formula inputs, source refs, connector refs, mappings, backfills, reconciliation, freshness, confidence, work queue/report refs, audit refs, owner, blockers, and next action before KPI cards or reports can be treated as explainable production output;
+- paid spend, campaign conversions, GA4/web conversions, email engagement, content traffic, ABM account domains, currency, timezone, stale-sync, and partial-data reconciliation checks pass or visibly block/degrade affected KPI readiness before production reports trust those KPIs;
+- zero CMO capabilities are marked production while backed only by `super().execute()` or generic LLM behavior;
+- every CMO/marketing agent surface has deterministic contract tests proving stable output shape, truthful status, policy/HITL/audit/write-safety behavior, and production blocking for stub or unavailable agents;
+- every production CMO workflow can run against configured real connectors or clearly fail with an actionable setup/degraded-state message;
+- every marketing workflow passes lint for known agents, declared actions, capability state, connector readiness, shadow-mode read-only behavior, and safe external-write metadata before production promotion;
+- connector contracts distinguish read readiness from write readiness, block missing write scopes, expose retry/idempotency metadata, and require external write confirmation with explicit external object IDs and audit evidence before active write steps are considered complete;
+- required CMO field mappings and historical backfill states are present, valid, fresh, and visible before KPI confidence can be marked ready;
+- weekly, daily ad, monthly ROI, campaign ad-hoc, and executive summary report quality gates pass before reports are delivered as trusted production output; blocked or warning reports are labeled `draft_only` or `internal_only`;
+- the CMO dashboard and `/kpis/cmo` expose a prioritized work queue for approvals, escalations, connector issues, mapping/backfill blockers, workflow blockers, external-write failures, policy/audit gaps, KPI/reconciliation problems, and report gate blockers before those issues can be treated as resolved;
+- the CMO dashboard and `/kpis/cmo` expose approval review projections for approval-sensitive actions, including preview/diff, budget and audience impact, risk flags, source refs, rationale, policy/escalation/timeout/write/audit refs, rollback/stop plan, blocked reasons, allowed actions, and CTA; approval fails closed when policy, write readiness, timeout, or audit prerequisites are unsafe or missing;
+- `/kpis/cmo` exposes a CMO pilot proof package/summary with status, score, proven and unproven capabilities, blockers, risks, source/report/audit/test evidence refs, and next actions; demo and test-double environments cannot return production-passed proof, vendor-sandbox proof cannot be marketed as real-vendor proof, and Social Media, ABM, Competitive Intel, and Brand Monitor beta capabilities cannot be marketed as production without real-vendor/pilot proof;
+- every CMO workflow exposes a shadow, blocked, ready, active, degraded, paused, or unavailable activation state and remains read-only until that individual workflow is explicitly promoted;
+- every externally visible action has HITL policy, timeout outcome, escalation route, structured decision-audit package, audit record, and rollback or stop behavior;
+- dashboard and docs distinguish production, beta, shadow, unavailable, demo, and degraded states;
+- at least one pilot tenant completes onboarding with real connected marketing systems and generates a weekly report from real data.
 
 ### 3.2 Virtual Employee System
 
@@ -223,7 +285,7 @@ The sales agent sends **different emails based on role**:
 | CFO/Finance | "₹69,800/mo your AP team is leaving on the table" | Invoice processing in 11 seconds |
 | CHRO/HR | "Zero payroll errors, onboarding in hours not weeks" | 4-hour onboarding, zero PF/ESI errors |
 | COO/CTO/Ops | "88% of your support tickets auto-triaged" | War rooms in 30 seconds |
-| CMO/Marketing | "3.2x campaign ROI on autopilot" | Campaigns launch in minutes |
+| CMO/Marketing | "Connect your marketing stack before trusting ROI" | Real connected campaigns, approvals, and KPI lineage |
 | CEO/Unknown | "Your back office, fully automated" | 3 bullet metrics |
 
 All emails sign as **"Sanjeev Kumar, Founder, AgenticOrg"** — not as AI. Calendar link: https://calendar.app.google/p6P4DpRn85yxHua99

--- a/docs/PRD_CxO_v5.0.md
+++ b/docs/PRD_CxO_v5.0.md
@@ -43,7 +43,7 @@ The platform has real infrastructure but demo product surface:
 | Connectors | 54 native + 1000+ Composio | All connector classes exist with real API integrations (Tally TDL/XML, Darwinbox POST-based, GSTN GSP auth, AA consent flow, etc.) |
 | Agents | 35 registered types | All 35 agent classes are empty shells that call `super().execute()` with no domain logic. The BaseAgent handles LLM reasoning, tool calling, and HITL but individual agents add nothing. |
 | CFO Dashboard | Exists | Renders hardcoded demo data from `/kpis/cfo` endpoint. Shows AR/AP aging charts, P&L table, bank balances, tax calendar -- all static numbers. |
-| CMO Dashboard | Exists | Renders hardcoded demo data from `/kpis/cmo` endpoint. Shows CAC, MQLs, ROAS, email metrics, social engagement -- all static numbers. |
+| CMO Dashboard | Exists | Reads `/kpis/cmo` basic KPI/task metrics and now receives marketing connector setup, connector contract, field-mapping, backfill, workflow-promotion readiness, a unified CMO KPI schema/evaluation projection, KPI drill-down/data-lineage projection, KPI reconciliation checks/summary, report quality gates/summary, a prioritized CMO work queue/summary, approval review projection/summary, and pilot proof projection/summary. Real tenant data gaps, failed reconciliation, failed report gates, unresolved work queue blockers, blocked approvals, unsafe write readiness, blocked KPI lineage, or demo/test-double pilot proof must remain labeled blocked/degraded/demo-only/test-only rather than hidden behind demo values. |
 | CHRO Dashboard | Does NOT exist | No page, no route, no API endpoint. |
 | COO Dashboard | Does NOT exist | No page, no route, no API endpoint. |
 | CBO Dashboard | Does NOT exist | No page, no route, no API endpoint. |
@@ -419,7 +419,7 @@ The CEO/Admin role serves as the cross-departmental command center with visibili
   - UNIT: `test_recon_no_match` -- Bank txn with no corresponding book entry -> flagged as unmatched.
   - UNIT: `test_recon_break_escalation` -- Break of 60,000 (> 50,000 threshold) triggers HITL.
   - UNIT: `test_recon_old_outstanding_flag` -- Item unmatched for 35 days -> flagged.
-  - INTEGRATION: `test_recon_daily_workflow_execution` -- Full workflow runs with mock AA and Tally data.
+  - INTEGRATION: `test_recon_daily_workflow_execution` -- Full workflow runs with AA and Tally contract test doubles; production readiness still requires real connector or sandbox proof.
   - E2E: `test_recon_brs_report_download` -- BRS report generates and is downloadable from dashboard.
 
 #### 2.2.5 Tax Compliance
@@ -481,7 +481,7 @@ The CEO/Admin role serves as the cross-departmental command center with visibili
   - UNIT: `test_tds_computation_vendor` -- Given vendor payment of 50,000 for professional services, verify TDS @ 10%.
   - UNIT: `test_advance_tax_estimation` -- Given YTD income, verify advance tax installment calculation.
   - UNIT: `test_tax_calendar_upcoming_alert` -- Filing due in 5 days triggers alert.
-  - INTEGRATION: `test_gstr3b_filing_workflow` -- Full GSTR-3B workflow with mock GSTN responses.
+  - INTEGRATION: `test_gstr3b_filing_workflow` -- Full GSTR-3B workflow with GSTN contract test doubles; production readiness still requires real connector or sandbox proof.
   - E2E: `test_tax_tab_shows_calendar` -- CFO dashboard Tax tab shows 12-month filing calendar with correct statuses.
   - E2E: `test_tax_tab_shows_itc_mismatch` -- ITC reconciliation section shows mismatch amount.
 
@@ -526,7 +526,7 @@ The CEO/Admin role serves as the cross-departmental command center with visibili
   - UNIT: `test_close_depreciation_calculation` -- Given asset of 10L with 10% SLM, verify monthly depreciation = 8,333.
   - UNIT: `test_close_trial_balance_validation_pass` -- Debit = Credit -> pass.
   - UNIT: `test_close_trial_balance_validation_fail` -- Debit != Credit -> HITL triggered.
-  - INTEGRATION: `test_close_full_workflow` -- All close steps execute in sequence with mock Tally.
+  - INTEGRATION: `test_close_full_workflow` -- All close steps execute in sequence with Tally contract test doubles; production readiness still requires real connector or sandbox proof.
   - E2E: `test_close_tab_shows_checklist` -- CFO dashboard Close tab shows checklist with completion percentage.
 
 #### 2.2.7 Budgeting & FP&A
@@ -945,6 +945,176 @@ The CEO/Admin role serves as the cross-departmental command center with visibili
 
 ### 2.4 CMO (Chief Marketing Officer)
 
+**Implementation truth note (2026-05-24):** The CMO section below is a target specification unless a capability is explicitly marked production or beta in the table below. AgenticOrg must not claim an end-to-end CMO organization is agent-run today. Campaign Pilot is production-strength. Content Factory, Email Marketing, Social Media, ABM, Competitive Intel, Brand Monitor, SEO Strategist, and CRM Intelligence (deepened by CMO-4.3) are beta. Every CMO marketing-agent pillar in `core/agents/marketing` now has first-class deterministic beta code with policy/approval/audit/external-write-confirmation safety gates; production claim still requires real-vendor pilot proof.
+
+| Capability | Current status | Product truth |
+|------------|----------------|---------------|
+| Campaign Pilot | Production | Domain-specific campaign execution, budget checks, performance polling, optimization decisions, and HITL gates exist. |
+| Content Factory | Beta | Substantial content generation and brand-check workflow exists; formal QA, policy, and performance feedback loops are incomplete. |
+| Email Marketing | Beta | Separate LangGraph path and approval-gated tooling exist; not a complete autonomous CMO pillar. |
+| Brand Monitor | Beta | First-class deterministic brand monitoring logic for mentions, sentiment trends, spike detection, false-positive suppression, crisis severity, playbooks, and safety-gated public response; not production-grade without real-vendor/pilot proof. |
+| SEO Strategist | Beta | First-class deterministic SEO logic for keyword gaps, ranking deltas, technical issue prioritization, effort/impact recommendation bundling, content optimization, sprint planning, and safety-gated site changes; not production-grade without real-vendor/pilot proof. |
+| CRM Intelligence | Beta | First-class deterministic CRM/pipeline intelligence for pipeline velocity, funnel conversion (with safe division and low-sample handling), lead scoring refresh, churn risk signal extraction, segment recommendation, SQL promotion criteria, account/deal health, and stale/partial/missing-mapping data handling. CRM writes (lead score push, lifecycle stage change, segment/list change, target-account change, bulk CRM update) are gated by policy/approval/audit/connector-write-safety/external-write-confirmation. Not production-grade without real HubSpot/Salesforce/intent connector readiness, policy/approval/audit evidence, confirmed writes, and pilot proof. |
+| Social Media | Beta first-class core agent | Domain-specific `core/agents/marketing/social_media.py` exists for calendar, scheduling, triage, risk classification, drafts, and guarded publishing. It is not production-ready without Social connector write readiness, policy/approval/escalation/audit evidence, confirmed writes, and real-vendor/pilot proof. |
+| ABM | Beta first-class core agent | Domain-specific `core/agents/marketing/abm_agent.py` exists for account scoring, ICP fit, intent heat, source weighting, next-best-action planning, CSV ingest validation, high-intent alerts, and guarded ABM actions. It is not production-ready without ABM/CRM connector readiness, policy/approval/escalation/audit evidence, confirmed writes, and real-vendor/pilot proof. |
+| Competitive Intel | Beta first-class core agent | Domain-specific `core/agents/marketing/competitive_intel.py` exists for competitor snapshots, profile normalization, pricing-change detection, feature/capability diffing, win/loss signal extraction, duplicate suppression, alert thresholds, and guarded positioning/public-response recommendations. It is not production-ready without competitive-source connector readiness, policy/approval/escalation/audit evidence, confirmed writes where applicable, and real-vendor/pilot proof. |
+| CMO KPI dashboard feed | Demo when `"demo": true` | Demo KPI values are sample data, not proof of autonomous CMO execution. |
+
+#### 2.4.0 CMO Production Replan For Real Companies
+
+The CMO product must be planned as a real marketing operating system for companies with existing teams, agencies, tools, budgets, legal constraints, and revenue targets. It must not be a dashboard of mock KPIs or a collection of prompt wrappers.
+
+**Production principle:** a feature is production CMO software only when it can operate on a tenant's configured marketing systems, expose its data lineage, respect approval policy, and produce an auditable decision or recommendation. Test doubles are acceptable in automated tests. Customer-facing production tenants must use real configured data sources, cached real data, or explicit empty/degraded states.
+
+##### Real Marketing Team Personas
+
+| Persona | Jobs to be done | UX requirement |
+|---------|-----------------|----------------|
+| CMO | Understand pipeline impact, approve high-risk actions, explain marketing performance to CEO/CFO | Executive cockpit with KPI lineage, risks, approvals, and board-ready exports |
+| VP/Growth Lead | Run campaign calendar, optimize spend, launch experiments | Campaign workbench with budgets, experiments, channel drill-downs, and recommendations |
+| Marketing Ops / RevOps | Keep CRM, attribution, UTM, lifecycle stages, and reporting clean | Data quality queue, field mapping, source health, reconciliation, and formula controls |
+| Content Lead | Plan, review, approve, and measure content | Editorial calendar, brand review, SEO guidance, approval history, and post-publish feedback |
+| Brand/Comms Lead | Monitor sentiment, crisis risks, competitor moves, and public claims | Brand room with alerts, severity, response drafts, playbooks, and escalation |
+| SDR/Sales Partner | Receive SQLs and account context without noise | Handoff view with reason, source signals, next action, and CRM sync status |
+| CFO/CEO Viewer | Validate spend efficiency and pipeline contribution | Read-only financial summary with CAC, ROAS, payback, forecast, and confidence |
+
+##### Real Data Foundation
+
+Every CMO tenant needs a source map before agents can be promoted to active mode.
+
+| Data domain | Required source options | Required setup proof |
+|-------------|-------------------------|----------------------|
+| CRM and pipeline | HubSpot or Salesforce | OAuth/API key validation, lifecycle-stage mapping, opportunity/revenue field mapping, owner mapping |
+| Paid media | Google Ads, Meta Ads, LinkedIn Ads | Account selection, currency/timezone validation, campaign ID sync, spend/conversion read access |
+| Web analytics | GA4, Mixpanel where configured | Property selection, conversion event mapping, UTM parameter validation |
+| Content/CMS | WordPress or configured CMS adapter | Draft/create/update permissions, publish permission separated from draft permission |
+| Email | Mailchimp, SendGrid, MoEngage | List/audience mapping, consent/unsubscribe fields, send permission separated from draft permission |
+| Social and scheduling | Buffer, Twitter/X, YouTube, LinkedIn/Facebook where adapter exists | Profile mapping, post permission separated from draft/schedule permission |
+| SEO and content intelligence | Ahrefs, GA4, Search Console where available | Domain verification, keyword/ranking pull, site-audit pull |
+| Brand/listening | Brandwatch and social search adapters | Brand query configuration, competitor list, baseline window |
+| ABM intent | Bombora, G2, TrustRadius | Account-domain matching, topic taxonomy mapping, scoring weights |
+| Finance alignment | FP&A/Tally/ERP where configured | Marketing spend categories, budget owner, period close status |
+
+No dashboard KPI may silently fall back to sample data in a production tenant. Missing sources must produce explicit setup CTAs, partial-data warnings, and confidence downgrades.
+
+##### Agent Production Criteria
+
+Each marketing agent must satisfy all criteria below before its status can move to production.
+
+1. Domain implementation exists in `core/agents/marketing` and does more than invoke shared/base behavior.
+2. The agent has typed input and output schemas, including `status`, `confidence`, `rationale`, `source_refs`, `policy_result`, `recommended_actions`, and `audit_refs`.
+3. The agent reads from real connector adapters or persisted tenant data populated from real connectors.
+4. The agent can run in shadow mode without writing to external systems.
+5. Write actions are separated from read/recommendation actions and require policy evaluation before execution.
+6. HITL approvals include full context, risk labels, budget/audience impact, preview, rollback plan, and timeout behavior.
+7. Every decision writes an audit record with input snapshot hash, source refs, agent version, prompt/template version, connector versions, approver, and final action.
+8. Tests cover unit, contract, connector-error, stale-data, authorization, HITL, workflow, and UI behavior.
+9. The UI labels production, beta, shadow, degraded, unavailable, and demo states consistently.
+
+##### Enterprise Onboarding And Promotion Flow
+
+1. **Workspace setup:** admin creates company, region, currency, fiscal calendar, marketing org roles, and approval owners.
+2. **Connector setup:** Marketing Ops connects CRM, ad platforms, analytics, CMS, email, social, SEO, and brand/intent tools. Each connector shows validated scopes, account IDs, last sync, health, and owner.
+3. **Field mapping:** RevOps maps lifecycle stages, campaign naming, UTM fields, revenue fields, account domains, consent fields, and custom segments.
+4. **Policy setup:** CMO configures budget thresholds, allowed channels, blocked claims, competitor mention rules, legal categories, review SLAs, escalation path, and auto-cancel rules.
+5. **Historical backfill:** product imports 6-12 months of campaign, pipeline, content, email, and web data where APIs permit. Backfill progress and gaps are visible.
+6. **Shadow mode:** agents produce recommendations only. CMO can compare recommendations against past performance and approve promotion per workflow.
+7. **Controlled activation:** CMO activates one workflow at a time: weekly report, campaign optimization, content pipeline, ABM sprint, or brand monitor.
+8. **Operational review:** after each cycle, the product shows agent precision, approval rate, override rate, time saved, KPI movement, and failure causes.
+
+**Implementation note (CMO-1.1, 2026-05-23):** `GET /kpis/cmo` now returns `connector_setup` and `connector_setup_summary` so the dashboard can show configured, missing, stale, expired-auth, insufficient-scope, healthy, and degraded marketing connectors before KPI cards. Strict production runtimes suppress silent demo KPI fallback with `production_data_blocked: true` when real CMO data is absent.
+
+**Implementation note (CMO-1.2, 2026-05-23):** `GET /kpis/cmo` now also returns `field_mapping_status`, `field_mapping_summary`, `backfill_status`, `backfill_summary`, and `kpi_readiness`. Field mappings cover lifecycle stages, opportunity revenue, campaign IDs, UTM fields, account domains, consent/unsubscribe, fiscal calendar, currency, and timezone. Historical backfill projections expose source connector key, requested date range, record counts where stored, last run, blocker, and next action. Strict production runtimes mark KPI confidence as blocked or degraded when mappings or backfills are incomplete, instead of treating sample or incomplete data as production-ready.
+
+**Implementation note (CMO-1.3, 2026-05-23; updated by CMO-3.1 on 2026-05-24):** `GET /kpis/cmo` now also returns `workflow_activation_status` and `workflow_activation_summary` for weekly report, campaign launch, daily spend optimization, content pipeline, lead nurture, social publishing, ABM sprint, brand crisis response, and SEO sprint workflows. Workflow states are `unavailable`, `shadow`, `promotion_blocked`, `promotion_ready`, `active`, `degraded`, and `paused`. A workflow reaches `active` only through explicit per-workflow promotion after required connectors, field mappings, backfills, approval/policy owners, and shadow-run quality gates pass. Shadow and non-active states are read-only for external marketing writes.
+
+**Implementation note (CMO-2.1, 2026-05-23):** `GET /kpis/cmo` now also returns `connector_contracts` and `connector_contract_summary`. Connector contracts distinguish read capabilities from write capabilities, required scopes from granted scopes, read readiness from write readiness, and production proof from mock/test-double proof. They expose auth state, health/contract state, data freshness/TTL, source refs, retry-budget metadata, idempotency-key support, degraded-mode reason, and external write confirmation status. Workflow activation consumes these contract rows so workflows that need external writes are blocked unless the required connector category is write-ready; write-oriented steps cannot be treated as complete without external write confirmation unless the workflow remains shadow/draft/internal-only.
+
+**Implementation note (CMO-5.2, 2026-05-23):** Marketing connector retry and degraded-mode behavior is now policy-backed for timeout, rate limit, vendor 5xx, expired auth, insufficient scope, partial data, stale data, malformed payload, quota exhaustion, and disabled connector states. Connector contracts expose the failure class, retryability, max attempts, backoff metadata, idempotency requirements, confidence impact, external-write blocking, production KPI confidence blocking, CTA, audit event code, and structured degraded-mode projection. Data readiness, workflow activation, external-write completion, and marketing workflow linting consume this policy so read-only/reporting workflows degrade visibly, production KPI confidence is blocked or downgraded, and active external writes fail closed when the connector is not write-safe.
+
+**Implementation note (CMO-5.3, 2026-05-23):** Marketing workflow step execution now evaluates concrete external-write final states: `accepted`, `rejected`, `timeout_unknown`, `retry_scheduled`, `idempotent_recovered`, `write_confirmed`, `write_unconfirmed`, `draft_created`, and `shadow_only`. Active external write steps fail closed unless the connector output includes explicit write confirmation with connector key, external object ID, idempotency metadata where applicable, request fingerprint, confirmation timestamp, available actor/agent/workflow/run IDs, and audit reference. Shadow workflows remain read-only, draft/internal steps must be labeled as such, timeout retries require idempotency metadata, and duplicate retries can recover only an existing confirmed write with the same idempotency key.
+
+**Implementation note (CMO-5.4, 2026-05-23):** CMO approval timeout policy is now code-backed for approval-sensitive marketing actions: ad campaign launch, ad budget change, email send, content publish, landing-page change, target account list change, crisis/public response, social post targeting, and high-risk copy/pricing/claims review. Timeout outcomes are `auto_cancel`, `auto_escalate`, `continue_read_only`, `pause_workflow`, and `require_manual_resolution`, each with SLA, escalation role, external-write allowance, notification/audit event code, and fallback CTA/message. Workflow activation exposes timeout-policy readiness, workflow lint flags production approval-sensitive steps without timeout policy, active external writes fail closed after timeout unless explicitly pre-approved, and `GET /kpis/cmo` returns `approval_timeout_risk` for pending/overdue marketing HITL approvals.
+
+**Implementation note (CMO-6.1, 2026-05-23):** CMO marketing policy is now represented by `core.marketing.policy_manifest`, a machine-checkable manifest with conservative default rules for budget thresholds, publish/send/launch approvals, high-risk copy, pricing/legal/compliance/comparative/competitor claims, region constraints, audience and target-account thresholds, crisis/public response, allowed read-only autonomous actions, disallowed destructive actions, required owner roles, and required audit evidence. Policy evaluation returns `allowed`, `blocked`, `requires_approval`, `requires_escalation`, `read_only_only`, or `missing_policy` with matched rules, reason, approver/escalation role, audit evidence, affected workflow/action, and CTA. Workflow activation, workflow linting, approval timeout decisions, external-write completion, and `GET /kpis/cmo` consume this policy; active customer-facing writes fail closed without matching policy coverage and satisfied approval/escalation evidence.
+
+**Implementation note (CMO-6.2, 2026-05-23):** CMO escalation routing is now represented by `core.marketing.escalation_matrix`, a machine-checkable matrix with conservative default routes for approval timeouts, crisis/public response, budget threshold exceptions, connector auth/degraded failures, data mapping blockers, backfill failures, missing policy, rejected or timeout/unknown external writes, high-risk copy, pricing/legal claims, and target-account changes. Escalation evaluation returns owner role, backup owner, escalation chain, SLA/due time, fallback outcome, notification channels, audit event code, audit reference, and decision (`notify_owner`, `escalate`, `escalate_to_legal`, `escalate_to_finance`, `escalate_to_admin`, `pause_workflow`, or `require_manual_resolution`). Approval timeouts, marketing policy decisions, connector retry/degraded states, data readiness blockers, external-write completion, workflow activation, workflow linting, and `GET /kpis/cmo` now consume escalation route/evidence; production workflows with escalation-sensitive actions block when no route exists.
+
+**Implementation note (CMO-6.3, 2026-05-23):** CMO decision auditing is now represented by `core.marketing.decision_audit`, a deterministic package shape with schema version, audit ID/reference, tenant/company IDs, workflow/run/step IDs, agent/action/capability, event and decision type, actor identity, timestamps, input snapshot hash, source/connector refs, policy/escalation/approval/timeout/external-write refs, rationale, alternatives, risk flags, confidence, final outcome, override fields, and WORM-ready canonical JSON serialization with secret/token redaction. Policy evaluation, escalation routing, approval timeouts, connector degraded/failure projections, data readiness blockers, workflow activation/promotion, external-write attempts/final states, workflow linting, and `GET /kpis/cmo` now consume or expose decision-audit evidence; production customer-facing workflow lint fails when required audit evidence metadata is missing.
+
+**Implementation note (CMO-7.1, 2026-05-23):** Unified CMO KPI schema and formula foundations are now represented by `core.marketing.kpi_schema`, with schema version `2026-05-23.cmo-7.1` and deterministic definitions/evaluators for CAC, MQL, SQL, MQL-to-SQL conversion, ROAS, pipeline contribution, conversion rates by funnel stage, LTV/CAC, experiment velocity, content performance, email performance, brand sentiment, and ABM intent/account readiness. Each KPI definition carries formula, required connector categories/source domains, required mappings/backfills, TTL, unit, owner, confidence/freshness rules, missing-data behavior, source lineage refs, and audit evidence classes. `GET /kpis/cmo` now exposes `unified_cmo_kpi_schema`, `unified_cmo_kpi_results`, and `unified_cmo_kpi_summary`; individual KPI results return `ready`, `degraded`, `blocked`, or `unavailable` with formula refs, source refs, missing requirements, freshness, confidence, and next action. Production KPI paths still fail blocked/degraded when connector, mapping, backfill, freshness, or source facts are missing.
+
+**Implementation note (CMO-7.2, 2026-05-23):** CMO KPI reconciliation checks are now represented by `core.marketing.kpi_reconciliation`, with projection version `2026-05-23.cmo-7.2`. The checks compare paid spend totals by channel against campaign-level spend, ad platform conversions against CRM campaign-attributed outcomes, GA4/web conversions against CRM leads, email sends/clicks/unsubscribes against CRM/list engagement, WordPress/content traffic against GA4 content performance, ABM target account domains against CRM and intent-source domains, currency/timezone consistency, and stale-sync or partial-data impact. `GET /kpis/cmo` now exposes `cmo_kpi_reconciliation_checks` and `cmo_kpi_reconciliation_summary`; high-severity failed or blocked checks block affected KPIs, while warnings and medium-severity failures downgrade confidence/freshness. CMO-7.2 itself did not implement report quality gates or persistent KPI history storage.
+
+**Implementation note (CMO-7.3, 2026-05-23):** CMO report quality gates are now represented by `core.marketing.report_quality`, with projection version `2026-05-23.cmo-7.3`. Gates cover weekly marketing reports, daily ad performance, monthly marketing ROI, campaign ad-hoc reports, and executive board summaries. Each gate consumes unified KPI status/confidence/freshness, KPI reconciliation checks, connector setup/contracts, mapping/backfill readiness, workflow activation state, policy/escalation/audit readiness, approval refs for sensitive or external delivery, and production demo/sample/fallback data policy. `GET /kpis/cmo` now exposes `report_quality_gates` and `report_quality_summary`; CMO report generation attaches gate metadata and the scheduled report task skips external delivery unless the CMO report gate is `deliverable`. This task does not implement persistent report history storage, a full report editor, missing production marketing agents, or vendor-specific adapters.
+
+**Implementation note (CMO-8.1, 2026-05-23):** The CMO work queue is now represented by `core.marketing.work_queue`, with projection version `2026-05-23.cmo-8.1`. It aggregates approval timeout risk, escalations, connector setup/contract issues, data readiness blockers, workflow activation blockers, external-write failures, policy/audit gaps, blocked/degraded KPIs, failed/warning reconciliation checks, report quality gate blockers/warnings, demo/sample production blockers, and crisis/public-response risks where available. `GET /kpis/cmo` now exposes `cmo_work_queue` and `cmo_work_queue_summary`, and the CMO dashboard renders the queue ahead of readiness sections with priority, severity, owner, affected object, due time, and CTA. This task does not implement KPI drill-down/data-lineage UX, full approval review UX, persistent task storage, missing production marketing agents, or vendor-specific adapters.
+
+**Implementation note (CMO-8.2, 2026-05-23):** CMO KPI drill-down/data lineage is now represented by `core.marketing.kpi_drilldown`, with projection version `2026-05-23.cmo-8.2`. Drill-downs explain canonical KPI status, value, unit, confidence, formula, resolved formula inputs, required and actual source/connector refs, field mappings, backfill state, reconciliation checks, freshness, confidence impact, missing requirements, work queue item refs, report gate refs, policy/audit refs, owner role, and next action CTA. `GET /kpis/cmo` now exposes `cmo_kpi_drilldowns` and `cmo_kpi_drilldown_summary`, and the CMO dashboard renders a compact lineage table after the work queue. Demo, mock, stub, hardcoded, sample, fallback, and test-double inputs are explicitly blocked from production lineage proof. This task does not implement persistent KPI history storage, a full drill-down workbench, report rendering, full approval review UX, missing production marketing agents, or vendor-specific adapters.
+
+**Implementation note (CMO-8.3, 2026-05-23):** CMO approval review UX is now represented by `core.marketing.approval_review`, with projection version `2026-05-23.cmo-8.3`. Approval reviews cover campaign launch, ad budget change, content publish, email send, landing-page change, target-account list change, crisis/public response, high-risk copy/pricing/legal claim, and workflow promotion contexts. `GET /kpis/cmo` now exposes `cmo_approval_reviews` and `cmo_approval_review_summary`, links approval-timeout decisions to review IDs, and lets work queue approval items point at the review payload. Each review carries preview payload, before/after diff, budget and audience impact, brand/legal/policy risk flags, source and connector refs, agent rationale, policy/escalation/timeout/write/audit refs, rollback/stop plan, allowed reviewer actions, blocked reasons, and CTA. Approve fails closed when policy coverage is missing or blocking, connector/write readiness is unsafe, timeout policy requires manual resolution, or required decision-audit evidence is absent. The CMO dashboard renders compact approval review cards after the work queue without implementing persistent approval storage or vendor-specific write adapters.
+
+**Implementation note (CMO-9.1, 2026-05-24):** CMO per-agent contract coverage is now represented by `core.marketing.agent_contracts`, with contract version `2026-05-24.cmo-9.1`, required output keys, truthful capability statuses, aliases, and production-readiness blockers for Campaign Pilot, Content Factory, Email Marketing / `email_agent`, Brand Monitor, SEO Strategist, CRM Intelligence, Social Media, ABM / `abm_agent`, and Competitive Intel. Campaign Pilot and Content Factory emit the shared contract fields for approval/HITL state, policy result, audit reference, source refs, degraded or blocked reasons, external-write confirmation status, and production status. Campaign Pilot active write paths now fail closed when write confirmation is absent, and Content Factory publish/schedule paths remain draft/approval-gated until external delivery is explicitly confirmed. The contract tests prove implemented/beta shape and safety behavior while also proving stub/unavailable surfaces stay non-production and blocked from active production workflows.
+
+**Implementation note (CMO-9.4, 2026-05-24):** CMO pilot proof is now represented by `core.marketing.pilot_proof`, with proof version `2026-05-24.cmo-9.4`. The proof package evaluates connector setup, connector contracts, field mapping/backfill, workflow activation/linting, policy, escalation, approval timeout readiness, external-write confirmation, decision-audit evidence, unified KPIs, reconciliation, report quality gates, work queue blockers, KPI drill-down lineage, approval reviews, agent contract status, and scenario/chaos test evidence. `GET /kpis/cmo` now exposes `cmo_pilot_proof`, `cmo_pilot_proof_summary`, and a redacted evidence bundle. Demo tenants return `demo_only`, test-double/mock environments return `test_only`, vendor-sandbox proof can pass only sandbox criteria, and real-vendor proof can pass only when critical readiness criteria pass. Social Media, ABM, Competitive Intel, Brand Monitor, and SEO Strategist beta remain unproven for production until real-vendor/pilot proof exists. This task adds proof packaging, not live vendor credentials, persistent proof storage, full pilot rollout, or missing agent implementations.
+
+**Implementation note (CMO-4.1, 2026-05-24):** Brand Monitor now has first-class deterministic beta logic in `core.agents.marketing.brand_monitor` for mention aggregation, sentiment classification/trends, negative-volume spike detection, false-positive suppression, crisis severity classification, competitor/brand grouping, response playbooks, and escalation recommendations. Public/crisis response and claim-making paths remain policy, approval, escalation, audit, connector write-safety, and write-confirmation gated. This is not production proof; Brand Monitor still requires real Brand/Social connectors and pilot evidence before production claims.
+
+**Implementation note (CMO-4.2, 2026-05-24):** SEO Strategist now has first-class deterministic beta logic in `core.agents.marketing.seo_strategist` for keyword gap analysis, ranking delta computation, technical SEO issue prioritization, effort/impact recommendation bundling, content optimization recommendations, SEO sprint planning, and stale/partial data handling. Technical site changes such as metadata, canonical, redirect, robots, sitemap, landing-page, and indexing actions remain policy, approval, audit, connector write-safety, and write-confirmation gated. This is not production proof; SEO Strategist still requires real SEO/Analytics/CMS connectors and pilot evidence before production claims.
+
+**Implementation note (CMO-4.3, 2026-05-24):** CRM Intelligence now has first-class deterministic beta logic in `core.agents.marketing.crm_intelligence` for pipeline velocity analysis (per-stage averages, bottlenecks, stuck deals), funnel conversion analysis with safe division and low-sample handling, deterministic explainable lead scoring refresh, churn risk signal extraction, segment recommendation (with enrol/follow-up/win-back action plans), SQL promotion classification, account/deal health composite scoring, and stale/partial/missing-mapping data handling. CRM writes such as lead score push, lifecycle stage change, segment/list change, target-account change, and bulk CRM update remain policy, approval, audit, connector write-safety, and write-confirmation gated. This is not production proof; CRM Intelligence still requires real HubSpot/Salesforce/intent connectors and pilot evidence before production claims.
+
+**Implementation note (CMO-PROD-1, 2026-05-24):** A strict weekly-marketing-report pilot-evidence path now exists in `core.marketing.weekly_report_pilot_proof`, with a CLI validator at `scripts/validate_weekly_report_pilot_proof.py` and a redacted projection at `/kpis/cmo` (`weekly_report_pilot_proof`, `_summary`, `_evidence_bundle`). The proof gate is fail-closed: demo, test-double, vendor-sandbox, and unknown inputs never produce a real-vendor production claim, and missing connectors, mappings, backfill, KPIs, reconciliation, report-quality gates, report artifacts, decision-audit refs, or source-lineage refs each produce explicit blockers with next actions. No live or vendor-sandbox evidence is present in the worktree, so the proof gate is the path — pilot tenants must supply a real `WeeklyReportPilotEvidence` bundle before any external "weekly report production-proven" claim is permitted.
+
+**Implementation note (CMO-PROD-2, 2026-05-24):** Weekly-report pilot proof verdicts are now durably representable. A new ORM model `WeeklyReportPilotProof` plus Alembic migration `v4917_weekly_report_proof` (on top of `v4916_merge_p0_heads`) defines an append-only `weekly_report_pilot_proofs` table. `core.marketing.weekly_report_pilot_persistence` exposes a persistence helper (`persist_weekly_report_pilot_proof`), a latest-by-tenant retrieval (`latest_weekly_report_pilot_proof`), an evidence builder that turns a successful weekly-report run into a `WeeklyReportPilotEvidence` bundle, and a Celery-safe sync wrapper. `core/tasks/report_tasks.generate_report` now calls the wrapper after every `cmo_weekly` / `weekly_marketing_report` run, so verdicts (including `blocked` and `unavailable` outcomes when evidence is incomplete) flow into durable storage. `/kpis/cmo` exposes the latest persisted verdict alongside the existing ad-hoc projection. Secret/token redaction runs both in the validator and again at persistence time. **The migration is included but no `weekly_report_pilot_proofs` row exists in any tenant DB in this worktree**; a credentialed pilot tenant must actually run the weekly report before the first verdict materialises.
+
+**Implementation note (CMO-PROD-3, 2026-05-24):** A fail-closed sandbox walk-through orchestrator now exists at `core.marketing.weekly_report_sandbox_pilot.run_sandbox_pilot` with a CLI wrapper at `scripts/run_weekly_report_sandbox_pilot.py`. The orchestrator discovers configuration *only* from `AGENTICORG_CMO_SANDBOX_*` env vars (per repo convention) plus the standard `AGENTICORG_DB_URL`; it refuses to invent data and never inserts a synthetic row. When env vars are missing it returns a redacted preflight envelope listing the exact missing connectors and next actions; when env vars are present it invokes the same `generate_report` Celery entry point production uses, with `params.pilot_environment_type="vendor_sandbox"`, so the CMO-PROD-2 hook persists a `sandbox_proven` / `partial` / `blocked` row — never a real-vendor `passed`. **As of 2026-05-24 no sandbox credentials and no DB are configured in this worktree, so CMO-PROD-3 is BLOCKED on prerequisites.** The backlog's CMO-PROD-3 section carries the exact runbook (env vars, alembic upgrade, expected SQL verification) a pilot operator must follow.
+
+**Implementation note (CMO-3.1, 2026-05-24):** Social Media is now represented by `core.agents.marketing.social_media`, a deterministic beta core marketing agent. It generates content calendars, optimizes posting schedules, triages engagement, classifies reply risk, drafts social posts, recommends crisis escalation, and gates post/reply publishing through connector write-safety, marketing policy, HITL approval, escalation, decision-audit evidence, and external-write confirmation. Shadow mode remains read-only. This is not a production readiness claim: live vendor credentials/adapters, real-vendor pilot proof, and persistent proof operations remain required before Social Media can be marketed as production autonomous social management.
+
+**Implementation note (CMO-3.2, 2026-05-24):** ABM is now represented by `core.agents.marketing.abm_agent`, a deterministic beta core marketing agent. It scores accounts, computes ICP fit and intent heat, applies configurable Bombora/G2/TrustRadius/CRM source weights, recommends next-best actions, validates CSV account ingest, raises high-intent or risky target-list alerts, and gates ABM writes through connector write-safety, marketing policy, HITL approval, escalation, decision-audit evidence, and external-write confirmation. Shadow mode remains read-only. This is not a production readiness claim: live vendor credentials/adapters, real-vendor pilot proof, and persistent proof operations remain required before ABM can be marketed as production account-based marketing automation.
+
+**Implementation note (CMO-3.3, 2026-05-24):** Competitive Intel is now represented by `core.agents.marketing.competitive_intel`, a deterministic beta core marketing agent. It creates weekly competitor snapshots, normalizes competitor profiles, detects pricing changes with confidence scores, diffs features/capabilities, extracts win/loss signals, suppresses duplicate changes, applies alert thresholds, and recommends positioning or next-best actions. Public response, pricing claim, comparative claim, and competitive campaign actions are gated through connector write-safety, marketing policy, HITL approval, escalation, decision-audit evidence, and external-write confirmation. Shadow mode remains read-only. This is not a production readiness claim: live competitive-source/social/ads connectors, vendor-specific adapters, real-vendor pilot proof, and persistent proof operations remain required before Competitive Intel can be marketed as production competitive-intelligence automation.
+
+**Implementation note (CMO-5.1, 2026-05-23):** `core.marketing.workflow_linter` now provides code-backed lint entry points for marketing workflow YAML. Lint findings identify workflow file, workflow id/name, step id/name, severity, code, message, and suggested fix. Production lint fails undefined marketing agents/actions, stub or unavailable production behavior, missing connector contract readiness, unsafe external-write steps, missing write-confirmation/idempotency metadata, and shadow-mode external-write attempts. Target, demo, and shadow workflows can still carry roadmap placeholders, but only as warnings rather than production proof.
+
+##### Production CMO Workflows
+
+| Workflow | Real input | Agent actions | Required HITL | Production output |
+|----------|------------|---------------|---------------|-------------------|
+| Weekly Marketing Review | CRM pipeline, ad spend, GA4, email, content, brand data | Reconcile KPIs, explain deltas, flag risks, draft executive summary | Required before external delivery | PDF/XLSX report with formulas, lineage, exceptions, and confidence |
+| Campaign Launch | Approved brief, audience, budget, landing page, assets | Draft variants, validate policy, create platform drafts, prepare tracking plan | Required before launch and spend commitment | Campaigns created in draft or active state per approval, audit package |
+| Daily Spend Optimization | Paid media performance and budget plan | Detect overspend/underperformance, recommend pause/scale/reallocate | Required above threshold; auto-pause only if pre-approved policy allows | Recommendation or approved budget/action update with rollback plan |
+| Content Pipeline | Keyword gaps, calendar, brand guide, CMS data | Brief, draft, SEO review, brand/legal check, CMS draft creation | Required before publish | CMS draft/published post, approval record, performance tracking task |
+| Lead Nurture | CRM leads, consent, email engagement | Segment, draft sequence, monitor events, recommend SQL handoff | Required before send/list changes | Email workflow in draft/active state, CRM sync, handoff tasks |
+| ABM Sprint | Target account list, intent signals, CRM engagement | Score accounts, identify next best action, recommend LinkedIn/email/content plays | Required for target list or budget changes | Ranked account plan, CRM tasks, campaign drafts |
+| Brand Crisis Response | Mentions, sentiment, volume baseline, competitor/news signals | Classify severity, summarize evidence, draft holding response, notify owners | Required for any public response | Incident room, escalation trail, approved response package |
+| SEO Sprint | Ahrefs/GA4/Search Console data, content inventory | Prioritize fixes, generate content/update briefs, estimate impact | Required for technical site changes | Sprint plan with effort/impact, tasks, and measurable target |
+
+##### UX Requirements For A Serious CMO Team
+
+The CMO dashboard must be a working cockpit, not a marketing brochure.
+
+- **Header:** date range, connected company, data freshness, connector health, active policy mode, and global refresh.
+- **Command center:** prioritized work queue for approvals, risks, stale data, connector issues, budget exceptions, and agent recommendations.
+- **KPI cards:** each card shows value, trend, target, formula, owner, last sync, confidence, data coverage, and drill-down.
+- **Agent status:** each agent tile shows status, current mode, last run, success rate, open approvals, blocked connectors, and exact reason if unavailable.
+- **Approvals:** approval pages show preview, diff, risk flags, budget/audience impact, source refs, agent rationale, policy result, timeout, and rollback/stop action.
+- **Campaigns:** operators can inspect spend, pacing, ROAS, conversion lag, experiment status, and generated recommendations without leaving the dashboard.
+- **Content:** editorial calendar supports draft/review/approved/published states, assigned owner, channel, SEO target, and performance feedback.
+- **ABM:** account table supports search, filters, score decomposition, source signals, CRM owner, next action, and sync status.
+- **Brand:** crisis alerts show severity, evidence, volume baseline, sentiment trend, response status, and escalation owner.
+- **Accessibility and responsiveness:** all charts require table/text equivalents, keyboard navigation, and WCAG 2.1 AA contrast. Tablet view is fully usable for review/approval flows.
+
+##### What Must Not Ship
+
+- Production CMO dashboard cards backed by hardcoded values or sample arrays.
+- Agent statuses that say production while implementation is a prompt wrapper.
+- Workflow steps that mark external actions complete without connector write confirmation.
+- Reports that omit missing critical fields without a visible confidence downgrade.
+- Approval requests without source data, policy result, and rollback/stop plan.
+- Demo data mixed into a real tenant without an explicit demo-mode tenant flag.
+
 #### 2.4.1 Demand Generation
 
 - **Description:** Lead generation campaign management across Google Ads, Meta Ads, and LinkedIn, including landing page optimization and webinar management.
@@ -1070,8 +1240,10 @@ The CEO/Admin role serves as the cross-departmental command center with visibili
 
 #### 2.4.5 Social Media
 
+- **Status:** Beta first-class core marketing agent. The implementation is deterministic and guarded, but not production-ready without real Social connector write readiness, policy/HITL approval, escalation/audit evidence, confirmed external writes, and pilot proof.
 - **Description:** Post scheduling, engagement monitoring, influencer identification, crisis monitoring, and community management.
 - **Agents Responsible:**
+  - `social_media` -- Content calendar generation, posting schedule optimization, engagement triage, reply risk classification, social post draft/recommendation, and guarded publish/reply actions
   - `content_factory` -- Post creation and scheduling
   - `brand_monitor` -- Social listening, crisis detection
 - **Connectors Required:**
@@ -1091,6 +1263,7 @@ The CEO/Admin role serves as the cross-departmental command center with visibili
 - **Test Cases:**
   - UNIT: `test_social_engagement_aggregation` -- Sum across platforms.
   - UNIT: `test_crisis_detection` -- Negative sentiment spike > 3x baseline -> alert.
+  - UNIT: `test_social_media_publish_requires_confirmation` -- Active publish blocks until connector write readiness, policy/approval/audit, and confirmed external write evidence exist.
   - E2E: `test_brand_tab_shows_sentiment` -- Brand tab renders sentiment gauge.
 
 #### 2.4.6 ABM (Account-Based Marketing)
@@ -1778,13 +1951,13 @@ class ApProcessorAgent(BaseAgent):
 
 **Marketing Domain Agents:**
 
-| Agent | Pre-Processing | Domain Rules | Tool Selection | Post-Processing | Confidence Floor |
-|-------|---------------|--------------|----------------|-----------------|-----------------|
-| `campaign_pilot` | Parse campaign brief, extract objectives | Budget allocation rules, ROAS minimum (1.5x), overspend alert (>120%) | Google Ads, Meta Ads, LinkedIn Ads for campaigns, HubSpot for leads | Verify ROAS calculated, budget tracked | 0.85 |
-| `content_factory` | Identify content type and audience | Brand voice check, competitor mention review, SEO keyword inclusion | WordPress for blog, Buffer for social, Mailchimp for email | Verify readability score, SEO score | 0.82 |
-| `seo_strategist` | Analyze current rankings and gaps | Keyword difficulty threshold (< 70 for targeting), content gap rules | Ahrefs for SEO data, GA4 for traffic | Verify keyword recommendations, audit score | 0.85 |
-| `brand_monitor` | Ingest social mentions and news | Sentiment baseline comparison (>3x negative = crisis), competitive tracking | Brandwatch for monitoring, Twitter for mentions | Verify sentiment calculation, crisis detection | 0.82 |
-| `crm_intelligence` | Aggregate CRM and intent data | Intent threshold (>70 = target), ABM engagement scoring | HubSpot for CRM, Bombora + G2 + TrustRadius for intent | Verify intent scores, target list updates | 0.85 |
+| Agent | Current status | Pre-Processing | Domain Rules | Tool Selection | Post-Processing | Confidence Floor |
+|-------|----------------|---------------|--------------|----------------|-----------------|-----------------|
+| `campaign_pilot` | Production | Parse campaign brief, extract objectives | Budget allocation rules, ROAS minimum (1.5x), overspend alert (>120%) | Google Ads, Meta Ads, LinkedIn Ads for campaigns, HubSpot for leads | Verify ROAS calculated, budget tracked | 0.85 |
+| `content_factory` | Beta | Identify content type and audience | Brand voice check, competitor mention review, SEO keyword inclusion | WordPress for blog, Buffer for social, Mailchimp for email | Verify readability score, SEO score | 0.82 |
+| `seo_strategist` | Beta in core marketing agent layer | Deterministic keyword gap analysis, ranking deltas, technical SEO prioritization, content optimization, and sprint planning | Keyword difficulty threshold (< 70 for targeting), content gap rules, severity/impact/effort issue ordering, write-confirmation gates for site changes | Ahrefs/Search Console for SEO data, GA4 for traffic, CMS for site changes | Verify keyword recommendations, ranking deltas, technical priority order, degraded data labels, approval/audit/write gates | 0.84 |
+| `brand_monitor` | Beta in core marketing agent layer | Ingest social mentions and news | Deterministic mention aggregation, sentiment distribution/trends, negative spike detection, false-positive suppression, crisis severity classification, competitor/brand grouping, playbook recommendation | Brandwatch for monitoring, Twitter/Social for mentions and guarded response | Verify sentiment calculation, crisis detection, false-positive suppression, approval/escalation/write gates | 0.85 |
+| `crm_intelligence` | Stub in core marketing agent layer | Aggregate CRM and intent data | Intent threshold (>70 = target), ABM engagement scoring | HubSpot for CRM, Bombora + G2 + TrustRadius for intent | Verify intent scores, target list updates | 0.85 |
 
 **Ops Domain Agents:**
 
@@ -3092,39 +3265,54 @@ Response includes:
 
 **Route:** `/dashboard/cmo` (existing)
 
-**Changes:** Add tab navigation, replace hardcoded data.
+**Changes:** Add tab navigation, replace hardcoded data, and make the screen usable by real marketing teams operating real companies. The dashboard must never hide mock or stub behavior behind polished UI. It should show connected data, explicit empty/degraded states, and a clear path from insight to approval to action.
 
 **Tab Navigation:** Pipeline | Campaigns | Content | ABM | Brand
+
+**Top-level CMO Cockpit Requirements:**
+- Header includes company selector, date range, active currency, data freshness, connector health, and policy mode.
+- First row prioritizes work: pending approvals, spend exceptions, stale data, connector failures, agent recommendations, and crisis alerts.
+- Every KPI card supports drill-down with formula, source rows, last sync, confidence, and owner.
+- Every agent/capability card shows status (`production`, `beta`, `shadow`, `stub`, `unavailable`, `demo`, `degraded`) and the reason for that status.
+- No card may render as a success state when its required connector is missing, stale, unauthorized, or returning demo data.
+- Primary actions are concrete: approve, reject, override, reconnect, create campaign draft, open incident room, export report, assign owner.
 
 **Tab: Pipeline** (default)
 - MQL/SQL funnel: Vertical funnel chart with numbers and conversion rates at each stage.
 - CAC trend: Line chart (12 months). Target line at company CAC goal.
 - LTV/CAC ratio: Large number with trend arrow.
 - Pipeline value: Large number with stage breakdown.
+- Data quality panel: lifecycle-stage mapping status, attribution coverage, stale CRM sync warnings, and unmapped campaigns.
 
 **Tab: Campaigns**
 - Active campaigns table: Campaign name, channel, budget, spend, impressions, clicks, conversions, ROAS. Sortable.
 - Spend vs Budget: Stacked bar chart by channel.
 - ROAS by channel: Existing bar chart with real data.
 - Campaign performance trend: Line chart of daily conversions.
+- Experiment tracker: active A/B tests, sample size, winner confidence, next decision date, and approval status.
+- Budget guardrail panel: overspend risk, policy threshold, agent recommendation, and rollback/stop action.
 
 **Tab: Content**
 - Content calendar: Monthly view with planned vs published content.
 - Top performing content: Existing table with real data from GA4 / WordPress.
 - Social engagement: Existing chart with real data from Buffer / Twitter.
 - Email metrics: Open rate, click rate, unsubscribe rate with trends.
+- Editorial queue: draft, review, approved, scheduled, and published states with owner and due date.
+- Content quality panel: SEO score, brand-policy flags, legal-risk flags, and post-publish feedback.
 
 **Tab: ABM**
 - Target accounts table: Company name, intent score (Bombora), engagement score, pipeline stage. Sortable.
 - Intent heatmap: Topic x Company matrix with surge scores.
 - ABM pipeline: Pipeline value from ABM-tagged accounts.
 - Multi-touch attribution: Pie chart showing channel contributions.
+- Account drill-down: score decomposition, signal sources, CRM owner, last engagement, next best action, and sync status.
 
 **Tab: Brand**
 - Brand sentiment gauge: Existing gauge with real data from Brandwatch.
 - Share of voice: Donut chart (brand vs competitors).
 - Media mentions: Timeline chart with daily mention count.
 - Competitor tracking: Table with competitor name, sentiment, SOV, recent activity.
+- Crisis room: severity, evidence, baseline comparison, assigned owner, response draft, approval status, and escalation trail.
 
 ### 6.5 COO Dashboard (NEW `COODashboard.tsx`)
 
@@ -3317,10 +3505,12 @@ For each of the 6 KPI endpoints, test:
 
 For each of the 54 connectors, test:
 
+These tests use contract test doubles only to make CI deterministic. They do not count as production readiness. Every production connector also needs setup validation, health checks, and either real vendor-sandbox proof or pilot-tenant proof before customer rollout.
+
 | Test Category | Test Count per Connector | Total |
 |---------------|-------------------------|-------|
-| Auth flow (mock) | 1 | 54 |
-| Each tool function (mock external API) | 2-8 (varies) | ~300 |
+| Auth flow with contract test double | 1 | 54 |
+| Each tool function with contract test double | 2-8 (varies) | ~300 |
 | Error handling (timeout, 401, 500) | 3 | 162 |
 | Rate limiting | 1 | 54 |
 | Health check | 1 | 54 |
@@ -3330,11 +3520,11 @@ For each of the 54 connectors, test:
 
 | Test | Description | Components Involved |
 |------|-------------|-------------------|
-| `test_cfo_dashboard_real_data_pipeline` | CFO API -> FPA agent -> Tally connector -> Mock Tally -> KPI cache -> API response | API, agent, connector, cache |
-| `test_chro_dashboard_real_data_pipeline` | CHRO API -> Payroll agent -> Darwinbox connector -> Mock Darwinbox -> KPI cache -> API | API, agent, connector, cache |
-| `test_cmo_dashboard_real_data_pipeline` | CMO API -> Campaign agent -> HubSpot connector -> Mock HubSpot -> KPI cache -> API | API, agent, connector, cache |
-| `test_coo_dashboard_real_data_pipeline` | COO API -> IT Ops agent -> PagerDuty connector -> Mock PagerDuty -> KPI cache -> API | API, agent, connector, cache |
-| `test_cbo_dashboard_real_data_pipeline` | CBO API -> Legal Ops agent -> DocuSign connector -> Mock DocuSign -> KPI cache -> API | API, agent, connector, cache |
+| `test_cfo_dashboard_real_data_pipeline` | CFO API -> FPA agent -> Tally connector -> Tally contract test double -> KPI cache -> API response | API, agent, connector, cache |
+| `test_chro_dashboard_real_data_pipeline` | CHRO API -> Payroll agent -> Darwinbox connector -> Darwinbox contract test double -> KPI cache -> API | API, agent, connector, cache |
+| `test_cmo_dashboard_real_data_pipeline` | CMO API -> Campaign agent -> HubSpot connector -> HubSpot contract test double -> KPI cache -> API | API, agent, connector, cache |
+| `test_coo_dashboard_real_data_pipeline` | COO API -> IT Ops agent -> PagerDuty connector -> PagerDuty contract test double -> KPI cache -> API | API, agent, connector, cache |
+| `test_cbo_dashboard_real_data_pipeline` | CBO API -> Legal Ops agent -> DocuSign connector -> DocuSign contract test double -> KPI cache -> API | API, agent, connector, cache |
 | `test_ceo_dashboard_aggregation` | CEO API -> All 5 CxO agent results -> Aggregation -> API response | API, 5 agents, cache |
 | `test_invoice_processing_workflow` | Invoice upload -> AP agent -> GSTN + Tally -> Match -> Post -> Notify | Workflow engine, agent, 3 connectors |
 | `test_bank_recon_workflow` | Daily trigger -> Recon agent -> AA + Tally -> Match -> Report | Workflow engine, agent, 2 connectors |
@@ -3657,9 +3847,9 @@ Note: Combined with existing test suite (~2,500 tests), total reaches **~4,000 t
 **New sections to add to `Landing.tsx`:**
 
 1. **Role-Specific Sections:**
-   - "For CHROs" section: Headcount dashboard mockup, payroll automation stats, compliance calendar
-   - "For COOs" section: Incident dashboard mockup, support deflection stats, vendor management
-   - "For CBOs" section: Contract review mockup, compliance scoring, board meeting management
+   - "For CHROs" section: Real dashboard screenshot or clearly labeled illustrative preview, payroll automation stats, compliance calendar
+   - "For COOs" section: Real incident dashboard screenshot or clearly labeled illustrative preview, support deflection stats, vendor management
+   - "For CBOs" section: Real contract review screenshot or clearly labeled illustrative preview, compliance scoring, board meeting management
    - (CFO and CMO sections already exist -- update with new dashboard screenshots)
 
 2. **"For Enterprise" Section:**
@@ -3764,7 +3954,7 @@ Note: Combined with existing test suite (~2,500 tests), total reaches **~4,000 t
   14. `contract_intelligence` -- Contract lifecycle
   15. `risk_sentinel` -- Risk scoring + fraud detection
   16. `compliance_guard` -- Compliance scoring + deadline tracking
-  17-25. Remaining agents (competitive_intel, email_agent, expense_manager, fixed_assets_agent, nexus_orchestrator, notification_agent, rev_rec_agent, sales_agent, social_media, treasury_agent)
+  17-25. Remaining or appendix-only agents (email_agent, expense_manager, fixed_assets_agent, nexus_orchestrator, notification_agent, rev_rec_agent, sales_agent, treasury_agent); Competitive Intel now has first-class beta CMO coverage, not production proof
 - [ ] Write unit tests for remaining agents (~540 tests)
 
 **Week 8:**
@@ -3812,7 +4002,9 @@ Note: Combined with existing test suite (~2,500 tests), total reaches **~4,000 t
 
 **Week 12:**
 - [ ] Customer pilot preparation:
-  - Set up demo tenant with sample data
+  - Set up an explicitly labeled demo tenant for sales/demo flows only; it must never be used as production-readiness proof
+  - Set up pilot tenant with real or vendor-sandbox connector credentials and connected marketing/finance/HR/ops data
+  - Generate and attach the redacted CMO pilot proof bundle; demo and test-double bundles must remain `demo_only` or `test_only`
   - Create onboarding runbook for pilot customers
   - Configure monitoring and alerting for pilot
 - [ ] Deploy to production (GCP)
@@ -3898,6 +4090,8 @@ Note: Combined with existing test suite (~2,500 tests), total reaches **~4,000 t
 
 ### Appendix A. Complete Agent Registry
 
+Registration alone is not a production-readiness claim. For current CMO truth labels, use the CMO capability table in Section 2.4: Campaign Pilot is production; Content Factory, Email Marketing, Social Media, ABM, Competitive Intel, Brand Monitor, SEO Strategist, and CRM Intelligence are beta. Every CMO marketing-agent pillar now has first-class deterministic beta code in `core/agents/marketing`; production claim still requires real-vendor pilot proof.
+
 | # | Agent Type | Domain | Prompt File | Confidence Floor | HITL Conditions | Authorized Tools |
 |---|-----------|--------|-------------|-----------------|-----------------|-----------------|
 | 1 | `ap_processor` | finance | `ap_processor.prompt.txt` | 0.88 | amount > 500K, match delta > 2%, vendor risk > 7, confidence < 0.88 | tally.post_voucher, tally.get_ledger_balance, gstn.generate_einvoice_irn, banking_aa.fetch_bank_statement, sendgrid.send_email |
@@ -3914,7 +4108,7 @@ Note: Combined with existing test suite (~2,500 tests), total reaches **~4,000 t
 | 12 | `offboarding_agent` | hr | `offboarding_agent.prompt.txt` | 0.95 | F&F > 5L, access not revoked in 24h, F&F dispute | darwinbox.terminate_employee, okta.deactivate_user, slack.remove_user, jira.create_issue, epfo.check_claim_status, docusign.send_envelope, sendgrid.send_email |
 | 13 | `campaign_pilot` | marketing | `campaign_pilot.prompt.txt` | 0.85 | daily spend > 120% budget, ROAS < 1.5x, new campaign > 1L | google_ads.search_campaigns, google_ads.get_campaign_performance, google_ads.mutate_campaign_budget, meta_ads.get_campaign_insights, linkedin_ads.get_campaign_analytics, hubspot.create_contact |
 | 14 | `content_factory` | marketing | `content_factory.prompt.txt` | 0.82 | competitor mention in blog, email > 10K recipients, product launch video | wordpress.create_post, wordpress.get_posts, buffer.create_post, buffer.get_analytics, youtube.upload_video, mailchimp.create_campaign |
-| 15 | `seo_strategist` | marketing | `seo_strategist.prompt.txt` | 0.85 | (none -- advisory only) | ahrefs.get_backlinks, ahrefs.get_keywords, ahrefs.get_site_audit, ga4.get_report |
+| 15 | `seo_strategist` | marketing | `seo_strategist.prompt.txt` | 0.84 | technical site changes require policy approval, audit, connector write safety, and confirmed write evidence | ahrefs.get_backlinks, ahrefs.get_keywords, ahrefs.get_site_audit, ga4.get_report, wordpress.apply_seo_site_change, google_search_console.submit_url_to_index |
 | 16 | `brand_monitor` | marketing | `brand_monitor.prompt.txt` | 0.82 | negative sentiment > 3x baseline (crisis), competitor campaign detected | brandwatch.get_mentions, brandwatch.get_sentiment, brandwatch.get_competitors, twitter.search_mentions |
 | 17 | `crm_intelligence` | marketing | `crm_intelligence.prompt.txt` | 0.85 | target list change > 20%, ABM budget > 50K/month | bombora.get_surge_scores, bombora.search_companies, g2.get_buyer_intent, trustradius.get_intent, hubspot.list_companies, hubspot.update_contact, linkedin_ads.get_campaign_analytics |
 | 18 | `it_operations` | ops | `it_operations.prompt.txt` | 0.88 | P1 not ack'd in 5min, change to production, uptime < 99.5%, MTTR > 60min for P1 | pagerduty.create_incident, pagerduty.acknowledge_incident, pagerduty.resolve_incident, pagerduty.get_on_call, pagerduty.list_incidents, pagerduty.create_postmortem, servicenow.create_incident, servicenow.submit_change_request, servicenow.check_sla_status, jira.create_issue, jira.search_issues |
@@ -4439,16 +4633,16 @@ Every agent mentioned in Section 2 (CxO Role Definitions) must appear in Appendi
 | `risk_sentinel` | 2.1.1H, 2.5.7, 2.6.2, 2.6.5 (CEO, COO, CBO) | #25 | Back Office Domain Agents | Yes |
 | `facilities_agent` | 2.5.4 (COO) | #26 | Back Office Domain Agents | Yes |
 | `email_agent` | Mentioned in Appendix only | #27 | Not in 3.2.2 tables | **GAP -- Added below** |
-| `social_media` | Mentioned in Appendix only | #28 | Not in 3.2.2 tables | **GAP -- Added below** |
+| `social_media` | 2.4.5 (CMO Social Media) | #28 | Marketing Domain Agents | Beta first-class core agent; not production without connector/write/policy/audit/pilot proof |
 | `expense_manager` | Mentioned in Appendix only | #29 | Not in 3.2.2 tables | **GAP -- Added below** |
 | `fixed_assets_agent` | Mentioned in Appendix only | #30 | Not in 3.2.2 tables | **GAP -- Added below** |
 | `rev_rec_agent` | Mentioned in Appendix only | #31 | Not in 3.2.2 tables | **GAP -- Added below** |
 | `treasury_agent` | Mentioned in Appendix only | #32 | Not in 3.2.2 tables | **GAP -- Added below** |
 | `sales_agent` | Mentioned in Appendix only | #33 | Not in 3.2.2 tables | **GAP -- Added below** |
-| `competitive_intel` | Mentioned in Appendix only | #34 | Not in 3.2.2 tables | **GAP -- Added below** |
+| `competitive_intel` | Appendix plus CMO beta implementation | #34 | First-class beta core marketing agent | **Implemented beta -- not production without connector/write, policy, approval, audit, and pilot proof** |
 | `notification_agent` | Mentioned in Appendix only | #35 | Not in 3.2.2 tables | **GAP -- Added below** |
 
-**Agents 27-35 Domain Logic (fills the gap from Section 3.2.2):**
+**Agents 27-35 Target Domain Logic:** These rows describe intended behavior. Social Media, ABM, Competitive Intel, Brand Monitor, and SEO Strategist now have beta first-class `core/agents/marketing` implementations and tests, but that still does not prove production readiness without real connector/write, policy, approval, audit, and pilot evidence.
 
 | Agent | Pre-Processing | Domain Rules | Tool Selection | Post-Processing | Confidence Floor |
 |-------|---------------|--------------|----------------|-----------------|-----------------|

--- a/docs/STRICT_CMO_AGENTIC_EXECUTION_BACKLOG_2026-05-23.md
+++ b/docs/STRICT_CMO_AGENTIC_EXECUTION_BACKLOG_2026-05-23.md
@@ -1,0 +1,1904 @@
+# Strict CMO Agentic Execution Backlog
+
+Date: 2026-05-23
+Source review: root workspace CMO review moved into this local AgenticOrg task
+Purpose: convert the CMO autonomy gap review into a strict local execution backlog for Codex CLI tasks
+Status: CMO-1.1, CMO-1.2, CMO-1.3, CMO-2.1, CMO-3.1, CMO-3.2, CMO-3.3, CMO-4.1, CMO-4.2, CMO-4.3, CMO-5.1, CMO-5.2, CMO-5.3, CMO-5.4, CMO-6.1, CMO-6.2, CMO-6.3, CMO-7.1, CMO-7.2, CMO-7.3, CMO-8.1, CMO-8.2, CMO-8.3, CMO-9.1, CMO-9.2, CMO-9.3, and CMO-9.4 complete; CMO-PROD-1 (weekly-report pilot-evidence validation path), CMO-PROD-2 (durable persistence + report-task wiring), and CMO-PROD-3 (sandbox walk-through runner with fail-closed preflight) complete in code; CMO-PROD-3-DB-LOCAL (local Postgres setup) completed 2026-05-24 — a `pgvector/pgvector:pg16` container `agenticorg-cmo-postgres` runs on host port 5433, the `weekly_report_pilot_proofs` table exists, `alembic_version` is stamped at `v4917_weekly_report_proof`, the table has **0 rows** (no fake / synthetic proof inserted), and the CMO-PROD-3 preflight's database blocker is resolved; remaining CMO-PROD-3 blockers are QA-owned (`AGENTICORG_CMO_SANDBOX_TENANT_ID` + one connector group per CRM/Ads/Analytics/Email category — see CMO-PROD-3 "Local DB setup status" for the exact QA command sequence). Remaining work is live sandbox/vendor execution, real-vendor pilot evidence capture, and a CMO-PROD UI surface.
+
+## Target State
+
+AgenticOrg should be able to run the CMO organization through agents, with humans involved only at explicit policy gates such as high-risk copy, budget changes, legal claims, crisis escalation, and executive approval.
+
+## Brutal Current Status
+
+CMO autonomous operations capability today: **40/100**.
+
+What is production-credible or beta-implemented now: **7.5 of 9 CMO agent pillars** (Campaign Pilot is production; Content Factory, Email Marketing, Brand Monitor, SEO Strategist, CRM Intelligence, Social Media, ABM, and Competitive Intel are beta).
+
+- Stronger: Campaign Pilot, Content Factory
+- Partial/minimal: Email Marketing through a separate LangGraph path
+- New beta first-class core agents: Social Media, ABM, Competitive Intel, Brand Monitor, SEO Strategist, CRM Intelligence
+- CMO-WS-3 first-class agent buildout and CMO-WS-4 wrapper deepening are both complete at beta status; production proof is still absent
+
+This is not ready to claim "CMO org fully run by agents." Every marketing-agent pillar in `core/agents/marketing` now has first-class deterministic code, but production claim requires real-vendor pilot proof, persistent evidence storage, and vendor adapter rollout — none of which is delivered by the deepening tasks alone.
+
+## Evidence-Based Gaps
+
+## 1. Agent Coverage Gap
+
+Claimed in `docs/cmo_guide.md`: 9 marketing agents with broad capabilities and strict HITL behavior.
+
+Implemented in `core/agents/marketing` (as of 2026-05-24):
+
+- `campaign_pilot.py`: substantial logic (production)
+- `content_factory.py`: substantial logic (beta)
+- `brand_monitor.py`: first-class beta brand monitoring logic (CMO-4.1)
+- `seo_strategist.py`: first-class beta SEO logic (CMO-4.2)
+- `crm_intelligence.py`: first-class beta CRM/pipeline intelligence logic (CMO-4.3)
+
+No CMO-WS-3 or CMO-WS-4 pillar remains as a wrapper or stub-only marketing agent. Brand Monitor, SEO Strategist, CRM Intelligence, Social Media, ABM, and Competitive Intel have first-class deterministic beta core logic with policy/approval/audit/external-write-confirmation safety gates.
+
+Impact: AgenticOrg cannot honestly sell or demo a fully autonomous CMO organization while beta Brand Monitor, SEO Strategist, CRM Intelligence, Social Media, ABM, and Competitive Intel lack real-vendor pilot proof, persistent evidence stores, and vendor-adapter rollout. The honest claim today is "every CMO agent pillar has first-class deterministic beta code with safety gates; production claims still require pilot proof."
+
+## 2. Workflow-To-Agent Mismatch Gap
+
+Marketing workflows reference agent types such as `social_media`, `abm_agent`, and `competitive_intel`. All three now have first-class beta core logic, while production workflow activation still depends on connector/write, policy, approval, escalation, audit, and pilot-proof evidence.
+
+Impact: workflows can appear complete while execution either falls back to generic behavior or lacks domain-specific outputs.
+
+## 3. Functional Depth Gap
+
+Campaign Pilot is the strongest current marketing agent.
+
+Current strengths:
+
+- Budget allocation logic
+- Channel performance polling
+- ROAS-driven pause/scale actions
+- HITL triggers for high-budget scenarios
+
+Remaining gaps:
+
+- Robust attribution model strategy
+- Rollback/safe-mode orchestration
+- Policy controls by spend tier, region, and product
+
+Content Factory is useful but incomplete.
+
+Current strengths:
+
+- LLM content generation
+- Brand and compliance checks
+- WordPress and Buffer scheduling hooks
+
+Remaining gaps:
+
+- Formal content QA rubric with graded publish gates
+- Stronger brand policy framework beyond brittle keyword checks
+- Draft to approval to publish to performance feedback loop
+
+Brand Monitor now has deterministic beta domain logic for mention aggregation, sentiment trends, spike detection, false-positive suppression, crisis classification, playbook recommendation, escalation, and safety-gated response actions. SEO Strategist now has deterministic beta domain logic for keyword gaps, ranking deltas, technical issue prioritization, recommendation bundling, content optimization, sprint planning, and safety-gated site changes. CRM Intelligence is not yet a CMO-grade operator; its local file still mostly defers to shared/base behavior instead of owning domain-specific execution.
+
+## 4. Testing And Reliability Gap
+
+Missing proof for "fully by agents":
+
+- End-to-end regression packs for each CMO workflow
+- Connector contract tests plus real connector or vendor-sandbox proof for production paths
+- Failure injection for API outages, stale channel data, approval timeout, malformed payloads, and budget overspend races
+- Golden KPI datasets across channels and CRM outcomes
+
+## 5. Governance Gap
+
+A real CMO agent org needs machine-checkable operating policy:
+
+- Budget authority matrix by role, channel, threshold, and region
+- Legal/compliance rules per channel and geography
+- Escalation matrix and SLA clocks
+- Approval timeout behavior, the broader marketing policy manifest, escalation matrix, and structured decision audit package are now code-backed for CMO workflows.
+- Persistent audit storage/UI remains open beyond the CMO-6.3 package object.
+
+Current HITL pieces are not yet a full CMO operating policy layer.
+
+## 6. Measurement Gap
+
+AgenticOrg needs a CMO agent scorecard:
+
+- Pipeline contribution quality
+- Experiment throughput
+- Forecast accuracy
+- Creative quality index
+- Autonomous decision cost
+- Human override rate
+- SLA adherence
+
+Without this, the CMO agent org cannot be managed like a real department.
+
+## Program Rules
+
+1. No CMO agent may ship as production-ready if it only wraps shared/base execution.
+2. Every workflow `agent_type` and `action` must resolve to implemented, tested behavior.
+3. Any budget, publishing, claim-making, crisis-response, or customer-facing action must pass HITL policy.
+4. KPI claims must be derived from canonical formulas and source-of-truth priority rules.
+5. Dashboard labels must distinguish production, beta, stub, unavailable, and demo states.
+6. No customer-facing production tenant may use mocks, sample arrays, hardcoded KPI values, or fake connector success as a substitute for real configured data.
+7. Test doubles are allowed only inside automated tests and local harnesses. They are not production proof.
+8. Every task below must include proof: tests, changed files, behavior notes, real-data path, and known residual risk.
+
+## Global Definition Of Done
+
+This backlog is done only when all of the following are true:
+
+- All 9 CMO agents have domain-specific production logic.
+- No marketing agent in `core/agents/marketing` is merely a pass-through wrapper.
+- Core CMO workflows pass deterministic end-to-end tests with contract test doubles and separate production-readiness proof against real connectors, vendor sandboxes, or pilot tenant integrations.
+- Failure scenarios are tested for each high-risk workflow.
+- HITL policies are explicit, enforceable, and audited.
+- KPI calculations are canonical, reconciled, and freshness-aware.
+- CMO dashboards truthfully label capability maturity and confidence.
+- A weekly autonomous CMO runbook can execute with measurable SLA and quality thresholds.
+- A real-company onboarding path exists: connect systems, validate scopes, map fields, configure policy, backfill data, run shadow mode, and promote workflows individually.
+- Production CMO surfaces never silently fall back to demo data, stubs, or mock connector results.
+- The CMO UX is good enough for daily marketing work: work queue, approvals, drill-downs, data lineage, connector health, confidence, freshness, and clear next actions.
+
+## Sequenced Workstreams
+
+Execution order is mandatory unless dependencies are formally reworked.
+
+| Workstream | Priority | Purpose |
+| --- | --- | --- |
+| CMO-WS-0 PRD And Product Reality Gate | P0 | Replan the CMO PRD around real companies, real connectors, and excellent operator UX |
+| CMO-WS-1 Enterprise Onboarding And Data Foundation | P0 | Build real-company setup: connectors, field mapping, policies, backfill, shadow mode |
+| CMO-WS-2 Real Connector Readiness | P0 | Ensure marketing connectors have setup UI, health, scopes, sync, retries, and degraded states |
+| CMO-WS-3 Missing Agent Buildout | P0 | Social Media, ABM, and Competitive Intel beta complete; production proof still required |
+| CMO-WS-4 Wrapper Agent Deepening | P0 | Brand Monitor and SEO Strategist beta complete; upgrade CRM Intelligence |
+| CMO-WS-5 Workflow Integrity | P0 | Ensure every workflow reference maps to implemented behavior and confirmed external writes |
+| CMO-WS-6 Governance OS | P0 | Encode budget, legal, approval, escalation, audit, rollback, and timeout policy |
+| CMO-WS-7 KPI Trust Layer | P0 | Canonicalize marketing metrics, reconciliation, freshness, and data lineage |
+| CMO-WS-8 CMO UX Workbench | P0 | Build a serious marketing cockpit, not decorative status cards |
+| CMO-WS-9 Test Hardening And Pilot Proof | P0 | Add contract, E2E, failure-injection, and pilot-readiness evidence |
+
+## CMO-WS-0 PRD And Product Reality Gate
+
+### CMO-0.1 Replan PRD For Real CMO Departments
+
+Priority: P0
+
+Objective: replan the PRD so the CMO product is designed for real companies and marketing departments, not mocks, stubs, or demo-only dashboards.
+
+Files in scope:
+
+- `docs/PRD.md`
+- `docs/cmo_guide.md`
+- `docs/PRD_CxO_v5.0.md`
+- `ui/src/pages/CMODashboard.tsx`
+- Related locale/test files if dashboard copy changes
+
+Required planning content:
+
+- Define what "production CMO" means: real tenant data, real connectors, field mapping, policies, approvals, audit, and rollback.
+- Add real-company onboarding: connector setup, scope validation, historical backfill, field mapping, policy setup, shadow mode, workflow promotion.
+- Add marketing-team personas: CMO, growth lead, RevOps/Marketing Ops, content lead, brand/comms lead, SDR/sales partner, CFO/CEO viewer.
+- Add no-mock rule: mocks and stubs are allowed only in tests/local harnesses and must never count as production readiness.
+- Add UX requirements: work queue, approvals, drill-downs, data lineage, connector health, confidence, freshness, empty/degraded states, and concrete next actions.
+- Add production gates: zero hardcoded production KPI values, zero prompt-wrapper agents marked production, no external action without connector confirmation and audit.
+
+Acceptance tests:
+
+- `npm --prefix ui test -- CMODashboard` if UI changes
+- Any existing docs or markdown lint command if configured
+- Search PRD/docs for unqualified claims that the CMO org is already fully autonomous
+
+Definition of done:
+
+- `docs/PRD.md` and `docs/PRD_CxO_v5.0.md` define real-company production requirements.
+- CMO surfaces distinguish production, beta, shadow, stub, unavailable, demo, and degraded capabilities.
+- No "fully autonomous CMO" claim remains without qualification or production proof.
+- Existing dashboard tests are updated if UI behavior changes.
+
+### CMO-0.2 Mark Current Capability Honestly In Product
+
+Priority: P0
+
+Objective: prevent product/docs/UI from implying full CMO autonomy before implementation proves it.
+
+Files in scope:
+
+- `docs/cmo_guide.md`
+- `docs/PRD_CxO_v5.0.md`
+- `ui/src/pages/CMODashboard.tsx`
+- Related locale/test files if dashboard copy changes
+
+Acceptance tests:
+
+- `npm --prefix ui test -- CMODashboard`
+- Search docs/UI for remaining unqualified CMO autonomy claims.
+
+Definition of done:
+
+- CMO UI/docs distinguish production, beta, shadow, stub, unavailable, demo, and degraded states.
+- No "fully autonomous CMO" claim remains without qualification.
+- Tests cover displayed capability states.
+
+## CMO-WS-1 Enterprise Onboarding And Data Foundation
+
+### CMO-1.1 Build Marketing Connector Setup Checklist
+
+Priority: P0
+
+Status: Complete on 2026-05-23
+
+Objective: give real companies a clear path to connect CRM, ads, analytics, CMS, email, social, SEO, brand, ABM, and finance systems.
+
+Required behavior:
+
+- Connector setup UI shows owner, account ID, scopes, health, last sync, data coverage, and reconnect action.
+- Missing connectors create actionable setup states instead of fake "healthy" cards.
+- Production tenants cannot use demo data unless explicitly marked as demo tenants.
+
+Acceptance tests:
+
+- Tests for missing connector, healthy connector, expired auth, stale sync, insufficient scope, and reconnect CTA.
+
+Completion notes:
+
+- Added a code-backed CMO marketing connector setup projection from existing `connector_configs` fields.
+- `GET /kpis/cmo` now returns `connector_setup` and `connector_setup_summary`.
+- Strict production runtimes suppress silent CMO demo KPI fallback and return `production_data_blocked: true` when no real CMO KPI data exists.
+- The CMO dashboard now shows connected, missing, stale, expired-auth, insufficient-scope, healthy, and degraded connector states with setup/reconnect/add-scope/refresh/review CTAs.
+- Tests added/updated for missing connector, healthy connector, expired auth, insufficient scope, stale sync, degraded state, reconnect/setup CTA rendering, and production tenant demo fallback suppression.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_marketing_connector_setup.py`, `python -m ruff check core\marketing\connector_setup.py api\v1\kpis.py tests\unit\test_cmo_marketing_connector_setup.py`, `npm --prefix ui test -- CMODashboard`, `npm --prefix ui test -- i18n_coverage_tripwire`, `npm --prefix ui run typecheck`, `python -m compileall core\marketing\connector_setup.py api\v1\kpis.py`, and `git diff --check`.
+
+Remaining work moves to CMO-1.3 and CMO-2.1: shadow promotion gates, live vendor-sandbox proof, and external write confirmation are not implemented by this task.
+
+### CMO-1.2 Build Marketing Field Mapping And Backfill
+
+Priority: P0
+
+Status: Complete on 2026-05-23
+
+Objective: map real customer data into canonical CMO metrics before agents can act.
+
+Required mappings:
+
+- Lifecycle stages
+- Opportunity revenue fields
+- Campaign IDs
+- UTM fields
+- Account domains
+- Consent/unsubscribe fields
+- Fiscal calendar and currency
+
+Acceptance tests:
+
+- Tests for required-field validation, partial mapping, currency/timezone handling, and backfill progress states.
+
+Completion notes:
+
+- Added a code-backed CMO marketing data readiness projection from existing `connector_configs.config` metadata.
+- Field mapping readiness now covers lifecycle stages, opportunity revenue fields, campaign IDs, UTM fields, account domains, consent/unsubscribe fields, fiscal calendar, currency, and timezone.
+- Field mapping states include `unmapped`, `partially_mapped`, `valid`, `invalid`, `stale`, and `blocked`.
+- Backfill states include `not_started`, `queued`, `running`, `completed`, `partial`, `failed`, and `blocked`, with source connector key, requested date range, available record counts, last run timestamp, blocking reason, and next action.
+- `GET /kpis/cmo` now returns `field_mapping_status`, `field_mapping_summary`, `backfill_status`, `backfill_summary`, and `kpi_readiness`.
+- Strict production runtimes now mark CMO KPI confidence blocked or degraded when required mappings/backfills are incomplete, instead of silently treating incomplete real data or demo fallback as production-ready.
+- The CMO dashboard now shows marketing data readiness before KPI cards, including mapping/backfill status, blockers, stale/partial states, and action CTAs.
+- Tests added/updated for all required mappings present, missing lifecycle mapping, missing revenue mapping, missing consent mapping, invalid currency/timezone, partial/stale mapping, completed/failed/blocked/progress backfill states, production KPI confidence blocking, and dashboard rendering.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_marketing_data_readiness.py tests\unit\test_cmo_marketing_connector_setup.py`, `python -m ruff check core\marketing\connector_setup.py core\marketing\data_readiness.py api\v1\kpis.py tests\unit\test_cmo_marketing_connector_setup.py tests\unit\test_cmo_marketing_data_readiness.py`, `python -m compileall core\marketing\connector_setup.py core\marketing\data_readiness.py api\v1\kpis.py tests\unit\test_cmo_marketing_connector_setup.py tests\unit\test_cmo_marketing_data_readiness.py`, `npm --prefix ui test -- CMODashboard`, `npm --prefix ui test -- i18n_coverage_tripwire`, `npm --prefix ui run typecheck`, and `git diff --check`.
+
+Remaining work moves to CMO-1.3, CMO-2.1, and CMO-7.1: this task does not implement shadow-mode promotion gates, live vendor-sandbox proof, external write confirmation, or canonical KPI formulas.
+
+### CMO-1.3 Add Shadow Mode Promotion Gates
+
+Priority: P0
+
+Status: Complete on 2026-05-23
+
+Objective: prevent agents from writing to external systems until a CMO promotes a workflow from shadow to active.
+
+Required behavior:
+
+- Shadow mode recommendations are read-only.
+- Promotion is per workflow, not global.
+- Promotion requires connector health, policy setup, and passing recent shadow-run quality gates.
+
+Acceptance tests:
+
+- Tests prove shadow mode cannot write externally.
+- Tests prove promotion fails if connector/policy prerequisites are missing.
+
+Completion notes:
+
+- Added a code-backed CMO workflow activation projection from existing connector setup, field mapping, backfill, and workflow metadata stored in `connector_configs.config`.
+- `GET /kpis/cmo` now returns `workflow_activation_status` and `workflow_activation_summary`.
+- Workflow states include `unavailable`, `shadow`, `promotion_blocked`, `promotion_ready`, `active`, `degraded`, and `paused`.
+- Covered workflows are `weekly_marketing_report`, `campaign_launch`, `daily_spend_optimization`, `content_pipeline`, `lead_nurture`, `social_publishing`, `abm_sprint`, `brand_crisis_response`, and `seo_sprint`.
+- Promotion is per workflow. A workflow is active only when its own activation row is explicitly promoted and connectors, mappings, backfills, approval/policy owners, and shadow-run quality gates pass.
+- Shadow, ready, blocked, degraded, paused, and unavailable states are read-only for external marketing writes. Read-only actions such as recommendation, draft, simulation, and internal approval creation remain allowed.
+- Social Publishing, ABM Sprint, Brand Crisis Response, and SEO Sprint are beta-gated and remain blocked until their required connectors, mapping/backfill, policy, approval, escalation, audit, and write-confirmation gates pass. Connector setup alone does not mark those workflow pillars production-grade.
+- The CMO dashboard now shows workflow activation state, owners, shadow quality, blockers/degraded reasons, external-write readiness, and next action before KPI cards.
+- Tests added/updated for default non-active workflow state, missing/unhealthy connector blockers, invalid mapping blockers, failed/blocked backfill blockers, missing approval/policy owner blockers, promotion-ready state, explicit active promotion, read-only shadow enforcement, per-workflow promotion isolation, degraded optional/partial data, unavailable stub workflows, and dashboard rendering.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_marketing_data_readiness.py tests\unit\test_cmo_marketing_connector_setup.py`, `python -m ruff check core\marketing\connector_setup.py core\marketing\data_readiness.py core\marketing\workflow_activation.py api\v1\kpis.py tests\unit\test_cmo_marketing_connector_setup.py tests\unit\test_cmo_marketing_data_readiness.py tests\unit\test_cmo_workflow_activation.py`, `python -m compileall core\marketing\connector_setup.py core\marketing\data_readiness.py core\marketing\workflow_activation.py api\v1\kpis.py tests\unit\test_cmo_marketing_connector_setup.py tests\unit\test_cmo_marketing_data_readiness.py tests\unit\test_cmo_workflow_activation.py`, `npm --prefix ui test -- CMODashboard`, `npm --prefix ui test -- i18n_coverage_tripwire`, `npm --prefix ui run typecheck`, `git diff --check`, and claim search for unqualified CMO autonomy language.
+
+Remaining work moves to CMO-2.1, CMO-5.3, CMO-6.2/CMO-6.3, and missing production agents: this task does not implement external write confirmation, escalation matrices, decision audit packages, or missing production agents.
+
+## CMO-WS-2 Real Connector Readiness
+
+### CMO-2.1 Marketing Connector Contract Hardening
+
+Priority: P0
+
+Status: Complete on 2026-05-23
+
+Objective: harden connector adapters so CMO agents can rely on real data and confirmed writes.
+
+Required behavior:
+
+- Read/write permission separation.
+- `last_sync_at`, `source_account_id`, `source_object_id`, and `source_url` where available.
+- Idempotency keys for write actions.
+- Retry budgets and explicit degraded output on failures.
+- External write confirmation before workflow step is marked complete.
+
+Acceptance tests:
+
+- Contract tests for success, 401/expired auth, 403/insufficient scope, 429/rate limit, 5xx, partial data, stale data, and duplicate write retry.
+
+Completion notes:
+
+- Added `core.marketing.connector_contracts`, a code-backed marketing connector contract projection from existing connector setup and connector configuration metadata.
+- Contract rows distinguish read capabilities, write capabilities, required read scopes, required write scopes, granted scopes, missing scopes, auth status, health status, contract state, read readiness, write readiness, data freshness/TTL, retry budget metadata, idempotency-key support, source object refs, degraded-mode reason, and external write confirmation status.
+- Contract states now cover `healthy`, `missing_scope`, `auth_expired`, `rate_limited`, `timeout`, `vendor_5xx`, `partial_data`, `stale_data`, `degraded`, `write_unconfirmed`, and `write_confirmed`.
+- A connector with read access alone is not write-ready. Missing write scopes, missing idempotency proof, expired auth, stale data, partial data, rate limits, timeouts, vendor 5xx, or mock/test-double proof block or degrade production readiness instead of passing silently.
+- Added write-completion and retry helpers so active workflow write steps cannot be marked complete without an external write confirmation, while shadow/draft/internal-only modes can remain internal without pretending a vendor write happened.
+- `GET /kpis/cmo` now returns `connector_contracts` and `connector_contract_summary`; strict production runtimes block CMO production confidence when connector contracts are blocked or based on mock/test proof, and degrade confidence when connector contracts are degraded.
+- Workflow activation now consumes connector contract rows. Workflows that require external writes are blocked until the required connector category has a write-ready contract; read-ready connector contracts are also required for required connector categories.
+- Marketing connector setup and KPI readiness now downgrade stale/partial/degraded contract states so stale or partial connector data cannot produce fake healthy KPI readiness.
+- The CMO dashboard now renders a connector contract table before mapping/backfill readiness, including read/write readiness, auth/freshness, retry/idempotency state, external write confirmation, degraded reasons, mock-proof warnings, and setup/reconnect/add-scope/retry/idempotency CTAs.
+- Tests added/updated for read-only connectors not being write-ready, missing write scopes blocking workflow readiness, expired auth blocking readiness, rate-limit/timeout/vendor-5xx degraded states with retry metadata, partial/stale data downgrading KPI readiness, write-confirmation requirements, confirmed writes completing, idempotent duplicate retry planning, and mock/test proof not satisfying production readiness.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_marketing_connector_contracts.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_marketing_data_readiness.py tests\unit\test_cmo_marketing_connector_setup.py tests\unit\test_workflow_no_false_success.py`, `python -m ruff check core\marketing\connector_setup.py core\marketing\data_readiness.py core\marketing\workflow_activation.py core\marketing\connector_contracts.py api\v1\kpis.py workflows\step_types.py workflows\step_results.py tests\unit\test_cmo_marketing_connector_setup.py tests\unit\test_cmo_marketing_data_readiness.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_marketing_connector_contracts.py tests\unit\test_workflow_no_false_success.py`, `python -m compileall core\marketing\connector_setup.py core\marketing\data_readiness.py core\marketing\workflow_activation.py core\marketing\connector_contracts.py api\v1\kpis.py workflows\step_types.py workflows\step_results.py tests\unit\test_cmo_marketing_connector_setup.py tests\unit\test_cmo_marketing_data_readiness.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_marketing_connector_contracts.py tests\unit\test_workflow_no_false_success.py`, `npm --prefix ui test -- CMODashboard`, `npm --prefix ui test -- i18n_coverage_tripwire`, `npm --prefix ui run typecheck`, `git diff --check`, and claim search for unqualified CMO autonomy language.
+- No dedicated markdown/docs lint script is configured in `ui/package.json`; no root `package.json` exists in this worktree.
+
+Remaining work moves to CMO-5.3, CMO-6.2/CMO-6.3, and the agent production-proof/deepening tracks: this task does not implement full vendor write execution for every connector, escalation matrices, decision audit packages, canonical KPI formulas, or Social Media/ABM/Competitive Intel production proof.
+
+## CMO-WS-3 Missing Agent Buildout
+
+### CMO-3.1 Create Social Media Agent
+
+Priority: P0
+
+Status: Complete on 2026-05-24
+
+Objective: add a first-class Social Media agent with domain-specific execution.
+
+Files in scope:
+
+- `core/agents/marketing/social_media.py`
+- `core/agents/marketing/__init__.py`
+- Agent registry files
+- Prompt files if this repo uses prompt-backed agent registration
+- Unit tests under `tests/`
+
+Required behavior:
+
+- Content calendar generation
+- Posting schedule optimization
+- Engagement triage
+- Escalation rules for sensitive replies, claims, pricing, legal, crisis, and executive mentions
+- HITL gate for high-risk replies and publish actions
+
+Acceptance tests:
+
+- Add focused pytest coverage for each action path.
+- Run the smallest relevant pytest command for marketing agents.
+
+Definition of done:
+
+- Agent is registered and callable by the same `agent_type` used in workflows.
+- Tests prove happy path, risky-content HITL, malformed input, and connector failure behavior.
+
+Implementation summary:
+
+- Added `core.agents.marketing.social_media`, a first-class beta Social Media agent registered under `agent_type="social_media"` with deterministic domain actions for content calendar generation, posting schedule optimization, engagement triage, reply risk classification, social post drafting, and guarded post/reply publishing paths.
+- Social Media outputs now follow the CMO agent contract shape: status, confidence, rationale, recommended actions, source refs, policy result/ref, approval/HITL flags, escalation refs where required, audit refs/packages, degraded/blocker reasons, and external-write refs only when a write confirmation exists.
+- Publishing and replying fail closed unless the workflow is active, the Social connector is write-safe, policy and approval requirements are satisfied, decision-audit evidence exists, and the external write is confirmed with vendor object evidence. Shadow, draft, and internal-only modes remain read-only and cannot execute external writes.
+- Social Media is registered in the agent loader, reflected in `core.marketing.agent_contracts` as beta/non-production, recognized by workflow linting and workflow activation, and integrated with marketing policy, approval timeout, escalation, audit, connector/write-readiness, and pilot-proof truth labels.
+- Tests cover content calendar generation, schedule optimization, engagement triage classifications, high-risk reply approval/escalation, shadow read-only behavior, connector/write-safety blockers, unconfirmed-write blocking, confirmed-write completion, contract output shape, workflow linter behavior, workflow activation gating, and pilot-proof non-production truth.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_social_media_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_pilot_proof.py -q --tb=short`, `python -m ruff check core\agents\marketing\social_media.py core\agents\__init__.py core\marketing\agent_contracts.py core\marketing\workflow_linter.py core\marketing\workflow_activation.py core\marketing\policy_manifest.py core\marketing\approval_timeouts.py core\marketing\pilot_proof.py tests\unit\test_cmo_social_media_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_pilot_proof.py`, `python -m compileall core\agents\marketing\social_media.py core\agents\__init__.py core\marketing\agent_contracts.py core\marketing\workflow_linter.py core\marketing\workflow_activation.py core\marketing\policy_manifest.py core\marketing\approval_timeouts.py core\marketing\pilot_proof.py tests\unit\test_cmo_social_media_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_pilot_proof.py`, and `git diff --check`.
+
+Remaining work:
+
+- Social Media remains beta, not production: no live vendor credentials, vendor-specific production adapters, persistent evidence store, or real-vendor pilot proof was added.
+- ABM is completed as beta by CMO-3.2; Competitive Intel is completed as beta by CMO-3.3.
+- Brand Monitor is completed as beta by CMO-4.1; SEO Strategist is completed as beta by CMO-4.2; CRM Intelligence is completed as beta by CMO-4.3 (production claim still requires real-vendor pilot proof).
+
+### CMO-3.2 Create ABM Agent
+
+Priority: P0
+
+Status: Complete on 2026-05-24
+
+Objective: add a first-class ABM agent for account scoring and next-best-action planning.
+
+Files in scope:
+
+- `core/agents/marketing/abm_agent.py`
+- `core/agents/marketing/__init__.py`
+- Agent registry files
+- Tests under `tests/`
+
+Required behavior:
+
+- Account scoring using Bombora, G2, TrustRadius, CRM, and CSV inputs where available
+- Configurable scoring weights
+- ICP fit scoring
+- Intent heat scoring
+- Next-best-action output
+- CSV account ingest validation
+
+Acceptance tests:
+
+- Tests for weighting math, threshold alerts, missing fields, malformed CSV, and deterministic NBA output.
+
+Definition of done:
+
+- ABM agent is registered and workflow-addressable.
+- Outputs include score, rationale, confidence, and recommended action.
+
+Implementation completed:
+
+- Added `core.agents.marketing.abm_agent`, a first-class beta ABM agent registered under `agent_type="abm"` with deterministic account scoring, ICP fit scoring, intent heat scoring, configurable Bombora/G2/TrustRadius/CRM-style weighting, engagement aggregation, next-best-action planning, CSV account ingest validation, high-intent alerts, and guarded target-list/campaign/budget write paths.
+- Updated ABM contract, workflow lint, workflow activation, policy manifest, approval-timeout, escalation, decision-audit, and pilot-proof metadata so ABM is known and beta, not unavailable, while production writes remain blocked without connector write safety, policy approval, escalation/audit evidence, write confirmation, and pilot proof.
+- Tests cover ABM scoring, weighting math, ICP fit, intent heat, next-best action, CSV happy/invalid paths, high-intent alerting, target-list approval, budget approval/escalation, shadow read-only behavior, unsafe connector blocking, unconfirmed-write blocking, confirmed-write evidence, contract shape, workflow linter status, activation gating, and pilot-proof non-production truth.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_abm_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_pilot_proof.py tests\unit\test_cmo_e2e_scenarios.py -q --tb=short`, `python -m ruff check core\agents\marketing\abm_agent.py core\agents\__init__.py core\marketing\agent_contracts.py core\marketing\workflow_linter.py core\marketing\workflow_activation.py core\marketing\policy_manifest.py core\marketing\approval_timeouts.py core\marketing\escalation_matrix.py core\marketing\decision_audit.py core\marketing\pilot_proof.py tests\unit\test_cmo_abm_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_pilot_proof.py tests\unit\test_cmo_e2e_scenarios.py`, `python -m compileall core\agents\marketing\abm_agent.py core\agents\__init__.py core\marketing\agent_contracts.py core\marketing\workflow_linter.py core\marketing\workflow_activation.py core\marketing\policy_manifest.py core\marketing\approval_timeouts.py core\marketing\escalation_matrix.py core\marketing\decision_audit.py core\marketing\pilot_proof.py tests\unit\test_cmo_abm_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_pilot_proof.py tests\unit\test_cmo_e2e_scenarios.py`, and `git diff --check`.
+
+Remaining work:
+
+- ABM remains beta, not production: no live ABM/CRM/Ads vendor credentials, vendor-specific production write adapters, persistent evidence store, or real-vendor pilot proof was added.
+- Competitive Intel is completed as beta by CMO-3.3.
+- Brand Monitor is completed as beta by CMO-4.1; SEO Strategist is completed as beta by CMO-4.2; CRM Intelligence is completed as beta by CMO-4.3 (production claim still requires real-vendor pilot proof).
+
+### CMO-3.3 Create Competitive Intel Agent
+
+Priority: P0
+
+Status: Complete on 2026-05-24
+
+Objective: add a first-class Competitive Intel agent for market monitoring and competitive alerts.
+
+Files in scope:
+
+- `core/agents/marketing/competitive_intel.py`
+- `core/agents/marketing/__init__.py`
+- Agent registry files
+- Tests under `tests/`
+
+Required behavior:
+
+- Weekly competitor snapshot
+- Pricing-change detection
+- Win/loss signal extraction
+- Change diffing
+- Confidence score for detected changes
+- Alerting thresholds
+
+Acceptance tests:
+
+- Tests for signal parsing, diff confidence, duplicate suppression, and alert threshold behavior.
+
+Definition of done:
+
+- Competitive Intel agent is registered and workflow-addressable.
+- Outputs are structured and auditable.
+
+Implementation completed:
+
+- Added `core.agents.marketing.competitive_intel`, a first-class beta Competitive Intel agent registered under `agent_type="competitive_intel"` with deterministic weekly competitor snapshots, profile normalization, pricing-change detection, feature/capability diffing, win/loss signal extraction, confidence scoring, duplicate suppression, alert thresholding, and positioning recommendation logic.
+- Updated Competitive Intel contract, workflow lint, workflow activation, policy manifest, approval-timeout, escalation, decision-audit, and pilot-proof metadata so Competitive Intel is known and beta, not unavailable, while production external actions remain blocked without connector write safety, policy approval, escalation/audit evidence, write confirmation, and pilot proof.
+- Tests cover weekly snapshots, profile normalization, pricing-change confidence, feature diffing, win/loss extraction, duplicate suppression, alert severity thresholds, positioning next-best actions, comparative/pricing policy requirements, major-launch/crisis escalation, degraded connector behavior, shadow read-only behavior, unsafe connector blocking, unconfirmed-write blocking, confirmed-write evidence, contract shape, workflow linter status, activation gating, and pilot-proof non-production truth.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_competitive_intel_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_pilot_proof.py -q --tb=short`, `python -m ruff check core\agents\marketing\competitive_intel.py core\agents\__init__.py core\marketing\agent_contracts.py core\marketing\workflow_linter.py core\marketing\workflow_activation.py core\marketing\policy_manifest.py core\marketing\approval_timeouts.py core\marketing\escalation_matrix.py core\marketing\decision_audit.py core\marketing\pilot_proof.py tests\unit\test_cmo_competitive_intel_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_pilot_proof.py`, `python -m compileall core\agents\marketing\competitive_intel.py core\agents\__init__.py core\marketing\agent_contracts.py core\marketing\workflow_linter.py core\marketing\workflow_activation.py core\marketing\policy_manifest.py core\marketing\approval_timeouts.py core\marketing\escalation_matrix.py core\marketing\decision_audit.py core\marketing\pilot_proof.py tests\unit\test_cmo_competitive_intel_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_pilot_proof.py`, and `git diff --check`.
+
+Remaining work:
+
+- Competitive Intel remains beta, not production: no live Brandwatch/Ahrefs/social/ads credentials, vendor-specific production adapters, persistent evidence store, or real-vendor pilot proof was added.
+- Brand Monitor is completed as beta by CMO-4.1; SEO Strategist is completed as beta by CMO-4.2; CRM Intelligence is completed as beta by CMO-4.3 (production claim still requires real-vendor pilot proof).
+
+## CMO-WS-4 Wrapper Agent Deepening
+
+### CMO-4.1 Deepen Brand Monitor
+
+Priority: P0
+
+Objective: replace wrapper behavior with explicit brand monitoring logic.
+
+Files in scope:
+
+- `core/agents/marketing/brand_monitor.py`
+- Relevant connector adapters
+- Tests under `tests/`
+
+Required behavior:
+
+- Mention aggregation
+- Sentiment trend detection
+- Spike detection
+- False-positive suppression
+- Crisis severity classification
+- Escalation playbooks
+
+Acceptance tests:
+
+- Tests for false positives, spike detection, crisis escalation, and normal-noise suppression.
+
+Status: Complete on 2026-05-24.
+
+Implementation completed:
+
+- Replaced Brand Monitor wrapper behavior with `core.agents.marketing.brand_monitor.BrandMonitorAgent`, a first-class beta marketing agent with deterministic mention aggregation, sentiment classification/trends, negative-volume spike detection, false-positive suppression, crisis severity classification, competitor/brand grouping, response playbook recommendation, and escalation recommendation.
+- Updated Brand Monitor contract, workflow lint, workflow activation, policy manifest, approval-timeout, escalation, decision-audit, and pilot-proof metadata so Brand Monitor is beta/implemented, not stub-only, while active public/crisis response remains blocked without connector write safety, policy approval, escalation/audit evidence, write confirmation, and pilot proof.
+- Tests cover grouping, sentiment distribution, spike alerts, false-positive suppression, crisis severity, competitor/brand grouping, deterministic playbooks, public/crisis approval and escalation gates, degraded connector behavior, shadow read-only behavior, unsafe connector blocking, unconfirmed-write blocking, confirmed-write evidence, contract shape, workflow linter/activation status, and pilot-proof non-production truth.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_brand_monitor_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_pilot_proof.py tests\unit\test_cmo_e2e_scenarios.py -q --tb=short`, `python -m pytest tests\unit\test_cmo_brand_monitor_agent.py -q --tb=short`, `python -m ruff check core\agents\marketing\brand_monitor.py core\marketing\agent_contracts.py core\marketing\workflow_linter.py core\marketing\workflow_activation.py core\marketing\policy_manifest.py core\marketing\approval_timeouts.py core\marketing\escalation_matrix.py core\marketing\decision_audit.py tests\unit\test_cmo_brand_monitor_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_pilot_proof.py tests\unit\test_cmo_e2e_scenarios.py`, `python -m compileall core\agents\marketing\brand_monitor.py core\marketing\agent_contracts.py core\marketing\workflow_linter.py core\marketing\workflow_activation.py core\marketing\policy_manifest.py core\marketing\approval_timeouts.py core\marketing\escalation_matrix.py core\marketing\decision_audit.py tests\unit\test_cmo_brand_monitor_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_pilot_proof.py tests\unit\test_cmo_e2e_scenarios.py`, and `git diff --check`.
+
+Remaining work:
+
+- Brand Monitor remains beta, not production: no live Brandwatch/Twitter credentials, vendor-specific production adapters, persistent evidence store, real-vendor pilot proof, or production delivery rollout was added.
+- SEO Strategist is completed as beta by CMO-4.2; CRM Intelligence is completed as beta by CMO-4.3 (production claim still requires real-vendor pilot proof).
+
+### CMO-4.2 Deepen SEO Strategist
+
+Priority: P0
+
+Objective: replace wrapper behavior with SEO analysis and recommendation logic.
+
+Files in scope:
+
+- `core/agents/marketing/seo_strategist.py`
+- Relevant connector adapters
+- Tests under `tests/`
+
+Required behavior:
+
+- Keyword gap analysis
+- Ranking deltas
+- Technical issue prioritization
+- Recommendation bundling by effort and impact
+
+Acceptance tests:
+
+- Tests for ranking trend math, issue ordering, and deterministic recommendation shape.
+
+Status: Complete on 2026-05-24.
+
+Implementation completed:
+
+- Replaced SEO Strategist wrapper behavior with `core.agents.marketing.seo_strategist.SeoStrategistAgent`, a first-class beta marketing agent with deterministic keyword gap analysis, ranking delta computation, technical SEO issue prioritization, effort/impact recommendation bundling, content optimization recommendations, SEO sprint planning, and stale/partial data handling.
+- Updated SEO Strategist contract, workflow lint, workflow activation, policy manifest, approval-timeout, decision-audit, and pilot-proof metadata so SEO Strategist is beta/implemented, not stub-only, while active technical site changes remain blocked without CMS/SEO connector write safety, policy approval, audit/escalation evidence where needed, external write confirmation, and pilot proof.
+- Tests cover keyword gaps, ranking improvements/drops/new/lost terms, technical issue ordering, recommendation bundling, content optimization, sprint planning, stale/partial connector degradation, approval/policy/audit/write gates, shadow read-only behavior, unsafe connector blocking, unconfirmed-write blocking, confirmed-write evidence, contract shape, workflow linter/activation status, and pilot-proof non-production truth.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_seo_strategist_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_pilot_proof.py -q --tb=short`, `python -m ruff check core\agents\marketing\seo_strategist.py core\marketing\agent_contracts.py core\marketing\workflow_linter.py core\marketing\workflow_activation.py core\marketing\policy_manifest.py core\marketing\approval_timeouts.py core\marketing\decision_audit.py tests\unit\test_cmo_seo_strategist_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_pilot_proof.py`, `python -m compileall core\agents\marketing\seo_strategist.py core\marketing\agent_contracts.py core\marketing\workflow_linter.py core\marketing\workflow_activation.py core\marketing\policy_manifest.py core\marketing\approval_timeouts.py core\marketing\decision_audit.py tests\unit\test_cmo_seo_strategist_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_pilot_proof.py`, and `git diff --check`.
+
+Remaining work:
+
+- SEO Strategist remains beta, not production: no live Ahrefs/Search Console/GA4/CMS credentials, vendor-specific production adapters, persistent evidence store, real-vendor pilot proof, or production delivery rollout was added.
+- CRM Intelligence remains stub/non-production until CMO-4.3 replaces shared/base behavior.
+
+### CMO-4.3 Deepen CRM Intelligence
+
+Priority: P0
+
+Objective: replace wrapper behavior with pipeline intelligence and segmentation logic.
+
+Files in scope:
+
+- `core/agents/marketing/crm_intelligence.py`
+- `core/marketing/agent_contracts.py`
+- `core/marketing/workflow_linter.py`
+- `core/marketing/workflow_activation.py`
+- `core/marketing/policy_manifest.py`
+- `core/marketing/approval_timeouts.py`
+- Tests under `tests/`
+
+Required behavior:
+
+- Pipeline velocity analysis
+- Funnel conversion analysis (safe division, low-sample handling)
+- Lead scoring refresh (deterministic, explainable)
+- Churn risk signal extraction
+- Segment recommendation
+- SQL promotion criteria
+- Account/deal health summary
+- Stale/partial/missing-mapping data handling
+- Policy/approval/audit/connector-write/external-write-confirmation gates for CRM writes
+
+Acceptance tests:
+
+- Tests for pipeline velocity bottlenecks, funnel math, scoring refresh, churn signal thresholds, segment output schema, SQL promotion classifier, account health, degraded data, write safety, target-account threshold approval, contract shape, workflow linter/activation, and pilot-proof truth.
+
+Status: Complete on 2026-05-24.
+
+Implementation completed:
+
+- Replaced CRM Intelligence wrapper behavior with `core.agents.marketing.crm_intelligence.CrmIntelligenceAgent`, a first-class beta marketing agent with deterministic pipeline velocity analysis (per-stage averages, bottlenecks, stuck deals), funnel conversion analysis with safe division and low-sample handling, deterministic explainable lead scoring refresh, churn risk signal extraction (login inactivity, support load, NPS, payment health, usage trend), segment recommendation (industry/size/behaviour buckets with enrol/follow-up/win-back action plans), SQL promotion classification (score floor + recent engagement + demo/intent), account/deal health composite scoring, and stale/partial/missing-mapping data handling.
+- Promoted CRM Intelligence contract from stub to beta in `core.marketing.agent_contracts`, registered all read and write actions, and added per-action lint/activation/policy/approval-timeout rules in `core.marketing.workflow_linter`, `core.marketing.workflow_activation`, `core.marketing.policy_manifest`, and `core.marketing.approval_timeouts`. Pilot proof keeps CRM Intelligence non-production until a real vendor/sandbox pilot lands evidence.
+- Active CRM writes (lead score push, lifecycle stage change, segment/list change, target account change, bulk CRM update) require active mode, write-safe CRM connector contract, satisfied policy decision (`requires_approval` / `requires_escalation`), audit reference, and confirmed external-write evidence (`external_write_confirmation_status="write_confirmed"` plus `external_object_id` / `source_url` / `confirmed_at` / `audit_ref`). Without those, the agent fails closed with `blocked` / `write_unconfirmed` / `shadow_only` outputs and HITL routing.
+- Tests in `tests/unit/test_cmo_crm_intelligence_agent.py` cover pipeline velocity bottlenecks, funnel safe division and low sample, deterministic lead scoring with explanations, SQL promotion criteria, segment buckets and action plan, churn signals, account health, stale/partial/missing-mapping degradation, shadow read-only block, active-write approval/audit/connector requirements, target-account threshold approval and escalation, unsafe-connector blocking, unconfirmed-write blocking, confirmed-write evidence with contract shape, and workflow-linter/activation/pilot-proof non-production truth.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_crm_intelligence_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_pilot_proof.py tests\unit\test_cmo_marketing_policy_manifest.py tests\unit\test_cmo_approval_timeout_policy.py tests\unit\test_cmo_escalation_matrix.py tests\unit\test_cmo_decision_audit_package.py tests\unit\test_cmo_seo_strategist_agent.py tests\unit\test_cmo_brand_monitor_agent.py tests\unit\test_cmo_social_media_agent.py tests\unit\test_cmo_abm_agent.py tests\unit\test_cmo_competitive_intel_agent.py tests\unit\test_cmo_e2e_scenarios.py tests\unit\test_cmo_chaos_failure_modes.py -q --tb=short`, `python -m ruff check core\agents\marketing\crm_intelligence.py core\marketing\agent_contracts.py core\marketing\workflow_linter.py core\marketing\workflow_activation.py core\marketing\policy_manifest.py core\marketing\approval_timeouts.py tests\unit\test_cmo_crm_intelligence_agent.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py`, `python -m compileall core\agents\marketing\crm_intelligence.py core\marketing\agent_contracts.py core\marketing\workflow_linter.py core\marketing\workflow_activation.py core\marketing\policy_manifest.py core\marketing\approval_timeouts.py tests\unit\test_cmo_crm_intelligence_agent.py`, and `git diff --check`.
+
+Remaining work:
+
+- CRM Intelligence remains beta, not production: no live HubSpot/Salesforce/Bombora/G2/TrustRadius credentials, vendor-specific production adapters, persistent evidence store, real-vendor pilot proof, or production delivery rollout was added.
+- CMO-WS-3 (first-class agent buildout) and CMO-WS-4 (wrapper agent deepening) are now both closed at beta status across Brand Monitor, SEO Strategist, CRM Intelligence, Social Media, ABM, and Competitive Intel.
+
+## CMO-WS-5 Workflow Integrity
+
+### CMO-5.1 Add Marketing Workflow Linter
+
+Priority: P0
+
+Status: Complete on 2026-05-23
+
+Objective: fail fast when marketing workflow YAML references undefined agents or actions.
+
+Files in scope:
+
+- `workflows/examples/*.yaml`
+- Workflow parser/validation modules
+- Tests under `tests/`
+
+Acceptance tests:
+
+- A test fixture with an unknown `agent_type` fails validation.
+- A test fixture with an unknown action fails validation.
+- Existing valid marketing workflows pass validation.
+
+Completion notes:
+
+- Added `core.marketing.workflow_linter`, a code-backed marketing workflow linter with `lint_marketing_workflow`, `lint_marketing_workflow_file`, and `lint_marketing_workflow_paths` entry points.
+- Lint findings are structured with workflow file, workflow id/name, step id/name, severity (`error`, `warning`, `info`), code, message, and suggested fix.
+- The linter applies only to marketing workflows, either by top-level `domain: marketing` or by marketing `agent_type`, and reports non-marketing workflows as out of scope instead of making CI noisy for unrelated domains.
+- Production/active workflow lint now fails unknown marketing `agent_type`, unknown actions when action metadata exists, beta Brand Monitor/SEO Strategist/CRM Intelligence/Social Media/ABM/Competitive Intel production-safety gaps, missing connector contracts where connector requirements are declared, and unsafe production external-write steps.
+- Target/demo/shadow workflows can reference stub or unavailable marketing agents only with warnings, not as production passes.
+- Shadow workflow lint enforces read-only behavior: recommendation/report/simulation style steps can pass, but external-write actions fail lint.
+- Production external-write steps must declare connector key/category, have matching write-ready connector contracts, include CMO-5.3 write-confirmation metadata, and include idempotency metadata before lint can pass.
+- Existing `workflows/examples/*.yaml` can now be linted directly. Current target/demo workflow gaps are exposed rather than silently treated as production-ready; for example `campaign_launch.yaml` reports beta-agent production-safety gaps and unsafe write metadata gaps.
+- Tests added for unknown agent, unknown action, valid implemented action, Social Media/ABM/Competitive Intel beta production-safety blockers, stub agent production blocker, target/demo/shadow warnings, write-ready connector contract checks, missing idempotency/write-confirmation metadata, shadow read-only behavior, non-marketing out-of-scope handling, and linting a real workflow example file.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_external_write_completion.py tests\unit\test_cmo_marketing_connector_contracts.py tests\unit\test_workflow_templates.py`, `python -m ruff check core\marketing\workflow_linter.py tests\unit\test_cmo_marketing_workflow_linter.py`, `python -m compileall core\marketing\workflow_linter.py tests\unit\test_cmo_marketing_workflow_linter.py`, and `git diff --check`.
+- No UI files were changed for CMO-5.1, so CMO dashboard, locale, Playwright, and typecheck commands were not rerun for this task.
+- No dedicated markdown/docs lint script is configured: there is no root `package.json`, and `ui/package.json` exposes ESLint but no markdown/docs validation script.
+
+Remaining work moves to CMO-6.2/CMO-6.3, CMO-7.1, and the agent production-proof/deepening tracks: this task does not implement Social Media/ABM/Competitive Intel production proof, deepen wrapper agents, escalation matrices, decision audit packages, or make current target/demo workflows production-ready.
+
+### CMO-5.2 Add Connector Retry And Degraded Mode Policy
+
+Priority: P0
+
+Status: Complete on 2026-05-23
+
+Objective: make marketing workflows resilient to connector outages and stale data.
+
+Files in scope:
+
+- Marketing agents
+- Connector framework modules
+- Workflow retry modules
+- Tests under `tests/`
+
+Acceptance tests:
+
+- Tests simulate connector timeout, partial response, stale data, and rate limiting.
+- Outputs clearly mark degraded mode and confidence impact.
+
+Completion notes:
+
+- Added `core.marketing.connector_retry_policy`, a shared code-backed retry/degraded-mode policy for `timeout`, `rate_limited`, `vendor_5xx`, `auth_expired`, `insufficient_scope`, `partial_data`, `stale_data`, `malformed_payload`, `quota_exhausted`, and `connector_disabled`.
+- Each failure class now exposes retryability, max attempts, backoff metadata, idempotency requirements, degraded-mode allowance, confidence impact, external-write blocking, production KPI confidence blocking, CTA, and audit event code.
+- Marketing connector contracts now project `failure_class`, `retry_policy`, retry-budget defaults from policy, `write_safe`, `blocks_external_writes`, `blocks_production_kpi_confidence`, and structured `degraded_mode` metadata.
+- Connector setup recognizes malformed payload, quota exhaustion, and disabled-connector states with actionable CTAs instead of generic healthy/degraded ambiguity.
+- CMO data readiness consumes connector degraded-mode policy so production KPI readiness is blocked or degraded with affected KPIs, affected connectors, confidence impact, and next action.
+- Workflow activation consumes degraded-mode policy: read-only/reporting workflows can become explicitly degraded when policy allows, while external-write workflows remain blocked unless matching connector contracts are write-safe.
+- Marketing external-write completion now fails closed when an explicit connector contract marks the connector non-write-safe, while shadow/internal workflows remain read-only and can continue with labeled recommendations.
+- Marketing workflow linting flags production workflow dependencies that can only run in degraded mode and uses `write_safe` rather than optimistic write readiness for external-write steps.
+- Tests added for every failure class, retry/backoff metadata, auth/scope/setup CTAs, partial and stale confidence downgrades, malformed/quota/disabled behavior, workflow degradation/blocking, external write fail-closed behavior, shadow read-only continuation, and linter degraded-only dependency reporting.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_connector_retry_policy.py tests\unit\test_cmo_marketing_connector_contracts.py tests\unit\test_cmo_marketing_data_readiness.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_external_write_completion.py tests\unit\test_cmo_marketing_workflow_linter.py`, `python -m ruff check core\marketing\connector_retry_policy.py core\marketing\connector_contracts.py core\marketing\connector_setup.py core\marketing\data_readiness.py core\marketing\workflow_activation.py core\marketing\external_writes.py core\marketing\workflow_linter.py api\v1\kpis.py tests\unit\test_cmo_connector_retry_policy.py tests\unit\test_cmo_marketing_connector_contracts.py tests\unit\test_cmo_marketing_data_readiness.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_external_write_completion.py tests\unit\test_cmo_marketing_workflow_linter.py`, `python -m compileall core\marketing\connector_retry_policy.py core\marketing\connector_contracts.py core\marketing\connector_setup.py core\marketing\data_readiness.py core\marketing\workflow_activation.py core\marketing\external_writes.py core\marketing\workflow_linter.py api\v1\kpis.py tests\unit\test_cmo_connector_retry_policy.py`, and `git diff --check`.
+- No UI files were changed for CMO-5.2, so CMO dashboard, locale, Playwright, and typecheck commands were not rerun for this task.
+- No dedicated markdown/docs lint script is configured: there is no root `package.json`, and `ui/package.json` exposes ESLint but no markdown/docs validation script.
+
+Remaining work moves to CMO-6.2/CMO-6.3, CMO-7.1, and the agent production-proof/deepening tracks: this task does not implement vendor-specific adapters for every marketing platform, escalation matrices, decision audit packages, canonical KPI formulas, or Social Media/ABM/Competitive Intel production proof.
+
+### CMO-5.3 Confirm External Writes Before Completion
+
+Priority: P0
+
+Status: Complete on 2026-05-23
+
+Objective: prevent workflows from marking posts, emails, campaigns, or CRM updates complete until the external connector confirms the write.
+
+Acceptance tests:
+
+- Tests simulate connector accepted, connector rejected, timeout after write, duplicate retry, and idempotent recovery.
+
+Completion notes:
+
+- Added `core.marketing.external_writes`, a code-backed final-state evaluator for marketing workflow external-write steps.
+- Workflow step result handling now distinguishes `accepted`, `rejected`, `timeout_unknown`, `retry_scheduled`, `idempotent_recovered`, `write_confirmed`, `write_unconfirmed`, `draft_created`, and `shadow_only`.
+- Active marketing workflows fail closed when publish/send/launch/update actions are rejected, timed out without safe idempotency metadata, unconfirmed, missing an explicit external object ID, or only created a draft.
+- Accepted connector writes complete only when the step output carries explicit external confirmation evidence, including connector key, external object ID, optional source URL, idempotency key, request fingerprint, confirmation timestamp, actor/agent/workflow/run IDs when available, and audit reference.
+- Generic business IDs such as `campaign_id` are not treated as connector confirmation unless they appear inside an explicit external-write confirmation payload; this prevents draft or internal identifiers from masquerading as customer-facing writes.
+- Timeout/unknown writes schedule retry only when idempotency metadata is present. Retry requests without idempotency fail closed instead of risking duplicate vendor actions.
+- Duplicate retries recover a prior confirmed write only when the prior confirmation matches the same idempotency key, returning `idempotent_recovered` without duplicating the external action.
+- Shadow workflows remain read-only. They can complete recommendations, drafts, simulations, and internal approval records as `shadow_only`, but any reported external object or confirmation is rejected as a shadow-mode violation.
+- Draft/internal-only steps can complete only when the final state is explicitly draft/internal and are not labeled as published, sent, launched, or externally updated.
+- Every write decision embeds audit evidence in the step output for attempt, confirmation, rejection, timeout, retry scheduling, and idempotent recovery.
+- Tests added/updated for accepted confirmed writes, rejected writes, timeout/unknown writes, retry blocked without idempotency, retry scheduled with idempotency, idempotent recovery, draft/internal completion, shadow read-only enforcement, active unconfirmed failure, and audit evidence.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_external_write_completion.py tests\unit\test_cmo_marketing_connector_contracts.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_marketing_data_readiness.py tests\unit\test_cmo_marketing_connector_setup.py tests\unit\test_workflow_no_false_success.py`, `python -m ruff check core\marketing\connector_setup.py core\marketing\data_readiness.py core\marketing\workflow_activation.py core\marketing\connector_contracts.py core\marketing\external_writes.py api\v1\kpis.py workflows\step_types.py workflows\step_results.py tests\unit\test_cmo_marketing_connector_setup.py tests\unit\test_cmo_marketing_data_readiness.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_marketing_connector_contracts.py tests\unit\test_cmo_external_write_completion.py tests\unit\test_workflow_no_false_success.py`, `python -m compileall core\marketing\connector_setup.py core\marketing\data_readiness.py core\marketing\workflow_activation.py core\marketing\connector_contracts.py core\marketing\external_writes.py api\v1\kpis.py workflows\step_types.py workflows\step_results.py tests\unit\test_cmo_marketing_connector_setup.py tests\unit\test_cmo_marketing_data_readiness.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_marketing_connector_contracts.py tests\unit\test_cmo_external_write_completion.py tests\unit\test_workflow_no_false_success.py`, `git diff --check`, and claim search for unqualified CMO autonomy language.
+- No UI files were changed for CMO-5.3, so CMO dashboard, locale, and typecheck commands were not rerun for this task.
+- No dedicated markdown/docs lint script is configured: there is no root `package.json`, and `ui/package.json` exposes ESLint but no markdown/docs validation script.
+
+Remaining work moves to CMO-6.2/CMO-6.3 and the agent production-proof/deepening tracks: this task does not implement vendor-specific write adapters for every marketing platform, escalation matrices, decision audit packages, canonical KPI formulas, or Social Media/ABM/Competitive Intel production proof.
+
+### CMO-5.4 Add Approval Timeout Policy
+
+Priority: P0
+
+Status: Complete on 2026-05-23
+
+Objective: enforce policy when HITL approvals are not completed within SLA.
+
+Files in scope:
+
+- HITL/approval modules
+- Workflow event wait modules
+- Marketing workflow tests
+
+Acceptance tests:
+
+- Timeout can auto-cancel, auto-escalate, or continue in read-only mode based on policy.
+- Timeout decisions are auditable.
+
+Completion notes:
+
+- Added `core.marketing.approval_timeouts`, a code-backed CMO approval timeout policy projection for ad campaign launch, ad budget change, email send, content publish, landing-page change, target account list change, crisis/public response, social post targeting, and high-risk copy/pricing/claims actions.
+- Timeout outcomes now include `auto_cancel`, `auto_escalate`, `continue_read_only`, `pause_workflow`, and `require_manual_resolution`, with default SLA duration, escalation role, external-write allowance, notification/audit event code, and safe fallback CTA/message.
+- Timed-out approval decisions create structured audit evidence with approval/workflow/run/step IDs where available, requested approver/role, created/due/timed-out timestamps, outcome, escalation target, blocked action, external-write allowance, and audit reference.
+- Active customer-facing marketing writes fail closed after approval timeout unless the timeout policy explicitly pre-approves external writes after timeout. Shadow/draft/internal-only paths remain read-only.
+- Workflow activation rows now expose `approval_timeout_policy` readiness and block approval-sensitive workflow promotion when timeout policy is missing.
+- Marketing workflow linting now flags production approval-sensitive steps that do not have either a known default timeout policy or explicit timeout policy metadata.
+- `GET /kpis/cmo` now returns `approval_timeout_risk`, a pending/overdue CMO HITL approval projection for marketing/content/sales-domain HITL items.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_approval_timeout_policy.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_external_write_completion.py`, `python -m ruff check core\marketing\approval_timeouts.py core\marketing\workflow_activation.py core\marketing\workflow_linter.py core\marketing\external_writes.py api\v1\kpis.py workflows\step_types.py tests\unit\test_cmo_approval_timeout_policy.py tests\unit\test_cmo_workflow_activation.py`, `python -m compileall core\marketing\approval_timeouts.py core\marketing\workflow_activation.py core\marketing\workflow_linter.py core\marketing\external_writes.py api\v1\kpis.py workflows\step_types.py tests\unit\test_cmo_approval_timeout_policy.py tests\unit\test_cmo_workflow_activation.py`, and `git diff --check`.
+- No UI files were changed for CMO-5.4, so CMO dashboard, locale, Playwright, and typecheck commands were not rerun for this task.
+
+Remaining work moves to CMO-6.2, CMO-6.3, CMO-7.1, and the agent production-proof/deepening tracks: this task does not implement complete escalation matrix UX, vendor-specific write adapters, canonical KPI formulas, or Social Media/ABM/Competitive Intel production proof.
+
+## CMO-WS-6 Governance OS
+
+### CMO-6.1 Add Marketing Policy Manifest
+
+Priority: P0
+
+Status: Complete on 2026-05-23
+
+Objective: define machine-checkable policy for marketing decisions.
+
+Required policy areas:
+
+- Budget thresholds by channel
+- High-risk copy categories
+- Region and legal constraints
+- Approval owners
+- Allowed autonomous actions
+- Disallowed autonomous actions
+
+Completion notes:
+
+- Added `core.marketing.policy_manifest`, a code-backed CMO marketing policy manifest with policy ID/version, conservative default rules, budget thresholds by channel, audience/list-size and target-account thresholds, high-risk copy/legal/compliance/comparative/competitor/crisis rules, region/legal constraints, allowed/disallowed autonomous actions, required owner roles, and required audit evidence classes.
+- Policy evaluation now returns deterministic decisions: `allowed`, `blocked`, `requires_approval`, `requires_escalation`, `read_only_only`, and `missing_policy`, with matched rules, reason, approver/escalation role, required audit evidence, affected workflow/action, and next action CTA.
+- Workflow activation rows now expose `marketing_policy` readiness and block promotion when required active/customer-facing write policy is missing or blocking.
+- Marketing workflow linting now flags production workflow steps with missing, blocking, or read-only-only policy coverage while preserving non-marketing workflow scope boundaries.
+- Active marketing external-write completion now requires both connector write confirmation and policy allowance or satisfied approval/escalation evidence; missing policy, blocked policy, read-only-only policy, or unsatisfied approval/escalation fails closed.
+- Approval timeout decisions now include the manifest-derived required policy role where applicable, so timeout audit evidence can point to the required owner/escalation role.
+- `GET /kpis/cmo` now returns the active/default `marketing_policy_manifest` and `marketing_policy_summary` projection used by CMO readiness gates.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_marketing_policy_manifest.py tests\unit\test_cmo_external_write_completion.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_approval_timeout_policy.py`, `python -m ruff check core\marketing\policy_manifest.py core\marketing\workflow_activation.py core\marketing\workflow_linter.py core\marketing\external_writes.py core\marketing\approval_timeouts.py api\v1\kpis.py workflows\step_types.py tests\unit\test_cmo_marketing_policy_manifest.py tests\unit\test_cmo_external_write_completion.py`, `python -m compileall core\marketing\policy_manifest.py core\marketing\workflow_activation.py core\marketing\workflow_linter.py core\marketing\external_writes.py core\marketing\approval_timeouts.py api\v1\kpis.py workflows\step_types.py tests\unit\test_cmo_marketing_policy_manifest.py tests\unit\test_cmo_external_write_completion.py`, and `git diff --check`.
+- No UI files were changed for CMO-6.1, so CMO dashboard, locale, Playwright, and typecheck commands were not rerun for this task.
+
+Remaining work moves to CMO-7.1 through CMO-7.3 and the agent production-proof/deepening tracks: CMO-6.3 now adds the decision audit package; this task still does not implement vendor-specific write adapters, canonical KPI formulas, persistent audit storage/UI, or Social Media/ABM/Competitive Intel production proof.
+
+### CMO-6.2 Add Escalation Matrix
+
+Priority: P0
+
+Status: Complete on 2026-05-23
+
+Objective: define escalation ownership and SLA behavior.
+
+Required behavior:
+
+- Owner map: Growth Lead to CMO to CEO
+- SLA timers
+- Notification channels
+- Fallback behavior
+
+Completion notes:
+
+- Added `core.marketing.escalation_matrix`, a code-backed CMO escalation matrix with policy ID/version, trigger types, severity, primary/backup owner roles, escalation chains, SLA duration, notification channels, fallback outcome, audit event code, next action CTA, and deterministic evaluation decisions.
+- Default routes now cover approval timeout, crisis/public response, budget threshold exceeded, connector auth expired, connector degraded, data mapping blocked, backfill failed, missing policy, external write rejected, external write timeout/unknown, high-risk copy, pricing/legal claims, and target account changes.
+- Escalation decisions now include structured evidence with event ID/type, workflow/run/step IDs where available, severity, owner/escalation target, SLA/due time, fallback outcome, notification channels, audit event code, and audit reference.
+- Approval timeout decisions now include escalation decisions/evidence in both the decision body and timeout audit evidence.
+- Marketing policy evaluation now attaches escalation route/evidence for missing policy, budget threshold, target-account, crisis, high-risk, pricing/legal, and approval-sensitive decisions.
+- Connector retry/degraded projections and CMO data readiness blockers now expose escalation evidence for connector auth/degradation, data mapping blockers, and failed/blocked backfills.
+- Marketing external-write completion now attaches escalation evidence for approval timeout, missing policy, non-write-safe connector state, rejected writes, timeout/unknown writes, and unconfirmed write failures; workflow step outputs preserve this escalation evidence.
+- Workflow activation rows now expose `escalation_matrix` readiness and block promotion when an active/write workflow has escalation-sensitive actions but no escalation route.
+- Marketing workflow linting now flags production escalation-sensitive steps when their required escalation route is missing.
+- `GET /kpis/cmo` now returns `marketing_escalation_matrix` and `marketing_escalation_summary`.
+- Tests added/updated for default matrix coverage, approval timeout evidence, crisis routing, finance routing, admin/IT routing, data mapping/backfill routing, missing-policy route, external-write rejection route, legal/pricing route, target-account route, connector/data readiness escalation evidence, workflow activation missing-route blocker, linter missing-route blocker, and unrelated workflow isolation.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_escalation_matrix.py tests\unit\test_cmo_approval_timeout_policy.py tests\unit\test_cmo_marketing_policy_manifest.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_connector_retry_policy.py tests\unit\test_cmo_external_write_completion.py`, `python -m ruff check core\marketing\approval_timeouts.py core\marketing\connector_retry_policy.py core\marketing\data_readiness.py core\marketing\escalation_matrix.py core\marketing\external_writes.py core\marketing\policy_manifest.py core\marketing\workflow_activation.py core\marketing\workflow_linter.py api\v1\kpis.py workflows\step_types.py tests\unit\test_cmo_escalation_matrix.py`, and `python -m compileall core\marketing api\v1\kpis.py workflows\step_types.py tests\unit\test_cmo_escalation_matrix.py`.
+- No UI files were changed for CMO-6.2, so CMO dashboard, locale, Playwright, and typecheck commands were not rerun for this task.
+
+Remaining work moves to CMO-7.1 through CMO-7.3, CMO-8.x, persistent audit storage/UI, and the agent production-proof/deepening tracks: CMO-6.3 now adds the decision audit package; this task still does not implement a full escalation editor UI, vendor-specific write adapters, canonical KPI formulas, or Social Media/ABM/Competitive Intel production proof.
+
+### CMO-6.3 Add Decision Audit Package
+
+Priority: P0
+
+Status: Complete on 2026-05-23
+
+Objective: persist rationale, alternatives, and overridden decisions for major marketing actions.
+
+Required behavior:
+
+- Every budget, publish, campaign, crisis, and high-confidence recommendation action is auditable.
+- Human overrides are recorded with actor, timestamp, reason, and replacement action.
+
+Implementation completed:
+
+- Added `core.marketing.decision_audit`, a code-backed CMO decision audit package model with schema version `2026-05-23.cmo-6.3`, deterministic `audit_id`, WORM-ready canonical JSON serialization, input snapshot hashing, source/connector refs, policy/escalation/approval/timeout/write refs, actor identity, rationale, alternatives, risk flags, confidence, final outcome, override fields, and secret/token redaction.
+- Policy manifest evaluations now attach `decision_audit`, `decision_audit_ref`, and audit references for policy decisions.
+- Escalation matrix evaluations now attach decision audit packages and add audit refs into escalation evidence.
+- Approval timeout decisions now attach decision audit packages into the decision and timeout audit evidence.
+- External-write handling now creates audit packages for write attempts and final states including confirmation, rejection, timeout/unknown, retry scheduling, idempotent recovery, unconfirmed writes, draft creation, and shadow-only results.
+- Connector degraded/failure projections, data mapping blockers, and backfill blockers now attach decision audit refs where they create governance evidence.
+- Workflow activation rows now expose decision-audit readiness and workflow-promotion audit packages; production workflows block when decision audit is disabled.
+- Marketing workflow linting now flags production customer-facing steps that lack CMO-6.3 decision-audit evidence metadata.
+- `GET /kpis/cmo` now exposes `marketing_decision_audit` and `marketing_decision_audit_summary` projections.
+- Tests added/updated for stable audit shape, WORM serialization, policy/escalation/timeout/write/promotion audit evidence, override fields, input snapshot/source refs, production lint blocking for missing audit evidence, shadow read-only auditability, and secret redaction.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_decision_audit_package.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_marketing_policy_manifest.py tests\unit\test_cmo_escalation_matrix.py tests\unit\test_cmo_approval_timeout_policy.py tests\unit\test_cmo_connector_retry_policy.py tests\unit\test_cmo_external_write_completion.py tests\unit\test_cmo_workflow_activation.py`, `python -m ruff check core\marketing\decision_audit.py core\marketing\approval_timeouts.py core\marketing\connector_retry_policy.py core\marketing\data_readiness.py core\marketing\escalation_matrix.py core\marketing\external_writes.py core\marketing\policy_manifest.py core\marketing\workflow_activation.py core\marketing\workflow_linter.py api\v1\kpis.py workflows\step_types.py tests\unit\test_cmo_decision_audit_package.py tests\unit\test_cmo_marketing_workflow_linter.py`, `python -m compileall core\marketing api\v1\kpis.py workflows\step_types.py tests\unit\test_cmo_decision_audit_package.py tests\unit\test_cmo_marketing_workflow_linter.py`, and `git diff --check`.
+
+Remaining work moves to CMO-7.1 through CMO-7.3, CMO-8.x, persistent audit storage/UI, and the agent production-proof/deepening tracks: this task does not implement an audit log UI, vendor-specific write adapters, canonical KPI formulas, or Social Media/ABM/Competitive Intel production proof.
+
+## CMO-WS-7 KPI Trust Layer
+
+### CMO-7.1 Define Unified KPI Schema
+
+Priority: P0
+
+Objective: canonicalize CMO metrics.
+
+Status: Complete on 2026-05-23
+
+Implementation completed:
+
+- Added `core.marketing.kpi_schema`, a code-backed CMO KPI schema with schema version `2026-05-23.cmo-7.1` and stable definitions for CAC, MQL, SQL, MQL-to-SQL conversion rate, ROAS, pipeline contribution, conversion rates by funnel stage, LTV/CAC, experiment velocity, content performance, email performance, brand sentiment, and ABM intent/account readiness.
+- Each KPI definition now carries display name, description, formula, required connector categories/source domains, required field mappings, required backfill categories, refresh TTL, unit, owner role, confidence/freshness rules, missing-data behavior, source lineage refs, and required audit evidence classes.
+- Added deterministic KPI evaluation helpers that compute only from structured source facts and otherwise return `ready`, `degraded`, `blocked`, or `unavailable` with value, unit, confidence, formula refs, source refs, missing requirements, freshness status, last computed timestamp, and next action CTA.
+- KPI readiness now consumes the CMO-1.1 connector setup projection, CMO-1.2 field mapping/backfill readiness, CMO-2.1 connector contracts, CMO-5.2 degraded/confidence impact, and CMO-6.3 audit refs where available.
+- `GET /kpis/cmo` now exposes `unified_cmo_kpi_schema`, `unified_cmo_kpi_results`, and `unified_cmo_kpi_summary` without changing the existing dashboard KPI-card compatibility fields.
+- Production paths do not convert source facts into ready KPI values when required connectors, connector contracts, mappings, backfills, or source fields are missing; affected KPI results are blocked/degraded with actionable CTAs instead of using sample/demo/hardcoded proof.
+- Tests cover stable KPI definitions, CAC, MQL, SQL, MQL-to-SQL zero denominator behavior, ROAS, pipeline contribution, experiment velocity, conversion rates, stale freshness downgrade, partial-readiness downgrade, missing connector/mapping/backfill blocking, formula/source lineage, all-core-KPI ready evaluation from mapped fresh inputs, and blocked production projection with no connector readiness.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_unified_kpi_schema.py`, `python -m ruff check core\marketing\kpi_schema.py api\v1\kpis.py tests\unit\test_cmo_unified_kpi_schema.py`, and `python -m compileall core\marketing\kpi_schema.py api\v1\kpis.py tests\unit\test_cmo_unified_kpi_schema.py`.
+
+Remaining work moves to CMO-7.2 and CMO-7.3: this task does not implement KPI reconciliation checks, report quality gates, persistent KPI history storage, missing production marketing agents, or vendor-specific adapters.
+
+Required metrics:
+
+- CAC
+- MQL
+- SQL
+- ROAS
+- Pipeline contribution
+- Conversion rates
+- Experiment velocity
+
+### CMO-7.2 Add KPI Reconciliation Checks
+
+Priority: P0
+
+Objective: cross-check ad platform totals against CRM-attributed outcomes.
+
+Status: Complete on 2026-05-23
+
+Implementation completed:
+
+- Added `core.marketing.kpi_reconciliation`, a code-backed reconciliation projection with schema version `2026-05-23.cmo-7.2`.
+- Reconciliation checks now cover paid spend totals by channel vs campaign-level spend, ad platform conversions vs CRM campaign-attributed MQLs, GA4/web conversion events vs CRM lead creation, email sends/clicks/unsubscribes vs CRM/list engagement, WordPress/CMS content traffic vs GA4 content sessions, ABM target account domains vs CRM and intent-source domains, source currency consistency, source timezone consistency, and stale/partial connector data.
+- Each reconciliation result returns reconciliation key, status (`passed`, `warning`, `failed`, `blocked`, `unavailable`), severity, affected KPI keys, compared sources, expected/observed values, absolute/percentage delta, tolerance, confidence/freshness impact, source refs, missing requirements, next action CTA, and decision-audit ref for non-passing checks.
+- Unified KPI evaluation now consumes reconciliation results. High-severity failed or blocked reconciliation checks block affected KPIs; medium warning/failed checks degrade affected KPIs and lower confidence. KPI results now expose reconciliation status, refs, and confidence impact.
+- `GET /kpis/cmo` now exposes `cmo_kpi_reconciliation_checks` and `cmo_kpi_reconciliation_summary` through the unified CMO KPI projection while preserving the existing dashboard compatibility fields.
+- Tests cover matching spend, spend mismatch blocking CAC/ROAS, ad conversion vs CRM mismatch downgrading affected KPIs, GA4 conversion mismatch, email unsubscribe mismatch, content traffic mismatch, ABM domain mismatch, currency mismatch, timezone warning, stale source freshness impact, partial-data warning, missing source blocking, `/kpis/cmo` reconciliation exposure, and failed reconciliation changing KPI status/confidence.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_unified_kpi_schema.py tests\unit\test_cmo_kpi_reconciliation.py`, `python -m ruff check core\marketing\kpi_schema.py core\marketing\kpi_reconciliation.py api\v1\kpis.py tests\unit\test_cmo_unified_kpi_schema.py tests\unit\test_cmo_kpi_reconciliation.py`, `python -m compileall core\marketing\kpi_schema.py core\marketing\kpi_reconciliation.py api\v1\kpis.py tests\unit\test_cmo_unified_kpi_schema.py tests\unit\test_cmo_kpi_reconciliation.py`, and `git diff --check`.
+
+Remaining work moves to CMO-7.3: this task does not implement report quality gates, weekly report blocking, persistent KPI history storage, missing production marketing agents, or vendor-specific adapters.
+
+Acceptance tests:
+
+- Tests cover matching totals, mismatched totals, missing attribution, stale sync, and confidence downgrade.
+
+### CMO-7.3 Add Report Quality Gates
+
+Priority: P0
+
+Objective: block weekly CMO report generation when critical fields are missing or confidence is below threshold.
+
+Status: Complete on 2026-05-23
+
+Implementation summary:
+
+- Added `core.marketing.report_quality`, a code-backed report quality gate projection with schema version `2026-05-23.cmo-7.3`.
+- Gate coverage now includes `weekly_marketing_report`, `daily_ad_performance`, `monthly_marketing_roi`, `campaign_performance_ad_hoc`, and `executive_board_summary`, with aliases for existing `cmo_weekly` and `campaign_report` report generator types.
+- Each gate evaluates required KPI definitions/results from CMO-7.1, reconciliation results from CMO-7.2, connector setup/contracts, field-mapping/backfill readiness, workflow activation mode, policy/escalation/audit readiness, source freshness, confidence floor, approval refs for sensitive/external delivery, and production demo/sample/fallback data blocking.
+- Gate output now includes report key/type, status (`pass`, `warning`, `blocked`, `unavailable`), severity, required KPI keys, blocked/degraded KPI keys, failed reconciliation keys, stale/missing source refs, confidence floor and actual confidence, required approval/escalation/audit refs, missing requirements, next action CTA, and safe report mode (`draft_only`, `internal_only`, `deliverable`).
+- `GET /kpis/cmo` now exposes `report_quality_gates`, `report_quality_summary`, and the report quality spec alongside unified KPI and reconciliation projections.
+- The existing report generator attaches CMO report quality gate metadata and renders a visible quality-gate banner for non-deliverable CMO reports. The scheduled report task now skips external delivery when a CMO report gate is not `deliverable`.
+- Tests cover weekly pass, missing CAC/pipeline blockers, missing ad source blockers, monthly ROI reconciliation/confidence blockers, ad-hoc stale optional warning, draft-only mode, demo/hardcoded production denial, failed reconciliation blocking, stale critical source blocking, missing approval for sensitive delivery, `/kpis/cmo` exposure, and delivery helper denial for non-deliverable gates.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_unified_kpi_schema.py tests\unit\test_cmo_kpi_reconciliation.py tests\unit\test_cmo_report_quality_gates.py`, `python -m pytest tests\unit\test_report_engine.py -q --tb=short`, `python -m ruff check core\marketing\report_quality.py api\v1\kpis.py core\reports\generator.py core\tasks\report_tasks.py tests\unit\test_cmo_report_quality_gates.py`, `python -m compileall core\marketing\report_quality.py api\v1\kpis.py core\reports\generator.py core\tasks\report_tasks.py tests\unit\test_cmo_report_quality_gates.py`, and `git diff --check`.
+
+Remaining work moves to CMO-8.x, persistent KPI/report/audit storage, and production proof for beta marketing agents: this task does not build a full report rendering engine, persistent report history, Social Media/ABM/Competitive Intel production proof, or vendor-specific adapters.
+
+Acceptance tests:
+
+- Reports fail closed for missing critical KPI fields.
+- Reports include confidence and freshness metadata.
+
+## CMO-WS-8 CMO UX Workbench
+
+### CMO-8.1 Build CMO Work Queue
+
+Priority: P0
+
+Objective: give the CMO a daily operating queue for approvals, risks, stale data, connector issues, budget exceptions, crisis alerts, and recommendations.
+
+Status: Complete on 2026-05-23
+
+Implementation summary:
+
+- Added `core.marketing.work_queue`, a deterministic CMO work queue projection with schema version `2026-05-23.cmo-8.1`.
+- The queue now derives prioritized operator-visible work items from approval timeout risk, escalations, connector setup/contract failures, field-mapping/backfill blockers, workflow activation blockers, external-write rejected/timeout/unconfirmed states, policy and audit gaps, blocked/degraded KPIs, failed/warning reconciliation checks, report quality gates, production demo/sample blockers, and crisis/public-response risks where available.
+- Work items include item ID, type/category, severity, priority score, title/message, affected workflow/capability/KPI/report/connector, owner role, due/SLA timestamp, source refs, audit refs, CTA label/path/action key, status, and created/updated timestamps.
+- Priority rules put customer-facing external-write risk first, overdue approvals/escalations ahead of stale optional data, write-blocking policy/audit/connector issues ahead of read-only warnings, and report blockers ahead of report warnings. Related connector setup and connector-contract items are grouped where practical.
+- `GET /kpis/cmo` now exposes `cmo_work_queue` and `cmo_work_queue_summary`.
+- The CMO dashboard renders the queue before connector/data/workflow readiness sections, with critical/high summary badges, per-item severity/status, owner/affected object/due date, CTA buttons, and a non-deceptive empty state that does not imply stub/demo/unavailable capabilities are production-ready.
+- Tests cover connector auth issues, missing mapping/backfill, workflow activation blockers, overdue approvals/escalations, external-write failures, policy/audit gaps, blocked KPIs, failed reconciliation, blocked/warning report gates, prioritization, connector deduping, API exposure, dashboard rendering, and empty state.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_work_queue.py -q --tb=short`, `npm --prefix ui test -- CMODashboard`, `npm --prefix ui test -- i18n_coverage_tripwire`, `python -m ruff check core\marketing\work_queue.py api\v1\kpis.py tests\unit\test_cmo_work_queue.py`, `python -m compileall core\marketing\work_queue.py api\v1\kpis.py tests\unit\test_cmo_work_queue.py`, `npm --prefix ui run typecheck`, and `git diff --check`.
+
+Remaining work after CMO-8.1 has since moved through CMO-8.2, CMO-8.3, CMO-3.1, CMO-3.2, CMO-3.3, CMO-4.1, and CMO-4.2; open gaps are persistent task/approval storage, beta-agent production proof, and vendor-specific adapters.
+
+Acceptance tests:
+
+- Tests cover prioritization, filters, empty state, connector issue, approval item, and risk item.
+
+### CMO-8.2 Add KPI Drill-Down And Data Lineage
+
+Priority: P0
+
+Objective: every KPI should explain formula, source systems, source rows, last sync, confidence, owner, and reconciliation state.
+
+Status: Complete on 2026-05-23
+
+Implementation summary:
+
+- Added `core.marketing.kpi_drilldown`, a deterministic KPI drill-down/data-lineage projection with schema version `2026-05-23.cmo-8.2`.
+- Drill-downs now cover canonical CMO KPI rows from the unified KPI schema, including CAC, MQL, SQL, MQL-to-SQL conversion, ROAS, pipeline contribution, experiment velocity, content performance, email performance, brand sentiment, and ABM intent/account readiness.
+- Each drill-down includes KPI key/name/description, current status/value/unit/confidence, formula refs, resolved formula inputs where source facts are available, required source domains/connectors/mappings/backfills, connector refs, field mappings used, backfill state, reconciliation checks affecting the KPI, freshness/TTL state, confidence-impact reasons, missing requirements, blockers/degraders, related work queue item IDs, related report gate IDs, policy/audit refs, owner role, and next action CTA.
+- Demo, hardcoded, mock, stub, sample, fallback, or test-double lineage is explicitly marked as not production proof; drill-down rows clear source refs and block production lineage instead of claiming those inputs are trusted.
+- `GET /kpis/cmo` now exposes `cmo_kpi_drilldowns` and `cmo_kpi_drilldown_summary`.
+- The CMO dashboard renders a compact KPI drill-down table after the work queue and before readiness sections, showing formula, inputs, connector/freshness, confidence, issue, work queue/report refs, and CTA without redesigning the full dashboard.
+- Tests cover CAC formula/input/source/confidence/CTA, MQL/SQL lifecycle mapping and CRM refs, zero-denominator MQL-to-SQL explanation, ROAS spend/revenue and reconciliation refs, pipeline opportunity/revenue lineage, stale freshness/confidence impact, missing mapping/backfill blockers, related work queue/report refs, required core KPI coverage, `/kpis/cmo` exposure, dashboard rendering, and demo/mock lineage denial.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_kpi_drilldown.py -q --tb=short`, `python -m ruff check core\marketing\kpi_drilldown.py api\v1\kpis.py tests\unit\test_cmo_kpi_drilldown.py`, `python -m compileall core\marketing\kpi_drilldown.py api\v1\kpis.py tests\unit\test_cmo_kpi_drilldown.py`, `npm --prefix ui test -- CMODashboard`, `npm --prefix ui test -- i18n_coverage_tripwire`, `npm --prefix ui run typecheck`, and `git diff --check`.
+
+Remaining work moves to persistent KPI history/storage, deeper KPI drill-down interactions, and production proof for beta marketing agents: this task does not implement full persistent KPI history, report rendering, approval decision persistence, Social Media/ABM/Competitive Intel production proof, or vendor-specific adapters.
+
+Acceptance tests:
+
+- Tests cover drill-down render, missing data, stale data, confidence downgrade, and export.
+
+### CMO-8.3 Improve Approval Review UX
+
+Priority: P0
+
+Objective: make approvals useful for real marketing decisions.
+
+Status: Complete on 2026-05-23
+
+Implementation summary:
+
+- Added `core.marketing.approval_review`, a deterministic approval-review projection with schema version `2026-05-23.cmo-8.3`.
+- Approval reviews cover campaign launch, ad budget change, content publish, email send, landing page change, target account list change, crisis/public response, high-risk copy/pricing/legal claim, and workflow promotion approval contexts.
+- Each review row includes approval/workflow/run/step refs, action type/status, requester/agent/approver refs, created/due/timeout state, preview payload, before/after diff, budget impact, audience/list impact, risk flags, source and connector refs, agent rationale, policy/escalation/timeout/write/audit refs, rollback/stop plan, allowed reviewer actions, blockers, related work queue item IDs, and CTA.
+- Approval decision helpers fail closed: approve is blocked when the policy result is missing or blocking, write readiness is unsafe, timeout policy requires manual resolution, or required audit evidence is missing. Reject/override/request-change/escalate/pause request shapes require an explicit reason, and override also requires a replacement action.
+- `GET /kpis/cmo` now exposes `cmo_approval_reviews` and `cmo_approval_review_summary`, links approval-timeout decisions to approval-review IDs, and lets CMO work queue approval items point at their review payloads.
+- The CMO dashboard now renders compact approval review cards after the work queue and before KPI lineage, showing status, owner/due date, risk flags, budget/audience impact, diff, rationale, policy/timeout/write/audit safeguards, rollback/stop plan, allowed actions, related work queue refs, and CTA without redesigning the dashboard.
+- Tests cover preview/diff/rationale/source refs, campaign budget/audience impact and rollback plan, content/email brand/legal risk flags, crisis escalation/timeout/policy refs, fail-closed behavior for missing policy, unsafe write readiness, manual-timeout resolution, missing audit evidence, reject/override request shapes, allowed actions by status/risk, work queue review links, `/kpis/cmo` approval review summary exposure, and dashboard rendering.
+- Proof commands run: `python -m pytest tests\unit\test_cmo_approval_review.py -q --tb=short`, `python -m ruff check core\marketing\approval_review.py core\marketing\work_queue.py api\v1\kpis.py tests\unit\test_cmo_approval_review.py`, `python -m compileall core\marketing\approval_review.py core\marketing\work_queue.py api\v1\kpis.py tests\unit\test_cmo_approval_review.py`, `npm --prefix ui test -- CMODashboard`, `npm --prefix ui test -- i18n_coverage_tripwire`, `npm --prefix ui run typecheck`, and `git diff --check`.
+
+Remaining work moves to CMO-9.x pilot/test hardening, persistent approval/task/audit storage, deeper approval decision UI, beta-agent production proof, and vendor-specific write adapters. This task does not implement a full persistent approvals system or bypass HITL, policy, timeout, escalation, external-write, or audit safeguards.
+
+Required behavior:
+
+- Before/after preview
+- Budget impact
+- Audience impact
+- Brand/legal risk flags
+- Source refs
+- Agent rationale
+- Policy result
+- Timeout
+- Rollback/stop action
+
+Acceptance tests:
+
+- Tests cover approve, reject, override, timeout, and audit record.
+
+## CMO-WS-9 Test Hardening And Pilot Proof
+
+### CMO-9.1 Per-Agent Contract Tests
+
+Priority: P0
+
+Status: Complete on 2026-05-24
+
+Objective: define input/output contracts for every marketing agent action.
+
+Implementation summary:
+
+- Added `core.marketing.agent_contracts`, a deterministic CMO agent contract projection with contract version `2026-05-24.cmo-9.1`, required output keys, truthful capability status, aliases, and production-readiness blockers.
+- Contract inventory now covers Campaign Pilot, Content Factory, Email Marketing / `email_agent`, Brand Monitor, SEO Strategist, CRM Intelligence, Social Media, ABM / `abm_agent`, and Competitive Intel.
+- Campaign Pilot and Content Factory now emit the shared CMO contract fields for approval/HITL state, policy result, audit reference, source refs, degraded or blocked reasons, external-write confirmation, and production status.
+- Campaign Pilot active write paths now fail closed when connector write confirmation is absent; Content Factory publish/schedule paths remain draft/approval-gated until external delivery is explicitly confirmed.
+- Marketing workflow linting recognizes the `email_agent` beta surface while continuing to block stub or unavailable agents from active production workflows.
+
+Validation completed:
+
+- `tests/unit/test_cmo_agent_contracts.py` covers implemented/beta happy paths, invalid input, HITL/policy paths, degraded connector state, audit/source/confidence shape, external-write safety, and stub/unavailable production blocking.
+- Focused regression coverage was run with workflow linter and workflow activation tests to prove stub/unavailable production workflows remain blocked.
+
+Definition of done:
+
+- All 9 CMO agents have contract tests.
+- Tests cover happy path, invalid input, HITL path, connector failure, and degraded output.
+
+Remaining work:
+
+- CMO-9.1 did not implement production agents; CMO-3.1, CMO-3.2, and CMO-3.3 now add Social Media, ABM, and Competitive Intel as beta/non-production.
+- CMO-9.1 did not deepen Brand Monitor, SEO Strategist, or CRM Intelligence. CMO-4.1 now deepens Brand Monitor to beta; CMO-4.2 now deepens SEO Strategist to beta; CMO-4.3 now deepens CRM Intelligence to beta.
+- CMO-9.4 now adds code-backed pilot proof packaging; live shadow-run evaluation metrics, persistent pilot evidence history, and pilot go/no-go execution remain outside CMO-9.1.
+
+### CMO-9.2 End-To-End CMO Scenario Tests
+
+Priority: P0
+
+Status: Complete on 2026-05-24
+
+Objective: prove the CMO operating-system projections work together across readiness, governance, KPI/report quality, workbench, approval, write-safety, audit, and agent-contract surfaces without network, LLM, or vendor dependencies.
+
+Implementation summary:
+
+- Added `tests/unit/test_cmo_e2e_scenarios.py`, a deterministic E2E-style scenario suite that composes the same CMO projection builders used by API/dashboard paths.
+- Weekly marketing review scenario proves blocked KPI/reconciliation/report gates prevent trusted report delivery, preserve `draft_only` safe mode, create work queue items, and expose KPI drill-down lineage for blocked CAC.
+- Campaign launch scenario proves shadow/non-promoted workflows do not become active, active launch requires write-ready connectors, valid data readiness, policy approval, approval review, decision-audit evidence, linter-safe metadata, and confirmed external write before completion.
+- Crisis response scenario proves public response remains unavailable in workflow activation, requires escalation, timeout/approval review, policy result, decision-audit evidence, and fails closed for public writes without approval/escalation safeguards.
+- ABM sprint scenario now proves ABM is a beta first-class core marketing agent that still blocks production workflow lint/activation unless connector, policy, approval, audit, write-confirmation, and pilot-proof gates pass; target/demo/shadow paths remain explicitly non-production.
+- Content production-to-publish scenario proves Content Factory can produce contract-shaped draft output, publishing requires approval/policy/audit/write-safe connector state, and unconfirmed publish writes cannot complete as published.
+
+Validation completed:
+
+- `python -m pytest tests\unit\test_cmo_e2e_scenarios.py tests\unit\test_cmo_agent_contracts.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_external_write_completion.py tests\unit\test_cmo_approval_review.py tests\unit\test_cmo_approval_timeout_policy.py tests\unit\test_cmo_unified_kpi_schema.py tests\unit\test_cmo_kpi_reconciliation.py tests\unit\test_cmo_report_quality_gates.py tests\unit\test_cmo_work_queue.py tests\unit\test_cmo_kpi_drilldown.py -q --tb=short` passed.
+- `python -m ruff check tests\unit\test_cmo_e2e_scenarios.py` passed.
+- `python -m compileall tests\unit\test_cmo_e2e_scenarios.py` passed.
+
+Required scenarios:
+
+- Weekly marketing review
+- Campaign launch
+- Crisis response
+- ABM sprint
+- Content production to approval to publish
+
+Remaining work:
+
+- CMO-9.2 does not implement missing agents; CMO-3.1, CMO-3.2, and CMO-3.3 later add Social Media, ABM, and Competitive Intel as beta/non-production.
+- CMO-9.2 does not add vendor-specific live integrations, persistent scenario history, or live pilot execution.
+- CMO-9.3 now covers chaos/failure tests across outage, stale-data, malformed-payload, timeout, overspend race, and duplicate replay cases; CMO-9.4 now packages pilot proof status without replacing live tenant rollout.
+
+### CMO-9.3 Chaos And Failure Tests
+
+Priority: P0
+
+Status: Complete on 2026-05-24
+
+Objective: prove CMO readiness/governance/KPI/report/workbench/agent-contract surfaces fail closed or degrade explicitly under deterministic connector, data, approval, policy, write, audit, reconciliation, and report failures.
+
+Implementation summary:
+
+- Added `tests/unit/test_cmo_chaos_failure_modes.py`, a deterministic chaos/failure suite that composes connector retry/degraded policy, connector contracts, setup, data readiness, workflow activation, workflow linter, policy manifest, escalation matrix, approval timeout policy, external write completion, decision audit, KPI schema/reconciliation/report gates, work queue, approval review, and agent contract projections.
+- Covered connector outage, auth expiry, insufficient scope, rate limiting, quota exhaustion, stale/partial data windows, malformed payloads, approval timeout, budget overspend race, duplicate event replay, timeout/unknown writes, rejected writes, idempotent recovery, missing policy/escalation/audit evidence, report quality gate failure, and KPI reconciliation failure.
+- Adjusted connector-contract write-step tests so active write-confirmation assertions explicitly satisfy marketing policy approval before testing missing or present external-write confirmation.
+
+Validation:
+
+- `python -m pytest tests\unit\test_cmo_chaos_failure_modes.py -q --tb=short`
+- `python -m pytest tests\unit\test_cmo_chaos_failure_modes.py tests\unit\test_cmo_e2e_scenarios.py tests\unit\test_cmo_marketing_connector_contracts.py tests\unit\test_cmo_connector_retry_policy.py tests\unit\test_cmo_external_write_completion.py tests\unit\test_cmo_workflow_activation.py tests\unit\test_cmo_marketing_workflow_linter.py tests\unit\test_cmo_report_quality_gates.py tests\unit\test_cmo_kpi_reconciliation.py -q --tb=short`
+
+Remaining work:
+
+- CMO-9.3 does not add live vendor integrations, persistent chaos-run history, or live pilot execution.
+- CMO-9.3 does not implement production agents; CMO-3.1, CMO-3.2, and CMO-3.3 later add Social Media, ABM, and Competitive Intel as beta/non-production.
+- CMO-9.4 now adds the pilot proof package; complete CMO production readiness still requires real-vendor pilot evidence, beta-agent production proof, and persistent rollout operations.
+
+Required scenarios:
+
+- Connector outages
+- Stale data windows
+- Malformed payloads
+- Approval timeout
+- Budget overspend race
+- Duplicate event replay
+
+### CMO-9.4 Pilot Tenant Proof
+
+Priority: P0
+
+Status: Complete on 2026-05-24
+
+Objective: add a code-backed pilot proof package that shows what is and is not proven for a real-vendor, vendor-sandbox, demo, test-double, or unknown CMO tenant without treating mocks, stubs, or sample data as production readiness.
+
+Implementation summary:
+
+- Added `core.marketing.pilot_proof`, a deterministic proof package with proof version `2026-05-24.cmo-9.4`, stable proof IDs, redacted evidence bundle serialization, readiness scoring, proof status, proven/unproven capabilities, blockers, risks, evidence refs, source refs, report refs, audit refs, test evidence refs, and next actions.
+- Pilot proof evaluates connector setup, connector contracts, data mapping/backfill, workflow activation, workflow linting, policy, escalation, approval timeout readiness, external-write confirmation, decision-audit evidence, unified KPIs, reconciliation, report quality gates, work queue blockers, KPI drill-down/data lineage, approval review readiness, agent contract status, and scenario/chaos test evidence.
+- Demo environments return `demo_only`; test-double/mock environments return `test_only`; neither can produce production-passed proof.
+- Vendor-sandbox proof can pass only sandbox criteria and never sets a real-vendor production claim. Real-vendor proof can pass only when all critical criteria pass.
+- Social Media, ABM, Competitive Intel, Brand Monitor, and SEO Strategist are now first-class beta CMO capabilities but remain explicitly unproven for production until real-vendor/pilot proof exists.
+- `GET /kpis/cmo` now exposes `cmo_pilot_proof`, `cmo_pilot_proof_summary`, and the redacted pilot evidence bundle alongside existing CMO readiness surfaces.
+
+Validation completed:
+
+- `python -m pytest tests\unit\test_cmo_pilot_proof.py -q --tb=short` passed.
+- Focused CMO regression subset covering agent contracts, approval review/timeouts, chaos/failure, connector contracts/retry/setup, decision audit, E2E scenarios, escalation, external writes, KPI drill-down/reconciliation/schema, marketing policy, workflow linter/activation, report quality, work queue, and pilot proof passed.
+- `python -m ruff check core\marketing\pilot_proof.py api\v1\kpis.py tests\unit\test_cmo_pilot_proof.py tests\unit\test_cmo_marketing_connector_setup.py` passed.
+- `python -m compileall core\marketing\pilot_proof.py api\v1\kpis.py tests\unit\test_cmo_pilot_proof.py tests\unit\test_cmo_marketing_connector_setup.py` passed.
+
+Definition of done:
+
+- Pilot proof package exists in code and is deterministic/test-covered.
+- Demo/test-double proof cannot be mistaken for production proof.
+- Real-vendor, vendor-sandbox, demo, test-only, and unknown states are clearly distinguished.
+- Proof output includes status, score, proven/unproven capabilities, blockers, risks, refs, and next actions.
+- Missing production agents and beta agents without pilot proof remain explicitly unproven.
+- Serialization redacts secrets/tokens.
+
+Remaining work:
+
+- CMO-9.4 is proof packaging, not live pilot rollout; real customer or vendor-sandbox credentials, persistent pilot evidence storage, monitoring, and pilot go/no-go operations remain to be done.
+- Complete CMO autonomy still requires beta-agent production pilot proof, and live vendor adapter rollout where needed.
+
+## Production Proof (post-beta)
+
+The Production Proof track exists because every CMO marketing pillar in
+`core/agents/marketing` now has first-class deterministic beta code with
+policy/approval/audit/external-write-confirmation gates, *but no
+real-vendor or vendor-sandbox proof has been recorded in the worktree*.
+A capability is only honestly "production" when:
+
+1. The deterministic code path is complete (CMO-WS-1 → CMO-WS-9 + CMO-WS-3
+   + CMO-WS-4 ✅).
+2. A pilot tenant supplies real or vendor-sandbox credentials, configured
+   connectors, mapping, backfill, and consents.
+3. A strict, code-backed proof gate verifies the evidence and refuses to
+   mark proof passed for demo / sample / mock / test-double inputs.
+4. The proof artefact (signed, redacted) is stored alongside the report,
+   audit, and KPI artefacts that back it.
+
+Production Proof tasks introduce step 3 first (so the moment a pilot lands
+in step 2, step 4 has somewhere to land).
+
+### CMO-PROD-1 Real-Vendor Pilot Evidence Path For Weekly Marketing Report
+
+Priority: P0
+Status (2026-05-24): Code-backed validation path complete; **no live or
+vendor-sandbox evidence is present in the worktree**, so no production
+claim is allowed today.
+
+Objective: prove the read-only `weekly_marketing_report` workflow on real
+connected CRM + Ads + Analytics + Email sources for one pilot tenant,
+through a strict evidence model that fails closed for demo / test-double
+/ vendor-sandbox shortcuts.
+
+Files in scope:
+
+- `core/marketing/weekly_report_pilot_proof.py` (new module)
+- `scripts/validate_weekly_report_pilot_proof.py` (new CLI / callable)
+- `api/v1/kpis.py` (wires the projection into `/kpis/cmo`)
+- `tests/unit/test_cmo_weekly_report_pilot_proof.py` (acceptance tests)
+- `docs/STRICT_CMO_AGENTIC_EXECUTION_BACKLOG_2026-05-23.md` (this section)
+
+Required behavior — delivered:
+
+- `WeeklyReportPilotEvidence` dataclass capturing tenant/company IDs,
+  environment type, connector evidence, mapping evidence, backfill
+  evidence, KPI results, reconciliation checks, report-quality gates,
+  report artifact refs, decision-audit refs, source refs, generated_at,
+  and a free-form `source_context`.
+- `evaluate_weekly_marketing_report_proof()` returns a deterministic
+  redacted verdict with `proof_status`, `production_claim_allowed`,
+  `real_vendor_claim_allowed`, blockers, risks, proven capabilities,
+  evidence refs, next actions, and a stable `proof_id`.
+- Validation rules enforce environment honesty:
+  - `demo` → `demo_only`, `production_claim_allowed=False`;
+  - `test_double` → `test_only`, `production_claim_allowed=False`;
+  - `vendor_sandbox` → `sandbox_proven` / `partial`, never real-vendor;
+  - `real_vendor` → `passed` only when CRM/Ads/Analytics/Email are
+    configured + read-ready, every required mapping is `valid`, every
+    required backfill category is `completed`, every required weekly
+    report KPI is present and not blocked, every reconciliation check
+    is `pass` (or warning at most), the `weekly_marketing_report`
+    quality gate is `pass`, and at least one report artifact + decision
+    audit ref + real source-lineage ref is attached;
+  - mock / test-double markers on any connector evidence row block.
+- Bundle serializer (`serialize_weekly_marketing_report_evidence_bundle`)
+  redacts any map key containing `secret`, `token`, `password`,
+  `api_key`, `apikey`, `authorization`, `credential`, or `private_key`.
+- CLI/callable validator at `scripts/validate_weekly_report_pilot_proof.py`
+  reads JSON evidence from a file or STDIN, prints a human-readable
+  verdict (or `--format json` redacted bundle), and exits with code
+  `0` for `passed` / `sandbox_proven`, `2` for `partial`, `3` for
+  `blocked` / `demo_only` / `test_only` / `unavailable`.
+- `/kpis/cmo` now exposes `weekly_report_pilot_proof`,
+  `weekly_report_pilot_proof_summary`, and
+  `weekly_report_pilot_evidence_bundle` alongside the broader CMO
+  pilot proof.
+
+Acceptance tests run (24 passing):
+
+- demo evidence returns `demo_only` and blocks production claim
+- test-double evidence returns `test_only` and blocks production claim
+- unknown environment blocks production claim
+- mock/test-double connector marker blocks proof
+- vendor-sandbox evidence returns sandbox/partial only, never real-vendor
+- vendor-sandbox missing optional refs degrades to partial
+- real-vendor evidence with all critical criteria passes
+- real-vendor missing each of CRM / Ads / Analytics / Email blocks proof
+- real-vendor missing a required field mapping blocks proof
+- real-vendor missing a required backfill category blocks proof
+- failed KPI reconciliation blocks proof
+- blocked report-quality gate blocks proof
+- missing audit/report artifact refs block real-vendor proof
+- demo/test-double source markers on `source_refs` block proof
+- proof bundle serializer redacts `api_key` / `authorization` / `password`
+- summary returns proof_status + next action CTA + schema version
+- projection wraps proof + summary + redacted bundle
+- CLI returns exit 0 for real-vendor passed
+- CLI returns exit 3 for demo evidence with blockers in stdout
+- CLI `--format json` output is secret-redacted
+- CLI reads evidence from STDIN
+
+Definition of done:
+
+- Strict code-backed validation path exists and is exercised by tests.
+- Proof cannot be satisfied by demo / test-double / sample / mock
+  inputs.
+- Missing evidence produces explicit blockers and next actions.
+- Secret / token redaction is tested.
+- Backlog clearly distinguishes (a) beta feature completeness across
+  CMO-WS-1 → CMO-WS-9 + CMO-WS-3 / 4; (b) proof validation path
+  complete via CMO-PROD-1; (c) live / vendor-sandbox proof present or
+  absent — currently **absent**.
+
+Live evidence status (2026-05-24):
+
+- No real-vendor evidence file is present in the worktree.
+- No vendor-sandbox evidence file is present in the worktree.
+- `core/marketing/weekly_report_pilot_proof.PILOT_PROOFS` does not
+  exist; once a pilot lands, a tenant-specific JSON evidence file
+  (or hydrated `WeeklyReportPilotEvidence`) should be passed through
+  the validator before any "weekly report production-proven" claim is
+  made externally.
+
+Remaining work:
+
+- Acquire real-vendor or vendor-sandbox credentials for HubSpot or
+  Salesforce + Google Ads / Meta Ads / LinkedIn Ads + GA4 + Mailchimp
+  or SendGrid for at least one pilot tenant.
+- Persist evidence bundles and proof verdicts in durable storage
+  (database + WORM audit log) so a future UI can render the bundle
+  without re-running the validator from session state.
+- Wire the deterministic report-generation path (`core/reports/generator.py`,
+  `core/tasks/report_tasks.py`) to attach `report_artifact_refs` and
+  `decision_audit_refs` for weekly reports as they are produced.
+- Add scheduled CI / cron run of the validator against the persisted
+  evidence to detect when a pilot tenant's proof degrades.
+
+### CMO-PROD-2 Persist Weekly Report Pilot Evidence And Wire Report Generator
+
+Priority: P0
+Status (2026-05-24): Persistence path and report-task wiring complete in
+code; **no live or vendor-sandbox evidence rows exist in any tenant DB**.
+The first persisted row will only land when a configured tenant actually
+runs the CMO weekly report against connected systems.
+
+Objective: give CMO-PROD-1 a durable home. Each successful CMO weekly
+report run hydrates a `WeeklyReportPilotEvidence` bundle from the same
+`/kpis/cmo` projections the report itself uses, runs the CMO-PROD-1
+validator, redacts secrets, and persists the verdict in a dedicated
+append-only table. The CMO KPI endpoint exposes the latest persisted
+verdict so dashboards stop relying on ad-hoc validator runs.
+
+Files in scope:
+
+- `core/models/weekly_report_pilot_proof.py` (new ORM model)
+- `migrations/versions/v4_9_17_weekly_report_pilot_proof.py` (new
+  Alembic migration; revision id `v4917_weekly_report_proof`, 25 chars,
+  on top of `v4916_merge_p0_heads`)
+- `core/marketing/weekly_report_pilot_persistence.py` (new persistence
+  helper, evidence builder, sync wrapper for Celery)
+- `core/tasks/report_tasks.py` (wires the persistence call after a
+  successful `cmo_weekly` / `weekly_marketing_report` run)
+- `api/v1/kpis.py` (adds `latest_weekly_report_pilot_proof` and
+  `latest_weekly_report_pilot_proof_summary` to `/kpis/cmo`)
+- `tests/unit/test_cmo_weekly_report_pilot_persistence.py` (20 tests)
+
+Required behavior — delivered:
+
+- New ORM model `WeeklyReportPilotProof` (table
+  `weekly_report_pilot_proofs`) with: tenant_id, company_id, proof_id,
+  environment_type, proof_status, production_claim_allowed,
+  real_vendor_claim_allowed, readiness_score, evaluated_at,
+  evidence_bundle (JSONB), verdict (JSONB), blockers, next_actions,
+  report_artifact_refs, decision_audit_refs, created_at, updated_at.
+- Idempotent migration: `CREATE TABLE IF NOT EXISTS` plus
+  `(tenant_id, company_id, evaluated_at)` composite index for the
+  "latest verdict per tenant/company" lookup.
+- `persist_weekly_report_pilot_proof()` accepts evidence (dict or
+  `WeeklyReportPilotEvidence`), invokes the CMO-PROD-1 validator,
+  redacts secrets/tokens/API keys, and writes a single new row per
+  evaluation. It never UPDATEs; rows are an append-only verdict log.
+- `latest_weekly_report_pilot_proof()` returns the newest persisted row
+  for a tenant + optional company, ordered by `evaluated_at DESC`.
+- `build_weekly_report_evidence_from_report_output()` turns a
+  successful weekly-report run + the `/kpis/cmo` payload that fed it
+  into a `WeeklyReportPilotEvidence` bundle, attaching
+  `report_artifact_refs` (artifact id + path + format) and
+  `decision_audit_refs` (`weekly_report_delivered` plus any
+  `required_approval_audit_refs` from the report quality gate).
+- `persist_weekly_report_pilot_proof_from_report_output_sync()` is the
+  Celery-safe entry point. It refuses to persist when the tenant id is
+  not a UUID (e.g., the demo `"default"` literal), swallows DB errors
+  with a `weekly_report_pilot_proof_persist_failed` log entry, and
+  returns the verdict summary so the report task can include it in
+  its return value.
+- `core/tasks/report_tasks.generate_report` calls the sync wrapper only
+  for `cmo_weekly` / `weekly_marketing_report` runs and includes the
+  resulting summary in the task return payload.
+- `/kpis/cmo` exposes `latest_weekly_report_pilot_proof` (full
+  serialised row, redacted) and `latest_weekly_report_pilot_proof_summary`
+  (proof_id, environment_type, proof_status, production_claim_allowed,
+  readiness_score, blocker count, next-action CTA). The CMO-PROD-1
+  ad-hoc projection from CMO-PROD-1 remains alongside the persisted
+  fields so existing consumers don't need to migrate.
+- Both layers redact: the validator redacts in-flight, the persistence
+  helper redacts again before INSERT, and the `serialize_persisted_proof`
+  projection returns the redacted JSONB back to the API surface.
+
+Acceptance tests run (20 passing):
+
+- persists demo evidence as `demo_only` with `production_claim_allowed=False`
+- persists test-double evidence as `test_only` with `production_claim_allowed=False`
+- persists vendor-sandbox evidence as `sandbox_proven`/`partial`, not real-vendor
+- persists real-vendor `passed` only when all CMO-PROD-1 criteria met
+- persists `blocked` when required report_artifact_refs missing
+- persists `blocked` when required decision_audit_refs missing
+- persists `blocked` when a required connector category is missing
+- stored evidence/verdict/blockers JSON redacts `api_key` /
+  `authorization` / `credential.password` triples
+- `latest_weekly_report_pilot_proof()` returns the newest row when two
+  exist for the same tenant + company
+- evidence builder attaches report artifact + audit refs from a
+  successful weekly run
+- evidence builder marks `demo` env when `report_data.demo=True`
+- sync wrapper skips persistence when tenant id is not a UUID
+  (e.g., the literal `default` used in non-tenant tests)
+- sync wrapper persists and returns summary when DB available
+- sync wrapper persists `blocked` verdict when evidence is incomplete
+- sync wrapper swallows DB errors and returns `None` rather than
+  failing the Celery report task
+- `report_tasks.generate_report` calls the persistence wrapper on
+  `cmo_weekly` runs and returns the summary in the task result
+- `report_tasks.generate_report` does NOT call the persistence wrapper
+  for non-weekly reports (e.g., `cfo_daily`)
+- `/kpis/cmo` helper returns `None` when no persisted row exists
+- `/kpis/cmo` helper returns the redacted serialised row + summary
+  when a persisted row exists
+- summariser handles `None` input gracefully
+
+Definition of done:
+
+- Verdicts are durably representable and test-covered.
+- Report generation/task path attaches artifact/audit refs into the
+  evidence bundle on successful weekly runs.
+- CMO-PROD-1 remains the only authority for what counts as
+  `production_claim_allowed=True`.
+- Missing evidence persists as `blocked` / `unavailable` rather than
+  silently succeeding.
+- `/kpis/cmo` exposes the latest persisted proof + summary.
+
+Live evidence status (2026-05-24):
+
+- Migration is included but **has not been deployed to any tenant DB
+  in this worktree**. Running `alembic upgrade head` against a CI or
+  staging Postgres will create the table.
+- No row has been INSERTed by the production code path; the
+  `weekly_report_pilot_proofs` table will be empty until a tenant runs
+  the CMO weekly report with credentials.
+- The Celery report task already calls the persistence wrapper, but it
+  short-circuits whenever the tenant id is not a UUID (e.g., during
+  the existing `default` / demo path in `report_tasks` tests), so no
+  fake / demo evidence ever lands in the table.
+
+Remaining work / hand-off to CMO-PROD-3:
+
+- A first pilot tenant must actually run the weekly report on
+  configured CRM + Ads + Analytics + Email connectors so the first
+  persisted verdict materialises. CMO-PROD-3 should walk one
+  vendor-sandbox tenant end-to-end (connector setup → mapping →
+  backfill → weekly run → persisted `sandbox_proven` verdict in
+  `weekly_report_pilot_proofs`).
+- A WORM audit-trail link from `audit_log` to
+  `weekly_report_pilot_proofs.proof_id` would let auditors trace each
+  verdict back to the report run that produced it. Currently the link
+  is implicit via `report_artifact_refs.artifact_id` matching the
+  report-task `report_id`.
+- A minimal CMO dashboard panel that surfaces
+  `latest_weekly_report_pilot_proof_summary` is out of scope; the
+  data is on `/kpis/cmo` ready to be rendered.
+
+### CMO-PROD-3 Vendor-Sandbox Pilot Walk-Through For Weekly Marketing Report
+
+Priority: P0
+Status (2026-05-24, ops run 1): **Code path complete. Live sandbox proof
+BLOCKED on credentials and a running DB.** No row has been inserted into
+`weekly_report_pilot_proofs`. The most recent CMO-PROD-3-OPS run on
+2026-05-24 confirmed the blocked status; see "Last CMO-PROD-3-OPS run"
+below for verbatim evidence of which prerequisites are still missing.
+
+Re-run `python scripts/run_weekly_report_sandbox_pilot.py` after
+populating the env vars below to materialise the first `sandbox_proven`
+verdict.
+
+#### Last CMO-PROD-3-OPS run
+
+| Field | Value |
+|---|---|
+| Run date | 2026-05-24 |
+| Worktree | `C:\tmp\agenticorg-cmo-1-1` |
+| `alembic upgrade head` | **Failed** — no `AGENTICORG_DB_URL`; default URL pointed at `localhost:5432`, no server listening. Migration `v4917_weekly_report_proof` was **not applied**. |
+| Preflight CLI exit code | `3` (blocked) |
+| Tenant id | missing (`AGENTICORG_CMO_SANDBOX_TENANT_ID` not set) |
+| Company id | not set |
+| Missing connector categories | CRM, Ads, Analytics, Email |
+| `weekly_report_pilot_proofs` rows inserted by this run | **0** |
+| Fake / synthetic evidence inserted | **None.** Runner refused to invent data. |
+| `production_claim_allowed` claimed | always `False` |
+| `real_vendor_claim_allowed` claimed | always `False` |
+| Secrets / tokens printed | none (only env-var names appear in output) |
+
+#### Local DB setup status (CMO-PROD-3-DB-LOCAL, 2026-05-24)
+
+A local Postgres has been provisioned on this workstation so the CMO-PROD-3
+preflight no longer fails on DB connectivity. The DB blocker is resolved;
+remaining blockers are QA-owned (sandbox tenant + per-category connector
+env vars).
+
+| Field | Value |
+|---|---|
+| DB setup method | New Docker container, repo `pgvector/pgvector:pg16` image (matches `docker-compose.yml` for parity). No existing project DB or container was modified or deleted; an unrelated stopped `grantex-postgres-1` container was left untouched. |
+| Container name | `agenticorg-cmo-postgres` |
+| Host port | `5433` (5432 reserved by the unrelated stopped container; using 5433 avoids any future conflict) |
+| `AGENTICORG_DB_URL` shape (password redacted) | `postgresql+asyncpg://agenticorg:[REDACTED]@localhost:5433/agenticorg` |
+| Postgres extensions enabled | `uuid-ossp`, `vector` (one-shot `CREATE EXTENSION IF NOT EXISTS …` on the fresh DB; required by repo migrations) |
+| Schema bootstrap method | `BaseModel.metadata.create_all` via `import core.models` (the same path `tests/unit/conftest.py` uses for fresh DBs), then `alembic stamp head` to record the version. This is the documented "fresh dev DB" path because the v4.x migration chain expects `init_db()`-style baseline tables (e.g., `tenants`) to pre-exist before `v4_8_6_knowledge_embedding` runs. |
+| Alembic migration status | `alembic_version.version_num = v4917_weekly_report_proof` (head). No pending migrations. |
+| `weekly_report_pilot_proofs` table | **exists** with the 18 columns + 4 indexes from migration `v4917_weekly_report_proof`. Row count = **0**. |
+| Fake / synthetic rows inserted | **None.** The DB is empty by design. |
+| CMO-PROD-3 preflight result after DB setup | exit code `3` (still blocked), but the **`database` blocker is gone**. Remaining blockers are: `tenant` (1) + `connector` × 4 categories (CRM, Ads, Analytics, Email). |
+| Remaining QA-owned setup | Preferred path: tenant-scoped `ConnectorConfig` rows for CRM, Ads, Analytics, and Email with usable status/health, `config.proof_scope=vendor_sandbox`, no `local_test_only`, and no `mock_or_test_double`. Env vars remain local/dev fallback only. |
+| Acceptance checks | `pytest` on the three CMO-PROD-3 test files → **62 passed** after CMO-PROD-3E. `ruff check` on the three CMO-PROD-3 modules → all checks passed. `compileall` → exit 0. `git diff --check` → clean. |
+
+QA command sequence to materialise the first `sandbox_proven` row from
+this workstation:
+
+```
+# 1. Export the DB URL this CMO-PROD-3-DB-LOCAL pass created.
+export AGENTICORG_DB_URL=postgresql+asyncpg://agenticorg:agenticorg_dev_password@localhost:5433/agenticorg
+
+# 2. Pick / create a sandbox tenant UUID and export it (optionally company too).
+export AGENTICORG_CMO_SANDBOX_TENANT_ID=<sandbox-tenant-uuid>
+# optional:
+export AGENTICORG_CMO_SANDBOX_COMPANY_ID=<sandbox-company-uuid>
+
+# 3. Preferred: configure tenant ConnectorConfig rows through the normal
+#    connector setup path for CRM, Ads, Analytics, and Email.
+#    Required row metadata:
+#    - status is configured/active/healthy/ready equivalent
+#    - health_status is healthy/ready/connected/unknown
+#    - config.cmo_category is CRM, Ads, Analytics, or Email
+#    - config.proof_scope=vendor_sandbox
+#    - config.local_test_only=false or absent
+#    - config.mock_or_test_double=false or absent
+#    Store real sandbox secrets only through ConnectorConfig credential storage.
+#
+#    Local/dev fallback only: populate ONE env connector group per missing
+#    DB category from SANDBOX_CONNECTOR_OPTIONS.
+
+# 4. Confirm preflight is now READY (exit 0):
+python scripts/run_weekly_report_sandbox_pilot.py --preflight-only
+
+# 5. Run the pilot, redacted JSON output, persist verdict:
+python scripts/run_weekly_report_sandbox_pilot.py --format json > sandbox-proof.json
+
+# 6. Verify in DB (host port 5433 from the CMO-PROD-3-DB-LOCAL container):
+docker exec agenticorg-cmo-postgres psql -U agenticorg -d agenticorg -c \
+  "SELECT proof_id, environment_type, proof_status, production_claim_allowed, \
+          real_vendor_claim_allowed, readiness_score, evaluated_at \
+   FROM weekly_report_pilot_proofs ORDER BY evaluated_at DESC LIMIT 1;"
+```
+
+Missing env vars (verbatim from preflight output, names only — no
+values are ever printed):
+
+  - `AGENTICORG_DB_URL`
+  - `AGENTICORG_CMO_SANDBOX_TENANT_ID`
+  - `AGENTICORG_CMO_SANDBOX_HUBSPOT_ACCESS_TOKEN`
+    *(or the Salesforce 4-var alternative)*
+  - `AGENTICORG_CMO_SANDBOX_GOOGLE_ADS_DEVELOPER_TOKEN`,
+    `_REFRESH_TOKEN`, `_CUSTOMER_ID`, `_CLIENT_ID`, `_CLIENT_SECRET`
+    *(or one of the Meta / LinkedIn Ads alternatives)*
+  - `AGENTICORG_CMO_SANDBOX_GA4_PROPERTY_ID`, `_REFRESH_TOKEN`,
+    `_CLIENT_ID`, `_CLIENT_SECRET`
+  - `AGENTICORG_CMO_SANDBOX_SENDGRID_API_KEY`, `_SENDER`
+    *(or the Mailchimp 3-var alternative)*
+
+Acceptance checks rerun by this CMO-PROD-3-OPS pass:
+
+- `python -m pytest tests/unit/test_cmo_weekly_report_sandbox_runner.py
+   tests/unit/test_cmo_weekly_report_pilot_persistence.py
+   tests/unit/test_cmo_weekly_report_pilot_proof.py --no-cov -q` → **62 passed**.
+- `python -m ruff check` on the three CMO-PROD-3 modules → all checks passed.
+- `python -m compileall` on the three CMO-PROD-3 modules → exit 0.
+- `git diff --check` → clean (CRLF informational warnings only).
+
+#### CMO-PROD-3E ConnectorConfig Sandbox Preflight
+
+Status: Complete in code on 2026-05-24; live `sandbox_proven` remains blocked until QA replaces local/preflight-only rows with real vendor-sandbox ConnectorConfig rows.
+
+Implementation summary:
+
+- `discover_sandbox_pilot_config()` now prefers tenant-scoped `ConnectorConfig` rows for `AGENTICORG_CMO_SANDBOX_TENANT_ID`, maps CRM, Ads, Analytics, and Email categories, and uses env vars only for missing DB categories or DB-discovery outage.
+- DB rows are considered usable only when status/health are configured/active/healthy equivalents, category metadata is present, `proof_scope` is `vendor_sandbox` or equivalent, and the row is not `local_test_only` or `mock_or_test_double`.
+- Rows marked `config.local_test_only=true` or `config.proof_scope=preflight_only` produce `proof_status=local_preflight_only`, `production_claim_allowed=false`, `real_vendor_claim_allowed=false`, and `proof_inserted=false`; the report task is not invoked for those rows.
+- JSON/text output includes only safe connector key/name/source/readiness metadata. Credential payloads, tokens, API keys, refresh tokens, and secret-like fields are not emitted.
+- Tests now prove DB rows satisfy category preflight, local/preflight-only rows do not insert proof, missing DB categories stay blocked unless env fallback is configured, env fallback still works, DB rows beat env vars, and mock/test-double DB rows block proof even when env vars exist.
+
+Exact QA instructions:
+
+- Apply Alembic head and verify `weekly_report_pilot_proofs` exists.
+- For tenant `d3f0d84c-836f-4cda-8896-ce2f1623213d`, configure one real vendor-sandbox ConnectorConfig row each for CRM, Ads, Analytics, and Email.
+- Required ConnectorConfig metadata: `status` configured/active/healthy/ready equivalent, `health_status` healthy/ready/connected/unknown, `config.cmo_category` set to the category, `config.proof_scope=vendor_sandbox`, no `config.local_test_only=true`, and no `config.mock_or_test_double=true`.
+- Store all sandbox secrets only in normal ConnectorConfig credential storage. Do not put secrets in docs, logs, env output, or committed files.
+- Run `python scripts/run_weekly_report_sandbox_pilot.py --preflight-only --format json`. Expected: four categories are `source=db`, `readiness_state=ready`, `proof_status=preflight_ready`, and not `local_preflight_only`.
+- Only then run `python scripts/run_weekly_report_sandbox_pilot.py --format json > sandbox-proof.json` and verify the persisted row remains `environment_type=vendor_sandbox`, `production_claim_allowed=false`, and `real_vendor_claim_allowed=false`.
+
+#### CMO-PROD-3F Vendor-Sandbox ConnectorConfig Configuration
+
+Status: Blocked on 2026-05-25; this worktree has no local `.env`, no gitignored `secrets/cmo_vendor_sandbox_connectors.json`, and this shell has no `AGENTICORG_DB_URL`, no `AGENTICORG_CMO_SANDBOX_TENANT_ID`, and no complete CRM/Ads/Analytics/Email sandbox credential groups. No ConnectorConfig rows were changed and no proof row was inserted.
+
+Implementation completed:
+
+- Added `scripts/configure_cmo_vendor_sandbox_connectors.py`, a local QA helper that reads real sandbox credentials from env vars or gitignored `secrets/cmo_vendor_sandbox_connectors.json`, encrypts credentials with the repo's `encrypt_for_tenant()` convention, and upserts tenant `ConnectorConfig` rows only when all four categories are supplied.
+- The helper refuses to proceed without tenant UUID and all four real category credential sets, never logs credential values, and emits only safe connector metadata.
+- The weekly report sandbox runner now also supports `--json` as an alias for `--format json`.
+- 2026-05-25 UI follow-up: added an admin-only guided setup path at
+  `/dashboard/connectors/cmo-vendor-sandbox` backed by
+  `GET/POST /api/v1/connectors/cmo-vendor-sandbox`. The path upserts one
+  encrypted ConnectorConfig row each for CRM, Ads, Analytics, and Email,
+  sets `proof_scope=vendor_sandbox`, `environment_type=vendor_sandbox`,
+  `local_test_only=false`, and `mock_or_test_double=false`, refuses obvious
+  placeholder credential values, and returns only safe metadata plus
+  credential key names. Full QA instructions live in
+  `docs/CMO_VENDOR_SANDBOX_QA_FLOW.md`.
+
+Observed local status:
+
+- 2026-05-25 follow-up: `.env` is absent, `secrets/cmo_vendor_sandbox_connectors.json`
+  is absent, and the process environment does not contain the required DB URL,
+  target tenant id, or any complete vendor-sandbox credential group. Because
+  `AGENTICORG_DB_URL` is missing, this run could not re-verify
+  `alembic_version`, `weekly_report_pilot_proofs`, or tenant
+  `ConnectorConfig` rows. Real vendor-sandbox categories verified from DB:
+  **none**. Preflight passed: **no**. Proof row inserted: **no**.
+- `python scripts/configure_cmo_vendor_sandbox_connectors.py --tenant-id
+  d3f0d84c-836f-4cda-8896-ce2f1623213d --dry-run --format json` returned
+  `blocked`; missing categories are CRM, Ads, Analytics, and Email. No
+  credential values were printed and no DB writes were attempted.
+- `python scripts/run_weekly_report_sandbox_pilot.py --preflight-only --json`
+  returned `blocked` with `db_discovery_state=not_checked`, `tenant_id=null`,
+  missing `AGENTICORG_DB_URL`, missing `AGENTICORG_CMO_SANDBOX_TENANT_ID`, and
+  missing CRM/Ads/Analytics/Email credential groups. No env fallback was usable.
+- 2026-05-24 follow-up: local DB connectivity works with the workstation
+  Postgres on port 5433. Direct DB inspection confirmed
+  `alembic_version=v4917_weekly_report_proof`,
+  `weekly_report_pilot_proofs` exists, tenant
+  `d3f0d84c-836f-4cda-8896-ce2f1623213d` now exists with slug
+  `cmo-weekly-sandbox-local`, `connector_configs` row count for the tenant
+  is **0**, and `weekly_report_pilot_proofs` row count is **0**.
+- `python scripts/run_weekly_report_sandbox_pilot.py --preflight-only --json`
+  now reaches DB discovery and reports `db_discovery_state=ready`, but it
+  remains blocked because CRM, Ads, Analytics, and Email have no usable DB
+  ConnectorConfig rows and no env fallback credentials.
+- `python scripts/configure_cmo_vendor_sandbox_connectors.py --dry-run --format json`
+  now reaches tenant validation and returns `blocked` because real
+  vendor-sandbox credentials are missing for CRM, Ads, Analytics, and Email.
+- No ConnectorConfig rows were created by the dry-run, no full proof was run,
+  no `sandbox-proof.json` was created, and no proof row was inserted.
+
+
+Remaining QA actions:
+
+- Keep `AGENTICORG_DB_URL` and `AGENTICORG_CMO_SANDBOX_TENANT_ID=d3f0d84c-836f-4cda-8896-ce2f1623213d` available in the local shell when running the helper/runner.
+- Provide real vendor-sandbox credentials either through existing `AGENTICORG_CMO_SANDBOX_*` env vars or a gitignored `secrets/cmo_vendor_sandbox_connectors.json` file.
+- Run `python scripts/configure_cmo_vendor_sandbox_connectors.py --dry-run --format json`; only when it reports all four categories ready, rerun without `--dry-run`.
+- Then run `python scripts/run_weekly_report_sandbox_pilot.py --preflight-only --json` and verify CRM, Ads, Analytics, and Email are all `source=db`, `readiness_state=ready`, `proof_scope=vendor_sandbox`, `local_test_only=false`, and `mock_or_test_double=false`.
+- Vendor-sandbox proof is still not real-vendor production proof; `production_claim_allowed` and `real_vendor_claim_allowed` must remain false for any `vendor_sandbox` row.
+
+Hand-off to a credentialed operator: re-run this CMO-PROD-3-OPS task in
+an environment that has the tenant ConnectorConfig rows + Postgres listed above.
+The same runner is expected to produce a `vendor_sandbox` / `sandbox_proven` row;
+this Status section should be updated with that run's `proof_id`,
+`evaluated_at`, `readiness_score`, and the SQL verification query from
+the CMO-PROD-3 runbook immediately above.
+
+
+Objective: prove an honest first `vendor_sandbox` verdict end-to-end:
+tenant ConnectorConfig rows or local/dev env fallback + DB + migration → real sandbox connectors → real
+weekly-report run → CMO-PROD-2 persistence → readback verdict that has
+`environment_type="vendor_sandbox"`, `proof_status="sandbox_proven"`,
+`production_claim_allowed=False`, `real_vendor_claim_allowed=False`.
+
+Files in scope (delivered):
+
+- `core/marketing/weekly_report_sandbox_pilot.py` — pure orchestration
+  module: `discover_sandbox_pilot_config()` (tenant `ConnectorConfig` preferred, env fallback),
+  `build_blocked_preflight_envelope()`, and `run_sandbox_pilot()`. The
+  ready-preflight branch calls `core.tasks.report_tasks.generate_report.run`
+  unchanged so the CMO-PROD-2 hook persists the verdict.
+- `scripts/run_weekly_report_sandbox_pilot.py` — CLI wrapper. `--preflight-only`
+  reports missing env vars without invoking the report task. `--format json`
+  emits a secret-redacted bundle. Exit codes: `0`=passed/sandbox_proven,
+  `2`=partial, `3`=blocked / preflight-failed / unavailable.
+- `tests/unit/test_cmo_weekly_report_sandbox_runner.py` — 18 acceptance
+  tests covering every fail-closed path.
+
+Preflight result in this worktree (2026-05-24):
+
+```
+$ python scripts/run_weekly_report_sandbox_pilot.py --preflight-only
+Preflight status:         blocked
+Tenant id:                <missing>
+Missing connector categories: CRM, Ads, Analytics, Email
+Missing env vars:
+  - AGENTICORG_CMO_SANDBOX_HUBSPOT_ACCESS_TOKEN
+  - AGENTICORG_CMO_SANDBOX_GOOGLE_ADS_DEVELOPER_TOKEN
+  - AGENTICORG_CMO_SANDBOX_GOOGLE_ADS_REFRESH_TOKEN
+  - AGENTICORG_CMO_SANDBOX_GOOGLE_ADS_CUSTOMER_ID
+  - AGENTICORG_CMO_SANDBOX_GOOGLE_ADS_CLIENT_ID
+  - AGENTICORG_CMO_SANDBOX_GOOGLE_ADS_CLIENT_SECRET
+  - AGENTICORG_CMO_SANDBOX_GA4_PROPERTY_ID
+  - AGENTICORG_CMO_SANDBOX_GA4_REFRESH_TOKEN
+  - AGENTICORG_CMO_SANDBOX_GA4_CLIENT_ID
+  - AGENTICORG_CMO_SANDBOX_GA4_CLIENT_SECRET
+  - AGENTICORG_CMO_SANDBOX_SENDGRID_API_KEY
+  - AGENTICORG_CMO_SANDBOX_SENDGRID_SENDER
+  - AGENTICORG_DB_URL
+  - AGENTICORG_CMO_SANDBOX_TENANT_ID
+Exit code: 3
+```
+
+Runbook — exact command sequence to run once a sandbox tenant is ready:
+
+1. **Stand up Postgres + apply the migration:**
+
+   ```
+   export AGENTICORG_DB_URL=postgresql+asyncpg://USER:PASS@HOST:5432/agenticorg
+   alembic upgrade head
+   ```
+
+   This applies `v4917_weekly_report_proof` and creates the
+   `weekly_report_pilot_proofs` table.
+
+2. **Pick a sandbox tenant UUID and export it:**
+
+   ```
+   export AGENTICORG_CMO_SANDBOX_TENANT_ID=<uuid-of-sandbox-tenant>
+   # optional:
+   export AGENTICORG_CMO_SANDBOX_COMPANY_ID=<uuid-of-sandbox-company>
+   ```
+
+3. **Populate one sandbox connector per category** (the runner accepts
+   any of the listed alternatives — fill one group per category, not
+   all of them):
+
+   - **CRM** — HubSpot test portal *or* Salesforce sandbox:
+     - `AGENTICORG_CMO_SANDBOX_HUBSPOT_ACCESS_TOKEN`
+     - *or* `AGENTICORG_CMO_SANDBOX_SALESFORCE_INSTANCE_URL` +
+       `AGENTICORG_CMO_SANDBOX_SALESFORCE_REFRESH_TOKEN` +
+       `AGENTICORG_CMO_SANDBOX_SALESFORCE_CLIENT_ID` +
+       `AGENTICORG_CMO_SANDBOX_SALESFORCE_CLIENT_SECRET`
+   - **Ads** — Google Ads test account, Meta sandbox, or LinkedIn Ads sandbox:
+     - `AGENTICORG_CMO_SANDBOX_GOOGLE_ADS_DEVELOPER_TOKEN`,
+       `_REFRESH_TOKEN`, `_CUSTOMER_ID`, `_CLIENT_ID`, `_CLIENT_SECRET`
+     - *or* `AGENTICORG_CMO_SANDBOX_META_ADS_ACCESS_TOKEN` +
+       `AGENTICORG_CMO_SANDBOX_META_ADS_AD_ACCOUNT_ID`
+     - *or* `AGENTICORG_CMO_SANDBOX_LINKEDIN_ADS_REFRESH_TOKEN`,
+       `_ACCOUNT_ID`, `_CLIENT_ID`, `_CLIENT_SECRET`
+   - **Analytics** — GA4 demo property:
+     - `AGENTICORG_CMO_SANDBOX_GA4_PROPERTY_ID`, `_REFRESH_TOKEN`,
+       `_CLIENT_ID`, `_CLIENT_SECRET`
+   - **Email** — SendGrid sandbox or Mailchimp test account:
+     - `AGENTICORG_CMO_SANDBOX_SENDGRID_API_KEY` +
+       `AGENTICORG_CMO_SANDBOX_SENDGRID_SENDER`
+     - *or* `AGENTICORG_CMO_SANDBOX_MAILCHIMP_API_KEY` +
+       `AGENTICORG_CMO_SANDBOX_MAILCHIMP_SERVER_PREFIX` +
+       `AGENTICORG_CMO_SANDBOX_MAILCHIMP_AUDIENCE_ID`
+
+4. **Complete CMO field mapping + backfill in the dashboard / API**
+   for the sandbox tenant: `lifecycle_stages`, `opportunity_revenue`,
+   `campaign_ids`, `utm_fields`, `consent_unsubscribe`,
+   `fiscal_calendar`, `currency`, `timezone`. The runner does not
+   bypass these — the underlying CMO-PROD-1 validator requires every
+   mapping to be `valid` before any verdict can be `sandbox_proven`.
+
+5. **Confirm preflight passes:**
+
+   ```
+   python scripts/run_weekly_report_sandbox_pilot.py --preflight-only
+   # expect: "Preflight status: ready" and exit code 0
+   ```
+
+6. **Run the pilot:**
+
+   ```
+   python scripts/run_weekly_report_sandbox_pilot.py --format json | tee sandbox-proof.json
+   ```
+
+   The runner invokes `core.tasks.report_tasks.generate_report.run(...)`
+   with `params.pilot_environment_type="vendor_sandbox"`, which fires
+   the CMO-PROD-2 hook and inserts a single row in
+   `weekly_report_pilot_proofs`. The script then re-reads the latest
+   row from `/kpis/cmo` and prints the redacted summary.
+
+7. **Verify the row landed and is honest:**
+
+   ```
+   psql $AGENTICORG_DB_URL -c "
+     SELECT proof_id, environment_type, proof_status,
+            production_claim_allowed, real_vendor_claim_allowed,
+            readiness_score, evaluated_at
+       FROM weekly_report_pilot_proofs
+       WHERE tenant_id = '$AGENTICORG_CMO_SANDBOX_TENANT_ID'
+       ORDER BY evaluated_at DESC LIMIT 1;
+   "
+   ```
+
+   - `environment_type` MUST be `vendor_sandbox`.
+   - `proof_status` MUST be `sandbox_proven` (or `partial` / `blocked`
+     if any evidence is still incomplete — never silently `passed`).
+   - `production_claim_allowed` and `real_vendor_claim_allowed` MUST
+     both be `false`.
+
+Acceptance tests (13 passing, all in
+`tests/unit/test_cmo_weekly_report_sandbox_runner.py`):
+
+- preflight with empty env → `blocked` envelope, `production_claim_allowed=False`
+- preflight with complete env → `ready`, picks one connector per category
+- preflight with missing single category lists only that category
+- preflight envelope is redactable (no leaked secret-named values when
+  the redactor runs)
+- `run_sandbox_pilot()` with missing creds returns the blocked envelope
+  and never calls the persistence helper
+- `run_sandbox_pilot()` with ready env calls `generate_report.run` with
+  `params.pilot_environment_type="vendor_sandbox"` and the persisted
+  verdict is sandbox/partial only — never real-vendor passed
+- `run_sandbox_pilot()` tolerates DB readback failure and still returns
+  the task-result summary with `production_claim_allowed=False`
+- runner reads back the latest persisted verdict via the
+  `latest_weekly_report_pilot_proof` helper
+- runner output redacts `api_key` / `authorization` named fields in
+  the task result
+- CLI `--preflight-only` exits 3 when blocked and lists the missing
+  envs
+- CLI `--format json` does not echo any sandbox env var values
+- `SANDBOX_CONNECTOR_OPTIONS` covers the same categories as
+  `REQUIRED_BACKFILL_CATEGORIES` (CRM/Ads/Analytics/Email)
+- preflight is pure (does not mutate env)
+
+Definition of done (CMO-PROD-3):
+
+- ✅ Fail-closed sandbox runner exists and is test-covered.
+- ✅ Runner never inserts a fake / synthetic row.
+- ✅ Runner forces `environment_type="vendor_sandbox"` upstream so a
+  successful pilot can never accidentally produce a real-vendor
+  production claim.
+- ✅ All output (text and JSON) goes through the same secret-marker
+  redactor used by `core.marketing.weekly_report_pilot_proof`.
+- ✅ Backlog distinguishes "validator complete" / "persistence
+  complete" / "sandbox live evidence present or blocked" cleanly.
+- ⏳ A pilot tenant must populate the listed env vars before the first
+  `sandbox_proven` row can materialise. **No row exists today**.
+
+Hand-off to CMO-PROD-4:
+
+- After the first `sandbox_proven` row lands, CMO-PROD-4 walks one
+  real-customer tenant through the same orchestrator with live
+  vendor credentials to produce the first `real_vendor` + `passed`
+  verdict. The runner already supports this — `environment_type` will
+  be inferred from `source_context` / connector contracts at evidence-
+  build time. No code changes are expected for CMO-PROD-4 beyond the
+  decision to label a tenant `real_vendor` in its connector contracts.
+
+## Suggested Sprint Order
+
+1. Week 1: CMO-0.1, CMO-0.2
+2. Week 1-2: CMO-1.1, CMO-1.2, CMO-1.3, CMO-2.1
+3. Week 2-4: CMO-3.1, CMO-3.2, CMO-3.3, CMO-4.1, CMO-4.2, CMO-4.3
+4. Week 4-5: CMO-5.1, CMO-5.2, CMO-5.3, CMO-5.4, CMO-6.1, CMO-6.2, CMO-6.3
+5. Week 5-6: CMO-7.1, CMO-7.2, CMO-7.3, CMO-8.1, CMO-8.2, CMO-8.3
+6. Week 6+: CMO-9.1, CMO-9.2, CMO-9.3, CMO-9.4; then live pilot rollout, persistent evidence storage/UI, beta-agent production proof, and vendor adapter rollout
+
+Sequencing note after CMO-5.1, CMO-5.2, CMO-5.3, CMO-5.4, CMO-6.1, CMO-6.2, CMO-6.3, CMO-7.1, CMO-7.2, CMO-7.3, CMO-8.1, CMO-8.2, CMO-8.3, CMO-9.1, CMO-9.2, CMO-9.3, CMO-9.4, CMO-3.1, CMO-3.2, CMO-3.3, CMO-4.1, and CMO-4.2: connector contracts now expose read/write readiness, retry/degraded policy, confidence impact, idempotency metadata, mock/test proof blocking, and external write confirmation status; marketing workflow steps fail closed on rejected, timeout/unknown, unconfirmed, non-write-safe connector states, unsafe retry, approval timeout, missing/blocking marketing policy, unsatisfied policy approval/escalation, missing escalation routes, missing decision-audit evidence, and shadow-mode external-write attempts; marketing workflow YAML can be linted before execution for undefined agents/actions, beta/stub/unavailable production behavior, connector-readiness gaps, degraded-only production dependencies, unsafe external-write metadata, missing approval timeout policy, missing/blocking marketing policy coverage, missing escalation routes, missing CMO-6.3 decision-audit evidence, and CMO-9.1 agent contract status; pending/overdue CMO approval timeout risk and approval-review payloads are visible in the CMO KPI API; the CMO KPI API exposes the active/default marketing policy manifest, marketing escalation matrix, decision audit package schema/summaries, unified CMO KPI schema/evaluation projection, KPI reconciliation checks/summary, report quality gates/summary, a prioritized CMO work queue/summary, KPI drill-down/data-lineage projection, approval-review projection, and CMO pilot proof projection/summary; per-agent contract tests now prove implemented/beta contract shape plus stub/unavailable non-production status; deterministic CMO E2E-style scenarios now prove weekly review, campaign launch, crisis response, ABM sprint, and content-to-publish paths fail closed across those surfaces; deterministic chaos/failure tests now prove connector outage, auth/scope failure, rate/quota limits, stale/partial/malformed data, approval timeout, budget race, duplicate replay, unsafe writes, missing policy/escalation/audit evidence, failed reconciliation, and report-gate failure are surfaced as blocked, degraded, draft/internal-only, retry-scheduled, or manual-resolution states rather than hidden production success; pilot proof packaging now distinguishes real-vendor, vendor-sandbox, demo, test-double, and unknown tenants while keeping demo/test-double proof from passing production readiness; and Social Media/ABM/Competitive Intel/Brand Monitor/SEO Strategist/CRM Intelligence now have first-class beta core logic while remaining unproven for production without real-vendor/pilot proof. The next safety gaps are live pilot execution, persistent KPI/report/audit/task/approval/proof storage and UI, vendor adapter rollout where needed, and production proof for beta CMO agents before claiming complete CMO autonomy.
+
+## Codex CLI Task Template
+
+Use this template for each implementation task:
+
+```text
+Task ID:
+Objective:
+Files in scope:
+Non-goals:
+Acceptance tests:
+Definition of done:
+Risk checks:
+```
+
+## First Codex CLI Task To Start
+
+```text
+Task ID: CMO-0.1
+Objective: Replan the CMO PRD so real companies can use it with real data, real connectors, real approvals, and a serious marketing-team UX.
+Files in scope:
+- docs/PRD.md
+- docs/cmo_guide.md
+- docs/PRD_CxO_v5.0.md
+- ui/src/pages/CMODashboard.tsx
+- related locale/test files if dashboard copy changes
+Non-goals:
+- Do not implement missing agents in this task.
+- Do not redesign the dashboard.
+Acceptance tests:
+- npm --prefix ui test -- CMODashboard if UI changed.
+- Run any existing markdown/docs validation if available.
+- Search docs/UI for unqualified CMO autonomy claims and mock/stub production claims.
+Definition of done:
+- PRD defines real-company onboarding, data foundation, connector readiness, governance, UX, production gates, and pilot proof.
+- CMO UI/docs distinguish production, beta, shadow, stub, unavailable, demo, and degraded capabilities.
+- No unqualified "fully autonomous CMO" claim remains.
+- No mock/stub-only capability is treated as production-ready.
+Risk checks:
+- Search for CMO autonomy claims after the edit.
+- Confirm copy does not undercut implemented Campaign Pilot and Content Factory capabilities.
+- Confirm the plan requires real connector data and does not bless mock-only implementation.
+```

--- a/docs/cmo_guide.md
+++ b/docs/cmo_guide.md
@@ -2,15 +2,127 @@
 
 ## Overview
 
-AgenticOrg gives CMOs a unified command center for marketing operations. Instead of toggling between Google Ads, HubSpot, social platforms, email tools, and analytics dashboards, you get 9 specialized AI agents that handle content creation, campaign management, A/B testing, email drip sequences, SEO, CRM intelligence, brand monitoring, email marketing, social media, account-based marketing with intent data, and competitive intelligence — all with mandatory human approval on every publishing decision. Web push notifications let you approve or reject agent decisions with a single tap from your browser.
+AgenticOrg gives CMOs a unified command center for marketing operations, but the CMO agent surface is not yet production-grade across all CMO pillars. Current production-strength work is concentrated in Campaign Pilot, with substantial beta capability in Content Factory, Email Marketing, Social Media, ABM, Competitive Intel, Brand Monitor, SEO Strategist, and CRM Intelligence. Every CMO marketing-agent pillar in `core/agents/marketing` now has first-class deterministic code, but production claim still requires real-vendor pilot proof, persistent evidence storage, and vendor adapter rollout. Web push notifications and HITL approvals apply where the underlying workflow is implemented.
 
-This guide covers everything a CMO needs: the marketing dashboard, each marketing agent, A/B testing, email drip sequences, ABM with intent data, web push HITL, natural language querying, report scheduling, workflow templates, and the approval gates that keep your brand safe.
+This guide distinguishes production, beta, stub, unavailable, and demo surfaces so buyers and operators do not confuse roadmap or demo coverage with production-grade CMO autonomy.
+
+### Real-Company Readiness Rule
+
+A CMO capability is production-ready only when it works against a company's configured marketing systems, exposes data lineage and freshness, follows approval policy, and writes audit records for recommendations and actions. Mocks, sample data, and stubs are allowed only in tests, local development, or explicitly labeled demo tenants. They must not be used to claim production readiness for a real marketing department.
 
 ---
 
 ## Marketing Dashboard (`/dashboard/cmo`)
 
-The CMO Dashboard is your real-time marketing command center. It aggregates data from all 9 marketing agents and 19 connected marketing platforms into a single view. Access it at `/dashboard/cmo` or by selecting "CMO Dashboard" from the sidebar.
+The CMO Dashboard is the marketing command center for currently available KPI and agent-task data. It does not prove that all 9 CMO pillars are production-ready. If the API returns `"demo": true`, the dashboard shows a **Demo Data** badge and the KPI values should be treated as sample data. Access it at `/dashboard/cmo` or by selecting "CMO Dashboard" from the sidebar.
+
+### CMO Work Queue
+
+The CMO KPI API now includes `cmo_work_queue` and `cmo_work_queue_summary`. This is a deterministic operator queue, not persistent task storage. It turns hidden readiness metadata into visible work items for approvals, overdue approval timeout risk, escalations, connector auth/scope/health/degraded issues, field-mapping and backfill blockers, workflow promotion blockers, external write rejection/timeout/unconfirmed states, missing policy or decision-audit evidence, blocked/degraded KPI results, failed/warning reconciliation checks, blocked/warning/internal-only/draft-only report quality gates, production demo/sample blockers, and crisis/public-response risks where available.
+
+Each work item includes severity, priority score, owner role, affected workflow/capability/KPI/report/connector, due/SLA timestamp, source refs, audit refs, status, and a next-action CTA. Prioritization puts critical customer-facing external-write risk first, then overdue approvals and escalations, then write-blocking connector/policy/audit issues, report delivery blockers, KPI/reconciliation blockers, and lower-severity read-only or stale optional-data warnings.
+
+The dashboard renders the queue before connector, data, and workflow readiness sections. An empty queue only means there are no projected open work items; it is not a production-readiness claim for stub, unavailable, or demo capabilities.
+
+### CMO Approval Review
+
+The CMO KPI API now includes `cmo_approval_reviews` and `cmo_approval_review_summary`. This is a deterministic approval-review projection, not a full persistent approvals system. It gives reviewers enough context to approve, reject, override, request changes, escalate, or pause approval-sensitive marketing actions without bypassing HITL, policy, timeout, escalation, external-write, or audit safeguards.
+
+Approval reviews cover campaign launches, ad budget changes, content publishing, email sends, landing-page changes, target-account list changes, crisis/public responses, high-risk copy/pricing/legal claims, and workflow promotion. Each row includes approval/workflow/run/step refs, requester and agent refs, assigned approver/role, created and due timestamps, timeout state, preview payload, before/after diff, budget impact, audience/list impact, brand/legal/policy risk flags, source and connector refs, agent rationale, policy result/ref, escalation result/ref, timeout result/ref, external-write readiness/result ref, audit refs, rollback/stop plan, allowed reviewer actions, blocked reasons, related work queue item IDs, and next-action CTA.
+
+Approval review fails closed. A reviewer cannot approve a customer-facing or external-write action when policy coverage is missing or blocking, connector/write readiness is unsafe, timeout policy requires manual resolution, or required decision-audit evidence is absent. Shadow and draft/internal-only actions remain clearly labeled and non-executable. The dashboard renders compact approval review cards after the work queue, showing the preview, impact, safeguards, rollback/stop plan, allowed actions, and CTA before KPI lineage or readiness sections.
+
+### CMO Pilot Proof
+
+The CMO KPI API now includes `cmo_pilot_proof` and `cmo_pilot_proof_summary`. This is a deterministic evidence package for a pilot tenant, not proof that the CMO organization is fully production-ready. It evaluates connector setup, connector contracts, field mapping/backfill, workflow activation and linting, policy, escalation, approval timeout readiness, external-write confirmation, decision-audit evidence, KPI schema and reconciliation, report quality gates, work queue blockers, KPI drill-down lineage, approval reviews, agent contracts, and scenario/chaos test evidence where available.
+
+Pilot proof distinguishes `real_vendor`, `vendor_sandbox`, `demo`, `test_double`, and `unknown` environments. Demo tenants return `demo_only`; test-double/mock environments return `test_only`; neither can pass production proof. Vendor-sandbox proof can pass only sandbox criteria and must not be described as real-vendor production proof. Real-vendor proof can pass only when all critical readiness criteria pass. Social Media, ABM, Competitive Intel, Brand Monitor, SEO Strategist, and CRM Intelligence are first-class beta but remain unproven for production until real-vendor/pilot proof exists. The evidence bundle serializer redacts obvious secrets and tokens before it can be attached to docs or a future UI.
+
+### Weekly Marketing Report Pilot Proof (CMO-PROD-1)
+
+`/kpis/cmo` also exposes `weekly_report_pilot_proof`, `weekly_report_pilot_proof_summary`, and `weekly_report_pilot_evidence_bundle`. This is a stricter, read-only proof gate specifically for the weekly marketing report. It is satisfied only when CRM + Ads + Analytics + Email connectors are configured and read-ready, every required field mapping (lifecycle_stages, opportunity_revenue, campaign_ids, utm_fields, consent_unsubscribe, fiscal_calendar, currency, timezone) is valid, every required backfill category is completed, every required weekly-report KPI (CAC, MQL, SQL, MQL→SQL conversion rate, ROAS, pipeline contribution, conversion rates by funnel stage, email performance) is present and not blocked, every reconciliation check passes, the weekly-report quality gate is `pass`, and a report artifact + decision-audit + real-source-lineage reference set is attached. Demo, test-double, and vendor-sandbox inputs never produce a real-vendor production claim. A `scripts/validate_weekly_report_pilot_proof.py` CLI accepts a JSON evidence file (or STDIN) and emits a redacted verdict for pilot-tenant operators. **As of 2026-05-24 no live or vendor-sandbox evidence is present in the worktree**, so the proof returns `unavailable` / `blocked` until a pilot tenant supplies a real evidence bundle.
+
+### Persisted Weekly Report Pilot Proof (CMO-PROD-2)
+
+Every successful CMO weekly report run now persists a verdict to `weekly_report_pilot_proofs` (Alembic migration `v4917_weekly_report_proof`). The report generator hydrates a `WeeklyReportPilotEvidence` bundle from the same `/kpis/cmo` projections it already uses for the report (connector setup, mapping + backfill, unified KPIs, reconciliation, report-quality gate), attaches `report_artifact_refs` and `decision_audit_refs`, runs the CMO-PROD-1 validator, redacts secrets, and inserts a single append-only row. `/kpis/cmo` exposes `latest_weekly_report_pilot_proof` (full redacted row) and `latest_weekly_report_pilot_proof_summary` (proof status, environment, production-claim flag, readiness score, blocker count, next-action CTA). The CMO-PROD-1 validator remains the only authority for `production_claim_allowed=True`; the persistence path adds durability, not laxity. Demo / non-UUID tenants short-circuit before INSERT so the table never contains fake evidence. **No `weekly_report_pilot_proofs` row exists yet**; the first row will only appear when a credentialed pilot tenant runs the weekly report.
+
+### Sandbox Walk-Through Runner (CMO-PROD-3)
+
+A fail-closed orchestrator lives at `scripts/run_weekly_report_sandbox_pilot.py` (callable via `core.marketing.weekly_report_sandbox_pilot.run_sandbox_pilot`). It discovers sandbox configuration only from `AGENTICORG_CMO_SANDBOX_*` env vars and `AGENTICORG_DB_URL`, refuses to insert fake proof, and forces `params.pilot_environment_type="vendor_sandbox"` upstream so a successful pilot can never produce a real-vendor production claim. Run `python scripts/run_weekly_report_sandbox_pilot.py --preflight-only` to see exactly which env vars must be populated before the first `sandbox_proven` verdict can materialise. The full env-var list and runbook are in `docs/STRICT_CMO_AGENTIC_EXECUTION_BACKLOG_2026-05-23.md` under "CMO-PROD-3". **As of 2026-05-24, no sandbox credentials are configured in this worktree, so the runner returns `unavailable` / `blocked` (exit code 3) and no row is inserted.**
+
+### CMO Agent Contract Coverage
+
+CMO agent contract tests now cover the current marketing surfaces: Campaign Pilot, Content Factory, Email Marketing / `email_agent`, Brand Monitor, SEO Strategist, CRM Intelligence, Social Media, ABM / `abm_agent`, and Competitive Intel. Implemented and beta surfaces must return a stable contract shape with status, confidence, rationale, recommended actions, source refs, policy/approval/HITL state, audit refs, degraded or blocked reasons, and external-write confirmation status where applicable.
+
+The contract tests are a safety net, not a production-readiness shortcut. Campaign Pilot has the strongest production implementation today. Content Factory, Email Marketing, Social Media, ABM, Competitive Intel, Brand Monitor, SEO Strategist, and CRM Intelligence remain beta. Production workflow linting and activation continue to block beta or unavailable agents from active customer-facing workflows when connector/write, policy, approval, escalation, audit, or pilot-proof prerequisites are missing.
+
+### Marketing Connector Setup Checklist
+
+The CMO KPI API now includes a `connector_setup` checklist for real-company onboarding. Each row exposes the connector key, name, category, required scopes or credentials, configured/unconfigured status, health status, last sync timestamp, owner, account/workspace ID when stored, data coverage, missing scopes, and the setup/reconnect action state.
+
+The dashboard renders this checklist before KPI cards so operators can see which marketing systems are connected, missing, stale, expired, insufficiently scoped, healthy, or degraded. Missing systems create setup actions; expired OAuth creates reconnect actions; missing permissions create add-scope actions; stale syncs create refresh actions. A production tenant with no real CMO data must not silently fall back to demo KPI values. Instead the API suppresses the demo flag, returns `production_data_blocked: true`, and points operators back to connector setup.
+
+### Marketing Connector Contracts
+
+The CMO KPI API also returns `connector_contracts` and `connector_contract_summary`. These rows harden connector setup into a contract that agents and workflow gates can rely on. Each connector contract separates read capabilities from write capabilities, lists required and granted scopes, reports missing read or write scopes, exposes auth and health state, tracks account/workspace/source object refs where stored, shows data freshness and TTL, and includes retry-budget and idempotency-key metadata.
+
+Contract rows can report `healthy`, `missing_scope`, `insufficient_scope`, `auth_expired`, `rate_limited`, `timeout`, `vendor_5xx`, `partial_data`, `stale_data`, `malformed_payload`, `quota_exhausted`, `connector_disabled`, `degraded`, `write_unconfirmed`, or `write_confirmed`. Read access does not imply write readiness. A connector can be read-ready while still blocking active workflows that need to publish, send, spend, update CRM, or mutate ad budgets.
+
+The retry/degraded-mode projection is now policy-backed. Connector failure classes expose retryability, max attempts, backoff strategy metadata, safe-retry idempotency requirements, degraded-mode allowance, confidence impact, external-write blocking, production KPI confidence blocking, the required operator CTA, and audit event code. Reporting and recommendation workflows may continue only in explicitly labeled degraded mode with affected connectors, workflows, KPIs, capability, confidence impact, and next action visible. Active external-write workflows fail closed when connector state is not write-safe.
+
+External write steps cannot be treated as complete unless the connector contract has matching external write confirmation, or the workflow is explicitly in shadow/draft/internal-only mode. Mock, sample, stub, or test-double connector proof is blocked from production readiness. The dashboard shows connector contract read/write readiness, auth/freshness, retry/idempotency state, write confirmation, degraded reasons, and next action before field mapping and backfill readiness.
+
+Workflow step execution now carries the same confirmation discipline. Marketing external-write steps can finish as `write_confirmed`, `idempotent_recovered`, `retry_scheduled`, `rejected`, `timeout_unknown`, `write_unconfirmed`, `draft_created`, or `shadow_only`. Active publish, send, launch, spend, or CRM-update steps fail closed unless a confirmed write includes an explicit external object ID, connector key, idempotency key where applicable, request fingerprint, confirmation timestamp, actor/agent/workflow/run IDs where available, and audit reference. Shadow workflows never execute external writes; they can only complete recommendations, simulations, drafts, or internal approval records. Timeout retries are scheduled only when idempotency metadata exists, and duplicate retries recover prior confirmed writes only when the same idempotency key is present.
+
+Approval-sensitive CMO actions now have explicit timeout policy. Ad campaign launches, ad budget changes, email sends, content publishing, landing-page changes, target-account list changes, crisis/public responses, social post targeting, and high-risk copy/pricing/claims reviews each carry default SLA, escalation role, timeout outcome, audit event code, and safe fallback CTA. Supported timeout outcomes are `auto_cancel`, `auto_escalate`, `continue_read_only`, `pause_workflow`, and `require_manual_resolution`. Customer-facing writes fail closed after timeout unless a policy explicitly pre-approves that action after timeout. The CMO KPI API exposes `approval_timeout_risk` for pending and overdue marketing approvals.
+
+A machine-checkable CMO marketing policy manifest now defines conservative default rules for budget thresholds, publishing/sending/launching, high-risk copy, pricing/legal/compliance claims, competitor mentions, region constraints, audience and target-account thresholds, crisis/public response, allowed autonomous read-only actions, disallowed destructive actions, required owner roles, and required audit evidence classes. Policy evaluation returns `allowed`, `blocked`, `requires_approval`, `requires_escalation`, `read_only_only`, or `missing_policy` with matched rules, reason, required approver/escalation role, required audit evidence, affected workflow/action, and next action CTA. Active customer-facing writes fail closed without policy coverage and satisfied approval/escalation evidence; shadow/read-only recommendations can continue only when clearly non-executable. The CMO KPI API exposes `marketing_policy_manifest` and `marketing_policy_summary`.
+
+A code-backed CMO escalation matrix now defines routes for approval timeouts, crisis/public response, budget threshold exceptions, connector auth/degraded failures, data mapping blockers, backfill failures, missing policy, rejected or unknown external writes, high-risk copy, pricing/legal claims, and target-account changes. Escalation decisions return `notify_owner`, `escalate`, `escalate_to_legal`, `escalate_to_finance`, `escalate_to_admin`, `pause_workflow`, or `require_manual_resolution` with owner role, backup role, chain, SLA, due time, fallback outcome, notification channels, audit event code, and audit reference. The CMO KPI API exposes `marketing_escalation_matrix` and `marketing_escalation_summary`.
+
+CMO decision audit packages are now code-backed for major marketing decisions. Policy decisions, escalation decisions, approval timeouts, connector degraded/failure decisions, workflow promotion evaluations, and external write attempts/final states attach deterministic audit packages with actor identity, timestamps, workflow/run/step IDs, input snapshot hashes, source and connector refs, policy/escalation/approval/timeout/write refs, rationale, alternatives, risk flags, confidence, final outcome, override reason/replacement action, and WORM-ready canonical JSON serialization. The package redacts obvious secrets/tokens before serialization. Production customer-facing workflow linting fails when a step lacks CMO-6.3 decision-audit evidence metadata. The CMO KPI API exposes `marketing_decision_audit` and `marketing_decision_audit_summary`.
+
+### Marketing Field Mapping And Backfill Readiness
+
+The CMO KPI API also returns `field_mapping_status`, `backfill_status`, and `kpi_readiness`. These are code-backed projections from stored connector configuration metadata, not demo proof. Field mappings cover lifecycle stages, opportunity revenue fields, campaign IDs, UTM fields, account domains, consent/unsubscribe fields, fiscal calendar, currency, and timezone.
+
+Mapping rows can be `unmapped`, `partially_mapped`, `valid`, `invalid`, `stale`, or `blocked`. Backfill rows can be `not_started`, `queued`, `running`, `completed`, `partial`, `failed`, or `blocked`, and include the source connector key, requested date range, available record counts, last run timestamp, blocking reason, and next action. The dashboard renders these states before KPI cards so Marketing Ops can see why CAC, ROAS, pipeline, email, or nurture readiness is blocked or degraded.
+
+Production tenants must not treat KPI values as confident when required mappings or historical backfills are missing. In strict production mode, `/kpis/cmo` marks `kpi_confidence_status` as `blocked` or `degraded` and returns an operator-facing message instead of silently presenting sample, hardcoded, or incomplete data as production-ready.
+
+### Unified CMO KPI Schema
+
+The CMO KPI API now also returns `unified_cmo_kpi_schema`, `unified_cmo_kpi_results`, and `unified_cmo_kpi_summary`. The schema defines canonical formulas and readiness requirements for CAC, MQL, SQL, MQL-to-SQL conversion, ROAS, pipeline contribution, conversion rates by funnel stage, LTV/CAC, experiment velocity, content performance, email performance, brand sentiment, and ABM intent/account readiness.
+
+Each KPI result is computed only from structured tenant source facts that satisfy connector setup, connector contract, field-mapping, backfill, freshness, degraded-mode, and audit-lineage requirements. Results are labeled `ready`, `degraded`, `blocked`, or `unavailable` and include formula refs, source refs, missing requirements, confidence, freshness status, last computed timestamp, and next action. Production tenants must not use sample/demo/hardcoded values as KPI proof; missing connectors, stale/partial data, missing mappings, missing backfills, or absent source fields block or downgrade only the affected KPIs.
+
+### CMO KPI Drill-Down And Data Lineage
+
+The CMO KPI API now also returns `cmo_kpi_drilldowns` and `cmo_kpi_drilldown_summary`. Drill-down rows explain each canonical KPI with KPI name/description, current status/value/unit/confidence, formula, resolved formula inputs where available, required source domains/connectors/mappings/backfills, actual connector and source refs, field mappings used, backfill state, reconciliation checks affecting the KPI, freshness/TTL state, confidence-impact reasons, missing requirements, related work queue item IDs, related report gate IDs, policy/audit refs, owner role, and next action CTA.
+
+The dashboard renders these drill-downs as a compact lineage table after the work queue and before readiness setup sections. This is not persistent KPI history storage and not a full drill-down workbench yet; it is the code-backed explanation layer that prevents KPI cards and reports from hiding source, freshness, confidence, reconciliation, mapping, or backfill gaps. Demo, mock, stub, hardcoded, sample, fallback, or test-double inputs are explicitly marked as not production lineage proof and do not count as trusted production source refs.
+
+### CMO KPI Reconciliation
+
+The CMO KPI API now also returns `cmo_kpi_reconciliation_checks` and `cmo_kpi_reconciliation_summary`. Reconciliation checks compare paid spend totals against campaign-level spend, ad platform conversions against CRM campaign-attributed outcomes, GA4 conversions against CRM leads, email engagement against CRM/list data, CMS content traffic against GA4 content performance, ABM target account domains against CRM and intent domains, and currency/timezone consistency across sources.
+
+Each reconciliation result is labeled `passed`, `warning`, `failed`, `blocked`, or `unavailable` and includes severity, affected KPI keys, compared sources, expected and observed values, absolute and percentage deltas, tolerance, confidence/freshness impact, source refs, missing requirements, next action, and decision-audit ref where relevant. Failed high-severity checks block affected KPIs such as CAC, ROAS, LTV/CAC, pipeline contribution, and ABM readiness. Warnings and medium-severity failures downgrade confidence instead of pretending the KPI is fully trusted. Production KPI and report readiness must not ignore failed reconciliation; report quality gates consume this reconciliation state before a report can be deliverable.
+
+### CMO Report Quality Gates
+
+The CMO KPI API now also returns `report_quality_gates` and `report_quality_summary`. These gates cover `weekly_marketing_report`, `daily_ad_performance`, `monthly_marketing_roi`, `campaign_performance_ad_hoc`, and `executive_board_summary`, with compatibility aliases for existing `cmo_weekly` and `campaign_report` generator paths.
+
+Each gate consumes unified KPI status/confidence/freshness, KPI reconciliation results, connector setup/contracts, mapping/backfill readiness, workflow activation mode, policy/escalation/audit readiness, approval refs for sensitive or external delivery, and production data policy. Gate status can be `pass`, `warning`, `blocked`, or `unavailable`; safe report mode can be `deliverable`, `internal_only`, or `draft_only`. A report is externally deliverable only when the gate passes. Blocked or warning reports may still exist as clearly labeled draft/internal outputs, but they must not be sent as trusted production reports.
+
+### CMO Workflow Promotion Gates
+
+The CMO KPI API also returns `workflow_activation_status` and `workflow_activation_summary`. This projection covers `weekly_marketing_report`, `campaign_launch`, `daily_spend_optimization`, `content_pipeline`, `lead_nurture`, `social_publishing`, `abm_sprint`, `brand_crisis_response`, and `seo_sprint`.
+
+Workflow rows can be `unavailable`, `shadow`, `promotion_blocked`, `promotion_ready`, `active`, `degraded`, or `paused`. Promotion is per workflow. A workflow cannot become active just because the CMO dashboard or another workflow is active. Each row shows required connector categories, required mappings, required backfills, approval owner, policy owner, marketing policy readiness, approval timeout policy readiness, escalation matrix readiness, shadow-run quality status, blocked/degraded reasons, and the next action.
+
+Shadow mode is read-only. Agents may recommend, draft, simulate, and create internal approval records, but they must not publish, send, spend, update CRM, mutate ad budgets, or write to external systems unless that specific workflow is active. Social Publishing, ABM Sprint, Brand Crisis Response, and SEO Sprint are beta-gated workflows and can become promotion-ready only after their required connectors, mapping/backfill, policy, approval, escalation, audit, and write-confirmation gates pass. Connector setup alone does not make those workflow pillars production-grade.
+
+Marketing workflow YAML can also be linted through `core.marketing.workflow_linter` before promotion or execution. The linter validates known marketing `agent_type` values, declared action metadata, production/beta/stub/unavailable capability state, declared connector key/category readiness, CMO-5.3 write-confirmation metadata, idempotency metadata, CMO-5.4 approval timeout policy, CMO-6.1 marketing policy coverage, CMO-6.2 escalation routes, CMO-6.3 decision-audit evidence metadata, and shadow-mode read-only behavior. Production lint fails undefined agents/actions, stub or unavailable production steps, missing write-ready connector contracts, missing approval timeout policy, missing/blocking marketing policy, missing escalation route, missing decision-audit evidence, and unsafe external-write steps. Target, demo, and shadow workflows can carry roadmap placeholders only as warnings.
 
 ### KPI Cards
 
@@ -31,11 +143,28 @@ Each KPI card refreshes on a configurable schedule — typically every 30 minute
 
 The dashboard respects RBAC: only users with CMO or CEO roles can access `/dashboard/cmo`.
 
+### Current Capability Status
+
+| Capability | Status | Current truth |
+|------------|--------|---------------|
+| Campaign Pilot | Production | Strongest CMO agent today: domain-specific campaign execution, budget checks, performance polling, and HITL gates. |
+| Content Factory | Beta | Substantial content workflow exists, including draft generation and brand checks; publish feedback loops and QA policy are still maturing. |
+| Email Marketing | Beta | Available through a separate LangGraph path and approval-gated tooling; not a complete autonomous CMO pillar yet. |
+| Brand Monitor | Beta | First-class deterministic brand monitoring for mention aggregation, sentiment trends, spike detection, false-positive suppression, crisis severity, playbook recommendation, escalation, and safety-gated public response; not production-grade without real-vendor/pilot proof. |
+| SEO Strategist | Beta | First-class deterministic SEO logic for keyword gaps, ranking deltas, technical issue prioritization, recommendation bundling, content optimization, sprint planning, stale/partial data handling, and guarded technical site-write actions; not production-grade without real SEO/Analytics/CMS connectors, policy/approval/audit evidence, confirmed writes, and pilot proof. |
+| CRM Intelligence | Beta | First-class deterministic CRM/pipeline intelligence for pipeline velocity, funnel conversion, lead scoring refresh, churn risk signal extraction, segment recommendation, SQL promotion criteria, account/deal health, stale/partial/missing-mapping data handling, and guarded CRM-write actions (lead score, lifecycle stage, segment/list, target accounts, bulk CRM update); not production-grade without real HubSpot/Salesforce/intent connector readiness, policy/approval/audit evidence, confirmed writes, and pilot proof. |
+| Social Media | Beta | First-class core marketing agent for calendar, schedule optimization, engagement triage, reply risk classification, drafts, and guarded publish/reply recommendations; not production without real Social connector write readiness, policy/approval/escalation/audit evidence, confirmed writes, and pilot proof. |
+| ABM | Beta | First-class core marketing agent for account scoring, ICP fit, intent heat scoring, configurable intent-source weighting, next-best action, CSV ingest validation, high-intent alerts, and guarded target-list/campaign/budget actions; not production without real ABM/CRM/Ads connector readiness, policy/approval/escalation/audit evidence, confirmed writes, and pilot proof. |
+| Competitive Intel | Beta | First-class core marketing agent for weekly competitor snapshots, profile normalization, pricing-change detection, feature/capability diffing, win/loss signal extraction, duplicate suppression, alert thresholds, and guarded positioning/public-response recommendations; not production without real competitive-source connectors, policy/approval/escalation/audit evidence, confirmed writes where applicable, and pilot proof. |
+| CMO KPI feed | Demo when badge is shown | Demo KPI data is sample data, not proof of end-to-end autonomous CMO operation. |
+
 ---
 
-## Marketing Agents (9)
+## CMO Capability Inventory
 
 ### 1. Content Factory
+**Status**: Beta. Content Factory has substantial core marketing logic, but publishing policy, formal QA scoring, and performance feedback loops are still maturing.
+
 **What it does**: End-to-end content creation — from ideation to drafting to SEO optimization to publishing.
 
 **Key capabilities**: Topic ideation based on keyword gaps (via Ahrefs/Semrush). Content brief generation with target keywords, word count, and structure. Draft creation with brand voice consistency. SEO optimization (title tags, meta descriptions, heading structure, internal linking). WordPress publishing via API.
@@ -45,6 +174,8 @@ The dashboard respects RBAC: only users with CMO or CEO roles can access `/dashb
 **Connected systems**: WordPress, Ahrefs, Semrush, GA4.
 
 ### 2. Campaign Pilot
+**Status**: Production. Campaign Pilot is the strongest current CMO agent and has domain-specific execution logic for campaign setup, budget checks, channel performance polling, optimization decisions, and HITL triggers.
+
 **What it does**: Multi-channel advertising campaign management — from setup to optimization to reporting.
 
 **Key capabilities**: Campaign creation across Google Ads, Meta Ads, and LinkedIn Ads. Budget allocation optimization based on ROAS. A/B test management (ad copy, targeting, bidding). Bid adjustment recommendations. Campaign performance reporting with cross-channel attribution.
@@ -54,16 +185,20 @@ The dashboard respects RBAC: only users with CMO or CEO roles can access `/dashb
 **Connected systems**: Google Ads, Meta Ads, LinkedIn Ads, GA4.
 
 ### 3. SEO Strategist
-**What it does**: Technical and content SEO — from site audits to keyword research to ranking tracking.
+**Status**: Beta first-class core marketing agent. `core/agents/marketing/seo_strategist.py` now implements deterministic SEO domain logic, but SEO Strategist is not production-ready until real SEO/Analytics/CMS connectors, write scopes, policy approval, audit evidence, confirmed external writes where applicable, and pilot proof are present.
 
-**Key capabilities**: Technical SEO audits (crawl errors, page speed, mobile-friendliness, structured data). Keyword research and gap analysis. Ranking position tracking. Backlink profile monitoring. Content optimization recommendations. Competitor SEO analysis.
+**Implemented beta behavior**: Technical and content SEO recommendations - keyword gap analysis, ranking delta computation, technical SEO issue prioritization, effort/impact recommendation bundling, content optimization recommendations, SEO sprint planning, stale/partial data handling, and guarded technical site-write paths.
 
-**HITL triggers**: Technical changes (robots.txt, sitemap, redirects) require approval. Content recommendations flagged for review.
+**Key capabilities**: Keyword gap analysis and content opportunity scoring. Ranking improvements, drops, new terms, and lost terms. Technical SEO issue prioritization by severity, impact, effort, and affected pages. Recommendation bundling by effort and impact. Content optimization recommendations for titles, metadata, headings, content depth, and internal links. SEO sprint planning from structured SEO, analytics, and CMS inputs. Guarded technical site changes for metadata, canonical tags, redirects, robots.txt, sitemaps, landing-page updates, and indexing submissions.
 
-**Connected systems**: Ahrefs, Semrush, GA4, Google Search Console (via GA4).
+**HITL triggers**: Technical site changes (robots.txt, sitemaps, redirects, canonical tags, page metadata, landing-page updates, indexing submissions) require policy coverage, approval, audit evidence, connector write safety, and confirmed external write evidence. Advisory recommendations can remain read-only in beta/shadow mode.
+
+**Connected systems**: Ahrefs, Semrush, GA4, Google Search Console, and CMS/WordPress where configured. Active technical site changes additionally require a write-safe CMS/SEO connector contract and confirmed external write evidence.
 
 ### 4. CRM Intelligence
-**What it does**: CRM data analysis — pipeline health, lead scoring, customer segmentation, and lifecycle analysis.
+**Status**: Beta first-class core marketing agent. `core/agents/marketing/crm_intelligence.py` now implements deterministic CRM/pipeline intelligence (pipeline velocity, funnel conversion, lead scoring refresh, churn risk extraction, segment recommendation, SQL promotion, account/deal health, stale/partial/missing-mapping handling) with policy/approval/audit/connector-write/external-write-confirmation gates. Production claim is blocked until real HubSpot/Salesforce/intent connector readiness, policy/approval/audit evidence, confirmed external CRM writes, and pilot proof are present.
+
+**Target behavior**: CRM data analysis — pipeline health, lead scoring, customer segmentation, and lifecycle analysis.
 
 **Key capabilities**: Pipeline health scoring (velocity, conversion rates, deal size trends). Lead scoring model management. Customer segmentation (by industry, size, behavior, engagement). Churn risk identification. Customer lifetime value estimation. Win/loss analysis.
 
@@ -72,15 +207,19 @@ The dashboard respects RBAC: only users with CMO or CEO roles can access `/dashb
 **Connected systems**: HubSpot, Salesforce.
 
 ### 5. Brand Monitor
-**What it does**: Brand reputation monitoring — social listening, sentiment analysis, and crisis detection.
+**Status**: Beta first-class core marketing agent. `core/agents/marketing/brand_monitor.py` now implements deterministic brand monitoring domain logic, but Brand Monitor is not production-ready until real Brand/Social connectors, policy approval, escalation, audit evidence, confirmed external writes where applicable, and pilot proof are present.
+
+**Implemented beta behavior**: Brand reputation monitoring recommendations -- mention aggregation, sentiment classification and trend calculation, negative spike detection, false-positive suppression, crisis severity classification, competitor/brand grouping, deterministic response playbooks, and guarded public/crisis response paths.
 
 **Key capabilities**: Real-time social media monitoring across Twitter/X, LinkedIn, Reddit, and news. Sentiment analysis (positive/negative/neutral with trend). Brand mention tracking with alert thresholds. Competitor brand monitoring. Crisis detection and escalation. Share of voice analysis.
 
-**HITL triggers**: Negative sentiment spikes. Crisis indicators (volume + negativity above threshold). Competitor activity alerts.
+**HITL triggers**: Negative sentiment spikes. Crisis indicators (volume + negativity above threshold). Public/crisis responses. Pricing, legal, comparative, or other high-risk brand claims.
 
-**Connected systems**: Brandwatch, Twitter/X, YouTube.
+**Connected systems**: Brandwatch, Twitter/X, YouTube, and social publishing systems where configured. Active public response additionally requires a write-safe Social connector contract and confirmed external write evidence.
 
 ### 6. Email Marketing Agent
+**Status**: Beta. Email Marketing is available through a separate LangGraph path with approval-gated tools. Treat it as partial CMO coverage, not a complete autonomous pillar.
+
 **What it does**: Email campaign management — from list management to campaign creation to performance analysis.
 
 **Key capabilities**: Email campaign creation with templates. List segmentation based on behavior, demographics, and engagement. A/B testing (subject lines, content, send times). Automated drip sequences. Deliverability monitoring. Unsubscribe management and compliance (CAN-SPAM, GDPR).
@@ -90,16 +229,20 @@ The dashboard respects RBAC: only users with CMO or CEO roles can access `/dashb
 **Connected systems**: Mailchimp, SendGrid, HubSpot (contact data).
 
 ### 7. Social Media Agent
-**What it does**: Social media management — content scheduling, engagement monitoring, and analytics.
+**Status**: Beta first-class core marketing agent. `core/agents/marketing/social_media.py` now implements deterministic domain logic, but Social Media is not production-ready until real Social connectors, write scopes, policy approval, escalation, audit, confirmed external writes, and pilot proof are present.
 
-**Key capabilities**: Post scheduling across Twitter/X, LinkedIn, Facebook, Instagram. Engagement monitoring (replies, mentions, DMs). Hashtag performance analysis. Best-time-to-post optimization. Social content calendar management. User-generated content discovery.
+**Current behavior**: Social media management recommendations — content calendar generation, posting schedule optimization, engagement triage, reply risk classification, social post draft/recommendation, and guarded publish/reply paths.
+
+**Key capabilities**: Content calendar creation across channels, deterministic best-time posting recommendations, triage of normal/negative/pricing-legal/executive/crisis mentions, risk classification for replies, social post drafts with source refs and rationale, escalation recommendations for crisis/high-risk mentions, and publish/reply safeguards that refuse unconfirmed external writes.
 
 **HITL triggers**: All social media posts require CMO approval before publishing. Responses to negative mentions. Content involving brand claims or pricing.
 
-**Connected systems**: Buffer, Twitter/X, YouTube, MoEngage.
+**Connected systems**: Buffer, Twitter/X, YouTube, MoEngage where configured. Active publishing additionally requires a write-safe Social connector contract and confirmed external write evidence.
 
 ### 8. ABM Agent (Account-Based Marketing)
-**What it does**: Account-based marketing — target account identification, intent signal monitoring, and personalized outreach. Now powered by real intent data from Bombora, G2, and TrustRadius.
+**Status**: Beta first-class core marketing agent. `core/agents/marketing/abm_agent.py` now implements deterministic ABM domain logic, but ABM is not production-ready until real ABM/CRM/Ads connectors, write scopes, policy approval, escalation, audit, confirmed external writes, and pilot proof are present.
+
+**Implemented beta behavior**: Account-based marketing account scoring, ICP fit scoring, intent signal aggregation, high-intent alerting, next-best-action recommendation, and CSV target-account ingest validation using structured account data and configurable Bombora, G2, TrustRadius, and CRM-style weights.
 
 **Key capabilities**: Target account list management (ICP scoring). **Intent data aggregation** — Bombora (40% weight), G2 (30%), TrustRadius (30%) for account-level buying signals. Account-level engagement scoring. Personalized content recommendations per account. Multi-touch attribution at the account level. ABM campaign orchestration. **CSV upload** for target account lists. **Intent heatmap** visualization.
 
@@ -108,13 +251,15 @@ The dashboard respects RBAC: only users with CMO or CEO roles can access `/dashb
 **Connected systems**: HubSpot/Salesforce (CRM), Bombora (intent data), G2 (buyer intent), TrustRadius (review + intent), GA4 (intent signals), LinkedIn Ads (account targeting).
 
 ### 9. Competitive Intel Agent
-**What it does**: Competitive intelligence — competitor monitoring, pricing analysis, feature comparison, and market positioning.
+**Status**: Beta first-class core marketing agent. `core/agents/marketing/competitive_intel.py` now implements deterministic domain logic, but Competitive Intel is not production-ready until real competitive-source connectors, policy approval, escalation, audit evidence, confirmed external writes where applicable, and pilot proof are present.
 
-**Key capabilities**: Competitor website and content monitoring. Pricing change detection and alerting. Feature/capability comparison matrix maintenance. Market positioning analysis. Win/loss pattern analysis by competitor. New competitor entry detection.
+**Implemented beta behavior**: Competitive intelligence recommendations — weekly competitor snapshots, profile normalization, pricing-change detection, feature/capability diffing, win/loss signal extraction, change confidence scoring, duplicate suppression, alert thresholding, and positioning recommendations.
 
-**HITL triggers**: Competitive pricing changes. New competitor product launches. Win rate drops against specific competitors.
+**Key capabilities**: Competitor website and content monitoring. Pricing change detection and alerting. Feature/capability comparison matrix maintenance. Market positioning analysis. Win/loss pattern analysis by competitor. New competitor entry detection. Public response, pricing claim, comparative claim, and campaign actions are guarded by policy, approval, escalation, audit, connector write-safety, and external-write confirmation.
 
-**Connected systems**: Ahrefs (competitor SEO), social platforms (competitor mentions), CRM (win/loss data).
+**HITL triggers**: Competitive pricing changes. New competitor product launches. Win rate drops against specific competitors. Comparative/pricing claims, public responses, and competitive campaign actions require approval or escalation before any external action.
+
+**Connected systems**: Ahrefs (competitor SEO), Brandwatch or social listening sources (competitor mentions), CRM (win/loss data), and Social/Ads connectors only for guarded external actions.
 
 ---
 
@@ -176,7 +321,7 @@ Navigate to **Reports > Scheduled Reports** to set up automated marketing report
 ## Workflow Templates for Marketing
 
 ### Campaign Launch (`campaign_launch`)
-**Agents involved**: Content Factory, Campaign Pilot, SEO Strategist, Social Media, Email Marketing
+**Agents involved**: Content Factory (beta), Campaign Pilot (production), SEO Strategist (beta; production gated), Social Media (beta), Email Marketing (beta)
 
 **Steps**:
 1. Content Factory: Generate campaign brief from business objectives
@@ -187,11 +332,11 @@ Navigate to **Reports > Scheduled Reports** to set up automated marketing report
 6. Email Marketing: Create and schedule email sequence
 7. Social Media: Schedule social posts for launch
 8. HITL: CMO gives final launch approval (mandatory)
-9. All agents: Activate campaigns simultaneously
+9. Implemented production/beta steps activate only after approval and connector/write/audit confirmation gates pass; stub and unavailable steps remain target behavior
 10. Campaign Pilot: Begin performance monitoring
 
 ### Content Pipeline (`content_pipeline`)
-**Agents involved**: Content Factory, SEO Strategist
+**Agents involved**: Content Factory (beta), SEO Strategist (beta; production gated)
 
 **Steps**:
 1. SEO Strategist: Identify keyword gaps and content opportunities
@@ -203,7 +348,7 @@ Navigate to **Reports > Scheduled Reports** to set up automated marketing report
 7. SEO Strategist: Submit URL to Google for indexing
 
 ### Lead Nurture (`lead_nurture`)
-**Agents involved**: CRM Intelligence, Email Marketing, ABM
+**Agents involved**: CRM Intelligence (beta; production gated), Email Marketing (beta), ABM (beta first-class core agent; production gated)
 
 **Steps**:
 1. CRM Intelligence: Score and segment new leads
@@ -215,7 +360,7 @@ Navigate to **Reports > Scheduled Reports** to set up automated marketing report
 7. CRM Intelligence: Hand off SQLs to sales team with context
 
 ### Weekly Marketing Report (`weekly_marketing_report`)
-**Agents involved**: Campaign Pilot, CRM Intelligence, SEO Strategist, Email Marketing, Brand Monitor
+**Agents involved**: Campaign Pilot (production), CRM Intelligence (beta; production gated), SEO Strategist (beta; production gated), Email Marketing (beta), Brand Monitor (beta; production gated)
 
 **Steps**:
 1. Campaign Pilot: Collect ad performance data across all channels
@@ -231,7 +376,7 @@ Navigate to **Reports > Scheduled Reports** to set up automated marketing report
 
 ## CMO Approval Gates
 
-**All publishing actions require CMO approval.** This is a hard requirement — no agent can publish content, send emails, launch ads, or post to social media without explicit CMO sign-off.
+**All implemented publishing actions require CMO approval.** This is a hard requirement for production and beta workflows — implemented agents cannot publish content, send emails, or launch ads without explicit CMO sign-off. For stub or unavailable capabilities, approval behavior is target behavior until the domain-specific agent exists.
 
 ### What Requires Approval
 
@@ -241,10 +386,10 @@ Navigate to **Reports > Scheduled Reports** to set up automated marketing report
 | Ad campaign launch | Campaign Pilot | Budget commitment, brand representation |
 | Ad budget changes | Campaign Pilot | Financial impact |
 | Email campaign send | Email Marketing | Recipient list, content, compliance (CAN-SPAM, GDPR) |
-| Social media post | Social Media | Brand representation, timing, tone |
+| Social media post | Social Media (beta; production publish requires proof) | Brand representation, timing, tone |
 | Drip sequence changes | Email Marketing | Customer experience impact |
-| Target account list changes | ABM | Resource allocation |
-| Landing page changes | Content Factory + SEO | Brand, conversion impact |
+| Target account list changes | ABM (beta; production changes require approval, policy, audit, connector write safety, and confirmed write evidence) | Resource allocation |
+| Landing page changes | Content Factory + SEO Strategist (beta; production changes require approval, policy, audit, connector write safety, and confirmed write evidence) | Brand, conversion impact |
 
 ### Approval Workflow
 
@@ -253,6 +398,10 @@ Navigate to **Reports > Scheduled Reports** to set up automated marketing report
 3. CMO reviews in the Approvals queue (`/approvals`) — sees the full content, targeting, budget, and agent recommendation
 4. CMO clicks **Approve** (agent publishes), **Reject** (agent stops, with reason logged), or **Override** (CMO edits and publishes modified version)
 5. Every decision is logged in the WORM-compliant audit trail
+
+### Approval Timeout Policy
+
+Pending approvals do not hang forever. Approval-sensitive marketing work is evaluated against default CMO timeout policy unless a stricter workflow policy is supplied. The default is fail-closed for customer-facing writes: timed-out campaign launches auto-cancel, ad budget changes and crisis responses auto-escalate, email sends/content/social targeting pause the workflow, and landing-page, target-account, and high-risk copy/pricing/claims changes require manual resolution. A timed-out decision writes audit evidence with approval ID, workflow/run/step IDs where available, requested approver and role, created/due/timed-out timestamps, outcome, escalation target, blocked action, escalation route evidence, and audit reference.
 
 ### Why Mandatory Approval Matters
 
@@ -315,7 +464,7 @@ All events are stored and linked to the drip sequence, updating lead scores and 
 
 ## ABM with Intent Data
 
-The ABM Dashboard (`/dashboard/abm`) provides a unified view of target accounts and their buying intent.
+The ABM Dashboard (`/dashboard/abm`) provides a unified view of target accounts and their buying intent. Dashboard/API surfaces and the beta first-class ABM core agent are not proof that ABM is production-ready without real connector, policy, approval, audit, write-confirmation, and pilot evidence.
 
 ### Intent Data Sources
 | Source | Weight | What It Provides |

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -2283,7 +2283,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "connectors.read",
-    "source_line": 568,
+    "source_line": 796,
     "tenant_required": true
   },
   {
@@ -2301,7 +2301,43 @@
     "public_exempt_reason": null,
     "rate_limit": "admin-mutating",
     "scope": "connectors.create",
-    "source_line": 637,
+    "source_line": 865,
+    "tenant_required": true
+  },
+  {
+    "audit_event": "connectors.cmo_vendor_sandbox.read",
+    "auth_required": true,
+    "function": "get_cmo_vendor_sandbox_connectors",
+    "idempotency": "read-only",
+    "key": "GET /api/v1/connectors/cmo-vendor-sandbox api/v1/connectors.py:get_cmo_vendor_sandbox_connectors",
+    "metadata_present": true,
+    "methods": [
+      "GET"
+    ],
+    "module": "api/v1/connectors.py",
+    "path": "/api/v1/connectors/cmo-vendor-sandbox",
+    "public_exempt_reason": null,
+    "rate_limit": "standard",
+    "scope": "connectors.read",
+    "source_line": 1028,
+    "tenant_required": true
+  },
+  {
+    "audit_event": "connectors.cmo_vendor_sandbox.upsert",
+    "auth_required": true,
+    "function": "upsert_cmo_vendor_sandbox_connectors",
+    "idempotency": "tenant-cmo-vendor-sandbox-upsert",
+    "key": "POST /api/v1/connectors/cmo-vendor-sandbox api/v1/connectors.py:upsert_cmo_vendor_sandbox_connectors",
+    "metadata_present": true,
+    "methods": [
+      "POST"
+    ],
+    "module": "api/v1/connectors.py",
+    "path": "/api/v1/connectors/cmo-vendor-sandbox",
+    "public_exempt_reason": null,
+    "rate_limit": "admin-mutating",
+    "scope": "connectors.create",
+    "source_line": 1089,
     "tenant_required": true
   },
   {
@@ -2373,7 +2409,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "connectors.registry.read",
-    "source_line": 430,
+    "source_line": 658,
     "tenant_required": false
   },
   {
@@ -2391,7 +2427,7 @@
     "public_exempt_reason": null,
     "rate_limit": "admin-mutating",
     "scope": "connectors.delete",
-    "source_line": 1055,
+    "source_line": 1524,
     "tenant_required": true
   },
   {
@@ -2409,7 +2445,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "connectors.read",
-    "source_line": 801,
+    "source_line": 1270,
     "tenant_required": true
   },
   {
@@ -2427,7 +2463,7 @@
     "public_exempt_reason": null,
     "rate_limit": "admin-mutating",
     "scope": "connectors.update",
-    "source_line": 840,
+    "source_line": 1309,
     "tenant_required": true
   },
   {
@@ -2445,7 +2481,7 @@
     "public_exempt_reason": null,
     "rate_limit": "connector-test",
     "scope": "connectors.health.read",
-    "source_line": 1088,
+    "source_line": 1557,
     "tenant_required": true
   },
   {
@@ -2463,7 +2499,7 @@
     "public_exempt_reason": null,
     "rate_limit": "connector-test",
     "scope": "connectors.test",
-    "source_line": 1143,
+    "source_line": 1612,
     "tenant_required": true
   },
   {
@@ -3183,7 +3219,7 @@
     "public_exempt_reason": null,
     "rate_limit": "business-metrics-read",
     "scope": "kpis.executive.sensitive.cbo",
-    "source_line": 593,
+    "source_line": 996,
     "tenant_required": true
   },
   {
@@ -3201,7 +3237,7 @@
     "public_exempt_reason": null,
     "rate_limit": "business-metrics-read",
     "scope": "kpis.executive.sensitive.ceo",
-    "source_line": 473,
+    "source_line": 876,
     "tenant_required": true
   },
   {
@@ -3219,7 +3255,7 @@
     "public_exempt_reason": null,
     "rate_limit": "business-metrics-read",
     "scope": "kpis.executive.sensitive.cfo",
-    "source_line": 502,
+    "source_line": 905,
     "tenant_required": true
   },
   {
@@ -3237,7 +3273,7 @@
     "public_exempt_reason": null,
     "rate_limit": "business-metrics-read",
     "scope": "kpis.executive.sensitive.chro",
-    "source_line": 536,
+    "source_line": 939,
     "tenant_required": true
   },
   {
@@ -3255,7 +3291,7 @@
     "public_exempt_reason": null,
     "rate_limit": "business-metrics-read",
     "scope": "kpis.executive.sensitive.cmo",
-    "source_line": 555,
+    "source_line": 958,
     "tenant_required": true
   },
   {
@@ -3273,7 +3309,7 @@
     "public_exempt_reason": null,
     "rate_limit": "business-metrics-read",
     "scope": "kpis.executive.sensitive.coo",
-    "source_line": 574,
+    "source_line": 977,
     "tenant_required": true
   },
   {
@@ -4695,7 +4731,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "connectors.tools.read",
-    "source_line": 491,
+    "source_line": 719,
     "tenant_required": false
   },
   {

--- a/migrations/versions/v4_9_17_weekly_report_pilot_proof.py
+++ b/migrations/versions/v4_9_17_weekly_report_pilot_proof.py
@@ -1,0 +1,97 @@
+"""CMO-PROD-2 — weekly_report_pilot_proofs durable verdict log.
+
+Revision ID: v4917_weekly_report_proof
+Revises: v4916_merge_p0_heads
+Create Date: 2026-05-24
+
+CMO-PROD-1 added a strict, code-backed weekly-marketing-report pilot proof
+gate. CMO-PROD-2 needs a durable home for verdicts and the redacted
+evidence bundle that produced them, so the CMO dashboard / future UI can
+read the latest verdict per tenant + company without re-running the
+validator from ephemeral state.
+
+Schema choices:
+- ``proof_id`` is the deterministic hash from
+  ``core.marketing.weekly_report_pilot_proof._proof_id`` so the same
+  evidence input produces the same proof identity (idempotent re-runs
+  can be detected).
+- ``evidence_bundle`` and ``verdict`` are JSONB. They are persisted
+  *after* the validator's secret-marker redaction; raw evidence with
+  tokens or API keys never lands in this table.
+- ``(tenant_id, company_id, evaluated_at DESC)`` composite index supports
+  the common "latest verdict per tenant/company" lookup.
+- Append-only by convention: the persistence helper inserts a new row
+  per evaluation. There is no UPDATE path, so this is effectively a
+  proof log.
+
+Idempotent: CREATE TABLE / INDEX use IF NOT EXISTS so re-running on an
+environment that already has the table is a no-op.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v4917_weekly_report_proof"
+down_revision = "v4916_merge_p0_heads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS weekly_report_pilot_proofs (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id UUID NOT NULL,
+            company_id UUID,
+            proof_id TEXT NOT NULL,
+            environment_type TEXT NOT NULL,
+            proof_status TEXT NOT NULL,
+            production_claim_allowed BOOLEAN NOT NULL DEFAULT FALSE,
+            real_vendor_claim_allowed BOOLEAN NOT NULL DEFAULT FALSE,
+            readiness_score INTEGER NOT NULL DEFAULT 0,
+            evaluated_at TIMESTAMPTZ NOT NULL,
+            evidence_bundle JSONB NOT NULL DEFAULT '{}'::jsonb,
+            verdict JSONB NOT NULL DEFAULT '{}'::jsonb,
+            blockers JSONB NOT NULL DEFAULT '[]'::jsonb,
+            next_actions JSONB NOT NULL DEFAULT '[]'::jsonb,
+            report_artifact_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+            decision_audit_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ
+        );
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_weekly_report_pilot_proofs_tenant_id
+            ON weekly_report_pilot_proofs (tenant_id);
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_weekly_report_pilot_proofs_proof_id
+            ON weekly_report_pilot_proofs (proof_id);
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_weekly_report_pilot_proofs_company_id
+            ON weekly_report_pilot_proofs (company_id);
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_weekly_report_pilot_proofs_tenant_evaluated
+            ON weekly_report_pilot_proofs (tenant_id, company_id, evaluated_at);
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_weekly_report_pilot_proofs_tenant_evaluated;")
+    op.execute("DROP INDEX IF EXISTS ix_weekly_report_pilot_proofs_company_id;")
+    op.execute("DROP INDEX IF EXISTS ix_weekly_report_pilot_proofs_proof_id;")
+    op.execute("DROP INDEX IF EXISTS ix_weekly_report_pilot_proofs_tenant_id;")
+    op.execute("DROP TABLE IF EXISTS weekly_report_pilot_proofs;")

--- a/scripts/configure_cmo_vendor_sandbox_connectors.py
+++ b/scripts/configure_cmo_vendor_sandbox_connectors.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Configure CMO weekly-report vendor-sandbox ConnectorConfig rows.
+
+This is a local/QA helper. It never invents credentials and never logs raw
+credential values. Credentials can be supplied either through the existing
+`AGENTICORG_CMO_SANDBOX_*` env vars used by the runner, or through a gitignored
+JSON file such as `secrets/cmo_vendor_sandbox_connectors.json`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core.marketing.weekly_report_sandbox_pilot import (  # noqa: E402
+    SANDBOX_CONNECTOR_OPTIONS,
+    SANDBOX_ENV_PREFIX,
+)
+
+CATEGORY_ORDER = ("CRM", "Ads", "Analytics", "Email")
+DEFAULT_CONFIG_PATH = REPO_ROOT / "secrets" / "cmo_vendor_sandbox_connectors.json"
+SECRET_KEY_MARKERS = ("secret", "token", "password", "credential", "api_key", "authorization")
+
+
+@dataclass(frozen=True)
+class ConnectorInput:
+    category: str
+    connector_name: str
+    display_name: str
+    auth_type: str
+    credentials: dict[str, Any]
+    non_secret_config: dict[str, Any]
+    source: str
+
+
+def _load_local_dotenv() -> None:
+    env_path = REPO_ROOT / ".env"
+    if not env_path.exists():
+        return
+    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default=str(DEFAULT_CONFIG_PATH),
+        help="Gitignored JSON file containing QA-provided sandbox connector credentials.",
+    )
+    parser.add_argument(
+        "--tenant-id",
+        default=None,
+        help=f"Tenant UUID. Defaults to {SANDBOX_ENV_PREFIX}TENANT_ID.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Validate only; do not write DB rows.")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    return parser.parse_args()
+
+
+def _load_file_inputs(path: Path) -> dict[str, ConnectorInput]:
+    if not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    connectors = payload.get("connectors", payload)
+    if not isinstance(connectors, Mapping):
+        raise ValueError("Connector config file must contain a connectors object.")
+
+    loaded: dict[str, ConnectorInput] = {}
+    for category in CATEGORY_ORDER:
+        row = connectors.get(category) or connectors.get(category.lower())
+        if not isinstance(row, Mapping):
+            continue
+        credentials = row.get("credentials")
+        if not isinstance(credentials, Mapping) or not credentials:
+            continue
+        connector_name = str(row.get("connector_name") or row.get("provider") or "").strip()
+        if not connector_name:
+            raise ValueError(f"{category} config is missing connector_name/provider.")
+        loaded[category] = ConnectorInput(
+            category=category,
+            connector_name=connector_name,
+            display_name=str(row.get("display_name") or connector_name),
+            auth_type=str(row.get("auth_type") or "oauth2"),
+            credentials=dict(credentials),
+            non_secret_config=_safe_non_secret_config(row.get("config")),
+            source=f"file:{path.name}",
+        )
+    return loaded
+
+
+def _load_env_inputs(env: Mapping[str, str]) -> dict[str, ConnectorInput]:
+    loaded: dict[str, ConnectorInput] = {}
+    for category, options in SANDBOX_CONNECTOR_OPTIONS.items():
+        for option in options:
+            missing = [name for name in option["required_envs"] if not env.get(name)]
+            if missing:
+                continue
+            credential_env_map = option["credential_env_map"]
+            credentials = {
+                key: str(env[name])
+                for key, name in credential_env_map.items()
+                if env.get(name) is not None
+            }
+            loaded[category] = ConnectorInput(
+                category=category,
+                connector_name=str(option["connector_key"]),
+                display_name=str(option["connector_key"]).replace("_", " ").title(),
+                auth_type="oauth2",
+                credentials=credentials,
+                non_secret_config={},
+                source="env",
+            )
+            break
+    return loaded
+
+
+async def _upsert_connector_configs(
+    tenant_id: uuid.UUID,
+    inputs: Mapping[str, ConnectorInput],
+    *,
+    dry_run: bool,
+) -> dict[str, Any]:
+    from sqlalchemy import select
+
+    from core.crypto import encrypt_for_tenant
+    from core.database import async_session_factory
+    from core.models.connector_config import ConnectorConfig
+    from core.models.tenant import Tenant
+
+    async with async_session_factory() as session:
+        tenant_result = await session.execute(select(Tenant.id).where(Tenant.id == tenant_id))
+        if tenant_result.scalar_one_or_none() is None:
+            return {
+                "status": "blocked",
+                "message": "Target tenant does not exist.",
+                "categories": [],
+                "missing_categories": list(CATEGORY_ORDER),
+            }
+
+        summaries: list[dict[str, Any]] = []
+        for category in CATEGORY_ORDER:
+            connector_input = inputs[category]
+            config = _vendor_sandbox_config(connector_input)
+            encrypted = await encrypt_for_tenant(
+                json.dumps(connector_input.credentials, sort_keys=True),
+                tenant_id,
+            )
+            existing_result = await session.execute(
+                select(ConnectorConfig).where(
+                    ConnectorConfig.tenant_id == tenant_id,
+                    ConnectorConfig.connector_name == connector_input.connector_name,
+                )
+            )
+            existing = existing_result.scalar_one_or_none()
+            action = "would_insert" if dry_run else "inserted"
+            if existing is not None:
+                action = "would_update" if dry_run else "updated"
+                if not _replacement_has_real_sandbox_metadata(config, connector_input.credentials):
+                    return {
+                        "status": "blocked",
+                        "message": f"Refusing to overwrite {category}; replacement is not real vendor-sandbox metadata.",
+                        "categories": summaries,
+                        "missing_categories": [],
+                    }
+                if not dry_run:
+                    existing.display_name = connector_input.display_name
+                    existing.auth_type = connector_input.auth_type
+                    existing.credentials_encrypted = {"_encrypted": encrypted}
+                    existing.config = config
+                    existing.status = "configured"
+                    existing.health_status = "healthy"
+                    existing.sync_error = None
+            elif not dry_run:
+                session.add(
+                    ConnectorConfig(
+                        tenant_id=tenant_id,
+                        connector_name=connector_input.connector_name,
+                        display_name=connector_input.display_name,
+                        auth_type=connector_input.auth_type,
+                        credentials_encrypted={"_encrypted": encrypted},
+                        config=config,
+                        status="configured",
+                        health_status="healthy",
+                    )
+                )
+            summaries.append(
+                {
+                    "category": category,
+                    "connector_name": connector_input.connector_name,
+                    "source": connector_input.source,
+                    "action": action,
+                    "credential_keys_present": sorted(connector_input.credentials),
+                    "proof_scope": "vendor_sandbox",
+                    "local_test_only": False,
+                    "mock_or_test_double": False,
+                }
+            )
+        if not dry_run:
+            await session.commit()
+        return {
+            "status": "ready",
+            "message": "Vendor-sandbox ConnectorConfig rows validated." if dry_run else "Vendor-sandbox ConnectorConfig rows configured.",
+            "categories": summaries,
+            "missing_categories": [],
+        }
+
+
+def _vendor_sandbox_config(connector_input: ConnectorInput) -> dict[str, Any]:
+    safe_config = {
+        **connector_input.non_secret_config,
+        "cmo_category": connector_input.category,
+        "proof_scope": "vendor_sandbox",
+        "environment_type": "vendor_sandbox",
+        "local_test_only": False,
+        "mock_or_test_double": False,
+        "sandbox_preflight_ready": True,
+        "configured_by": "scripts/configure_cmo_vendor_sandbox_connectors.py",
+        "configured_at": datetime.now(UTC).isoformat(),
+    }
+    return _strip_secret_like_keys(safe_config)
+
+
+def _replacement_has_real_sandbox_metadata(config: Mapping[str, Any], credentials: Mapping[str, Any]) -> bool:
+    return (
+        bool(credentials)
+        and config.get("proof_scope") == "vendor_sandbox"
+        and config.get("environment_type") == "vendor_sandbox"
+        and config.get("local_test_only") is False
+        and config.get("mock_or_test_double") is False
+    )
+
+
+def _safe_non_secret_config(value: Any) -> dict[str, Any]:
+    return _strip_secret_like_keys(value if isinstance(value, dict) else {})
+
+
+def _strip_secret_like_keys(value: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        str(key): item
+        for key, item in value.items()
+        if not _is_secret_key(str(key)) and not isinstance(item, Mapping)
+    }
+
+
+def _is_secret_key(key: str) -> bool:
+    normalized = key.lower().replace("-", "_")
+    return any(marker in normalized for marker in SECRET_KEY_MARKERS)
+
+
+def _safe_summary(summary: Mapping[str, Any]) -> dict[str, Any]:
+    redacted = json.loads(json.dumps(summary, default=str))
+    for category in redacted.get("categories", []):
+        if isinstance(category, dict) and "credential_keys_present" in category:
+            category["credential_values_redacted"] = True
+    return redacted
+
+
+async def _amain() -> int:
+    _load_local_dotenv()
+    args = _parse_args()
+    tenant_id_raw = args.tenant_id or os.getenv(f"{SANDBOX_ENV_PREFIX}TENANT_ID")
+    if not tenant_id_raw:
+        summary = {
+            "status": "blocked",
+            "message": f"Missing {SANDBOX_ENV_PREFIX}TENANT_ID.",
+            "missing_categories": list(CATEGORY_ORDER),
+        }
+    else:
+        try:
+            tenant_id = uuid.UUID(str(tenant_id_raw))
+        except ValueError:
+            summary = {
+                "status": "blocked",
+                "message": f"{SANDBOX_ENV_PREFIX}TENANT_ID is not a valid UUID.",
+                "missing_categories": list(CATEGORY_ORDER),
+            }
+        else:
+            file_inputs = _load_file_inputs(Path(args.config))
+            env_inputs = _load_env_inputs(os.environ)
+            inputs = {**env_inputs, **file_inputs}
+            missing = [category for category in CATEGORY_ORDER if category not in inputs]
+            if missing:
+                summary = {
+                    "status": "blocked",
+                    "message": "Missing real vendor-sandbox credentials for one or more categories.",
+                    "missing_categories": missing,
+                    "configured_categories": sorted(inputs),
+                    "config_file_checked": str(Path(args.config)),
+                }
+            else:
+                summary = await _upsert_connector_configs(
+                    tenant_id,
+                    inputs,
+                    dry_run=args.dry_run,
+                )
+
+    safe = _safe_summary(summary)
+    if args.format == "json":
+        print(json.dumps(safe, indent=2, sort_keys=True))
+    else:
+        print(f"Status: {safe.get('status')}")
+        print(str(safe.get("message") or ""))
+        for category in safe.get("categories", []):
+            print(
+                f"- {category['category']}: {category['connector_name']} "
+                f"({category['action']}, source={category['source']})"
+            )
+        missing = safe.get("missing_categories") or []
+        if missing:
+            print("Missing categories: " + ", ".join(missing))
+    return 0 if safe.get("status") == "ready" else 3
+
+
+def main() -> int:
+    return asyncio.run(_amain())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_weekly_report_sandbox_pilot.py
+++ b/scripts/run_weekly_report_sandbox_pilot.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""CMO-PROD-3 — sandbox pilot walk-through for the weekly marketing report.
+
+Fail-closed orchestrator. Discovers sandbox configuration from tenant
+ConnectorConfig rows first, then local/dev environment variable fallback,
+validates DB/migration/
+connector/mapping/backfill prerequisites, and either:
+
+  * runs the real ``generate_report`` -> CMO-PROD-2 persistence flow and
+    prints the redacted verdict that landed in
+    ``weekly_report_pilot_proofs``; or
+  * prints a redacted preflight envelope listing exactly which env vars
+    must be populated and refuses to insert any DB row.
+
+Exit codes:
+
+  0  -> sandbox_proven verdict was persisted (real connectors only).
+  2  -> partial / blocked verdict was persisted (still vendor_sandbox,
+        still production_claim_allowed=False).
+  3  -> preflight failed (no creds / no DB / no migration applied).
+
+Run:
+
+    python scripts/run_weekly_report_sandbox_pilot.py [--format text|json]
+
+This script never prints raw secrets. Output is redacted by the same
+marker list used by ``core.marketing.weekly_report_pilot_proof``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from core.marketing.weekly_report_sandbox_pilot import (  # noqa: E402
+    build_blocked_preflight_envelope,
+    discover_sandbox_pilot_config,
+    run_sandbox_pilot,
+)
+
+
+_EXIT_PASSED = 0
+_EXIT_PARTIAL = 2
+_EXIT_BLOCKED = 3
+
+
+def _exit_code(summary: dict) -> int:
+    proof_summary = summary.get("latest_weekly_report_pilot_proof") or summary.get(
+        "weekly_report_pilot_proof"
+    )
+    if isinstance(proof_summary, dict):
+        status = str(proof_summary.get("proof_status") or "blocked")
+    else:
+        status = str(summary.get("proof_status") or "blocked")
+    if status in {"passed", "sandbox_proven"}:
+        return _EXIT_PASSED
+    if status == "partial":
+        return _EXIT_PARTIAL
+    return _EXIT_BLOCKED
+
+
+def _format_text(summary: dict) -> str:
+    preflight_status = summary.get("preflight_status") or "blocked"
+    lines = [
+        "CMO-PROD-3 Sandbox Pilot Walk-Through",
+        "======================================",
+        f"Preflight status:         {preflight_status}",
+        f"Environment type:         {summary.get('environment_type')}",
+        f"Tenant id:                {summary.get('tenant_id') or '<missing>'}",
+        f"Company id:               {summary.get('company_id') or '<not set>'}",
+    ]
+    if preflight_status != "ready":
+        missing_envs = summary.get("missing_envs") or []
+        missing_categories = summary.get("missing_categories") or []
+        lines.append(f"Missing connector categories: {', '.join(missing_categories) or 'none'}")
+        if missing_envs:
+            lines.append("Missing env vars:")
+            for name in missing_envs:
+                lines.append(f"  - {name}")
+        blockers = summary.get("blockers") or []
+        if blockers:
+            lines.append("")
+            lines.append("Blockers:")
+            for row in blockers:
+                lines.append(
+                    f"  - [{row.get('severity', 'n/a')}] {row.get('category', '')}: "
+                    f"{row.get('message', '')} -> {row.get('next_action', '')}"
+                )
+        next_actions = summary.get("next_actions") or []
+        if next_actions:
+            lines.append("")
+            lines.append("Next actions:")
+            for row in next_actions:
+                lines.append(f"  - {row.get('action_key', '')}: {row.get('label', '')}")
+        lines.append("")
+        lines.append(str(summary.get("note") or ""))
+        return "\n".join(lines)
+
+    proof = summary.get("latest_weekly_report_pilot_proof") or summary.get(
+        "weekly_report_pilot_proof"
+    ) or summary
+    lines.append(f"Proof id:                {proof.get('proof_id')}")
+    lines.append(f"Proof status:            {proof.get('proof_status')}")
+    lines.append(
+        f"Production claim allowed:{proof.get('production_claim_allowed')}"
+    )
+    lines.append(
+        f"Real-vendor claim:       {proof.get('real_vendor_claim_allowed')}"
+    )
+    lines.append(f"Readiness score:         {proof.get('readiness_score')}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format. JSON output is secret-redacted.",
+    )
+    parser.add_argument("--json", action="store_true", help="Alias for --format json.")
+    parser.add_argument(
+        "--preflight-only",
+        action="store_true",
+        help="Run the env/DB/connector preflight without invoking the report task.",
+    )
+    args = parser.parse_args(argv)
+
+    output_format = "json" if args.json else args.format
+
+    if args.preflight_only:
+        preflight = discover_sandbox_pilot_config()
+        summary: dict = build_blocked_preflight_envelope(preflight) if preflight.preflight_status != "ready" else {
+            "schema_version": "preflight_only",
+            "preflight_status": "ready",
+            "environment_type": "vendor_sandbox",
+            "proof_status": preflight.proof_status,
+            "production_claim_allowed": False,
+            "real_vendor_claim_allowed": False,
+            "proof_inserted": False,
+            "tenant_id": preflight.config.tenant_id,
+            "company_id": preflight.config.company_id,
+            "db_discovery_state": preflight.config.db_discovery_state,
+            "chosen_connectors": preflight.config.chosen_connectors,
+            "note": "Preflight passes. Re-run without --preflight-only to execute the pilot.",
+        }
+    else:
+        summary = asyncio.run(run_sandbox_pilot())
+
+    if output_format == "json":
+        print(json.dumps(summary, indent=2, default=str, sort_keys=True))
+    else:
+        print(_format_text(summary))
+    return _exit_code(summary)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_weekly_report_pilot_proof.py
+++ b/scripts/validate_weekly_report_pilot_proof.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Validate a weekly-marketing-report pilot evidence bundle (CMO-PROD-1).
+
+Reads a JSON evidence file (or STDIN) and prints the deterministic proof
+verdict. Exit codes:
+
+  0  -> ``passed`` (real_vendor) or ``sandbox_proven`` (vendor_sandbox)
+  2  -> ``partial`` (informational; not production)
+  3  -> ``blocked`` / ``demo_only`` / ``test_only`` / ``unavailable``
+
+The evaluator is in :mod:`core.marketing.weekly_report_pilot_proof`. This
+script never invents data: if the file is missing or empty, evidence is
+treated as empty and the proof fails closed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Allow direct script invocation: ensure the repo root is on sys.path so
+# `core.marketing.weekly_report_pilot_proof` resolves whether the script
+# is run via `python scripts/validate_weekly_report_pilot_proof.py` or
+# `python -m scripts.validate_weekly_report_pilot_proof`.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from core.marketing.weekly_report_pilot_proof import (  # noqa: E402
+    build_weekly_marketing_report_evidence_bundle,
+    evaluate_weekly_marketing_report_proof,
+    serialize_weekly_marketing_report_evidence_bundle,
+    summarize_weekly_marketing_report_proof,
+)
+
+
+_EXIT_PASSED = 0
+_EXIT_PARTIAL = 2
+_EXIT_BLOCKED = 3
+
+
+def _load_evidence(path: str | None) -> dict[str, Any]:
+    if not path or path == "-":
+        text = sys.stdin.read()
+    else:
+        text = Path(path).read_text(encoding="utf-8")
+    if not text.strip():
+        return {}
+    return json.loads(text)
+
+
+def _exit_code(status: str) -> int:
+    if status in {"passed", "sandbox_proven"}:
+        return _EXIT_PASSED
+    if status == "partial":
+        return _EXIT_PARTIAL
+    return _EXIT_BLOCKED
+
+
+def _format_output(proof: dict[str, Any], *, fmt: str) -> str:
+    if fmt == "json":
+        return serialize_weekly_marketing_report_evidence_bundle(
+            build_weekly_marketing_report_evidence_bundle(proof)
+        )
+    summary = summarize_weekly_marketing_report_proof(proof)
+    lines = [
+        "CMO-PROD-1 Weekly Marketing Report Pilot Proof",
+        "==============================================",
+        f"Proof ID:                 {summary.get('proof_id')}",
+        f"Environment:              {summary.get('environment_type')}",
+        f"Status:                   {summary.get('proof_status')}",
+        f"Readiness score:          {summary.get('readiness_score')} / 100",
+        f"Production claim allowed: {summary.get('production_claim_allowed')}",
+        f"Real-vendor claim:        {summary.get('real_vendor_claim_allowed')}",
+        f"Proven capabilities:      {summary.get('proven_capabilities')}",
+        f"Blockers:                 {summary.get('blockers')}",
+        f"Risks:                    {summary.get('risks')}",
+        f"Next action CTA:          {summary.get('next_action_cta')}",
+        "",
+    ]
+    blockers = proof.get("blockers") or []
+    if blockers:
+        lines.append("Blockers:")
+        for row in blockers:
+            lines.append(
+                f"  - [{row.get('severity', 'n/a')}] {row.get('category', '')}: "
+                f"{row.get('message', '')} -> {row.get('next_action', '')}"
+            )
+        lines.append("")
+    risks = proof.get("risks") or []
+    if risks:
+        lines.append("Risks:")
+        for row in risks:
+            lines.append(
+                f"  - [{row.get('severity', 'n/a')}] {row.get('category', '')}: "
+                f"{row.get('message', '')} -> {row.get('next_action', '')}"
+            )
+        lines.append("")
+    next_actions = proof.get("next_actions") or []
+    if next_actions:
+        lines.append("Next actions:")
+        for row in next_actions:
+            lines.append(f"  - {row.get('action_key', '')}: {row.get('label', '')}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--evidence",
+        "-e",
+        help="Path to JSON evidence file. Use '-' or omit to read from STDIN.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format. JSON output is secret-redacted.",
+    )
+    args = parser.parse_args(argv)
+    try:
+        evidence = _load_evidence(args.evidence)
+    except FileNotFoundError as exc:
+        print(f"error: evidence file not found: {exc.filename}", file=sys.stderr)
+        return _EXIT_BLOCKED
+    except json.JSONDecodeError as exc:
+        print(f"error: evidence JSON is invalid: {exc}", file=sys.stderr)
+        return _EXIT_BLOCKED
+    proof = evaluate_weekly_marketing_report_proof(evidence)
+    print(_format_output(proof, fmt=args.format))
+    return _exit_code(str(proof.get("proof_status") or "blocked"))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_cmo_abm_agent.py
+++ b/tests/unit/test_cmo_abm_agent.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.agents.marketing.abm_agent import ABMAgent
+from core.agents.registry import AgentRegistry
+from core.marketing.agent_contracts import (
+    build_marketing_agent_contract_output,
+    contract_has_required_shape,
+    get_marketing_agent_contract_spec,
+)
+from core.marketing.pilot_proof import build_cmo_pilot_proof_projection
+from core.marketing.workflow_linter import lint_marketing_workflow
+from core.schemas.messages import TargetAgent, TaskAssignment, TaskInput
+
+
+class FakeToolGateway:
+    def __init__(self, responses: dict[tuple[str, str], dict[str, Any] | Exception]):
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    async def execute(
+        self,
+        *,
+        tenant_id: str,
+        agent_id: str,
+        agent_scopes: list[str],
+        connector_name: str,
+        tool_name: str,
+        params: dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "tenant_id": tenant_id,
+                "agent_id": agent_id,
+                "agent_scopes": agent_scopes,
+                "connector_name": connector_name,
+                "tool_name": tool_name,
+                "params": params,
+                "idempotency_key": idempotency_key,
+            }
+        )
+        response = self.responses.get((connector_name, tool_name), {})
+        if isinstance(response, Exception):
+            raise response
+        return dict(response)
+
+
+def _assignment(action: str, inputs: dict[str, Any]) -> TaskAssignment:
+    return TaskAssignment(
+        message_id=f"msg-abm-{action}",
+        correlation_id="corr-abm",
+        workflow_run_id="run-abm",
+        workflow_definition_id="wf-abm",
+        step_id=f"step-{action}",
+        step_index=0,
+        total_steps=1,
+        target_agent=TargetAgent(
+            agent_id="agent-abm",
+            agent_type="abm",
+            agent_token="test-token",
+        ),
+        task=TaskInput(action=action, inputs=inputs),
+    )
+
+
+def _agent(gateway: FakeToolGateway | None = None) -> ABMAgent:
+    return ABMAgent(
+        agent_id="agent-abm",
+        tenant_id="tenant-cmo",
+        tool_gateway=gateway,
+        authorized_tools=["hubspot.update_target_accounts", "linkedin_ads.create_abm_campaign"],
+    )
+
+
+def _accounts() -> list[dict[str, Any]]:
+    return [
+        {
+            "company_name": "Alpha Bank",
+            "domain": "alpha.example",
+            "industry": "financial_services",
+            "employee_count": 1200,
+            "annual_revenue": 250000000,
+            "region": "apac",
+            "tier": "strategic",
+            "bombora": 92,
+            "g2": 84,
+            "trustradius": 78,
+            "crm": 74,
+            "website_visits": 80,
+            "email_clicks": 14,
+            "form_submissions": 3,
+            "meetings": 1,
+        },
+        {
+            "company_name": "Beta Manufacturing",
+            "domain": "beta.example",
+            "industry": "manufacturing",
+            "employee_count": 250,
+            "annual_revenue": 35000000,
+            "region": "emea",
+            "tier": "commercial",
+            "bombora": 40,
+            "g2": 20,
+            "trustradius": 30,
+            "crm": 50,
+        },
+    ]
+
+
+def _icp() -> dict[str, Any]:
+    return {
+        "target_industries": ["financial_services", "software"],
+        "employee_min": 500,
+        "employee_max": 5000,
+        "revenue_min": 100000000,
+        "regions": ["apac", "amer"],
+        "tiers": ["strategic", "enterprise"],
+    }
+
+
+def _write_contract(**overrides: object) -> dict[str, Any]:
+    contract = {
+        "connector_key": "hubspot",
+        "category": "CRM",
+        "read_ready": True,
+        "write_ready": True,
+        "write_safe": True,
+        "idempotency_key_supported": True,
+        "retry_budget": {
+            "idempotency_key": "abm:write:001",
+            "idempotency_supported": True,
+            "remaining_attempts": 2,
+        },
+    }
+    contract.update(overrides)
+    return contract
+
+
+def _workflow(step: dict[str, Any], *, mode: str = "production") -> dict[str, Any]:
+    return {
+        "id": "wf_abm",
+        "name": "ABM Sprint",
+        "domain": "marketing",
+        "mode": mode,
+        "steps": [step],
+    }
+
+
+def _workflow_step(action: str, **overrides: object) -> dict[str, Any]:
+    step: dict[str, Any] = {
+        "id": "step_abm",
+        "name": "ABM Step",
+        "type": "agent",
+        "agent_type": "abm_agent",
+        "action": action,
+    }
+    step.update(overrides)
+    return step
+
+
+@pytest.mark.asyncio
+async def test_abm_agent_happy_path_account_scoring_has_contract_shape() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "score_accounts",
+            {"accounts": _accounts(), "icp": _icp(), "high_intent_threshold": 80},
+        )
+    )
+    contract = build_marketing_agent_contract_output(
+        "abm_agent",
+        "score_accounts",
+        result=result,
+        audit_ref=result.output["audit_ref"],
+    )
+
+    assert result.status == "completed"
+    assert result.output["status"] == "accounts_scored"
+    assert result.output["account_scores"][0]["domain"] == "alpha.example"
+    assert result.output["account_scores"][0]["score_band"] == "hot"
+    assert result.output["intent_alerts"]
+    assert contract_has_required_shape(contract)
+    assert contract["maturity"] == "beta"
+    assert contract["production_ready"] is False
+
+
+@pytest.mark.asyncio
+async def test_abm_configurable_bombora_g2_trustradius_crm_weighting_math() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "score_intent_heat",
+            {
+                "accounts": [
+                    {
+                        "company_name": "Weighted Co",
+                        "domain": "weighted.example",
+                        "bombora": 100,
+                        "g2": 0,
+                        "trustradius": 0,
+                        "crm": 0,
+                    }
+                ],
+                "source_weights": {"bombora": 1.0, "g2": 0.0, "trustradius": 0.0, "crm": 0.0},
+            },
+        )
+    )
+
+    row = result.output["account_scores"][0]
+    assert result.status == "completed"
+    assert row["intent_heat_score"] == 100
+    assert result.output["source_weights"] == {"bombora": 1.0, "g2": 0.0, "trustradius": 0.0, "crm": 0.0}
+
+
+@pytest.mark.asyncio
+async def test_abm_icp_fit_scoring_is_deterministic() -> None:
+    result = await _agent().execute(
+        _assignment("score_icp_fit", {"accounts": _accounts(), "icp": _icp()})
+    )
+
+    by_domain = {row["domain"]: row for row in result.output["account_scores"]}
+    assert by_domain["alpha.example"]["icp_fit_score"] == 100
+    assert by_domain["beta.example"]["icp_fit_score"] < 50
+    assert "industry_matches_icp" in by_domain["alpha.example"]["icp_fit_reasons"]
+
+
+@pytest.mark.asyncio
+async def test_abm_deterministic_next_best_action_output() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "recommend_next_best_action",
+            {"accounts": _accounts(), "icp": _icp()},
+        )
+    )
+
+    actions = {row["account_domain"]: row["action"] for row in result.output["recommended_actions"]}
+    assert result.status == "completed"
+    assert actions["alpha.example"] == "create_sales_alert"
+    assert actions["beta.example"] in {"monitor_intent", "add_to_nurture_segment", "route_to_sdr_research"}
+
+
+@pytest.mark.asyncio
+async def test_abm_csv_account_ingest_validation_happy_path() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "validate_account_csv",
+            {
+                "csv_content": (
+                    "company_name,domain,industry,tier\n"
+                    "Alpha Bank,alpha.example,financial_services,strategic\n"
+                    "Beta Manufacturing,beta.example,manufacturing,commercial\n"
+                )
+            },
+        )
+    )
+
+    assert result.status == "completed"
+    assert result.output["status"] == "csv_validated"
+    assert len(result.output["valid_accounts"]) == 2
+    assert result.output["invalid_rows"] == []
+
+
+@pytest.mark.asyncio
+async def test_abm_csv_validation_rejects_missing_required_fields_and_malformed_rows() -> None:
+    missing_header = await _agent().execute(
+        _assignment("validate_account_csv", {"csv_content": "company_name,industry\nAlpha Bank,finance\n"})
+    )
+    malformed_row = await _agent().execute(
+        _assignment(
+            "validate_account_csv",
+            {"csv_content": "company_name,domain\nAlpha Bank,not-a-domain\nMissing Domain,\n"},
+        )
+    )
+
+    assert missing_header.status == "hitl_triggered"
+    assert missing_header.output["status"] == "blocked"
+    assert "domain" in missing_header.output["missing_headers"]
+    assert malformed_row.status == "hitl_triggered"
+    assert len(malformed_row.output["invalid_rows"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_high_intent_account_creates_alert_and_recommendation() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "score_accounts",
+            {
+                "accounts": _accounts(),
+                "icp": _icp(),
+                "high_intent_threshold": 80,
+            },
+        )
+    )
+
+    assert result.output["intent_alerts"][0]["account_domain"] == "alpha.example"
+    assert result.output["recommended_actions"][0]["action"] == "review_high_intent_alerts"
+
+
+@pytest.mark.asyncio
+async def test_target_account_list_change_above_threshold_requires_approval() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "update_target_accounts",
+            {
+                "workflow_mode": "active",
+                "accounts": _accounts(),
+                "target_account_delta": 30,
+                "connector_contract": _write_contract(),
+            },
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["status"] == "blocked"
+    assert result.output["approval_required"] is True
+    assert result.output["policy_result"]["decision"] == "requires_approval"
+    assert result.output["policy_ref"]
+    assert result.output["audit_ref"].startswith("abm:")
+
+
+@pytest.mark.asyncio
+async def test_abm_budget_action_requires_policy_approval_and_escalation_ref() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "launch_abm_campaign",
+            {
+                "workflow_mode": "active",
+                "accounts": _accounts(),
+                "budget_amount": 50000,
+                "connector_contract": _write_contract(connector_key="linkedin_ads", category="Ads"),
+            },
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["approval_required"] is True
+    assert result.output["policy_result"]["decision"] == "requires_approval"
+    assert result.output["escalation_ref"]
+    assert result.output["audit_ref"].startswith("abm:")
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_cannot_write_abm_externally() -> None:
+    gateway = FakeToolGateway({("hubspot", "update_target_accounts"): {"status": "write_confirmed"}})
+    result = await _agent(gateway).execute(
+        _assignment(
+            "update_target_accounts",
+            {
+                "workflow_mode": "shadow",
+                "accounts": _accounts(),
+                "connector_contract": _write_contract(),
+            },
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["status"] == "shadow_only"
+    assert result.output["external_writes_completed"] is False
+    assert gateway.calls == []
+
+
+@pytest.mark.asyncio
+async def test_active_external_action_blocks_when_connector_is_not_write_safe() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "update_target_accounts",
+            {
+                "workflow_mode": "active",
+                "accounts": _accounts(),
+                "approved": True,
+                "connector_contract": _write_contract(write_ready=False, write_safe=False),
+            },
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["status"] == "blocked"
+    assert any("not write-safe" in reason for reason in result.output["blocked_reasons"])
+
+
+@pytest.mark.asyncio
+async def test_active_external_action_cannot_complete_without_confirmed_write_evidence() -> None:
+    gateway = FakeToolGateway(
+        {("hubspot", "update_target_accounts"): {"status": "accepted", "external_object_id": "list-accepted"}}
+    )
+    result = await _agent(gateway).execute(
+        _assignment(
+            "update_target_accounts",
+            {
+                "workflow_mode": "active",
+                "accounts": _accounts(),
+                "approved": True,
+                "approval_ref": "approval-abm-1",
+                "connector_contract": _write_contract(),
+                "idempotency_key": "abm:list:update:1",
+            },
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["external_write_confirmation_status"] == "accepted"
+    assert result.output["external_writes_completed"] is False
+    assert any("unconfirmed" in reason for reason in result.output["blocked_reasons"])
+
+
+@pytest.mark.asyncio
+async def test_confirmed_abm_external_action_has_policy_audit_and_write_ref() -> None:
+    gateway = FakeToolGateway(
+        {
+            ("hubspot", "update_target_accounts"): {
+                "status": "write_confirmed",
+                "connector_key": "hubspot",
+                "external_object_id": "target-list-1",
+                "source_url": "https://crm.example/lists/1",
+                "idempotency_key": "abm:list:update:1",
+                "confirmed_at": "2026-05-24T12:00:00+00:00",
+                "audit_ref": "audit-abm-write-1",
+            }
+        }
+    )
+    result = await _agent(gateway).execute(
+        _assignment(
+            "update_target_accounts",
+            {
+                "workflow_mode": "active",
+                "accounts": _accounts(),
+                "approved": True,
+                "approval_ref": "approval-abm-1",
+                "connector_contract": _write_contract(),
+                "idempotency_key": "abm:list:update:1",
+            },
+        )
+    )
+
+    assert result.status == "completed"
+    assert result.output["external_write_confirmation_status"] == "write_confirmed"
+    assert result.output["external_writes_completed"] is True
+    assert result.output["external_write_ref"]["external_object_id"] == "target-list-1"
+    assert result.output["audit_ref"].startswith("abm:")
+
+
+def test_abm_registered_and_contract_metadata_is_beta() -> None:
+    assert AgentRegistry.get_by_type("abm") is ABMAgent
+    spec = get_marketing_agent_contract_spec("abm_agent")
+    assert spec["agent_type"] == "abm"
+    assert spec["maturity"] == "beta"
+    assert spec["production_ready"] is False
+    assert spec["surface"] == "core.agents.marketing.abm_agent"
+    assert "score_accounts" in spec["actions"]
+
+
+def test_workflow_linter_no_longer_treats_abm_as_unknown_but_blocks_unsafe_production_write() -> None:
+    recommendation = lint_marketing_workflow(
+        _workflow(_workflow_step("score_accounts")),
+        connector_contracts=[
+            _write_contract(connector_key="hubspot", category="CRM"),
+            _write_contract(connector_key="bombora", category="ABM", write_ready=False, write_safe=False),
+        ],
+    )
+    unsafe_write = lint_marketing_workflow(
+        _workflow(_workflow_step("update_target_accounts")),
+        connector_contracts=[
+            _write_contract(connector_key="hubspot", category="CRM"),
+            _write_contract(connector_key="bombora", category="ABM", write_ready=False, write_safe=False),
+        ],
+    )
+
+    recommendation_codes = {finding.code for finding in recommendation.findings}
+    unsafe_codes = {finding.code for finding in unsafe_write.findings}
+    assert "marketing_agent_type_unknown" not in recommendation_codes
+    assert "marketing_agent_unavailable_for_production" not in recommendation_codes
+    assert "marketing_agent_beta_in_production" in recommendation_codes
+    assert unsafe_write.has_errors is True
+    assert "marketing_external_write_confirmation_metadata_missing" in unsafe_codes
+    assert "marketing_decision_audit_evidence_missing" in unsafe_codes
+
+
+def test_abm_production_lint_passes_only_with_write_policy_audit_metadata() -> None:
+    result = lint_marketing_workflow(
+        _workflow(
+            _workflow_step(
+                "update_target_accounts",
+                external_write_confirmation_required=True,
+                expected_confirmation_fields=["external_object_id", "confirmed_at"],
+                idempotency_key_template="abm:{account_list_id}:update",
+                decision_audit_required=True,
+                approval_timeout_policy={"approval_type": "target_account_list_change"},
+            )
+        ),
+        connector_contracts=[
+            _write_contract(connector_key="hubspot", category="CRM"),
+            _write_contract(connector_key="bombora", category="ABM", write_ready=False, write_safe=False),
+        ],
+    )
+
+    codes = {finding.code for finding in result.findings}
+    assert "marketing_agent_unavailable_for_production" not in codes
+    assert "marketing_external_write_connector_not_ready" not in codes
+    assert "marketing_external_write_confirmation_metadata_missing" not in codes
+
+
+def test_pilot_proof_keeps_abm_unproven_without_real_vendor_production_proof() -> None:
+    projection = build_cmo_pilot_proof_projection(
+        environment_type="vendor_sandbox",
+        source_context={"tenant_id": "tenant-cmo", "source": "vendor_sandbox"},
+        connector_setup=[],
+        connector_contracts=[],
+        agent_contracts=[get_marketing_agent_contract_spec("abm")],
+    )
+    proof = projection["cmo_pilot_proof"]
+    proven = {row["capability_key"] for row in proof["proven_capabilities"]}
+    unproven = {row["capability_key"]: row for row in proof["unproven_capabilities"]}
+
+    assert "agent:abm" not in proven
+    assert unproven["agent:abm"]["status"] == "beta"
+    assert proof["production_claim_allowed"] is False

--- a/tests/unit/test_cmo_agent_contracts.py
+++ b/tests/unit/test_cmo_agent_contracts.py
@@ -1,0 +1,561 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.agents.marketing.campaign_pilot import CampaignPilotAgent
+from core.agents.marketing.content_factory import ContentFactoryAgent
+from core.llm.router import LLMResponse, llm_router
+from core.marketing.agent_contracts import (
+    build_marketing_agent_contract_output,
+    contract_has_required_shape,
+    get_marketing_agent_contract_spec,
+    marketing_agent_contract_specs,
+)
+from core.marketing.policy_manifest import evaluate_marketing_policy
+from core.marketing.workflow_activation import build_cmo_workflow_activation
+from core.marketing.workflow_linter import lint_marketing_workflow
+from core.schemas.messages import TargetAgent, TaskAssignment, TaskInput
+
+
+class FakeToolGateway:
+    def __init__(self, responses: dict[tuple[str, str], dict[str, Any] | Exception]):
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    async def execute(
+        self,
+        *,
+        tenant_id: str,
+        agent_id: str,
+        agent_scopes: list[str],
+        connector_name: str,
+        tool_name: str,
+        params: dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "tenant_id": tenant_id,
+                "agent_id": agent_id,
+                "agent_scopes": agent_scopes,
+                "connector_name": connector_name,
+                "tool_name": tool_name,
+                "params": params,
+                "idempotency_key": idempotency_key,
+            }
+        )
+        response = self.responses.get((connector_name, tool_name), {})
+        if isinstance(response, Exception):
+            raise response
+        return dict(response)
+
+
+def _assignment(
+    agent_type: str,
+    action: str,
+    inputs: dict[str, Any],
+) -> TaskAssignment:
+    return TaskAssignment(
+        message_id=f"msg-{agent_type}",
+        correlation_id=f"corr-{agent_type}",
+        workflow_run_id="run-cmo-agent-contract",
+        workflow_definition_id="wf-cmo-agent-contract",
+        step_id=f"step-{agent_type}",
+        step_index=0,
+        total_steps=1,
+        target_agent=TargetAgent(
+            agent_id=f"agent-{agent_type}",
+            agent_type=agent_type,
+            agent_token="test-token",
+        ),
+        task=TaskInput(action=action, inputs=inputs),
+    )
+
+
+def _campaign_agent(
+    gateway: FakeToolGateway,
+) -> CampaignPilotAgent:
+    return CampaignPilotAgent(
+        agent_id="agent-campaign-pilot",
+        tenant_id="tenant-cmo",
+        tool_gateway=gateway,
+        authorized_tools=["google_ads.get_campaign_performance", "google_ads.pause_campaign"],
+    )
+
+
+def _content_agent(
+    gateway: FakeToolGateway | None = None,
+) -> ContentFactoryAgent:
+    return ContentFactoryAgent(
+        agent_id="agent-content-factory",
+        tenant_id="tenant-cmo",
+        tool_gateway=gateway,
+        authorized_tools=["wordpress.create_draft", "sendgrid.create_campaign"],
+    )
+
+
+def _workflow(agent_type: str, action: str, *, mode: str = "production") -> dict[str, Any]:
+    return {
+        "id": "wf_contract_test",
+        "name": "CMO Contract Test",
+        "domain": "marketing",
+        "mode": mode,
+        "steps": [
+            {
+                "id": "step_1",
+                "name": "Step 1",
+                "type": "agent",
+                "agent_type": agent_type,
+                "action": action,
+            }
+        ],
+    }
+
+
+async def _fake_llm_complete(
+    messages: list[dict[str, str]],
+    model_override: str | None = None,
+    temperature: float | None = None,
+    max_tokens: int = 4096,
+) -> LLMResponse:
+    del messages, model_override, temperature, max_tokens
+    content = " ".join(["growth content strategy"] * 40)
+    return LLMResponse(content=content, model="test-llm", tokens_used=12)
+
+
+def _assert_contract_shape(contract: dict[str, Any]) -> None:
+    assert contract_has_required_shape(contract)
+    assert isinstance(contract["status"], str)
+    assert isinstance(contract["confidence"], float | int)
+    assert isinstance(contract["rationale"], str)
+    assert isinstance(contract["recommended_actions"], list)
+    assert isinstance(contract["source_refs"], list)
+    assert isinstance(contract["policy_result"], dict)
+    assert isinstance(contract["approval_required"], bool)
+    assert isinstance(contract["hitl_required"], bool)
+    assert isinstance(contract["degraded_reasons"], list)
+    assert isinstance(contract["blocked_reasons"], list)
+
+
+def test_contract_inventory_covers_all_cmo_marketing_agent_surfaces() -> None:
+    specs = {row["agent_type"]: row for row in marketing_agent_contract_specs()}
+
+    expected = {
+        "campaign_pilot",
+        "content_factory",
+        "email_marketing",
+        "brand_monitor",
+        "seo_strategist",
+        "crm_intelligence",
+        "social_media",
+        "abm",
+        "competitive_intel",
+    }
+    assert expected.issubset(specs)
+    assert get_marketing_agent_contract_spec("email_agent")["agent_type"] == "email_marketing"
+    assert specs["campaign_pilot"]["maturity"] == "production"
+    assert specs["content_factory"]["maturity"] == "beta"
+    assert specs["email_marketing"]["maturity"] == "beta"
+    assert specs["brand_monitor"]["maturity"] == "beta"
+    assert specs["seo_strategist"]["maturity"] == "beta"
+    assert specs["crm_intelligence"]["maturity"] == "beta"
+    assert specs["social_media"]["maturity"] == "beta"
+    assert specs["abm"]["maturity"] == "beta"
+    assert specs["competitive_intel"]["maturity"] == "beta"
+    assert all(not specs[key]["production_ready"] for key in expected - {"campaign_pilot"})
+
+
+def test_all_agent_contract_outputs_have_required_shape_or_blocker() -> None:
+    for spec in marketing_agent_contract_specs():
+        action = spec["actions"][0]
+        contract = build_marketing_agent_contract_output(spec["agent_type"], action)
+
+        _assert_contract_shape(contract)
+        if spec["maturity"] in {"stub", "unavailable"}:
+            assert contract["production_ready"] is False
+            assert contract["blocked_reasons"]
+            assert contract["audit_ref"] is None
+
+
+@pytest.mark.asyncio
+async def test_campaign_pilot_happy_path_contract_shape() -> None:
+    gateway = FakeToolGateway(
+        {
+            ("google_ads", "get_campaign_performance"): {
+                "spend": 100,
+                "revenue": 220,
+                "impressions": 1000,
+                "clicks": 100,
+                "conversions": 10,
+            }
+        }
+    )
+    result = await _campaign_agent(gateway).execute(
+        _assignment(
+            "campaign_pilot",
+            "manage_campaign",
+            {
+                "campaign_id": "cmp-1",
+                "campaign_name": "Pipeline Sprint",
+                "budget": 1000,
+                "channels": ["google_ads"],
+                "channel_budgets": {"google_ads": 500},
+            },
+        )
+    )
+
+    contract = build_marketing_agent_contract_output(
+        "campaign_pilot",
+        "manage_campaign",
+        result=result,
+        audit_ref=result.output["audit_ref"],
+    )
+
+    assert result.status == "completed"
+    assert result.output["hitl_required"] is False
+    assert result.output["source_refs"]
+    _assert_contract_shape(contract)
+    assert contract["status"] == "completed"
+    assert contract["confidence"] >= 0.85
+    assert contract["blocked_reasons"] == []
+
+
+@pytest.mark.asyncio
+async def test_campaign_pilot_policy_and_hitl_path_requires_approval() -> None:
+    gateway = FakeToolGateway(
+        {
+            ("google_ads", "get_campaign_performance"): {
+                "spend": 100,
+                "revenue": 200,
+                "impressions": 1000,
+                "clicks": 100,
+                "conversions": 10,
+            }
+        }
+    )
+    result = await _campaign_agent(gateway).execute(
+        _assignment(
+            "campaign_pilot",
+            "create",
+            {
+                "campaign_name": "Enterprise Launch",
+                "budget": 600000,
+                "channels": ["google_ads"],
+            },
+        )
+    )
+
+    contract = build_marketing_agent_contract_output(
+        "campaign_pilot",
+        "create",
+        result=result,
+        audit_ref=result.output["audit_ref"],
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.hitl_request is not None
+    assert result.output["policy_result"]["decision"] == "requires_approval"
+    assert contract["approval_required"] is True
+    assert contract["hitl_required"] is True
+
+
+@pytest.mark.asyncio
+async def test_campaign_pilot_does_not_complete_external_write_without_confirmation() -> None:
+    gateway = FakeToolGateway(
+        {
+            ("google_ads", "get_campaign_performance"): {
+                "spend": 100,
+                "revenue": 50,
+                "impressions": 1000,
+                "clicks": 100,
+                "conversions": 4,
+            },
+            ("google_ads", "pause_campaign"): {
+                "status": "accepted",
+                "external_object_id": "campaign-pause-1",
+            },
+        }
+    )
+    result = await _campaign_agent(gateway).execute(
+        _assignment(
+            "campaign_pilot",
+            "manage_campaign",
+            {
+                "campaign_id": "cmp-low-roas",
+                "campaign_name": "Low ROAS Campaign",
+                "budget": 1000,
+                "channels": ["google_ads"],
+                "channel_budgets": {"google_ads": 500},
+            },
+        )
+    )
+    contract = build_marketing_agent_contract_output(
+        "campaign_pilot",
+        "pause_campaign",
+        result=result,
+        audit_ref=result.output["audit_ref"],
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["external_write_confirmation_status"] == "write_unconfirmed"
+    assert result.output["external_writes_completed"] is False
+    assert result.output["actions_taken"][0]["success"] is False
+    assert "write confirmation" in result.output["blocked_reasons"][0]
+    assert contract["external_writes_completed"] is False
+    assert contract["blocked_reasons"]
+
+
+@pytest.mark.asyncio
+async def test_campaign_pilot_invalid_input_has_failed_contract() -> None:
+    result = await _campaign_agent(FakeToolGateway({})).execute(
+        _assignment(
+            "campaign_pilot",
+            "manage_campaign",
+            {
+                "campaign_name": "Broken Campaign",
+                "budget": "not-a-number",
+                "channels": ["google_ads"],
+            },
+        )
+    )
+    contract = build_marketing_agent_contract_output(
+        "campaign_pilot",
+        "manage_campaign",
+        result=result,
+    )
+
+    assert result.status == "failed"
+    assert result.error and result.error["code"] == "CAMPAIGN_ERR"
+    _assert_contract_shape(contract)
+    assert "Decision audit evidence is missing." in contract["blocked_reasons"]
+
+
+@pytest.mark.asyncio
+async def test_content_factory_happy_path_contract_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(llm_router, "complete", _fake_llm_complete)
+    result = await _content_agent().execute(
+        _assignment(
+            "content_factory",
+            "generate_content",
+            {
+                "content_type": "social",
+                "topic": "Demand generation operating cadence",
+                "target_audience": "CMOs",
+                "keywords": ["growth"],
+            },
+        )
+    )
+    contract = build_marketing_agent_contract_output(
+        "content_factory",
+        "generate_content",
+        result=result,
+        audit_ref=result.output["audit_ref"],
+    )
+
+    assert result.status == "completed"
+    assert result.output["approval_required"] is False
+    assert result.output["policy_result"]["decision"] == "allowed"
+    _assert_contract_shape(contract)
+    assert contract["maturity"] == "beta"
+    assert contract["blocked_reasons"] == []
+
+
+@pytest.mark.asyncio
+async def test_content_factory_publish_approval_path_creates_draft_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(llm_router, "complete", _fake_llm_complete)
+    gateway = FakeToolGateway(
+        {
+            ("wordpress", "create_draft"): {
+                "status": "draft_created",
+                "id": "post-1",
+                "url": "https://cms.example.test/post-1",
+            }
+        }
+    )
+    result = await _content_agent(gateway).execute(
+        _assignment(
+            "content_factory",
+            "publish_to_wordpress",
+            {
+                "content_type": "blog",
+                "topic": "Pipeline quality report",
+                "target_audience": "CMOs",
+                "keywords": ["growth"],
+                "publish_date": "2026-05-25T10:00:00+00:00",
+                "channel": "website",
+            },
+        )
+    )
+    contract = build_marketing_agent_contract_output(
+        "content_factory",
+        "publish_to_wordpress",
+        result=result,
+        audit_ref=result.output["audit_ref"],
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["approval_required"] is True
+    assert result.output["publish_state"] == "draft_created_pending_approval"
+    assert result.output["external_writes_completed"] is False
+    assert contract["approval_required"] is True
+    assert contract["external_writes_completed"] is False
+
+
+@pytest.mark.asyncio
+async def test_content_factory_degraded_connector_path_is_visible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(llm_router, "complete", _fake_llm_complete)
+    gateway = FakeToolGateway(
+        {
+            ("wordpress", "create_draft"): RuntimeError("cms timeout"),
+        }
+    )
+    result = await _content_agent(gateway).execute(
+        _assignment(
+            "content_factory",
+            "schedule_content",
+            {
+                "content_type": "blog",
+                "topic": "Degraded CMS campaign",
+                "target_audience": "CMOs",
+                "keywords": ["growth"],
+                "publish_date": "2026-05-25T10:00:00+00:00",
+                "channel": "website",
+            },
+        )
+    )
+    contract = build_marketing_agent_contract_output(
+        "content_factory",
+        "schedule_content",
+        result=result,
+        audit_ref=result.output["audit_ref"],
+        connector_ready=False,
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["scheduled"] is False
+    assert result.output["degraded_reasons"]
+    assert "Required connector is unavailable or degraded." in contract["degraded_reasons"]
+
+
+def test_email_marketing_contract_requires_approval_for_sends_and_unsubscribe_risk() -> None:
+    policy = evaluate_marketing_policy(
+        {
+            "workflow_id": "lead_nurture",
+            "action": "send_email",
+            "workflow_mode": "active",
+            "audience_size": 75000,
+            "risk_flags": ["unsubscribe_rate_above_policy"],
+            "external_write_required": True,
+        }
+    )
+    contract = build_marketing_agent_contract_output(
+        "email_agent",
+        "send_email",
+        policy_result={
+            **policy,
+            "reason": "Unsubscribe risk and large audience require CMO approval.",
+        },
+        audit_ref="audit-email-send-contract",
+        external_write_confirmation_status="write_unconfirmed",
+    )
+
+    _assert_contract_shape(contract)
+    assert contract["agent_type"] == "email_marketing"
+    assert contract["maturity"] == "beta"
+    assert contract["approval_required"] is True
+    assert contract["policy_result"]["decision"] == "requires_approval"
+    assert "Unsubscribe risk" in contract["policy_result"]["reason"]
+    assert contract["external_writes_completed"] is False
+
+
+def test_crm_intelligence_is_beta_not_stub_but_not_production_ready() -> None:
+    """CMO-4.3 promoted CRM Intelligence out of the stub state."""
+
+    contract = build_marketing_agent_contract_output(
+        "crm_intelligence",
+        "pipeline_velocity_analysis",
+        audit_ref="audit-crm-intelligence-contract",
+    )
+    lint = lint_marketing_workflow(_workflow("crm_intelligence", "pipeline_velocity_analysis"))
+    codes = {finding.code for finding in lint.findings}
+
+    _assert_contract_shape(contract)
+    assert contract["maturity"] == "beta"
+    assert contract["production_ready"] is False
+    assert "marketing_agent_stub_for_production" not in codes
+    assert "marketing_agent_unavailable_for_production" not in codes
+    assert "marketing_agent_beta_in_production" in codes
+
+
+def test_competitive_intel_is_beta_not_unavailable_but_not_production_ready() -> None:
+    contract = build_marketing_agent_contract_output(
+        "competitive_intel",
+        "weekly_market_snapshot",
+        audit_ref="audit-competitive-contract",
+    )
+    lint = lint_marketing_workflow(_workflow("competitive_intel", "weekly_market_snapshot"))
+    codes = {finding.code for finding in lint.findings}
+
+    _assert_contract_shape(contract)
+    assert contract["maturity"] == "beta"
+    assert contract["production_ready"] is False
+    assert "marketing_agent_unavailable_for_production" not in codes
+    assert "marketing_agent_beta_in_production" in codes
+
+
+def test_brand_monitor_is_beta_not_stub_but_not_production_ready() -> None:
+    contract = build_marketing_agent_contract_output(
+        "brand_monitor",
+        "detect_crisis",
+        audit_ref="audit-brand-monitor-contract",
+    )
+    lint = lint_marketing_workflow(_workflow("brand_monitor", "detect_crisis"))
+    codes = {finding.code for finding in lint.findings}
+
+    _assert_contract_shape(contract)
+    assert contract["maturity"] == "beta"
+    assert contract["production_ready"] is False
+    assert "marketing_agent_stub_for_production" not in codes
+    assert "marketing_agent_unavailable_for_production" not in codes
+    assert "marketing_agent_beta_in_production" in codes
+
+
+def test_seo_strategist_is_beta_not_stub_but_not_production_ready() -> None:
+    contract = build_marketing_agent_contract_output(
+        "seo_strategist",
+        "keyword_gap_analysis",
+        audit_ref="audit-seo-strategist-contract",
+    )
+    lint = lint_marketing_workflow(_workflow("seo_strategist", "keyword_gap_analysis"))
+    codes = {finding.code for finding in lint.findings}
+
+    _assert_contract_shape(contract)
+    assert contract["maturity"] == "beta"
+    assert contract["production_ready"] is False
+    assert "marketing_agent_stub_for_production" not in codes
+    assert "marketing_agent_unavailable_for_production" not in codes
+    assert "marketing_agent_beta_in_production" in codes
+
+
+def test_workflow_activation_keeps_missing_agent_workflows_blocked_or_unavailable() -> None:
+    activation = build_cmo_workflow_activation(
+        connector_setup=[],
+        data_readiness={"field_mapping_status": [], "backfill_status": []},
+        connector_configs=[],
+        connector_contracts=[],
+    )
+    rows = {row["workflow_key"]: row for row in activation["workflow_activation_status"]}
+
+    assert rows["abm_sprint"]["state"] == "promotion_blocked"
+    assert rows["competitive_intel_monitoring"]["state"] == "promotion_blocked"
+    assert rows["brand_crisis_response"]["state"] == "promotion_blocked"
+    assert rows["seo_sprint"]["state"] == "promotion_blocked"
+    assert "Required ABM connector" in " ".join(rows["abm_sprint"]["blocked_reasons"])
+    assert "Required Brand connector" in " ".join(rows["brand_crisis_response"]["blocked_reasons"])
+    assert "Required SEO connector" in " ".join(rows["seo_sprint"]["blocked_reasons"])

--- a/tests/unit/test_cmo_approval_review.py
+++ b/tests/unit/test_cmo_approval_review.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+import api.v1.kpis as kpis_api
+from core.marketing.approval_review import (
+    build_cmo_approval_decision_request,
+    build_cmo_approval_review_projection,
+)
+from core.marketing.approval_timeouts import build_approval_timeout_risk
+
+NOW = datetime(2026, 5, 23, 12, 0, tzinfo=UTC)
+
+
+def _ready_connector(key: str = "google_ads") -> dict:
+    return {
+        "connector_key": key,
+        "category": "Ads",
+        "write_ready": True,
+        "write_safe": True,
+        "write_status": "ready",
+        "read_status": "ready",
+        "contract_state": "healthy",
+        "missing_write_scopes": [],
+        "mock_or_test_double": False,
+        "blocks_external_writes": False,
+    }
+
+
+def _unsafe_connector(key: str = "google_ads") -> dict:
+    return {
+        **_ready_connector(key),
+        "write_ready": False,
+        "write_safe": False,
+        "write_status": "blocked",
+        "missing_write_scopes": ["adwords.write"],
+        "blocks_external_writes": True,
+    }
+
+
+def _approval(**overrides: object) -> dict:
+    base = {
+        "approval_id": "apr-campaign-1",
+        "workflow_id": "campaign_launch",
+        "workflow_run_id": "run-1",
+        "step_id": "launch",
+        "action": "launch_campaign",
+        "approval_type": "ad_campaign_launch",
+        "status": "pending",
+        "agent_id": "agent-campaign",
+        "agent_type": "campaign_pilot",
+        "requested_approver": "cmo@example.com",
+        "requested_approver_role": "cmo",
+        "created_at": (NOW - timedelta(hours=1)).isoformat(),
+        "due_at": (NOW + timedelta(hours=3)).isoformat(),
+        "preview_payload": {
+            "campaign_name": "Q2 Pipeline Sprint",
+            "channels": ["google_ads"],
+            "headline": "Pipeline without guesswork",
+        },
+        "before_after_diff": {
+            "before": "Campaign is draft only",
+            "after": "Campaign launches to search audience",
+        },
+        "budget_impact": {"amount": 1200, "currency": "USD", "period": "daily"},
+        "audience_impact": {"estimated_recipients": 25000, "segments": ["enterprise_search"]},
+        "brand_legal_risk_flags": ["budget_change"],
+        "source_refs": [{"type": "campaign_brief", "id": "brief-1"}],
+        "connector_key": "google_ads",
+        "agent_rationale": "ROAS shadow runs exceeded launch threshold.",
+        "audit_refs": ["audit-approval-context"],
+        "rollback_stop_plan": {
+            "summary": "Pause campaign and restore previous budget cap.",
+        },
+        "external_write_required": True,
+        "customer_facing": True,
+        "workflow_mode": "active",
+    }
+    base.update(overrides)
+    return base
+
+
+def _projection(approval: dict, connectors: list[dict] | None = None) -> dict:
+    return build_cmo_approval_review_projection(
+        [approval],
+        connector_contracts=connectors or [_ready_connector()],
+        approval_timeout_risk=build_approval_timeout_risk([approval], now=NOW),
+        now=NOW,
+    )
+
+
+def _review(approval: dict, connectors: list[dict] | None = None) -> dict:
+    return _projection(approval, connectors)["cmo_approval_reviews"][0]
+
+
+def test_approval_review_includes_preview_diff_rationale_and_source_refs() -> None:
+    review = _review(_approval())
+
+    assert review["preview_payload"]["campaign_name"] == "Q2 Pipeline Sprint"
+    assert review["before_after_diff"]["after"] == "Campaign launches to search audience"
+    assert review["agent_rationale"] == "ROAS shadow runs exceeded launch threshold."
+    assert review["source_refs"] == [{"type": "campaign_brief", "id": "brief-1"}]
+    assert review["policy_result"]["decision"] == "requires_approval"
+    assert review["timeout_state"] == "pending"
+    assert "approve" in review["allowed_reviewer_actions"]
+
+
+def test_campaign_launch_approval_includes_budget_audience_and_rollback_plan() -> None:
+    review = _review(_approval())
+
+    assert review["action_type"] == "campaign_launch"
+    assert review["budget_impact"]["amount"] == 1200
+    assert review["audience_impact"]["estimated_recipients"] == 25000
+    assert "Pause campaign" in review["rollback_stop_plan"]["summary"]
+
+
+def test_content_email_approval_includes_brand_legal_risk_flags() -> None:
+    review = _review(
+        _approval(
+            approval_id="apr-email-1",
+            action="send_email",
+            approval_type="email_send",
+            connector_key="mailchimp",
+            brand_legal_risk_flags=["legal_claim", "unsubscribe_compliance"],
+        ),
+        [_ready_connector("mailchimp")],
+    )
+
+    assert review["action_type"] == "email_send"
+    assert "legal_claim" in review["risk_flags"]
+    assert "unsubscribe_compliance" in review["risk_flags"]
+
+
+def test_crisis_response_approval_includes_escalation_timeout_and_policy_refs() -> None:
+    review = _review(
+        _approval(
+            approval_id="apr-crisis-1",
+            action="public_response",
+            approval_type="crisis_public_response",
+            connector_key="buffer",
+            crisis_response=True,
+            public_response=True,
+            brand_legal_risk_flags=["crisis"],
+        ),
+        [_ready_connector("buffer")],
+    )
+
+    assert review["action_type"] == "crisis_public_response"
+    assert review["policy_result"]["decision"] == "requires_escalation"
+    assert review["policy_result_ref"]
+    assert review["escalation_result_ref"]
+    assert review["timeout_result_ref"]
+    assert "approve" not in review["allowed_reviewer_actions"]
+    assert "escalate" in review["allowed_reviewer_actions"]
+
+
+def test_approval_fails_closed_when_policy_result_is_missing() -> None:
+    review = _review(_approval(marketing_policy_manifest_disabled=True))
+
+    assert review["status"] == "blocked"
+    assert review["policy_result"]["decision"] == "missing_policy"
+    assert "approve" not in review["allowed_reviewer_actions"]
+    assert any("policy" in reason.lower() for reason in review["blocked_reasons"])
+
+
+def test_approval_fails_closed_when_connector_write_readiness_is_unsafe() -> None:
+    review = _review(_approval(), [_unsafe_connector()])
+
+    assert review["status"] == "blocked"
+    assert review["external_write_readiness"]["status"] == "unsafe"
+    assert "approve" not in review["allowed_reviewer_actions"]
+    assert "adwords.write" in review["external_write_readiness"]["reason"]
+
+
+def test_approval_fails_closed_when_timeout_requires_manual_resolution() -> None:
+    approval = _approval(
+        approval_id="apr-landing-1",
+        action="update_landing_page",
+        approval_type="landing_page_change",
+        connector_key="wordpress",
+        due_at=(NOW - timedelta(minutes=1)).isoformat(),
+    )
+    review = _review(approval, [_ready_connector("wordpress")])
+
+    assert review["status"] == "timed_out"
+    assert review["timeout_result"]["outcome"] == "require_manual_resolution"
+    assert "approve" not in review["allowed_reviewer_actions"]
+    assert any("manual resolution" in reason for reason in review["blocked_reasons"])
+
+
+def test_approval_fails_closed_when_required_audit_evidence_is_missing() -> None:
+    approval = _approval()
+    approval.pop("audit_refs")
+    review = _review(approval)
+
+    assert review["status"] == "blocked"
+    assert review["audit_evidence"]["ready"] is False
+    assert "approve" not in review["allowed_reviewer_actions"]
+
+
+def test_reject_and_override_decision_requests_record_reason_and_replacement() -> None:
+    review = _review(_approval())
+
+    rejected = build_cmo_approval_decision_request(
+        review,
+        decision="reject",
+        actor_id="user-1",
+        actor_role="cmo",
+        reason="Audience is too broad.",
+        now=NOW,
+    )
+    assert rejected["decision"] == "reject"
+    assert rejected["reason"] == "Audience is too broad."
+    assert rejected["decision_audit_ref"]
+
+    override = build_cmo_approval_decision_request(
+        review,
+        decision="override",
+        actor_id="user-1",
+        actor_role="cmo",
+        reason="Reduce budget and narrow the segment.",
+        replacement_action={"action_id": "launch-v2", "budget_amount": 600},
+        now=NOW,
+    )
+    assert override["decision"] == "override"
+    assert override["replacement_action"]["budget_amount"] == 600
+    assert override["decision_audit"]["override"]["reason"] == "Reduce budget and narrow the segment."
+
+
+def test_allowed_reviewer_actions_change_based_on_status_and_risk() -> None:
+    ready = _review(_approval())
+    blocked = _review(_approval(marketing_policy_manifest_disabled=True))
+    timed_out = _review(
+        _approval(
+            action="update_landing_page",
+            approval_type="landing_page_change",
+            connector_key="wordpress",
+            due_at=(NOW - timedelta(minutes=1)).isoformat(),
+        ),
+        [_ready_connector("wordpress")],
+    )
+
+    assert "approve" in ready["allowed_reviewer_actions"]
+    assert "approve" not in blocked["allowed_reviewer_actions"]
+    assert "request_changes" in blocked["allowed_reviewer_actions"]
+    assert "approve" not in timed_out["allowed_reviewer_actions"]
+    assert "pause" in timed_out["allowed_reviewer_actions"]
+
+
+def test_work_queue_link_is_present_on_approval_review_payload() -> None:
+    review = _review(_approval(approval_id="apr-link-1"))
+
+    assert review["related_work_queue_item_ids"][0].startswith("cmo_wq_")
+
+
+@pytest.mark.asyncio
+async def test_kpis_cmo_exposes_approval_review_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_base(tenant_id: str, role: str, company_id: str) -> dict:
+        return {
+            "demo": False,
+            "company_id": company_id,
+            "agent_count": 1,
+            "total_tasks_30d": 1,
+            "success_rate": 100,
+            "hitl_interventions": 1,
+            "total_cost_usd": 0,
+            "domain_breakdown": [],
+        }
+
+    async def fake_configs(tenant_id: str) -> list:
+        return []
+
+    async def fake_approval_timeout(tenant_id: str, company_id: str) -> dict:
+        approval = _approval(external_write_required=False, customer_facing=False)
+        risk = build_approval_timeout_risk([approval], now=NOW)
+        risk["approval_records"] = [approval]
+        return risk
+
+    monkeypatch.setattr(kpis_api, "_build_kpi_response", fake_base)
+    monkeypatch.setattr(kpis_api, "_load_marketing_connector_configs", fake_configs)
+    monkeypatch.setattr(kpis_api, "_load_cmo_approval_timeout_risk", fake_approval_timeout)
+
+    response = await kpis_api._build_cmo_kpi_response("tenant-1", "company-1")
+
+    assert "cmo_approval_reviews" in response
+    assert response["cmo_approval_review_summary"]["total"] == 1
+    assert response["approval_timeout_risk"]["approval_timeout_decisions"][0]["approval_review_id"]

--- a/tests/unit/test_cmo_approval_timeout_policy.py
+++ b/tests/unit/test_cmo_approval_timeout_policy.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from core.marketing.approval_timeouts import (
+    build_approval_timeout_risk,
+    build_workflow_approval_timeout_status,
+    evaluate_approval_timeout,
+)
+from core.marketing.external_writes import evaluate_marketing_external_write_result
+from core.marketing.workflow_linter import lint_marketing_workflow
+
+NOW = datetime(2026, 5, 23, 12, 0, tzinfo=UTC)
+
+
+def _approval(**overrides: object) -> dict:
+    approval = {
+        "approval_id": "apr_campaign_1",
+        "workflow_id": "campaign_launch",
+        "workflow_run_id": "run_campaign_1",
+        "step_id": "launch_ads",
+        "action": "launch_campaign",
+        "requested_approver": "cmo@example.com",
+        "requested_approver_role": "cmo",
+        "created_at": NOW - timedelta(hours=5),
+        "due_at": NOW - timedelta(hours=1),
+        "status": "pending",
+    }
+    approval.update(overrides)
+    return approval
+
+
+def _contract() -> dict:
+    return {
+        "connector_key": "google_ads",
+        "write_safe": True,
+        "idempotency_key_supported": True,
+        "retry_budget": {
+            "max_attempts": 3,
+            "attempts_used": 0,
+            "remaining_attempts": 3,
+            "idempotency_key": "ads-launch-1",
+        },
+        "external_write_confirmations": [],
+    }
+
+
+def _confirmed_output(decision: dict) -> dict:
+    return {
+        "external_write_state": "write_confirmed",
+        "external_object_id": "customers/123/campaigns/456",
+        "source_url": "https://ads.google.com/campaigns/456",
+        "idempotency_key": "ads-launch-1",
+        "request_fingerprint": "fp-launch-1",
+        "approval_timeout_decision": decision,
+    }
+
+
+def _workflow(step: dict) -> dict:
+    return {
+        "id": "wf_timeout",
+        "name": "Timeout Workflow",
+        "domain": "marketing",
+        "mode": "production",
+        "steps": [step],
+    }
+
+
+def test_pending_approval_before_sla_is_not_timed_out() -> None:
+    decision = evaluate_approval_timeout(
+        _approval(created_at=NOW - timedelta(minutes=30), due_at=NOW + timedelta(hours=1)),
+        now=NOW,
+    )
+
+    assert decision["status"] == "pending"
+    assert decision["timed_out"] is False
+    assert decision["workflow_state"] == "waiting_hitl"
+    assert decision["external_writes_allowed"] is False
+    assert decision["audit_evidence"] is None
+
+
+def test_approval_after_due_at_triggers_timeout_evaluation() -> None:
+    decision = evaluate_approval_timeout(_approval(), now=NOW)
+
+    assert decision["timed_out"] is True
+    assert decision["status"] == "timed_out"
+    assert decision["timed_out_at"] == NOW.isoformat()
+    assert decision["outcome"] == "auto_cancel"
+    assert decision["next_action_cta"] == "restart_approval"
+
+
+def test_default_timeout_outcome_fails_closed_for_external_writes() -> None:
+    decision = evaluate_approval_timeout(_approval(), now=NOW)
+
+    assert decision["external_writes_allowed"] is False
+    assert decision["workflow_state"] == "cancelled"
+    assert decision["audit_evidence"]["external_writes_allowed"] is False
+    assert decision["audit_evidence"]["blocked_action"] == "launch_campaign"
+
+
+def test_auto_cancel_blocks_step_and_creates_audit_evidence() -> None:
+    decision = evaluate_approval_timeout(_approval(), now=NOW)
+
+    assert decision["outcome"] == "auto_cancel"
+    assert decision["workflow_state"] == "cancelled"
+    assert decision["step_status"] == "cancelled"
+    assert decision["progress_allowed"] is False
+    audit = decision["audit_evidence"]
+    assert audit["event_type"] == "cmo_approval_timeout_auto_cancel"
+    assert audit["approval_id"] == "apr_campaign_1"
+    assert audit["workflow_run_id"] == "run_campaign_1"
+    assert audit["step_id"] == "launch_ads"
+    assert audit["requested_approver_role"] == "cmo"
+    assert audit["created_at"] == (NOW - timedelta(hours=5)).isoformat()
+    assert audit["due_at"] == (NOW - timedelta(hours=1)).isoformat()
+    assert audit["timed_out_at"] == NOW.isoformat()
+    assert audit["outcome"] == "auto_cancel"
+    assert audit["escalation_target"] == "cmo"
+    assert audit["audit_reference"].startswith("mkt_approval_timeout_")
+
+
+def test_auto_escalate_changes_owner_and_creates_audit_evidence() -> None:
+    decision = evaluate_approval_timeout(
+        _approval(
+            approval_id="apr_budget_1",
+            action="mutate_ad_budget",
+            workflow_id="daily_spend_optimization",
+        ),
+        now=NOW,
+    )
+
+    assert decision["outcome"] == "auto_escalate"
+    assert decision["workflow_state"] == "waiting_hitl"
+    assert decision["escalated"] is True
+    assert decision["escalation_target"] == "cmo"
+    assert decision["external_writes_allowed"] is False
+    assert decision["audit_evidence"]["event_type"] == "cmo_approval_timeout_auto_escalate"
+
+
+def test_continue_read_only_allows_only_recommendation_continuation() -> None:
+    decision = evaluate_approval_timeout(
+        _approval(action="publish"),
+        policy_source={
+            "approval_timeout_policies": {
+                "content_publish": {
+                    "timeout_outcome": "continue_read_only",
+                    "escalation_role": "content_lead",
+                }
+            }
+        },
+        now=NOW,
+    )
+
+    assert decision["outcome"] == "continue_read_only"
+    assert decision["workflow_state"] == "degraded"
+    assert decision["progress_allowed"] is True
+    assert decision["read_only_continuation_allowed"] is True
+    assert decision["external_writes_allowed"] is False
+    assert decision["next_action_cta"] == "continue_read_only"
+    assert decision["audit_evidence"]["blocked_action"] == "publish"
+
+
+def test_pause_workflow_pauses_and_blocks_external_writes() -> None:
+    decision = evaluate_approval_timeout(
+        _approval(action="send_email", workflow_id="lead_nurture"),
+        now=NOW,
+    )
+
+    assert decision["outcome"] == "pause_workflow"
+    assert decision["workflow_state"] == "paused"
+    assert decision["external_writes_allowed"] is False
+    assert decision["next_action_cta"] == "resume_after_manual_approval"
+    assert decision["audit_evidence"]["event_type"] == "cmo_approval_timeout_pause_workflow"
+
+
+def test_require_manual_resolution_blocks_progress_until_human_resolution() -> None:
+    decision = evaluate_approval_timeout(
+        _approval(action="pricing_claim", workflow_id="content_pipeline"),
+        now=NOW,
+    )
+
+    assert decision["outcome"] == "require_manual_resolution"
+    assert decision["workflow_state"] == "blocked"
+    assert decision["progress_allowed"] is False
+    assert decision["external_writes_allowed"] is False
+    assert decision["audit_evidence"]["event_type"] == "cmo_approval_timeout_manual_resolution"
+
+
+def test_missing_timeout_policy_blocks_production_approval_sensitive_workflow_step() -> None:
+    step = {
+        "id": "approve_custom_plan",
+        "type": "agent",
+        "agent_type": "campaign_pilot",
+        "action": "create_plan",
+        "approval_required": True,
+    }
+
+    result = lint_marketing_workflow(_workflow(step))
+
+    assert result.has_errors is True
+    assert "marketing_approval_timeout_policy_missing" in {finding.code for finding in result.findings}
+
+
+def test_workflow_linter_accepts_default_policy_for_known_sensitive_step() -> None:
+    step = {
+        "id": "launch_ads",
+        "type": "agent",
+        "agent_type": "campaign_pilot",
+        "action": "activate_campaign",
+        "connector_key": "google_ads",
+        "external_write_confirmation_required": True,
+        "expected_confirmation_fields": ["external_object_id", "confirmed_at"],
+        "idempotency_key_template": "campaign:{campaign_id}:activate",
+    }
+
+    result = lint_marketing_workflow(_workflow(step), connector_contracts=[_contract()])
+
+    assert "marketing_approval_timeout_policy_missing" not in {finding.code for finding in result.findings}
+
+
+def test_timeout_policy_does_not_activate_unrelated_workflows() -> None:
+    campaign = build_workflow_approval_timeout_status(
+        "campaign_launch",
+        ["launch_campaign"],
+        {"approval_timeout_policy_disabled": True},
+    )
+    weekly_report = build_workflow_approval_timeout_status(
+        "weekly_marketing_report",
+        [],
+        {"approval_timeout_policy_disabled": True},
+    )
+
+    assert campaign["status"] == "missing_policy"
+    assert campaign["next_action_cta"] == "configure_approval_timeout_policy"
+    assert weekly_report["status"] == "not_required"
+    assert weekly_report["next_action_cta"] == "none"
+
+
+def test_approval_timeout_risk_projection_summarizes_pending_and_overdue_items() -> None:
+    risk = build_approval_timeout_risk(
+        [
+            _approval(approval_id="pending", due_at=NOW + timedelta(hours=1)),
+            _approval(approval_id="overdue", due_at=NOW - timedelta(minutes=1)),
+        ],
+        now=NOW,
+    )
+
+    assert risk["status"] == "blocked"
+    assert risk["pending"] == 1
+    assert risk["overdue"] == 1
+    assert risk["blocked_external_writes"] == 1
+    assert risk["next_action_cta"] == "resolve_overdue_approvals"
+
+
+def test_active_external_write_after_timeout_fails_closed() -> None:
+    timeout_decision = evaluate_approval_timeout(_approval(), now=NOW)
+
+    result = evaluate_marketing_external_write_result(
+        [_contract()],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="active",
+        output=_confirmed_output(timeout_decision),
+        step={"id": "launch_ads", "idempotency_key": "ads-launch-1"},
+        state={"workflow_id": "campaign_launch", "id": "run_campaign_1"},
+        now=NOW,
+    )
+
+    assert result["step_status"] == "failed"
+    assert result["error_code"] == "external_write_approval_timeout"
+    assert result["can_mark_complete"] is False
+    assert "Approval timed out" in result["reason"]
+
+
+def test_preapproved_timeout_policy_can_allow_confirmed_external_write() -> None:
+    timeout_decision = evaluate_approval_timeout(
+        _approval(action="publish", preapproved_after_timeout=True),
+        policy_source={
+            "approval_timeout_policies": {
+                "content_publish": {
+                    "timeout_outcome": "auto_escalate",
+                    "external_writes_allowed_after_timeout": True,
+                    "preapproved_after_timeout": True,
+                }
+            }
+        },
+        now=NOW,
+    )
+
+    result = evaluate_marketing_external_write_result(
+        [_contract()],
+        connector_key="google_ads",
+        action="publish",
+        workflow_mode="active",
+        output=_confirmed_output(timeout_decision),
+        step={"id": "publish_content", "idempotency_key": "ads-launch-1"},
+        state={"workflow_id": "content_pipeline", "id": "run_content_1"},
+        now=NOW,
+    )
+
+    assert timeout_decision["external_writes_allowed"] is True
+    assert result["step_status"] == "completed"
+    assert result["final_state"] == "write_confirmed"

--- a/tests/unit/test_cmo_brand_monitor_agent.py
+++ b/tests/unit/test_cmo_brand_monitor_agent.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.agents.marketing.brand_monitor import BrandMonitorAgent
+from core.marketing.agent_contracts import (
+    build_marketing_agent_contract_output,
+    contract_has_required_shape,
+    get_marketing_agent_contract_spec,
+)
+from core.marketing.pilot_proof import build_cmo_pilot_proof_projection
+from core.marketing.workflow_linter import lint_marketing_workflow
+from core.schemas.messages import TargetAgent, TaskAssignment, TaskInput
+
+
+class FakeToolGateway:
+    def __init__(self, responses: dict[tuple[str, str], dict[str, Any] | Exception]):
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    async def execute(
+        self,
+        *,
+        tenant_id: str,
+        agent_id: str,
+        agent_scopes: list[str],
+        connector_name: str,
+        tool_name: str,
+        params: dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "tenant_id": tenant_id,
+                "agent_id": agent_id,
+                "agent_scopes": agent_scopes,
+                "connector_name": connector_name,
+                "tool_name": tool_name,
+                "params": params,
+                "idempotency_key": idempotency_key,
+            }
+        )
+        response = self.responses.get((connector_name, tool_name), {})
+        if isinstance(response, Exception):
+            raise response
+        return dict(response)
+
+
+def _assignment(action: str, inputs: dict[str, Any]) -> TaskAssignment:
+    return TaskAssignment(
+        message_id=f"msg-brand-{action}",
+        correlation_id="corr-brand",
+        workflow_run_id="run-brand",
+        workflow_definition_id="wf-brand",
+        step_id=f"step-{action}",
+        step_index=0,
+        total_steps=1,
+        target_agent=TargetAgent(
+            agent_id="agent-brand",
+            agent_type="brand_monitor",
+            agent_token="test-token",
+        ),
+        task=TaskInput(action=action, inputs=inputs),
+    )
+
+
+def _agent(gateway: FakeToolGateway | None = None) -> BrandMonitorAgent:
+    return BrandMonitorAgent(
+        agent_id="agent-brand",
+        tenant_id="tenant-cmo",
+        tool_gateway=gateway,
+        authorized_tools=["buffer.publish_brand_response", "brandwatch.record_brand_claim"],
+    )
+
+
+def _mentions() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "m1",
+            "source": "twitter",
+            "channel": "social",
+            "topic": "support",
+            "text": "AgenticOrg support resolved our issue quickly. Great team.",
+            "sentiment": "positive",
+            "url": "https://x.example/m1",
+        },
+        {
+            "id": "m2",
+            "source": "twitter",
+            "channel": "social",
+            "topic": "reliability",
+            "text": "AgenticOrg is down again and the outage is unacceptable.",
+            "sentiment": "negative",
+            "url": "https://x.example/m2",
+        },
+        {
+            "id": "m3",
+            "source": "news",
+            "channel": "news",
+            "topic": "legal",
+            "text": "Regulator asks questions after AgenticOrg security incident.",
+            "sentiment": "negative",
+            "influence": "journalist",
+            "url": "https://news.example/m3",
+        },
+        {
+            "id": "m4",
+            "source": "reddit",
+            "channel": "community",
+            "topic": "general",
+            "text": "Bought a brand new monitor for my desk.",
+            "sentiment": "neutral",
+        },
+        {
+            "id": "m5",
+            "source": "brandwatch",
+            "channel": "social",
+            "topic": "competitor",
+            "entity_type": "competitor",
+            "competitor": "AcmeOps",
+            "text": "AcmeOps says AgenticOrg lacks governance features.",
+            "sentiment": "negative",
+        },
+    ]
+
+
+def _base_inputs(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "mentions": _mentions(),
+        "baseline_negative_mentions": 1,
+        "negative_spike_multiplier": 2,
+        "negative_spike_min_count": 2,
+        "source_refs": [{"type": "brandwatch", "ref_id": "query-brand"}],
+        "workflow_mode": "shadow",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_contract(**overrides: object) -> dict[str, Any]:
+    contract = {
+        "connector_key": "buffer",
+        "category": "Social",
+        "read_ready": True,
+        "write_ready": True,
+        "write_safe": True,
+        "idempotency_key_supported": True,
+        "retry_budget": {
+            "idempotency_key": "brand:write:001",
+            "idempotency_supported": True,
+            "remaining_attempts": 2,
+        },
+    }
+    contract.update(overrides)
+    return contract
+
+
+def _workflow(step: dict[str, Any], *, mode: str = "production") -> dict[str, Any]:
+    return {
+        "id": "wf_brand",
+        "name": "Brand Crisis Response",
+        "domain": "marketing",
+        "mode": mode,
+        "steps": [step],
+    }
+
+
+def _workflow_step(action: str, **overrides: object) -> dict[str, Any]:
+    step: dict[str, Any] = {
+        "id": "step_brand",
+        "name": "Brand Step",
+        "type": "agent",
+        "agent_type": "brand_monitor",
+        "action": action,
+    }
+    step.update(overrides)
+    return step
+
+
+@pytest.mark.asyncio
+async def test_brand_monitor_mention_aggregation_groups_mentions_by_source_channel_and_topic() -> None:
+    result = await _agent().execute(_assignment("mention_aggregation", _base_inputs()))
+    groups = result.output["brand_monitoring"]["mention_groups"]
+
+    assert result.output["status"] == "mentions_aggregated"
+    assert groups["by_source"]["twitter"] == 2
+    assert groups["by_channel"]["social"] == 3
+    assert groups["by_topic"]["reliability"] == 1
+    assert result.output["brand_monitoring"]["suppressed_mentions"] == 1
+
+
+@pytest.mark.asyncio
+async def test_brand_monitor_sentiment_trend_calculates_distribution() -> None:
+    result = await _agent().execute(_assignment("sentiment_trend", _base_inputs()))
+    trend = result.output["sentiment_trend"]
+
+    assert trend["counts"] == {"positive": 1, "neutral": 0, "negative": 3}
+    assert trend["distribution"]["negative"] == 0.75
+    assert trend["baseline_negative_mentions"] == 1
+
+
+@pytest.mark.asyncio
+async def test_brand_monitor_negative_spike_detection_triggers_alert_above_threshold() -> None:
+    result = await _agent().execute(_assignment("detect_negative_spike", _base_inputs()))
+    spike = result.output["negative_spike"]
+
+    assert spike["triggered"] is True
+    assert spike["current_negative_mentions"] == 3
+    assert spike["severity"] in {"medium", "high", "critical"}
+
+
+@pytest.mark.asyncio
+async def test_brand_monitor_false_positive_suppression_reduces_noise() -> None:
+    result = await _agent().execute(_assignment("false_positive_suppression", _base_inputs()))
+
+    assert len(result.output["mentions"]) == 4
+    assert len(result.output["suppressed_mentions"]) == 1
+    assert "brand new monitor" in result.output["suppressed_mentions"][0]["text"].lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mentions", "expected"),
+    [
+        ([{"text": "AgenticOrg is great", "sentiment": "positive"}], "low"),
+        (
+            [
+                {"text": "AgenticOrg support is bad", "sentiment": "negative"},
+                {"text": "AgenticOrg was slow", "sentiment": "negative"},
+                {"text": "AgenticOrg issue unresolved", "sentiment": "negative"},
+            ],
+            "medium",
+        ),
+        (
+            [{"text": "AgenticOrg outage is spreading and users are angry", "sentiment": "negative"}] * 8,
+            "high",
+        ),
+        (
+            [
+                {
+                    "text": "AgenticOrg security breach and regulator lawsuit after data leak",
+                    "sentiment": "negative",
+                    "influence": "journalist",
+                }
+            ],
+            "critical",
+        ),
+    ],
+)
+async def test_brand_monitor_crisis_severity_classification_returns_expected_levels(
+    mentions: list[dict[str, Any]],
+    expected: str,
+) -> None:
+    result = await _agent().execute(
+        _assignment(
+            "classify_crisis_severity",
+            _base_inputs(mentions=mentions, baseline_negative_mentions=1, negative_spike_min_count=3),
+        )
+    )
+
+    assert result.output["crisis_severity"]["severity"] == expected
+
+
+@pytest.mark.asyncio
+async def test_brand_monitor_competitor_and_brand_grouping_works_from_structured_input() -> None:
+    result = await _agent().execute(_assignment("competitor_brand_grouping", _base_inputs()))
+    groups = result.output["mention_groups"]
+
+    assert groups["by_entity"]["brand"] == 3
+    assert groups["by_entity"]["competitor"] == 1
+    assert groups["competitors"]["acmeops"] == 1
+
+
+@pytest.mark.asyncio
+async def test_brand_monitor_response_playbook_is_deterministic() -> None:
+    result = await _agent().execute(_assignment("recommend_response_playbook", _base_inputs()))
+    actions = [item["action"] for item in result.output["response_playbook"]]
+
+    assert actions[0] == "escalate_brand_crisis"
+    assert "prepare_approved_holding_statement" in actions
+
+
+@pytest.mark.asyncio
+async def test_public_crisis_response_requires_policy_approval_and_escalation() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "public_response",
+            _base_inputs(
+                workflow_mode="active",
+                connector_contract=_write_contract(),
+                severity="critical",
+                crisis_response=True,
+                message="We are investigating the reported security incident.",
+            ),
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["status"] == "blocked"
+    assert result.output["policy_result"]["decision"] == "requires_escalation"
+    assert result.output["approval_required"] is True
+    assert result.output["escalation_ref"]
+
+
+@pytest.mark.asyncio
+async def test_connector_degraded_read_only_monitoring_downgrades_output() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "monitor_mentions",
+            _base_inputs(connector_read_ready=False, connector_degraded=True),
+        )
+    )
+
+    assert result.output["status"] == "mentions_degraded"
+    assert result.output["degraded_reasons"]
+    assert result.output["confidence"] < 0.85
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_cannot_write_externally() -> None:
+    gateway = FakeToolGateway({})
+    result = await _agent(gateway).execute(
+        _assignment("public_response", _base_inputs(message="Draft public response", workflow_mode="shadow"))
+    )
+
+    assert result.output["status"] == "shadow_only"
+    assert result.output["external_write_confirmation_status"] == "shadow_only"
+    assert gateway.calls == []
+
+
+@pytest.mark.asyncio
+async def test_active_external_action_blocks_when_connector_is_not_write_safe() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "public_response",
+            _base_inputs(
+                workflow_mode="active",
+                approved=True,
+                escalation_ref="esc-brand-1",
+                connector_contract=_write_contract(write_ready=False, write_safe=False),
+            ),
+        )
+    )
+
+    assert result.output["status"] == "blocked"
+    assert any("not write-safe" in reason for reason in result.output["blocked_reasons"])
+
+
+@pytest.mark.asyncio
+async def test_active_external_action_cannot_complete_without_confirmed_write() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "public_response",
+            _base_inputs(
+                workflow_mode="active",
+                approved=True,
+                escalation_ref="esc-brand-1",
+                connector_contract=_write_contract(),
+                external_write_result={
+                    "connector_key": "buffer",
+                    "status": "accepted",
+                    "idempotency_key": "brand:response:1",
+                },
+            ),
+        )
+    )
+
+    assert result.output["status"] == "write_unconfirmed"
+    assert result.output["external_writes_completed"] is False
+    assert result.status == "hitl_triggered"
+
+
+@pytest.mark.asyncio
+async def test_confirmed_brand_response_write_has_refs_and_contract_shape() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "publish_brand_response",
+            _base_inputs(
+                workflow_mode="active",
+                approved=True,
+                escalation_ref="esc-brand-1",
+                connector_contract=_write_contract(),
+                external_write_result={
+                    "connector_key": "buffer",
+                    "status": "write_confirmed",
+                    "external_object_id": "updates/brand-response-1",
+                    "source_url": "https://publish.buffer.com/updates/brand-response-1",
+                    "idempotency_key": "brand:response:1",
+                    "confirmed_at": "2026-05-24T12:00:00Z",
+                    "audit_ref": "audit-brand-write",
+                },
+            ),
+        )
+    )
+    contract = build_marketing_agent_contract_output(
+        "brand_monitor",
+        "publish_brand_response",
+        result=result,
+        audit_ref=result.output["audit_ref"],
+        external_write_confirmation_status=result.output["external_write_confirmation_status"],
+    )
+
+    assert result.status == "completed"
+    assert result.output["external_write_ref"]["external_object_id"] == "updates/brand-response-1"
+    assert contract_has_required_shape(contract)
+    assert contract["maturity"] == "beta"
+    assert contract["external_writes_completed"] is True
+
+
+def test_brand_monitor_contract_linter_and_pilot_proof_are_truthful_beta() -> None:
+    contract = build_marketing_agent_contract_output(
+        "brand_monitor",
+        "monitor_mentions",
+        audit_ref="audit-brand-contract",
+    )
+    read_lint = lint_marketing_workflow(_workflow(_workflow_step("monitor_mentions")))
+    write_lint = lint_marketing_workflow(
+        _workflow(_workflow_step("public_response", connector_key="buffer")),
+        connector_contracts=[_write_contract()],
+    )
+    proof = build_cmo_pilot_proof_projection(
+        environment_type="vendor_sandbox",
+        source_context={"source": "vendor_sandbox"},
+        agent_contracts=[get_marketing_agent_contract_spec("brand_monitor")],
+    )["cmo_pilot_proof"]
+
+    assert contract_has_required_shape(contract)
+    assert contract["maturity"] == "beta"
+    assert contract["production_ready"] is False
+    assert "marketing_agent_stub_for_production" not in {finding.code for finding in read_lint.findings}
+    assert "marketing_agent_beta_in_production" in {finding.code for finding in read_lint.findings}
+    assert "marketing_external_write_confirmation_metadata_missing" in {
+        finding.code for finding in write_lint.findings
+    }
+    assert proof["production_claim_allowed"] is False
+    assert any(item["capability_key"] == "agent:brand_monitor" for item in proof["unproven_capabilities"])

--- a/tests/unit/test_cmo_chaos_failure_modes.py
+++ b/tests/unit/test_cmo_chaos_failure_modes.py
@@ -1,0 +1,1025 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from core.marketing.agent_contracts import (
+    build_marketing_agent_contract_output,
+    contract_has_required_shape,
+)
+from core.marketing.approval_review import build_cmo_approval_review_projection
+from core.marketing.approval_timeouts import build_approval_timeout_risk
+from core.marketing.connector_contracts import build_marketing_connector_contracts
+from core.marketing.connector_setup import build_marketing_connector_setup
+from core.marketing.data_readiness import build_marketing_data_readiness
+from core.marketing.decision_audit import (
+    build_cmo_decision_audit_package,
+    build_marketing_decision_audit_projection,
+)
+from core.marketing.escalation_matrix import (
+    build_marketing_escalation_projection,
+    evaluate_marketing_escalation,
+)
+from core.marketing.external_writes import evaluate_marketing_external_write_result
+from core.marketing.kpi_schema import build_unified_cmo_kpi_projection
+from core.marketing.policy_manifest import (
+    build_marketing_policy_projection,
+    evaluate_marketing_policy,
+)
+from core.marketing.report_quality import build_cmo_report_quality_projection
+from core.marketing.work_queue import build_cmo_work_queue_projection
+from core.marketing.workflow_activation import build_cmo_workflow_activation
+from core.marketing.workflow_linter import lint_marketing_workflow
+
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=UTC)
+FRESH_TS = (NOW - timedelta(hours=1)).isoformat()
+STALE_TS = (NOW - timedelta(days=3)).isoformat()
+MAPPING_TS = "2026-05-01T00:00:00+00:00"
+IDEMPOTENCY_KEY = "mkt-chaos-idempotency-001"
+
+
+def _connector_config(
+    connector_name: str,
+    *,
+    config: dict[str, Any],
+    health_status: str = "healthy",
+    last_sync_at: datetime | None = None,
+    sync_error: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        connector_name=connector_name,
+        display_name=None,
+        auth_type="oauth2",
+        credentials_encrypted={"_encrypted": "enc"},
+        config=config,
+        status="configured",
+        last_health_check=NOW,
+        health_status=health_status,
+        last_sync_at=last_sync_at or NOW - timedelta(hours=1),
+        sync_error=sync_error,
+    )
+
+
+def _backfill(status: str = "completed") -> dict[str, Any]:
+    return {
+        "status": status,
+        "requested_start": "2025-05-01",
+        "requested_end": "2026-05-24",
+        "records_discovered": 100,
+        "records_imported": 100 if status == "completed" else 55,
+        "records_skipped": 0,
+        "records_failed": 0 if status == "completed" else 6,
+        "last_run_at": "2026-05-24T10:00:00+00:00",
+        "blocking_reason": "Vendor export failed" if status in {"failed", "blocked"} else None,
+    }
+
+
+def _contract_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "idempotency_supported": True,
+        "retry_budget": {
+            "max_attempts": 3,
+            "attempts_used": 0,
+            "remaining_attempts": 3,
+            "next_retry_at": "2026-05-24T12:05:00+00:00",
+            "idempotency_supported": True,
+            "idempotency_key": IDEMPOTENCY_KEY,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _hubspot_mapping() -> dict[str, Any]:
+    return {
+        "lifecycle_stages": {
+            "source_field": "lifecyclestage",
+            "stage_map": {"mql": "marketingqualifiedlead", "sql": "salesqualifiedlead"},
+            "updated_at": MAPPING_TS,
+        },
+        "opportunity_revenue": {
+            "amount_field": "amount",
+            "close_date_field": "closedate",
+            "currency_field": "deal_currency_code",
+            "updated_at": MAPPING_TS,
+        },
+        "account_domains": {"domain_field": "website", "updated_at": MAPPING_TS},
+        "consent_unsubscribe": {
+            "consent_field": "marketing_opt_in",
+            "unsubscribe_field": "unsubscribed",
+            "updated_at": MAPPING_TS,
+        },
+        "fiscal_calendar": {"fiscal_year_start_month": 4, "updated_at": MAPPING_TS},
+        "currency": {"currency": "USD", "updated_at": MAPPING_TS},
+        "timezone": {"timezone": "Asia/Kolkata", "updated_at": MAPPING_TS},
+    }
+
+
+def _campaign_mapping() -> dict[str, Any]:
+    return {
+        "campaign_ids": {"campaign_id_field": "campaign_id", "updated_at": MAPPING_TS},
+        "utm_fields": {
+            "source": "utm_source",
+            "medium": "utm_medium",
+            "campaign": "utm_campaign",
+            "updated_at": MAPPING_TS,
+        },
+    }
+
+
+def _mailchimp_mapping() -> dict[str, Any]:
+    return {
+        **_campaign_mapping(),
+        "consent_unsubscribe": {
+            "consent_field": "marketing_permission",
+            "unsubscribe_field": "unsubscribe_status",
+            "updated_at": MAPPING_TS,
+        },
+    }
+
+
+def _base_configs() -> list[SimpleNamespace]:
+    return [
+        _connector_config(
+            "hubspot",
+            config={
+                "owner": "revops@example.com",
+                "account_id": "portal-123",
+                "granted_scopes": [
+                    "crm.objects.contacts.read",
+                    "crm.objects.deals.read",
+                    "automation",
+                ],
+                "data_coverage_status": "ready",
+                "marketing_field_mapping": _hubspot_mapping(),
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract_payload(),
+            },
+        ),
+        _connector_config(
+            "google_ads",
+            config={
+                "owner": "growth@example.com",
+                "customer_id": "123-456-7890",
+                "granted_scopes": ["https://www.googleapis.com/auth/adwords"],
+                "marketing_field_mapping": _campaign_mapping(),
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract_payload(),
+            },
+        ),
+        _connector_config(
+            "ga4",
+            config={
+                "owner": "analytics@example.com",
+                "property_id": "properties/123",
+                "granted_scopes": ["https://www.googleapis.com/auth/analytics.readonly"],
+                "marketing_field_mapping": _campaign_mapping(),
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract_payload(write_capabilities=[], required_write_scopes=[]),
+            },
+        ),
+        _connector_config(
+            "mailchimp",
+            config={
+                "owner": "email@example.com",
+                "audience_id": "aud-1",
+                "marketing_field_mapping": _mailchimp_mapping(),
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract_payload(),
+            },
+        ),
+        _connector_config(
+            "wordpress",
+            config={
+                "owner": "web@example.com",
+                "site_url": "https://www.agenticorg.ai",
+                "marketing_field_mapping": _campaign_mapping(),
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract_payload(),
+            },
+        ),
+    ]
+
+
+def _workflow_config(**overrides: Any) -> dict[str, Any]:
+    payload = {
+        "mode": "active",
+        "promoted": True,
+        "approval_owner": "cmo@example.com",
+        "policy_owner": "legal@example.com",
+        "shadow_quality": {
+            "status": "passed",
+            "sample_count": 6,
+            "success_rate": 0.95,
+            "last_run_at": "2026-05-24T09:00:00+00:00",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _with_workflow(
+    configs: list[SimpleNamespace],
+    workflow_key: str,
+    payload: dict[str, Any] | None = None,
+) -> list[SimpleNamespace]:
+    cloned = deepcopy(configs)
+    cloned[0].config.setdefault("marketing_workflows", {})[workflow_key] = payload or _workflow_config()
+    return cloned
+
+
+def _source_facts(**overrides: Any) -> dict[str, Any]:
+    facts: dict[str, Any] = {
+        "last_updated_at": FRESH_TS,
+        "total_marketing_spend": 1_000.0,
+        "ad_spend": 1_000.0,
+        "campaign_spend_by_channel": {"google": 600.0, "linkedin": 250.0, "meta": 150.0},
+        "new_customers": 10,
+        "lifecycle_stage_counts": {
+            "visitor": 1_000,
+            "lead": 250,
+            "mql": 100,
+            "sql": 40,
+            "opportunity": 20,
+            "customer": 10,
+        },
+        "ad_platform_conversions": 100,
+        "crm_campaign_attributed_mqls": 100,
+        "ga4_conversion_events": 250,
+        "crm_leads_created": 250,
+        "attributed_revenue": 5_000.0,
+        "opportunities": [{"amount": 2_500.0}, {"amount": 1_500.0}],
+        "customer_ltv": 2_000.0,
+        "completed_experiments": 6,
+        "period_days": 30,
+        "content_sessions": 1_000,
+        "content_conversions": 50,
+        "wordpress_content_sessions": 1_000,
+        "ga4_content_sessions": 1_000,
+        "emails_sent": 2_000,
+        "emails_opened": 900,
+        "emails_clicked": 300,
+        "emails_unsubscribed": 20,
+        "crm_email_sends": 2_000,
+        "crm_email_clicks": 300,
+        "crm_unsubscribed_contacts": 20,
+        "brand_positive_mentions": 70,
+        "brand_negative_mentions": 10,
+        "brand_neutral_mentions": 20,
+        "intent_ready_accounts": 25,
+        "target_accounts": 100,
+        "abm_target_account_domains": ["alpha.example", "beta.example"],
+        "crm_account_domains": ["alpha.example", "beta.example"],
+        "intent_account_domains": ["alpha.example", "beta.example"],
+        "source_currencies": {"ads": "USD", "crm": "USD", "finance": "USD"},
+        "source_timezones": {
+            "ads": "Asia/Kolkata",
+            "crm": "Asia/Kolkata",
+            "analytics": "Asia/Kolkata",
+            "email": "Asia/Kolkata",
+        },
+        "source_refs": [{"connector_key": "hubspot", "object": "deals"}],
+        "audit_refs": ["audit-kpi-source"],
+    }
+    facts.update(overrides)
+    return facts
+
+
+def _approval(**overrides: Any) -> dict[str, Any]:
+    approval = {
+        "approval_id": "apr-chaos-1",
+        "workflow_id": "campaign_launch",
+        "workflow_run_id": "run-chaos-1",
+        "step_id": "launch",
+        "action": "launch_campaign",
+        "approval_type": "ad_campaign_launch",
+        "status": "pending",
+        "agent_id": "agent-campaign",
+        "agent_type": "campaign_pilot",
+        "requested_approver": "cmo@example.com",
+        "requested_approver_role": "cmo",
+        "created_at": (NOW - timedelta(hours=1)).isoformat(),
+        "due_at": (NOW + timedelta(hours=3)).isoformat(),
+        "preview_payload": {"campaign_name": "Chaos-safe launch", "channels": ["google_ads"]},
+        "before_after_diff": {
+            "before": "Campaign remains draft only",
+            "after": "Campaign launches to selected audience",
+        },
+        "budget_impact": {"amount": 1200, "currency": "USD", "period": "daily"},
+        "audience_impact": {"estimated_recipients": 25000, "segments": ["enterprise_search"]},
+        "brand_legal_risk_flags": ["budget_change"],
+        "source_refs": [{"type": "campaign_brief", "id": "brief-chaos"}],
+        "connector_key": "google_ads",
+        "agent_rationale": "Shadow recommendations exceeded launch threshold.",
+        "audit_refs": ["audit-approval-context"],
+        "rollback_stop_plan": {"summary": "Pause campaign and restore previous budget cap."},
+        "external_write_required": True,
+        "customer_facing": True,
+        "workflow_mode": "active",
+    }
+    approval.update(overrides)
+    return approval
+
+
+def _operating_projection(
+    configs: list[SimpleNamespace],
+    *,
+    source_data: dict[str, Any] | None = None,
+    source_context: dict[str, Any] | None = None,
+    approval_records: list[dict[str, Any]] | None = None,
+    external_write_results: list[dict[str, Any]] | None = None,
+    report_types: tuple[str, ...] | None = None,
+    production_tenant: bool = False,
+) -> dict[str, Any]:
+    source_context = source_context or {"demo": False, "source": "computed"}
+    approval_records = approval_records or []
+    setup = build_marketing_connector_setup(configs, now=NOW)
+    contracts = build_marketing_connector_contracts(setup, configs, now=NOW)
+    readiness = build_marketing_data_readiness(
+        setup,
+        configs,
+        connector_contracts=contracts,
+        now=NOW,
+    )
+    activation = build_cmo_workflow_activation(
+        setup,
+        readiness,
+        configs,
+        connector_contracts=contracts,
+        now=NOW,
+    )
+    policy_projection = build_marketing_policy_projection(configs)
+    escalation_projection = build_marketing_escalation_projection(configs)
+    audit_projection = build_marketing_decision_audit_projection(configs)
+    unified = build_unified_cmo_kpi_projection(
+        connector_setup=setup,
+        data_readiness=readiness,
+        connector_contracts=contracts,
+        connector_configs=configs,
+        source_data=source_data or _source_facts(),
+        now=NOW,
+    )
+    report_quality = build_cmo_report_quality_projection(
+        kpi_results=unified["unified_cmo_kpi_results"],
+        reconciliation_checks=unified["cmo_kpi_reconciliation_checks"],
+        connector_setup=setup,
+        data_readiness=readiness,
+        connector_contracts=contracts,
+        workflow_activation=activation,
+        policy_projection=policy_projection,
+        escalation_projection=escalation_projection,
+        decision_audit_projection=audit_projection,
+        source_context=source_context,
+        report_types=report_types,
+        production_tenant=production_tenant,
+        now=NOW,
+    )
+    timeout_risk = build_approval_timeout_risk(approval_records, now=NOW)
+    approval_review = build_cmo_approval_review_projection(
+        approval_records,
+        connector_contracts=contracts,
+        policy_projection=policy_projection,
+        escalation_projection=escalation_projection,
+        decision_audit_projection=audit_projection,
+        approval_timeout_risk=timeout_risk,
+        now=NOW,
+    )
+    work_queue = build_cmo_work_queue_projection(
+        approval_timeout_risk=timeout_risk,
+        escalation_projection=escalation_projection,
+        connector_setup=setup,
+        connector_contracts=contracts,
+        data_readiness=readiness,
+        workflow_activation=activation,
+        policy_projection=policy_projection,
+        decision_audit_projection=audit_projection,
+        kpi_results=unified["unified_cmo_kpi_results"],
+        reconciliation_checks=unified["cmo_kpi_reconciliation_checks"],
+        report_quality_gates=report_quality["report_quality_gates"],
+        external_write_results=external_write_results or [],
+        source_context=source_context,
+        now=NOW,
+    )
+    return {
+        "connector_setup": setup,
+        "connector_contracts": contracts,
+        "data_readiness": readiness,
+        "workflow_activation": activation,
+        "policy_projection": policy_projection,
+        "escalation_projection": escalation_projection,
+        "audit_projection": audit_projection,
+        "approval_timeout_risk": timeout_risk,
+        "approval_review": approval_review,
+        **unified,
+        **report_quality,
+        **work_queue,
+    }
+
+
+def _contract_row(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    return next(row for row in payload["connector_contracts"] if row["connector_key"] == key)
+
+
+def _workflow_row(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    return next(
+        row
+        for row in payload["workflow_activation"]["workflow_activation_status"]
+        if row["workflow_key"] == key
+    )
+
+
+def _kpi(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    return next(row for row in payload["unified_cmo_kpi_results"] if row["kpi_key"] == key)
+
+
+def _reconciliation(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    return next(
+        row
+        for row in payload["cmo_kpi_reconciliation_checks"]
+        if row["reconciliation_key"] == key
+    )
+
+
+def _report_gate(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    return next(row for row in payload["report_quality_gates"] if row["report_key"] == key)
+
+
+def _work_item_categories(payload: dict[str, Any]) -> set[str]:
+    return {item["category"] for item in payload["cmo_work_queue"]}
+
+
+def _external_write_step(
+    *,
+    action: str = "launch_campaign",
+    connector_key: str = "google_ads",
+    agent_type: str = "campaign_pilot",
+) -> dict[str, Any]:
+    return {
+        "id": f"{action}_step",
+        "type": "agent",
+        "agent_type": agent_type,
+        "action": action,
+        "connector_key": connector_key,
+        "external_write_required": True,
+        "external_write_confirmation_required": True,
+        "expected_confirmation_fields": ["external_object_id", "confirmed_at"],
+        "idempotency_key": IDEMPOTENCY_KEY,
+        "decision_audit_required": True,
+        "inputs": {"campaign_name": "Chaos launch", "budget": 1200},
+    }
+
+
+def _direct_write_contract(
+    *,
+    idempotency_key_supported: bool = True,
+    remaining_attempts: int = 2,
+    confirmations: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "connector_key": "google_ads",
+        "category": "Ads",
+        "read_ready": True,
+        "write_ready": True,
+        "write_safe": True,
+        "idempotency_key_supported": idempotency_key_supported,
+        "blocks_external_writes": False,
+        "retry_budget": {
+            "max_attempts": 3,
+            "attempts_used": 1,
+            "remaining_attempts": remaining_attempts,
+            "next_retry_at": "2026-05-24T12:05:00+00:00",
+            "idempotency_supported": idempotency_key_supported,
+            "idempotency_key": IDEMPOTENCY_KEY if idempotency_key_supported else None,
+        },
+        "external_write_confirmations": confirmations or [],
+    }
+
+
+@pytest.mark.parametrize(
+    ("failure_state", "expected_status", "expected_cta"),
+    [
+        ("timeout", "degraded", "review_retry_budget"),
+        ("vendor_5xx", "degraded", "monitor_vendor_recovery"),
+        ("rate_limited", "degraded", "review_retry_budget"),
+        ("quota_exhausted", "degraded", "wait_for_quota_reset"),
+        ("malformed_payload", "blocked", "fix_connector_payload"),
+    ],
+)
+def test_connector_outage_rate_limit_quota_and_malformed_payload_fail_safely(
+    failure_state: str,
+    expected_status: str,
+    expected_cta: str,
+) -> None:
+    configs = _with_workflow(_base_configs(), "campaign_launch")
+    configs[1].config["marketing_connector_contract"] = _contract_payload(
+        state=failure_state,
+        retry_budget={
+            "attempts_used": 1,
+            "idempotency_supported": True,
+            "idempotency_key": IDEMPOTENCY_KEY,
+        },
+    )
+    payload = _operating_projection(configs, report_types=("campaign_performance_ad_hoc",))
+    google_ads = _contract_row(payload, "google_ads")
+    campaign = _workflow_row(payload, "campaign_launch")
+    lint = lint_marketing_workflow(
+        {
+            "id": "wf_connector_chaos",
+            "domain": "marketing",
+            "mode": "production",
+            "steps": [_external_write_step()],
+        },
+        connector_contracts=[google_ads],
+    )
+    write_result = evaluate_marketing_external_write_result(
+        [google_ads],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="active",
+        step=_external_write_step(),
+        state={
+            "workflow_id": "campaign_launch",
+            "workflow_run_id": "run-connector-chaos",
+            "marketing_policy_approval_satisfied": True,
+        },
+        output={
+            "external_write_state": "accepted",
+            "external_object_id": "customers/123/campaigns/456",
+            "idempotency_key": IDEMPOTENCY_KEY,
+        },
+        now=NOW,
+    )
+    contract_output = build_marketing_agent_contract_output(
+        "campaign_pilot",
+        "launch_campaign",
+        result={
+            "status": "blocked",
+            "confidence": 0.0,
+            "rationale": "Connector failure chaos run must not complete launch.",
+            "recommended_actions": [expected_cta],
+            "audit_ref": "audit-connector-chaos",
+            "source_refs": [{"connector_key": "google_ads", "failure_state": failure_state}],
+            "external_write_confirmation_status": "write_unconfirmed",
+        },
+        audit_ref="audit-connector-chaos",
+        workflow_mode="active",
+        connector_ready=google_ads["read_ready"],
+    )
+
+    assert google_ads["failure_class"] == failure_state
+    assert google_ads["read_status"] == expected_status
+    assert google_ads["write_safe"] is False
+    assert google_ads["retry_policy"]["failure_class"] == failure_state
+    assert google_ads["next_action_cta"] == expected_cta
+    assert campaign["state"] in {"promotion_blocked", "degraded"}
+    assert lint.has_errors is True
+    assert write_result["step_status"] == "failed"
+    assert write_result["error_code"] == "external_write_connector_not_write_safe"
+    assert "connector" in _work_item_categories(payload)
+    assert contract_has_required_shape(contract_output)
+    assert contract_output["external_writes_completed"] is False
+
+
+def test_auth_expired_and_insufficient_scope_create_actionable_setup_states() -> None:
+    auth_configs = _with_workflow(_base_configs(), "campaign_launch")
+    auth_configs[1].config["marketing_connector_contract"] = _contract_payload(auth_status="expired")
+    auth_payload = _operating_projection(auth_configs)
+    expired = _contract_row(auth_payload, "google_ads")
+
+    scope_configs = _with_workflow(_base_configs(), "campaign_launch")
+    scope_configs[1].config["marketing_connector_contract"] = _contract_payload(
+        required_write_scopes=["ads.write"],
+        write_capabilities=["campaigns.mutate"],
+    )
+    scope_payload = _operating_projection(scope_configs)
+    insufficient = _contract_row(scope_payload, "google_ads")
+    scope_lint = lint_marketing_workflow(
+        {
+            "id": "wf_scope_chaos",
+            "domain": "marketing",
+            "mode": "production",
+            "steps": [_external_write_step()],
+        },
+        connector_contracts=[insufficient],
+    )
+
+    assert expired["contract_state"] == "auth_expired"
+    assert expired["read_ready"] is False
+    assert expired["write_safe"] is False
+    assert expired["next_action_cta"] == "reconnect"
+    assert _workflow_row(auth_payload, "campaign_launch")["state"] == "promotion_blocked"
+    assert "connector" in _work_item_categories(auth_payload)
+    assert insufficient["failure_class"] == "insufficient_scope"
+    assert insufficient["read_ready"] is True
+    assert insufficient["write_safe"] is False
+    assert insufficient["missing_write_scopes"] == ["ads.write"]
+    assert insufficient["next_action_cta"] == "add_scope"
+    assert scope_lint.has_errors is True
+    assert "marketing_external_write_connector_not_ready" in {
+        finding.code for finding in scope_lint.errors
+    }
+
+
+def test_stale_and_partial_data_windows_are_explicit_degraded_not_hidden_success() -> None:
+    stale_configs = _with_workflow(_base_configs(), "weekly_marketing_report")
+    stale_configs[1].config["marketing_connector_contract"] = _contract_payload(
+        ttl_seconds=60,
+        last_sync_at=(NOW - timedelta(hours=2)).isoformat(),
+    )
+    stale_payload = _operating_projection(
+        stale_configs,
+        source_data=_source_facts(last_updated_at=STALE_TS),
+        report_types=("weekly_marketing_report",),
+        production_tenant=True,
+    )
+    stale_google = _contract_row(stale_payload, "google_ads")
+    stale_gate = _report_gate(stale_payload, "weekly_marketing_report")
+
+    partial_configs = _with_workflow(_base_configs(), "weekly_marketing_report")
+    partial_configs[2].config["marketing_connector_contract"] = _contract_payload(state="partial_data")
+    partial_payload = _operating_projection(partial_configs, report_types=("weekly_marketing_report",))
+    partial_check = _reconciliation(partial_payload, "source_freshness_and_partial_data")
+
+    assert stale_google["failure_class"] == "stale_data"
+    assert stale_google["data_freshness"]["status"] == "stale"
+    assert stale_payload["data_readiness"]["kpi_readiness"]["status"] == "degraded"
+    assert stale_gate["status"] == "blocked"
+    assert stale_gate["safe_report_mode"] == "draft_only"
+    assert stale_gate["trusted_delivery_allowed"] is False
+    assert "connector" in _work_item_categories(stale_payload)
+    assert _contract_row(partial_payload, "ga4")["failure_class"] == "partial_data"
+    assert partial_payload["data_readiness"]["kpi_readiness"]["status"] == "degraded"
+    assert partial_check["status"] == "warning"
+    assert partial_check["confidence_impact"] > 0
+    assert _kpi(partial_payload, "content_performance")["status"] == "degraded"
+
+
+def test_approval_timeout_blocks_review_external_write_and_queue() -> None:
+    overdue_approval = _approval(
+        approval_id="apr-timeout-chaos",
+        created_at=(NOW - timedelta(hours=5)).isoformat(),
+        due_at=(NOW - timedelta(hours=1)).isoformat(),
+    )
+    payload = _operating_projection(
+        _with_workflow(_base_configs(), "campaign_launch"),
+        approval_records=[overdue_approval],
+    )
+    timeout_decision = payload["approval_timeout_risk"]["approval_timeout_decisions"][0]
+    review = payload["approval_review"]["cmo_approval_reviews"][0]
+    write_result = evaluate_marketing_external_write_result(
+        [_contract_row(payload, "google_ads")],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="active",
+        step=_external_write_step(),
+        state={"workflow_id": "campaign_launch", "workflow_run_id": "run-timeout-chaos"},
+        output={
+            "external_write_state": "write_confirmed",
+            "external_object_id": "customers/123/campaigns/456",
+            "idempotency_key": IDEMPOTENCY_KEY,
+            "approval_timeout_decision": timeout_decision,
+        },
+        now=NOW,
+    )
+
+    assert timeout_decision["timed_out"] is True
+    assert timeout_decision["external_writes_allowed"] is False
+    assert timeout_decision["audit_evidence"]["audit_reference"].startswith("mkt_approval_timeout_")
+    assert review["status"] == "timed_out"
+    assert "approve" not in review["allowed_reviewer_actions"]
+    assert write_result["step_status"] == "failed"
+    assert write_result["error_code"] == "external_write_approval_timeout"
+    assert {"approval", "escalation"} <= _work_item_categories(payload)
+
+
+def test_budget_overspend_race_requires_policy_escalation_and_preserves_audit() -> None:
+    policy = evaluate_marketing_policy(
+        {
+            "workflow_id": "daily_spend_optimization",
+            "workflow_mode": "active",
+            "action": "mutate_ad_budget",
+            "channel": "google_ads",
+            "budget_delta": 7_500,
+            "external_write_required": True,
+        }
+    )
+    escalation = evaluate_marketing_escalation(
+        {
+            "trigger_type": "budget_threshold_exceeded",
+            "workflow_id": "daily_spend_optimization",
+            "action": "mutate_ad_budget",
+            "severity": "high",
+        },
+        now=NOW,
+    )
+    audit_package = build_cmo_decision_audit_package(
+        {
+            "workflow_id": "daily_spend_optimization",
+            "workflow_run_id": "run-budget-chaos",
+            "step_id": "budget_update",
+            "agent_type": "campaign_pilot",
+            "action": "mutate_ad_budget",
+            "input_snapshot": {
+                "previous_budget": 2_500,
+                "requested_budget": 10_000,
+                "budget_cap": 5_000,
+            },
+            "policy_result": policy,
+            "escalation_result": escalation,
+            "rationale": "Concurrent budget update exceeded the configured channel cap.",
+            "risk_flags": ["budget_overspend_race"],
+            "final_outcome": "rejected",
+        },
+        now=NOW,
+    )
+    rejected_write = evaluate_marketing_external_write_result(
+        [_direct_write_contract()],
+        connector_key="google_ads",
+        action="mutate_ad_budget",
+        workflow_mode="active",
+        step=_external_write_step(action="mutate_ad_budget"),
+        state={
+            "workflow_id": "daily_spend_optimization",
+            "workflow_run_id": "run-budget-chaos",
+            "marketing_policy_approval_satisfied": True,
+        },
+        output={
+            "external_write_state": "rejected",
+            "rejection_reason": "Vendor rejected payload because budget cap was exceeded.",
+            "next_action": "request_budget_approval",
+            "idempotency_key": IDEMPOTENCY_KEY,
+        },
+        now=NOW,
+    )
+    queue = build_cmo_work_queue_projection(
+        external_write_results=[rejected_write],
+        source_context={"demo": False, "source": "computed"},
+        now=NOW,
+    )
+    contract_output = build_marketing_agent_contract_output(
+        "campaign_pilot",
+        "mutate_ad_budget",
+        result={
+            "status": "blocked",
+            "confidence": 0.0,
+            "rationale": "Budget race detected; external update rejected.",
+            "recommended_actions": ["request_budget_approval"],
+            "audit_ref": audit_package["audit_reference"],
+            "source_refs": [{"connector_key": "google_ads", "object": "budget"}],
+            "external_write_confirmation_status": "write_unconfirmed",
+        },
+        policy_result=policy,
+        audit_ref=audit_package["audit_reference"],
+        workflow_mode="active",
+    )
+
+    assert policy["decision"] == "requires_approval"
+    assert policy["next_action_cta"] == "request_budget_approval"
+    assert escalation["decision"] == "escalate_to_finance"
+    assert audit_package["input_snapshot_hash"]
+    assert rejected_write["step_status"] == "failed"
+    assert rejected_write["final_state"] == "rejected"
+    assert rejected_write["escalation_decision"]["trigger_type"] == "external_write_rejected"
+    assert queue["cmo_work_queue"][0]["category"] == "external_write"
+    assert queue["cmo_work_queue"][0]["severity"] == "critical"
+    assert contract_has_required_shape(contract_output)
+    assert contract_output["approval_required"] is True
+    assert contract_output["external_writes_completed"] is False
+
+
+def test_duplicate_event_replay_schedules_retry_then_idempotently_recovers_without_duplicate() -> None:
+    retry_scheduled = evaluate_marketing_external_write_result(
+        [_direct_write_contract()],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="active",
+        step=_external_write_step(),
+        state={
+            "workflow_id": "campaign_launch",
+            "workflow_run_id": "run-replay-chaos",
+            "marketing_policy_approval_satisfied": True,
+        },
+        output={
+            "external_write_state": "timeout_unknown",
+            "idempotency_key": IDEMPOTENCY_KEY,
+            "request_fingerprint": "fp-replay-timeout",
+        },
+        now=NOW,
+    )
+    recovered = evaluate_marketing_external_write_result(
+        [
+            _direct_write_contract(
+                confirmations=[
+                    {
+                        "action": "launch_campaign",
+                        "status": "write_confirmed",
+                        "idempotency_key": IDEMPOTENCY_KEY,
+                        "external_object_id": "customers/123/campaigns/456",
+                        "source_url": "https://ads.google.com/campaigns/456",
+                        "confirmed_at": "2026-05-24T12:01:00+00:00",
+                    }
+                ]
+            )
+        ],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="active",
+        step=_external_write_step(),
+        state={
+            "workflow_id": "campaign_launch",
+            "workflow_run_id": "run-replay-chaos",
+            "marketing_policy_approval_satisfied": True,
+        },
+        output={
+            "external_write_state": "timeout_unknown",
+            "idempotency_key": IDEMPOTENCY_KEY,
+            "request_fingerprint": "fp-replay-duplicate",
+        },
+        now=NOW,
+    )
+
+    assert retry_scheduled["step_status"] == "waiting_delay"
+    assert retry_scheduled["final_state"] == "retry_scheduled"
+    assert retry_scheduled["retry_plan"]["duplicate_policy"] == "reuse_idempotency_key"
+    assert retry_scheduled["resume_at"] == "2026-05-24T12:05:00+00:00"
+    assert recovered["step_status"] == "completed"
+    assert recovered["final_state"] == "idempotent_recovered"
+    assert recovered["confirmation"]["external_object_id"] == "customers/123/campaigns/456"
+    assert recovered["audit_events"][-1]["decision_audit"]["event_type"] == "external_write_idempotent_recovery"
+
+
+def test_external_write_timeout_unknown_without_idempotency_and_rejection_fail_closed() -> None:
+    timeout_unknown = evaluate_marketing_external_write_result(
+        [_direct_write_contract(idempotency_key_supported=False)],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="active",
+        step={**_external_write_step(), "idempotency_key": None},
+        state={
+            "workflow_id": "campaign_launch",
+            "workflow_run_id": "run-timeout-write-chaos",
+            "marketing_policy_approval_satisfied": True,
+        },
+        output={
+            "external_write_state": "timeout_unknown",
+            "request_fingerprint": "fp-timeout-no-idempotency",
+        },
+        now=NOW,
+    )
+    rejected = evaluate_marketing_external_write_result(
+        [_direct_write_contract()],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="active",
+        step=_external_write_step(),
+        state={
+            "workflow_id": "campaign_launch",
+            "workflow_run_id": "run-rejected-write-chaos",
+            "marketing_policy_approval_satisfied": True,
+        },
+        output={
+            "external_write_state": "rejected",
+            "rejection_reason": "Vendor rejected invalid audience payload.",
+            "next_action": "fix_and_resubmit",
+            "idempotency_key": IDEMPOTENCY_KEY,
+        },
+        now=NOW,
+    )
+    queue = build_cmo_work_queue_projection(
+        external_write_results=[
+            {
+                **timeout_unknown,
+                "connector_key": timeout_unknown["attempt"]["connector_key"],
+                "workflow_id": timeout_unknown["attempt"]["workflow_id"],
+                "step_id": timeout_unknown["attempt"]["step_id"],
+            },
+            {
+                **rejected,
+                "connector_key": rejected["attempt"]["connector_key"],
+                "workflow_id": rejected["attempt"]["workflow_id"],
+                "step_id": rejected["attempt"]["step_id"],
+            },
+        ],
+        now=NOW,
+    )
+    external_write_items = [
+        item for item in queue["cmo_work_queue"] if item["category"] == "external_write"
+    ]
+
+    assert timeout_unknown["step_status"] == "failed"
+    assert timeout_unknown["final_state"] == "timeout_unknown"
+    assert timeout_unknown["next_action"] == "manual_reconcile_before_retry"
+    assert timeout_unknown["audit_events"][-1]["decision_audit"]["event_type"] == "external_write_timeout"
+    assert rejected["step_status"] == "failed"
+    assert rejected["final_state"] == "rejected"
+    assert rejected["audit_events"][-1]["decision_audit"]["event_type"] == "external_write_rejection"
+    assert all(item["severity"] == "critical" for item in external_write_items)
+    assert {item["affected_connector"] for item in external_write_items} == {"google_ads"}
+    assert "escalation" in {item["category"] for item in queue["cmo_work_queue"]}
+
+
+def test_missing_policy_escalation_route_and_audit_evidence_block_all_production_paths() -> None:
+    blocked_approval = _approval(marketing_policy_manifest_disabled=True)
+    blocked_approval.pop("audit_refs")
+    configs = _with_workflow(
+        _base_configs(),
+        "campaign_launch",
+        _workflow_config(
+            marketing_policy_manifest_disabled=True,
+            marketing_escalation_matrix_disabled=True,
+            decision_audit_disabled=True,
+        ),
+    )
+    missing_route = evaluate_marketing_escalation(
+        {
+            "event_id": "evt-missing-route-chaos",
+            "trigger_type": "missing_policy",
+            "workflow_id": "campaign_launch",
+            "severity": "high",
+        },
+        matrix={"marketing_escalation_matrix_disabled": True},
+        now=NOW,
+    )
+    payload = _operating_projection(
+        configs,
+        approval_records=[blocked_approval],
+        source_context={
+            "demo": False,
+            "source": "computed",
+            "marketing_escalation_decisions": [missing_route],
+        },
+    )
+    campaign = _workflow_row(payload, "campaign_launch")
+    lint = lint_marketing_workflow(
+        {
+            "id": "wf_missing_governance_chaos",
+            "domain": "marketing",
+            "mode": "production",
+            "steps": [
+                {
+                    **{
+                        key: value
+                        for key, value in _external_write_step().items()
+                        if key != "decision_audit_required"
+                    },
+                    "marketing_policy_manifest_disabled": True,
+                    "marketing_escalation_matrix_disabled": True,
+                }
+            ],
+        },
+        connector_contracts=[_contract_row(payload, "google_ads")],
+    )
+    review = payload["approval_review"]["cmo_approval_reviews"][0]
+    missing_policy = evaluate_marketing_policy(
+        {
+            "workflow_id": "campaign_launch",
+            "workflow_mode": "active",
+            "action": "launch_campaign",
+            "external_write_required": True,
+            "marketing_policy_manifest_disabled": True,
+        }
+    )
+
+    assert campaign["state"] == "promotion_blocked"
+    assert campaign["marketing_policy"]["status"] == "missing_policy"
+    assert campaign["escalation_matrix"]["status"] == "missing_route"
+    assert campaign["decision_audit"]["status"] == "missing_audit_evidence"
+    assert lint.has_errors is True
+    assert {
+        "marketing_policy_missing",
+        "marketing_escalation_route_missing",
+        "marketing_decision_audit_evidence_missing",
+    } <= {finding.code for finding in lint.errors}
+    assert missing_policy["decision"] == "missing_policy"
+    assert missing_route["route_found"] is False
+    assert review["status"] == "blocked"
+    assert "approve" not in review["allowed_reviewer_actions"]
+    assert {"workflow", "policy", "audit", "escalation"} <= _work_item_categories(payload)
+
+
+def test_report_quality_gate_and_kpi_reconciliation_failure_block_trusted_outputs() -> None:
+    payload = _operating_projection(
+        _with_workflow(_base_configs(), "weekly_marketing_report"),
+        source_data=_source_facts(
+            campaign_spend_by_channel={"google": 400.0, "linkedin": 150.0},
+            opportunities=[],
+        ),
+        report_types=("weekly_marketing_report",),
+        production_tenant=True,
+    )
+    spend_check = _reconciliation(payload, "paid_spend_totals_by_channel")
+    weekly_gate = _report_gate(payload, "weekly_marketing_report")
+
+    assert spend_check["status"] == "failed"
+    assert spend_check["severity"] == "high"
+    assert _kpi(payload, "cac")["status"] == "blocked"
+    assert _kpi(payload, "roas")["status"] == "blocked"
+    assert weekly_gate["status"] == "blocked"
+    assert weekly_gate["trusted_delivery_allowed"] is False
+    assert weekly_gate["safe_report_mode"] == "draft_only"
+    assert "paid_spend_totals_by_channel" in weekly_gate["failed_reconciliation_keys"]
+    assert {"report", "reconciliation", "kpi"} <= _work_item_categories(payload)

--- a/tests/unit/test_cmo_competitive_intel_agent.py
+++ b/tests/unit/test_cmo_competitive_intel_agent.py
@@ -1,0 +1,519 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.agents.marketing.competitive_intel import CompetitiveIntelAgent
+from core.agents.registry import AgentRegistry
+from core.marketing.agent_contracts import (
+    build_marketing_agent_contract_output,
+    contract_has_required_shape,
+    get_marketing_agent_contract_spec,
+)
+from core.marketing.pilot_proof import build_cmo_pilot_proof_projection
+from core.marketing.workflow_linter import lint_marketing_workflow
+from core.schemas.messages import TargetAgent, TaskAssignment, TaskInput
+
+
+class FakeToolGateway:
+    def __init__(self, responses: dict[tuple[str, str], dict[str, Any] | Exception]):
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    async def execute(
+        self,
+        *,
+        tenant_id: str,
+        agent_id: str,
+        agent_scopes: list[str],
+        connector_name: str,
+        tool_name: str,
+        params: dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "tenant_id": tenant_id,
+                "agent_id": agent_id,
+                "agent_scopes": agent_scopes,
+                "connector_name": connector_name,
+                "tool_name": tool_name,
+                "params": params,
+                "idempotency_key": idempotency_key,
+            }
+        )
+        response = self.responses.get((connector_name, tool_name), {})
+        if isinstance(response, Exception):
+            raise response
+        return dict(response)
+
+
+def _assignment(action: str, inputs: dict[str, Any]) -> TaskAssignment:
+    return TaskAssignment(
+        message_id=f"msg-competitive-{action}",
+        correlation_id="corr-competitive",
+        workflow_run_id="run-competitive",
+        workflow_definition_id="wf-competitive",
+        step_id=f"step-{action}",
+        step_index=0,
+        total_steps=1,
+        target_agent=TargetAgent(
+            agent_id="agent-competitive",
+            agent_type="competitive_intel",
+            agent_token="test-token",
+        ),
+        task=TaskInput(action=action, inputs=inputs),
+    )
+
+
+def _agent(gateway: FakeToolGateway | None = None) -> CompetitiveIntelAgent:
+    return CompetitiveIntelAgent(
+        agent_id="agent-competitive",
+        tenant_id="tenant-cmo",
+        tool_gateway=gateway,
+        authorized_tools=["buffer.publish_competitive_response", "linkedin_ads.launch_competitive_campaign"],
+    )
+
+
+def _profiles() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    previous = [
+        {
+            "name": "Acme CRM",
+            "domain": "acme.example",
+            "segment": "enterprise",
+            "price": 100,
+            "currency": "USD",
+            "features": ["sso", "analytics"],
+            "source": "brandwatch",
+            "source_url": "https://intel.example/acme-old",
+            "observed_at": "2026-05-10",
+        }
+    ]
+    current = [
+        {
+            "name": "Acme CRM",
+            "domain": "acme.example",
+            "segment": "enterprise",
+            "price": 125,
+            "currency": "USD",
+            "features": ["sso", "analytics", "ai assistant", "governance"],
+            "source": "brandwatch",
+            "source_url": "https://intel.example/acme-new",
+            "observed_at": "2026-05-24",
+        }
+    ]
+    return previous, current
+
+
+def _base_inputs(**overrides: Any) -> dict[str, Any]:
+    previous, current = _profiles()
+    payload: dict[str, Any] = {
+        "previous_profiles": previous,
+        "current_profiles": current,
+        "win_loss_notes": [
+            {
+                "deal_id": "deal-1",
+                "competitor": "Acme CRM",
+                "text": "Closed lost to Acme due to pricing and missing governance feature.",
+                "created_at": "2026-05-23",
+            }
+        ],
+        "source_refs": [{"type": "brandwatch", "ref_id": "query-1"}],
+        "workflow_mode": "shadow",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_contract(**overrides: object) -> dict[str, Any]:
+    contract = {
+        "connector_key": "buffer",
+        "category": "Social",
+        "read_ready": True,
+        "write_ready": True,
+        "write_safe": True,
+        "idempotency_key_supported": True,
+        "retry_budget": {
+            "idempotency_key": "competitive:write:001",
+            "idempotency_supported": True,
+            "remaining_attempts": 2,
+        },
+    }
+    contract.update(overrides)
+    return contract
+
+
+def _workflow(step: dict[str, Any], *, mode: str = "production") -> dict[str, Any]:
+    return {
+        "id": "wf_competitive",
+        "name": "Competitive Intel Monitoring",
+        "domain": "marketing",
+        "mode": mode,
+        "steps": [step],
+    }
+
+
+def _workflow_step(action: str, **overrides: object) -> dict[str, Any]:
+    step: dict[str, Any] = {
+        "id": "step_competitive",
+        "name": "Competitive Step",
+        "type": "agent",
+        "agent_type": "competitive_intel",
+        "action": action,
+    }
+    step.update(overrides)
+    return step
+
+
+def _proof_contracts() -> list[dict[str, Any]]:
+    return [
+        {
+            "agent_type": "campaign_pilot",
+            "maturity": "production",
+            "production_ready": True,
+            "blocker": None,
+        },
+        get_marketing_agent_contract_spec("competitive_intel"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_competitive_intel_happy_path_weekly_snapshot_has_contract_shape() -> None:
+    result = await _agent().execute(_assignment("weekly_market_snapshot", _base_inputs()))
+    contract = build_marketing_agent_contract_output(
+        "competitive_intel",
+        "weekly_market_snapshot",
+        result=result,
+        audit_ref=result.output["audit_ref"],
+    )
+
+    assert result.status == "completed"
+    assert result.output["status"] == "snapshot_ready"
+    assert result.output["competitor_snapshot"]["profiles"][0]["domain"] == "acme.example"
+    assert result.output["competitor_snapshot"]["pricing_changes"]
+    assert result.output["competitor_snapshot"]["feature_diffs"]
+    assert result.output["competitor_snapshot"]["win_loss_signals"]
+    assert contract_has_required_shape(contract)
+    assert contract["maturity"] == "beta"
+    assert contract["production_ready"] is False
+
+
+@pytest.mark.asyncio
+async def test_competitor_profile_normalization_is_deterministic() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "normalize_competitor_profiles",
+            {
+                "competitors": [
+                    {
+                        "competitor": " ACME CRM ",
+                        "website": "Acme.Example",
+                        "market_segment": "Enterprise",
+                        "features": "SSO, Analytics, SSO",
+                        "pricing": {"amount": "99", "currency": "USD", "plan": "team"},
+                    }
+                ]
+            },
+        )
+    )
+
+    profile = result.output["normalized_profiles"][0]
+    assert profile["name"] == "ACME CRM"
+    assert profile["domain"] == "acme.example"
+    assert profile["segment"] == "enterprise"
+    assert profile["pricing"]["amount"] == 99
+    assert profile["features"] == ["analytics", "sso"]
+
+
+@pytest.mark.asyncio
+async def test_pricing_change_detection_returns_confidence_score() -> None:
+    result = await _agent().execute(_assignment("pricing_change_detection", _base_inputs()))
+    pricing_change = result.output["pricing_changes"][0]
+
+    assert pricing_change["change_type"] == "pricing"
+    assert pricing_change["value_delta"]["delta_pct"] == 25
+    assert pricing_change["confidence"] >= 0.8
+
+
+@pytest.mark.asyncio
+async def test_feature_capability_diffing_detects_added_features() -> None:
+    result = await _agent().execute(_assignment("feature_capability_diffing", _base_inputs()))
+    diff = result.output["feature_diffs"][0]
+
+    assert diff["change_type"] == "feature"
+    assert diff["value_delta"]["added"] == ["ai assistant", "governance"]
+
+
+@pytest.mark.asyncio
+async def test_win_loss_signal_extraction_classifies_loss_reason() -> None:
+    result = await _agent().execute(_assignment("win_loss_signal_extraction", _base_inputs()))
+    signal = result.output["win_loss_signals"][0]
+
+    assert signal["change_type"] == "win_loss_loss"
+    assert signal["value_delta"]["reason"] == "pricing"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_change_suppression_dedupes_repeated_changes() -> None:
+    duplicate = {
+        "competitor": "Acme CRM",
+        "type": "pricing",
+        "summary": "Acme lowered entry plan pricing.",
+        "severity": "high",
+        "confidence": 0.8,
+        "observed_at": "2026-05-24",
+    }
+    result = await _agent().execute(
+        _assignment(
+            "duplicate_change_suppression",
+            {"changes": [duplicate, dict(duplicate)], "workflow_mode": "shadow"},
+        )
+    )
+
+    assert result.output["suppressed_duplicate_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_alert_threshold_severity_behavior() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "evaluate_alert_thresholds",
+            {
+                "changes": [
+                    {
+                        "competitor": "Acme CRM",
+                        "type": "major_launch",
+                        "summary": "Acme launched an enterprise AI suite.",
+                        "severity": "critical",
+                        "confidence": 0.9,
+                    }
+                ],
+                "alert_thresholds": {"critical": 0.85},
+            },
+        )
+    )
+
+    alert = result.output["alerts"][0]
+    assert alert["severity"] == "critical"
+    assert alert["requires_escalation"] is True
+
+
+@pytest.mark.asyncio
+async def test_positioning_recommendation_next_best_action_output() -> None:
+    result = await _agent().execute(_assignment("positioning_recommendation", _base_inputs()))
+    action = result.output["positioning_recommendations"][0]
+
+    assert action["action"] in {"prepare_battlecard_update", "prepare_positioning_update"}
+    assert action["mode"] == "read_only_recommendation"
+
+
+@pytest.mark.asyncio
+async def test_comparative_or_pricing_claim_requires_policy_approval_and_escalation() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "comparative_claim",
+            {
+                "workflow_mode": "active",
+                "connector_write_ready": True,
+                "claim": "We are cheaper than Acme for regulated enterprises.",
+            },
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["approval_required"] is True
+    assert result.output["policy_result"]["decision"] in {"requires_approval", "requires_escalation"}
+    assert result.output["escalation_ref"]
+
+
+@pytest.mark.asyncio
+async def test_major_competitor_launch_or_crisis_signal_requires_escalation() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "weekly_market_snapshot",
+            {
+                "changes": [
+                    {
+                        "competitor": "Acme CRM",
+                        "type": "major_launch",
+                        "summary": "Acme launched a major crisis response campaign.",
+                        "severity": "critical",
+                        "confidence": 0.92,
+                    }
+                ]
+            },
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["hitl_required"] is True
+    assert result.output["escalation_ref"]
+
+
+@pytest.mark.asyncio
+async def test_connector_degraded_state_downgrades_read_only_snapshot() -> None:
+    result = await _agent().execute(
+        _assignment("weekly_market_snapshot", _base_inputs(connector_read_ready=False))
+    )
+
+    assert result.status == "completed"
+    assert result.output["status"] == "snapshot_degraded"
+    assert result.output["degraded_reasons"]
+    assert result.output["confidence"] < 0.8
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_cannot_write_competitive_response_externally() -> None:
+    gateway = FakeToolGateway({("buffer", "publish_competitive_response"): {"status": "write_confirmed"}})
+    result = await _agent(gateway).execute(
+        _assignment(
+            "publish_competitive_response",
+            {"workflow_mode": "shadow", "connector_write_ready": True},
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["status"] == "shadow_only"
+    assert result.output["external_write_confirmation_status"] == "shadow_only"
+    assert gateway.calls == []
+
+
+@pytest.mark.asyncio
+async def test_active_external_action_blocks_when_connector_not_write_safe() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "publish_competitive_response",
+            {"workflow_mode": "active", "connector_write_ready": False, "approved": True, "escalation_ref": "esc-1"},
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["status"] == "blocked"
+    assert any("not write-safe" in reason for reason in result.output["blocked_reasons"])
+
+
+@pytest.mark.asyncio
+async def test_active_external_action_cannot_complete_without_confirmed_write() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "publish_competitive_response",
+            {
+                "workflow_mode": "active",
+                "connector_write_ready": True,
+                "approved": True,
+                "escalation_ref": "esc-1",
+                "external_write_result": {
+                    "status": "accepted",
+                    "connector_key": "buffer",
+                    "idempotency_key": "competitive:write:1",
+                },
+            },
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["status"] == "write_unconfirmed"
+    assert result.output["external_writes_completed"] is False
+    assert result.output["blocked_reasons"]
+
+
+@pytest.mark.asyncio
+async def test_confirmed_competitive_write_has_policy_audit_escalation_and_write_ref() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "publish_competitive_response",
+            {
+                "workflow_mode": "active",
+                "connector_write_ready": True,
+                "approved": True,
+                "escalation_ref": "esc-1",
+                "external_write_result": {
+                    "status": "write_confirmed",
+                    "connector_key": "buffer",
+                    "external_object_id": "post-123",
+                    "idempotency_key": "competitive:write:1",
+                    "confirmed_at": "2026-05-24T10:00:00Z",
+                    "audit_ref": "audit-competitive-write-1",
+                },
+            },
+        )
+    )
+
+    assert result.status == "completed"
+    assert result.output["external_writes_completed"] is True
+    assert result.output["external_write_ref"]["external_object_id"] == "post-123"
+    assert result.output["audit_ref"].startswith("competitive_intel:")
+    assert result.output["policy_ref"]
+    assert result.output["escalation_ref"]
+
+
+def test_competitive_intel_registered_and_contract_metadata_is_beta() -> None:
+    assert AgentRegistry.get_by_type("competitive_intel") is CompetitiveIntelAgent
+    spec = get_marketing_agent_contract_spec("competitive_intel")
+    assert spec["maturity"] == "beta"
+    assert spec["production_ready"] is False
+    assert spec["surface"] == "core.agents.marketing.competitive_intel"
+
+
+def test_workflow_linter_no_longer_treats_competitive_intel_as_unknown() -> None:
+    result = lint_marketing_workflow(
+        _workflow(_workflow_step("weekly_market_snapshot"), mode="target"),
+        connector_contracts=[
+            _write_contract(connector_key="brandwatch", category="Brand", write_ready=False),
+            _write_contract(connector_key="ahrefs", category="SEO", write_ready=False),
+        ],
+    )
+    codes = {finding.code for finding in result.findings}
+
+    assert "marketing_agent_type_unknown" not in codes
+    assert "marketing_agent_unavailable_target_only" not in codes
+
+
+def test_production_workflow_blocks_competitive_external_action_without_write_proof() -> None:
+    result = lint_marketing_workflow(
+        _workflow(_workflow_step("publish_competitive_response", connector_key="buffer")),
+        connector_contracts=[_write_contract(connector_key="buffer", category="Social")],
+    )
+    codes = {finding.code for finding in result.findings}
+
+    assert "marketing_agent_type_unknown" not in codes
+    assert "marketing_agent_unavailable_for_production" not in codes
+    assert "marketing_agent_beta_in_production" in codes
+    assert "marketing_external_write_confirmation_metadata_missing" in codes
+    assert "marketing_decision_audit_evidence_missing" in codes
+
+
+def test_competitive_production_lint_passes_only_with_write_policy_audit_metadata() -> None:
+    result = lint_marketing_workflow(
+        _workflow(
+            _workflow_step(
+                "publish_competitive_response",
+                connector_key="buffer",
+                external_write_confirmation_required=True,
+                expected_confirmation_fields=["external_object_id", "confirmed_at"],
+                idempotency_key_template="competitive:{competitor}:response",
+                decision_audit_required=True,
+            )
+        ),
+        connector_contracts=[_write_contract(connector_key="buffer", category="Social")],
+    )
+    codes = {finding.code for finding in result.findings}
+
+    assert "marketing_external_write_confirmation_metadata_missing" not in codes
+    assert "marketing_decision_audit_evidence_missing" not in codes
+    assert "marketing_external_write_connector_not_ready" not in codes
+    assert "marketing_agent_beta_in_production" in codes
+
+
+def test_pilot_proof_keeps_competitive_intel_unproven_without_real_vendor_production_proof() -> None:
+    proof = build_cmo_pilot_proof_projection(
+        environment_type="real_vendor",
+        agent_contracts=_proof_contracts(),
+    )
+    unproven = {item["capability_key"]: item for item in proof["cmo_pilot_proof"]["unproven_capabilities"]}
+    proven = {item["capability_key"] for item in proof["cmo_pilot_proof"]["proven_capabilities"]}
+
+    assert "agent:competitive_intel" not in proven
+    assert unproven["agent:competitive_intel"]["status"] == "beta"
+    assert proof["cmo_pilot_proof"]["full_cmo_autonomy_claim_allowed"] is False

--- a/tests/unit/test_cmo_connector_retry_policy.py
+++ b/tests/unit/test_cmo_connector_retry_policy.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from core.marketing.connector_contracts import build_marketing_connector_contracts
+from core.marketing.connector_retry_policy import (
+    CONNECTOR_FAILURE_CLASSES,
+    policy_projection,
+)
+from core.marketing.connector_setup import build_marketing_connector_setup
+from core.marketing.data_readiness import build_marketing_data_readiness
+from core.marketing.external_writes import evaluate_marketing_external_write_result
+from core.marketing.workflow_activation import build_cmo_workflow_activation
+from core.marketing.workflow_linter import lint_marketing_workflow
+
+NOW = datetime(2026, 5, 23, 12, 0, tzinfo=UTC)
+
+
+def _connector_config(
+    connector_name: str,
+    *,
+    config: dict,
+    health_status: str = "healthy",
+    last_sync_at: datetime | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        connector_name=connector_name,
+        display_name=None,
+        auth_type="oauth2",
+        credentials_encrypted={"_encrypted": "enc"},
+        config=config,
+        status="configured",
+        last_health_check=NOW,
+        health_status=health_status,
+        last_sync_at=last_sync_at or NOW - timedelta(hours=1),
+        sync_error=None,
+    )
+
+
+def _backfill(status: str = "completed") -> dict:
+    return {
+        "status": status,
+        "requested_start": "2025-05-01",
+        "requested_end": "2026-05-23",
+        "records_discovered": 100,
+        "records_imported": 100 if status == "completed" else 50,
+        "records_skipped": 0,
+        "records_failed": 0 if status == "completed" else 50,
+        "last_run_at": "2026-05-23T10:00:00+00:00",
+    }
+
+
+def _contract(**overrides: object) -> dict:
+    base = {
+        "idempotency_supported": True,
+        "retry_budget": {
+            "max_attempts": 3,
+            "attempts_used": 1,
+            "remaining_attempts": 2,
+            "next_retry_at": "2026-05-23T12:05:00+00:00",
+            "idempotency_supported": True,
+            "idempotency_key": "mkt-write-001",
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def _base_configs() -> list[SimpleNamespace]:
+    updated_at = "2026-05-01T00:00:00+00:00"
+    hubspot_mapping = {
+        "lifecycle_stages": {
+            "source_field": "lifecyclestage",
+            "stage_map": {"mql": "marketingqualifiedlead", "sql": "salesqualifiedlead"},
+            "updated_at": updated_at,
+        },
+        "opportunity_revenue": {
+            "amount_field": "amount",
+            "close_date_field": "closedate",
+            "currency_field": "deal_currency_code",
+            "updated_at": updated_at,
+        },
+        "account_domains": {"domain_field": "website", "updated_at": updated_at},
+        "consent_unsubscribe": {
+            "consent_field": "marketing_opt_in",
+            "unsubscribe_field": "unsubscribed",
+            "updated_at": updated_at,
+        },
+        "fiscal_calendar": {"fiscal_year_start_month": 4, "updated_at": updated_at},
+        "currency": {"currency": "USD", "updated_at": updated_at},
+        "timezone": {"timezone": "Asia/Kolkata", "updated_at": updated_at},
+    }
+    campaign_mapping = {
+        "campaign_ids": {"campaign_id_field": "campaign_id", "updated_at": updated_at},
+        "utm_fields": {
+            "source": "utm_source",
+            "medium": "utm_medium",
+            "campaign": "utm_campaign",
+            "updated_at": updated_at,
+        },
+    }
+    mailchimp_mapping = {
+        **campaign_mapping,
+        "consent_unsubscribe": {
+            "consent_field": "marketing_permission",
+            "unsubscribe_field": "unsubscribe_status",
+            "updated_at": updated_at,
+        },
+    }
+    return [
+        _connector_config(
+            "hubspot",
+            config={
+                "owner": "revops@example.com",
+                "account_id": "portal-123",
+                "granted_scopes": [
+                    "crm.objects.contacts.read",
+                    "crm.objects.deals.read",
+                    "automation",
+                ],
+                "data_coverage_status": "ready",
+                "marketing_field_mapping": hubspot_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        ),
+        _connector_config(
+            "google_ads",
+            config={
+                "owner": "growth@example.com",
+                "customer_id": "123-456-7890",
+                "granted_scopes": ["https://www.googleapis.com/auth/adwords"],
+                "marketing_field_mapping": campaign_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        ),
+        _connector_config(
+            "ga4",
+            config={
+                "owner": "analytics@example.com",
+                "property_id": "properties/123",
+                "granted_scopes": ["https://www.googleapis.com/auth/analytics.readonly"],
+                "marketing_field_mapping": campaign_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(write_capabilities=[], required_write_scopes=[]),
+            },
+        ),
+        _connector_config(
+            "mailchimp",
+            config={
+                "owner": "email@example.com",
+                "audience_id": "aud-1",
+                "marketing_field_mapping": mailchimp_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        ),
+    ]
+
+
+def _with_workflow(configs: list[SimpleNamespace], workflow_key: str) -> list[SimpleNamespace]:
+    configs = deepcopy(configs)
+    configs[0].config.setdefault("marketing_workflows", {})[workflow_key] = {
+        "mode": "shadow",
+        "approval_owner": "cmo@example.com",
+        "policy_owner": "legal@example.com",
+        "shadow_quality": {
+            "status": "passed",
+            "sample_count": 5,
+            "success_rate": 0.95,
+            "last_run_at": "2026-05-23T09:00:00+00:00",
+        },
+    }
+    return configs
+
+
+def _contracts(configs: list[SimpleNamespace]) -> list[dict]:
+    setup = build_marketing_connector_setup(configs, now=NOW)
+    return build_marketing_connector_contracts(setup, configs, now=NOW)
+
+
+def _row(rows: list[dict], connector_key: str) -> dict:
+    return next(row for row in rows if row["connector_key"] == connector_key)
+
+
+def test_every_failure_class_has_complete_policy_metadata() -> None:
+    for failure_class in CONNECTOR_FAILURE_CLASSES:
+        policy = policy_projection(failure_class)
+
+        assert policy["failure_class"] == failure_class
+        assert isinstance(policy["retryable"], bool)
+        assert isinstance(policy["max_attempts"], int)
+        assert policy["backoff_strategy"]["type"]
+        assert isinstance(policy["safe_retry_requires_idempotency"], bool)
+        assert isinstance(policy["degraded_mode_allowed"], bool)
+        assert 0 <= policy["confidence_impact"] <= 1
+        assert isinstance(policy["blocks_external_writes"], bool)
+        assert isinstance(policy["blocks_production_kpi_confidence"], bool)
+        assert policy["required_cta"] != "none"
+        assert policy["audit_event_code"].startswith("cmo_connector_")
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_cta", "expected_attempts"),
+    [
+        ("timeout", "review_retry_budget", 3),
+        ("rate_limited", "review_retry_budget", 5),
+        ("vendor_5xx", "monitor_vendor_recovery", 3),
+        ("quota_exhausted", "wait_for_quota_reset", 1),
+    ],
+)
+def test_retryable_failures_project_backoff_and_degraded_read_only_mode(
+    state: str,
+    expected_cta: str,
+    expected_attempts: int,
+) -> None:
+    configs = _base_configs()
+    configs[1].config["marketing_connector_contract"] = _contract(
+        state=state,
+        retry_budget={"attempts_used": 0, "idempotency_supported": True},
+    )
+
+    google_ads = _row(_contracts(configs), "google_ads")
+
+    assert google_ads["failure_class"] == state
+    assert google_ads["read_status"] == "degraded"
+    assert google_ads["write_safe"] is False
+    assert google_ads["retry_policy"]["retryable"] is True
+    assert google_ads["retry_budget"]["max_attempts"] == expected_attempts
+    assert google_ads["retry_budget"]["backoff_strategy"]["type"] != "none"
+    assert google_ads["degraded_mode"]["allowed"] is True
+    assert google_ads["degraded_mode"]["confidence_impact"] > 0
+    assert google_ads["next_action_cta"] == expected_cta
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_cta"),
+    [
+        ("auth_expired", "reconnect"),
+        ("malformed_payload", "fix_connector_payload"),
+        ("connector_disabled", "enable_connector"),
+    ],
+)
+def test_non_retryable_blocking_failures_are_not_healthy(
+    state: str,
+    expected_cta: str,
+) -> None:
+    configs = _base_configs()
+    configs[1].config["marketing_connector_contract"] = _contract(state=state)
+
+    google_ads = _row(_contracts(configs), "google_ads")
+
+    assert google_ads["failure_class"] == state
+    assert google_ads["read_ready"] is False
+    assert google_ads["write_safe"] is False
+    assert google_ads["retry_policy"]["retryable"] is False
+    assert google_ads["degraded_mode"]["status"] == "blocked"
+    assert google_ads["blocks_production_kpi_confidence"] is True
+    assert google_ads["next_action_cta"] == expected_cta
+
+
+def test_insufficient_scope_blocks_affected_write_capability_with_setup_cta() -> None:
+    configs = _base_configs()
+    configs[1].config["marketing_connector_contract"] = _contract(
+        required_write_scopes=["ads.write"],
+        write_capabilities=["campaigns.mutate"],
+    )
+
+    google_ads = _row(_contracts(configs), "google_ads")
+
+    assert google_ads["failure_class"] == "insufficient_scope"
+    assert google_ads["read_ready"] is True
+    assert google_ads["write_safe"] is False
+    assert google_ads["write_status"] == "missing_scope"
+    assert google_ads["next_action_cta"] == "add_scope"
+    assert google_ads["degraded_mode"]["affected_capability"] == "Ads"
+
+
+def test_partial_data_downgrades_confidence_and_marks_kpis_and_workflows() -> None:
+    configs = _with_workflow(_base_configs(), "weekly_marketing_report")
+    configs[1].config["marketing_connector_contract"] = _contract(state="partial_data")
+    setup = build_marketing_connector_setup(configs, now=NOW)
+    contracts = build_marketing_connector_contracts(setup, configs, now=NOW)
+    readiness = build_marketing_data_readiness(
+        setup,
+        configs,
+        connector_contracts=contracts,
+        now=NOW,
+    )
+    activation = build_cmo_workflow_activation(
+        setup,
+        readiness,
+        configs,
+        connector_contracts=contracts,
+        now=NOW,
+    )
+    weekly = next(
+        row
+        for row in activation["workflow_activation_status"]
+        if row["workflow_key"] == "weekly_marketing_report"
+    )
+
+    assert readiness["kpi_readiness"]["status"] == "degraded"
+    assert "ROAS" in readiness["kpi_readiness"]["degraded_mode"]["affected_kpis"]
+    assert weekly["state"] == "degraded"
+    assert weekly["degraded_mode"]["confidence_impact"] >= 0.45
+    assert "weekly_marketing_report" in weekly["degraded_mode"]["affected_workflows"]
+
+
+def test_stale_data_is_labeled_degraded_not_fresh_production_confidence() -> None:
+    configs = _base_configs()
+    configs[1].config["marketing_connector_contract"] = _contract(
+        ttl_seconds=60,
+        last_sync_at="2026-05-23T10:00:00+00:00",
+    )
+    setup = build_marketing_connector_setup(configs, now=NOW)
+    contracts = build_marketing_connector_contracts(setup, configs, now=NOW)
+    readiness = build_marketing_data_readiness(
+        setup,
+        configs,
+        connector_contracts=contracts,
+        now=NOW,
+    )
+    google_ads = _row(contracts, "google_ads")
+
+    assert google_ads["failure_class"] == "stale_data"
+    assert google_ads["data_freshness"]["status"] == "stale"
+    assert google_ads["degraded_mode"]["status"] == "degraded"
+    assert readiness["kpi_readiness"]["status"] == "degraded"
+    assert readiness["kpi_readiness"]["degraded_mode"]["active"] is True
+
+
+def test_connector_disabled_blocks_dependent_workflow() -> None:
+    configs = _with_workflow(_base_configs(), "campaign_launch")
+    configs[1].config["marketing_connector_contract"] = _contract(state="connector_disabled")
+    setup = build_marketing_connector_setup(configs, now=NOW)
+    contracts = build_marketing_connector_contracts(setup, configs, now=NOW)
+    readiness = build_marketing_data_readiness(
+        setup,
+        configs,
+        connector_contracts=contracts,
+        now=NOW,
+    )
+    activation = build_cmo_workflow_activation(
+        setup,
+        readiness,
+        configs,
+        connector_contracts=contracts,
+        now=NOW,
+    )
+    campaign = next(
+        row
+        for row in activation["workflow_activation_status"]
+        if row["workflow_key"] == "campaign_launch"
+    )
+
+    assert campaign["state"] == "promotion_blocked"
+    assert any("Ads connector" in reason for reason in campaign["blocked_reasons"])
+
+
+def test_external_write_fails_closed_for_non_write_safe_connector_state() -> None:
+    decision = evaluate_marketing_external_write_result(
+        [
+            {
+                "connector_key": "google_ads",
+                "write_safe": False,
+                "blocks_external_writes": True,
+                "failure_class": "rate_limited",
+                "next_action_cta": "respect_rate_limit",
+                "degraded_mode": {
+                    "reason": "Connector is rate limited.",
+                    "next_action_cta": "respect_rate_limit",
+                },
+            }
+        ],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="active",
+        output={
+            "external_write_state": "accepted",
+            "external_object_id": "customers/123/campaigns/456",
+            "idempotency_key": "ads-launch-1",
+        },
+        step={"id": "launch_ads", "idempotency_key": "ads-launch-1"},
+        state={"workflow_id": "campaign_launch", "workflow_run_id": "run-1"},
+        now=NOW,
+    )
+
+    assert decision["step_status"] == "failed"
+    assert decision["error_code"] == "external_write_connector_not_write_safe"
+    assert decision["next_action"] == "respect_rate_limit"
+
+
+def test_shadow_read_only_recommendation_can_continue_in_degraded_mode() -> None:
+    decision = evaluate_marketing_external_write_result(
+        [
+            {
+                "connector_key": "google_ads",
+                "write_safe": False,
+                "read_status": "degraded",
+                "failure_class": "partial_data",
+            }
+        ],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="shadow",
+        output={"recommendation": "Keep campaign in draft until connector recovers."},
+        step={"id": "launch_ads"},
+        state={"workflow_id": "campaign_launch", "workflow_run_id": "run-1"},
+        now=NOW,
+    )
+
+    assert decision["step_status"] == "completed"
+    assert decision["final_state"] == "shadow_only"
+
+
+def test_linter_flags_production_dependency_on_degraded_only_connector() -> None:
+    result = lint_marketing_workflow(
+        {
+            "id": "weekly_marketing_report",
+            "domain": "marketing",
+            "mode": "production",
+            "steps": [
+                {
+                    "id": "compile_report",
+                    "type": "agent",
+                    "agent_type": "campaign_pilot",
+                    "action": "create_plan",
+                    "connector_key": "google_ads",
+                }
+            ],
+        },
+        connector_contracts=[
+            {
+                "connector_key": "google_ads",
+                "category": "Ads",
+                "read_ready": False,
+                "read_status": "degraded",
+                "degraded_mode": {"status": "degraded", "allowed": True},
+            }
+        ],
+    )
+
+    assert result.has_errors is True
+    assert "marketing_connector_degraded_only" in {finding.code for finding in result.findings}

--- a/tests/unit/test_cmo_crm_intelligence_agent.py
+++ b/tests/unit/test_cmo_crm_intelligence_agent.py
@@ -1,0 +1,532 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.agents.marketing.crm_intelligence import CrmIntelligenceAgent
+from core.marketing.agent_contracts import (
+    build_marketing_agent_contract_output,
+    contract_has_required_shape,
+    get_marketing_agent_contract_spec,
+)
+from core.marketing.pilot_proof import build_cmo_pilot_proof_projection
+from core.marketing.workflow_linter import lint_marketing_workflow
+from core.schemas.messages import TargetAgent, TaskAssignment, TaskInput
+
+
+class FakeToolGateway:
+    def __init__(self, responses: dict[tuple[str, str], dict[str, Any] | Exception]):
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    async def execute(
+        self,
+        *,
+        tenant_id: str,
+        agent_id: str,
+        agent_scopes: list[str],
+        connector_name: str,
+        tool_name: str,
+        params: dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "tenant_id": tenant_id,
+                "agent_id": agent_id,
+                "agent_scopes": agent_scopes,
+                "connector_name": connector_name,
+                "tool_name": tool_name,
+                "params": params,
+                "idempotency_key": idempotency_key,
+            }
+        )
+        response = self.responses.get((connector_name, tool_name), {})
+        if isinstance(response, Exception):
+            raise response
+        return dict(response)
+
+
+def _assignment(action: str, inputs: dict[str, Any]) -> TaskAssignment:
+    return TaskAssignment(
+        message_id=f"msg-crm-{action}",
+        correlation_id="corr-crm",
+        workflow_run_id="run-crm",
+        workflow_definition_id="wf-crm",
+        step_id=f"step-{action}",
+        step_index=0,
+        total_steps=1,
+        target_agent=TargetAgent(
+            agent_id="agent-crm",
+            agent_type="crm_intelligence",
+            agent_token="test-token",
+        ),
+        task=TaskInput(action=action, inputs=inputs),
+    )
+
+
+def _agent(gateway: FakeToolGateway | None = None) -> CrmIntelligenceAgent:
+    return CrmIntelligenceAgent(
+        agent_id="agent-crm",
+        tenant_id="tenant-cmo",
+        tool_gateway=gateway,
+        authorized_tools=[
+            "hubspot.update_lifecycle_stage",
+            "hubspot.update_lead_scores",
+            "hubspot.update_segment_membership",
+            "salesforce.update_target_accounts",
+            "hubspot.bulk_crm_update",
+        ],
+    )
+
+
+def _crm_inputs(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "deals": [
+            {"id": "d1", "stage": "discovery", "days_in_stage": 5, "amount": 5000},
+            {"id": "d2", "stage": "discovery", "days_in_stage": 7, "amount": 8000},
+            {"id": "d3", "stage": "proposal", "days_in_stage": 9, "amount": 12000},
+            {"id": "d4", "stage": "proposal", "days_in_stage": 10, "amount": 9000},
+            {"id": "d5", "stage": "negotiation", "days_in_stage": 45, "amount": 30000},
+            {"id": "d6", "stage": "negotiation", "days_in_stage": 60, "amount": 22000},
+        ],
+        "funnel_stage_counts": {
+            "visit": 5000,
+            "lead": 1200,
+            "mql": 400,
+            "sql": 90,
+            "opportunity": 30,
+        },
+        "contacts": [
+            {
+                "id": "c1",
+                "lead_score": 30.0,
+                "firmographic_fit": 0.9,
+                "title_seniority": "vp",
+                "days_since_last_activity": 2,
+                "engagement_depth": 0.8,
+                "intent_score": 80,
+                "demo_request": True,
+                "industry": "Fintech",
+                "company_size": "enterprise",
+                "engagement_score": 85,
+                "recent_engagement": True,
+            },
+            {
+                "id": "c2",
+                "lead_score": 10.0,
+                "firmographic_fit": 0.2,
+                "title_seniority": "ic",
+                "days_since_last_activity": 60,
+                "engagement_depth": 0.1,
+                "intent_score": 5,
+                "demo_request": False,
+                "industry": "Retail",
+                "company_size": "smb",
+                "engagement_score": 20,
+            },
+            {
+                "id": "c3",
+                "lead_score": 40.0,
+                "firmographic_fit": 0.7,
+                "title_seniority": "director",
+                "days_since_last_activity": 5,
+                "engagement_depth": 0.5,
+                "intent_score": 50,
+                "demo_request": False,
+                "industry": "Fintech",
+                "company_size": "midmarket",
+                "engagement_score": 55,
+            },
+        ],
+        "accounts": [
+            {
+                "id": "acct_a",
+                "mrr": 12000,
+                "engagement_score": 90,
+                "open_support_tickets": 0,
+                "nps": 70,
+                "payment_health": "ok",
+                "days_since_last_login": 1,
+                "usage_trend": "growing",
+            },
+            {
+                "id": "acct_b",
+                "mrr": 2500,
+                "engagement_score": 10,
+                "open_support_tickets": 9,
+                "nps": -70,
+                "payment_health": "overdue",
+                "days_since_last_login": 45,
+                "usage_trend": "declining",
+            },
+        ],
+        "source_refs": [{"type": "hubspot", "ref_id": "tenant-cmo"}],
+        "workflow_mode": "shadow",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_contract(**overrides: object) -> dict[str, Any]:
+    contract: dict[str, Any] = {
+        "connector_key": "hubspot",
+        "category": "CRM",
+        "read_ready": True,
+        "write_ready": True,
+        "write_safe": True,
+        "idempotency_key_supported": True,
+        "retry_budget": {
+            "idempotency_key": "crm-write-001",
+            "idempotency_supported": True,
+            "remaining_attempts": 2,
+        },
+    }
+    contract.update(overrides)
+    return contract
+
+
+def _workflow(step: dict[str, Any], *, mode: str = "production") -> dict[str, Any]:
+    return {
+        "id": "wf_crm",
+        "name": "CRM Pipeline Intelligence",
+        "domain": "marketing",
+        "mode": mode,
+        "steps": [step],
+    }
+
+
+def _workflow_step(action: str, **overrides: object) -> dict[str, Any]:
+    step: dict[str, Any] = {
+        "id": "step_crm",
+        "name": "CRM Step",
+        "type": "agent",
+        "agent_type": "crm_intelligence",
+        "action": action,
+    }
+    step.update(overrides)
+    return step
+
+
+# ---------------------------------------------------------------------------
+# Pipeline velocity / funnel conversion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pipeline_velocity_analysis_detects_bottlenecks() -> None:
+    result = await _agent().execute(_assignment("pipeline_velocity_analysis", _crm_inputs()))
+    velocity = result.output["pipeline_velocity"]
+
+    assert result.output["status"] == "pipeline_velocity_analyzed"
+    assert velocity["deal_count"] == 6
+    assert velocity["avg_days_in_stage"]["discovery"] == pytest.approx(6.0)
+    assert velocity["avg_days_in_stage"]["negotiation"] == pytest.approx(52.5)
+    bottleneck_stages = {row["stage"] for row in velocity["bottlenecks"]}
+    assert "negotiation" in bottleneck_stages
+    assert any(action["action"] == "review_stuck_deals" for action in velocity["recommended_actions"])
+
+
+@pytest.mark.asyncio
+async def test_funnel_conversion_with_low_sample_and_safe_division() -> None:
+    inputs = _crm_inputs(
+        funnel_stage_counts={"visit": 0, "lead": 5, "mql": 1, "sql": 0},
+    )
+    result = await _agent().execute(_assignment("funnel_conversion_analysis", inputs))
+    funnel = result.output["funnel_conversion"]
+
+    assert funnel["conversion_rates"]["visit->lead"] is None
+    assert funnel["conversion_rates"]["lead->mql"] == pytest.approx(0.20)
+    assert funnel["sufficient_sample"] is False
+    assert any(
+        action["action"] == "increase_funnel_sample_size"
+        for action in funnel["recommended_actions"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lead scoring / SQL promotion / segments
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lead_scoring_refresh_is_deterministic_and_explainable() -> None:
+    inputs = _crm_inputs()
+    first = await _agent().execute(_assignment("lead_scoring_refresh", inputs))
+    second = await _agent().execute(_assignment("lead_scoring_refresh", inputs))
+
+    first_scoring = first.output["lead_scoring"]
+    second_scoring = second.output["lead_scoring"]
+
+    assert first_scoring["contacts"] == second_scoring["contacts"]
+    top = first_scoring["contacts"][0]
+    assert "explanation" in top
+    assert sum(top["breakdown"].values()) == pytest.approx(top["score"], rel=1e-3)
+    qualifications = {c["contact_id"]: c["qualification"] for c in first_scoring["contacts"]}
+    assert qualifications["c1"] in {"mql", "sql"}
+    assert qualifications["c2"] == "lead"
+
+
+@pytest.mark.asyncio
+async def test_sql_promotion_classification_uses_clear_criteria() -> None:
+    inputs = _crm_inputs()
+    result = await _agent().execute(_assignment("sql_promotion_criteria", inputs))
+    promotion = result.output["sql_promotion"]
+
+    ids_promotable = {entry["contact_id"] for entry in promotion["promotable"]}
+    ids_non_promotable = {entry["contact_id"] for entry in promotion["non_promotable"]}
+    assert "c1" in ids_promotable
+    assert "c2" in ids_non_promotable
+    c2_reasons = next(
+        entry["reasons"] for entry in promotion["non_promotable"] if entry["contact_id"] == "c2"
+    )
+    assert any("intent" in reason or "engagement" in reason or "score" in reason for reason in c2_reasons)
+
+
+@pytest.mark.asyncio
+async def test_segment_recommendation_returns_action_plan() -> None:
+    inputs = _crm_inputs()
+    result = await _agent().execute(_assignment("segment_recommendation", inputs))
+    segments = result.output["segments"]
+
+    assert set(segments["by_behaviour"].keys()) >= {"high_intent", "warm", "dormant"}
+    actions = {action["action"] for action in segments["recommended_actions"]}
+    assert "enroll_in_nurture" in actions
+    assert "win_back_campaign" in actions
+
+
+# ---------------------------------------------------------------------------
+# Churn risk / account health
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_churn_risk_signals_identify_at_risk_accounts() -> None:
+    inputs = _crm_inputs()
+    result = await _agent().execute(_assignment("extract_churn_signals", inputs))
+    churn = result.output["churn_signals"]
+
+    risky_ids = {entry["account_id"] for entry in churn["at_risk_accounts"]}
+    assert "acct_b" in risky_ids
+    assert "acct_a" not in risky_ids
+    assert churn["signal_summary"]
+
+
+@pytest.mark.asyncio
+async def test_account_deal_health_summary_orders_by_health() -> None:
+    inputs = _crm_inputs()
+    result = await _agent().execute(_assignment("account_health_summary", inputs))
+    accounts = result.output["account_health"]["accounts"]
+    scores = {entry["account_id"]: entry["health_score"] for entry in accounts}
+
+    assert scores["acct_a"] > scores["acct_b"]
+    unhealthy = {entry["account_id"] for entry in result.output["account_health"]["unhealthy_accounts"]}
+    assert "acct_b" in unhealthy
+    assert "acct_a" not in unhealthy
+
+
+# ---------------------------------------------------------------------------
+# Degraded / missing mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stale_partial_or_missing_mapping_downgrades_or_blocks() -> None:
+    inputs = _crm_inputs(
+        connector_read_ready=False,
+        stale_data=True,
+        partial_data=True,
+        mapping_status="invalid",
+    )
+    result = await _agent().execute(_assignment("pipeline_velocity_analysis", inputs))
+
+    assert result.output["status"] == "pipeline_velocity_degraded"
+    assert result.output["degraded_reasons"]
+    assert result.output["confidence"] < 0.85
+
+
+# ---------------------------------------------------------------------------
+# Write safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_cannot_write_externally() -> None:
+    gateway = FakeToolGateway({})
+    result = await _agent(gateway).execute(
+        _assignment(
+            "update_lifecycle_stage",
+            _crm_inputs(
+                workflow_mode="shadow",
+                contact_ids=["c1"],
+                lifecycle_stage="mql",
+                affected_contacts=1,
+            ),
+        )
+    )
+
+    assert result.output["status"] == "shadow_only"
+    assert result.output["external_write_confirmation_status"] == "shadow_only"
+    assert gateway.calls == []
+
+
+@pytest.mark.asyncio
+async def test_active_crm_write_requires_policy_approval_audit_and_write_readiness() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "update_lead_scores",
+            _crm_inputs(
+                workflow_mode="active",
+                connector_contract=_write_contract(),
+                contact_ids=["c1", "c2"],
+                affected_contacts=2,
+                lead_score_updates={"c1": 78, "c2": 22},
+            ),
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["status"] == "blocked"
+    assert result.output["policy_result"]["decision"] == "requires_approval"
+    assert result.output["approval_required"] is True
+    assert result.output["audit_ref"].startswith("crm_intelligence:")
+    assert result.output["external_write_confirmation_status"] == "write_unconfirmed"
+
+
+@pytest.mark.asyncio
+async def test_target_account_list_change_above_threshold_requires_approval() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "change_target_accounts",
+            _crm_inputs(
+                workflow_mode="active",
+                connector_contract=_write_contract(connector_key="salesforce"),
+                affected_accounts=100,
+                target_account_delta=100,
+            ),
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["policy_result"]["decision"] in {"requires_approval", "requires_escalation"}
+    assert result.output["approval_required"] is True
+    assert result.output["escalation_ref"]
+
+
+@pytest.mark.asyncio
+async def test_connector_not_write_safe_blocks_active_write() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "update_lifecycle_stage",
+            _crm_inputs(
+                workflow_mode="active",
+                approved=True,
+                connector_contract=_write_contract(write_ready=False, write_safe=False),
+                contact_ids=["c1"],
+                affected_contacts=1,
+            ),
+        )
+    )
+
+    assert result.output["status"] == "blocked"
+    assert any("not write-safe" in reason for reason in result.output["blocked_reasons"])
+
+
+@pytest.mark.asyncio
+async def test_active_crm_write_cannot_complete_without_confirmed_external_write() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "update_lead_scores",
+            _crm_inputs(
+                workflow_mode="active",
+                approved=True,
+                connector_contract=_write_contract(),
+                contact_ids=["c1"],
+                affected_contacts=1,
+                external_write_result={
+                    "connector_key": "hubspot",
+                    "status": "accepted",
+                    "idempotency_key": "crm:score:1",
+                },
+            ),
+        )
+    )
+
+    assert result.output["status"] == "write_unconfirmed"
+    assert result.output["external_writes_completed"] is False
+    assert result.status == "hitl_triggered"
+
+
+@pytest.mark.asyncio
+async def test_confirmed_crm_write_emits_policy_audit_escalation_refs_when_required() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "change_target_accounts",
+            _crm_inputs(
+                workflow_mode="active",
+                approved=True,
+                escalation_ref="esc-target-accounts",
+                connector_contract=_write_contract(connector_key="salesforce"),
+                affected_accounts=120,
+                target_account_delta=120,
+                external_write_result={
+                    "connector_key": "salesforce",
+                    "status": "write_confirmed",
+                    "external_object_id": "list-007",
+                    "source_url": "https://crm.example/list-007",
+                    "idempotency_key": "crm:targets:1",
+                    "confirmed_at": "2026-05-24T12:00:00Z",
+                    "audit_ref": "audit-crm-write",
+                },
+            ),
+        )
+    )
+    contract = build_marketing_agent_contract_output(
+        "crm_intelligence",
+        "change_target_accounts",
+        result=result,
+        audit_ref=result.output["audit_ref"],
+        external_write_confirmation_status=result.output["external_write_confirmation_status"],
+    )
+
+    assert result.status == "completed"
+    assert result.output["policy_result"]["decision"] in {"requires_approval", "requires_escalation"}
+    assert result.output["escalation_ref"]
+    assert result.output["external_write_ref"]["external_object_id"] == "list-007"
+    assert contract_has_required_shape(contract)
+    assert contract["maturity"] == "beta"
+    assert contract["external_writes_completed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Contract / workflow linter / pilot proof
+# ---------------------------------------------------------------------------
+
+
+def test_contract_workflow_linter_activation_and_pilot_proof_are_truthful_beta() -> None:
+    read_lint = lint_marketing_workflow(_workflow(_workflow_step("pipeline_velocity_analysis"), mode="target"))
+    write_lint = lint_marketing_workflow(
+        _workflow(_workflow_step("update_lifecycle_stage", connector_key="hubspot")),
+        connector_contracts=[_write_contract()],
+    )
+    proof = build_cmo_pilot_proof_projection(
+        environment_type="vendor_sandbox",
+        source_context={"source": "vendor_sandbox"},
+        agent_contracts=[get_marketing_agent_contract_spec("crm_intelligence")],
+    )["cmo_pilot_proof"]
+    contract = build_marketing_agent_contract_output(
+        "crm_intelligence",
+        "pipeline_velocity_analysis",
+        audit_ref="audit-crm-contract",
+    )
+
+    assert contract_has_required_shape(contract)
+    assert contract["maturity"] == "beta"
+    assert contract["production_ready"] is False
+    assert "marketing_agent_type_unknown" not in {finding.code for finding in read_lint.findings}
+    assert "marketing_agent_stub_target_only" not in {finding.code for finding in read_lint.findings}
+    assert "marketing_agent_stub_for_production" not in {finding.code for finding in write_lint.findings}
+    assert "marketing_agent_beta_in_production" in {finding.code for finding in write_lint.findings}
+    assert proof["production_claim_allowed"] is False
+    assert any(item["capability_key"] == "agent:crm_intelligence" for item in proof["unproven_capabilities"])

--- a/tests/unit/test_cmo_decision_audit_package.py
+++ b/tests/unit/test_cmo_decision_audit_package.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from core.marketing.approval_timeouts import evaluate_approval_timeout
+from core.marketing.decision_audit import (
+    build_cmo_decision_audit_package,
+    build_workflow_decision_audit_status,
+    build_workflow_promotion_audit_package,
+    serialize_cmo_decision_audit_package,
+)
+from core.marketing.escalation_matrix import evaluate_marketing_escalation
+from core.marketing.external_writes import evaluate_marketing_external_write_result
+from core.marketing.policy_manifest import evaluate_marketing_policy
+from core.marketing.workflow_linter import lint_marketing_workflow
+
+NOW = datetime(2026, 5, 23, 12, 0, tzinfo=UTC)
+
+
+def test_audit_package_has_stable_id_shape_and_worm_serialization() -> None:
+    context = {
+        "tenant_id": "tenant-1",
+        "company_id": "company-1",
+        "workflow_id": "campaign_launch",
+        "workflow_run_id": "run-1",
+        "step_id": "launch",
+        "agent": "campaign_pilot",
+        "action": "launch_campaign",
+        "actor_type": "agent",
+        "actor_id": "agent-campaign-pilot",
+        "input_snapshot": {
+            "campaign": "Spring launch",
+            "api_token": "secret-token-value",
+        },
+        "source_refs": [{"type": "brief", "id": "brief-1"}],
+        "rationale": "Launch meets policy and connector prerequisites.",
+        "alternatives_considered": ["keep_draft", "reduce_budget"],
+        "risk_flags": ["budget"],
+        "confidence": 0.91,
+        "final_outcome": "requires_approval",
+        "created_at": NOW.isoformat(),
+    }
+
+    first = build_cmo_decision_audit_package(context, now=NOW)
+    second = build_cmo_decision_audit_package(context, now=NOW)
+    serialized = serialize_cmo_decision_audit_package(first)
+
+    assert first["audit_id"] == second["audit_id"]
+    assert first["schema_version"] == "2026-05-23.cmo-6.3"
+    assert first["event_type"] == "campaign_launch"
+    assert first["input_snapshot_hash"]
+    assert first["source_refs"] == [{"type": "brief", "id": "brief-1"}]
+    assert first["worm_ready"] is True
+    assert first["serialization"]["format"] == "canonical_json"
+    assert "secret-token-value" not in serialized
+    assert "[REDACTED]" in serialized
+
+
+def test_policy_decision_creates_audit_ref_and_evidence() -> None:
+    decision = evaluate_marketing_policy(
+        {
+            "workflow_id": "campaign_launch",
+            "workflow_mode": "active",
+            "action": "launch_campaign",
+            "external_write_required": True,
+        }
+    )
+
+    package = decision["decision_audit"]
+    assert decision["audit_reference"] == package["audit_reference"]
+    assert package["event_type"] == "policy_decision"
+    assert package["policy_result"]["decision"] == "requires_approval"
+    assert package["policy_result_ref"].startswith("policy:")
+
+
+def test_escalation_decision_creates_audit_ref_and_evidence() -> None:
+    decision = evaluate_marketing_escalation(
+        {
+            "trigger_type": "crisis_public_response",
+            "workflow_id": "brand_crisis_response",
+            "step_id": "public_response",
+        },
+        now=NOW,
+    )
+
+    assert decision["decision_audit"]["event_type"] == "escalation_decision"
+    assert decision["decision_audit_ref"].startswith("cmo_decision_audit:")
+    assert decision["evidence"]["decision_audit_ref"] == decision["decision_audit_ref"]
+
+
+def test_approval_timeout_creates_audit_ref_and_evidence() -> None:
+    decision = evaluate_approval_timeout(
+        {
+            "approval_id": "approval-1",
+            "workflow_id": "campaign_launch",
+            "workflow_run_id": "run-1",
+            "step_id": "launch",
+            "action": "launch_campaign",
+            "created_at": NOW - timedelta(hours=5),
+            "due_at": NOW - timedelta(hours=1),
+            "status": "pending",
+        },
+        now=NOW,
+    )
+
+    assert decision["timed_out"] is True
+    assert decision["decision_audit"]["event_type"] == "approval_timeout"
+    assert decision["audit_evidence"]["decision_audit_ref"] == decision["decision_audit_ref"]
+    assert decision["decision_audit"]["timeout_result_ref"].startswith("mkt_approval_timeout")
+
+
+def test_external_write_attempt_and_confirmation_create_audit_evidence() -> None:
+    decision = evaluate_marketing_external_write_result(
+        [_write_contract()],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="active",
+        output={
+            "external_write_state": "accepted",
+            "external_object_id": "customers/123/campaigns/456",
+            "source_url": "https://ads.google.com/campaigns/456",
+            "idempotency_key": "launch-1",
+            "request_fingerprint": "fp-launch-1",
+        },
+        step={"id": "launch", "idempotency_key": "launch-1"},
+        state={
+            "tenant_id": "tenant-1",
+            "workflow_id": "campaign_launch",
+            "workflow_run_id": "run-1",
+            "marketing_policy_approval_satisfied": True,
+        },
+        now=NOW,
+    )
+
+    attempt, final = decision["audit_events"]
+    assert attempt["decision_audit"]["event_type"] == "external_write_attempt"
+    assert final["decision_audit"]["event_type"] == "external_write_confirmation"
+    assert final["decision_audit"]["external_write_result"]["external_object_id"].endswith("/456")
+    assert decision["decision_audit_ref"] == final["decision_audit_ref"]
+
+
+def test_external_write_rejection_timeout_and_recovery_create_final_audit_evidence() -> None:
+    rejected = evaluate_marketing_external_write_result(
+        [_write_contract()],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="active",
+        output={
+            "external_write_state": "rejected",
+            "idempotency_key": "launch-1",
+            "rejection_reason": "Vendor rejected budget payload.",
+        },
+        step={"id": "launch", "idempotency_key": "launch-1"},
+        state={"workflow_id": "campaign_launch", "marketing_policy_approval_satisfied": True},
+        now=NOW,
+    )
+    timeout = evaluate_marketing_external_write_result(
+        [_write_contract(idempotency_key_supported=False)],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="active",
+        output={
+            "external_write_state": "timeout_unknown",
+            "request_fingerprint": "fp-timeout",
+        },
+        step={"id": "launch"},
+        state={"workflow_id": "campaign_launch", "marketing_policy_approval_satisfied": True},
+        now=NOW,
+    )
+    recovered = evaluate_marketing_external_write_result(
+        [
+            _write_contract(
+                confirmations=[
+                    {
+                        "action": "launch_campaign",
+                        "status": "write_confirmed",
+                        "idempotency_key": "launch-1",
+                        "external_object_id": "customers/123/campaigns/456",
+                        "confirmed_at": NOW.isoformat(),
+                    }
+                ]
+            )
+        ],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="active",
+        output={
+            "external_write_state": "timeout_unknown",
+            "idempotency_key": "launch-1",
+            "request_fingerprint": "fp-recovered",
+        },
+        step={"id": "launch", "idempotency_key": "launch-1"},
+        state={"workflow_id": "campaign_launch", "marketing_policy_approval_satisfied": True},
+        now=NOW,
+    )
+
+    assert rejected["audit_events"][-1]["decision_audit"]["event_type"] == "external_write_rejection"
+    assert timeout["audit_events"][-1]["decision_audit"]["event_type"] == "external_write_timeout"
+    assert recovered["audit_events"][-1]["decision_audit"]["event_type"] == "external_write_idempotent_recovery"
+
+
+def test_workflow_promotion_and_override_are_auditable() -> None:
+    promotion = build_workflow_promotion_audit_package(
+        {
+            "workflow_key": "campaign_launch",
+            "state": "active",
+            "marketing_policy": {"status": "ready"},
+            "escalation_matrix": {"status": "ready"},
+            "approval_timeout_policy": {"status": "ready"},
+        },
+        now=NOW,
+    )
+    override = build_cmo_decision_audit_package(
+        {
+            "event_type": "override",
+            "workflow_id": "campaign_launch",
+            "action": "launch_campaign",
+            "actor_type": "user",
+            "actor_id": "user-1",
+            "actor_role": "cmo",
+            "override_reason": "Replace launch with lower-risk draft.",
+            "replacement_action": "create_draft",
+            "created_at": NOW.isoformat(),
+        },
+        now=NOW,
+    )
+
+    assert promotion["event_type"] == "workflow_promotion"
+    assert promotion["final_outcome"] == "active"
+    assert override["override"]["actor_id"] == "user-1"
+    assert override["override"]["reason"] == "Replace launch with lower-risk draft."
+    assert override["override"]["replacement_action"] == "create_draft"
+
+
+def test_missing_audit_evidence_blocks_production_customer_facing_lint() -> None:
+    result = lint_marketing_workflow(
+        {
+            "id": "wf_campaign",
+            "domain": "marketing",
+            "mode": "production",
+            "steps": [
+                {
+                    "id": "launch",
+                    "type": "agent",
+                    "agent_type": "campaign_pilot",
+                    "action": "launch_campaign",
+                    "connector_key": "google_ads",
+                    "external_write_confirmation_required": True,
+                    "expected_confirmation_fields": ["external_object_id"],
+                    "idempotency_key": "launch-1",
+                }
+            ],
+        },
+        connector_contracts=[_write_contract()],
+    )
+
+    assert result.has_errors is True
+    assert "marketing_decision_audit_evidence_missing" in {
+        finding.code for finding in result.errors
+    }
+
+
+def test_shadow_read_only_decision_is_auditable_and_non_executable() -> None:
+    package = build_cmo_decision_audit_package(
+        {
+            "event_type": "shadow_only",
+            "workflow_id": "weekly_marketing_report",
+            "action": "recommend",
+            "actor_type": "agent",
+            "rationale": "Recommendation only; no external execution.",
+            "final_outcome": "shadow_only",
+            "created_at": NOW.isoformat(),
+        },
+        now=NOW,
+    )
+
+    assert package["event_type"] == "shadow_only"
+    assert package["final_outcome"] == "shadow_only"
+    assert package["external_write_result"] is None
+
+
+def test_workflow_audit_status_blocks_when_decision_audit_disabled() -> None:
+    status = build_workflow_decision_audit_status(
+        "campaign_launch",
+        ["launch_campaign"],
+        {"decision_audit_disabled": True},
+    )
+
+    assert status["status"] == "missing_audit_evidence"
+    assert status["next_action_cta"] == "configure_decision_audit_package"
+
+
+def _write_contract(
+    *,
+    idempotency_key_supported: bool = True,
+    confirmations: list[dict] | None = None,
+) -> dict:
+    return {
+        "connector_key": "google_ads",
+        "category": "Ads",
+        "read_ready": True,
+        "write_ready": True,
+        "write_safe": True,
+        "idempotency_key_supported": idempotency_key_supported,
+        "retry_budget": {
+            "idempotency_key": "launch-1",
+            "idempotency_supported": idempotency_key_supported,
+            "remaining_attempts": 2,
+            "next_retry_at": "2026-05-23T12:05:00+00:00",
+        },
+        "external_write_confirmations": confirmations or [],
+    }

--- a/tests/unit/test_cmo_e2e_scenarios.py
+++ b/tests/unit/test_cmo_e2e_scenarios.py
@@ -1,0 +1,977 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+from core.marketing.agent_contracts import (
+    build_marketing_agent_contract_output,
+    contract_has_required_shape,
+)
+from core.marketing.approval_review import build_cmo_approval_review_projection
+from core.marketing.approval_timeouts import build_approval_timeout_risk
+from core.marketing.connector_contracts import build_marketing_connector_contracts
+from core.marketing.connector_setup import build_marketing_connector_setup
+from core.marketing.data_readiness import build_marketing_data_readiness
+from core.marketing.decision_audit import (
+    build_cmo_decision_audit_package,
+    build_marketing_decision_audit_projection,
+)
+from core.marketing.escalation_matrix import (
+    build_marketing_escalation_projection,
+    evaluate_marketing_escalation,
+)
+from core.marketing.external_writes import evaluate_marketing_external_write_result
+from core.marketing.kpi_drilldown import build_cmo_kpi_drilldown_projection
+from core.marketing.kpi_schema import build_unified_cmo_kpi_projection
+from core.marketing.policy_manifest import (
+    build_marketing_policy_projection,
+    evaluate_marketing_policy,
+)
+from core.marketing.report_quality import build_cmo_report_quality_projection
+from core.marketing.work_queue import build_cmo_work_queue_projection
+from core.marketing.workflow_activation import build_cmo_workflow_activation
+from core.marketing.workflow_linter import lint_marketing_workflow
+
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=UTC)
+FRESH_TS = (NOW - timedelta(hours=1)).isoformat()
+MAPPING_TS = "2026-05-01T00:00:00+00:00"
+IDEMPOTENCY_KEY = "mkt-e2e-idempotency-001"
+
+
+def _connector_config(
+    connector_name: str,
+    *,
+    config: dict[str, Any],
+    health_status: str = "healthy",
+    last_sync_at: datetime | None = None,
+    sync_error: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        connector_name=connector_name,
+        display_name=None,
+        auth_type="oauth2",
+        credentials_encrypted={"_encrypted": "enc"},
+        config=config,
+        status="configured",
+        last_health_check=NOW,
+        health_status=health_status,
+        last_sync_at=last_sync_at or NOW - timedelta(hours=1),
+        sync_error=sync_error,
+    )
+
+
+def _backfill(status: str = "completed") -> dict[str, Any]:
+    return {
+        "status": status,
+        "requested_start": "2025-05-01",
+        "requested_end": "2026-05-24",
+        "records_discovered": 100,
+        "records_imported": 100 if status == "completed" else 60,
+        "records_skipped": 0,
+        "records_failed": 0 if status == "completed" else 5,
+        "last_run_at": "2026-05-24T10:00:00+00:00",
+        "blocking_reason": "Vendor export failed" if status in {"failed", "blocked"} else None,
+    }
+
+
+def _contract_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "idempotency_supported": True,
+        "retry_budget": {
+            "max_attempts": 3,
+            "attempts_used": 0,
+            "remaining_attempts": 3,
+            "idempotency_supported": True,
+            "idempotency_key": IDEMPOTENCY_KEY,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _hubspot_mapping() -> dict[str, Any]:
+    return {
+        "lifecycle_stages": {
+            "source_field": "lifecyclestage",
+            "stage_map": {"mql": "marketingqualifiedlead", "sql": "salesqualifiedlead"},
+            "updated_at": MAPPING_TS,
+        },
+        "opportunity_revenue": {
+            "amount_field": "amount",
+            "close_date_field": "closedate",
+            "currency_field": "deal_currency_code",
+            "updated_at": MAPPING_TS,
+        },
+        "account_domains": {"domain_field": "website", "updated_at": MAPPING_TS},
+        "consent_unsubscribe": {
+            "consent_field": "marketing_opt_in",
+            "unsubscribe_field": "unsubscribed",
+            "updated_at": MAPPING_TS,
+        },
+        "fiscal_calendar": {"fiscal_year_start_month": 4, "updated_at": MAPPING_TS},
+        "currency": {"currency": "USD", "updated_at": MAPPING_TS},
+        "timezone": {"timezone": "Asia/Kolkata", "updated_at": MAPPING_TS},
+    }
+
+
+def _campaign_mapping() -> dict[str, Any]:
+    return {
+        "campaign_ids": {"campaign_id_field": "campaign_id", "updated_at": MAPPING_TS},
+        "utm_fields": {
+            "source": "utm_source",
+            "medium": "utm_medium",
+            "campaign": "utm_campaign",
+            "updated_at": MAPPING_TS,
+        },
+    }
+
+
+def _mailchimp_mapping() -> dict[str, Any]:
+    return {
+        **_campaign_mapping(),
+        "consent_unsubscribe": {
+            "consent_field": "marketing_permission",
+            "unsubscribe_field": "unsubscribe_status",
+            "updated_at": MAPPING_TS,
+        },
+    }
+
+
+def _base_configs(
+    *,
+    include_wordpress: bool = False,
+    include_buffer: bool = False,
+    include_brandwatch: bool = False,
+) -> list[SimpleNamespace]:
+    configs = [
+        _connector_config(
+            "hubspot",
+            config={
+                "owner": "revops@example.com",
+                "account_id": "portal-123",
+                "granted_scopes": [
+                    "crm.objects.contacts.read",
+                    "crm.objects.deals.read",
+                    "automation",
+                ],
+                "data_coverage_status": "ready",
+                "marketing_field_mapping": _hubspot_mapping(),
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract_payload(),
+            },
+        ),
+        _connector_config(
+            "google_ads",
+            config={
+                "owner": "growth@example.com",
+                "customer_id": "123-456-7890",
+                "granted_scopes": ["https://www.googleapis.com/auth/adwords"],
+                "marketing_field_mapping": _campaign_mapping(),
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract_payload(),
+            },
+        ),
+        _connector_config(
+            "ga4",
+            config={
+                "owner": "analytics@example.com",
+                "property_id": "properties/123",
+                "granted_scopes": ["https://www.googleapis.com/auth/analytics.readonly"],
+                "marketing_field_mapping": _campaign_mapping(),
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract_payload(),
+            },
+        ),
+        _connector_config(
+            "mailchimp",
+            config={
+                "owner": "email@example.com",
+                "audience_id": "aud-1",
+                "marketing_field_mapping": _mailchimp_mapping(),
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract_payload(),
+            },
+        ),
+    ]
+    if include_wordpress:
+        configs.append(
+            _connector_config(
+                "wordpress",
+                config={
+                    "owner": "web@example.com",
+                    "site_url": "https://www.agenticorg.ai",
+                    "marketing_field_mapping": _campaign_mapping(),
+                    "marketing_backfill": _backfill(),
+                    "marketing_connector_contract": _contract_payload(),
+                },
+            )
+        )
+    if include_buffer:
+        configs.append(
+            _connector_config(
+                "buffer",
+                config={
+                    "owner": "social@example.com",
+                    "granted_scopes": ["profile:read", "updates:create"],
+                    "marketing_field_mapping": _campaign_mapping(),
+                    "marketing_backfill": _backfill(),
+                    "marketing_connector_contract": _contract_payload(),
+                },
+            )
+        )
+    if include_brandwatch:
+        configs.append(
+            _connector_config(
+                "brandwatch",
+                config={
+                    "owner": "brand@example.com",
+                    "project_id": "brand-project-123",
+                    "granted_scopes": ["read_mentions", "read_queries"],
+                    "marketing_field_mapping": {
+                        "timezone": {"timezone": "Asia/Kolkata", "updated_at": MAPPING_TS},
+                    },
+                    "marketing_backfill": _backfill(),
+                    "marketing_connector_contract": _contract_payload(),
+                },
+            )
+        )
+    return configs
+
+
+def _workflow_config(
+    *,
+    mode: str = "shadow",
+    promoted: bool = False,
+    approval_owner: str | None = "cmo@example.com",
+    policy_owner: str | None = "legal@example.com",
+) -> dict[str, Any]:
+    return {
+        "mode": mode,
+        "promoted": promoted,
+        "approval_owner": approval_owner,
+        "policy_owner": policy_owner,
+        "shadow_quality": {
+            "status": "passed",
+            "sample_count": 5,
+            "success_rate": 0.95,
+            "last_run_at": "2026-05-24T09:00:00+00:00",
+        },
+    }
+
+
+def _with_workflow(
+    configs: list[SimpleNamespace],
+    workflow_key: str,
+    payload: dict[str, Any],
+) -> list[SimpleNamespace]:
+    cloned = deepcopy(configs)
+    workflows = cloned[0].config.setdefault("marketing_workflows", {})
+    workflows[workflow_key] = payload
+    return cloned
+
+
+def _source_facts(**overrides: Any) -> dict[str, Any]:
+    facts: dict[str, Any] = {
+        "last_updated_at": FRESH_TS,
+        "total_marketing_spend": 1_000.0,
+        "ad_spend": 1_000.0,
+        "campaign_spend_by_channel": {"google": 600.0, "linkedin": 250.0, "meta": 150.0},
+        "new_customers": 10,
+        "lifecycle_stage_counts": {
+            "visitor": 1_000,
+            "lead": 250,
+            "mql": 100,
+            "sql": 40,
+            "opportunity": 20,
+            "customer": 10,
+        },
+        "ad_platform_conversions": 100,
+        "crm_campaign_attributed_mqls": 100,
+        "ga4_conversion_events": 250,
+        "crm_leads_created": 250,
+        "attributed_revenue": 5_000.0,
+        "opportunities": [{"amount": 2_500.0}, {"amount": 1_500.0}],
+        "customer_ltv": 2_000.0,
+        "completed_experiments": 6,
+        "period_days": 30,
+        "content_sessions": 1_000,
+        "content_conversions": 50,
+        "wordpress_content_sessions": 1_000,
+        "ga4_content_sessions": 1_000,
+        "emails_sent": 2_000,
+        "emails_opened": 900,
+        "emails_clicked": 300,
+        "emails_unsubscribed": 20,
+        "crm_email_sends": 2_000,
+        "crm_email_clicks": 300,
+        "crm_unsubscribed_contacts": 20,
+        "brand_positive_mentions": 70,
+        "brand_negative_mentions": 10,
+        "brand_neutral_mentions": 20,
+        "intent_ready_accounts": 25,
+        "target_accounts": 100,
+        "abm_target_account_domains": ["alpha.example", "beta.example"],
+        "crm_account_domains": ["alpha.example", "beta.example"],
+        "intent_account_domains": ["alpha.example", "beta.example"],
+        "source_currencies": {"ads": "USD", "crm": "USD", "finance": "USD"},
+        "source_timezones": {
+            "ads": "Asia/Kolkata",
+            "crm": "Asia/Kolkata",
+            "analytics": "Asia/Kolkata",
+            "email": "Asia/Kolkata",
+        },
+        "source_refs": [{"connector_key": "hubspot", "object": "deals"}],
+        "audit_refs": ["audit-kpi-source"],
+    }
+    facts.update(overrides)
+    return facts
+
+
+def _approval(**overrides: Any) -> dict[str, Any]:
+    approval = {
+        "approval_id": "apr-e2e-1",
+        "workflow_id": "campaign_launch",
+        "workflow_run_id": "run-e2e-1",
+        "step_id": "launch",
+        "action": "launch_campaign",
+        "approval_type": "ad_campaign_launch",
+        "status": "pending",
+        "agent_id": "agent-campaign",
+        "agent_type": "campaign_pilot",
+        "requested_approver": "cmo@example.com",
+        "requested_approver_role": "cmo",
+        "created_at": (NOW - timedelta(hours=1)).isoformat(),
+        "due_at": (NOW + timedelta(hours=3)).isoformat(),
+        "preview_payload": {"campaign_name": "Pipeline Sprint", "channels": ["google_ads"]},
+        "before_after_diff": {
+            "before": "Campaign is draft only",
+            "after": "Campaign launches to selected audience",
+        },
+        "budget_impact": {"amount": 1200, "currency": "USD", "period": "daily"},
+        "audience_impact": {"estimated_recipients": 25000, "segments": ["enterprise_search"]},
+        "brand_legal_risk_flags": ["budget_change"],
+        "source_refs": [{"type": "campaign_brief", "id": "brief-1"}],
+        "connector_key": "google_ads",
+        "agent_rationale": "Shadow recommendations exceeded launch threshold.",
+        "audit_refs": ["audit-approval-context"],
+        "rollback_stop_plan": {"summary": "Pause campaign and restore previous budget cap."},
+        "external_write_required": True,
+        "customer_facing": True,
+        "workflow_mode": "active",
+    }
+    approval.update(overrides)
+    return approval
+
+
+def _operating_projection(
+    configs: list[SimpleNamespace],
+    *,
+    source_data: dict[str, Any] | None = None,
+    source_context: dict[str, Any] | None = None,
+    approval_records: list[dict[str, Any]] | None = None,
+    external_write_results: list[dict[str, Any]] | None = None,
+    report_types: tuple[str, ...] | None = None,
+    production_tenant: bool = False,
+) -> dict[str, Any]:
+    source_context = source_context or {"demo": False, "source": "computed"}
+    approval_records = approval_records or []
+    setup = build_marketing_connector_setup(configs, now=NOW)
+    contracts = build_marketing_connector_contracts(setup, configs, now=NOW)
+    readiness = build_marketing_data_readiness(
+        setup,
+        configs,
+        connector_contracts=contracts,
+        now=NOW,
+    )
+    activation = build_cmo_workflow_activation(setup, readiness, configs, now=NOW)
+    policy_projection = build_marketing_policy_projection(configs)
+    escalation_projection = build_marketing_escalation_projection(configs)
+    audit_projection = build_marketing_decision_audit_projection(configs)
+    unified = build_unified_cmo_kpi_projection(
+        connector_setup=setup,
+        data_readiness=readiness,
+        connector_contracts=contracts,
+        connector_configs=configs,
+        source_data=source_data or _source_facts(),
+        now=NOW,
+    )
+    report_quality = build_cmo_report_quality_projection(
+        kpi_results=unified["unified_cmo_kpi_results"],
+        reconciliation_checks=unified["cmo_kpi_reconciliation_checks"],
+        connector_setup=setup,
+        data_readiness=readiness,
+        connector_contracts=contracts,
+        workflow_activation=activation,
+        policy_projection=policy_projection,
+        escalation_projection=escalation_projection,
+        decision_audit_projection=audit_projection,
+        source_context=source_context,
+        report_types=report_types,
+        production_tenant=production_tenant,
+        now=NOW,
+    )
+    timeout_risk = build_approval_timeout_risk(approval_records, now=NOW)
+    approval_review = build_cmo_approval_review_projection(
+        approval_records,
+        connector_contracts=contracts,
+        policy_projection=policy_projection,
+        escalation_projection=escalation_projection,
+        decision_audit_projection=audit_projection,
+        approval_timeout_risk=timeout_risk,
+        now=NOW,
+    )
+    work_queue = build_cmo_work_queue_projection(
+        approval_timeout_risk=timeout_risk,
+        escalation_projection=escalation_projection,
+        connector_setup=setup,
+        connector_contracts=contracts,
+        data_readiness=readiness,
+        workflow_activation=activation,
+        policy_projection=policy_projection,
+        decision_audit_projection=audit_projection,
+        kpi_results=unified["unified_cmo_kpi_results"],
+        reconciliation_checks=unified["cmo_kpi_reconciliation_checks"],
+        report_quality_gates=report_quality["report_quality_gates"],
+        external_write_results=external_write_results or [],
+        source_context=source_context,
+        now=NOW,
+    )
+    drilldown = build_cmo_kpi_drilldown_projection(
+        kpi_schema=unified["unified_cmo_kpi_schema"],
+        kpi_results=unified["unified_cmo_kpi_results"],
+        reconciliation_checks=unified["cmo_kpi_reconciliation_checks"],
+        connector_setup=setup,
+        data_readiness=readiness,
+        connector_contracts=contracts,
+        work_queue=work_queue["cmo_work_queue"],
+        report_quality_gates=report_quality["report_quality_gates"],
+        source_data=source_data or _source_facts(),
+        source_context=source_context,
+        now=NOW,
+    )
+    return {
+        "connector_setup": setup,
+        "connector_contracts": contracts,
+        "data_readiness": readiness,
+        "workflow_activation": activation,
+        "policy_projection": policy_projection,
+        "escalation_projection": escalation_projection,
+        "audit_projection": audit_projection,
+        "approval_timeout_risk": timeout_risk,
+        "approval_review": approval_review,
+        **unified,
+        **report_quality,
+        **work_queue,
+        **drilldown,
+    }
+
+
+def _report_gate(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    return next(item for item in payload["report_quality_gates"] if item["report_key"] == key)
+
+
+def _workflow_row(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    return next(
+        item
+        for item in payload["workflow_activation"]["workflow_activation_status"]
+        if item["workflow_key"] == key
+    )
+
+
+def _kpi(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    return next(item for item in payload["unified_cmo_kpi_results"] if item["kpi_key"] == key)
+
+
+def _drilldown(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    return next(item for item in payload["cmo_kpi_drilldowns"] if item["kpi_key"] == key)
+
+
+def _contract(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    return next(item for item in payload["connector_contracts"] if item["connector_key"] == key)
+
+
+def _write_step(
+    *,
+    agent_type: str = "campaign_pilot",
+    action: str = "launch_campaign",
+    connector_key: str = "google_ads",
+) -> dict[str, Any]:
+    return {
+        "id": f"{action}_step",
+        "type": "agent",
+        "agent_type": agent_type,
+        "action": action,
+        "connector_key": connector_key,
+        "external_write_required": True,
+        "external_write_confirmation_required": True,
+        "expected_confirmation_fields": ["external_object_id", "confirmed_at"],
+        "idempotency_key": IDEMPOTENCY_KEY,
+        "decision_audit_required": True,
+    }
+
+
+def _confirmed_write_output(**overrides: Any) -> dict[str, Any]:
+    output = {
+        "external_write_state": "accepted",
+        "external_object_id": "customers/123/campaigns/456",
+        "source_url": "https://ads.google.com/campaigns/456",
+        "idempotency_key": IDEMPOTENCY_KEY,
+        "request_fingerprint": "fp-e2e-confirmed",
+    }
+    output.update(overrides)
+    return output
+
+
+def test_weekly_marketing_review_blocks_delivery_and_surfaces_operator_work() -> None:
+    configs = _with_workflow(
+        _base_configs(),
+        "weekly_marketing_report",
+        _workflow_config(mode="active", promoted=True),
+    )
+    payload = _operating_projection(
+        configs,
+        source_data=_source_facts(
+            new_customers=None,
+            opportunities=[],
+            campaign_spend_by_channel={"google": 450.0, "linkedin": 125.0},
+        ),
+        report_types=("weekly_marketing_report",),
+        production_tenant=True,
+    )
+
+    gate = _report_gate(payload, "weekly_marketing_report")
+    queue_categories = {item["category"] for item in payload["cmo_work_queue"]}
+
+    assert payload["connector_setup"]
+    assert payload["connector_contracts"]
+    assert payload["data_readiness"]["field_mapping_status"]
+    assert payload["workflow_activation"]["workflow_activation_status"]
+    assert payload["policy_projection"]["marketing_policy_summary"]["status"] == "ready"
+    assert payload["escalation_projection"]["marketing_escalation_summary"]["status"] == "ready"
+    assert payload["audit_projection"]["marketing_decision_audit_summary"]["status"] == "ready"
+    assert gate["status"] == "blocked"
+    assert gate["safe_report_mode"] == "draft_only"
+    assert gate["trusted_delivery_allowed"] is False
+    assert "paid_spend_totals_by_channel" in gate["failed_reconciliation_keys"]
+    assert _kpi(payload, "cac")["status"] == "blocked"
+    assert {"report", "kpi", "reconciliation"} <= queue_categories
+    assert payload["cmo_work_queue_summary"]["readiness"] in {"blocked", "needs_action"}
+    cac_lineage = _drilldown(payload, "cac")
+    assert cac_lineage["status"] == "blocked"
+    assert cac_lineage["related_work_queue_item_ids"]
+    assert cac_lineage["related_report_gate_ids"]
+
+
+def test_campaign_launch_requires_readiness_approval_audit_and_confirmed_write() -> None:
+    shadow_payload = _operating_projection(
+        _with_workflow(_base_configs(), "campaign_launch", _workflow_config()),
+        source_data=_source_facts(),
+    )
+    active_payload = _operating_projection(
+        _with_workflow(
+            _base_configs(),
+            "campaign_launch",
+            _workflow_config(mode="active", promoted=True),
+        ),
+        source_data=_source_facts(),
+        approval_records=[_approval()],
+        report_types=("campaign_performance_ad_hoc",),
+    )
+    google_contract = _contract(active_payload, "google_ads")
+    workflow = {
+        "id": "wf_campaign_launch_e2e",
+        "domain": "marketing",
+        "mode": "production",
+        "steps": [_write_step()],
+    }
+    lint = lint_marketing_workflow(workflow, connector_contracts=[google_contract])
+    policy_decision = evaluate_marketing_policy(
+        {
+            "workflow_id": "campaign_launch",
+            "workflow_mode": "active",
+            "action": "launch_campaign",
+            "external_write_required": True,
+        }
+    )
+    audit_package = build_cmo_decision_audit_package(
+        {
+            "tenant_id": "tenant-1",
+            "workflow_id": "campaign_launch",
+            "workflow_run_id": "run-e2e-1",
+            "step_id": "launch",
+            "agent_type": "campaign_pilot",
+            "action": "launch_campaign",
+            "policy_result": policy_decision,
+            "source_refs": [{"type": "campaign_brief", "id": "brief-1"}],
+            "rationale": "Launch after successful shadow run.",
+        },
+        now=NOW,
+    )
+    unconfirmed = evaluate_marketing_external_write_result(
+        [google_contract],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="active",
+        step=_write_step(),
+        state={
+            "id": "run-e2e-1",
+            "workflow_id": "campaign_launch",
+            "workflow_mode": "active",
+            "marketing_policy_approval_satisfied": True,
+        },
+        output={"external_write_state": "write_unconfirmed", "idempotency_key": IDEMPOTENCY_KEY},
+        now=NOW,
+    )
+    confirmed = evaluate_marketing_external_write_result(
+        [google_contract],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="active",
+        step=_write_step(),
+        state={
+            "id": "run-e2e-1",
+            "workflow_id": "campaign_launch",
+            "workflow_mode": "active",
+            "marketing_policy_approval_satisfied": True,
+        },
+        output=_confirmed_write_output(),
+        now=NOW,
+    )
+    contract = build_marketing_agent_contract_output(
+        "campaign_pilot",
+        "launch_campaign",
+        result={
+            "status": "completed",
+            "confidence": 0.93,
+            "rationale": "Campaign launch is ready after policy approval.",
+            "recommended_actions": ["Launch campaign after approval."],
+            "audit_ref": audit_package["audit_reference"],
+            "source_refs": [{"connector_key": "google_ads", "object": "campaign"}],
+            "external_write_confirmation_status": "write_confirmed",
+        },
+        policy_result=policy_decision,
+        audit_ref=audit_package["audit_reference"],
+        workflow_mode="active",
+    )
+
+    assert _workflow_row(shadow_payload, "campaign_launch")["state"] == "promotion_ready"
+    assert _workflow_row(active_payload, "campaign_launch")["state"] == "active"
+    assert google_contract["write_ready"] is True
+    assert google_contract["write_safe"] is True
+    assert active_payload["data_readiness"]["kpi_readiness"]["status"] in {"ready", "degraded"}
+    assert lint.has_errors is False
+    assert policy_decision["decision"] == "requires_approval"
+    assert active_payload["approval_review"]["cmo_approval_review_summary"]["approval_ready"] >= 1
+    assert audit_package["audit_reference"].startswith("cmo_decision_audit:")
+    assert unconfirmed["step_status"] == "failed"
+    assert unconfirmed["final_state"] == "write_unconfirmed"
+    assert confirmed["step_status"] == "completed"
+    assert confirmed["final_state"] == "write_confirmed"
+    assert contract_has_required_shape(contract)
+    assert contract["external_writes_completed"] is True
+
+
+def test_crisis_response_requires_escalation_timeout_review_and_audit_before_public_write() -> None:
+    approval = _approval(
+        approval_id="apr-crisis-1",
+        workflow_id="brand_crisis_response",
+        workflow_run_id="run-crisis-1",
+        step_id="public_response",
+        action="public_response",
+        approval_type="crisis_public_response",
+        agent_type="brand_monitor",
+        connector_key="buffer",
+        crisis_response=True,
+        public_response=True,
+        brand_legal_risk_flags=["crisis", "legal_claim"],
+        created_at=(NOW - timedelta(hours=4)).isoformat(),
+        due_at=(NOW - timedelta(hours=1)).isoformat(),
+    )
+    payload = _operating_projection(
+        _with_workflow(
+            _base_configs(include_buffer=True, include_brandwatch=True),
+            "brand_crisis_response",
+            _workflow_config(mode="active", promoted=True),
+        ),
+        approval_records=[approval],
+        source_context={
+            "demo": False,
+            "source": "computed",
+            "crisis_risk": {
+                "risk_id": "brand-crisis-1",
+                "title": "Potential public brand crisis",
+                "public_response_required": True,
+                "severity": "critical",
+                "audit_refs": ["audit-crisis-risk"],
+            },
+        },
+    )
+    policy_decision = evaluate_marketing_policy(
+        {
+            "workflow_id": "brand_crisis_response",
+            "workflow_mode": "active",
+            "action": "public_response",
+            "public_response": True,
+            "external_write_required": True,
+        }
+    )
+    escalation = evaluate_marketing_escalation(
+        {
+            "trigger_type": "crisis_public_response",
+            "workflow_id": "brand_crisis_response",
+            "workflow_run_id": "run-crisis-1",
+            "step_id": "public_response",
+            "severity": "critical",
+        },
+        now=NOW,
+    )
+    audit_package = build_cmo_decision_audit_package(
+        {
+            "workflow_id": "brand_crisis_response",
+            "workflow_run_id": "run-crisis-1",
+            "step_id": "public_response",
+            "agent_type": "brand_monitor",
+            "action": "public_response",
+            "policy_result": policy_decision,
+            "escalation_result": escalation,
+            "approval_result": payload["approval_review"]["cmo_approval_reviews"][0],
+            "risk_flags": ["crisis", "legal_claim"],
+            "rationale": "Public response requires CMO, Legal, and CEO path.",
+        },
+        now=NOW,
+    )
+    unsafe_public_write = evaluate_marketing_external_write_result(
+        [_contract(payload, "buffer")],
+        connector_key="buffer",
+        action="public_response",
+        workflow_mode="active",
+        step=_write_step(agent_type="brand_monitor", action="public_response", connector_key="buffer"),
+        state={"id": "run-crisis-1", "workflow_id": "brand_crisis_response", "workflow_mode": "active"},
+        output=_confirmed_write_output(
+            external_object_id="updates/urgent-public-response",
+            source_url="https://publish.buffer.com/updates/urgent-public-response",
+        ),
+        now=NOW,
+    )
+
+    assert _workflow_row(payload, "brand_crisis_response")["state"] == "active"
+    assert policy_decision["decision"] == "requires_escalation"
+    assert policy_decision["required_escalation_role"] == "ceo"
+    assert escalation["decision"] in {"escalate", "escalate_to_legal"}
+    assert escalation["audit_reference"].startswith("mkt_escalation_")
+    assert payload["approval_timeout_risk"]["status"] == "blocked"
+    review = payload["approval_review"]["cmo_approval_reviews"][0]
+    assert review["action_type"] == "crisis_public_response"
+    assert review["status"] in {"blocked", "timed_out", "escalated"}
+    assert review["policy_result_ref"]
+    assert review["escalation_result_ref"]
+    assert audit_package["audit_reference"].startswith("cmo_decision_audit:")
+    assert unsafe_public_write["step_status"] == "failed"
+    assert unsafe_public_write["error_code"] in {
+        "external_write_marketing_policy_approval_required",
+        "external_write_approval_timeout_blocked",
+    }
+    assert "crisis_risk" in {item["category"] for item in payload["cmo_work_queue"]}
+
+
+def test_abm_sprint_beta_agent_still_blocks_production_without_required_gates() -> None:
+    payload = _operating_projection(
+        _with_workflow(
+            _base_configs(),
+            "abm_sprint",
+            _workflow_config(mode="active", promoted=True),
+        ),
+        source_data=_source_facts(),
+    )
+    production_lint = lint_marketing_workflow(
+        {
+            "id": "wf_abm_production",
+            "domain": "marketing",
+            "mode": "production",
+            "steps": [
+                {
+                    "id": "aggregate_intent",
+                    "type": "agent",
+                    "agent_type": "abm_agent",
+                    "action": "aggregate_intent",
+                }
+            ],
+        }
+    )
+    target_lint = lint_marketing_workflow(
+        {
+            "id": "wf_abm_target",
+            "domain": "marketing",
+            "mode": "target",
+            "steps": [
+                {
+                    "id": "aggregate_intent",
+                    "type": "agent",
+                    "agent_type": "abm_agent",
+                    "action": "aggregate_intent",
+                }
+            ],
+        }
+    )
+    contract = build_marketing_agent_contract_output(
+        "abm_agent",
+        "aggregate_intent",
+        result={"status": "degraded", "rationale": "ABM core agent is beta without production proof."},
+        workflow_mode="target",
+        audit_ref="audit-abm-target-contract",
+    )
+
+    assert _workflow_row(payload, "abm_sprint")["state"] == "promotion_blocked"
+    assert "Required ABM connector" in " ".join(_workflow_row(payload, "abm_sprint")["blocked_reasons"])
+    assert production_lint.has_errors is True
+    assert "marketing_agent_unavailable_for_production" not in {finding.code for finding in production_lint.errors}
+    assert "marketing_agent_beta_in_production" in {finding.code for finding in production_lint.warnings}
+    assert target_lint.has_errors is False
+    assert "marketing_agent_unavailable_target_only" not in {finding.code for finding in target_lint.warnings}
+    assert contract_has_required_shape(contract)
+    assert contract["maturity"] == "beta"
+    assert contract["production_ready"] is False
+    assert contract["external_write_confirmation_status"] == "not_required"
+
+
+def test_content_production_to_approval_to_publish_fails_closed_until_write_confirmed() -> None:
+    approval = _approval(
+        approval_id="apr-content-1",
+        workflow_id="content_pipeline",
+        workflow_run_id="run-content-1",
+        step_id="publish",
+        action="publish_to_wordpress",
+        approval_type="content_publish",
+        agent_type="content_factory",
+        connector_key="wordpress",
+        preview_payload={"title": "How AI agents improve marketing operations"},
+        before_after_diff={"before": "Draft only", "after": "Published WordPress post"},
+        brand_legal_risk_flags=["brand_claim"],
+        source_refs=[{"type": "content_brief", "id": "brief-content-1"}],
+        audit_refs=["audit-content-approval"],
+    )
+    payload = _operating_projection(
+        _with_workflow(
+            _base_configs(include_wordpress=True),
+            "content_pipeline",
+            _workflow_config(mode="active", promoted=True),
+        ),
+        source_data=_source_facts(),
+        approval_records=[approval],
+        report_types=("campaign_performance_ad_hoc",),
+    )
+    wordpress_contract = _contract(payload, "wordpress")
+    draft_contract = build_marketing_agent_contract_output(
+        "content_factory",
+        "create_draft",
+        result={
+            "status": "completed",
+            "confidence": 0.88,
+            "rationale": "Draft matches the campaign brief.",
+            "recommended_actions": ["Send draft to CMO approval."],
+            "audit_ref": "mkt_audit_content_draft",
+            "source_refs": [{"type": "content_brief", "id": "brief-content-1"}],
+            "external_write_confirmation_status": "not_required",
+        },
+        audit_ref="mkt_audit_content_draft",
+        workflow_mode="shadow",
+    )
+    publish_policy = evaluate_marketing_policy(
+        {
+            "workflow_id": "content_pipeline",
+            "workflow_mode": "active",
+            "action": "publish_to_wordpress",
+            "external_write_required": True,
+        }
+    )
+    unconfirmed_publish = evaluate_marketing_external_write_result(
+        [wordpress_contract],
+        connector_key="wordpress",
+        action="publish_to_wordpress",
+        workflow_mode="active",
+        step=_write_step(
+            agent_type="content_factory",
+            action="publish_to_wordpress",
+            connector_key="wordpress",
+        ),
+        state={
+            "id": "run-content-1",
+            "workflow_id": "content_pipeline",
+            "workflow_mode": "active",
+            "marketing_policy_approval_satisfied": True,
+        },
+        output={"external_write_state": "write_unconfirmed", "idempotency_key": IDEMPOTENCY_KEY},
+        now=NOW,
+    )
+    confirmed_publish = evaluate_marketing_external_write_result(
+        [wordpress_contract],
+        connector_key="wordpress",
+        action="publish_to_wordpress",
+        workflow_mode="active",
+        step=_write_step(
+            agent_type="content_factory",
+            action="publish_to_wordpress",
+            connector_key="wordpress",
+        ),
+        state={
+            "id": "run-content-1",
+            "workflow_id": "content_pipeline",
+            "workflow_mode": "active",
+            "marketing_policy_approval_satisfied": True,
+        },
+        output=_confirmed_write_output(
+            external_object_id="wp-post-4242",
+            source_url="https://www.agenticorg.ai/blog/ai-agents-marketing",
+        ),
+        now=NOW,
+    )
+    publish_contract = build_marketing_agent_contract_output(
+        "content_factory",
+        "publish_to_wordpress",
+        result={
+            "status": "completed",
+            "confidence": 0.86,
+            "rationale": "Publishing can complete only after confirmation.",
+            "recommended_actions": ["Publish after approval."],
+            "audit_ref": "mkt_audit_content_publish",
+            "source_refs": [{"connector_key": "wordpress", "object": "post"}],
+            "external_write_confirmation_status": "write_confirmed",
+        },
+        policy_result=publish_policy,
+        audit_ref="mkt_audit_content_publish",
+        workflow_mode="active",
+    )
+    lint = lint_marketing_workflow(
+        {
+            "id": "wf_content_publish_e2e",
+            "domain": "marketing",
+            "mode": "production",
+            "steps": [
+                _write_step(
+                    agent_type="content_factory",
+                    action="publish_to_wordpress",
+                    connector_key="wordpress",
+                )
+            ],
+        },
+        connector_contracts=[wordpress_contract],
+    )
+
+    assert _workflow_row(payload, "content_pipeline")["state"] in {"active", "promotion_ready"}
+    assert contract_has_required_shape(draft_contract)
+    assert draft_contract["maturity"] == "beta"
+    assert draft_contract["shadow_read_only"] is True
+    assert draft_contract["external_writes_completed"] is False
+    assert publish_policy["decision"] == "requires_approval"
+    assert payload["approval_review"]["cmo_approval_reviews"][0]["action_type"] == "content_publish"
+    assert "approve" in payload["approval_review"]["cmo_approval_reviews"][0]["allowed_reviewer_actions"]
+    assert wordpress_contract["write_safe"] is True
+    assert unconfirmed_publish["step_status"] == "failed"
+    assert unconfirmed_publish["final_state"] == "write_unconfirmed"
+    assert confirmed_publish["step_status"] == "completed"
+    assert confirmed_publish["final_state"] == "write_confirmed"
+    assert contract_has_required_shape(publish_contract)
+    assert publish_contract["external_writes_completed"] is True
+    assert lint.has_errors is False

--- a/tests/unit/test_cmo_escalation_matrix.py
+++ b/tests/unit/test_cmo_escalation_matrix.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from core.marketing.approval_timeouts import evaluate_approval_timeout
+from core.marketing.connector_retry_policy import (
+    build_degraded_mode_projection,
+    policy_projection,
+)
+from core.marketing.connector_setup import build_marketing_connector_setup
+from core.marketing.data_readiness import build_marketing_data_readiness
+from core.marketing.escalation_matrix import (
+    ESCALATION_TRIGGER_TYPES,
+    build_workflow_escalation_status,
+    default_marketing_escalation_matrix,
+    evaluate_marketing_escalation,
+)
+from core.marketing.external_writes import evaluate_marketing_external_write_result
+from core.marketing.policy_manifest import evaluate_marketing_policy
+from core.marketing.workflow_activation import build_cmo_workflow_activation
+from core.marketing.workflow_linter import lint_marketing_workflow
+
+NOW = datetime(2026, 5, 23, 12, 0, tzinfo=UTC)
+
+
+def test_default_escalation_matrix_loads_with_version_and_policy_ids() -> None:
+    matrix = default_marketing_escalation_matrix()
+
+    assert matrix["policy_id"] == "cmo_default_escalation_matrix"
+    assert matrix["version"] == "2026-05-23.cmo-6.2"
+    assert {route["trigger_type"] for route in matrix["routes"]} == set(ESCALATION_TRIGGER_TYPES)
+    assert all(route["audit_event_code"].startswith("cmo_escalation_") for route in matrix["routes"])
+
+
+def test_approval_timeout_escalates_to_configured_owner_chain_and_evidence() -> None:
+    decision = evaluate_approval_timeout(
+        {
+            "approval_id": "apr-1",
+            "workflow_id": "campaign_launch",
+            "workflow_run_id": "run-1",
+            "step_id": "launch",
+            "action": "launch_campaign",
+            "created_at": NOW - timedelta(hours=5),
+            "due_at": NOW - timedelta(hours=1),
+            "status": "pending",
+        },
+        now=NOW,
+    )
+
+    evidence = decision["escalation_evidence"]
+    assert decision["timed_out"] is True
+    assert decision["escalation_decision"]["trigger_type"] == "approval_timeout"
+    assert decision["escalation_decision"]["decision"] == "escalate"
+    assert evidence["owner_role"] == "cmo"
+    assert evidence["workflow_id"] == "campaign_launch"
+    assert evidence["workflow_run_id"] == "run-1"
+    assert evidence["step_id"] == "launch"
+    assert evidence["due_at"] == (NOW + timedelta(hours=1)).isoformat()
+    assert evidence["audit_reference"].startswith("mkt_escalation_")
+    assert decision["audit_evidence"]["escalation_evidence"] == evidence
+
+
+def test_crisis_public_response_escalates_to_cmo_ceo_and_legal_chain() -> None:
+    decision = evaluate_marketing_escalation(
+        {
+            "trigger_type": "crisis_public_response",
+            "workflow_id": "brand_crisis_response",
+            "step_id": "public_response",
+        },
+        now=NOW,
+    )
+
+    assert decision["decision"] == "escalate"
+    assert decision["severity"] == "critical"
+    assert decision["primary_owner_role"] == "cmo"
+    assert {"cmo", "ceo", "legal"}.issubset(set(decision["escalation_chain"]))
+
+
+def test_major_budget_threshold_routes_to_finance_owner() -> None:
+    decision = evaluate_marketing_escalation(
+        {
+            "trigger_type": "budget_threshold_exceeded",
+            "workflow_id": "daily_spend_optimization",
+            "action": "mutate_ad_budget",
+        },
+        now=NOW,
+    )
+
+    assert decision["decision"] == "escalate_to_finance"
+    assert "cfo" in decision["escalation_chain"]
+    assert decision["next_action_cta"] == "request_finance_budget_review"
+
+
+def test_connector_auth_failure_routes_to_admin_or_it_owner() -> None:
+    decision = evaluate_marketing_escalation(
+        {
+            "trigger_type": "connector_auth_expired",
+            "connector_key": "google_ads",
+            "failure_class": "auth_expired",
+        },
+        now=NOW,
+    )
+
+    assert decision["decision"] == "escalate_to_admin"
+    assert decision["primary_owner_role"] == "admin_it_owner"
+    assert "admin_it_owner" in decision["escalation_chain"]
+
+
+def test_data_mapping_and_backfill_failures_route_to_marketing_ops_revops() -> None:
+    mapping = evaluate_marketing_escalation({"trigger_type": "data_mapping_blocked"}, now=NOW)
+    backfill = evaluate_marketing_escalation({"trigger_type": "backfill_failed"}, now=NOW)
+
+    assert mapping["decision"] == "require_manual_resolution"
+    assert mapping["primary_owner_role"] == "marketing_ops"
+    assert "revops_lead" in mapping["escalation_chain"]
+    assert backfill["decision"] == "require_manual_resolution"
+    assert "admin_it_owner" in backfill["escalation_chain"]
+
+
+def test_missing_policy_requires_manual_resolution_or_owner_notification() -> None:
+    decision = evaluate_marketing_escalation(
+        {"trigger_type": "missing_policy", "workflow_id": "campaign_launch"},
+        now=NOW,
+    )
+
+    assert decision["decision"] == "require_manual_resolution"
+    assert decision["primary_owner_role"] == "policy_owner"
+    assert decision["fallback_outcome"] == "require_manual_resolution"
+
+
+def test_external_write_rejected_routes_to_workflow_owner_and_cmo() -> None:
+    decision = evaluate_marketing_external_write_result(
+        [_write_contract()],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="active",
+        output={
+            "external_write_state": "rejected",
+            "error": "Vendor rejected budget payload.",
+            "idempotency_key": "launch-1",
+            "approved": True,
+        },
+        step={"id": "launch", "idempotency_key": "launch-1"},
+        state={"workflow_id": "campaign_launch", "workflow_run_id": "run-1"},
+        now=NOW,
+    )
+
+    assert decision["step_status"] == "failed"
+    assert decision["escalation_decision"]["trigger_type"] == "external_write_rejected"
+    assert decision["escalation_evidence"]["owner_role"] == "workflow_owner"
+    assert "cmo" in decision["escalation_decision"]["escalation_chain"]
+
+
+def test_pricing_or_legal_claim_inserts_legal_compliance_reviewer() -> None:
+    escalation = evaluate_marketing_escalation(
+        {"trigger_type": "pricing_or_legal_claim", "action": "pricing_claim"},
+        now=NOW,
+    )
+    policy = evaluate_marketing_policy(
+        {
+            "workflow_id": "content_pipeline",
+            "workflow_mode": "active",
+            "action": "publish",
+            "pricing_claim": True,
+        }
+    )
+
+    assert escalation["decision"] == "escalate_to_legal"
+    assert escalation["primary_owner_role"] == "legal"
+    assert "compliance" in escalation["escalation_chain"]
+    assert policy["escalation_decision"]["trigger_type"] == "pricing_or_legal_claim"
+    assert policy["escalation_evidence"]["owner_role"] == "legal"
+
+
+def test_target_account_change_routes_to_cmo_and_growth_owner() -> None:
+    decision = evaluate_marketing_escalation(
+        {"trigger_type": "target_account_change", "workflow_id": "abm_sprint"},
+        now=NOW,
+    )
+
+    assert decision["decision"] == "escalate"
+    assert decision["primary_owner_role"] == "growth_lead"
+    assert "cmo" in decision["escalation_chain"]
+
+
+def test_connector_retry_and_data_readiness_expose_escalation_evidence() -> None:
+    degraded = build_degraded_mode_projection(
+        connector_key="google_ads",
+        connector_name="Google Ads",
+        category="Ads",
+        failure_class="auth_expired",
+        reason="OAuth token expired.",
+        policy=policy_projection("auth_expired"),
+        read_status="blocked",
+        write_status="blocked",
+        next_action_cta="reconnect",
+    )
+    readiness = build_marketing_data_readiness(
+        [
+            {
+                "key": "hubspot",
+                "name": "HubSpot",
+                "category": "CRM",
+                "configured_status": "configured",
+                "health_status": "expired_auth",
+                "detail": "OAuth token expired.",
+            }
+        ],
+        [],
+        now=NOW,
+    )
+
+    lifecycle = next(row for row in readiness["field_mapping_status"] if row["key"] == "lifecycle_stages")
+    backfill = next(row for row in readiness["backfill_status"] if row["source_connector_key"] == "hubspot")
+    assert degraded["escalation_decision"]["trigger_type"] == "connector_auth_expired"
+    assert degraded["escalation_evidence"]["owner_role"] == "admin_it_owner"
+    assert lifecycle["escalation_decision"]["trigger_type"] == "data_mapping_blocked"
+    assert lifecycle["escalation_evidence"]["owner_role"] == "marketing_ops"
+    assert backfill["escalation_decision"]["trigger_type"] == "backfill_failed"
+
+
+def test_workflow_activation_blocks_when_required_escalation_route_is_missing() -> None:
+    configs = _with_workflow(
+        _base_configs(),
+        "campaign_launch",
+        _workflow_config(marketing_escalation_matrix_disabled=True),
+    )
+    setup = build_marketing_connector_setup(configs, now=NOW)
+    readiness = build_marketing_data_readiness(setup, configs, now=NOW)
+    activation = build_cmo_workflow_activation(setup, readiness, configs, now=NOW)
+
+    campaign = next(
+        row
+        for row in activation["workflow_activation_status"]
+        if row["workflow_key"] == "campaign_launch"
+    )
+
+    assert campaign["state"] == "promotion_blocked"
+    assert campaign["next_action_cta"] == "configure_escalation_matrix"
+    assert campaign["escalation_matrix"]["status"] == "missing_route"
+    assert any("Escalation route is missing" in reason for reason in campaign["blocked_reasons"])
+
+
+def test_workflow_linter_flags_escalation_sensitive_production_step_without_route() -> None:
+    result = lint_marketing_workflow(
+        {
+            "id": "wf_campaign",
+            "domain": "marketing",
+            "mode": "production",
+            "steps": [
+                {
+                    "id": "launch",
+                    "type": "agent",
+                    "agent_type": "campaign_pilot",
+                    "action": "launch_campaign",
+                    "connector_key": "google_ads",
+                    "external_write_confirmation_required": True,
+                    "expected_confirmation_fields": ["external_object_id"],
+                    "idempotency_key": "launch-1",
+                    "marketing_escalation_matrix_disabled": True,
+                }
+            ],
+        },
+        connector_contracts=[_write_contract()],
+    )
+
+    assert result.has_errors is True
+    assert "marketing_escalation_route_missing" in {finding.code for finding in result.errors}
+
+
+def test_escalation_status_does_not_activate_unrelated_workflows() -> None:
+    campaign = build_workflow_escalation_status(
+        "campaign_launch",
+        ["launch_campaign"],
+        {"marketing_escalation_matrix_disabled": True},
+    )
+    weekly = build_workflow_escalation_status(
+        "weekly_marketing_report",
+        [],
+        {"marketing_escalation_matrix_disabled": True},
+    )
+
+    assert campaign["status"] == "missing_route"
+    assert campaign["next_action_cta"] == "configure_escalation_matrix"
+    assert weekly["status"] == "not_required"
+    assert weekly["next_action_cta"] == "none"
+
+
+def _connector_config(
+    connector_name: str,
+    *,
+    config: dict,
+    health_status: str = "healthy",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        connector_name=connector_name,
+        display_name=None,
+        auth_type="oauth2",
+        credentials_encrypted={"_encrypted": "enc"},
+        config=config,
+        status="configured",
+        last_health_check=NOW,
+        health_status=health_status,
+        last_sync_at=NOW - timedelta(hours=1),
+        sync_error=None,
+    )
+
+
+def _backfill() -> dict:
+    return {
+        "status": "completed",
+        "requested_start": "2025-05-01",
+        "requested_end": "2026-05-23",
+        "records_discovered": 100,
+        "records_imported": 100,
+        "records_skipped": 0,
+        "records_failed": 0,
+        "last_run_at": "2026-05-23T10:00:00+00:00",
+    }
+
+
+def _contract() -> dict:
+    return {
+        "idempotency_supported": True,
+        "retry_budget": {
+            "max_attempts": 3,
+            "attempts_used": 0,
+            "remaining_attempts": 3,
+            "idempotency_supported": True,
+            "idempotency_key": "mkt-setup-001",
+        },
+    }
+
+
+def _write_contract() -> dict:
+    return {
+        "connector_key": "google_ads",
+        "category": "Ads",
+        "read_ready": True,
+        "write_ready": True,
+        "write_safe": True,
+        "idempotency_key_supported": True,
+        "retry_budget": {
+            "idempotency_key": "launch-1",
+            "idempotency_supported": True,
+            "remaining_attempts": 2,
+        },
+    }
+
+
+def _base_configs() -> list[SimpleNamespace]:
+    updated_at = "2026-05-01T00:00:00+00:00"
+    hubspot_mapping = {
+        "lifecycle_stages": {
+            "source_field": "lifecyclestage",
+            "stage_map": {"mql": "marketingqualifiedlead", "sql": "salesqualifiedlead"},
+            "updated_at": updated_at,
+        },
+        "opportunity_revenue": {
+            "amount_field": "amount",
+            "close_date_field": "closedate",
+            "currency_field": "deal_currency_code",
+            "updated_at": updated_at,
+        },
+        "account_domains": {"domain_field": "website", "updated_at": updated_at},
+        "consent_unsubscribe": {
+            "consent_field": "marketing_opt_in",
+            "unsubscribe_field": "unsubscribed",
+            "updated_at": updated_at,
+        },
+        "fiscal_calendar": {"fiscal_year_start_month": 4, "updated_at": updated_at},
+        "currency": {"currency": "USD", "updated_at": updated_at},
+        "timezone": {"timezone": "Asia/Kolkata", "updated_at": updated_at},
+    }
+    campaign_mapping = {
+        "campaign_ids": {"campaign_id_field": "campaign_id", "updated_at": updated_at},
+        "utm_fields": {
+            "source": "utm_source",
+            "medium": "utm_medium",
+            "campaign": "utm_campaign",
+            "updated_at": updated_at,
+        },
+    }
+    mailchimp_mapping = {
+        **campaign_mapping,
+        "consent_unsubscribe": {
+            "consent_field": "marketing_permission",
+            "unsubscribe_field": "unsubscribe_status",
+            "updated_at": updated_at,
+        },
+    }
+    return [
+        _connector_config(
+            "hubspot",
+            config={
+                "owner": "revops@example.com",
+                "account_id": "portal-123",
+                "granted_scopes": [
+                    "crm.objects.contacts.read",
+                    "crm.objects.deals.read",
+                    "automation",
+                ],
+                "marketing_field_mapping": hubspot_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        ),
+        _connector_config(
+            "google_ads",
+            config={
+                "owner": "growth@example.com",
+                "customer_id": "123-456-7890",
+                "granted_scopes": ["https://www.googleapis.com/auth/adwords"],
+                "marketing_field_mapping": campaign_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        ),
+        _connector_config(
+            "ga4",
+            config={
+                "owner": "analytics@example.com",
+                "property_id": "properties/123",
+                "granted_scopes": ["https://www.googleapis.com/auth/analytics.readonly"],
+                "marketing_field_mapping": campaign_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": {"retry_budget": {"remaining_attempts": 3}},
+            },
+        ),
+        _connector_config(
+            "mailchimp",
+            config={
+                "owner": "email@example.com",
+                "audience_id": "aud-1",
+                "marketing_field_mapping": mailchimp_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        ),
+    ]
+
+
+def _workflow_config(**overrides: object) -> dict:
+    payload = {
+        "mode": "shadow",
+        "promoted": False,
+        "approval_owner": "cmo@example.com",
+        "policy_owner": "legal@example.com",
+        "shadow_quality": {
+            "status": "passed",
+            "sample_count": 5,
+            "success_rate": 0.95,
+            "last_run_at": "2026-05-23T09:00:00+00:00",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _with_workflow(
+    configs: list[SimpleNamespace],
+    workflow_key: str,
+    payload: dict,
+) -> list[SimpleNamespace]:
+    configs = deepcopy(configs)
+    workflows = configs[0].config.setdefault("marketing_workflows", {})
+    workflows[workflow_key] = payload
+    return configs

--- a/tests/unit/test_cmo_external_write_completion.py
+++ b/tests/unit/test_cmo_external_write_completion.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import pytest
+
+
+def _contract(
+    *,
+    idempotency_supported: bool = True,
+    remaining_attempts: int = 2,
+    next_retry_at: str = "2026-05-23T12:05:00+00:00",
+    confirmations: list[dict] | None = None,
+) -> dict:
+    return {
+        "connector_key": "google_ads",
+        "idempotency_key_supported": idempotency_supported,
+        "retry_budget": {
+            "max_attempts": 3,
+            "attempts_used": 1,
+            "remaining_attempts": remaining_attempts,
+            "next_retry_at": next_retry_at,
+            "idempotency_key": "ads-launch-1",
+        },
+        "external_write_confirmations": confirmations or [],
+    }
+
+
+def _active_state(**overrides: object) -> dict:
+    state = {
+        "id": "wfr_cmo_write",
+        "tenant_id": "tenant-1",
+        "workflow_id": "campaign_launch",
+        "workflow_mode": "active",
+        "domain": "marketing",
+        "connector_contracts": [_contract()],
+        "marketing_policy_approval_satisfied": True,
+    }
+    state.update(overrides)
+    return state
+
+
+def _write_step(**overrides: object) -> dict:
+    step = {
+        "id": "launch_ads",
+        "type": "agent",
+        "agent_type": "campaign_pilot",
+        "action": "launch_campaign",
+        "connector_key": "google_ads",
+        "external_write_required": True,
+        "idempotency_key": "ads-launch-1",
+        "inputs": {"campaign_name": "Spring launch", "budget": 5000},
+    }
+    step.update(overrides)
+    return step
+
+
+def _patch_workflow_agent(monkeypatch: pytest.MonkeyPatch, output: dict) -> None:
+    from core.agents.registry import AgentRegistry
+    from core.schemas.messages import TaskResult
+    from workflows import step_types
+
+    monkeypatch.setattr(step_types.settings, "env", "production")
+    monkeypatch.setattr(step_types.external_keys, "google_gemini_api_key", "test-key")
+    monkeypatch.setattr(step_types, "_llm_available_for_workflow", lambda: True)
+
+    class FakeAgent:
+        async def execute(self, task):
+            return TaskResult(
+                message_id="msg-test",
+                correlation_id=task.correlation_id,
+                workflow_run_id=task.workflow_run_id,
+                step_id=task.step_id,
+                agent_id=task.target_agent.agent_id,
+                status="completed",
+                output=output,
+                confidence=0.95,
+            )
+
+    monkeypatch.setattr(
+        AgentRegistry,
+        "create_from_config",
+        staticmethod(lambda config: FakeAgent()),
+    )
+
+
+async def _run_marketing_write(
+    monkeypatch: pytest.MonkeyPatch,
+    output: dict,
+    *,
+    step: dict | None = None,
+    state: dict | None = None,
+) -> dict:
+    from workflows.step_types import execute_step
+
+    _patch_workflow_agent(monkeypatch, output)
+    return await execute_step(step or _write_step(), state or _active_state())
+
+
+def _event_types(result: dict) -> list[str]:
+    return [
+        event["event_type"]
+        for event in result["output"].get("external_write_audit", [])
+    ]
+
+
+@pytest.mark.asyncio
+async def test_accepted_connector_write_with_external_object_id_becomes_confirmed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = await _run_marketing_write(
+        monkeypatch,
+        {
+            "external_write_state": "accepted",
+            "external_object_id": "customers/123/campaigns/456",
+            "source_url": "https://ads.google.com/campaigns/456",
+            "idempotency_key": "ads-launch-1",
+            "request_fingerprint": "fp-launch-1",
+        },
+    )
+
+    assert result["status"] == "completed"
+    assert result["output"]["external_write_state"] == "write_confirmed"
+    confirmation = result["output"]["external_write_confirmation"]
+    assert confirmation["connector_key"] == "google_ads"
+    assert confirmation["external_object_id"] == "customers/123/campaigns/456"
+    assert confirmation["source_url"] == "https://ads.google.com/campaigns/456"
+    assert confirmation["idempotency_key"] == "ads-launch-1"
+    assert confirmation["request_fingerprint"] == "fp-launch-1"
+    assert confirmation["workflow_run_id"] == "wfr_cmo_write"
+    assert confirmation["audit_reference"].startswith("mkt_write_")
+    assert _event_types(result) == [
+        "marketing_external_write_attempted",
+        "marketing_external_write_write_confirmed",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_active_external_write_requires_marketing_policy_approval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = await _run_marketing_write(
+        monkeypatch,
+        {
+            "external_write_state": "accepted",
+            "external_object_id": "customers/123/campaigns/456",
+            "idempotency_key": "ads-launch-1",
+        },
+        state=_active_state(marketing_policy_approval_satisfied=False),
+    )
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "external_write_marketing_policy_approval_required"
+    assert result["output"]["marketing_policy_decision"]["decision"] == "requires_approval"
+
+
+@pytest.mark.asyncio
+async def test_rejected_connector_write_does_not_complete_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = await _run_marketing_write(
+        monkeypatch,
+        {
+            "external_write_state": "rejected",
+            "rejection_reason": "Budget cap exceeded",
+            "next_action": "request_budget_approval",
+            "idempotency_key": "ads-launch-1",
+        },
+    )
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "external_write_rejected"
+    assert result["error"]["details"]["final_state"] == "rejected"
+    assert result["error"]["details"]["next_action"] == "request_budget_approval"
+    assert "Budget cap exceeded" in result["error"]["details"]["reason"]
+    assert _event_types(result) == [
+        "marketing_external_write_attempted",
+        "marketing_external_write_rejected",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_timeout_unknown_without_idempotency_does_not_complete_active_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = await _run_marketing_write(
+        monkeypatch,
+        {
+            "external_write_state": "timeout_unknown",
+            "request_fingerprint": "fp-timeout-1",
+        },
+        step=_write_step(idempotency_key=None),
+        state=_active_state(connector_contracts=[_contract(idempotency_supported=False)]),
+    )
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "external_write_timeout_unknown"
+    assert result["error"]["details"]["next_action"] == "manual_reconcile_before_retry"
+    assert result["output"]["external_write_state"] == "timeout_unknown"
+    assert _event_types(result)[-1] == "marketing_external_write_timeout_unknown"
+
+
+@pytest.mark.asyncio
+async def test_retry_without_idempotency_metadata_is_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = await _run_marketing_write(
+        monkeypatch,
+        {"external_write_state": "retry_scheduled"},
+        step=_write_step(idempotency_key=None),
+        state=_active_state(connector_contracts=[_contract(idempotency_supported=False)]),
+    )
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "external_write_retry_blocked"
+    assert result["output"]["external_write_next_action"] == "manual_reconcile_before_retry"
+
+
+@pytest.mark.asyncio
+async def test_retry_with_idempotency_metadata_is_scheduled_safely(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = await _run_marketing_write(
+        monkeypatch,
+        {
+            "external_write_state": "timeout_unknown",
+            "idempotency_key": "ads-launch-1",
+            "request_fingerprint": "fp-timeout-2",
+        },
+    )
+
+    assert result["status"] == "waiting_delay"
+    assert result["resume_at"] == "2026-05-23T12:05:00+00:00"
+    assert result["output"]["external_write_state"] == "retry_scheduled"
+    assert result["output"]["external_write_retry_plan"]["safe_to_retry"] is True
+    assert result["output"]["external_write_retry_plan"]["duplicate_policy"] == "reuse_idempotency_key"
+    assert _event_types(result)[-1] == "marketing_external_write_retry_scheduled"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_retry_recovers_existing_confirmed_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = await _run_marketing_write(
+        monkeypatch,
+        {
+            "external_write_state": "timeout_unknown",
+            "idempotency_key": "ads-launch-1",
+            "request_fingerprint": "fp-timeout-recovered",
+        },
+        state=_active_state(
+            connector_contracts=[
+                _contract(
+                    confirmations=[
+                        {
+                            "action": "launch_campaign",
+                            "status": "write_confirmed",
+                            "idempotency_key": "ads-launch-1",
+                            "external_object_id": "customers/123/campaigns/456",
+                            "source_url": "https://ads.google.com/campaigns/456",
+                            "confirmed_at": "2026-05-23T12:01:00+00:00",
+                        }
+                    ],
+                )
+            ]
+        ),
+    )
+
+    assert result["status"] == "completed"
+    assert result["output"]["external_write_state"] == "idempotent_recovered"
+    confirmation = result["output"]["external_write_confirmation"]
+    assert confirmation["external_object_id"] == "customers/123/campaigns/456"
+    assert confirmation["idempotency_key"] == "ads-launch-1"
+    assert _event_types(result)[-1] == "marketing_external_write_idempotent_recovered"
+
+
+@pytest.mark.asyncio
+async def test_draft_created_can_complete_only_as_draft_or_internal_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    draft_output = {
+        "external_write_state": "draft_created",
+        "draft_id": "draft-123",
+        "idempotency_key": "ads-launch-1",
+    }
+
+    internal = await _run_marketing_write(
+        monkeypatch,
+        draft_output,
+        state=_active_state(workflow_mode="internal"),
+    )
+    assert internal["status"] == "completed"
+    assert internal["output"]["external_write_state"] == "draft_created"
+
+    active = await _run_marketing_write(monkeypatch, draft_output)
+    assert active["status"] == "failed"
+    assert active["error"]["code"] == "external_write_draft_only"
+    assert active["output"]["external_write_next_action"] == "promote_draft_or_mark_step_internal"
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_rejects_external_write_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = await _run_marketing_write(
+        monkeypatch,
+        {
+            "external_write_state": "write_confirmed",
+            "external_object_id": "customers/123/campaigns/456",
+            "idempotency_key": "ads-launch-1",
+        },
+        state=_active_state(workflow_mode="shadow"),
+    )
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "external_write_shadow_violation"
+    assert result["error"]["details"]["next_action"] == "remove_external_write_from_shadow_step"
+
+
+@pytest.mark.asyncio
+async def test_shadow_only_recommendation_can_complete_without_external_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = await _run_marketing_write(
+        monkeypatch,
+        {"recommendation": "Keep campaign in draft until CMO approves."},
+        state=_active_state(workflow_mode="shadow"),
+    )
+
+    assert result["status"] == "completed"
+    assert result["output"]["external_write_state"] == "shadow_only"
+    assert _event_types(result)[-1] == "marketing_external_write_shadow_only"
+
+
+@pytest.mark.asyncio
+async def test_active_launch_step_cannot_complete_with_write_unconfirmed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = await _run_marketing_write(
+        monkeypatch,
+        {
+            "external_write_state": "write_unconfirmed",
+            "idempotency_key": "ads-launch-1",
+        },
+    )
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "external_write_confirmation_missing"
+    assert result["error"]["details"]["final_state"] == "write_unconfirmed"
+    assert result["output"]["external_write_audit_reference"].startswith("mkt_write_")

--- a/tests/unit/test_cmo_kpi_drilldown.py
+++ b/tests/unit/test_cmo_kpi_drilldown.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from api.v1 import kpis as kpis_api
+from core.marketing.kpi_drilldown import build_cmo_kpi_drilldown_projection
+from core.marketing.kpi_schema import build_unified_cmo_kpi_projection
+from core.marketing.report_quality import build_cmo_report_quality_projection
+from core.marketing.work_queue import build_cmo_work_queue_projection
+
+NOW = datetime(2026, 5, 23, 12, 0, tzinfo=UTC)
+FRESH_TS = (NOW - timedelta(hours=1)).isoformat()
+STALE_TS = (NOW - timedelta(days=3)).isoformat()
+
+ALL_CONNECTOR_CATEGORIES = (
+    "CRM",
+    "Ads",
+    "Analytics",
+    "CMS",
+    "Email",
+    "Brand",
+    "ABM",
+    "Finance",
+)
+ALL_MAPPING_KEYS = (
+    "lifecycle_stages",
+    "opportunity_revenue",
+    "campaign_ids",
+    "utm_fields",
+    "account_domains",
+    "consent_unsubscribe",
+    "fiscal_calendar",
+    "currency",
+    "timezone",
+)
+
+
+def _setup_rows(
+    *,
+    categories: tuple[str, ...] = ALL_CONNECTOR_CATEGORIES,
+    health_overrides: dict[str, str] | None = None,
+) -> list[dict]:
+    health_overrides = health_overrides or {}
+    return [
+        {
+            "key": category.lower(),
+            "name": f"{category} connector",
+            "category": category,
+            "configured_status": "configured",
+            "health_status": health_overrides.get(category, "healthy"),
+            "last_sync_at": FRESH_TS,
+            "account_id": f"{category.lower()}-acct",
+        }
+        for category in categories
+    ]
+
+
+def _contract_rows(
+    *,
+    categories: tuple[str, ...] = ALL_CONNECTOR_CATEGORIES,
+    mock: bool = False,
+) -> list[dict]:
+    return [
+        {
+            "connector_key": category.lower(),
+            "category": category,
+            "configured_status": "configured",
+            "read_ready": True,
+            "read_status": "ready",
+            "write_status": "ready",
+            "health_status": "healthy",
+            "contract_state": "healthy",
+            "blocks_production_kpi_confidence": False,
+            "mock_or_test_double": mock,
+            "degraded_mode": {"status": "none", "confidence_impact": 0.0},
+        }
+        for category in categories
+    ]
+
+
+def _data_readiness(
+    *,
+    mapping_overrides: dict[str, str] | None = None,
+    backfill_overrides: dict[str, str] | None = None,
+    categories: tuple[str, ...] = ALL_CONNECTOR_CATEGORIES,
+) -> dict:
+    mapping_overrides = mapping_overrides or {}
+    backfill_overrides = backfill_overrides or {}
+    return {
+        "field_mapping_status": [
+            {
+                "key": key,
+                "name": key.replace("_", " ").title(),
+                "status": mapping_overrides.get(key, "valid"),
+                "sources": ["hubspot"],
+                "decision_audit_ref": f"audit-mapping-{key}",
+            }
+            for key in ALL_MAPPING_KEYS
+        ],
+        "backfill_status": [
+            {
+                "source_connector_key": category.lower(),
+                "source_name": f"{category} connector",
+                "category": category,
+                "status": backfill_overrides.get(category, "completed"),
+                "last_run_at": FRESH_TS,
+                "decision_audit_ref": f"audit-backfill-{category.lower()}",
+            }
+            for category in categories
+        ],
+        "kpi_readiness": {"status": "ready"},
+    }
+
+
+def _source_facts(**overrides: object) -> dict:
+    facts = {
+        "last_updated_at": FRESH_TS,
+        "total_marketing_spend": 1_000.0,
+        "ad_spend": 1_000.0,
+        "campaign_spend_by_channel": {"google": 600.0, "linkedin": 250.0, "meta": 150.0},
+        "new_customers": 10,
+        "lifecycle_stage_counts": {
+            "visitor": 1_000,
+            "lead": 250,
+            "mql": 100,
+            "sql": 40,
+            "opportunity": 20,
+            "customer": 10,
+        },
+        "ad_platform_conversions": 100,
+        "crm_campaign_attributed_mqls": 100,
+        "ga4_conversion_events": 250,
+        "crm_leads_created": 250,
+        "attributed_revenue": 5_000.0,
+        "opportunities": [{"amount": 2_500.0, "id": "opp-1"}, {"amount": 1_500.0, "id": "opp-2"}],
+        "customer_ltv": 2_000.0,
+        "completed_experiments": 6,
+        "period_days": 30,
+        "content_sessions": 1_000,
+        "content_conversions": 50,
+        "wordpress_content_sessions": 1_000,
+        "ga4_content_sessions": 1_000,
+        "emails_sent": 2_000,
+        "emails_opened": 900,
+        "emails_clicked": 300,
+        "emails_unsubscribed": 20,
+        "crm_email_sends": 2_000,
+        "crm_email_clicks": 300,
+        "crm_unsubscribed_contacts": 20,
+        "brand_positive_mentions": 70,
+        "brand_negative_mentions": 10,
+        "brand_neutral_mentions": 20,
+        "intent_ready_accounts": 25,
+        "target_accounts": 100,
+        "abm_target_account_domains": ["alpha.example", "beta.example"],
+        "crm_account_domains": ["alpha.example", "beta.example"],
+        "intent_account_domains": ["alpha.example", "beta.example"],
+        "source_currencies": {"ads": "USD", "crm": "USD", "finance": "USD"},
+        "source_timezones": {
+            "ads": "Asia/Kolkata",
+            "crm": "Asia/Kolkata",
+            "analytics": "Asia/Kolkata",
+            "email": "Asia/Kolkata",
+        },
+        "source_refs": [{"connector_key": "hubspot", "object": "deals"}],
+        "audit_refs": ["audit-kpi-source"],
+    }
+    facts.update(overrides)
+    return facts
+
+
+def _workflow_activation() -> dict:
+    return {
+        "workflow_activation_status": [
+            {"workflow_key": "weekly_marketing_report", "state": "active"},
+            {"workflow_key": "daily_spend_optimization", "state": "active"},
+        ],
+        "workflow_activation_summary": {"readiness": "ready"},
+    }
+
+
+def _full_projection(
+    facts: dict | None = None,
+    *,
+    setup_rows: list[dict] | None = None,
+    contract_rows: list[dict] | None = None,
+    data_readiness: dict | None = None,
+    source_context: dict | None = None,
+) -> dict:
+    facts = facts or _source_facts()
+    setup = setup_rows or _setup_rows()
+    contracts = contract_rows or _contract_rows()
+    readiness = data_readiness or _data_readiness()
+    unified = build_unified_cmo_kpi_projection(
+        connector_setup=setup,
+        connector_contracts=contracts,
+        data_readiness=readiness,
+        source_data=facts,
+        now=NOW,
+    )
+    report_quality = build_cmo_report_quality_projection(
+        kpi_results=unified["unified_cmo_kpi_results"],
+        reconciliation_checks=unified["cmo_kpi_reconciliation_checks"],
+        connector_setup=setup,
+        connector_contracts=contracts,
+        data_readiness=readiness,
+        workflow_activation=_workflow_activation(),
+        source_context=source_context or {"demo": False, "source": "computed"},
+        now=NOW,
+    )
+    work_queue = build_cmo_work_queue_projection(
+        kpi_results=unified["unified_cmo_kpi_results"],
+        reconciliation_checks=unified["cmo_kpi_reconciliation_checks"],
+        report_quality_gates=report_quality["report_quality_gates"],
+        connector_setup=setup,
+        connector_contracts=contracts,
+        data_readiness=readiness,
+        source_context=source_context or {"demo": False, "source": "computed"},
+        now=NOW,
+    )
+    drilldown = build_cmo_kpi_drilldown_projection(
+        kpi_schema=unified["unified_cmo_kpi_schema"],
+        kpi_results=unified["unified_cmo_kpi_results"],
+        reconciliation_checks=unified["cmo_kpi_reconciliation_checks"],
+        connector_setup=setup,
+        connector_contracts=contracts,
+        data_readiness=readiness,
+        work_queue=work_queue["cmo_work_queue"],
+        report_quality_gates=report_quality["report_quality_gates"],
+        source_data=facts,
+        source_context=source_context or {"demo": False, "source": "computed"},
+        now=NOW,
+    )
+    return {**unified, **report_quality, **work_queue, **drilldown}
+
+
+def _drilldown(projection: dict, key: str) -> dict:
+    return next(item for item in projection["cmo_kpi_drilldowns"] if item["kpi_key"] == key)
+
+
+def _input(drilldown: dict, name: str) -> dict:
+    return next(item for item in drilldown["formula_inputs"] if item["name"] == name)
+
+
+def test_cac_drilldown_includes_formula_inputs_sources_confidence_and_cta() -> None:
+    projection = _full_projection()
+    cac = _drilldown(projection, "cac")
+
+    assert cac["formula"] == "total_marketing_spend / new_customers"
+    assert _input(cac, "total_marketing_spend")["value"] == 1_000.0
+    assert _input(cac, "new_customers")["value"] == 10
+    assert any(ref.get("connector_key") == "hubspot" for ref in cac["source_refs"])
+    assert any(ref.get("category") == "Ads" for ref in cac["connector_refs"])
+    assert cac["confidence"] > 0.9
+    assert cac["next_action_cta"]["action_key"] == "none"
+
+
+def test_mql_and_sql_drilldowns_include_lifecycle_mapping_and_crm_refs() -> None:
+    projection = _full_projection()
+    mql = _drilldown(projection, "mql")
+    sql = _drilldown(projection, "sql")
+
+    assert _input(mql, "mql_count")["value"] == 100
+    assert _input(sql, "sql_count")["value"] == 40
+    assert any(row["key"] == "lifecycle_stages" for row in mql["field_mappings_used"])
+    assert any(ref.get("category") == "CRM" for ref in mql["connector_refs"])
+
+
+def test_mql_to_sql_drilldown_handles_zero_denominator_and_explains_degraded_state() -> None:
+    projection = _full_projection(_source_facts(lifecycle_stage_counts={"mql": 0, "sql": 0}))
+    conversion = _drilldown(projection, "mql_to_sql_conversion_rate")
+
+    assert conversion["status"] == "degraded"
+    assert conversion["value"] == 0.0
+    assert any("Zero denominator" in reason for reason in conversion["confidence_impact_reasons"])
+    assert _input(conversion, "mql_count")["value"] == 0
+
+
+def test_roas_drilldown_includes_revenue_spend_inputs_and_reconciliation_refs() -> None:
+    projection = _full_projection(_source_facts(campaign_spend_by_channel={"google": 1_300.0}))
+    roas = _drilldown(projection, "roas")
+
+    assert _input(roas, "attributed_revenue")["value"] == 5_000.0
+    assert _input(roas, "ad_spend")["value"] == 1_000.0
+    assert any(check["reconciliation_key"] == "paid_spend_totals_by_channel" for check in roas["reconciliation_checks"])
+    assert any(ref.startswith("cmo_decision_audit") for ref in roas["audit_refs"])
+
+
+def test_pipeline_contribution_drilldown_includes_opportunity_mapping_and_refs() -> None:
+    projection = _full_projection()
+    pipeline = _drilldown(projection, "pipeline_contribution")
+
+    assert pipeline["value"] == 4_000.0
+    assert _input(pipeline, "pipeline_contribution")["value"] == 4_000.0
+    assert any(row["key"] == "opportunity_revenue" for row in pipeline["field_mappings_used"])
+    assert any(row["category"] == "CRM" for row in pipeline["backfill_state"])
+
+
+def test_stale_source_data_appears_in_freshness_and_confidence_reasons() -> None:
+    projection = _full_projection(_source_facts(last_updated_at=STALE_TS))
+    roas = _drilldown(projection, "roas")
+
+    assert roas["status"] == "degraded"
+    assert roas["freshness_status"] == "stale"
+    assert any("stale" in reason.lower() for reason in roas["confidence_impact_reasons"])
+    assert roas["next_action_cta"]["action_key"] == "refresh_source_data"
+
+
+def test_missing_mapping_and_backfill_appear_as_blockers_with_cta() -> None:
+    readiness = _data_readiness(
+        mapping_overrides={"opportunity_revenue": "unmapped"},
+        backfill_overrides={"Ads": "failed"},
+    )
+    projection = _full_projection(data_readiness=readiness)
+    cac = _drilldown(projection, "cac")
+
+    assert cac["status"] == "blocked"
+    assert "opportunity_revenue" in cac["missing_requirements"]["field_mappings"]
+    assert "Ads" in cac["missing_requirements"]["backfills"]
+    assert cac["next_action_cta"]["action_key"] == "fix_required_mapping"
+    assert any(row["status"] == "unmapped" for row in cac["field_mappings_used"])
+
+
+def test_related_work_queue_and_report_gate_refs_appear_when_applicable() -> None:
+    projection = _full_projection(_source_facts(campaign_spend_by_channel={"google": 1_300.0}))
+    cac = _drilldown(projection, "cac")
+
+    assert any(item_id.startswith("cmo_wq_") for item_id in cac["related_work_queue_item_ids"])
+    assert "weekly_marketing_report" in cac["related_report_gate_ids"]
+
+
+@pytest.mark.parametrize(
+    "kpi_key",
+    [
+        "cac",
+        "mql",
+        "sql",
+        "mql_to_sql_conversion_rate",
+        "roas",
+        "pipeline_contribution",
+        "experiment_velocity",
+        "content_performance",
+        "email_performance",
+        "brand_sentiment",
+        "abm_intent_account_readiness",
+    ],
+)
+def test_required_core_drilldowns_are_present(kpi_key: str) -> None:
+    projection = _full_projection()
+
+    assert _drilldown(projection, kpi_key)["drilldown_id"] == f"cmo_kpi_drilldown:{kpi_key}"
+
+
+@pytest.mark.asyncio
+async def test_kpis_cmo_response_exposes_kpi_drilldowns(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_base(tenant_id: str, role: str, company_id: str) -> dict:
+        return {
+            "demo": False,
+            "stale": False,
+            "source": "computed",
+            "company_id": company_id,
+            "agent_count": 0,
+            "total_tasks_30d": 0,
+        }
+
+    async def fake_configs(tenant_id: str) -> list:
+        return []
+
+    async def fake_approval_timeout(tenant_id: str, company_id: str) -> dict:
+        return {"pending": 0, "overdue": 0, "approval_timeout_decisions": []}
+
+    monkeypatch.setattr(kpis_api, "_build_kpi_response", fake_base)
+    monkeypatch.setattr(kpis_api, "_load_marketing_connector_configs", fake_configs)
+    monkeypatch.setattr(kpis_api, "_load_cmo_approval_timeout_risk", fake_approval_timeout)
+
+    response = await kpis_api._build_cmo_kpi_response("tenant-1", "company-1")
+
+    assert "cmo_kpi_drilldowns" in response
+    assert "cmo_kpi_drilldown_summary" in response
+    assert response["cmo_kpi_drilldown_summary"]["total"] >= 11
+
+
+def test_drilldown_does_not_claim_demo_or_mock_lineage_as_production_proof() -> None:
+    projection = _full_projection(
+        _source_facts(source="sample"),
+        contract_rows=_contract_rows(mock=True),
+        source_context={"demo": True, "source": "demo"},
+    )
+    cac = _drilldown(projection, "cac")
+
+    assert cac["production_lineage_ready"] is False
+    assert cac["production_lineage_status"] == "blocked"
+    assert cac["source_refs"] == []
+    assert "real_production_lineage" in cac["missing_requirements"]["source_data"]
+    assert cac["next_action_cta"]["action_key"] == "connect_real_marketing_sources"

--- a/tests/unit/test_cmo_kpi_reconciliation.py
+++ b/tests/unit/test_cmo_kpi_reconciliation.py
@@ -1,0 +1,400 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from api.v1 import kpis as kpis_api
+from core.marketing.kpi_schema import build_unified_cmo_kpi_projection
+
+NOW = datetime(2026, 5, 23, 12, 0, tzinfo=UTC)
+FRESH_TS = (NOW - timedelta(hours=1)).isoformat()
+
+ALL_CONNECTOR_CATEGORIES = (
+    "CRM",
+    "Ads",
+    "Analytics",
+    "CMS",
+    "Email",
+    "Brand",
+    "ABM",
+    "Finance",
+)
+ALL_MAPPING_KEYS = (
+    "lifecycle_stages",
+    "opportunity_revenue",
+    "campaign_ids",
+    "utm_fields",
+    "account_domains",
+    "consent_unsubscribe",
+    "fiscal_calendar",
+    "currency",
+    "timezone",
+)
+
+
+def _setup_rows(
+    *,
+    categories: tuple[str, ...] = ALL_CONNECTOR_CATEGORIES,
+    health_overrides: dict[str, str] | None = None,
+) -> list[dict]:
+    health_overrides = health_overrides or {}
+    return [
+        {
+            "key": category.lower(),
+            "name": f"{category} connector",
+            "category": category,
+            "configured_status": "configured",
+            "health_status": health_overrides.get(category, "healthy"),
+            "last_sync_at": FRESH_TS,
+        }
+        for category in categories
+    ]
+
+
+def _contract_rows(
+    *,
+    categories: tuple[str, ...] = ALL_CONNECTOR_CATEGORIES,
+    failure_overrides: dict[str, str] | None = None,
+) -> list[dict]:
+    failure_overrides = failure_overrides or {}
+    rows = []
+    for category in categories:
+        failure = failure_overrides.get(category)
+        rows.append(
+            {
+                "connector_key": category.lower(),
+                "category": category,
+                "configured_status": "configured",
+                "read_ready": True,
+                "read_status": "ready",
+                "failure_class": failure,
+                "blocks_production_kpi_confidence": False,
+                "degraded_mode": {
+                    "status": "degraded" if failure == "partial_data" else "none",
+                    "confidence_impact": 0.15 if failure == "partial_data" else 0.0,
+                },
+            }
+        )
+    return rows
+
+
+def _data_readiness(categories: tuple[str, ...] = ALL_CONNECTOR_CATEGORIES) -> dict:
+    return {
+        "field_mapping_status": [
+            {
+                "key": key,
+                "name": key.replace("_", " ").title(),
+                "status": "valid",
+                "decision_audit_ref": f"audit-mapping-{key}",
+            }
+            for key in ALL_MAPPING_KEYS
+        ],
+        "backfill_status": [
+            {
+                "source_connector_key": category.lower(),
+                "source_name": f"{category} connector",
+                "category": category,
+                "status": "completed",
+                "decision_audit_ref": f"audit-backfill-{category.lower()}",
+            }
+            for category in categories
+        ],
+        "kpi_readiness": {"status": "ready"},
+    }
+
+
+def _source_facts(**overrides: object) -> dict:
+    facts = {
+        "last_updated_at": FRESH_TS,
+        "total_marketing_spend": 1_000.0,
+        "ad_spend": 1_000.0,
+        "campaign_spend_by_channel": {
+            "google": 600.0,
+            "linkedin": 250.0,
+            "meta": 150.0,
+        },
+        "new_customers": 10,
+        "lifecycle_stage_counts": {
+            "visitor": 1_000,
+            "lead": 250,
+            "mql": 100,
+            "sql": 40,
+            "opportunity": 20,
+            "customer": 10,
+        },
+        "ad_platform_conversions": 100,
+        "crm_campaign_attributed_mqls": 100,
+        "ga4_conversion_events": 250,
+        "crm_leads_created": 250,
+        "attributed_revenue": 5_000.0,
+        "opportunities": [{"amount": 2_500.0}, {"amount": 1_500.0}],
+        "customer_ltv": 2_000.0,
+        "completed_experiments": 6,
+        "period_days": 30,
+        "content_sessions": 1_000,
+        "content_conversions": 50,
+        "wordpress_content_sessions": 1_000,
+        "ga4_content_sessions": 1_000,
+        "emails_sent": 2_000,
+        "emails_opened": 900,
+        "emails_clicked": 300,
+        "emails_unsubscribed": 20,
+        "crm_email_sends": 2_000,
+        "crm_email_clicks": 300,
+        "crm_unsubscribed_contacts": 20,
+        "brand_positive_mentions": 70,
+        "brand_negative_mentions": 10,
+        "brand_neutral_mentions": 20,
+        "intent_ready_accounts": 25,
+        "target_accounts": 100,
+        "abm_target_account_domains": ["alpha.example", "beta.example"],
+        "crm_account_domains": ["alpha.example", "beta.example"],
+        "intent_account_domains": ["alpha.example", "beta.example"],
+        "source_currencies": {
+            "ads": "USD",
+            "crm": "USD",
+            "finance": "USD",
+        },
+        "source_timezones": {
+            "ads": "Asia/Kolkata",
+            "crm": "Asia/Kolkata",
+            "analytics": "Asia/Kolkata",
+            "email": "Asia/Kolkata",
+        },
+        "source_refs": [{"connector_key": "hubspot", "object": "deals"}],
+        "audit_refs": ["audit-kpi-source"],
+    }
+    facts.update(overrides)
+    return facts
+
+
+def _projection(
+    facts: dict | None = None,
+    *,
+    setup_rows: list[dict] | None = None,
+    contract_rows: list[dict] | None = None,
+) -> dict:
+    return build_unified_cmo_kpi_projection(
+        connector_setup=setup_rows or _setup_rows(),
+        connector_contracts=contract_rows or _contract_rows(),
+        data_readiness=_data_readiness(),
+        source_data=facts or _source_facts(),
+        now=NOW,
+    )
+
+
+def _check(projection: dict, key: str) -> dict:
+    return next(
+        item
+        for item in projection["cmo_kpi_reconciliation_checks"]
+        if item["reconciliation_key"] == key
+    )
+
+
+def _kpi(projection: dict, key: str) -> dict:
+    return next(
+        item
+        for item in projection["unified_cmo_kpi_results"]
+        if item["kpi_key"] == key
+    )
+
+
+def test_matching_ad_spend_totals_pass_reconciliation() -> None:
+    projection = _projection()
+    spend = _check(projection, "paid_spend_totals_by_channel")
+
+    assert spend["status"] == "passed"
+    assert spend["expected_value"] == 1_000.0
+    assert spend["observed_value"] == 1_000.0
+    assert projection["cmo_kpi_reconciliation_summary"]["readiness"] == "ready"
+
+
+def test_spend_mismatch_fails_and_blocks_cac_roas_readiness() -> None:
+    projection = _projection(
+        _source_facts(campaign_spend_by_channel={"google": 400.0, "linkedin": 150.0})
+    )
+    spend = _check(projection, "paid_spend_totals_by_channel")
+    cac = _kpi(projection, "cac")
+    roas = _kpi(projection, "roas")
+
+    assert spend["status"] == "failed"
+    assert spend["severity"] == "high"
+    assert spend["delta_percentage"] == 45.0
+    assert cac["status"] == "blocked"
+    assert roas["status"] == "blocked"
+    assert cac["confidence"] == 0.0
+    assert spend["decision_audit_ref"].startswith("cmo_decision_audit:")
+
+
+def test_ad_conversions_vs_crm_mql_mismatch_downgrades_affected_kpis() -> None:
+    projection = _projection(
+        _source_facts(ad_platform_conversions=180, crm_campaign_attributed_mqls=100)
+    )
+    check = _check(projection, "ad_conversions_vs_crm_attribution")
+    mql = _kpi(projection, "mql")
+
+    assert check["status"] == "failed"
+    assert check["severity"] == "medium"
+    assert mql["status"] == "degraded"
+    assert mql["value"] == 100.0
+    assert mql["confidence"] < 0.8
+
+
+def test_ga4_conversion_events_without_crm_leads_fail_reconciliation() -> None:
+    projection = _projection(_source_facts(ga4_conversion_events=250, crm_leads_created=0))
+    check = _check(projection, "ga4_web_conversions_vs_crm_leads")
+    conversion = _kpi(projection, "conversion_rates_by_funnel_stage")
+
+    assert check["status"] == "failed"
+    assert check["delta_percentage"] == 100.0
+    assert conversion["status"] == "degraded"
+    assert conversion["next_action_cta"] == "review_web_to_crm_lead_mapping"
+
+
+def test_email_unsubscribe_mismatch_downgrades_email_performance_kpi() -> None:
+    projection = _projection(_source_facts(crm_unsubscribed_contacts=80))
+    check = _check(projection, "email_engagement_vs_crm_list")
+    email = _kpi(projection, "email_performance")
+
+    assert check["status"] == "failed"
+    assert check["observed_value"]["crm_unsubscribed_contacts"] == 80.0
+    assert email["status"] == "degraded"
+    assert email["reconciliation_status"] == "failed"
+
+
+def test_content_traffic_mismatch_downgrades_content_performance_kpi() -> None:
+    projection = _projection(_source_facts(ga4_content_sessions=700))
+    check = _check(projection, "content_traffic_vs_ga4")
+    content = _kpi(projection, "content_performance")
+
+    assert check["status"] == "failed"
+    assert check["delta_percentage"] == 30.0
+    assert content["status"] == "degraded"
+    assert content["next_action_cta"] == "review_content_analytics_mapping"
+
+
+def test_abm_account_domain_mismatch_blocks_or_degrades_abm_readiness() -> None:
+    projection = _projection(
+        _source_facts(
+            abm_target_account_domains=["alpha.example", "beta.example"],
+            crm_account_domains=["alpha.example"],
+            intent_account_domains=["alpha.example"],
+        )
+    )
+    check = _check(projection, "abm_account_domain_consistency")
+    abm = _kpi(projection, "abm_intent_account_readiness")
+
+    assert check["status"] == "failed"
+    assert check["severity"] == "high"
+    assert "beta.example" in check["missing_requirements"]["domains"]
+    assert abm["status"] == "blocked"
+
+
+def test_currency_mismatch_fails_and_blocks_financial_kpis() -> None:
+    projection = _projection(
+        _source_facts(source_currencies={"ads": "USD", "crm": "INR", "finance": "USD"})
+    )
+    check = _check(projection, "currency_consistency")
+    cac = _kpi(projection, "cac")
+
+    assert check["status"] == "failed"
+    assert check["blocks_kpi_readiness"] is True
+    assert cac["status"] == "blocked"
+    assert cac["next_action_cta"] == "align_source_currency_mapping"
+
+
+def test_timezone_mismatch_warns_and_lowers_time_based_kpi_confidence() -> None:
+    projection = _projection(
+        _source_facts(
+            source_timezones={
+                "ads": "UTC",
+                "crm": "Asia/Kolkata",
+                "analytics": "Asia/Kolkata",
+            }
+        )
+    )
+    check = _check(projection, "timezone_consistency")
+    mql = _kpi(projection, "mql")
+
+    assert check["status"] == "warning"
+    assert check["severity"] == "medium"
+    assert mql["status"] == "degraded"
+    assert mql["confidence"] < 0.8
+
+
+def test_stale_source_data_downgrades_reconciliation_freshness_and_confidence() -> None:
+    projection = _projection(
+        setup_rows=_setup_rows(health_overrides={"Ads": "stale"}),
+    )
+    check = _check(projection, "source_freshness_and_partial_data")
+    roas = _kpi(projection, "roas")
+
+    assert check["status"] == "warning"
+    assert check["freshness_impact"] > 0
+    assert "ads" in check["observed_value"]["stale_sources"]
+    assert roas["status"] == "degraded"
+
+
+def test_partial_data_creates_warning_not_pass_and_degrades_affected_kpi() -> None:
+    projection = _projection(
+        contract_rows=_contract_rows(failure_overrides={"Analytics": "partial_data"}),
+    )
+    check = _check(projection, "source_freshness_and_partial_data")
+    content = _kpi(projection, "content_performance")
+
+    assert check["status"] == "warning"
+    assert check["confidence_impact"] > 0
+    assert "analytics" in check["observed_value"]["partial_sources"]
+    assert content["status"] == "degraded"
+
+
+def test_missing_required_source_creates_blocked_status_with_cta() -> None:
+    facts = _source_facts()
+    facts.pop("campaign_spend_by_channel")
+    projection = _projection(facts)
+    check = _check(projection, "paid_spend_totals_by_channel")
+
+    assert check["status"] == "blocked"
+    assert "campaign_level_spend" in check["missing_requirements"]["fields"]
+    assert check["next_action_cta"] == "resolve_spend_reconciliation"
+
+
+@pytest.mark.asyncio
+async def test_kpis_cmo_response_exposes_reconciliation_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_base(tenant_id: str, role: str, company_id: str) -> dict:
+        return {
+            "demo": False,
+            "stale": False,
+            "source": "computed",
+            "company_id": company_id,
+            "agent_count": 0,
+            "total_tasks_30d": 0,
+        }
+
+    async def fake_configs(tenant_id: str) -> list:
+        return []
+
+    async def fake_approval_timeout(tenant_id: str, company_id: str) -> dict:
+        return {"pending": 0, "overdue": 0}
+
+    monkeypatch.setattr(kpis_api, "_build_kpi_response", fake_base)
+    monkeypatch.setattr(kpis_api, "_load_marketing_connector_configs", fake_configs)
+    monkeypatch.setattr(kpis_api, "_load_cmo_approval_timeout_risk", fake_approval_timeout)
+
+    response = await kpis_api._build_cmo_kpi_response("tenant-1", "company-1")
+
+    assert "cmo_kpi_reconciliation_checks" in response
+    assert "cmo_kpi_reconciliation_summary" in response
+    assert response["cmo_kpi_reconciliation_summary"]["readiness"] == "blocked"
+
+
+def test_failed_reconciliation_changes_unified_kpi_result_status_and_confidence() -> None:
+    clean = _projection()
+    failed = _projection(
+        _source_facts(source_currencies={"ads": "USD", "crm": "EUR", "finance": "USD"})
+    )
+
+    assert _kpi(clean, "pipeline_contribution")["status"] == "ready"
+    assert _kpi(failed, "pipeline_contribution")["status"] == "blocked"
+    assert _kpi(failed, "pipeline_contribution")["confidence"] == 0.0

--- a/tests/unit/test_cmo_marketing_connector_contracts.py
+++ b/tests/unit/test_cmo_marketing_connector_contracts.py
@@ -1,0 +1,584 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from core.marketing.connector_contracts import (
+    build_marketing_connector_contracts,
+    evaluate_marketing_write_completion,
+    plan_marketing_write_retry,
+    summarize_marketing_connector_contracts,
+)
+from core.marketing.connector_setup import build_marketing_connector_setup
+from core.marketing.data_readiness import build_marketing_data_readiness
+from core.marketing.workflow_activation import build_cmo_workflow_activation
+
+NOW = datetime(2026, 5, 23, 12, 0, tzinfo=UTC)
+
+
+def _connector_config(
+    connector_name: str,
+    *,
+    config: dict,
+    health_status: str = "healthy",
+    last_sync_at: datetime | None = None,
+    sync_error: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        connector_name=connector_name,
+        display_name=None,
+        auth_type="oauth2",
+        credentials_encrypted={"_encrypted": "enc"},
+        config=config,
+        status="configured",
+        last_health_check=NOW,
+        health_status=health_status,
+        last_sync_at=last_sync_at or NOW - timedelta(hours=1),
+        sync_error=sync_error,
+    )
+
+
+def _backfill(status: str = "completed") -> dict:
+    return {
+        "status": status,
+        "requested_start": "2025-05-01",
+        "requested_end": "2026-05-23",
+        "records_discovered": 100,
+        "records_imported": 98 if status in {"completed", "partial"} else 0,
+        "records_skipped": 1,
+        "records_failed": 1 if status == "partial" else 0,
+        "last_run_at": "2026-05-23T10:00:00+00:00",
+        "blocking_reason": "Vendor export failed" if status in {"failed", "blocked"} else None,
+    }
+
+
+def _contract(**overrides: object) -> dict:
+    base = {
+        "idempotency_supported": True,
+        "retry_budget": {
+            "max_attempts": 3,
+            "attempts_used": 1,
+            "remaining_attempts": 2,
+            "next_retry_at": "2026-05-23T12:05:00+00:00",
+            "idempotency_supported": True,
+            "idempotency_key": "mkt-write-001",
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def _base_configs() -> list[SimpleNamespace]:
+    updated_at = "2026-05-01T00:00:00+00:00"
+    hubspot_mapping = {
+        "lifecycle_stages": {
+            "source_field": "lifecyclestage",
+            "stage_map": {"mql": "marketingqualifiedlead", "sql": "salesqualifiedlead"},
+            "updated_at": updated_at,
+        },
+        "opportunity_revenue": {
+            "amount_field": "amount",
+            "close_date_field": "closedate",
+            "currency_field": "deal_currency_code",
+            "updated_at": updated_at,
+        },
+        "account_domains": {
+            "domain_field": "website",
+            "updated_at": updated_at,
+        },
+        "consent_unsubscribe": {
+            "consent_field": "marketing_opt_in",
+            "unsubscribe_field": "unsubscribed",
+            "updated_at": updated_at,
+        },
+        "fiscal_calendar": {
+            "fiscal_year_start_month": 4,
+            "updated_at": updated_at,
+        },
+        "currency": {
+            "currency": "USD",
+            "updated_at": updated_at,
+        },
+        "timezone": {
+            "timezone": "Asia/Kolkata",
+            "updated_at": updated_at,
+        },
+    }
+    campaign_mapping = {
+        "campaign_ids": {
+            "campaign_id_field": "campaign_id",
+            "updated_at": updated_at,
+        },
+        "utm_fields": {
+            "source": "utm_source",
+            "medium": "utm_medium",
+            "campaign": "utm_campaign",
+            "updated_at": updated_at,
+        },
+    }
+    mailchimp_mapping = {
+        **campaign_mapping,
+        "consent_unsubscribe": {
+            "consent_field": "marketing_permission",
+            "unsubscribe_field": "unsubscribe_status",
+            "updated_at": updated_at,
+        },
+    }
+    return [
+        _connector_config(
+            "hubspot",
+            config={
+                "owner": "revops@example.com",
+                "account_id": "portal-123",
+                "source_object_id": "crm-list-7",
+                "source_url": "https://app.hubspot.com/lists/7",
+                "granted_scopes": [
+                    "crm.objects.contacts.read",
+                    "crm.objects.deals.read",
+                    "automation",
+                ],
+                "data_coverage_status": "ready",
+                "marketing_field_mapping": hubspot_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        ),
+        _connector_config(
+            "google_ads",
+            config={
+                "owner": "growth@example.com",
+                "customer_id": "123-456-7890",
+                "granted_scopes": ["https://www.googleapis.com/auth/adwords"],
+                "marketing_field_mapping": campaign_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        ),
+        _connector_config(
+            "ga4",
+            config={
+                "owner": "analytics@example.com",
+                "property_id": "properties/123",
+                "granted_scopes": ["https://www.googleapis.com/auth/analytics.readonly"],
+                "marketing_field_mapping": campaign_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": {
+                    "retry_budget": {
+                        "max_attempts": 3,
+                        "attempts_used": 0,
+                        "remaining_attempts": 3,
+                    },
+                },
+            },
+        ),
+        _connector_config(
+            "mailchimp",
+            config={
+                "owner": "email@example.com",
+                "audience_id": "aud-1",
+                "marketing_field_mapping": mailchimp_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        ),
+    ]
+
+
+def _contracts(configs: list[SimpleNamespace]) -> list[dict]:
+    setup = build_marketing_connector_setup(configs, now=NOW)
+    return build_marketing_connector_contracts(setup, configs, now=NOW)
+
+
+def _contract_row(rows: list[dict], connector_key: str) -> dict:
+    return next(row for row in rows if row["connector_key"] == connector_key)
+
+
+def _workflow_config() -> dict:
+    return {
+        "mode": "shadow",
+        "approval_owner": "cmo@example.com",
+        "policy_owner": "legal@example.com",
+        "shadow_quality": {
+            "status": "passed",
+            "sample_count": 5,
+            "success_rate": 0.95,
+            "last_run_at": "2026-05-23T09:00:00+00:00",
+        },
+    }
+
+
+def _campaign_workflow(configs: list[SimpleNamespace]) -> dict:
+    configs = deepcopy(configs)
+    configs[0].config.setdefault("marketing_workflows", {})["campaign_launch"] = _workflow_config()
+    setup = build_marketing_connector_setup(configs, now=NOW)
+    readiness = build_marketing_data_readiness(setup, configs, now=NOW)
+    contracts = build_marketing_connector_contracts(setup, configs, now=NOW)
+    activation = build_cmo_workflow_activation(
+        setup,
+        readiness,
+        configs,
+        connector_contracts=contracts,
+        now=NOW,
+    )
+    return next(row for row in activation["workflow_activation_status"] if row["workflow_key"] == "campaign_launch")
+
+
+def test_read_only_connector_is_not_write_ready() -> None:
+    configs = _base_configs()
+    configs[0].config["marketing_connector_contract"] = _contract(
+        write_capabilities=[],
+        required_write_scopes=[],
+    )
+
+    hubspot = _contract_row(_contracts(configs), "hubspot")
+
+    assert hubspot["read_ready"] is True
+    assert hubspot["write_ready"] is False
+    assert hubspot["write_status"] == "read_only"
+    assert hubspot["source_objects"][0]["source_object_id"] == "crm-list-7"
+
+
+def test_missing_write_scope_blocks_write_workflow_readiness() -> None:
+    configs = _base_configs()
+    configs[1].config["marketing_connector_contract"] = _contract(
+        required_write_scopes=["ads.write"],
+        write_capabilities=["campaigns.mutate"],
+    )
+
+    google_ads = _contract_row(_contracts(configs), "google_ads")
+    campaign = _campaign_workflow(configs)
+
+    assert google_ads["read_ready"] is True
+    assert google_ads["write_ready"] is False
+    assert google_ads["missing_write_scopes"] == ["ads.write"]
+    assert campaign["state"] == "promotion_blocked"
+    assert any("not write-ready" in reason for reason in campaign["blocked_reasons"])
+
+
+def test_missing_write_scope_state_does_not_block_read_contract() -> None:
+    configs = _base_configs()
+    configs[1].config["marketing_connector_contract"] = _contract(
+        state="missing_scope",
+        required_write_scopes=["ads.write"],
+        write_capabilities=["campaigns.mutate"],
+    )
+
+    google_ads = _contract_row(_contracts(configs), "google_ads")
+
+    assert google_ads["read_ready"] is True
+    assert google_ads["read_status"] == "ready"
+    assert google_ads["write_ready"] is False
+    assert google_ads["write_status"] == "missing_scope"
+    assert google_ads["missing_read_scopes"] == []
+    assert google_ads["missing_write_scopes"] == ["ads.write"]
+
+
+def test_expired_auth_blocks_connector_contract_readiness() -> None:
+    configs = _base_configs()
+    configs[1].config["marketing_connector_contract"] = _contract(auth_status="expired")
+
+    google_ads = _contract_row(_contracts(configs), "google_ads")
+
+    assert google_ads["contract_state"] == "auth_expired"
+    assert google_ads["auth_status"] == "expired"
+    assert google_ads["read_ready"] is False
+    assert google_ads["write_ready"] is False
+    assert google_ads["next_action_cta"] == "reconnect"
+
+
+def test_rate_limit_projects_degraded_state_and_retry_metadata() -> None:
+    configs = _base_configs()
+    configs[1].config["marketing_connector_contract"] = _contract(
+        state="rate_limited",
+        retry_budget={
+            "max_attempts": 5,
+            "attempts_used": 2,
+            "remaining_attempts": 3,
+            "next_retry_at": "2026-05-23T12:15:00+00:00",
+            "last_error": "429 rate_limited",
+            "idempotency_supported": True,
+            "idempotency_key": "ads-budget-1",
+        },
+    )
+
+    google_ads = _contract_row(_contracts(configs), "google_ads")
+
+    assert google_ads["contract_state"] == "rate_limited"
+    assert google_ads["read_status"] == "degraded"
+    assert google_ads["retry_budget"]["remaining_attempts"] == 3
+    assert google_ads["retry_budget"]["next_retry_at"] == "2026-05-23T12:15:00+00:00"
+    assert google_ads["next_action_cta"] == "review_retry_budget"
+
+
+def test_timeout_and_vendor_5xx_project_degraded_states() -> None:
+    timeout_configs = _base_configs()
+    timeout_configs[1].config["marketing_connector_contract"] = _contract(state="timeout")
+    timeout_row = _contract_row(_contracts(timeout_configs), "google_ads")
+
+    vendor_configs = _base_configs()
+    vendor_configs[1].config["marketing_connector_contract"] = _contract(
+        state="vendor_5xx",
+        degraded_mode_reason="Google Ads API returned 503",
+    )
+    vendor_row = _contract_row(_contracts(vendor_configs), "google_ads")
+
+    assert timeout_row["contract_state"] == "timeout"
+    assert timeout_row["read_status"] == "degraded"
+    assert "timed out" in timeout_row["degraded_mode_reason"]
+    assert vendor_row["contract_state"] == "vendor_5xx"
+    assert vendor_row["read_status"] == "degraded"
+    assert vendor_row["degraded_mode_reason"] == "Google Ads API returned 503"
+
+
+def test_partial_data_downgrades_kpi_readiness() -> None:
+    configs = _base_configs()
+    configs[1].config["marketing_connector_contract"] = _contract(state="partial_data")
+    setup = build_marketing_connector_setup(configs, now=NOW)
+    readiness = build_marketing_data_readiness(setup, configs, now=NOW)
+    google_ads = _contract_row(_contracts(configs), "google_ads")
+
+    assert google_ads["contract_state"] == "partial_data"
+    assert readiness["kpi_readiness"]["status"] == "degraded"
+    assert any(
+        "Google Ads connector is degraded" in reason
+        for reason in readiness["kpi_readiness"]["degraded_reasons"]
+    )
+
+
+def test_stale_data_downgrades_kpi_readiness() -> None:
+    configs = _base_configs()
+    configs[1].config["marketing_connector_contract"] = _contract(
+        ttl_seconds=60,
+        last_sync_at="2026-05-23T10:00:00+00:00",
+    )
+    setup = build_marketing_connector_setup(configs, now=NOW)
+    readiness = build_marketing_data_readiness(setup, configs, now=NOW)
+    google_ads = _contract_row(_contracts(configs), "google_ads")
+
+    assert google_ads["contract_state"] == "stale_data"
+    assert google_ads["data_freshness"]["status"] == "stale"
+    assert readiness["kpi_readiness"]["status"] == "degraded"
+    assert any("Google Ads connector is stale" in reason for reason in readiness["kpi_readiness"]["degraded_reasons"])
+
+
+def test_write_without_confirmation_cannot_be_marked_complete() -> None:
+    configs = _base_configs()
+    contracts = _contracts(configs)
+
+    result = evaluate_marketing_write_completion(
+        contracts,
+        "google_ads",
+        "launch_campaign",
+        workflow_mode="active",
+        idempotency_key="ads-launch-1",
+    )
+
+    assert result["can_mark_complete"] is False
+    assert result["status"] == "write_unconfirmed"
+    assert "confirmation is missing" in result["reason"]
+
+
+def test_confirmed_write_can_be_marked_complete() -> None:
+    configs = _base_configs()
+    configs[1].config["marketing_connector_contract"] = _contract(
+        write_confirmations={
+            "launch_campaign": {
+                "status": "write_confirmed",
+                "idempotency_key": "ads-launch-1",
+                "external_object_id": "customers/123/campaigns/456",
+                "source_url": "https://ads.google.com/campaigns/456",
+                "confirmed_at": "2026-05-23T12:02:00+00:00",
+            }
+        }
+    )
+    contracts = _contracts(configs)
+
+    result = evaluate_marketing_write_completion(
+        contracts,
+        "google_ads",
+        "launch_campaign",
+        workflow_mode="active",
+        idempotency_key="ads-launch-1",
+    )
+
+    assert result["can_mark_complete"] is True
+    assert result["status"] == "write_confirmed"
+    assert result["external_object_id"] == "customers/123/campaigns/456"
+
+
+def test_shadow_write_step_can_remain_internal_without_external_confirmation() -> None:
+    result = evaluate_marketing_write_completion(
+        _contracts(_base_configs()),
+        "google_ads",
+        "launch_campaign",
+        workflow_mode="shadow",
+    )
+
+    assert result["can_mark_complete"] is True
+    assert result["status"] == "internal_only"
+
+
+def test_duplicate_retry_uses_idempotency_metadata() -> None:
+    configs = _base_configs()
+    configs[1].config["marketing_connector_contract"] = _contract(
+        retry_budget={
+            "max_attempts": 3,
+            "attempts_used": 1,
+            "remaining_attempts": 2,
+            "next_retry_at": "2026-05-23T12:05:00+00:00",
+            "idempotency_supported": True,
+            "idempotency_key": "ads-launch-1",
+        },
+        write_confirmations={
+            "launch_campaign": {
+                "status": "write_unconfirmed",
+                "idempotency_key": "ads-launch-1",
+            }
+        },
+    )
+
+    retry = plan_marketing_write_retry(
+        _contracts(configs),
+        "google_ads",
+        "launch_campaign",
+        idempotency_key="ads-launch-1",
+    )
+
+    assert retry["safe_to_retry"] is True
+    assert retry["duplicate_policy"] == "reuse_idempotency_key"
+    assert retry["remaining_attempts"] == 2
+
+
+def test_production_readiness_cannot_be_satisfied_by_mock_only_contract() -> None:
+    configs = _base_configs()
+    configs[1].config["marketing_connector_contract"] = _contract(
+        production_proof="test_double",
+    )
+    contracts = _contracts(configs)
+    google_ads = _contract_row(contracts, "google_ads")
+    summary = summarize_marketing_connector_contracts(contracts)
+    campaign = _campaign_workflow(configs)
+
+    assert google_ads["mock_or_test_double"] is True
+    assert google_ads["production_ready"] is False
+    assert google_ads["read_ready"] is False
+    assert summary["mock_or_test_double"] == 1
+    assert campaign["state"] == "promotion_blocked"
+    assert any("not read-ready" in reason for reason in campaign["blocked_reasons"])
+
+
+def _patch_workflow_agent(monkeypatch: pytest.MonkeyPatch, output: dict) -> None:
+    from core.agents.registry import AgentRegistry
+    from core.schemas.messages import TaskResult
+    from workflows import step_types
+
+    monkeypatch.setattr(step_types.settings, "env", "production")
+    monkeypatch.setattr(step_types.external_keys, "google_gemini_api_key", "test-key")
+    monkeypatch.setattr(step_types, "_llm_available_for_workflow", lambda: True)
+
+    class FakeAgent:
+        async def execute(self, task):
+            return TaskResult(
+                message_id="msg-test",
+                correlation_id=task.correlation_id,
+                workflow_run_id=task.workflow_run_id,
+                step_id=task.step_id,
+                agent_id=task.target_agent.agent_id,
+                status="completed",
+                output=output,
+                confidence=0.95,
+            )
+
+    monkeypatch.setattr(
+        AgentRegistry,
+        "create_from_config",
+        staticmethod(lambda config: FakeAgent()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_marketing_write_agent_step_without_confirmation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from workflows.step_types import execute_step
+
+    _patch_workflow_agent(monkeypatch, {"campaign_id": "draft-1"})
+
+    result = await execute_step(
+        {
+            "id": "launch_ads",
+            "type": "agent",
+            "agent_type": "campaign_pilot",
+            "action": "launch_campaign",
+            "connector_key": "google_ads",
+            "external_write_required": True,
+            "marketing_policy_approval_satisfied": True,
+        },
+        {"domain": "marketing", "workflow_mode": "active"},
+    )
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "external_write_confirmation_missing"
+
+
+@pytest.mark.asyncio
+async def test_marketing_write_agent_step_with_confirmation_completes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from workflows.step_types import execute_step
+
+    _patch_workflow_agent(
+        monkeypatch,
+        {
+            "campaign_id": "customers/123/campaigns/456",
+            "external_write_confirmation": {
+                "action": "launch_campaign",
+                "status": "write_confirmed",
+                "idempotency_key": "ads-launch-1",
+                "external_object_id": "customers/123/campaigns/456",
+            },
+        },
+    )
+
+    result = await execute_step(
+        {
+            "id": "launch_ads",
+            "type": "agent",
+            "agent_type": "campaign_pilot",
+            "action": "launch_campaign",
+            "connector_key": "google_ads",
+            "external_write_required": True,
+            "marketing_policy_approval_satisfied": True,
+        },
+        {"domain": "marketing", "workflow_mode": "active"},
+    )
+
+    assert result["status"] == "completed"
+    assert result["output"]["campaign_id"] == "customers/123/campaigns/456"
+
+
+@pytest.mark.asyncio
+async def test_marketing_shadow_write_agent_step_can_remain_internal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from workflows.step_types import execute_step
+
+    _patch_workflow_agent(monkeypatch, {"recommendation": "launch later"})
+
+    result = await execute_step(
+        {
+            "id": "launch_ads",
+            "type": "agent",
+            "agent_type": "campaign_pilot",
+            "action": "launch_campaign",
+            "connector_key": "google_ads",
+            "external_write_required": True,
+        },
+        {"domain": "marketing", "workflow_mode": "shadow"},
+    )
+
+    assert result["status"] == "completed"
+    assert result["output"]["recommendation"] == "launch later"

--- a/tests/unit/test_cmo_marketing_connector_setup.py
+++ b/tests/unit/test_cmo_marketing_connector_setup.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+import api.v1.kpis as kpis
+from api.v1.kpis import _apply_cmo_production_data_policy
+from core.marketing.connector_setup import (
+    build_marketing_connector_setup,
+    summarize_marketing_connector_setup,
+)
+
+NOW = datetime(2026, 5, 23, 12, 0, tzinfo=UTC)
+
+
+def _connector_config(
+    connector_name: str,
+    *,
+    health_status: str = "healthy",
+    last_sync_at: datetime | None = None,
+    config: dict | None = None,
+    sync_error: str | None = None,
+    credentials: bool = True,
+):
+    return SimpleNamespace(
+        connector_name=connector_name,
+        display_name=None,
+        auth_type="oauth2",
+        credentials_encrypted={"_encrypted": "enc"} if credentials else {},
+        config=config or {},
+        status="configured",
+        last_health_check=NOW,
+        health_status=health_status,
+        last_sync_at=last_sync_at if last_sync_at is not None else NOW - timedelta(hours=1),
+        sync_error=sync_error,
+    )
+
+
+def _row(rows: list[dict], key: str) -> dict:
+    return next(row for row in rows if row["key"] == key)
+
+
+def test_missing_connector_creates_actionable_setup_state() -> None:
+    rows = build_marketing_connector_setup([], now=NOW)
+
+    hubspot = _row(rows, "hubspot")
+    assert hubspot["configured_status"] == "unconfigured"
+    assert hubspot["health_status"] == "missing"
+    assert hubspot["data_coverage_status"] == "missing"
+    assert hubspot["cta_state"] == "setup"
+
+
+def test_healthy_connector_exposes_owner_account_scopes_and_no_action() -> None:
+    rows = build_marketing_connector_setup(
+        [
+            _connector_config(
+                "hubspot",
+                config={
+                    "owner": "revops@example.com",
+                    "account_id": "portal-123",
+                    "granted_scopes": [
+                        "crm.objects.contacts.read",
+                        "crm.objects.deals.read",
+                        "automation",
+                    ],
+                    "data_coverage_status": "ready",
+                },
+            )
+        ],
+        now=NOW,
+    )
+
+    hubspot = _row(rows, "hubspot")
+    assert hubspot["configured_status"] == "configured"
+    assert hubspot["health_status"] == "healthy"
+    assert hubspot["owner"] == "revops@example.com"
+    assert hubspot["account_id"] == "portal-123"
+    assert hubspot["missing_scopes"] == []
+    assert hubspot["cta_state"] == "none"
+
+
+def test_expired_auth_requires_reconnect() -> None:
+    rows = build_marketing_connector_setup(
+        [
+            _connector_config(
+                "ga4",
+                health_status="unhealthy",
+                sync_error="OAuth token expired",
+                config={"property_id": "properties/123"},
+            )
+        ],
+        now=NOW,
+    )
+
+    ga4 = _row(rows, "ga4")
+    assert ga4["health_status"] == "expired_auth"
+    assert ga4["data_coverage_status"] == "blocked"
+    assert ga4["cta_state"] == "reconnect"
+
+
+def test_insufficient_scope_lists_missing_scopes_and_cta() -> None:
+    rows = build_marketing_connector_setup(
+        [
+            _connector_config(
+                "google_ads",
+                config={
+                    "customer_id": "123-456-7890",
+                    "granted_scopes": [],
+                },
+                sync_error="403 insufficient_scope",
+            )
+        ],
+        now=NOW,
+    )
+
+    google_ads = _row(rows, "google_ads")
+    assert google_ads["health_status"] == "insufficient_scope"
+    assert google_ads["data_coverage_status"] == "blocked"
+    assert google_ads["cta_state"] == "add_scope"
+    assert google_ads["missing_scopes"] == [
+        "https://www.googleapis.com/auth/adwords",
+    ]
+
+
+def test_stale_sync_is_not_fake_healthy() -> None:
+    rows = build_marketing_connector_setup(
+        [
+            _connector_config(
+                "ahrefs",
+                last_sync_at=NOW - timedelta(days=4),
+                config={"site_url": "agenticorg.ai"},
+            )
+        ],
+        now=NOW,
+    )
+
+    ahrefs = _row(rows, "ahrefs")
+    assert ahrefs["health_status"] == "stale"
+    assert ahrefs["data_coverage_status"] == "stale"
+    assert ahrefs["cta_state"] == "refresh"
+
+
+def test_degraded_connector_requires_review() -> None:
+    rows = build_marketing_connector_setup(
+        [
+            _connector_config(
+                "brandwatch",
+                health_status="degraded",
+                sync_error="rate_limited",
+                config={"project_id": "project-9"},
+            )
+        ],
+        now=NOW,
+    )
+
+    brandwatch = _row(rows, "brandwatch")
+    assert brandwatch["health_status"] == "degraded"
+    assert brandwatch["data_coverage_status"] == "partial"
+    assert brandwatch["cta_state"] == "review"
+
+
+def test_summary_counts_setup_states() -> None:
+    rows = build_marketing_connector_setup(
+        [
+            _connector_config(
+                "hubspot",
+                config={
+                    "granted_scopes": [
+                        "crm.objects.contacts.read",
+                        "crm.objects.deals.read",
+                        "automation",
+                    ],
+                },
+            ),
+            _connector_config(
+                "ga4",
+                health_status="unhealthy",
+                sync_error="OAuth token expired",
+            ),
+        ],
+        now=NOW,
+    )
+
+    summary = summarize_marketing_connector_setup(rows)
+    assert summary["healthy"] == 1
+    assert summary["auth_actions"] == 1
+    assert summary["missing"] > 0
+    assert summary["needs_action"] > 0
+    assert summary["readiness"] == "setup_required"
+
+
+def test_production_tenant_suppresses_demo_kpi_fallback() -> None:
+    base = {
+        "demo": True,
+        "source": "computed",
+        "agent_count": 0,
+        "total_tasks_30d": 0,
+    }
+
+    result = _apply_cmo_production_data_policy(
+        base,
+        {"readiness": "setup_required"},
+        None,
+        strict_runtime=True,
+    )
+
+    assert result["demo"] is False
+    assert result["demo_suppressed"] is True
+    assert result["production_data_blocked"] is True
+    assert result["data_coverage_status"] == "blocked_setup"
+    assert result["source"] == "empty_real_tenant"
+
+
+@pytest.mark.asyncio
+async def test_cmo_kpi_response_includes_connector_setup_and_policy(monkeypatch) -> None:
+    async def fake_base_response(tenant_id: str, role: str, company_id: str) -> dict:
+        assert role == "cmo"
+        return {
+            "demo": True,
+            "company_id": company_id,
+            "agent_count": 0,
+            "total_tasks_30d": 0,
+            "success_rate": 0,
+            "hitl_interventions": 0,
+            "total_cost_usd": 0,
+            "domain_breakdown": [],
+            "source": "computed",
+        }
+
+    async def fake_connector_configs(tenant_id: str) -> list[dict]:
+        return []
+
+    async def fake_approval_timeout(tenant_id: str, company_id: str) -> dict:
+        return {"pending": 0, "overdue": 0, "approval_timeout_decisions": []}
+
+    monkeypatch.setattr(kpis, "_build_kpi_response", fake_base_response)
+    monkeypatch.setattr(kpis, "_load_marketing_connector_configs", fake_connector_configs)
+    monkeypatch.setattr(kpis, "_load_cmo_approval_timeout_risk", fake_approval_timeout)
+    monkeypatch.setattr(kpis.settings, "env", "production")
+
+    response = await kpis._build_cmo_kpi_response("tenant-1", "company-1")
+
+    assert response["company_id"] == "company-1"
+    assert response["demo"] is False
+    assert response["production_data_blocked"] is True
+    assert response["connector_setup_summary"]["missing"] > 0
+    assert response["connector_setup"][0]["cta_state"] == "setup"
+    assert response["field_mapping_summary"]["readiness"] == "blocked"
+    assert response["backfill_summary"]["readiness"] == "blocked"

--- a/tests/unit/test_cmo_marketing_data_readiness.py
+++ b/tests/unit/test_cmo_marketing_data_readiness.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from api.v1.kpis import _apply_cmo_production_data_policy
+from core.marketing.connector_setup import build_marketing_connector_setup
+from core.marketing.data_readiness import build_marketing_data_readiness
+
+NOW = datetime(2026, 5, 23, 12, 0, tzinfo=UTC)
+
+
+def _connector_config(
+    connector_name: str,
+    *,
+    config: dict,
+    health_status: str = "healthy",
+    last_sync_at: datetime | None = None,
+    sync_error: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        connector_name=connector_name,
+        display_name=None,
+        auth_type="oauth2",
+        credentials_encrypted={"_encrypted": "enc"},
+        config=config,
+        status="configured",
+        last_health_check=NOW,
+        health_status=health_status,
+        last_sync_at=last_sync_at or NOW - timedelta(hours=1),
+        sync_error=sync_error,
+    )
+
+
+def _backfill(status: str = "completed") -> dict:
+    return {
+        "status": status,
+        "requested_start": "2025-05-01",
+        "requested_end": "2026-05-23",
+        "records_discovered": 100,
+        "records_imported": 98 if status in {"completed", "partial"} else 0,
+        "records_skipped": 1,
+        "records_failed": 1 if status == "partial" else 0,
+        "last_run_at": "2026-05-23T10:00:00+00:00",
+        "blocking_reason": "Vendor export failed" if status in {"failed", "blocked"} else None,
+    }
+
+
+def _base_configs() -> list[SimpleNamespace]:
+    updated_at = "2026-05-01T00:00:00+00:00"
+    hubspot_mapping = {
+        "lifecycle_stages": {
+            "source_field": "lifecyclestage",
+            "stage_map": {"mql": "marketingqualifiedlead", "sql": "salesqualifiedlead"},
+            "updated_at": updated_at,
+        },
+        "opportunity_revenue": {
+            "amount_field": "amount",
+            "close_date_field": "closedate",
+            "currency_field": "deal_currency_code",
+            "updated_at": updated_at,
+        },
+        "account_domains": {
+            "domain_field": "website",
+            "updated_at": updated_at,
+        },
+        "consent_unsubscribe": {
+            "consent_field": "marketing_opt_in",
+            "unsubscribe_field": "unsubscribed",
+            "updated_at": updated_at,
+        },
+        "fiscal_calendar": {
+            "fiscal_year_start_month": 4,
+            "updated_at": updated_at,
+        },
+        "currency": {
+            "currency": "USD",
+            "updated_at": updated_at,
+        },
+        "timezone": {
+            "timezone": "Asia/Kolkata",
+            "updated_at": updated_at,
+        },
+    }
+    campaign_mapping = {
+        "campaign_ids": {
+            "campaign_id_field": "campaign_id",
+            "updated_at": updated_at,
+        },
+        "utm_fields": {
+            "source": "utm_source",
+            "medium": "utm_medium",
+            "campaign": "utm_campaign",
+            "updated_at": updated_at,
+        },
+    }
+    mailchimp_mapping = {
+        **campaign_mapping,
+        "consent_unsubscribe": {
+            "consent_field": "marketing_permission",
+            "unsubscribe_field": "unsubscribe_status",
+            "updated_at": updated_at,
+        },
+    }
+    return [
+        _connector_config(
+            "hubspot",
+            config={
+                "owner": "revops@example.com",
+                "account_id": "portal-123",
+                "granted_scopes": [
+                    "crm.objects.contacts.read",
+                    "crm.objects.deals.read",
+                    "automation",
+                ],
+                "data_coverage_status": "ready",
+                "marketing_field_mapping": hubspot_mapping,
+                "marketing_backfill": _backfill(),
+            },
+        ),
+        _connector_config(
+            "google_ads",
+            config={
+                "owner": "growth@example.com",
+                "customer_id": "123-456-7890",
+                "granted_scopes": ["https://www.googleapis.com/auth/adwords"],
+                "marketing_field_mapping": campaign_mapping,
+                "marketing_backfill": _backfill(),
+            },
+        ),
+        _connector_config(
+            "ga4",
+            config={
+                "owner": "analytics@example.com",
+                "property_id": "properties/123",
+                "granted_scopes": ["https://www.googleapis.com/auth/analytics.readonly"],
+                "marketing_field_mapping": campaign_mapping,
+                "marketing_backfill": _backfill(),
+            },
+        ),
+        _connector_config(
+            "mailchimp",
+            config={
+                "owner": "email@example.com",
+                "audience_id": "aud-1",
+                "marketing_field_mapping": mailchimp_mapping,
+                "marketing_backfill": _backfill(),
+            },
+        ),
+    ]
+
+
+def _readiness(configs: list[SimpleNamespace]) -> dict:
+    setup = build_marketing_connector_setup(configs, now=NOW)
+    return build_marketing_data_readiness(setup, configs, now=NOW)
+
+
+def _mapping(readiness: dict, key: str) -> dict:
+    return next(row for row in readiness["field_mapping_status"] if row["key"] == key)
+
+
+def _backfill_row(readiness: dict, key: str) -> dict:
+    return next(row for row in readiness["backfill_status"] if row["source_connector_key"] == key)
+
+
+def test_all_required_mappings_and_completed_backfills_enable_kpi_readiness() -> None:
+    readiness = _readiness(_base_configs())
+
+    assert readiness["field_mapping_summary"]["readiness"] == "ready"
+    assert readiness["backfill_summary"]["readiness"] == "ready"
+    assert readiness["kpi_readiness"]["status"] == "ready"
+    assert readiness["kpi_readiness"]["historical_status"] == "ready"
+    assert _mapping(readiness, "lifecycle_stages")["status"] == "valid"
+    assert _backfill_row(readiness, "hubspot")["status"] == "completed"
+
+
+def test_missing_lifecycle_stage_mapping_blocks_kpi_readiness() -> None:
+    configs = _base_configs()
+    del configs[0].config["marketing_field_mapping"]["lifecycle_stages"]
+
+    readiness = _readiness(configs)
+
+    lifecycle = _mapping(readiness, "lifecycle_stages")
+    assert lifecycle["status"] == "unmapped"
+    assert lifecycle["next_action_cta"] == "map_fields"
+    assert readiness["kpi_readiness"]["status"] == "blocked"
+    assert any("Lifecycle stages" in reason for reason in readiness["kpi_readiness"]["blocked_reasons"])
+
+
+def test_missing_revenue_field_blocks_pipeline_cac_readiness() -> None:
+    configs = _base_configs()
+    del configs[0].config["marketing_field_mapping"]["opportunity_revenue"]
+
+    readiness = _readiness(configs)
+
+    revenue = _mapping(readiness, "opportunity_revenue")
+    assert revenue["status"] == "unmapped"
+    assert "Pipeline contribution" in revenue["affected_kpis"]
+    assert "CAC" in revenue["affected_kpis"]
+    assert readiness["kpi_readiness"]["status"] == "blocked"
+
+
+def test_missing_consent_fields_block_email_and_nurture_readiness() -> None:
+    configs = _base_configs()
+    del configs[0].config["marketing_field_mapping"]["consent_unsubscribe"]
+    del configs[3].config["marketing_field_mapping"]["consent_unsubscribe"]
+
+    readiness = _readiness(configs)
+
+    consent = _mapping(readiness, "consent_unsubscribe")
+    assert consent["status"] == "unmapped"
+    assert "Email performance" in consent["affected_kpis"]
+    assert "Lead nurture readiness" in consent["affected_kpis"]
+    assert readiness["kpi_readiness"]["status"] == "blocked"
+
+
+def test_invalid_currency_and_timezone_mappings_are_rejected() -> None:
+    configs = _base_configs()
+    mappings = configs[0].config["marketing_field_mapping"]
+    mappings["currency"] = {"currency": "ZZZ", "updated_at": "2026-05-01T00:00:00+00:00"}
+    mappings["timezone"] = {"timezone": "Mars/Base", "updated_at": "2026-05-01T00:00:00+00:00"}
+
+    readiness = _readiness(configs)
+
+    currency = _mapping(readiness, "currency")
+    timezone = _mapping(readiness, "timezone")
+    assert currency["status"] == "invalid"
+    assert "Currency" in currency["blocking_reason"]
+    assert timezone["status"] == "invalid"
+    assert "Timezone" in timezone["blocking_reason"]
+    assert readiness["kpi_readiness"]["status"] == "blocked"
+
+
+def test_partial_mapping_degrades_readiness_without_fake_healthy_state() -> None:
+    configs = _base_configs()
+    del configs[2].config["marketing_field_mapping"]["utm_fields"]
+
+    readiness = _readiness(configs)
+
+    utm = _mapping(readiness, "utm_fields")
+    assert utm["status"] == "partially_mapped"
+    assert utm["next_action_cta"] == "complete_mapping"
+    assert readiness["field_mapping_summary"]["readiness"] == "degraded"
+    assert readiness["kpi_readiness"]["status"] == "degraded"
+
+
+def test_stale_mapping_requires_review() -> None:
+    configs = _base_configs()
+    stale_mapping = configs[0].config["marketing_field_mapping"]["lifecycle_stages"]
+    stale_mapping["updated_at"] = "2025-01-01T00:00:00+00:00"
+
+    readiness = _readiness(configs)
+
+    lifecycle = _mapping(readiness, "lifecycle_stages")
+    assert lifecycle["status"] == "stale"
+    assert lifecycle["next_action_cta"] == "review_mapping"
+    assert readiness["kpi_readiness"]["status"] == "degraded"
+
+
+def test_failed_and_blocked_backfills_create_actionable_next_steps() -> None:
+    configs = _base_configs()
+    configs[1].config["marketing_backfill"] = _backfill("failed")
+    configs[2] = _connector_config(
+        "ga4",
+        config=configs[2].config,
+        health_status="expired_auth",
+        sync_error="OAuth token expired",
+    )
+
+    readiness = _readiness(configs)
+
+    google_ads = _backfill_row(readiness, "google_ads")
+    ga4 = _backfill_row(readiness, "ga4")
+    assert google_ads["status"] == "failed"
+    assert google_ads["next_action_cta"] == "retry_backfill"
+    assert google_ads["blocking_reason"] == "Vendor export failed"
+    assert ga4["status"] == "blocked"
+    assert ga4["next_action_cta"] == "resolve_blocker"
+    assert readiness["backfill_summary"]["readiness"] == "blocked"
+    assert readiness["kpi_readiness"]["status"] == "blocked"
+
+
+def test_production_tenant_cannot_treat_blocked_readiness_as_confident_kpis() -> None:
+    base = {
+        "demo": False,
+        "source": "computed",
+        "agent_count": 5,
+        "total_tasks_30d": 10,
+    }
+    result = _apply_cmo_production_data_policy(
+        base,
+        {"readiness": "ready"},
+        {
+            "status": "blocked",
+            "blocked_reasons": ["Lifecycle stages mapping is unmapped."],
+        },
+        strict_runtime=True,
+    )
+
+    assert result["demo"] is False
+    assert result["production_data_blocked"] is True
+    assert result["kpi_confidence_status"] == "blocked"
+    assert result["data_coverage_status"] == "blocked_mapping_or_backfill"
+    assert "field mappings" in result["message"]
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_cta"),
+    [
+        ("not_started", "start_backfill"),
+        ("queued", "monitor_backfill"),
+        ("running", "monitor_backfill"),
+        ("partial", "review_failed_records"),
+    ],
+)
+def test_backfill_progress_states_are_visible(status: str, expected_cta: str) -> None:
+    configs = deepcopy(_base_configs())
+    configs[1].config["marketing_backfill"] = _backfill(status)
+
+    readiness = _readiness(configs)
+
+    row = _backfill_row(readiness, "google_ads")
+    assert row["status"] == status
+    assert row["next_action_cta"] == expected_cta
+    assert row["requested_start"] == "2025-05-01"
+    assert row["records_discovered"] == 100

--- a/tests/unit/test_cmo_marketing_policy_manifest.py
+++ b/tests/unit/test_cmo_marketing_policy_manifest.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from core.marketing.approval_timeouts import evaluate_approval_timeout
+from core.marketing.connector_setup import build_marketing_connector_setup
+from core.marketing.data_readiness import build_marketing_data_readiness
+from core.marketing.external_writes import evaluate_marketing_external_write_result
+from core.marketing.policy_manifest import (
+    default_marketing_policy_manifest,
+    evaluate_marketing_policy,
+)
+from core.marketing.workflow_activation import build_cmo_workflow_activation
+from core.marketing.workflow_linter import lint_marketing_workflow
+
+NOW = datetime(2026, 5, 23, 12, 0, tzinfo=UTC)
+
+
+def test_default_manifest_loads_with_version_and_policy_ids() -> None:
+    manifest = default_marketing_policy_manifest()
+
+    assert manifest["policy_id"] == "cmo_default_marketing_policy"
+    assert manifest["version"] == "2026-05-23.cmo-6.1"
+    assert manifest["rules"]
+    assert {rule["rule_id"] for rule in manifest["rules"]} >= {
+        "cmo_publish_send_launch_approval",
+        "cmo_forbidden_destructive_actions",
+        "cmo_read_only_autonomy",
+    }
+
+
+def test_publish_send_and_launch_actions_require_approval() -> None:
+    for action in ("publish", "send_email", "launch_campaign"):
+        decision = evaluate_marketing_policy(
+            {
+                "workflow_id": "campaign_launch",
+                "workflow_mode": "active",
+                "action": action,
+                "external_write_required": True,
+            }
+        )
+
+        assert decision["decision"] == "requires_approval"
+        assert decision["required_approver_role"] == "cmo"
+        assert decision["required_audit_evidence"]
+
+
+def test_budget_increase_above_threshold_requires_approval() -> None:
+    decision = evaluate_marketing_policy(
+        {
+            "workflow_id": "daily_spend_optimization",
+            "workflow_mode": "active",
+            "action": "mutate_ad_budget",
+            "channel": "google_ads",
+            "budget_delta": 1500,
+        }
+    )
+
+    assert decision["decision"] == "requires_approval"
+    assert decision["matched_rules"][0]["rule_id"] == "cmo_budget_threshold_approval"
+    assert decision["next_action_cta"] == "request_budget_approval"
+
+
+def test_low_risk_read_only_recommendation_is_allowed_in_shadow_mode() -> None:
+    decision = evaluate_marketing_policy(
+        {
+            "workflow_id": "weekly_marketing_report",
+            "workflow_mode": "shadow",
+            "action": "recommend",
+        }
+    )
+
+    assert decision["decision"] == "allowed"
+    assert decision["next_action_cta"] == "none"
+
+
+def test_pricing_legal_and_comparative_claims_require_escalation() -> None:
+    for field in ("pricing_claim", "legal_claim", "comparative_claim"):
+        decision = evaluate_marketing_policy(
+            {
+                "workflow_id": "content_pipeline",
+                "workflow_mode": "active",
+                "action": "publish",
+                field: True,
+            }
+        )
+
+        assert decision["decision"] == "requires_escalation"
+        assert decision["required_escalation_role"] == "legal"
+
+
+def test_crisis_public_response_requires_escalation() -> None:
+    decision = evaluate_marketing_policy(
+        {
+            "workflow_id": "brand_crisis_response",
+            "workflow_mode": "active",
+            "action": "public_response",
+            "public_response": True,
+        }
+    )
+
+    assert decision["decision"] == "requires_escalation"
+    assert decision["required_escalation_role"] == "ceo"
+
+
+def test_target_account_list_change_above_threshold_requires_approval() -> None:
+    decision = evaluate_marketing_policy(
+        {
+            "workflow_id": "abm_sprint",
+            "workflow_mode": "active",
+            "action": "update_target_accounts",
+            "target_account_delta": 40,
+        }
+    )
+
+    assert decision["decision"] == "requires_approval"
+    assert decision["required_approver_role"] == "revops_lead"
+
+
+def test_disallowed_action_is_blocked() -> None:
+    decision = evaluate_marketing_policy(
+        {
+            "workflow_id": "campaign_launch",
+            "workflow_mode": "active",
+            "action": "delete_campaign",
+            "external_write_required": True,
+        }
+    )
+
+    assert decision["decision"] == "blocked"
+    assert decision["next_action_cta"] == "remove_destructive_action"
+
+
+def test_missing_policy_fails_closed_for_active_external_write() -> None:
+    decision = evaluate_marketing_policy(
+        {
+            "workflow_id": "campaign_launch",
+            "workflow_mode": "active",
+            "action": "launch_campaign",
+            "external_write_required": True,
+            "marketing_policy_manifest_disabled": True,
+        }
+    )
+
+    assert decision["decision"] == "missing_policy"
+    assert decision["next_action_cta"] == "configure_marketing_policy_manifest"
+
+
+def test_missing_policy_can_continue_only_as_shadow_read_only_recommendation() -> None:
+    decision = evaluate_marketing_policy(
+        {
+            "workflow_id": "weekly_marketing_report",
+            "workflow_mode": "shadow",
+            "action": "recommend",
+            "marketing_policy_manifest_disabled": True,
+        }
+    )
+
+    assert decision["decision"] == "read_only_only"
+    assert decision["next_action_cta"] == "label_as_read_only_recommendation"
+
+
+def test_workflow_activation_blocks_active_workflow_missing_required_policy() -> None:
+    configs = _with_workflow(
+        _base_configs(),
+        "campaign_launch",
+        _workflow_config(marketing_policy_manifest_disabled=True),
+    )
+    setup = build_marketing_connector_setup(configs, now=NOW)
+    readiness = build_marketing_data_readiness(setup, configs, now=NOW)
+    activation = build_cmo_workflow_activation(setup, readiness, configs, now=NOW)
+
+    campaign = next(
+        row
+        for row in activation["workflow_activation_status"]
+        if row["workflow_key"] == "campaign_launch"
+    )
+
+    assert campaign["state"] == "promotion_blocked"
+    assert campaign["next_action_cta"] == "configure_marketing_policy_manifest"
+    assert campaign["marketing_policy"]["status"] == "missing_policy"
+
+
+def test_workflow_linter_flags_production_step_missing_policy() -> None:
+    result = lint_marketing_workflow(
+        {
+            "id": "wf_campaign",
+            "domain": "marketing",
+            "mode": "production",
+            "steps": [
+                {
+                    "id": "launch",
+                    "type": "agent",
+                    "agent_type": "campaign_pilot",
+                    "action": "launch_campaign",
+                    "connector_key": "google_ads",
+                    "external_write_confirmation_required": True,
+                    "expected_confirmation_fields": ["external_object_id"],
+                    "idempotency_key": "launch-1",
+                    "marketing_policy_manifest_disabled": True,
+                }
+            ],
+        },
+        connector_contracts=[_write_contract()],
+    )
+
+    assert result.has_errors is True
+    assert "marketing_policy_missing" in {finding.code for finding in result.errors}
+
+
+def test_external_write_completion_refuses_customer_write_without_policy_approval() -> None:
+    decision = evaluate_marketing_external_write_result(
+        [_write_contract()],
+        connector_key="google_ads",
+        action="launch_campaign",
+        workflow_mode="active",
+        step={"id": "launch", "idempotency_key": "launch-1"},
+        state={"workflow_id": "campaign_launch", "workflow_mode": "active"},
+        output={
+            "external_write_state": "accepted",
+            "external_object_id": "customers/123/campaigns/456",
+            "idempotency_key": "launch-1",
+        },
+        now=NOW,
+    )
+
+    assert decision["step_status"] == "failed"
+    assert decision["error_code"] == "external_write_marketing_policy_approval_required"
+    assert decision["marketing_policy_decision"]["decision"] == "requires_approval"
+
+
+def test_approval_timeout_references_required_policy_role() -> None:
+    decision = evaluate_approval_timeout(
+        {
+            "approval_id": "apr-1",
+            "action": "pricing_claim",
+            "status": "pending",
+            "created_at": NOW - timedelta(hours=4),
+            "due_at": NOW - timedelta(hours=1),
+        },
+        now=NOW,
+    )
+
+    assert decision["timed_out"] is True
+    assert decision["policy_required_role"] == "legal"
+    assert decision["audit_evidence"]["policy_required_role"] == "legal"
+
+
+def _connector_config(
+    connector_name: str,
+    *,
+    config: dict,
+    health_status: str = "healthy",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        connector_name=connector_name,
+        display_name=None,
+        auth_type="oauth2",
+        credentials_encrypted={"_encrypted": "enc"},
+        config=config,
+        status="configured",
+        last_health_check=NOW,
+        health_status=health_status,
+        last_sync_at=NOW - timedelta(hours=1),
+        sync_error=None,
+    )
+
+
+def _backfill() -> dict:
+    return {
+        "status": "completed",
+        "requested_start": "2025-05-01",
+        "requested_end": "2026-05-23",
+        "records_discovered": 100,
+        "records_imported": 100,
+        "records_skipped": 0,
+        "records_failed": 0,
+        "last_run_at": "2026-05-23T10:00:00+00:00",
+    }
+
+
+def _contract() -> dict:
+    return {
+        "idempotency_supported": True,
+        "retry_budget": {
+            "max_attempts": 3,
+            "attempts_used": 0,
+            "remaining_attempts": 3,
+            "idempotency_supported": True,
+            "idempotency_key": "mkt-setup-001",
+        },
+    }
+
+
+def _write_contract() -> dict:
+    return {
+        "connector_key": "google_ads",
+        "category": "Ads",
+        "read_ready": True,
+        "write_ready": True,
+        "idempotency_key_supported": True,
+        "retry_budget": {
+            "idempotency_key": "launch-1",
+            "idempotency_supported": True,
+            "remaining_attempts": 2,
+        },
+    }
+
+
+def _base_configs() -> list[SimpleNamespace]:
+    updated_at = "2026-05-01T00:00:00+00:00"
+    hubspot_mapping = {
+        "lifecycle_stages": {
+            "source_field": "lifecyclestage",
+            "stage_map": {"mql": "marketingqualifiedlead", "sql": "salesqualifiedlead"},
+            "updated_at": updated_at,
+        },
+        "opportunity_revenue": {
+            "amount_field": "amount",
+            "close_date_field": "closedate",
+            "currency_field": "deal_currency_code",
+            "updated_at": updated_at,
+        },
+        "account_domains": {"domain_field": "website", "updated_at": updated_at},
+        "consent_unsubscribe": {
+            "consent_field": "marketing_opt_in",
+            "unsubscribe_field": "unsubscribed",
+            "updated_at": updated_at,
+        },
+        "fiscal_calendar": {"fiscal_year_start_month": 4, "updated_at": updated_at},
+        "currency": {"currency": "USD", "updated_at": updated_at},
+        "timezone": {"timezone": "Asia/Kolkata", "updated_at": updated_at},
+    }
+    campaign_mapping = {
+        "campaign_ids": {"campaign_id_field": "campaign_id", "updated_at": updated_at},
+        "utm_fields": {
+            "source": "utm_source",
+            "medium": "utm_medium",
+            "campaign": "utm_campaign",
+            "updated_at": updated_at,
+        },
+    }
+    mailchimp_mapping = {
+        **campaign_mapping,
+        "consent_unsubscribe": {
+            "consent_field": "marketing_permission",
+            "unsubscribe_field": "unsubscribe_status",
+            "updated_at": updated_at,
+        },
+    }
+    return [
+        _connector_config(
+            "hubspot",
+            config={
+                "owner": "revops@example.com",
+                "account_id": "portal-123",
+                "granted_scopes": [
+                    "crm.objects.contacts.read",
+                    "crm.objects.deals.read",
+                    "automation",
+                ],
+                "marketing_field_mapping": hubspot_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        ),
+        _connector_config(
+            "google_ads",
+            config={
+                "owner": "growth@example.com",
+                "customer_id": "123-456-7890",
+                "granted_scopes": ["https://www.googleapis.com/auth/adwords"],
+                "marketing_field_mapping": campaign_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        ),
+        _connector_config(
+            "ga4",
+            config={
+                "owner": "analytics@example.com",
+                "property_id": "properties/123",
+                "granted_scopes": ["https://www.googleapis.com/auth/analytics.readonly"],
+                "marketing_field_mapping": campaign_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        ),
+        _connector_config(
+            "mailchimp",
+            config={
+                "owner": "email@example.com",
+                "audience_id": "aud-1",
+                "marketing_field_mapping": mailchimp_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        ),
+    ]
+
+
+def _workflow_config(**overrides: object) -> dict:
+    payload = {
+        "mode": "shadow",
+        "promoted": False,
+        "approval_owner": "cmo@example.com",
+        "policy_owner": "legal@example.com",
+        "shadow_quality": {
+            "status": "passed",
+            "sample_count": 5,
+            "success_rate": 0.95,
+            "last_run_at": "2026-05-23T09:00:00+00:00",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _with_workflow(
+    configs: list[SimpleNamespace],
+    workflow_key: str,
+    payload: dict,
+) -> list[SimpleNamespace]:
+    configs = [SimpleNamespace(**vars(config)) for config in configs]
+    configs[0].config = dict(configs[0].config)
+    workflows = configs[0].config.setdefault("marketing_workflows", {})
+    workflows[workflow_key] = payload
+    return configs

--- a/tests/unit/test_cmo_marketing_workflow_linter.py
+++ b/tests/unit/test_cmo_marketing_workflow_linter.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.marketing.workflow_linter import (
+    lint_marketing_workflow,
+    lint_marketing_workflow_file,
+)
+
+WORKFLOWS_DIR = Path(__file__).resolve().parent.parent.parent / "workflows" / "examples"
+
+
+def _workflow(
+    step: dict,
+    *,
+    mode: str = "production",
+    domain: str = "marketing",
+) -> dict:
+    return {
+        "id": "wf_test",
+        "name": "Workflow Test",
+        "domain": domain,
+        "mode": mode,
+        "steps": [step],
+    }
+
+
+def _agent_step(
+    agent_type: str,
+    action: str,
+    **overrides: object,
+) -> dict:
+    step = {
+        "id": "step_1",
+        "name": "Step 1",
+        "type": "agent",
+        "agent_type": agent_type,
+        "action": action,
+    }
+    step.update(overrides)
+    return step
+
+
+def _write_contract(**overrides: object) -> dict:
+    contract = {
+        "connector_key": "google_ads",
+        "category": "Ads",
+        "read_ready": True,
+        "write_ready": True,
+        "idempotency_key_supported": True,
+        "retry_budget": {
+            "idempotency_key": "mkt-write-001",
+            "idempotency_supported": True,
+            "remaining_attempts": 2,
+        },
+    }
+    contract.update(overrides)
+    return contract
+
+
+def _codes(result) -> set[str]:
+    return {finding.code for finding in result.findings}
+
+
+def test_unknown_marketing_agent_type_fails_lint() -> None:
+    result = lint_marketing_workflow(
+        _workflow(_agent_step("growth_hacker", "launch_campaign"))
+    )
+
+    assert result.in_scope is True
+    assert result.has_errors is True
+    assert "marketing_agent_type_unknown" in _codes(result)
+    finding = result.errors[0].to_dict()
+    assert finding["workflow_file"] is None
+    assert finding["step_id"] == "step_1"
+    assert finding["severity"] == "error"
+    assert finding["suggested_fix"]
+
+
+def test_unknown_action_fails_when_agent_action_metadata_exists() -> None:
+    result = lint_marketing_workflow(
+        _workflow(_agent_step("campaign_pilot", "launch_the_moon"))
+    )
+
+    assert result.has_errors is True
+    assert "marketing_action_unknown" in _codes(result)
+
+
+def test_valid_implemented_marketing_agent_action_passes_lint() -> None:
+    result = lint_marketing_workflow(
+        _workflow(_agent_step("campaign_pilot", "create_plan"))
+    )
+
+    assert result.in_scope is True
+    assert result.findings == ()
+
+
+def test_no_marketing_agent_is_unknown_after_missing_agent_buildout() -> None:
+    result = lint_marketing_workflow(
+        _workflow(
+            _agent_step("competitive_intel", "weekly_market_snapshot"),
+            mode="target",
+        )
+    )
+
+    assert "marketing_agent_type_unknown" not in _codes(result)
+    assert "marketing_agent_unavailable_target_only" not in _codes(result)
+
+
+def test_social_media_is_beta_not_unavailable_but_production_write_still_requires_gates() -> None:
+    result = lint_marketing_workflow(
+        _workflow(
+            _agent_step(
+                "social_media",
+                "schedule_post",
+                connector_key="buffer",
+            )
+        ),
+        connector_contracts=[_write_contract(connector_key="buffer", category="Social")],
+    )
+
+    codes = _codes(result)
+    assert "marketing_agent_type_unknown" not in codes
+    assert "marketing_agent_unavailable_for_production" not in codes
+    assert "marketing_agent_beta_in_production" in codes
+    assert "marketing_external_write_confirmation_metadata_missing" in codes
+    assert "marketing_decision_audit_evidence_missing" in codes
+
+
+def test_abm_is_beta_not_unavailable_but_production_write_still_requires_gates() -> None:
+    result = lint_marketing_workflow(
+        _workflow(
+            _agent_step(
+                "abm_agent",
+                "update_target_accounts",
+            )
+        ),
+        connector_contracts=[
+            _write_contract(connector_key="hubspot", category="CRM"),
+            _write_contract(connector_key="bombora", category="ABM"),
+        ],
+    )
+
+    codes = _codes(result)
+    assert "marketing_agent_type_unknown" not in codes
+    assert "marketing_agent_unavailable_for_production" not in codes
+    assert "marketing_agent_beta_in_production" in codes
+    assert "marketing_external_write_confirmation_metadata_missing" in codes
+    assert "marketing_decision_audit_evidence_missing" in codes
+
+
+def test_brand_monitor_is_beta_not_stub_but_public_response_still_requires_gates() -> None:
+    result = lint_marketing_workflow(
+        _workflow(
+            _agent_step(
+                "brand_monitor",
+                "public_response",
+                connector_key="buffer",
+            )
+        ),
+        connector_contracts=[_write_contract(connector_key="buffer", category="Social")],
+    )
+
+    codes = _codes(result)
+    assert "marketing_agent_type_unknown" not in codes
+    assert "marketing_agent_stub_for_production" not in codes
+    assert "marketing_agent_unavailable_for_production" not in codes
+    assert "marketing_agent_beta_in_production" in codes
+    assert "marketing_external_write_confirmation_metadata_missing" in codes
+    assert "marketing_decision_audit_evidence_missing" in codes
+
+
+def test_seo_strategist_is_beta_not_stub_but_site_write_still_requires_gates() -> None:
+    result = lint_marketing_workflow(
+        _workflow(
+            _agent_step(
+                "seo_strategist",
+                "update_page_metadata",
+                connector_key="wordpress",
+            )
+        ),
+        connector_contracts=[_write_contract(connector_key="wordpress", category="CMS")],
+    )
+
+    codes = _codes(result)
+    assert "marketing_agent_type_unknown" not in codes
+    assert "marketing_agent_stub_for_production" not in codes
+    assert "marketing_agent_unavailable_for_production" not in codes
+    assert "marketing_agent_beta_in_production" in codes
+    assert "marketing_external_write_confirmation_metadata_missing" in codes
+    assert "marketing_decision_audit_evidence_missing" in codes
+
+
+def test_stub_agent_in_active_production_workflow_fails_lint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CRM Intelligence is now beta (CMO-4.3). Inject a synthetic stub agent
+    to assert the linter still fails production workflows that depend on a
+    stub-only marketing agent."""
+
+    from core.marketing import workflow_linter as wf_linter
+
+    monkeypatch.setitem(wf_linter.MARKETING_AGENT_STATES, "_synthetic_stub", "stub")
+    monkeypatch.setitem(wf_linter.MARKETING_AGENT_ACTIONS, "_synthetic_stub", {"score_lead"})
+
+    result = lint_marketing_workflow(
+        _workflow(_agent_step("_synthetic_stub", "score_lead"))
+    )
+
+    assert result.has_errors is True
+    assert "marketing_agent_stub_for_production" in _codes(result)
+
+
+@pytest.mark.parametrize("mode", ["target", "demo", "shadow"])
+def test_stub_agent_in_non_production_workflow_warns_only(
+    mode: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CRM Intelligence is now beta (CMO-4.3). Inject a synthetic stub agent
+    to assert the linter still flags stub agents in non-production workflows
+    as warnings only."""
+
+    from core.marketing import workflow_linter as wf_linter
+
+    monkeypatch.setitem(wf_linter.MARKETING_AGENT_STATES, "_synthetic_stub", "stub")
+    monkeypatch.setitem(wf_linter.MARKETING_AGENT_ACTIONS, "_synthetic_stub", {"score_lead"})
+
+    result = lint_marketing_workflow(
+        _workflow(_agent_step("_synthetic_stub", "score_lead"), mode=mode)
+    )
+
+    assert result.has_errors is False
+    assert "marketing_agent_stub_target_only" in _codes(result)
+    assert result.warnings
+
+
+def test_external_write_without_write_ready_connector_fails_production_lint() -> None:
+    step = _agent_step(
+        "campaign_pilot",
+        "activate_campaign",
+        connector_key="google_ads",
+        external_write_confirmation_required=True,
+        expected_confirmation_fields=["external_object_id", "confirmed_at"],
+        idempotency_key_template="campaign:{campaign_id}:activate",
+        decision_audit_required=True,
+    )
+
+    result = lint_marketing_workflow(
+        _workflow(step),
+        connector_contracts=[_write_contract(write_ready=False)],
+    )
+
+    assert result.has_errors is True
+    assert "marketing_external_write_connector_not_ready" in _codes(result)
+
+
+def test_external_write_without_idempotency_or_confirmation_metadata_fails_lint() -> None:
+    step = _agent_step(
+        "campaign_pilot",
+        "activate_campaign",
+        connector_key="google_ads",
+    )
+
+    result = lint_marketing_workflow(
+        _workflow(step),
+        connector_contracts=[_write_contract()],
+    )
+
+    assert result.has_errors is True
+    assert "marketing_external_write_confirmation_metadata_missing" in _codes(result)
+    assert "marketing_external_write_idempotency_metadata_missing" in _codes(result)
+
+
+def test_external_write_with_ready_contract_and_metadata_passes_lint() -> None:
+    step = _agent_step(
+        "campaign_pilot",
+        "activate_campaign",
+        connector_key="google_ads",
+        external_write_confirmation_required=True,
+        expected_confirmation_fields=["external_object_id", "confirmed_at"],
+        idempotency_key_template="campaign:{campaign_id}:activate",
+        decision_audit_required=True,
+    )
+
+    result = lint_marketing_workflow(
+        _workflow(step),
+        connector_contracts=[_write_contract()],
+    )
+
+    assert result.findings == ()
+
+
+def test_shadow_workflow_with_recommendation_only_steps_passes_read_only_lint() -> None:
+    result = lint_marketing_workflow(
+        _workflow(
+            _agent_step("campaign_pilot", "generate_weekly_report"),
+            mode="shadow",
+        )
+    )
+
+    assert result.has_errors is False
+    assert result.findings == ()
+
+
+def test_shadow_workflow_with_external_write_fails_read_only_lint() -> None:
+    result = lint_marketing_workflow(
+        _workflow(
+            _agent_step("campaign_pilot", "activate_campaign", connector_key="google_ads"),
+            mode="shadow",
+        )
+    )
+
+    assert result.has_errors is True
+    assert "marketing_shadow_external_write" in _codes(result)
+
+
+def test_non_marketing_workflow_is_reported_out_of_scope() -> None:
+    result = lint_marketing_workflow(
+        _workflow(
+            _agent_step("ap_processor", "extract_invoice"),
+            domain="finance",
+        )
+    )
+
+    assert result.in_scope is False
+    assert result.has_errors is False
+    assert _codes(result) == {"marketing_workflow_out_of_scope"}
+
+
+def test_actual_marketing_example_file_is_lintable_with_structured_findings() -> None:
+    result = lint_marketing_workflow_file(
+        WORKFLOWS_DIR / "campaign_launch.yaml",
+        connector_contracts=[_write_contract()],
+    )
+
+    assert result.in_scope is True
+    assert result.workflow_file.endswith("campaign_launch.yaml")
+    assert result.findings
+    assert all(finding.workflow_name == "Campaign Launch" for finding in result.findings)
+    codes = _codes(result)
+    assert "marketing_agent_unavailable_for_production" not in codes
+    assert "marketing_agent_beta_in_production" in codes
+    assert "marketing_external_write_confirmation_metadata_missing" in codes

--- a/tests/unit/test_cmo_pilot_proof.py
+++ b/tests/unit/test_cmo_pilot_proof.py
@@ -1,0 +1,473 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+import api.v1.kpis as kpis_api
+from core.marketing.pilot_proof import (
+    build_cmo_pilot_evidence_bundle,
+    build_cmo_pilot_proof_projection,
+    serialize_cmo_pilot_evidence_bundle,
+)
+
+NOW = datetime(2026, 5, 24, 15, 0, tzinfo=UTC)
+FRESH_TS = (NOW - timedelta(hours=1)).isoformat()
+
+
+def _connector_setup() -> list[dict[str, Any]]:
+    return [
+        {
+            "key": "hubspot",
+            "name": "HubSpot",
+            "category": "CRM",
+            "configured_status": "configured",
+            "health_status": "healthy",
+            "data_coverage_status": "ready",
+            "cta_state": "none",
+            "owner": "revops@example.com",
+            "last_sync_at": FRESH_TS,
+        },
+        {
+            "key": "google_ads",
+            "name": "Google Ads",
+            "category": "Paid Ads",
+            "configured_status": "configured",
+            "health_status": "healthy",
+            "data_coverage_status": "ready",
+            "cta_state": "none",
+            "owner": "growth@example.com",
+            "last_sync_at": FRESH_TS,
+        },
+    ]
+
+
+def _connector_contracts(*, mock: bool = False, confirmed_write: bool = True) -> list[dict[str, Any]]:
+    confirmation = []
+    if confirmed_write:
+        confirmation = [
+            {
+                "status": "write_confirmed",
+                "action": "launch_campaign",
+                "external_object_id": "customers/123/campaigns/456",
+                "source_url": "https://ads.example/campaigns/456",
+                "idempotency_key": "pilot-write-1",
+                "audit_reference": "audit-write-1",
+                "confirmed_at": FRESH_TS,
+            }
+        ]
+    return [
+        {
+            "connector_key": "hubspot",
+            "name": "HubSpot",
+            "category": "CRM",
+            "configured_status": "configured",
+            "read_status": "ready",
+            "write_status": "read_only",
+            "read_ready": True,
+            "write_ready": False,
+            "write_safe": True,
+            "production_ready": not mock,
+            "mock_or_test_double": mock,
+            "source_objects": [{"object": "deals", "source_url": "https://hubspot.example/deals"}],
+            "external_write_confirmation_status": "none",
+            "external_write_confirmations": [],
+        },
+        {
+            "connector_key": "google_ads",
+            "name": "Google Ads",
+            "category": "Paid Ads",
+            "configured_status": "configured",
+            "read_status": "ready",
+            "write_status": "ready",
+            "read_ready": True,
+            "write_ready": True,
+            "write_safe": True,
+            "production_ready": not mock,
+            "mock_or_test_double": mock,
+            "idempotency_key_supported": True,
+            "source_objects": [{"object": "campaign", "source_url": "https://ads.example/campaigns/456"}],
+            "external_write_confirmation_status": "write_confirmed" if confirmed_write else "none",
+            "external_write_confirmations": confirmation,
+        },
+    ]
+
+
+def _data_readiness(status: str = "ready") -> dict[str, Any]:
+    return {
+        "field_mapping_status": [
+            {"connector_key": "hubspot", "status": "valid"},
+            {"connector_key": "google_ads", "status": "valid"},
+        ],
+        "backfill_status": [
+            {"connector_key": "hubspot", "status": "completed"},
+            {"connector_key": "google_ads", "status": "completed"},
+        ],
+        "kpi_readiness": {
+            "status": status,
+            "field_mapping_readiness": "ready" if status == "ready" else "blocked",
+            "backfill_readiness": "ready" if status == "ready" else "blocked",
+            "next_action_cta": "none" if status == "ready" else "resolve_data_readiness",
+        },
+    }
+
+
+def _workflow_activation(state: str = "active") -> dict[str, Any]:
+    return {
+        "workflow_activation_status": [
+            {
+                "workflow_key": "weekly_marketing_report",
+                "state": state,
+                "blocked_reasons": [] if state == "active" else ["missing connector"],
+                "next_action_cta": "none" if state == "active" else "resolve_workflow_activation",
+            },
+            {
+                "workflow_key": "campaign_launch",
+                "state": state,
+                "blocked_reasons": [] if state == "active" else ["missing connector"],
+                "next_action_cta": "none" if state == "active" else "resolve_workflow_activation",
+            },
+        ],
+        "workflow_activation_summary": {"readiness": "ready" if state == "active" else "blocked"},
+    }
+
+
+def _policy_projection(status: str = "ready") -> dict[str, Any]:
+    return {
+        "marketing_policy_summary": {
+            "status": status,
+            "policy_id": "cmo-default-policy",
+            "version": "2026-05-24",
+            "next_action_cta": "none" if status == "ready" else "configure_marketing_policy_manifest",
+        }
+    }
+
+
+def _escalation_projection(status: str = "ready") -> dict[str, Any]:
+    return {
+        "marketing_escalation_summary": {
+            "status": status,
+            "policy_id": "cmo-default-escalation",
+            "version": "2026-05-24",
+            "next_action_cta": "none" if status == "ready" else "configure_escalation_matrix",
+        }
+    }
+
+
+def _audit_projection(status: str = "ready") -> dict[str, Any]:
+    return {
+        "marketing_decision_audit_summary": {
+            "status": status,
+            "schema_version": "2026-05-23.cmo-6.3",
+            "next_action_cta": "none" if status == "ready" else "configure_decision_audit_package",
+        }
+    }
+
+
+def _kpi_schema() -> list[dict[str, Any]]:
+    return [{"kpi_key": "cac"}, {"kpi_key": "roas"}, {"kpi_key": "pipeline_contribution"}]
+
+
+def _kpi_results(status: str = "ready") -> list[dict[str, Any]]:
+    return [
+        {
+            "kpi_key": "cac",
+            "status": status,
+            "value": 100,
+            "source_refs": [{"connector_key": "google_ads", "object": "spend"}],
+            "audit_refs": ["audit-kpi-cac"],
+        },
+        {
+            "kpi_key": "roas",
+            "status": status,
+            "value": 2.1,
+            "source_refs": [{"connector_key": "hubspot", "object": "deals"}],
+            "audit_refs": ["audit-kpi-roas"],
+        },
+    ]
+
+
+def _reconciliation(status: str = "passed") -> list[dict[str, Any]]:
+    return [
+        {
+            "reconciliation_key": "paid_spend_totals_by_channel",
+            "status": status,
+            "severity": "high" if status in {"failed", "blocked"} else "info",
+            "source_refs": [{"connector_key": "google_ads", "object": "campaigns"}],
+        }
+    ]
+
+
+def _report_gates(status: str = "pass", *, deliverable: bool = True) -> list[dict[str, Any]]:
+    return [
+        {
+            "report_key": "weekly_marketing_report",
+            "status": status,
+            "safe_report_mode": "deliverable" if deliverable else "draft_only",
+            "trusted_delivery_allowed": deliverable,
+            "audit_refs": ["audit-report-weekly"],
+        }
+    ]
+
+
+def _drilldowns(status: str = "ready", *, production_lineage_ready: bool = True) -> list[dict[str, Any]]:
+    return [
+        {
+            "kpi_key": "cac",
+            "status": status,
+            "production_lineage_ready": production_lineage_ready,
+            "production_lineage_status": "ready" if production_lineage_ready else "blocked",
+            "source_refs": [{"connector_key": "google_ads", "object": "campaign_spend"}],
+        },
+        {
+            "kpi_key": "roas",
+            "status": status,
+            "production_lineage_ready": production_lineage_ready,
+            "production_lineage_status": "ready" if production_lineage_ready else "blocked",
+            "source_refs": [{"connector_key": "hubspot", "object": "attributed_revenue"}],
+        },
+    ]
+
+
+def _approval_reviews(status: str = "approved") -> dict[str, Any]:
+    return {
+        "cmo_approval_reviews": [
+            {
+                "approval_id": "approval-pilot-1",
+                "status": status,
+                "audit_refs": ["audit-approval-1"],
+                "allowed_reviewer_actions": [],
+            }
+        ],
+        "cmo_approval_review_summary": {"total": 1, "approval_ready": 1 if status == "approved" else 0},
+    }
+
+
+def _lint_results(has_errors: bool = False) -> list[dict[str, Any]]:
+    return [
+        {
+            "workflow_file": "workflows/examples/cmo_campaign_launch.yaml",
+            "workflow_id": "campaign_launch",
+            "has_errors": has_errors,
+            "errors": [{"code": "marketing_connector_missing"}] if has_errors else [],
+            "warnings": [],
+        }
+    ]
+
+
+def _test_evidence(kind: str) -> list[dict[str, Any]]:
+    return [{"ref": f"tests/unit/test_cmo_{kind}.py", "scenario": kind, "status": "passed"}]
+
+
+def _proof(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "tenant_id": "tenant-pilot",
+        "company_id": "company-pilot",
+        "environment_type": "real_vendor",
+        "source_context": {"demo": False, "source": "computed"},
+        "connector_setup": _connector_setup(),
+        "connector_contracts": _connector_contracts(),
+        "data_readiness": _data_readiness(),
+        "workflow_activation": _workflow_activation(),
+        "workflow_lint_results": _lint_results(),
+        "policy_projection": _policy_projection(),
+        "escalation_projection": _escalation_projection(),
+        "approval_timeout_risk": {"pending": 0, "overdue": 0, "approval_timeout_decisions": []},
+        "external_write_results": [],
+        "decision_audit_projection": _audit_projection(),
+        "kpi_schema": _kpi_schema(),
+        "kpi_results": _kpi_results(),
+        "reconciliation_checks": _reconciliation(),
+        "report_quality_gates": _report_gates(),
+        "work_queue": [],
+        "kpi_drilldowns": _drilldowns(),
+        "approval_review_projection": _approval_reviews(),
+        "scenario_evidence": _test_evidence("e2e_scenarios"),
+        "chaos_evidence": _test_evidence("chaos_failure_modes"),
+        "now": NOW,
+    }
+    payload.update(overrides)
+    return build_cmo_pilot_proof_projection(**payload)
+
+
+def _proof_body(projection: dict[str, Any]) -> dict[str, Any]:
+    return projection["cmo_pilot_proof"]
+
+
+def test_demo_environment_returns_demo_only_not_production_passed() -> None:
+    projection = _proof(environment_type="demo", source_context={"demo": True, "source": "demo"})
+    proof = _proof_body(projection)
+
+    assert proof["proof_status"] == "demo_only"
+    assert proof["production_claim_allowed"] is False
+    assert projection["cmo_pilot_proof_summary"]["next_action_cta"] == "connect_real_or_vendor_sandbox"
+
+
+def test_test_double_environment_returns_test_only_not_production_passed() -> None:
+    projection = _proof(environment_type="test_double", connector_contracts=_connector_contracts(mock=True))
+    proof = _proof_body(projection)
+
+    assert proof["proof_status"] == "test_only"
+    assert proof["production_claim_allowed"] is False
+    assert any(blocker["category"] == "environment" for blocker in proof["blockers"])
+
+
+def test_missing_connectors_block_pilot_proof() -> None:
+    projection = _proof(connector_setup=[], connector_contracts=[])
+    proof = _proof_body(projection)
+
+    assert proof["proof_status"] == "blocked"
+    assert {"connector_setup", "connector_contracts"} <= {item["category"] for item in proof["blockers"]}
+
+
+def test_missing_mapping_or_backfill_blocks_or_partials_pilot_proof() -> None:
+    projection = _proof(environment_type="vendor_sandbox", data_readiness=_data_readiness("blocked"))
+    proof = _proof_body(projection)
+
+    assert proof["proof_status"] == "blocked"
+    assert "data_readiness" in {item["category"] for item in proof["blockers"]}
+
+
+def test_missing_policy_escalation_or_audit_readiness_blocks_proof() -> None:
+    projection = _proof(
+        policy_projection=_policy_projection("missing_policy"),
+        escalation_projection=_escalation_projection("missing_route"),
+        decision_audit_projection=_audit_projection("missing_audit_evidence"),
+    )
+    proof = _proof_body(projection)
+
+    assert proof["proof_status"] == "blocked"
+    assert {"policy", "escalation", "audit"} <= {item["category"] for item in proof["blockers"]}
+
+
+def test_failed_reconciliation_or_report_gate_blocks_proof() -> None:
+    projection = _proof(
+        reconciliation_checks=_reconciliation("failed"),
+        report_quality_gates=_report_gates("blocked", deliverable=False),
+    )
+    proof = _proof_body(projection)
+
+    assert proof["proof_status"] == "blocked"
+    assert {"kpi_reconciliation", "report_quality"} <= {item["category"] for item in proof["blockers"]}
+
+
+def test_work_queue_critical_blockers_prevent_passed_status() -> None:
+    projection = _proof(
+        work_queue=[
+            {
+                "item_id": "work-critical-1",
+                "category": "external_write",
+                "severity": "critical",
+                "status": "open",
+                "next_action_key": "resolve_external_write_failure",
+            }
+        ]
+    )
+    proof = _proof_body(projection)
+
+    assert proof["proof_status"] == "blocked"
+    assert "work_queue" in {item["category"] for item in proof["blockers"]}
+
+
+def test_vendor_sandbox_with_read_only_evidence_returns_partial() -> None:
+    projection = _proof(
+        environment_type="vendor_sandbox",
+        connector_contracts=_connector_contracts(confirmed_write=False),
+    )
+    proof = _proof_body(projection)
+
+    assert proof["proof_status"] == "partial"
+    assert proof["environment_type"] == "vendor_sandbox"
+    assert proof["real_vendor_claim_allowed"] is False
+    assert any(risk["category"] in {"external_write", "sandbox_criteria"} for risk in proof["risks"])
+
+
+def test_vendor_sandbox_with_confirmed_write_passes_only_sandbox_criteria() -> None:
+    projection = _proof(environment_type="vendor_sandbox")
+    proof = _proof_body(projection)
+
+    assert proof["proof_status"] == "passed"
+    assert proof["proof_scope"] == "sandbox"
+    assert proof["production_claim_allowed"] is False
+    assert proof["real_vendor_claim_allowed"] is False
+
+
+def test_real_vendor_with_all_critical_criteria_returns_passed() -> None:
+    projection = _proof()
+    proof = _proof_body(projection)
+
+    assert proof["proof_status"] == "passed"
+    assert proof["environment_type"] == "real_vendor"
+    assert proof["production_claim_allowed"] is True
+    assert proof["readiness_score"] == 100
+
+
+def test_beta_brand_social_abm_competitive_intel_and_seo_agents_are_unproven() -> None:
+    projection = _proof()
+    proof = _proof_body(projection)
+    unproven = {item["capability_key"]: item for item in proof["unproven_capabilities"]}
+
+    assert {
+        "agent:brand_monitor",
+        "agent:social_media",
+        "agent:abm",
+        "agent:competitive_intel",
+        "agent:seo_strategist",
+    } <= set(unproven)
+    assert unproven["agent:brand_monitor"]["status"] == "beta"
+    assert unproven["agent:social_media"]["status"] == "beta"
+    assert unproven["agent:abm"]["status"] == "beta"
+    assert unproven["agent:competitive_intel"]["status"] == "beta"
+    assert unproven["agent:seo_strategist"]["status"] == "beta"
+    assert proof["full_cmo_autonomy_claim_allowed"] is False
+
+
+def test_pilot_evidence_bundle_serialization_redacts_secrets_and_tokens() -> None:
+    projection = _proof()
+    proof = _proof_body(projection)
+    proof["evidence_refs"].append(
+        {
+            "type": "connector_secret",
+            "ref_id": "secret-ref",
+            "api_token": "live-token-value",
+            "credentials_encrypted": {"password": "do-not-serialize"},
+        }
+    )
+    bundle = build_cmo_pilot_evidence_bundle(proof)
+    serialized = serialize_cmo_pilot_evidence_bundle(bundle)
+
+    assert "live-token-value" not in serialized
+    assert "do-not-serialize" not in serialized
+    assert "[REDACTED]" in serialized
+
+
+@pytest.mark.asyncio
+async def test_kpis_cmo_response_exposes_pilot_proof_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_base(tenant_id: str, role: str, company_id: str) -> dict:
+        return {
+            "demo": False,
+            "stale": False,
+            "source": "computed",
+            "environment_type": "vendor_sandbox",
+            "company_id": company_id,
+            "agent_count": 0,
+            "total_tasks_30d": 0,
+        }
+
+    async def fake_configs(tenant_id: str) -> list:
+        return []
+
+    async def fake_approval_timeout(tenant_id: str, company_id: str) -> dict:
+        return {"pending": 0, "overdue": 0, "approval_timeout_decisions": []}
+
+    monkeypatch.setattr(kpis_api, "_build_kpi_response", fake_base)
+    monkeypatch.setattr(kpis_api, "_load_marketing_connector_configs", fake_configs)
+    monkeypatch.setattr(kpis_api, "_load_cmo_approval_timeout_risk", fake_approval_timeout)
+
+    response = await kpis_api._build_cmo_kpi_response("tenant-1", "company-1")
+
+    assert "cmo_pilot_proof" in response
+    assert "cmo_pilot_proof_summary" in response
+    assert response["cmo_pilot_proof_summary"]["environment_type"] == "vendor_sandbox"
+    assert response["cmo_pilot_proof_summary"]["production_claim_allowed"] is False

--- a/tests/unit/test_cmo_report_quality_gates.py
+++ b/tests/unit/test_cmo_report_quality_gates.py
@@ -1,0 +1,441 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from api.v1 import kpis as kpis_api
+from core.marketing.kpi_schema import build_unified_cmo_kpi_projection
+from core.marketing.report_quality import (
+    build_cmo_report_quality_projection,
+    cmo_report_gate_for_type,
+    cmo_report_trusted_delivery_allowed,
+)
+
+NOW = datetime(2026, 5, 23, 12, 0, tzinfo=UTC)
+FRESH_TS = (NOW - timedelta(hours=1)).isoformat()
+STALE_TS = (NOW - timedelta(days=3)).isoformat()
+
+ALL_CONNECTOR_CATEGORIES = (
+    "CRM",
+    "Ads",
+    "Analytics",
+    "CMS",
+    "Email",
+    "Brand",
+    "ABM",
+    "Finance",
+)
+ALL_MAPPING_KEYS = (
+    "lifecycle_stages",
+    "opportunity_revenue",
+    "campaign_ids",
+    "utm_fields",
+    "account_domains",
+    "consent_unsubscribe",
+    "fiscal_calendar",
+    "currency",
+    "timezone",
+)
+
+
+def _setup_rows(
+    *,
+    categories: tuple[str, ...] = ALL_CONNECTOR_CATEGORIES,
+    health_overrides: dict[str, str] | None = None,
+) -> list[dict]:
+    health_overrides = health_overrides or {}
+    return [
+        {
+            "key": category.lower(),
+            "name": f"{category} connector",
+            "category": category,
+            "configured_status": "configured",
+            "health_status": health_overrides.get(category, "healthy"),
+            "last_sync_at": FRESH_TS,
+        }
+        for category in categories
+    ]
+
+
+def _contract_rows(
+    *,
+    categories: tuple[str, ...] = ALL_CONNECTOR_CATEGORIES,
+) -> list[dict]:
+    return [
+        {
+            "connector_key": category.lower(),
+            "category": category,
+            "configured_status": "configured",
+            "read_ready": True,
+            "read_status": "ready",
+            "failure_class": None,
+            "blocks_production_kpi_confidence": False,
+            "degraded_mode": {"status": "none", "confidence_impact": 0.0},
+        }
+        for category in categories
+    ]
+
+
+def _data_readiness(categories: tuple[str, ...] = ALL_CONNECTOR_CATEGORIES) -> dict:
+    return {
+        "field_mapping_status": [
+            {
+                "key": key,
+                "name": key.replace("_", " ").title(),
+                "status": "valid",
+                "decision_audit_ref": f"audit-mapping-{key}",
+            }
+            for key in ALL_MAPPING_KEYS
+        ],
+        "backfill_status": [
+            {
+                "source_connector_key": category.lower(),
+                "source_name": f"{category} connector",
+                "category": category,
+                "status": "completed",
+                "decision_audit_ref": f"audit-backfill-{category.lower()}",
+            }
+            for category in categories
+        ],
+        "kpi_readiness": {"status": "ready"},
+    }
+
+
+def _source_facts(**overrides: object) -> dict:
+    facts = {
+        "last_updated_at": FRESH_TS,
+        "total_marketing_spend": 1_000.0,
+        "ad_spend": 1_000.0,
+        "campaign_spend_by_channel": {
+            "google": 600.0,
+            "linkedin": 250.0,
+            "meta": 150.0,
+        },
+        "new_customers": 10,
+        "lifecycle_stage_counts": {
+            "visitor": 1_000,
+            "lead": 250,
+            "mql": 100,
+            "sql": 40,
+            "opportunity": 20,
+            "customer": 10,
+        },
+        "ad_platform_conversions": 100,
+        "crm_campaign_attributed_mqls": 100,
+        "ga4_conversion_events": 250,
+        "crm_leads_created": 250,
+        "attributed_revenue": 5_000.0,
+        "opportunities": [{"amount": 2_500.0}, {"amount": 1_500.0}],
+        "customer_ltv": 2_000.0,
+        "completed_experiments": 6,
+        "period_days": 30,
+        "content_sessions": 1_000,
+        "content_conversions": 50,
+        "wordpress_content_sessions": 1_000,
+        "ga4_content_sessions": 1_000,
+        "emails_sent": 2_000,
+        "emails_opened": 900,
+        "emails_clicked": 300,
+        "emails_unsubscribed": 20,
+        "crm_email_sends": 2_000,
+        "crm_email_clicks": 300,
+        "crm_unsubscribed_contacts": 20,
+        "brand_positive_mentions": 70,
+        "brand_negative_mentions": 10,
+        "brand_neutral_mentions": 20,
+        "intent_ready_accounts": 25,
+        "target_accounts": 100,
+        "abm_target_account_domains": ["alpha.example", "beta.example"],
+        "crm_account_domains": ["alpha.example", "beta.example"],
+        "intent_account_domains": ["alpha.example", "beta.example"],
+        "source_currencies": {"ads": "USD", "crm": "USD", "finance": "USD"},
+        "source_timezones": {
+            "ads": "Asia/Kolkata",
+            "crm": "Asia/Kolkata",
+            "analytics": "Asia/Kolkata",
+            "email": "Asia/Kolkata",
+        },
+        "source_refs": [{"connector_key": "hubspot", "object": "deals"}],
+        "audit_refs": ["audit-kpi-source"],
+    }
+    facts.update(overrides)
+    return facts
+
+
+def _workflow_activation(*, state: str = "active") -> dict:
+    return {
+        "workflow_activation_status": [
+            {"workflow_key": "weekly_marketing_report", "state": state},
+            {"workflow_key": "daily_spend_optimization", "state": state},
+        ],
+        "workflow_activation_summary": {"readiness": "ready"},
+    }
+
+
+def _unified_projection(
+    facts: dict | None = None,
+    *,
+    setup_rows: list[dict] | None = None,
+    contract_rows: list[dict] | None = None,
+    data_readiness: dict | None = None,
+) -> dict:
+    return build_unified_cmo_kpi_projection(
+        connector_setup=setup_rows or _setup_rows(),
+        connector_contracts=contract_rows or _contract_rows(),
+        data_readiness=data_readiness or _data_readiness(),
+        source_data=facts or _source_facts(),
+        now=NOW,
+    )
+
+
+def _report_projection(
+    unified: dict | None = None,
+    *,
+    setup_rows: list[dict] | None = None,
+    contract_rows: list[dict] | None = None,
+    data_readiness: dict | None = None,
+    workflow_state: str = "active",
+    source_context: dict | None = None,
+    report_context: dict | None = None,
+    production_tenant: bool = False,
+) -> dict:
+    unified = unified or _unified_projection(
+        setup_rows=setup_rows,
+        contract_rows=contract_rows,
+        data_readiness=data_readiness,
+    )
+    return build_cmo_report_quality_projection(
+        kpi_results=unified["unified_cmo_kpi_results"],
+        reconciliation_checks=unified["cmo_kpi_reconciliation_checks"],
+        connector_setup=setup_rows or _setup_rows(),
+        data_readiness=data_readiness or _data_readiness(),
+        connector_contracts=contract_rows or _contract_rows(),
+        workflow_activation=_workflow_activation(state=workflow_state),
+        source_context=source_context or {"demo": False, "source": "computed"},
+        report_context=report_context,
+        production_tenant=production_tenant,
+        now=NOW,
+    )
+
+
+def _gate(projection: dict, key: str) -> dict:
+    return next(item for item in projection["report_quality_gates"] if item["report_key"] == key)
+
+
+def _kpi_result(key: str, **overrides: object) -> dict:
+    row = {
+        "kpi_key": key,
+        "status": "ready",
+        "confidence": 0.92,
+        "freshness_status": "fresh",
+        "source_refs": [{"connector_key": "test", "object": key}],
+        "missing_requirements": {},
+        "next_action_cta": "none",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_weekly_report_passes_when_required_kpis_ready_and_reconciliation_passes() -> None:
+    projection = _report_projection()
+    gate = _gate(projection, "weekly_marketing_report")
+
+    assert gate["status"] == "pass"
+    assert gate["safe_report_mode"] == "deliverable"
+    assert gate["trusted_delivery_allowed"] is True
+    assert projection["report_quality_summary"]["readiness"] == "ready"
+
+
+def test_weekly_report_blocks_when_cac_or_pipeline_contribution_is_blocked() -> None:
+    unified = _unified_projection(_source_facts(new_customers=None, opportunities=[]))
+    projection = _report_projection(unified)
+    gate = _gate(projection, "weekly_marketing_report")
+
+    assert gate["status"] == "blocked"
+    assert gate["safe_report_mode"] == "draft_only"
+    assert {"cac", "pipeline_contribution"} <= set(gate["blocked_kpi_keys"])
+
+
+def test_daily_ad_performance_blocks_when_ad_source_is_missing() -> None:
+    setup_rows = _setup_rows(categories=("CRM", "Analytics", "CMS", "Email", "Brand", "ABM", "Finance"))
+    contract_rows = _contract_rows(categories=("CRM", "Analytics", "CMS", "Email", "Brand", "ABM", "Finance"))
+    data_readiness = _data_readiness(categories=("CRM", "Analytics", "CMS", "Email", "Brand", "ABM", "Finance"))
+    unified = _unified_projection(
+        setup_rows=setup_rows,
+        contract_rows=contract_rows,
+        data_readiness=data_readiness,
+    )
+    projection = _report_projection(
+        unified,
+        setup_rows=setup_rows,
+        contract_rows=contract_rows,
+        data_readiness=data_readiness,
+    )
+    gate = _gate(projection, "daily_ad_performance")
+
+    assert gate["status"] == "blocked"
+    assert "Ads" in gate["missing_requirements"]["connectors"]
+    assert gate["next_action_cta"] == "fix_report_connectors"
+
+
+def test_monthly_roi_blocks_when_reconciliation_failed_or_confidence_below_floor() -> None:
+    unified = _unified_projection(
+        _source_facts(campaign_spend_by_channel={"google": 400.0, "linkedin": 150.0})
+    )
+    projection = _report_projection(unified)
+    gate = _gate(projection, "monthly_marketing_roi")
+
+    assert gate["status"] == "blocked"
+    assert "paid_spend_totals_by_channel" in gate["failed_reconciliation_keys"]
+    assert {"cac", "roas", "ltv_cac"} & set(gate["blocked_kpi_keys"])
+    assert gate["safe_report_mode"] == "draft_only"
+
+
+def test_campaign_ad_hoc_report_warns_for_stale_optional_data() -> None:
+    kpis = [
+        _kpi_result("roas"),
+        _kpi_result("mql"),
+        _kpi_result("sql"),
+        _kpi_result("conversion_rates_by_funnel_stage"),
+        _kpi_result(
+            "content_performance",
+            status="degraded",
+            confidence=0.62,
+            freshness_status="stale",
+        ),
+    ]
+    projection = build_cmo_report_quality_projection(
+        kpi_results=kpis,
+        reconciliation_checks=[],
+        connector_setup=_setup_rows(),
+        data_readiness=_data_readiness(),
+        connector_contracts=_contract_rows(),
+        workflow_activation=_workflow_activation(),
+        source_context={"demo": False, "source": "computed"},
+        now=NOW,
+    )
+    gate = _gate(projection, "campaign_performance_ad_hoc")
+
+    assert gate["status"] == "warning"
+    assert gate["safe_report_mode"] == "internal_only"
+    assert "content_performance" in gate["degraded_kpi_keys"]
+
+
+def test_draft_only_mode_allowed_for_incomplete_internal_report() -> None:
+    unified = _unified_projection(_source_facts(total_marketing_spend=None, ad_spend=None))
+    projection = _report_projection(unified)
+    gate = _gate(projection, "weekly_marketing_report")
+
+    assert gate["status"] == "blocked"
+    assert gate["safe_report_mode"] == "draft_only"
+    assert gate["trusted_delivery_allowed"] is False
+
+
+def test_deliverable_mode_denied_for_demo_or_hardcoded_production_data() -> None:
+    projection = _report_projection(
+        source_context={"demo": True, "source": "hardcoded"},
+        production_tenant=True,
+    )
+    gate = _gate(projection, "weekly_marketing_report")
+
+    assert gate["status"] == "blocked"
+    assert gate["safe_report_mode"] == "draft_only"
+    assert "real_tenant_kpi_data" in gate["missing_requirements"]["source_data"]
+
+
+def test_failed_reconciliation_blocks_affected_report() -> None:
+    unified = _unified_projection(_source_facts(source_currencies={"ads": "USD", "crm": "EUR"}))
+    projection = _report_projection(unified)
+    gate = _gate(projection, "weekly_marketing_report")
+
+    assert gate["status"] == "blocked"
+    assert "currency_consistency" in gate["failed_reconciliation_keys"]
+    assert gate["next_action_cta"] in {"resolve_report_reconciliation", "restore_required_kpis"}
+
+
+def test_stale_critical_source_blocks_trusted_weekly_report() -> None:
+    unified = _unified_projection(_source_facts(last_updated_at=STALE_TS))
+    projection = _report_projection(unified)
+    gate = _gate(projection, "weekly_marketing_report")
+
+    assert gate["status"] == "blocked"
+    assert gate["stale_missing_source_refs"]
+    assert gate["next_action_cta"] == "refresh_report_sources"
+
+
+def test_missing_policy_audit_or_approval_blocks_sensitive_report_delivery() -> None:
+    projection = _report_projection(
+        report_context={
+            "weekly_marketing_report": {
+                "external_delivery_requested": True,
+                "contains_sensitive_claims": True,
+            }
+        },
+    )
+    gate = _gate(projection, "weekly_marketing_report")
+
+    assert gate["status"] == "blocked"
+    assert "delivery_approval_ref" in gate["missing_requirements"]["approval"]
+    assert gate["safe_report_mode"] == "draft_only"
+
+
+@pytest.mark.asyncio
+async def test_kpis_cmo_response_exposes_report_quality_gate_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_base(tenant_id: str, role: str, company_id: str) -> dict:
+        return {
+            "demo": False,
+            "stale": False,
+            "source": "computed",
+            "company_id": company_id,
+            "agent_count": 0,
+            "total_tasks_30d": 0,
+        }
+
+    async def fake_configs(tenant_id: str) -> list:
+        return []
+
+    async def fake_approval_timeout(tenant_id: str, company_id: str) -> dict:
+        return {"pending": 0, "overdue": 0}
+
+    monkeypatch.setattr(kpis_api, "_build_kpi_response", fake_base)
+    monkeypatch.setattr(kpis_api, "_load_marketing_connector_configs", fake_configs)
+    monkeypatch.setattr(kpis_api, "_load_cmo_approval_timeout_risk", fake_approval_timeout)
+
+    response = await kpis_api._build_cmo_kpi_response("tenant-1", "company-1")
+
+    assert "report_quality_gates" in response
+    assert "report_quality_summary" in response
+    assert response["report_quality_summary"]["readiness"] == "blocked"
+
+
+def test_cmo_report_delivery_helper_denies_non_deliverable_gate() -> None:
+    payload = {
+        "demo": True,
+        "source": "report_generator_fallback",
+        "unified_cmo_kpi_results": [],
+        "cmo_kpi_reconciliation_checks": [],
+    }
+
+    gate = cmo_report_gate_for_type("cmo_weekly", payload, production_tenant=True)
+
+    assert gate is not None
+    assert gate["safe_report_mode"] == "draft_only"
+    assert cmo_report_trusted_delivery_allowed(gate) is False
+
+
+def test_cmo_report_generator_labels_fallback_report_as_draft_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    from core.reports.generator import ReportGenerator
+
+    monkeypatch.setattr(
+        ReportGenerator,
+        "_fetch_cmo_kpis",
+        staticmethod(lambda company_id: {"demo": True, "source": "report_generator_fallback"}),
+    )
+
+    output = ReportGenerator().generate("cmo_weekly", params={})
+    gate = output.content_data["report_quality_gate"]
+
+    assert gate["safe_report_mode"] == "draft_only"
+    assert gate["trusted_delivery_allowed"] is False
+    assert "Report quality gate" in output.content_html

--- a/tests/unit/test_cmo_seo_strategist_agent.py
+++ b/tests/unit/test_cmo_seo_strategist_agent.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.agents.marketing.seo_strategist import SeoStrategistAgent
+from core.marketing.agent_contracts import (
+    build_marketing_agent_contract_output,
+    contract_has_required_shape,
+    get_marketing_agent_contract_spec,
+)
+from core.marketing.pilot_proof import build_cmo_pilot_proof_projection
+from core.marketing.workflow_linter import lint_marketing_workflow
+from core.schemas.messages import TargetAgent, TaskAssignment, TaskInput
+
+
+class FakeToolGateway:
+    def __init__(self, responses: dict[tuple[str, str], dict[str, Any] | Exception]):
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    async def execute(
+        self,
+        *,
+        tenant_id: str,
+        agent_id: str,
+        agent_scopes: list[str],
+        connector_name: str,
+        tool_name: str,
+        params: dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "tenant_id": tenant_id,
+                "agent_id": agent_id,
+                "agent_scopes": agent_scopes,
+                "connector_name": connector_name,
+                "tool_name": tool_name,
+                "params": params,
+                "idempotency_key": idempotency_key,
+            }
+        )
+        response = self.responses.get((connector_name, tool_name), {})
+        if isinstance(response, Exception):
+            raise response
+        return dict(response)
+
+
+def _assignment(action: str, inputs: dict[str, Any]) -> TaskAssignment:
+    return TaskAssignment(
+        message_id=f"msg-seo-{action}",
+        correlation_id="corr-seo",
+        workflow_run_id="run-seo",
+        workflow_definition_id="wf-seo",
+        step_id=f"step-{action}",
+        step_index=0,
+        total_steps=1,
+        target_agent=TargetAgent(
+            agent_id="agent-seo",
+            agent_type="seo_strategist",
+            agent_token="test-token",
+        ),
+        task=TaskInput(action=action, inputs=inputs),
+    )
+
+
+def _agent(gateway: FakeToolGateway | None = None) -> SeoStrategistAgent:
+    return SeoStrategistAgent(
+        agent_id="agent-seo",
+        tenant_id="tenant-cmo",
+        tool_gateway=gateway,
+        authorized_tools=["wordpress.apply_seo_site_change", "google_search_console.submit_url_to_index"],
+    )
+
+
+def _seo_inputs(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "owned_keywords": [
+            {"keyword": "marketing automation", "rank": 18, "volume": 1600, "difficulty": 62},
+            {"keyword": "campaign roi", "rank": 5, "volume": 900, "difficulty": 44},
+        ],
+        "competitor_keywords": [
+            {
+                "keyword": "autonomous marketing agents",
+                "rank": 2,
+                "volume": 2600,
+                "difficulty": 45,
+                "intent": "commercial",
+            },
+            {"keyword": "ai cmo platform", "rank": 3, "volume": 2200, "difficulty": 48, "intent": "commercial"},
+            {"keyword": "marketing automation", "rank": 6, "volume": 1600, "difficulty": 62},
+        ],
+        "rankings": [
+            {"keyword": "marketing automation", "rank": 18, "url": "https://example.com/automation"},
+            {"keyword": "campaign roi", "rank": 5, "url": "https://example.com/roi"},
+            {"keyword": "ai cmo platform", "rank": 14, "url": "https://example.com/cmo"},
+        ],
+        "previous_rankings": [
+            {"keyword": "marketing automation", "rank": 23, "url": "https://example.com/automation"},
+            {"keyword": "campaign roi", "rank": 3, "url": "https://example.com/roi"},
+            {"keyword": "lost seo term", "rank": 9, "url": "https://example.com/lost"},
+        ],
+        "technical_issues": [
+            {
+                "id": "issue-cwv",
+                "type": "core_web_vitals",
+                "severity": "critical",
+                "impact": 90,
+                "effort": "medium",
+                "affected_pages": 14,
+            },
+            {
+                "id": "issue-meta",
+                "type": "metadata",
+                "severity": "medium",
+                "impact": 70,
+                "effort": "low",
+                "affected_pages": 40,
+            },
+        ],
+        "pages": [
+            {
+                "url": "https://example.com/cmo",
+                "title": "CMO operating system",
+                "meta_description": "Run marketing operations with agents.",
+                "headings": ["Marketing command center"],
+                "word_count": 650,
+                "internal_links": [],
+                "target_keyword": "ai cmo platform",
+            }
+        ],
+        "source_refs": [{"type": "ahrefs", "ref_id": "project-123"}],
+        "workflow_mode": "shadow",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_contract(**overrides: object) -> dict[str, Any]:
+    contract: dict[str, Any] = {
+        "connector_key": "wordpress",
+        "category": "CMS",
+        "read_ready": True,
+        "write_ready": True,
+        "write_safe": True,
+        "idempotency_key_supported": True,
+        "retry_budget": {
+            "idempotency_key": "seo-write-001",
+            "idempotency_supported": True,
+            "remaining_attempts": 2,
+        },
+    }
+    contract.update(overrides)
+    return contract
+
+
+def _workflow(step: dict[str, Any], *, mode: str = "production") -> dict[str, Any]:
+    return {
+        "id": "wf_seo",
+        "name": "SEO Sprint",
+        "domain": "marketing",
+        "mode": mode,
+        "steps": [step],
+    }
+
+
+def _workflow_step(action: str, **overrides: object) -> dict[str, Any]:
+    step: dict[str, Any] = {
+        "id": "step_seo",
+        "name": "SEO Step",
+        "type": "agent",
+        "agent_type": "seo_strategist",
+        "action": action,
+    }
+    step.update(overrides)
+    return step
+
+
+@pytest.mark.asyncio
+async def test_keyword_gap_analysis_identifies_missing_and_underperforming_opportunities() -> None:
+    result = await _agent().execute(_assignment("keyword_gap_analysis", _seo_inputs()))
+    gaps = result.output["keyword_gaps"]
+
+    assert result.output["status"] == "keyword_gaps_identified"
+    assert gaps[0]["keyword"] == "autonomous marketing agents"
+    assert gaps[0]["reason"] == "missing"
+    assert any(gap["keyword"] == "marketing automation" and gap["reason"] == "underperforming" for gap in gaps)
+
+
+@pytest.mark.asyncio
+async def test_ranking_delta_computation_handles_improvements_drops_new_and_lost() -> None:
+    result = await _agent().execute(_assignment("ranking_delta_computation", _seo_inputs()))
+    deltas = {row["keyword"]: row for row in result.output["ranking_deltas"]}
+
+    assert deltas["marketing automation"]["status"] == "improved"
+    assert deltas["campaign roi"]["status"] == "dropped"
+    assert deltas["ai cmo platform"]["status"] == "new"
+    assert deltas["lost seo term"]["status"] == "lost"
+
+
+@pytest.mark.asyncio
+async def test_technical_issue_prioritization_orders_by_severity_impact_and_effort() -> None:
+    result = await _agent().execute(_assignment("technical_issue_prioritization", _seo_inputs()))
+    issues = result.output["technical_issues"]
+
+    assert issues[0]["issue_id"] == "issue-cwv"
+    assert issues[0]["recommended_action"] == "improve_page_performance"
+    assert issues[0]["priority_score"] > issues[1]["priority_score"]
+
+
+@pytest.mark.asyncio
+async def test_recommendations_bundle_by_effort_and_impact() -> None:
+    result = await _agent().execute(_assignment("recommendation_bundling", _seo_inputs()))
+    bundles = result.output["recommendation_bundles"]
+
+    assert bundles["quick_wins"]
+    assert bundles["strategic"]
+    assert all("priority_score" in item for rows in bundles.values() for item in rows)
+
+
+@pytest.mark.asyncio
+async def test_content_optimization_recommendation_is_deterministic() -> None:
+    result = await _agent().execute(_assignment("content_optimization_recommendation", _seo_inputs()))
+    recommendation = result.output["content_recommendations"][0]
+
+    assert recommendation["url"] == "https://example.com/cmo"
+    assert "add_target_keyword_to_title" in recommendation["actions"]
+    assert "refresh_meta_description_with_target_keyword" in recommendation["actions"]
+    assert "add_internal_links" in recommendation["actions"]
+
+
+@pytest.mark.asyncio
+async def test_seo_sprint_plan_includes_prioritized_actions_and_expected_impact() -> None:
+    result = await _agent().execute(_assignment("seo_sprint_planning", _seo_inputs(sprint_capacity=4)))
+    sprint = result.output["sprint_plan"]
+
+    assert result.output["status"] == "seo_sprint_planned"
+    assert len(sprint["actions"]) == 4
+    assert sprint["expected_impact"]["technical_fixes"] >= 1
+    assert sprint["requires_approval_for_writes"] is True
+
+
+@pytest.mark.asyncio
+async def test_stale_or_partial_connector_data_downgrades_confidence_and_status() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "seo_sprint_planning",
+            _seo_inputs(connector_read_ready=False, stale_data=True, partial_data=True),
+        )
+    )
+
+    assert result.output["status"] == "seo_sprint_degraded"
+    assert result.output["degraded_reasons"]
+    assert result.output["confidence"] < 0.84
+
+
+@pytest.mark.asyncio
+async def test_technical_site_change_requires_policy_approval_audit_and_write_readiness() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "update_page_metadata",
+            _seo_inputs(
+                workflow_mode="active",
+                connector_contract=_write_contract(),
+                url="https://example.com/cmo",
+                title="AI CMO platform",
+                meta_description="AI CMO operating system for governed marketing.",
+            ),
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["status"] == "blocked"
+    assert result.output["policy_result"]["decision"] == "requires_approval"
+    assert result.output["approval_required"] is True
+    assert result.output["audit_ref"].startswith("seo_strategist:")
+    assert result.output["external_write_confirmation_status"] == "write_unconfirmed"
+
+
+@pytest.mark.asyncio
+async def test_connector_degraded_or_missing_state_downgrades_or_blocks_appropriately() -> None:
+    read_result = await _agent().execute(
+        _assignment("identify_content_gaps", _seo_inputs(connector_read_ready=False))
+    )
+    write_result = await _agent().execute(
+        _assignment(
+            "update_page_metadata",
+            _seo_inputs(
+                workflow_mode="active",
+                approved=True,
+                connector_contract=_write_contract(write_ready=False, write_safe=False),
+            ),
+        )
+    )
+
+    assert read_result.output["status"] == "keyword_gaps_degraded"
+    assert read_result.output["degraded_reasons"]
+    assert write_result.output["status"] == "blocked"
+    assert any("not write-safe" in reason for reason in write_result.output["blocked_reasons"])
+
+
+@pytest.mark.asyncio
+async def test_shadow_read_only_advisory_mode_cannot_write_externally() -> None:
+    gateway = FakeToolGateway({})
+    result = await _agent(gateway).execute(
+        _assignment("update_page_metadata", _seo_inputs(workflow_mode="shadow", title="Draft SEO title"))
+    )
+
+    assert result.output["status"] == "shadow_only"
+    assert result.output["external_write_confirmation_status"] == "shadow_only"
+    assert gateway.calls == []
+
+
+@pytest.mark.asyncio
+async def test_active_external_site_write_cannot_complete_without_confirmed_write() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "update_page_metadata",
+            _seo_inputs(
+                workflow_mode="active",
+                approved=True,
+                connector_contract=_write_contract(),
+                external_write_result={
+                    "connector_key": "wordpress",
+                    "status": "accepted",
+                    "idempotency_key": "seo:metadata:1",
+                },
+            ),
+        )
+    )
+
+    assert result.output["status"] == "write_unconfirmed"
+    assert result.output["external_writes_completed"] is False
+    assert result.status == "hitl_triggered"
+
+
+@pytest.mark.asyncio
+async def test_confirmed_site_write_has_policy_audit_escalation_refs_when_required() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "update_page_metadata",
+            _seo_inputs(
+                workflow_mode="active",
+                approved=True,
+                legal_claim=True,
+                connector_contract=_write_contract(),
+                external_write_result={
+                    "connector_key": "wordpress",
+                    "status": "write_confirmed",
+                    "external_object_id": "post-123:metadata",
+                    "source_url": "https://cms.example/post-123",
+                    "idempotency_key": "seo:metadata:1",
+                    "confirmed_at": "2026-05-24T12:00:00Z",
+                    "audit_ref": "audit-seo-write",
+                },
+            ),
+        )
+    )
+    contract = build_marketing_agent_contract_output(
+        "seo_strategist",
+        "update_page_metadata",
+        result=result,
+        audit_ref=result.output["audit_ref"],
+        external_write_confirmation_status=result.output["external_write_confirmation_status"],
+    )
+
+    assert result.status == "completed"
+    assert result.output["policy_result"]["decision"] == "requires_escalation"
+    assert result.output["escalation_ref"]
+    assert result.output["external_write_ref"]["external_object_id"] == "post-123:metadata"
+    assert contract_has_required_shape(contract)
+    assert contract["maturity"] == "beta"
+    assert contract["external_writes_completed"] is True
+
+
+def test_workflow_linter_activation_and_pilot_proof_are_truthful_beta() -> None:
+    read_lint = lint_marketing_workflow(_workflow(_workflow_step("keyword_gap_analysis"), mode="target"))
+    write_lint = lint_marketing_workflow(
+        _workflow(_workflow_step("update_page_metadata", connector_key="wordpress")),
+        connector_contracts=[_write_contract()],
+    )
+    proof = build_cmo_pilot_proof_projection(
+        environment_type="vendor_sandbox",
+        source_context={"source": "vendor_sandbox"},
+        agent_contracts=[get_marketing_agent_contract_spec("seo_strategist")],
+    )["cmo_pilot_proof"]
+    contract = build_marketing_agent_contract_output(
+        "seo_strategist",
+        "keyword_gap_analysis",
+        audit_ref="audit-seo-contract",
+    )
+
+    assert contract_has_required_shape(contract)
+    assert contract["maturity"] == "beta"
+    assert contract["production_ready"] is False
+    assert "marketing_agent_type_unknown" not in {finding.code for finding in read_lint.findings}
+    assert "marketing_agent_stub_target_only" not in {finding.code for finding in read_lint.findings}
+    assert "marketing_agent_beta_in_production" in {finding.code for finding in write_lint.findings}
+    assert "marketing_external_write_confirmation_metadata_missing" in {
+        finding.code for finding in write_lint.findings
+    }
+    assert proof["production_claim_allowed"] is False
+    assert any(item["capability_key"] == "agent:seo_strategist" for item in proof["unproven_capabilities"])

--- a/tests/unit/test_cmo_social_media_agent.py
+++ b/tests/unit/test_cmo_social_media_agent.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.agents.marketing.social_media import SocialMediaAgent
+from core.agents.registry import AgentRegistry
+from core.marketing.agent_contracts import (
+    build_marketing_agent_contract_output,
+    contract_has_required_shape,
+    get_marketing_agent_contract_spec,
+)
+from core.marketing.pilot_proof import build_cmo_pilot_proof_projection
+from core.marketing.workflow_linter import lint_marketing_workflow
+from core.schemas.messages import TargetAgent, TaskAssignment, TaskInput
+
+
+class FakeToolGateway:
+    def __init__(self, responses: dict[tuple[str, str], dict[str, Any] | Exception]):
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    async def execute(
+        self,
+        *,
+        tenant_id: str,
+        agent_id: str,
+        agent_scopes: list[str],
+        connector_name: str,
+        tool_name: str,
+        params: dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "tenant_id": tenant_id,
+                "agent_id": agent_id,
+                "agent_scopes": agent_scopes,
+                "connector_name": connector_name,
+                "tool_name": tool_name,
+                "params": params,
+                "idempotency_key": idempotency_key,
+            }
+        )
+        response = self.responses.get((connector_name, tool_name), {})
+        if isinstance(response, Exception):
+            raise response
+        return dict(response)
+
+
+def _assignment(action: str, inputs: dict[str, Any]) -> TaskAssignment:
+    return TaskAssignment(
+        message_id=f"msg-social-{action}",
+        correlation_id="corr-social",
+        workflow_run_id="run-social",
+        workflow_definition_id="wf-social",
+        step_id=f"step-{action}",
+        step_index=0,
+        total_steps=1,
+        target_agent=TargetAgent(
+            agent_id="agent-social",
+            agent_type="social_media",
+            agent_token="test-token",
+        ),
+        task=TaskInput(action=action, inputs=inputs),
+    )
+
+
+def _agent(gateway: FakeToolGateway | None = None) -> SocialMediaAgent:
+    return SocialMediaAgent(
+        agent_id="agent-social",
+        tenant_id="tenant-cmo",
+        tool_gateway=gateway,
+        authorized_tools=["buffer.create_post", "twitter.create_tweet", "youtube.create_community_post"],
+    )
+
+
+def _workflow_step(action: str, **overrides: object) -> dict[str, Any]:
+    step: dict[str, Any] = {
+        "id": "step_social",
+        "name": "Social Step",
+        "type": "agent",
+        "agent_type": "social_media",
+        "action": action,
+    }
+    step.update(overrides)
+    return step
+
+
+def _workflow(step: dict[str, Any], *, mode: str = "production") -> dict[str, Any]:
+    return {
+        "id": "wf_social",
+        "name": "Social Publishing",
+        "domain": "marketing",
+        "mode": mode,
+        "steps": [step],
+    }
+
+
+def _write_contract(**overrides: object) -> dict[str, Any]:
+    contract = {
+        "connector_key": "buffer",
+        "category": "Social",
+        "read_ready": True,
+        "write_ready": True,
+        "write_safe": True,
+        "idempotency_key_supported": True,
+        "retry_budget": {
+            "idempotency_key": "social:post:001",
+            "idempotency_supported": True,
+            "remaining_attempts": 2,
+        },
+    }
+    contract.update(overrides)
+    return contract
+
+
+@pytest.mark.asyncio
+async def test_social_media_content_calendar_generation_has_contract_shape() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "generate_content_calendar",
+            {
+                "campaign_theme": "pilot proof launch",
+                "channels": ["linkedin", "twitter"],
+                "weeks": 2,
+                "start_date": "2026-05-25",
+                "target_audience": "CMOs",
+            },
+        )
+    )
+    contract = build_marketing_agent_contract_output(
+        "social_media",
+        "generate_content_calendar",
+        result=result,
+        audit_ref=result.output["audit_ref"],
+    )
+
+    assert result.status == "completed"
+    assert result.output["status"] == "calendar_generated"
+    assert len(result.output["content_calendar"]) == 4
+    assert result.output["approval_required"] is False
+    assert contract_has_required_shape(contract)
+    assert contract["maturity"] == "beta"
+    assert contract["production_ready"] is False
+
+
+@pytest.mark.asyncio
+async def test_posting_schedule_optimization_is_deterministic() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "optimize_posting_schedule",
+            {
+                "channels": ["linkedin", "twitter"],
+                "historical_engagement": [
+                    {"channel": "linkedin", "day": "Mon", "hour": "09:00", "engagement_rate": 0.02},
+                    {"channel": "linkedin", "day": "Tue", "hour": "10:00", "engagement_rate": 0.07},
+                    {"channel": "twitter", "day": "Wed", "hour": "11:00", "engagement_rate": 0.04},
+                ],
+            },
+        )
+    )
+
+    slots = {row["channel"]: row["recommended_slot"] for row in result.output["schedule_recommendations"]}
+    assert result.status == "completed"
+    assert slots["linkedin"] == "Tue 10:00"
+    assert slots["twitter"] == "Wed 11:00"
+
+
+@pytest.mark.asyncio
+async def test_engagement_triage_classifies_normal_negative_legal_executive_and_crisis() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "triage_engagement",
+            {
+                "mentions": [
+                    {"id": "m1", "text": "Great product update"},
+                    {"id": "m2", "text": "I am angry about broken support"},
+                    {"id": "m3", "text": "Do you guarantee pricing vs competitor?"},
+                    {"id": "m4", "text": "Can your CEO comment to the press?"},
+                    {"id": "m5", "text": "Data breach and fraud allegations"},
+                ]
+            },
+        )
+    )
+
+    by_id = {row["mention_id"]: row for row in result.output["mentions"]}
+    assert by_id["m1"]["risk_type"] == "normal"
+    assert by_id["m2"]["risk_type"] == "negative_feedback"
+    assert by_id["m3"]["severity"] == "high"
+    assert by_id["m4"]["risk_type"] == "executive_or_press"
+    assert by_id["m5"]["risk_type"] == "crisis"
+    assert result.status == "hitl_triggered"
+    assert result.output["approval_required"] is True
+    assert result.output["escalation_ref"]
+
+
+@pytest.mark.asyncio
+async def test_high_risk_reply_requires_policy_review_and_escalation_ref() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "classify_reply_risk",
+            {"reply_text": "We guarantee lower pricing than every competitor."},
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["classification"]["severity"] == "high"
+    assert result.output["policy_result"]["decision"] in {"requires_approval", "requires_escalation"}
+    assert result.output["approval_required"] is True
+    assert result.output["audit_ref"].startswith("social_media:")
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_cannot_publish_or_post_externally() -> None:
+    gateway = FakeToolGateway({("buffer", "create_post"): {"status": "write_confirmed"}})
+    result = await _agent(gateway).execute(
+        _assignment(
+            "schedule_post",
+            {
+                "workflow_mode": "shadow",
+                "post_text": "Launch update for customers.",
+                "channel": "linkedin",
+                "connector_write_ready": True,
+            },
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["status"] == "shadow_only"
+    assert result.output["external_writes_completed"] is False
+    assert gateway.calls == []
+
+
+@pytest.mark.asyncio
+async def test_active_publish_blocks_when_connector_not_write_safe() -> None:
+    result = await _agent().execute(
+        _assignment(
+            "schedule_post",
+            {
+                "workflow_mode": "active",
+                "post_text": "Launch update for customers.",
+                "channel": "linkedin",
+                "connector_contract": _write_contract(write_ready=False, write_safe=False),
+                "approved": True,
+                "approval_ref": "approval-social-1",
+            },
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["status"] == "blocked"
+    assert any("not write-safe" in reason for reason in result.output["blocked_reasons"])
+
+
+@pytest.mark.asyncio
+async def test_active_publish_cannot_complete_without_confirmed_external_write() -> None:
+    gateway = FakeToolGateway(
+        {("buffer", "create_post"): {"status": "accepted", "external_object_id": "buf-accepted"}}
+    )
+    result = await _agent(gateway).execute(
+        _assignment(
+            "schedule_post",
+            {
+                "workflow_mode": "active",
+                "post_text": "Launch update for customers.",
+                "channel": "linkedin",
+                "connector_contract": _write_contract(),
+                "approved": True,
+                "approval_ref": "approval-social-1",
+                "idempotency_key": "social:post:launch",
+            },
+        )
+    )
+
+    assert result.status == "hitl_triggered"
+    assert result.output["external_write_confirmation_status"] == "accepted"
+    assert result.output["external_writes_completed"] is False
+    assert any("unconfirmed" in reason for reason in result.output["blocked_reasons"])
+
+
+@pytest.mark.asyncio
+async def test_confirmed_active_publish_has_policy_audit_and_write_ref() -> None:
+    gateway = FakeToolGateway(
+        {
+            ("buffer", "create_post"): {
+                "status": "write_confirmed",
+                "connector_key": "buffer",
+                "external_object_id": "buf-post-1",
+                "source_url": "https://social.example/post/1",
+                "idempotency_key": "social:post:launch",
+                "confirmed_at": "2026-05-24T12:00:00+00:00",
+                "audit_ref": "audit-social-write-1",
+            }
+        }
+    )
+    result = await _agent(gateway).execute(
+        _assignment(
+            "schedule_post",
+            {
+                "workflow_mode": "active",
+                "post_text": "Launch update for customers.",
+                "channel": "linkedin",
+                "connector_contract": _write_contract(),
+                "approved": True,
+                "approval_ref": "approval-social-1",
+                "idempotency_key": "social:post:launch",
+            },
+        )
+    )
+
+    assert result.status == "completed"
+    assert result.output["external_write_confirmation_status"] == "write_confirmed"
+    assert result.output["external_writes_completed"] is True
+    assert result.output["external_write_ref"]["external_object_id"] == "buf-post-1"
+    assert result.output["policy_result"]["decision"] == "requires_approval"
+    assert result.output["audit_ref"].startswith("social_media:")
+
+
+def test_social_media_registered_and_contract_metadata_is_beta() -> None:
+    assert AgentRegistry.get_by_type("social_media") is SocialMediaAgent
+    spec = get_marketing_agent_contract_spec("social_media")
+    assert spec["maturity"] == "beta"
+    assert spec["production_ready"] is False
+    assert spec["surface"] == "core.agents.marketing.social_media"
+    assert "generate_content_calendar" in spec["actions"]
+
+
+def test_workflow_linter_knows_social_media_but_blocks_unsafe_production_write() -> None:
+    recommendation = lint_marketing_workflow(
+        _workflow(_workflow_step("generate_content_calendar"))
+    )
+    unsafe_write = lint_marketing_workflow(
+        _workflow(_workflow_step("schedule_post", connector_key="buffer")),
+        connector_contracts=[_write_contract()],
+    )
+
+    assert "marketing_agent_type_unknown" not in {finding.code for finding in recommendation.findings}
+    assert "marketing_agent_unavailable_for_production" not in {
+        finding.code for finding in recommendation.findings
+    }
+    assert unsafe_write.has_errors is True
+    assert "marketing_external_write_confirmation_metadata_missing" in {
+        finding.code for finding in unsafe_write.findings
+    }
+    assert "marketing_decision_audit_evidence_missing" in {
+        finding.code for finding in unsafe_write.findings
+    }
+
+
+def test_social_media_production_lint_passes_only_with_write_policy_audit_metadata() -> None:
+    result = lint_marketing_workflow(
+        _workflow(
+            _workflow_step(
+                "schedule_post",
+                connector_key="buffer",
+                external_write_confirmation_required=True,
+                expected_confirmation_fields=["external_object_id", "confirmed_at"],
+                idempotency_key_template="social:{post_id}:schedule",
+                decision_audit_required=True,
+                approval_timeout_policy={"approval_type": "social_post_target_behavior"},
+            )
+        ),
+        connector_contracts=[_write_contract()],
+    )
+
+    codes = {finding.code for finding in result.findings}
+    assert "marketing_agent_unavailable_for_production" not in codes
+    assert "marketing_external_write_connector_not_ready" not in codes
+    assert "marketing_external_write_confirmation_metadata_missing" not in codes
+
+
+def test_pilot_proof_keeps_social_media_unproven_without_production_proof() -> None:
+    projection = build_cmo_pilot_proof_projection(
+        environment_type="vendor_sandbox",
+        source_context={"tenant_id": "tenant-cmo", "source": "vendor_sandbox"},
+        connector_setup=[],
+        connector_contracts=[],
+        agent_contracts=[get_marketing_agent_contract_spec("social_media")],
+    )
+    proof = projection["cmo_pilot_proof"]
+    proven = {row["capability_key"] for row in proof["proven_capabilities"]}
+    unproven = {row["capability_key"]: row for row in proof["unproven_capabilities"]}
+
+    assert "agent:social_media" not in proven
+    assert unproven["agent:social_media"]["status"] == "beta"
+    assert proof["production_claim_allowed"] is False

--- a/tests/unit/test_cmo_unified_kpi_schema.py
+++ b/tests/unit/test_cmo_unified_kpi_schema.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from core.marketing.kpi_schema import (
+    CMO_KPI_SCHEMA_VERSION,
+    build_unified_cmo_kpi_projection,
+    default_cmo_kpi_schema,
+    evaluate_cmo_kpi,
+    evaluate_cmo_kpis,
+)
+
+NOW = datetime(2026, 5, 23, 12, 0, tzinfo=UTC)
+FRESH_TS = (NOW - timedelta(hours=1)).isoformat()
+
+ALL_CONNECTOR_CATEGORIES = (
+    "CRM",
+    "Ads",
+    "Analytics",
+    "CMS",
+    "Email",
+    "Brand",
+    "ABM",
+    "Finance",
+)
+ALL_MAPPING_KEYS = (
+    "lifecycle_stages",
+    "opportunity_revenue",
+    "campaign_ids",
+    "utm_fields",
+    "account_domains",
+    "consent_unsubscribe",
+    "fiscal_calendar",
+    "currency",
+    "timezone",
+)
+
+
+def _setup_rows(*, categories: tuple[str, ...] = ALL_CONNECTOR_CATEGORIES) -> list[dict]:
+    return [
+        {
+            "key": category.lower(),
+            "name": f"{category} connector",
+            "category": category,
+            "configured_status": "configured",
+            "health_status": "healthy",
+            "last_sync_at": FRESH_TS,
+        }
+        for category in categories
+    ]
+
+
+def _contract_rows(*, categories: tuple[str, ...] = ALL_CONNECTOR_CATEGORIES) -> list[dict]:
+    return [
+        {
+            "connector_key": category.lower(),
+            "category": category,
+            "configured_status": "configured",
+            "read_ready": True,
+            "read_status": "ready",
+            "blocks_production_kpi_confidence": False,
+            "degraded_mode": {"status": "none", "confidence_impact": 0.0},
+        }
+        for category in categories
+    ]
+
+
+def _data_readiness(
+    *,
+    mapping_overrides: dict[str, str] | None = None,
+    backfill_overrides: dict[str, str] | None = None,
+    categories: tuple[str, ...] = ALL_CONNECTOR_CATEGORIES,
+) -> dict:
+    mapping_overrides = mapping_overrides or {}
+    backfill_overrides = backfill_overrides or {}
+    return {
+        "field_mapping_status": [
+            {
+                "key": key,
+                "name": key.replace("_", " ").title(),
+                "status": mapping_overrides.get(key, "valid"),
+                "decision_audit_ref": f"audit-mapping-{key}",
+            }
+            for key in ALL_MAPPING_KEYS
+        ],
+        "backfill_status": [
+            {
+                "source_connector_key": category.lower(),
+                "source_name": f"{category} connector",
+                "category": category,
+                "status": backfill_overrides.get(category, "completed"),
+                "decision_audit_ref": f"audit-backfill-{category.lower()}",
+            }
+            for category in categories
+        ],
+        "kpi_readiness": {"status": "ready"},
+    }
+
+
+def _source_facts(**overrides: object) -> dict:
+    facts = {
+        "last_updated_at": FRESH_TS,
+        "total_marketing_spend": 1_000.0,
+        "ad_spend": 1_000.0,
+        "new_customers": 10,
+        "lifecycle_stage_counts": {
+            "visitor": 1_000,
+            "lead": 250,
+            "mql": 100,
+            "sql": 40,
+            "opportunity": 20,
+            "customer": 10,
+        },
+        "attributed_revenue": 5_000.0,
+        "opportunities": [{"amount": 2_500.0}, {"amount": 1_500.0}],
+        "customer_ltv": 2_000.0,
+        "completed_experiments": 6,
+        "period_days": 30,
+        "content_sessions": 1_000,
+        "content_conversions": 50,
+        "emails_sent": 2_000,
+        "emails_opened": 900,
+        "emails_clicked": 300,
+        "emails_unsubscribed": 20,
+        "brand_positive_mentions": 70,
+        "brand_negative_mentions": 10,
+        "brand_neutral_mentions": 20,
+        "intent_ready_accounts": 25,
+        "target_accounts": 100,
+        "source_refs": [{"connector_key": "hubspot", "object": "deals"}],
+        "audit_refs": ["audit-kpi-source"],
+    }
+    facts.update(overrides)
+    return facts
+
+
+def _evaluate(key: str, source_data: dict | None = None, **readiness_overrides: object) -> dict:
+    return evaluate_cmo_kpi(
+        key,
+        source_data or _source_facts(),
+        connector_setup=_setup_rows(),
+        connector_contracts=_contract_rows(),
+        data_readiness=_data_readiness(**readiness_overrides),
+        now=NOW,
+    )
+
+
+def test_required_kpi_definitions_load_with_stable_keys_and_formulas() -> None:
+    schema = default_cmo_kpi_schema()
+    by_key = {item["key"]: item for item in schema["kpis"]}
+
+    assert schema["schema_version"] == CMO_KPI_SCHEMA_VERSION
+    assert set(by_key) == {
+        "cac",
+        "mql",
+        "sql",
+        "mql_to_sql_conversion_rate",
+        "roas",
+        "pipeline_contribution",
+        "conversion_rates_by_funnel_stage",
+        "ltv_cac",
+        "experiment_velocity",
+        "content_performance",
+        "email_performance",
+        "brand_sentiment",
+        "abm_intent_account_readiness",
+    }
+    assert by_key["cac"]["formula"] == "total_marketing_spend / new_customers"
+    assert by_key["roas"]["formula"] == "attributed_revenue / ad_spend"
+    assert by_key["pipeline_contribution"]["required_field_mappings"] == [
+        "opportunity_revenue",
+        "campaign_ids",
+        "currency",
+    ]
+
+
+def test_cac_formula_computes_from_spend_and_new_customers() -> None:
+    result = _evaluate("cac")
+
+    assert result["status"] == "ready"
+    assert result["value"] == 100.0
+    assert result["unit"] == "currency"
+    assert result["confidence"] > 0.9
+
+
+def test_cac_blocks_when_required_source_mapping_is_missing() -> None:
+    result = _evaluate(
+        "cac",
+        mapping_overrides={"opportunity_revenue": "unmapped"},
+    )
+
+    assert result["status"] == "blocked"
+    assert result["value"] is None
+    assert "opportunity_revenue" in result["missing_requirements"]["field_mappings"]
+    assert result["next_action_cta"] == "fix_required_mapping"
+
+
+def test_mql_and_sql_counts_compute_from_mapped_lifecycle_stages() -> None:
+    mql = _evaluate("mql")
+    sql = _evaluate("sql")
+
+    assert mql["status"] == "ready"
+    assert mql["value"] == 100.0
+    assert sql["status"] == "ready"
+    assert sql["value"] == 40.0
+
+
+def test_mql_to_sql_conversion_handles_zero_denominator_safely() -> None:
+    result = _evaluate(
+        "mql_to_sql_conversion_rate",
+        _source_facts(lifecycle_stage_counts={"mql": 0, "sql": 0}),
+    )
+
+    assert result["status"] == "degraded"
+    assert result["value"] == 0.0
+    assert result["zero_denominator"] is True
+    assert result["blocked_reasons"] == []
+
+
+def test_roas_computes_and_degrades_when_attribution_is_partial() -> None:
+    ready = _evaluate("roas")
+    degraded = _evaluate(
+        "roas",
+        _source_facts(attribution_status="partial", attribution_coverage=0.6),
+    )
+
+    assert ready["status"] == "ready"
+    assert ready["value"] == 5.0
+    assert degraded["status"] == "degraded"
+    assert degraded["value"] == 5.0
+    assert any("Attribution coverage is partial" in reason for reason in degraded["degraded_reasons"])
+
+
+def test_roas_blocks_when_attribution_source_data_is_missing() -> None:
+    facts = _source_facts()
+    facts.pop("attributed_revenue")
+
+    result = _evaluate("roas", facts)
+
+    assert result["status"] == "blocked"
+    assert result["value"] is None
+    assert "attributed_revenue" in result["missing_requirements"]["fields"]
+
+
+def test_pipeline_contribution_and_experiment_velocity_compute_from_structured_inputs() -> None:
+    pipeline = _evaluate("pipeline_contribution")
+    velocity = _evaluate("experiment_velocity")
+
+    assert pipeline["status"] == "ready"
+    assert pipeline["value"] == 4_000.0
+    assert velocity["status"] == "ready"
+    assert velocity["value"] == 6.0
+
+
+def test_conversion_rates_by_funnel_stage_compute_with_safe_zero_denominators() -> None:
+    result = _evaluate(
+        "conversion_rates_by_funnel_stage",
+        _source_facts(lifecycle_stage_counts={"visitor": 0, "lead": 0, "mql": 10, "sql": 5}),
+    )
+
+    assert result["status"] == "degraded"
+    assert result["value"]["visitor_to_lead"] == 0.0
+    assert result["value"]["mql_to_sql"] == 50.0
+    assert result["zero_denominator"] is True
+
+
+def test_stale_source_data_downgrades_confidence_and_freshness() -> None:
+    result = _evaluate(
+        "roas",
+        _source_facts(last_updated_at=(NOW - timedelta(days=2)).isoformat()),
+    )
+
+    assert result["status"] == "degraded"
+    assert result["freshness_status"] == "stale"
+    assert result["confidence"] < 0.8
+    assert result["next_action_cta"] == "refresh_source_data"
+
+
+def test_partial_source_readiness_degrades_instead_of_reporting_fake_ready() -> None:
+    result = _evaluate(
+        "roas",
+        mapping_overrides={"utm_fields": "partially_mapped"},
+    )
+
+    assert result["status"] == "degraded"
+    assert result["value"] == 5.0
+    assert "utm_fields" not in result["missing_requirements"]["field_mappings"]
+    assert any("utm_fields" in reason for reason in result["degraded_reasons"])
+
+
+def test_missing_connector_mapping_and_backfill_block_affected_kpi() -> None:
+    missing_connector = evaluate_cmo_kpi(
+        "roas",
+        _source_facts(),
+        connector_setup=_setup_rows(categories=("CRM", "Analytics")),
+        connector_contracts=_contract_rows(categories=("CRM", "Analytics")),
+        data_readiness=_data_readiness(categories=("CRM", "Analytics")),
+        now=NOW,
+    )
+    failed_backfill = _evaluate(
+        "roas",
+        backfill_overrides={"Analytics": "failed"},
+    )
+
+    assert missing_connector["status"] == "blocked"
+    assert "Ads" in missing_connector["missing_requirements"]["connectors"]
+    assert failed_backfill["status"] == "blocked"
+    assert "Analytics" in failed_backfill["missing_requirements"]["backfills"]
+
+
+def test_kpi_result_includes_formula_lineage_source_refs_and_action() -> None:
+    result = _evaluate("cac")
+
+    assert result["formula_refs"]["schema_version"] == CMO_KPI_SCHEMA_VERSION
+    assert result["formula_refs"]["formula_inputs"] == ["total_marketing_spend", "new_customers"]
+    assert result["source_lineage_refs"] == ["ads.spend", "crm.new_customers", "finance.currency"]
+    assert any(ref.get("connector_key") == "hubspot" for ref in result["source_refs"])
+    assert "audit-kpi-source" in result["audit_refs"]
+    assert result["next_action_cta"] == "none"
+
+
+def test_all_core_kpis_can_evaluate_ready_from_mapped_fresh_real_inputs() -> None:
+    results = evaluate_cmo_kpis(
+        _source_facts(),
+        connector_setup=_setup_rows(),
+        connector_contracts=_contract_rows(),
+        data_readiness=_data_readiness(),
+        now=NOW,
+    )
+
+    assert {result["kpi_key"] for result in results} == {
+        item["key"] for item in default_cmo_kpi_schema()["kpis"]
+    }
+    assert all(result["status"] == "ready" for result in results)
+
+
+def test_projection_blocks_production_kpis_instead_of_using_demo_or_hardcoded_values() -> None:
+    projection = build_unified_cmo_kpi_projection(
+        connector_setup=[],
+        connector_contracts=[],
+        data_readiness={"field_mapping_status": [], "backfill_status": []},
+        source_data=_source_facts(),
+        now=NOW,
+    )
+
+    assert projection["unified_cmo_kpi_summary"]["readiness"] == "blocked"
+    assert projection["unified_cmo_kpi_summary"]["blocked"] > 0
+    assert all(result["value"] is None for result in projection["unified_cmo_kpi_results"])
+    assert all(result["status"] == "blocked" for result in projection["unified_cmo_kpi_results"])

--- a/tests/unit/test_cmo_vendor_sandbox_connector_config.py
+++ b/tests/unit/test_cmo_vendor_sandbox_connector_config.py
@@ -1,0 +1,33 @@
+from api.v1 import connectors
+
+
+def test_cmo_vendor_sandbox_config_sets_preflight_metadata() -> None:
+    config = connectors._cmo_vendor_sandbox_config(
+        "Ads",
+        "google_ads",
+        {"owner": "qa@example.test", "developer_token": "must-not-store-here"},
+        {"customer_id": "1234567890", "client_secret": "secret"},
+    )
+
+    assert config["cmo_category"] == "Ads"
+    assert config["connector_provider"] == "google_ads"
+    assert config["proof_scope"] == "vendor_sandbox"
+    assert config["environment_type"] == "vendor_sandbox"
+    assert config["local_test_only"] is False
+    assert config["mock_or_test_double"] is False
+    assert config["customer_id"] == "1234567890"
+    assert "developer_token" not in config
+    assert "client_secret" not in config
+
+
+def test_cmo_vendor_sandbox_provider_aliases_are_canonical() -> None:
+    canonical, provider = connectors._cmo_provider_for("CRM", "hubspot_sandbox")
+
+    assert canonical == "hubspot"
+    assert provider["required_credentials"] == ("access_token",)
+
+
+def test_cmo_vendor_sandbox_rejects_placeholder_values() -> None:
+    assert connectors._cmo_looks_placeholder("REAL_GOOGLE_ADS_REFRESH_TOKEN")
+    assert connectors._cmo_looks_placeholder("verified-sender@example.com")
+    assert not connectors._cmo_looks_placeholder("246292667")

--- a/tests/unit/test_cmo_weekly_report_pilot_persistence.py
+++ b/tests/unit/test_cmo_weekly_report_pilot_persistence.py
@@ -1,0 +1,683 @@
+"""CMO-PROD-2 persistence and report-task wiring tests.
+
+These tests do not require a live Postgres. The persistence helpers are
+exercised against a hand-rolled ``AsyncSession`` stub that records the
+ORM rows it sees and answers ``select(...)`` calls deterministically.
+The Celery report task is exercised via direct function call with the
+async DB layer monkeypatched, so a failing DB does not propagate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from copy import deepcopy
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from core.marketing.weekly_report_pilot_persistence import (
+    build_weekly_report_evidence_from_report_output,
+    latest_weekly_report_pilot_proof,
+    persist_weekly_report_pilot_proof,
+    persist_weekly_report_pilot_proof_from_report_output_sync,
+    serialize_persisted_proof,
+    summarize_persisted_proof,
+)
+from core.marketing.weekly_report_pilot_proof import (
+    REQUIRED_BACKFILL_CATEGORIES,
+    REQUIRED_KPI_KEYS,
+    REQUIRED_MAPPINGS,
+)
+from core.models.weekly_report_pilot_proof import WeeklyReportPilotProof
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+_TENANT_UUID = "00000000-0000-0000-0000-000000000001"
+_COMPANY_UUID = "00000000-0000-0000-0000-000000000002"
+_TMP_DIR = Path(tempfile.gettempdir())
+
+
+class FakeSession:
+    """Minimal async-session shim that records ORM rows and answers selects."""
+
+    def __init__(self) -> None:
+        self.added: list[Any] = []
+        self.flushed = False
+        self.preset_rows: list[Any] = []
+
+    def add(self, obj: Any) -> None:
+        self.added.append(obj)
+
+    async def flush(self) -> None:
+        self.flushed = True
+
+    async def execute(self, _stmt: Any) -> Any:
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(
+            return_value=self.preset_rows[-1] if self.preset_rows else None
+        )
+        return result
+
+
+def _real_vendor_evidence() -> dict[str, Any]:
+    return {
+        "tenant_id": _TENANT_UUID,
+        "company_id": _COMPANY_UUID,
+        "environment_type": "real_vendor",
+        "connector_evidence": [
+            {
+                "connector_key": "hubspot",
+                "category": "CRM",
+                "health_status": "healthy",
+                "read_ready": True,
+                "source_account_id": "hub-9001",
+                "last_sync_at": "2026-05-24T11:30:00Z",
+            },
+            {
+                "connector_key": "google_ads",
+                "category": "Ads",
+                "health_status": "healthy",
+                "read_ready": True,
+                "source_account_id": "g-ads-9002",
+            },
+            {
+                "connector_key": "ga4",
+                "category": "Analytics",
+                "health_status": "healthy",
+                "read_ready": True,
+                "source_account_id": "ga4-9003",
+            },
+            {
+                "connector_key": "sendgrid",
+                "category": "Email",
+                "health_status": "healthy",
+                "read_ready": True,
+                "source_account_id": "sg-9004",
+            },
+        ],
+        "mapping_evidence": [
+            {"key": key, "status": "valid"} for key in REQUIRED_MAPPINGS
+        ],
+        "backfill_evidence": [
+            {"source_connector_key": "hubspot", "category": cat, "status": "completed"}
+            for cat in REQUIRED_BACKFILL_CATEGORIES
+        ],
+        "kpi_results": [
+            {"kpi_key": key, "status": "ready"} for key in REQUIRED_KPI_KEYS
+        ],
+        "reconciliation_checks": [
+            {"check_key": "cac_recon", "status": "pass"},
+            {"check_key": "roas_recon", "status": "pass"},
+        ],
+        "report_quality_gates": [
+            {"report_key": "weekly_marketing_report", "status": "pass"}
+        ],
+        "report_artifact_refs": [
+            {"artifact_id": "report-2026W21", "format": "pdf"}
+        ],
+        "decision_audit_refs": [
+            {"audit_id": "audit-weekly-2026W21"}
+        ],
+        "source_refs": [
+            {"connector_key": "hubspot", "ref_id": "portal-9001"},
+            {"connector_key": "google_ads", "ref_id": "customer-9002"},
+            {"connector_key": "ga4", "ref_id": "property-9003"},
+            {"connector_key": "sendgrid", "ref_id": "account-9004"},
+        ],
+        "source_context": {"source": "real_vendor"},
+    }
+
+
+def _drop_category(evidence: dict[str, Any], key: str, category: str) -> dict[str, Any]:
+    cloned = deepcopy(evidence)
+    cloned[key] = [row for row in cloned[key] if row.get("category") != category]
+    return cloned
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Persistence: environment classification
+# ---------------------------------------------------------------------------
+
+
+def test_persists_demo_evidence_as_demo_only_and_blocks_production_claim() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["environment_type"] = "demo"
+    evidence["source_context"] = {"source": "demo"}
+    session = FakeSession()
+
+    row = _run(
+        persist_weekly_report_pilot_proof(
+            session, tenant_id=_TENANT_UUID, company_id=_COMPANY_UUID, evidence=evidence
+        )
+    )
+
+    assert session.added == [row]
+    assert session.flushed is True
+    assert row.environment_type == "demo"
+    assert row.proof_status == "demo_only"
+    assert row.production_claim_allowed is False
+    assert row.real_vendor_claim_allowed is False
+    assert row.blockers and row.blockers[0]["category"] == "environment"
+
+
+def test_persists_test_double_evidence_as_test_only_and_blocks_production_claim() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["environment_type"] = "test_double"
+    session = FakeSession()
+
+    row = _run(
+        persist_weekly_report_pilot_proof(
+            session, tenant_id=_TENANT_UUID, company_id=_COMPANY_UUID, evidence=evidence
+        )
+    )
+
+    assert row.proof_status == "test_only"
+    assert row.production_claim_allowed is False
+    assert row.real_vendor_claim_allowed is False
+
+
+def test_persists_vendor_sandbox_as_sandbox_proven_not_real_vendor() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["environment_type"] = "vendor_sandbox"
+    session = FakeSession()
+
+    row = _run(
+        persist_weekly_report_pilot_proof(
+            session, tenant_id=_TENANT_UUID, company_id=_COMPANY_UUID, evidence=evidence
+        )
+    )
+
+    assert row.environment_type == "vendor_sandbox"
+    assert row.proof_status in {"sandbox_proven", "partial"}
+    assert row.production_claim_allowed is False
+    assert row.real_vendor_claim_allowed is False
+
+
+def test_persists_real_vendor_passed_only_when_all_criteria_met() -> None:
+    session = FakeSession()
+
+    row = _run(
+        persist_weekly_report_pilot_proof(
+            session,
+            tenant_id=_TENANT_UUID,
+            company_id=_COMPANY_UUID,
+            evidence=_real_vendor_evidence(),
+        )
+    )
+
+    assert row.environment_type == "real_vendor"
+    assert row.proof_status == "passed"
+    assert row.production_claim_allowed is True
+    assert row.real_vendor_claim_allowed is True
+    assert row.readiness_score >= 80
+
+
+# ---------------------------------------------------------------------------
+# Persistence: blocked verdicts for missing evidence
+# ---------------------------------------------------------------------------
+
+
+def test_persists_blocked_when_report_artifact_refs_missing() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["report_artifact_refs"] = []
+    session = FakeSession()
+
+    row = _run(
+        persist_weekly_report_pilot_proof(
+            session, tenant_id=_TENANT_UUID, company_id=_COMPANY_UUID, evidence=evidence
+        )
+    )
+
+    assert row.proof_status == "blocked"
+    assert row.production_claim_allowed is False
+    assert any(item["category"] == "report_artifact" for item in row.blockers)
+
+
+def test_persists_blocked_when_decision_audit_refs_missing() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["decision_audit_refs"] = []
+    session = FakeSession()
+
+    row = _run(
+        persist_weekly_report_pilot_proof(
+            session, tenant_id=_TENANT_UUID, company_id=_COMPANY_UUID, evidence=evidence
+        )
+    )
+
+    assert row.proof_status == "blocked"
+    assert any(item["category"] == "decision_audit" for item in row.blockers)
+
+
+def test_persists_blocked_when_required_connector_missing() -> None:
+    evidence = _drop_category(_real_vendor_evidence(), "connector_evidence", "CRM")
+    evidence = _drop_category(evidence, "backfill_evidence", "CRM")
+    session = FakeSession()
+
+    row = _run(
+        persist_weekly_report_pilot_proof(
+            session, tenant_id=_TENANT_UUID, company_id=_COMPANY_UUID, evidence=evidence
+        )
+    )
+
+    assert row.proof_status == "blocked"
+    assert any(item["category"] == "connector" for item in row.blockers)
+
+
+# ---------------------------------------------------------------------------
+# Persistence: secret/token redaction
+# ---------------------------------------------------------------------------
+
+
+def test_persisted_evidence_and_verdict_redact_secrets() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["connector_evidence"][0]["api_key"] = "sk-live-9001"
+    evidence["connector_evidence"][1]["authorization"] = "Bearer SECRETXYZ"
+    evidence["connector_evidence"][2]["credential"] = {"password": "p@ss"}
+    session = FakeSession()
+
+    row = _run(
+        persist_weekly_report_pilot_proof(
+            session, tenant_id=_TENANT_UUID, company_id=_COMPANY_UUID, evidence=evidence
+        )
+    )
+    serialised = json.dumps(
+        {
+            "evidence_bundle": row.evidence_bundle,
+            "verdict": row.verdict,
+            "blockers": row.blockers,
+        }
+    )
+
+    assert "sk-live-9001" not in serialised
+    assert "SECRETXYZ" not in serialised
+    assert "p@ss" not in serialised
+    assert "[REDACTED]" in serialised
+
+
+# ---------------------------------------------------------------------------
+# Latest-by-tenant retrieval
+# ---------------------------------------------------------------------------
+
+
+def test_latest_weekly_report_pilot_proof_returns_newest_row() -> None:
+    session = FakeSession()
+    older = WeeklyReportPilotProof(
+        tenant_id=__import__("uuid").UUID(_TENANT_UUID),
+        company_id=__import__("uuid").UUID(_COMPANY_UUID),
+        proof_id="wkly_report_proof_old",
+        environment_type="vendor_sandbox",
+        proof_status="sandbox_proven",
+        production_claim_allowed=False,
+        real_vendor_claim_allowed=False,
+        readiness_score=80,
+        evaluated_at=datetime(2026, 5, 23, tzinfo=UTC),
+        evidence_bundle={},
+        verdict={},
+        blockers=[],
+        next_actions=[],
+        report_artifact_refs=[],
+        decision_audit_refs=[],
+    )
+    newer = WeeklyReportPilotProof(
+        tenant_id=__import__("uuid").UUID(_TENANT_UUID),
+        company_id=__import__("uuid").UUID(_COMPANY_UUID),
+        proof_id="wkly_report_proof_new",
+        environment_type="real_vendor",
+        proof_status="passed",
+        production_claim_allowed=True,
+        real_vendor_claim_allowed=True,
+        readiness_score=95,
+        evaluated_at=datetime(2026, 5, 24, tzinfo=UTC),
+        evidence_bundle={},
+        verdict={},
+        blockers=[],
+        next_actions=[],
+        report_artifact_refs=[],
+        decision_audit_refs=[],
+    )
+    session.preset_rows = [older, newer]
+
+    latest = _run(
+        latest_weekly_report_pilot_proof(
+            session, tenant_id=_TENANT_UUID, company_id=_COMPANY_UUID
+        )
+    )
+
+    assert latest is newer
+
+
+# ---------------------------------------------------------------------------
+# Evidence builder from ReportOutput
+# ---------------------------------------------------------------------------
+
+
+def test_evidence_builder_attaches_report_artifact_and_audit_refs() -> None:
+    evidence = build_weekly_report_evidence_from_report_output(
+        tenant_id=_TENANT_UUID,
+        company_id=_COMPANY_UUID,
+        report_id="report-2026W21",
+        rendered_paths=[str(_TMP_DIR / "report.pdf")],
+        report_data={
+            "report_quality_gate": {
+                "report_key": "weekly_marketing_report",
+                "status": "pass",
+                "required_approval_audit_refs": ["audit-report-1"],
+            },
+        },
+    )
+
+    assert evidence.report_artifact_refs[0]["artifact_id"] == "report-2026W21"
+    assert evidence.report_artifact_refs[0]["format"] == "pdf"
+    assert any(
+        ref.get("audit_id") == "audit-report-1" for ref in evidence.decision_audit_refs
+    )
+    assert any(
+        ref.get("event_type") == "weekly_report_delivered"
+        for ref in evidence.decision_audit_refs
+    )
+
+
+def test_evidence_builder_marks_demo_when_report_data_demo_flag_set() -> None:
+    evidence = build_weekly_report_evidence_from_report_output(
+        tenant_id=_TENANT_UUID,
+        company_id=_COMPANY_UUID,
+        report_id="report-demo",
+        rendered_paths=[],
+        report_data={"demo": True, "source": "report_generator_fallback"},
+    )
+    assert evidence.environment_type == "demo"
+
+
+# ---------------------------------------------------------------------------
+# Celery task wiring: persist_weekly_report_pilot_proof_from_report_output_sync
+# ---------------------------------------------------------------------------
+
+
+def test_sync_wrapper_skips_when_tenant_id_is_not_uuid() -> None:
+    result = persist_weekly_report_pilot_proof_from_report_output_sync(
+        tenant_id="default",
+        company_id="default",
+        report_id="rep1",
+        report_data=_real_vendor_evidence(),
+        rendered_paths=[str(_TMP_DIR / "r.pdf")],
+    )
+    assert result is None
+
+
+def test_sync_wrapper_persists_and_returns_summary_when_db_available() -> None:
+    """Async DB layer monkeypatched: persistence runs and returns summary."""
+
+    session = FakeSession()
+
+    class _TenantSessionContext:
+        def __init__(self, _tenant_id):
+            pass
+
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    with patch("core.database.get_tenant_session", _TenantSessionContext):
+        result = persist_weekly_report_pilot_proof_from_report_output_sync(
+            tenant_id=_TENANT_UUID,
+            company_id=_COMPANY_UUID,
+            report_id="report-W21",
+            report_data={
+                "report_quality_gate": {
+                    "report_key": "weekly_marketing_report",
+                    "status": "pass",
+                    "required_approval_audit_refs": ["audit-1"],
+                },
+            },
+            rendered_paths=[str(_TMP_DIR / "cmo_weekly_report-W21.pdf")],
+            environment_type="vendor_sandbox",
+        )
+
+    assert result is not None
+    assert result["proof_status"] in {"sandbox_proven", "partial", "blocked"}
+    assert result["production_claim_allowed"] is False
+    # The fake session received the new row.
+    assert session.added and isinstance(session.added[0], WeeklyReportPilotProof)
+    row = session.added[0]
+    assert row.environment_type == "vendor_sandbox"
+    assert any(
+        ref.get("event_type") == "weekly_report_delivered"
+        for ref in row.decision_audit_refs
+    )
+
+
+def test_sync_wrapper_persists_blocked_when_evidence_incomplete() -> None:
+    session = FakeSession()
+
+    class _TenantSessionContext:
+        def __init__(self, _tenant_id):
+            pass
+
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    with patch("core.database.get_tenant_session", _TenantSessionContext):
+        result = persist_weekly_report_pilot_proof_from_report_output_sync(
+            tenant_id=_TENANT_UUID,
+            company_id=_COMPANY_UUID,
+            report_id="rep-empty",
+            report_data={},  # no quality gate, no connector evidence
+            rendered_paths=[],  # no artifacts
+            environment_type="real_vendor",
+        )
+
+    assert result is not None
+    assert result["proof_status"] == "blocked"
+    assert result["production_claim_allowed"] is False
+
+
+def test_sync_wrapper_swallows_db_errors_and_returns_none() -> None:
+    class _TenantSessionContext:
+        def __init__(self, _tenant_id):
+            raise RuntimeError("DB unavailable")
+
+    with patch("core.database.get_tenant_session", _TenantSessionContext):
+        result = persist_weekly_report_pilot_proof_from_report_output_sync(
+            tenant_id=_TENANT_UUID,
+            company_id=_COMPANY_UUID,
+            report_id="rep-down",
+            report_data=_real_vendor_evidence(),
+            rendered_paths=[str(_TMP_DIR / "x.pdf")],
+        )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Report task integration
+# ---------------------------------------------------------------------------
+
+
+def test_report_task_calls_persistence_for_weekly_run() -> None:
+    """`generate_report` should call the persistence sync wrapper for cmo_weekly."""
+
+    from core.tasks import report_tasks
+
+    fake_summary = {
+        "proof_id": "wkly_report_proof_abc",
+        "proof_status": "blocked",
+        "production_claim_allowed": False,
+    }
+    persist_calls: list[dict[str, Any]] = []
+
+    def _capture_persist(**kwargs):
+        persist_calls.append(kwargs)
+        return fake_summary
+
+    fake_output = MagicMock()
+    fake_output.content_data = {"report_quality_gate": {"status": "pass"}}
+    fake_output.content_html = "<html/>"
+    fake_output.report_type = "cmo_weekly"
+
+    fake_generator = MagicMock()
+    fake_generator.generate.return_value = fake_output
+
+    with (
+        patch.object(
+            report_tasks,
+            "_REPORTS_DIR",
+            _TMP_DIR / "agentic_test_reports",
+        ),
+        patch("core.reports.generator.ReportGenerator", return_value=fake_generator),
+        patch("core.reports.renderer.render_pdf", return_value=None),
+        patch(
+            "core.marketing.weekly_report_pilot_persistence.persist_weekly_report_pilot_proof_from_report_output_sync",
+            side_effect=_capture_persist,
+        ),
+    ):
+        result = report_tasks.generate_report.run(
+            {
+                "report_type": "cmo_weekly",
+                "params": {},
+                "company_id": _COMPANY_UUID,
+                "tenant_id": _TENANT_UUID,
+                "format": "pdf",
+                "delivery_channels": [],
+            },
+        )
+
+    assert result["status"] == "completed"
+    assert result["weekly_report_pilot_proof"] == fake_summary
+    assert persist_calls and persist_calls[0]["tenant_id"] == _TENANT_UUID
+    assert persist_calls[0]["report_data"] is fake_output.content_data
+
+
+def test_report_task_does_not_call_persistence_for_non_weekly_runs() -> None:
+    from core.tasks import report_tasks
+
+    fake_output = MagicMock()
+    fake_output.content_data = {}
+    fake_output.report_type = "cfo_daily"
+
+    fake_generator = MagicMock()
+    fake_generator.generate.return_value = fake_output
+
+    persist_calls: list[dict[str, Any]] = []
+
+    def _capture_persist(**kwargs):
+        persist_calls.append(kwargs)
+        return None
+
+    with (
+        patch.object(
+            report_tasks,
+            "_REPORTS_DIR",
+            _TMP_DIR / "agentic_test_reports",
+        ),
+        patch("core.reports.generator.ReportGenerator", return_value=fake_generator),
+        patch("core.reports.renderer.render_pdf", return_value=None),
+        patch(
+            "core.marketing.weekly_report_pilot_persistence.persist_weekly_report_pilot_proof_from_report_output_sync",
+            side_effect=_capture_persist,
+        ),
+    ):
+        result = report_tasks.generate_report.run(
+            {
+                "report_type": "cfo_daily",
+                "params": {},
+                "company_id": _COMPANY_UUID,
+                "tenant_id": _TENANT_UUID,
+                "format": "pdf",
+                "delivery_channels": [],
+            },
+        )
+
+    assert result["status"] == "completed"
+    assert "weekly_report_pilot_proof" not in result
+    assert persist_calls == []
+
+
+# ---------------------------------------------------------------------------
+# /kpis/cmo projection
+# ---------------------------------------------------------------------------
+
+
+def test_kpis_cmo_helper_returns_none_when_no_persisted_row() -> None:
+    from api.v1 import kpis as kpis_api
+
+    @AsyncMock
+    async def _fake_session_ctx(_tenant_id):
+        return None  # not used because tenant session never entered
+
+    class _Ctx:
+        def __init__(self, _tid):
+            pass
+
+        async def __aenter__(self):
+            return FakeSession()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    with patch("api.v1.kpis.get_tenant_session", _Ctx):
+        result = _run(
+            kpis_api._load_latest_weekly_report_pilot_proof(_TENANT_UUID, _COMPANY_UUID)
+        )
+    assert result is None
+
+
+def test_kpis_cmo_helper_serialises_persisted_row() -> None:
+    from api.v1 import kpis as kpis_api
+
+    row = WeeklyReportPilotProof(
+        tenant_id=__import__("uuid").UUID(_TENANT_UUID),
+        company_id=__import__("uuid").UUID(_COMPANY_UUID),
+        proof_id="wkly_report_proof_x",
+        environment_type="vendor_sandbox",
+        proof_status="sandbox_proven",
+        production_claim_allowed=False,
+        real_vendor_claim_allowed=False,
+        readiness_score=82,
+        evaluated_at=datetime(2026, 5, 24, tzinfo=UTC),
+        evidence_bundle={},
+        verdict={},
+        blockers=[],
+        next_actions=[],
+        report_artifact_refs=[],
+        decision_audit_refs=[],
+    )
+
+    class _Ctx:
+        def __init__(self, _tid):
+            pass
+
+        async def __aenter__(self):
+            session = FakeSession()
+            session.preset_rows = [row]
+            return session
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    with patch("api.v1.kpis.get_tenant_session", _Ctx):
+        result = _run(
+            kpis_api._load_latest_weekly_report_pilot_proof(_TENANT_UUID, _COMPANY_UUID)
+        )
+
+    assert result is not None
+    assert result["latest_weekly_report_pilot_proof"]["proof_id"] == "wkly_report_proof_x"
+    assert result["latest_weekly_report_pilot_proof_summary"]["proof_status"] == "sandbox_proven"
+
+
+def test_persisted_row_summariser_handles_missing_fields() -> None:
+    assert summarize_persisted_proof(None) is None
+    assert serialize_persisted_proof(None) is None

--- a/tests/unit/test_cmo_weekly_report_pilot_proof.py
+++ b/tests/unit/test_cmo_weekly_report_pilot_proof.py
@@ -1,0 +1,415 @@
+"""Acceptance tests for CMO-PROD-1 weekly-marketing-report pilot proof."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from core.marketing.weekly_report_pilot_proof import (
+    REQUIRED_BACKFILL_CATEGORIES,
+    REQUIRED_KPI_KEYS,
+    REQUIRED_MAPPINGS,
+    WEEKLY_REPORT_PROOF_VERSION,
+    build_weekly_marketing_report_evidence_bundle,
+    build_weekly_marketing_report_proof_projection,
+    evaluate_weekly_marketing_report_proof,
+    serialize_weekly_marketing_report_evidence_bundle,
+    summarize_weekly_marketing_report_proof,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _real_vendor_evidence() -> dict[str, Any]:
+    """A complete, real-vendor evidence bundle that should pass the proof."""
+
+    return {
+        "tenant_id": "tenant-pilot-001",
+        "company_id": "company-pilot-001",
+        "environment_type": "real_vendor",
+        "generated_at": "2026-05-24T12:00:00Z",
+        "connector_evidence": [
+            {
+                "connector_key": "hubspot",
+                "category": "CRM",
+                "health_status": "healthy",
+                "read_ready": True,
+                "source_account_id": "hub-portal-9001",
+                "last_sync_at": "2026-05-24T11:30:00Z",
+            },
+            {
+                "connector_key": "google_ads",
+                "category": "Ads",
+                "health_status": "healthy",
+                "read_ready": True,
+                "source_account_id": "g-ads-customer-9002",
+                "last_sync_at": "2026-05-24T11:35:00Z",
+            },
+            {
+                "connector_key": "ga4",
+                "category": "Analytics",
+                "health_status": "healthy",
+                "read_ready": True,
+                "source_account_id": "ga4-property-9003",
+                "last_sync_at": "2026-05-24T11:40:00Z",
+            },
+            {
+                "connector_key": "sendgrid",
+                "category": "Email",
+                "health_status": "healthy",
+                "read_ready": True,
+                "source_account_id": "sg-account-9004",
+                "last_sync_at": "2026-05-24T11:45:00Z",
+            },
+        ],
+        "mapping_evidence": [
+            {"key": key, "status": "valid"} for key in REQUIRED_MAPPINGS
+        ],
+        "backfill_evidence": [
+            {"source_connector_key": "hubspot", "category": cat, "status": "completed"}
+            for cat in REQUIRED_BACKFILL_CATEGORIES
+        ],
+        "kpi_results": [
+            {"kpi_key": key, "status": "ready"} for key in REQUIRED_KPI_KEYS
+        ],
+        "reconciliation_checks": [
+            {"check_key": "cac_recon", "status": "pass"},
+            {"check_key": "roas_recon", "status": "pass"},
+        ],
+        "report_quality_gates": [
+            {
+                "report_key": "weekly_marketing_report",
+                "status": "pass",
+                "next_action_cta": "none",
+            }
+        ],
+        "report_artifact_refs": [
+            {
+                "artifact_id": "report-2026W21",
+                "format": "pdf",
+                "delivered_at": "2026-05-24T12:00:00Z",
+            }
+        ],
+        "decision_audit_refs": [
+            {"audit_id": "audit-weekly-2026W21", "event_type": "weekly_report_delivered"}
+        ],
+        "source_refs": [
+            {"connector_key": "hubspot", "ref_id": "portal-9001"},
+            {"connector_key": "google_ads", "ref_id": "customer-9002"},
+            {"connector_key": "ga4", "ref_id": "property-9003"},
+            {"connector_key": "sendgrid", "ref_id": "account-9004"},
+        ],
+        "source_context": {"source": "real_vendor"},
+    }
+
+
+def _drop_connector(evidence: dict[str, Any], category: str) -> dict[str, Any]:
+    cloned = deepcopy(evidence)
+    cloned["connector_evidence"] = [
+        row for row in cloned["connector_evidence"] if row.get("category") != category
+    ]
+    cloned["backfill_evidence"] = [
+        row for row in cloned["backfill_evidence"] if row.get("category") != category
+    ]
+    return cloned
+
+
+# ---------------------------------------------------------------------------
+# Environment classification
+# ---------------------------------------------------------------------------
+
+
+def test_demo_evidence_returns_demo_only_and_blocks_production_claim() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["environment_type"] = "demo"
+    evidence["source_context"] = {"source": "demo"}
+    proof = evaluate_weekly_marketing_report_proof(evidence)
+
+    assert proof["environment_type"] == "demo"
+    assert proof["proof_status"] == "demo_only"
+    assert proof["production_claim_allowed"] is False
+    assert proof["real_vendor_claim_allowed"] is False
+    assert any(item["category"] == "environment" for item in proof["blockers"])
+
+
+def test_test_double_evidence_returns_test_only_and_blocks_production_claim() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["environment_type"] = "test_double"
+    proof = evaluate_weekly_marketing_report_proof(evidence)
+
+    assert proof["environment_type"] == "test_double"
+    assert proof["proof_status"] == "test_only"
+    assert proof["production_claim_allowed"] is False
+    assert proof["real_vendor_claim_allowed"] is False
+
+
+def test_unknown_environment_blocks_real_vendor_production_claim() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["environment_type"] = "unknown"
+    evidence["source_context"] = {}
+    proof = evaluate_weekly_marketing_report_proof(evidence)
+
+    assert proof["environment_type"] == "unknown"
+    assert proof["production_claim_allowed"] is False
+    assert proof["real_vendor_claim_allowed"] is False
+
+
+def test_mock_or_test_double_marker_on_any_connector_blocks_proof() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["connector_evidence"][0]["mock_or_test_double"] = True
+    proof = evaluate_weekly_marketing_report_proof(evidence)
+
+    assert proof["proof_status"] == "blocked"
+    assert any(
+        item["category"] == "environment"
+        and "mock/test-double" in item["message"]
+        for item in proof["blockers"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vendor sandbox
+# ---------------------------------------------------------------------------
+
+
+def test_vendor_sandbox_evidence_does_not_pass_as_real_vendor() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["environment_type"] = "vendor_sandbox"
+    evidence["source_context"] = {"source": "vendor_sandbox"}
+    proof = evaluate_weekly_marketing_report_proof(evidence)
+
+    assert proof["environment_type"] == "vendor_sandbox"
+    assert proof["proof_status"] == "sandbox_proven"
+    assert proof["production_claim_allowed"] is False
+    assert proof["real_vendor_claim_allowed"] is False
+    assert proof["proof_scope"] == "sandbox"
+
+
+def test_vendor_sandbox_missing_optional_evidence_reports_partial() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["environment_type"] = "vendor_sandbox"
+    evidence["report_artifact_refs"] = []
+    evidence["decision_audit_refs"] = []
+    proof = evaluate_weekly_marketing_report_proof(evidence)
+
+    assert proof["environment_type"] == "vendor_sandbox"
+    assert proof["proof_status"] in {"sandbox_proven", "partial"}
+    assert proof["production_claim_allowed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Real vendor pass / fail
+# ---------------------------------------------------------------------------
+
+
+def test_real_vendor_with_all_critical_criteria_passes() -> None:
+    proof = evaluate_weekly_marketing_report_proof(_real_vendor_evidence())
+
+    assert proof["environment_type"] == "real_vendor"
+    assert proof["proof_status"] == "passed"
+    assert proof["production_claim_allowed"] is True
+    assert proof["real_vendor_claim_allowed"] is True
+    assert proof["readiness_score"] >= 80
+    capability_keys = {row["capability_key"] for row in proof["proven_capabilities"]}
+    assert {"weekly_report_connectors", "weekly_report_mappings", "weekly_report_kpis"}.issubset(
+        capability_keys
+    )
+
+
+@pytest.mark.parametrize("missing_category", ["CRM", "Ads", "Analytics", "Email"])
+def test_real_vendor_missing_required_connector_blocks_proof(missing_category: str) -> None:
+    evidence = _drop_connector(_real_vendor_evidence(), missing_category)
+    proof = evaluate_weekly_marketing_report_proof(evidence)
+
+    assert proof["proof_status"] == "blocked"
+    assert proof["production_claim_allowed"] is False
+    assert any(
+        item["category"] == "connector"
+        and missing_category in (item.get("affected") or [])
+        for item in proof["blockers"]
+    )
+
+
+def test_real_vendor_missing_required_mapping_blocks_proof() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["mapping_evidence"] = [
+        row for row in evidence["mapping_evidence"] if row.get("key") != "lifecycle_stages"
+    ]
+    proof = evaluate_weekly_marketing_report_proof(evidence)
+
+    assert proof["proof_status"] == "blocked"
+    assert any(
+        item["category"] == "mapping"
+        and "lifecycle_stages" in (item.get("affected") or [])
+        for item in proof["blockers"]
+    )
+
+
+def test_real_vendor_missing_required_backfill_blocks_proof() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["backfill_evidence"] = [
+        row for row in evidence["backfill_evidence"] if row.get("category") != "Email"
+    ]
+    proof = evaluate_weekly_marketing_report_proof(evidence)
+
+    assert proof["proof_status"] == "blocked"
+    assert any(item["category"] == "backfill" for item in proof["blockers"])
+
+
+def test_failed_kpi_reconciliation_blocks_proof() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["reconciliation_checks"] = [
+        {"check_key": "cac_recon", "status": "failed"}
+    ]
+    proof = evaluate_weekly_marketing_report_proof(evidence)
+
+    assert proof["proof_status"] == "blocked"
+    assert any(item["category"] == "reconciliation" for item in proof["blockers"])
+
+
+def test_blocked_report_quality_gate_blocks_proof() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["report_quality_gates"] = [
+        {"report_key": "weekly_marketing_report", "status": "blocked"}
+    ]
+    proof = evaluate_weekly_marketing_report_proof(evidence)
+
+    assert proof["proof_status"] == "blocked"
+    assert any(item["category"] == "report_quality" for item in proof["blockers"])
+
+
+def test_missing_audit_or_report_artifact_blocks_real_vendor_proof() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["report_artifact_refs"] = []
+    evidence["decision_audit_refs"] = []
+    proof = evaluate_weekly_marketing_report_proof(evidence)
+
+    assert proof["proof_status"] == "blocked"
+    categories = {item["category"] for item in proof["blockers"]}
+    assert {"report_artifact", "decision_audit"}.issubset(categories)
+
+
+def test_demo_or_test_source_marker_on_source_refs_blocks_proof() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["source_refs"] = [{"connector_key": "demo"}]
+    proof = evaluate_weekly_marketing_report_proof(evidence)
+
+    assert proof["proof_status"] == "blocked"
+    assert any(item["category"] == "source_lineage" for item in proof["blockers"])
+
+
+# ---------------------------------------------------------------------------
+# Serialisation / redaction
+# ---------------------------------------------------------------------------
+
+
+def test_proof_bundle_serialisation_redacts_secrets() -> None:
+    evidence = _real_vendor_evidence()
+    evidence["connector_evidence"][0]["api_key"] = "sk-live-9001"
+    evidence["connector_evidence"][1]["authorization"] = "Bearer SECRETXYZ"
+    evidence["connector_evidence"][2]["credential"] = {"password": "p@ss"}
+    proof = evaluate_weekly_marketing_report_proof(evidence)
+    bundle = build_weekly_marketing_report_evidence_bundle(proof)
+    serialised = serialize_weekly_marketing_report_evidence_bundle(bundle)
+
+    assert "sk-live-9001" not in serialised
+    assert "SECRETXYZ" not in serialised
+    assert "p@ss" not in serialised
+    assert "[REDACTED]" in serialised
+
+
+def test_summary_reports_proof_status_and_next_action() -> None:
+    proof = evaluate_weekly_marketing_report_proof({"environment_type": "demo"})
+    summary = summarize_weekly_marketing_report_proof(proof)
+    assert summary["proof_status"] == "demo_only"
+    assert summary["production_claim_allowed"] is False
+    assert summary["next_action_cta"] == "connect_real_or_sandbox_sources"
+    assert summary["schema_version"] == WEEKLY_REPORT_PROOF_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Projection / KPI API integration
+# ---------------------------------------------------------------------------
+
+
+def test_projection_wraps_proof_summary_and_bundle() -> None:
+    projection = build_weekly_marketing_report_proof_projection(_real_vendor_evidence())
+
+    assert projection["weekly_report_pilot_proof_version"] == WEEKLY_REPORT_PROOF_VERSION
+    assert projection["weekly_report_pilot_proof"]["proof_status"] == "passed"
+    assert projection["weekly_report_pilot_proof_summary"]["production_claim_allowed"] is True
+    assert projection["weekly_report_pilot_evidence_bundle"]["bundle_type"] == "weekly_marketing_report_pilot_proof"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def real_vendor_evidence_file(tmp_path: Path) -> Path:
+    path = tmp_path / "evidence.json"
+    path.write_text(json.dumps(_real_vendor_evidence()), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def demo_evidence_file(tmp_path: Path) -> Path:
+    path = tmp_path / "evidence_demo.json"
+    path.write_text(
+        json.dumps({"environment_type": "demo", "source_context": {"source": "demo"}}),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _run_cli(args: list[str], *, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 -- pinned argv built from this test file only
+        [sys.executable, "scripts/validate_weekly_report_pilot_proof.py", *args],
+        cwd=Path(__file__).resolve().parent.parent.parent,
+        capture_output=True,
+        text=True,
+        input=stdin,
+        check=False,
+    )
+
+
+def test_cli_returns_zero_for_real_vendor_passed(real_vendor_evidence_file: Path) -> None:
+    result = _run_cli(["--evidence", str(real_vendor_evidence_file)])
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "passed" in result.stdout
+    assert "production claim allowed" in result.stdout.lower()
+
+
+def test_cli_returns_nonzero_for_demo_evidence(demo_evidence_file: Path) -> None:
+    result = _run_cli(["--evidence", str(demo_evidence_file)])
+    assert result.returncode == 3
+    assert "demo_only" in result.stdout
+    assert "Blockers:" in result.stdout
+
+
+def test_cli_json_output_is_redacted(tmp_path: Path) -> None:
+    evidence = _real_vendor_evidence()
+    evidence["connector_evidence"][0]["api_key"] = "sk-live-XYZ"
+    path = tmp_path / "evidence_secret.json"
+    path.write_text(json.dumps(evidence), encoding="utf-8")
+    result = _run_cli(["--evidence", str(path), "--format", "json"])
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    serialised = json.dumps(payload)
+    assert "sk-live-XYZ" not in serialised
+    assert "[REDACTED]" in serialised
+
+
+def test_cli_reads_from_stdin_when_no_evidence_path() -> None:
+    result = _run_cli(["--evidence", "-"], stdin=json.dumps({"environment_type": "unknown"}))
+    assert result.returncode == 3
+    assert "unavailable" in result.stdout or "blocked" in result.stdout

--- a/tests/unit/test_cmo_weekly_report_sandbox_runner.py
+++ b/tests/unit/test_cmo_weekly_report_sandbox_runner.py
@@ -1,0 +1,591 @@
+"""CMO-PROD-3 sandbox runner acceptance tests.
+
+These tests prove the runner is fail-closed: with no credentials it
+refuses to insert a proof row; with sandbox evidence it persists
+sandbox/partial only (never real-vendor passed); secrets are redacted
+in the runbook output.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+import sys
+from copy import deepcopy
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from core.marketing.weekly_report_pilot_proof import (
+    REQUIRED_BACKFILL_CATEGORIES,
+    REQUIRED_KPI_KEYS,
+    REQUIRED_MAPPINGS,
+)
+from core.marketing.weekly_report_sandbox_pilot import (
+    CMO_PROD_3_VERSION,
+    SANDBOX_CONNECTOR_OPTIONS,
+    SANDBOX_ENV_PREFIX,
+    build_blocked_preflight_envelope,
+    discover_sandbox_pilot_config,
+    run_sandbox_pilot,
+)
+from core.models.weekly_report_pilot_proof import WeeklyReportPilotProof
+
+_TENANT_UUID = "00000000-0000-0000-0000-000000000099"
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _populated_env() -> dict[str, str]:
+    """Return an env-var dict that satisfies preflight with one option per category."""
+
+    env: dict[str, str] = {
+        "AGENTICORG_DB_URL": "postgresql+asyncpg://test:test@localhost/test",
+        f"{SANDBOX_ENV_PREFIX}TENANT_ID": _TENANT_UUID,
+        f"{SANDBOX_ENV_PREFIX}HUBSPOT_ACCESS_TOKEN": "hub-secret-xyz",  # noqa: S105
+        f"{SANDBOX_ENV_PREFIX}GA4_PROPERTY_ID": "ga4-prop-123",
+        f"{SANDBOX_ENV_PREFIX}GA4_REFRESH_TOKEN": "ga4-refresh-xyz",  # noqa: S105
+        f"{SANDBOX_ENV_PREFIX}GA4_CLIENT_ID": "ga4-client",
+        f"{SANDBOX_ENV_PREFIX}GA4_CLIENT_SECRET": "ga4-secret",  # noqa: S105
+        f"{SANDBOX_ENV_PREFIX}SENDGRID_API_KEY": "sg-key-xyz",  # noqa: S105
+        f"{SANDBOX_ENV_PREFIX}SENDGRID_SENDER": "noreply@sandbox.example",
+    }
+    # Choose Google Ads as the Ads connector.
+    env.update(
+        {
+            f"{SANDBOX_ENV_PREFIX}GOOGLE_ADS_DEVELOPER_TOKEN": "dev-tok-xyz",  # noqa: S105
+            f"{SANDBOX_ENV_PREFIX}GOOGLE_ADS_REFRESH_TOKEN": "refresh-xyz",  # noqa: S105
+            f"{SANDBOX_ENV_PREFIX}GOOGLE_ADS_CUSTOMER_ID": "123-456-7890",
+            f"{SANDBOX_ENV_PREFIX}GOOGLE_ADS_CLIENT_ID": "gads-client",
+            f"{SANDBOX_ENV_PREFIX}GOOGLE_ADS_CLIENT_SECRET": "gads-secret",  # noqa: S105
+        }
+    )
+    return env
+
+
+def _base_db_env() -> dict[str, str]:
+    return {
+        "AGENTICORG_DB_URL": "postgresql+asyncpg://test:test@localhost/test",
+        f"{SANDBOX_ENV_PREFIX}TENANT_ID": _TENANT_UUID,
+    }
+
+
+def _db_row(
+    connector_name: str,
+    category: str,
+    *,
+    proof_scope: str = "vendor_sandbox",
+    local_test_only: bool = False,
+    mock_or_test_double: bool = False,
+    status: str = "configured",
+    health_status: str = "healthy",
+) -> dict[str, Any]:
+    return {
+        "connector_name": connector_name,
+        "display_name": f"{connector_name} display",
+        "status": status,
+        "health_status": health_status,
+        "config": {
+            "cmo_category": category,
+            "proof_scope": proof_scope,
+            "local_test_only": local_test_only,
+            "mock_or_test_double": mock_or_test_double,
+        },
+        "credentials_encrypted": {"ciphertext_ref": f"{connector_name}-credential-ref"},
+    }
+
+
+def _vendor_sandbox_rows() -> list[dict[str, Any]]:
+    return [
+        _db_row("hubspot_sandbox", "CRM"),
+        _db_row("google_ads_sandbox", "Ads"),
+        _db_row("ga4_sandbox", "Analytics"),
+        _db_row("sendgrid_sandbox", "Email"),
+    ]
+
+
+def _local_preflight_rows() -> list[dict[str, Any]]:
+    return [
+        _db_row("hubspot_local", "CRM", proof_scope="preflight_only", local_test_only=True),
+        _db_row("google_ads_local", "Ads", proof_scope="preflight_only", local_test_only=True),
+        _db_row("ga4_local", "Analytics", proof_scope="preflight_only", local_test_only=True),
+        _db_row("sendgrid_local", "Email", proof_scope="preflight_only", local_test_only=True),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Preflight: missing creds → blocked
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_with_empty_env_is_blocked() -> None:
+    preflight = discover_sandbox_pilot_config({})
+    assert preflight.preflight_status == "blocked"
+    assert "AGENTICORG_DB_URL" in {b.get("missing_env") for b in preflight.blockers}
+    assert preflight.config.missing_categories == ["CRM", "Ads", "Analytics", "Email"]
+    envelope = build_blocked_preflight_envelope(preflight)
+    assert envelope["environment_type"] == "vendor_sandbox"
+    assert envelope["proof_status"] == "unavailable"
+    assert envelope["production_claim_allowed"] is False
+    assert envelope["real_vendor_claim_allowed"] is False
+    assert envelope["schema_version"] == CMO_PROD_3_VERSION
+
+
+def test_preflight_with_complete_env_is_ready_and_picks_connectors() -> None:
+    preflight = discover_sandbox_pilot_config(_populated_env(), connector_rows=[])
+    assert preflight.preflight_status == "ready"
+    chosen = preflight.config.chosen_connectors
+    assert set(chosen) == {"CRM", "Ads", "Analytics", "Email"}
+    assert chosen["CRM"]["connector_key"] == "hubspot"
+    assert chosen["Ads"]["connector_key"] == "google_ads"
+    assert chosen["Analytics"]["connector_key"] == "ga4"
+    assert chosen["Email"]["connector_key"] == "sendgrid"
+
+
+def test_db_connector_config_rows_satisfy_preflight_by_category() -> None:
+    preflight = discover_sandbox_pilot_config(
+        _base_db_env(),
+        connector_rows=_vendor_sandbox_rows(),
+    )
+
+    assert preflight.preflight_status == "ready"
+    assert preflight.proof_status == "preflight_ready"
+    chosen = preflight.config.chosen_connectors
+    assert set(chosen) == {"CRM", "Ads", "Analytics", "Email"}
+    assert all(row["source"] == "db" for row in chosen.values())
+    assert all(row["readiness_state"] == "ready" for row in chosen.values())
+    assert all(row["proof_scope"] == "vendor_sandbox" for row in chosen.values())
+    assert not any(row["local_test_only"] for row in chosen.values())
+
+
+def test_local_test_only_db_rows_return_local_preflight_only_without_running_report() -> None:
+    fake_task = MagicMock()
+    fake_task.run = MagicMock()
+
+    with patch("core.tasks.report_tasks.generate_report", fake_task):
+        result = asyncio.run(
+            run_sandbox_pilot(env=_base_db_env(), connector_rows=_local_preflight_rows())
+        )
+
+    assert result["preflight_status"] == "ready"
+    assert result["proof_status"] == "local_preflight_only"
+    assert result["production_claim_allowed"] is False
+    assert result["real_vendor_claim_allowed"] is False
+    assert result["proof_inserted"] is False
+    fake_task.run.assert_not_called()
+
+
+def test_missing_db_connector_categories_stay_blocked_without_env_fallback() -> None:
+    preflight = discover_sandbox_pilot_config(
+        _base_db_env(),
+        connector_rows=[
+            _db_row("hubspot_sandbox", "CRM"),
+            _db_row("ga4_sandbox", "Analytics"),
+        ],
+    )
+
+    assert preflight.preflight_status == "blocked"
+    assert preflight.config.missing_categories == ["Ads", "Email"]
+    assert preflight.config.chosen_connectors["CRM"]["source"] == "db"
+    assert preflight.config.chosen_connectors["Analytics"]["source"] == "db"
+
+
+def test_db_connector_rows_beat_env_vars_when_both_exist() -> None:
+    preflight = discover_sandbox_pilot_config(
+        _populated_env(),
+        connector_rows=[_db_row("salesforce_sandbox", "CRM")],
+    )
+
+    assert preflight.preflight_status == "ready"
+    assert preflight.config.chosen_connectors["CRM"]["source"] == "db"
+    assert preflight.config.chosen_connectors["CRM"]["connector_key"] == "salesforce_sandbox"
+    assert preflight.config.chosen_connectors["Ads"]["source"] == "env"
+
+
+def test_db_connector_with_mock_marker_blocks_even_when_env_vars_exist() -> None:
+    preflight = discover_sandbox_pilot_config(
+        _populated_env(),
+        connector_rows=[_db_row("hubspot_mock", "CRM", mock_or_test_double=True)],
+    )
+
+    assert preflight.preflight_status == "blocked"
+    assert preflight.config.chosen_connectors["CRM"]["source"] == "db"
+    assert "mock_or_test_double" in preflight.config.chosen_connectors["CRM"]["missing_reason"]
+
+
+def test_preflight_with_missing_single_category_lists_only_that_category() -> None:
+    env = _populated_env()
+    for name in list(env):
+        if name.startswith(f"{SANDBOX_ENV_PREFIX}GA4_"):
+            env.pop(name)
+    preflight = discover_sandbox_pilot_config(env, connector_rows=[])
+    assert preflight.preflight_status == "blocked"
+    assert preflight.config.missing_categories == ["Analytics"]
+    assert all(
+        cat["connector_category"] != "CRM"
+        for cat in preflight.blockers
+        if cat.get("category") == "connector"
+    )
+
+
+def test_preflight_envelope_redacts_secret_named_keys() -> None:
+    preflight = discover_sandbox_pilot_config(_populated_env(), connector_rows=[])
+    envelope = build_blocked_preflight_envelope(preflight)
+    # Inject a secret-named value into next_actions and re-redact to confirm
+    # that anything carrying a known marker key would be replaced.
+    envelope["next_actions"].append(
+        {"action_key": "test", "label": "noop", "api_key": "sk-DO-NOT-LEAK"}
+    )
+    redacted = json.dumps(envelope)
+    # Build a fresh envelope wrapping that augmented dict to exercise the redactor.
+    from core.marketing.weekly_report_sandbox_pilot import _redact
+
+    redacted_envelope = _redact(envelope)
+    serialised = json.dumps(redacted_envelope)
+    assert "sk-DO-NOT-LEAK" not in serialised
+    assert "[REDACTED]" in serialised
+    # The original envelope's serialisation may still contain the raw value
+    # because we asserted that the *redactor* hides it after explicit pass.
+    assert "sk-DO-NOT-LEAK" in redacted  # raw envelope still has it -> redactor is the gate
+
+
+# ---------------------------------------------------------------------------
+# run_sandbox_pilot: missing creds → blocked envelope, no DB write
+# ---------------------------------------------------------------------------
+
+
+def test_run_sandbox_pilot_with_missing_creds_returns_blocked_envelope_only() -> None:
+    persist_calls: list[Any] = []
+
+    def _record(**kwargs):
+        persist_calls.append(kwargs)
+        return None
+
+    with patch(
+        "core.marketing.weekly_report_pilot_persistence.persist_weekly_report_pilot_proof_from_report_output_sync",
+        side_effect=_record,
+    ):
+        result = asyncio.run(run_sandbox_pilot(env={}))
+    assert result["preflight_status"] == "blocked"
+    assert result["production_claim_allowed"] is False
+    assert result["real_vendor_claim_allowed"] is False
+    assert result["environment_type"] == "vendor_sandbox"
+    assert persist_calls == [], "preflight failure must not trigger any persistence"
+
+
+# ---------------------------------------------------------------------------
+# run_sandbox_pilot: ready preflight → vendor_sandbox persists sandbox/partial only
+# ---------------------------------------------------------------------------
+
+
+def test_run_sandbox_pilot_with_ready_env_persists_sandbox_only() -> None:
+    """Ready preflight must drive the real report-task path; the verdict it
+    persists is never real-vendor passed because the runner forces
+    environment_type=vendor_sandbox upstream."""
+
+    fake_task_result = {
+        "report_id": "rep-sandbox-001",
+        "report_type": "cmo_weekly",
+        "paths": ["sandbox.pdf"],
+        "elapsed_sec": 1.23,
+        "status": "completed",
+        "weekly_report_pilot_proof": {
+            "proof_id": "wkly_report_proof_sandbox",
+            "environment_type": "vendor_sandbox",
+            "proof_status": "sandbox_proven",
+            "production_claim_allowed": False,
+            "real_vendor_claim_allowed": False,
+            "readiness_score": 88,
+            "next_action_cta": "none",
+        },
+    }
+    persisted_row = WeeklyReportPilotProof(
+        tenant_id=__import__("uuid").UUID(_TENANT_UUID),
+        company_id=None,
+        proof_id="wkly_report_proof_sandbox",
+        environment_type="vendor_sandbox",
+        proof_status="sandbox_proven",
+        production_claim_allowed=False,
+        real_vendor_claim_allowed=False,
+        readiness_score=88,
+        evaluated_at=datetime(2026, 5, 24, tzinfo=UTC),
+        evidence_bundle={"summary": {"proof_status": "sandbox_proven"}},
+        verdict={"proof_status": "sandbox_proven"},
+        blockers=[],
+        next_actions=[],
+        report_artifact_refs=[{"artifact_id": "rep-sandbox-001", "format": "pdf"}],
+        decision_audit_refs=[{"audit_id": "audit-rep-sandbox-001"}],
+    )
+
+    class _SessionCtx:
+        def __init__(self, _tid):
+            pass
+
+        async def __aenter__(self):
+            session = MagicMock()
+            result = MagicMock()
+            result.scalar_one_or_none = MagicMock(return_value=persisted_row)
+            session.execute = MagicMock(return_value=_resolved(result))
+            return session
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    def _resolved(value):
+        async def _coro():
+            return value
+
+        return _coro()
+
+    fake_task = MagicMock()
+    fake_task.run = MagicMock(return_value=fake_task_result)
+
+    with (
+        patch("core.tasks.report_tasks.generate_report", fake_task),
+        patch("core.database.get_tenant_session", _SessionCtx),
+    ):
+        result = asyncio.run(run_sandbox_pilot(env=_populated_env(), connector_rows=[]))
+
+    assert result["preflight_status"] == "ready"
+    assert result["environment_type"] == "vendor_sandbox"
+    proof_summary = result["weekly_report_pilot_proof"]
+    assert proof_summary["proof_status"] == "sandbox_proven"
+    assert proof_summary["production_claim_allowed"] is False
+    assert proof_summary["real_vendor_claim_allowed"] is False
+    # The runner re-reads from DB to confirm what landed.
+    assert result["latest_weekly_report_pilot_proof"]["proof_status"] == "sandbox_proven"
+    assert (
+        result["latest_weekly_report_pilot_proof"]["production_claim_allowed"] is False
+    )
+    # The report task was invoked with vendor_sandbox in params.
+    fake_task.run.assert_called_once()
+    args, _ = fake_task.run.call_args
+    assert args[0]["report_type"] == "cmo_weekly"
+    assert args[0]["params"]["pilot_environment_type"] == "vendor_sandbox"
+    assert args[0]["tenant_id"] == _TENANT_UUID
+
+
+def test_run_sandbox_pilot_blocked_verdict_keeps_production_claim_false() -> None:
+    """A ready preflight whose underlying report task still returns blocked
+    (e.g., a category is configured but data backfill is incomplete) must
+    keep production_claim_allowed=False."""
+
+    fake_task_result = {
+        "report_id": "rep-sandbox-002",
+        "report_type": "cmo_weekly",
+        "paths": ["sandbox.pdf"],
+        "status": "completed",
+        "weekly_report_pilot_proof": {
+            "proof_id": "wkly_report_proof_sandbox_blk",
+            "environment_type": "vendor_sandbox",
+            "proof_status": "blocked",
+            "production_claim_allowed": False,
+            "real_vendor_claim_allowed": False,
+            "readiness_score": 35,
+        },
+    }
+
+    class _SessionCtx:
+        def __init__(self, _tid):
+            pass
+
+        async def __aenter__(self):
+            raise RuntimeError("DB unreachable in this test")
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    fake_task = MagicMock()
+    fake_task.run = MagicMock(return_value=fake_task_result)
+
+    with (
+        patch("core.tasks.report_tasks.generate_report", fake_task),
+        patch("core.database.get_tenant_session", _SessionCtx),
+    ):
+        result = asyncio.run(run_sandbox_pilot(env=_populated_env(), connector_rows=[]))
+
+    assert result["preflight_status"] == "ready"
+    assert result["weekly_report_pilot_proof"]["proof_status"] == "blocked"
+    assert result["weekly_report_pilot_proof"]["production_claim_allowed"] is False
+    # DB readback failed but the runner tolerated it and returned the task result.
+    assert result["latest_weekly_report_pilot_proof"] is None
+
+
+# ---------------------------------------------------------------------------
+# Latest persisted proof: runner can fetch it
+# ---------------------------------------------------------------------------
+
+
+def test_runner_uses_latest_persisted_proof_helper_for_readback() -> None:
+    """The runner reads back via ``latest_weekly_report_pilot_proof``."""
+
+    persisted_row = WeeklyReportPilotProof(
+        tenant_id=__import__("uuid").UUID(_TENANT_UUID),
+        company_id=None,
+        proof_id="wkly_report_proof_readback",
+        environment_type="vendor_sandbox",
+        proof_status="partial",
+        production_claim_allowed=False,
+        real_vendor_claim_allowed=False,
+        readiness_score=70,
+        evaluated_at=datetime(2026, 5, 24, tzinfo=UTC),
+        evidence_bundle={},
+        verdict={"proof_status": "partial"},
+        blockers=[],
+        next_actions=[],
+        report_artifact_refs=[],
+        decision_audit_refs=[],
+    )
+
+    async def _fake_latest(session, **kwargs):
+        return persisted_row
+
+    class _SessionCtx:
+        def __init__(self, _tid):
+            pass
+
+        async def __aenter__(self):
+            return MagicMock()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    fake_task = MagicMock()
+    fake_task.run = MagicMock(return_value={"status": "completed", "weekly_report_pilot_proof": None})
+
+    with (
+        patch("core.tasks.report_tasks.generate_report", fake_task),
+        patch("core.database.get_tenant_session", _SessionCtx),
+        patch(
+            "core.marketing.weekly_report_pilot_persistence.latest_weekly_report_pilot_proof",
+            side_effect=_fake_latest,
+        ),
+    ):
+        result = asyncio.run(run_sandbox_pilot(env=_populated_env(), connector_rows=[]))
+
+    latest = result["latest_weekly_report_pilot_proof"]
+    assert latest is not None
+    assert latest["proof_id"] == "wkly_report_proof_readback"
+    assert latest["proof_status"] == "partial"
+    assert latest["production_claim_allowed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Secret redaction in runner output
+# ---------------------------------------------------------------------------
+
+
+def test_runner_output_redacts_secret_named_fields_in_task_result() -> None:
+    """Anything matching the secret-key markers in the task return value is
+    redacted before the runner emits its summary."""
+
+    fake_task_result = {
+        "status": "completed",
+        "report_id": "rep-secret-leak",
+        "paths": ["sandbox.pdf"],
+        "weekly_report_pilot_proof": {
+            "proof_status": "sandbox_proven",
+            "production_claim_allowed": False,
+            "real_vendor_claim_allowed": False,
+        },
+        "credentials": {"api_key": "sk-DO-NOT-LEAK"},
+        "authorization": "Bearer EXFIL",
+    }
+
+    fake_task = MagicMock()
+    fake_task.run = MagicMock(return_value=fake_task_result)
+
+    class _SessionCtx:
+        def __init__(self, _tid):
+            pass
+
+        async def __aenter__(self):
+            raise RuntimeError("skip readback")
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    with (
+        patch("core.tasks.report_tasks.generate_report", fake_task),
+        patch("core.database.get_tenant_session", _SessionCtx),
+    ):
+        result = asyncio.run(run_sandbox_pilot(env=_populated_env(), connector_rows=[]))
+
+    serialised = json.dumps(result, default=str)
+    assert "sk-DO-NOT-LEAK" not in serialised
+    assert "EXFIL" not in serialised
+    assert "[REDACTED]" in serialised
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke test (preflight-only, no DB / creds): exit code 3
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(args: list[str], *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    import os
+
+    full_env = dict(os.environ)
+    # Strip every sandbox env var to guarantee a clean preflight failure.
+    for name in list(full_env):
+        if name.startswith(SANDBOX_ENV_PREFIX) or name == "AGENTICORG_DB_URL":
+            full_env.pop(name)
+    if env:
+        full_env.update(env)
+    return subprocess.run(  # noqa: S603 -- pinned argv built from this test file only
+        [sys.executable, "scripts/run_weekly_report_sandbox_pilot.py", *args],
+        cwd=_REPO_ROOT,
+        env=full_env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_cli_preflight_only_blocked_exits_three() -> None:
+    result = _run_cli(["--preflight-only", "--format", "text"])
+    assert result.returncode == 3, result.stdout + result.stderr
+    assert "Preflight status:         blocked" in result.stdout
+    assert "AGENTICORG_DB_URL" in result.stdout
+
+
+def test_cli_preflight_only_json_output_is_redacted() -> None:
+    # Set one sandbox env var with a secret value to confirm the runner
+    # never echoes that value back even when other categories are missing.
+    fake_env = {
+        f"{SANDBOX_ENV_PREFIX}HUBSPOT_ACCESS_TOKEN": "hubspot-pat-SECRET-XYZ",
+    }
+    result = _run_cli(["--preflight-only", "--format", "json"], env=fake_env)
+    assert result.returncode == 3, result.stdout + result.stderr
+    # Names appear (they have "_TOKEN" / "_SECRET" in them) but the values do not.
+    assert "hubspot-pat-SECRET-XYZ" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Coverage of REQUIRED_* constants from the pilot proof module
+# ---------------------------------------------------------------------------
+
+
+def test_required_proof_constants_are_aligned() -> None:
+    """A safety net: the runner's preflight covers the same categories the
+    CMO-PROD-1 validator demands."""
+
+    expected_required = {"CRM", "Ads", "Analytics", "Email"}
+    assert set(SANDBOX_CONNECTOR_OPTIONS.keys()) == expected_required
+    assert set(REQUIRED_BACKFILL_CATEGORIES) == expected_required
+    assert REQUIRED_KPI_KEYS, "CMO-PROD-1 KPI key list must not regress to empty"
+    assert REQUIRED_MAPPINGS, "CMO-PROD-1 mapping list must not regress to empty"
+
+
+# ---------------------------------------------------------------------------
+# Sanity: deep-copying the populated env doesn't change preflight outcome
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_is_pure_and_does_not_mutate_env() -> None:
+    env = _populated_env()
+    snapshot = deepcopy(env)
+    preflight = discover_sandbox_pilot_config(env, connector_rows=[])
+    assert env == snapshot
+    assert preflight.preflight_status == "ready"

--- a/tests/unit/test_cmo_work_queue.py
+++ b/tests/unit/test_cmo_work_queue.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from api.v1 import kpis as kpis_api
+from core.marketing.work_queue import build_cmo_work_queue_projection
+
+NOW = datetime(2026, 5, 23, 12, 0, tzinfo=UTC)
+
+
+def _projection(**kwargs: object) -> dict:
+    return build_cmo_work_queue_projection(now=NOW, **kwargs)
+
+
+def _first(projection: dict, *, item_type: str | None = None, category: str | None = None) -> dict:
+    rows = projection["cmo_work_queue"]
+    for row in rows:
+        if item_type and row["type"] != item_type:
+            continue
+        if category and row["category"] != category:
+            continue
+        return row
+    raise AssertionError(f"work item not found: {item_type=} {category=}")
+
+
+def test_connector_auth_expired_creates_high_priority_reconnect_item() -> None:
+    projection = _projection(
+        connector_setup=[
+            {
+                "key": "ga4",
+                "name": "Google Analytics 4",
+                "category": "Analytics",
+                "configured_status": "configured",
+                "health_status": "expired_auth",
+                "owner": "marketing_ops",
+                "cta_state": "reconnect",
+            }
+        ]
+    )
+
+    item = _first(projection, category="connector")
+
+    assert item["severity"] in {"high", "critical"}
+    assert item["affected_connector"] == "ga4"
+    assert item["next_action_key"] == "reconnect"
+    assert item["next_action_label"] == "Reconnect"
+
+
+def test_missing_mapping_and_backfill_create_setup_work_items() -> None:
+    projection = _projection(
+        data_readiness={
+            "field_mapping_status": [
+                {
+                    "key": "lifecycle_stages",
+                    "name": "Lifecycle stages",
+                    "status": "unmapped",
+                    "next_action_cta": "map_fields",
+                }
+            ],
+            "backfill_status": [
+                {
+                    "source_connector_key": "hubspot",
+                    "source_name": "HubSpot",
+                    "category": "CRM",
+                    "status": "failed",
+                    "blocking_reason": "Vendor export failed",
+                    "next_action_cta": "retry_backfill",
+                }
+            ],
+        }
+    )
+
+    mapping = _first(projection, item_type="mapping_blocker")
+    backfill = _first(projection, item_type="backfill_blocker")
+
+    assert mapping["next_action_key"] == "map_fields"
+    assert mapping["status"] == "blocked"
+    assert backfill["next_action_key"] == "retry_backfill"
+    assert "Vendor export failed" in backfill["message"]
+
+
+def test_workflow_activation_blocker_creates_promotion_readiness_item() -> None:
+    projection = _projection(
+        workflow_activation={
+            "workflow_activation_status": [
+                {
+                    "workflow_key": "campaign_launch",
+                    "name": "Campaign Launch",
+                    "state": "promotion_blocked",
+                    "blocked_reasons": ["Required Ads connector is not healthy (missing)."],
+                    "next_action_cta": "fix_required_connector",
+                }
+            ]
+        }
+    )
+
+    item = _first(projection, item_type="workflow_activation")
+
+    assert item["affected_workflow"] == "campaign_launch"
+    assert item["severity"] == "high"
+    assert item["next_action_key"] == "fix_required_connector"
+
+
+def test_overdue_approval_timeout_creates_critical_escalation_item() -> None:
+    projection = _projection(
+        approval_timeout_risk={
+            "approval_timeout_decisions": [
+                {
+                    "approval_id": "apr-1",
+                    "approval_type": "ad_campaign_launch",
+                    "status": "timed_out",
+                    "timed_out": True,
+                    "created_at": (NOW - timedelta(hours=6)).isoformat(),
+                    "due_at": (NOW - timedelta(hours=2)).isoformat(),
+                    "external_writes_allowed": False,
+                    "safe_fallback_message": "Campaign launch was cancelled because approval expired.",
+                    "next_action_cta": "resolve_overdue_approvals",
+                    "audit_reference": "mkt_approval_timeout_1",
+                    "escalation_decision": {
+                        "event_id": "esc-1",
+                        "trigger_type": "approval_timeout",
+                        "decision": "escalate",
+                        "severity": "high",
+                        "escalation_target": "cmo",
+                        "due_at": (NOW + timedelta(hours=1)).isoformat(),
+                        "next_action_cta": "review_escalation",
+                    },
+                }
+            ]
+        }
+    )
+
+    approval = _first(projection, item_type="approval_timeout")
+    escalation = _first(projection, category="escalation")
+
+    assert approval["severity"] == "critical"
+    assert approval["status"] == "blocked"
+    assert approval["next_action_key"] == "resolve_overdue_approvals"
+    assert escalation["owner_role"] == "cmo"
+
+
+def test_external_write_rejected_and_timeout_create_critical_items() -> None:
+    projection = _projection(
+        external_write_results=[
+            {
+                "workflow_id": "campaign_launch",
+                "step_id": "launch_ads",
+                "connector_key": "google_ads",
+                "final_state": "rejected",
+                "reason": "Budget cap exceeded",
+                "next_action": "request_budget_approval",
+                "audit_reference": "mkt_write_rejected",
+            },
+            {
+                "workflow_id": "lead_nurture",
+                "step_id": "send_email",
+                "connector_key": "mailchimp",
+                "final_state": "timeout_unknown",
+                "reason": "Unknown vendor write state",
+                "next_action": "manual_reconcile_before_retry",
+            },
+        ]
+    )
+
+    items = [item for item in projection["cmo_work_queue"] if item["type"] == "external_write_failure"]
+
+    assert {item["affected_connector"] for item in items} == {"google_ads", "mailchimp"}
+    assert all(item["severity"] == "critical" for item in items)
+    assert all(item["status"] == "blocked" for item in items)
+
+
+def test_missing_policy_and_audit_evidence_create_blocked_readiness_items() -> None:
+    projection = _projection(
+        workflow_activation={
+            "workflow_activation_status": [
+                {
+                    "workflow_key": "content_pipeline",
+                    "name": "Content Pipeline",
+                    "state": "promotion_blocked",
+                    "blocked_reasons": ["Decision audit evidence is missing for publish."],
+                    "next_action_cta": "configure_decision_audit_package",
+                    "marketing_policy": {
+                        "status": "missing_policy",
+                        "missing_policy_actions": ["publish"],
+                        "next_action_cta": "configure_marketing_policy_manifest",
+                    },
+                    "decision_audit": {
+                        "status": "missing_audit_evidence",
+                        "missing_audit_actions": ["publish"],
+                        "next_action_cta": "configure_decision_audit_package",
+                    },
+                }
+            ]
+        }
+    )
+
+    policy = _first(projection, category="policy")
+    audit = _first(projection, category="audit")
+
+    assert policy["status"] == "blocked"
+    assert policy["next_action_key"] == "configure_marketing_policy_manifest"
+    assert audit["status"] == "blocked"
+    assert audit["next_action_key"] == "configure_decision_audit_package"
+
+
+def test_blocked_kpi_and_failed_reconciliation_create_work_items() -> None:
+    projection = _projection(
+        kpi_results=[
+            {
+                "kpi_key": "cac",
+                "status": "blocked",
+                "confidence": 0.0,
+                "missing_requirements": {"connectors": ["Ads"]},
+                "next_action_cta": "review_kpi_readiness",
+            }
+        ],
+        reconciliation_checks=[
+            {
+                "reconciliation_key": "paid_spend_totals_by_channel",
+                "status": "failed",
+                "severity": "high",
+                "affected_kpi_keys": ["cac", "roas"],
+                "next_action_cta": "resolve_reconciliation",
+                "decision_audit_ref": "cmo_decision_audit:spend",
+            }
+        ],
+    )
+
+    kpi = _first(projection, category="kpi")
+    reconciliation = _first(projection, category="reconciliation")
+
+    assert kpi["affected_kpi"] == "cac"
+    assert kpi["status"] == "blocked"
+    assert reconciliation["severity"] == "high"
+    assert "cmo_decision_audit:spend" in reconciliation["audit_refs"]
+
+
+def test_report_quality_blocked_and_warning_modes_create_prioritized_items() -> None:
+    projection = _projection(
+        report_quality_gates=[
+            {
+                "report_key": "weekly_marketing_report",
+                "display_name": "Weekly Marketing Report",
+                "status": "blocked",
+                "severity": "high",
+                "safe_report_mode": "draft_only",
+                "blocked_reasons": ["Required KPI cac is blocked."],
+                "next_action_cta": "restore_required_kpis",
+            },
+            {
+                "report_key": "campaign_performance_ad_hoc",
+                "display_name": "Campaign Ad Hoc",
+                "status": "warning",
+                "safe_report_mode": "internal_only",
+                "warning_reasons": ["Optional content data is stale."],
+                "next_action_cta": "review_report_quality_warnings",
+            },
+        ]
+    )
+
+    report_items = [item for item in projection["cmo_work_queue"] if item["category"] == "report"]
+
+    assert report_items[0]["affected_report"] == "weekly_marketing_report"
+    assert report_items[0]["severity"] == "high"
+    assert report_items[1]["affected_report"] == "campaign_performance_ad_hoc"
+    assert report_items[1]["severity"] == "medium"
+
+
+def test_prioritization_orders_critical_before_lower_severity_items() -> None:
+    projection = _projection(
+        report_quality_gates=[
+            {
+                "report_key": "campaign_performance_ad_hoc",
+                "display_name": "Campaign Ad Hoc",
+                "status": "warning",
+                "safe_report_mode": "internal_only",
+                "warning_reasons": ["Optional source is stale."],
+            }
+        ],
+        external_write_results=[
+            {
+                "workflow_id": "campaign_launch",
+                "step_id": "launch_ads",
+                "connector_key": "google_ads",
+                "final_state": "timeout_unknown",
+                "reason": "Unknown vendor write state",
+            }
+        ],
+    )
+
+    assert projection["cmo_work_queue"][0]["category"] == "external_write"
+    assert projection["cmo_work_queue"][0]["severity"] == "critical"
+    assert projection["cmo_work_queue"][1]["category"] == "report"
+
+
+def test_related_connector_items_are_deduped_and_grouped() -> None:
+    projection = _projection(
+        connector_setup=[
+            {
+                "key": "ga4",
+                "name": "Google Analytics 4",
+                "category": "Analytics",
+                "configured_status": "configured",
+                "health_status": "expired_auth",
+                "owner": "marketing_ops",
+                "cta_state": "reconnect",
+            }
+        ],
+        connector_contracts=[
+            {
+                "connector_key": "ga4",
+                "name": "Google Analytics 4",
+                "category": "Analytics",
+                "contract_state": "auth_expired",
+                "read_status": "blocked",
+                "write_status": "blocked",
+                "write_capabilities": [],
+                "next_action_cta": "reconnect",
+                "degraded_mode_reason": "Connector auth is expired.",
+            }
+        ],
+    )
+
+    connector_items = [item for item in projection["cmo_work_queue"] if item["category"] == "connector"]
+
+    assert len(connector_items) == 1
+    assert len(connector_items[0]["source_refs"]) == 2
+    assert connector_items[0]["next_action_key"] == "reconnect"
+
+
+@pytest.mark.asyncio
+async def test_kpis_cmo_response_exposes_work_queue_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_base(tenant_id: str, role: str, company_id: str) -> dict:
+        return {
+            "demo": False,
+            "stale": False,
+            "source": "computed",
+            "company_id": company_id,
+            "agent_count": 0,
+            "total_tasks_30d": 0,
+        }
+
+    async def fake_configs(tenant_id: str) -> list:
+        return []
+
+    async def fake_approval_timeout(tenant_id: str, company_id: str) -> dict:
+        return {"pending": 0, "overdue": 0, "approval_timeout_decisions": []}
+
+    monkeypatch.setattr(kpis_api, "_build_kpi_response", fake_base)
+    monkeypatch.setattr(kpis_api, "_load_marketing_connector_configs", fake_configs)
+    monkeypatch.setattr(kpis_api, "_load_cmo_approval_timeout_risk", fake_approval_timeout)
+
+    response = await kpis_api._build_cmo_kpi_response("tenant-1", "company-1")
+
+    assert "cmo_work_queue" in response
+    assert "cmo_work_queue_summary" in response
+    assert response["cmo_work_queue_summary"]["total"] > 0
+    assert response["cmo_work_queue_summary"]["readiness"] == "blocked"
+
+
+def test_empty_work_queue_state_is_clear_and_non_deceptive() -> None:
+    projection = _projection()
+
+    assert projection["cmo_work_queue"] == []
+    assert projection["cmo_work_queue_summary"]["readiness"] == "ready"
+    assert "does not upgrade stub" in projection["cmo_work_queue_summary"]["empty_state"]

--- a/tests/unit/test_cmo_workflow_activation.py
+++ b/tests/unit/test_cmo_workflow_activation.py
@@ -1,0 +1,621 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from core.marketing.connector_setup import build_marketing_connector_setup
+from core.marketing.data_readiness import build_marketing_data_readiness
+from core.marketing.workflow_activation import (
+    build_cmo_workflow_activation,
+    evaluate_cmo_workflow_external_write,
+)
+
+NOW = datetime(2026, 5, 23, 12, 0, tzinfo=UTC)
+
+
+def _connector_config(
+    connector_name: str,
+    *,
+    config: dict,
+    health_status: str = "healthy",
+    last_sync_at: datetime | None = None,
+    sync_error: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        connector_name=connector_name,
+        display_name=None,
+        auth_type="oauth2",
+        credentials_encrypted={"_encrypted": "enc"},
+        config=config,
+        status="configured",
+        last_health_check=NOW,
+        health_status=health_status,
+        last_sync_at=last_sync_at or NOW - timedelta(hours=1),
+        sync_error=sync_error,
+    )
+
+
+def _backfill(status: str = "completed") -> dict:
+    return {
+        "status": status,
+        "requested_start": "2025-05-01",
+        "requested_end": "2026-05-23",
+        "records_discovered": 100,
+        "records_imported": 98 if status in {"completed", "partial"} else 0,
+        "records_skipped": 1,
+        "records_failed": 1 if status == "partial" else 0,
+        "last_run_at": "2026-05-23T10:00:00+00:00",
+        "blocking_reason": "Vendor export failed" if status in {"failed", "blocked"} else None,
+    }
+
+
+def _contract(**overrides: object) -> dict:
+    base = {
+        "idempotency_supported": True,
+        "retry_budget": {
+            "max_attempts": 3,
+            "attempts_used": 0,
+            "remaining_attempts": 3,
+            "idempotency_supported": True,
+            "idempotency_key": "mkt-setup-001",
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def _base_configs() -> list[SimpleNamespace]:
+    updated_at = "2026-05-01T00:00:00+00:00"
+    hubspot_mapping = {
+        "lifecycle_stages": {
+            "source_field": "lifecyclestage",
+            "stage_map": {"mql": "marketingqualifiedlead", "sql": "salesqualifiedlead"},
+            "updated_at": updated_at,
+        },
+        "opportunity_revenue": {
+            "amount_field": "amount",
+            "close_date_field": "closedate",
+            "currency_field": "deal_currency_code",
+            "updated_at": updated_at,
+        },
+        "account_domains": {
+            "domain_field": "website",
+            "updated_at": updated_at,
+        },
+        "consent_unsubscribe": {
+            "consent_field": "marketing_opt_in",
+            "unsubscribe_field": "unsubscribed",
+            "updated_at": updated_at,
+        },
+        "fiscal_calendar": {
+            "fiscal_year_start_month": 4,
+            "updated_at": updated_at,
+        },
+        "currency": {
+            "currency": "USD",
+            "updated_at": updated_at,
+        },
+        "timezone": {
+            "timezone": "Asia/Kolkata",
+            "updated_at": updated_at,
+        },
+    }
+    campaign_mapping = {
+        "campaign_ids": {
+            "campaign_id_field": "campaign_id",
+            "updated_at": updated_at,
+        },
+        "utm_fields": {
+            "source": "utm_source",
+            "medium": "utm_medium",
+            "campaign": "utm_campaign",
+            "updated_at": updated_at,
+        },
+    }
+    mailchimp_mapping = {
+        **campaign_mapping,
+        "consent_unsubscribe": {
+            "consent_field": "marketing_permission",
+            "unsubscribe_field": "unsubscribe_status",
+            "updated_at": updated_at,
+        },
+    }
+    return [
+        _connector_config(
+            "hubspot",
+            config={
+                "owner": "revops@example.com",
+                "account_id": "portal-123",
+                "granted_scopes": [
+                    "crm.objects.contacts.read",
+                    "crm.objects.deals.read",
+                    "automation",
+                ],
+                "data_coverage_status": "ready",
+                "marketing_field_mapping": hubspot_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        ),
+        _connector_config(
+            "google_ads",
+            config={
+                "owner": "growth@example.com",
+                "customer_id": "123-456-7890",
+                "granted_scopes": ["https://www.googleapis.com/auth/adwords"],
+                "marketing_field_mapping": campaign_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        ),
+        _connector_config(
+            "ga4",
+            config={
+                "owner": "analytics@example.com",
+                "property_id": "properties/123",
+                "granted_scopes": ["https://www.googleapis.com/auth/analytics.readonly"],
+                "marketing_field_mapping": campaign_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": {
+                    "retry_budget": {
+                        "max_attempts": 3,
+                        "attempts_used": 0,
+                        "remaining_attempts": 3,
+                    },
+                },
+            },
+        ),
+        _connector_config(
+            "mailchimp",
+            config={
+                "owner": "email@example.com",
+                "audience_id": "aud-1",
+                "marketing_field_mapping": mailchimp_mapping,
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        ),
+    ]
+
+
+def _workflow_config(
+    *,
+    mode: str = "shadow",
+    promoted: bool = False,
+    approval_owner: str | None = "cmo@example.com",
+    policy_owner: str | None = "legal@example.com",
+    quality_status: str = "passed",
+    sample_count: int = 5,
+    success_rate: float = 0.95,
+    accepted_partial_backfills: list[str] | None = None,
+) -> dict:
+    payload = {
+        "mode": mode,
+        "promoted": promoted,
+        "approval_owner": approval_owner,
+        "policy_owner": policy_owner,
+        "shadow_quality": {
+            "status": quality_status,
+            "sample_count": sample_count,
+            "success_rate": success_rate,
+            "last_run_at": "2026-05-23T09:00:00+00:00",
+        },
+    }
+    if accepted_partial_backfills:
+        payload["accepted_partial_backfills"] = accepted_partial_backfills
+    return payload
+
+
+def _with_workflow(
+    configs: list[SimpleNamespace],
+    workflow_key: str,
+    payload: dict,
+) -> list[SimpleNamespace]:
+    configs = deepcopy(configs)
+    workflows = configs[0].config.setdefault("marketing_workflows", {})
+    workflows[workflow_key] = payload
+    return configs
+
+
+def _activation(configs: list[SimpleNamespace]) -> dict:
+    setup = build_marketing_connector_setup(configs, now=NOW)
+    readiness = build_marketing_data_readiness(setup, configs, now=NOW)
+    return build_cmo_workflow_activation(setup, readiness, configs, now=NOW)
+
+
+def _workflow(activation: dict, key: str) -> dict:
+    return next(row for row in activation["workflow_activation_status"] if row["workflow_key"] == key)
+
+
+def test_workflows_default_to_shadow_or_blocked_never_active() -> None:
+    activation = _activation(_base_configs())
+
+    campaign = _workflow(activation, "campaign_launch")
+    assert campaign["state"] == "promotion_blocked"
+    assert campaign["external_writes_allowed"] is False
+    assert all(row["state"] != "active" for row in activation["workflow_activation_status"])
+
+    configs = _with_workflow(
+        _base_configs(),
+        "campaign_launch",
+        _workflow_config(quality_status="not_measured", sample_count=0, success_rate=0),
+    )
+    shadow = _workflow(_activation(configs), "campaign_launch")
+    assert shadow["state"] == "shadow"
+    assert shadow["next_action_cta"] == "run_shadow_quality"
+
+
+def test_promotion_blocked_when_required_connector_is_missing_or_unhealthy() -> None:
+    configs = [config for config in _base_configs() if config.connector_name != "google_ads"]
+    configs = _with_workflow(configs, "campaign_launch", _workflow_config())
+
+    campaign = _workflow(_activation(configs), "campaign_launch")
+
+    assert campaign["state"] == "promotion_blocked"
+    assert campaign["next_action_cta"] == "fix_required_connector"
+    assert any("Ads connector" in reason for reason in campaign["blocked_reasons"])
+
+
+def test_promotion_blocked_when_required_mapping_is_invalid() -> None:
+    configs = _base_configs()
+    configs[0].config["marketing_field_mapping"]["currency"] = {
+        "currency": "ZZZ",
+        "updated_at": "2026-05-01T00:00:00+00:00",
+    }
+    configs = _with_workflow(configs, "campaign_launch", _workflow_config())
+
+    campaign = _workflow(_activation(configs), "campaign_launch")
+
+    assert campaign["state"] == "promotion_blocked"
+    assert campaign["next_action_cta"] == "fix_required_mapping"
+    assert any("Currency" in reason and "invalid" in reason for reason in campaign["blocked_reasons"])
+
+
+def test_promotion_blocked_when_required_backfill_failed_or_blocked() -> None:
+    configs = _base_configs()
+    configs[1].config["marketing_backfill"] = _backfill("failed")
+    configs = _with_workflow(configs, "campaign_launch", _workflow_config())
+
+    campaign = _workflow(_activation(configs), "campaign_launch")
+
+    assert campaign["state"] == "promotion_blocked"
+    assert campaign["next_action_cta"] == "complete_backfill"
+    assert any("Ads backfill" in reason for reason in campaign["blocked_reasons"])
+
+
+def test_promotion_blocked_when_approval_or_policy_owner_missing() -> None:
+    configs = _with_workflow(
+        _base_configs(),
+        "campaign_launch",
+        _workflow_config(approval_owner=None, policy_owner=None),
+    )
+
+    campaign = _workflow(_activation(configs), "campaign_launch")
+
+    assert campaign["state"] == "promotion_blocked"
+    assert campaign["next_action_cta"] == "configure_policy_owner"
+    assert "Approval owner is not configured." in campaign["blocked_reasons"]
+    assert "Policy owner is not configured." in campaign["blocked_reasons"]
+
+
+def test_promotion_blocked_when_approval_timeout_policy_is_missing() -> None:
+    payload = _workflow_config()
+    payload["approval_timeout_policy_disabled"] = True
+    configs = _with_workflow(_base_configs(), "campaign_launch", payload)
+
+    campaign = _workflow(_activation(configs), "campaign_launch")
+
+    assert campaign["state"] == "promotion_blocked"
+    assert campaign["next_action_cta"] == "configure_approval_timeout_policy"
+    assert campaign["approval_timeout_policy"]["status"] == "missing_policy"
+    assert any("Approval timeout policy" in reason for reason in campaign["blocked_reasons"])
+
+
+def test_promotion_ready_when_prerequisites_pass_but_workflow_not_promoted() -> None:
+    configs = _with_workflow(_base_configs(), "campaign_launch", _workflow_config())
+
+    campaign = _workflow(_activation(configs), "campaign_launch")
+
+    assert campaign["state"] == "promotion_ready"
+    assert campaign["next_action_cta"] == "promote_workflow"
+    assert campaign["external_writes_allowed"] is False
+    assert campaign["approval_timeout_policy"]["status"] == "ready"
+
+
+def test_active_only_when_explicitly_promoted() -> None:
+    configs = _with_workflow(
+        _base_configs(),
+        "campaign_launch",
+        _workflow_config(mode="active", promoted=True),
+    )
+
+    campaign = _workflow(_activation(configs), "campaign_launch")
+
+    assert campaign["state"] == "active"
+    assert campaign["external_writes_allowed"] is True
+
+
+def test_shadow_and_ready_modes_prevent_external_write_actions() -> None:
+    configs = _with_workflow(_base_configs(), "campaign_launch", _workflow_config())
+    rows = _activation(configs)["workflow_activation_status"]
+
+    publish = evaluate_cmo_workflow_external_write(rows, "campaign_launch", "publish")
+    draft = evaluate_cmo_workflow_external_write(rows, "campaign_launch", "draft")
+
+    assert publish["allowed"] is False
+    assert publish["state"] == "promotion_ready"
+    assert "promoted to active" in publish["reason"]
+    assert draft["allowed"] is True
+
+
+def test_active_workflow_can_attempt_external_write_subject_to_downstream_confirmation() -> None:
+    configs = _with_workflow(
+        _base_configs(),
+        "campaign_launch",
+        _workflow_config(mode="active", promoted=True),
+    )
+    rows = _activation(configs)["workflow_activation_status"]
+
+    decision = evaluate_cmo_workflow_external_write(rows, "campaign_launch", "publish")
+
+    assert decision["allowed"] is True
+    assert decision["state"] == "active"
+    assert "downstream connector confirmation" in decision["reason"]
+
+
+def test_per_workflow_promotion_does_not_activate_unrelated_workflows() -> None:
+    configs = _base_configs()
+    configs = _with_workflow(
+        configs,
+        "campaign_launch",
+        _workflow_config(mode="active", promoted=True),
+    )
+    configs = _with_workflow(configs, "lead_nurture", _workflow_config())
+
+    activation = _activation(configs)
+
+    assert _workflow(activation, "campaign_launch")["state"] == "active"
+    assert _workflow(activation, "lead_nurture")["state"] == "promotion_ready"
+    assert _workflow(activation, "daily_spend_optimization")["state"] != "active"
+
+
+def test_degraded_when_optional_connector_or_data_is_stale_or_partial() -> None:
+    configs = _base_configs()
+    configs.append(
+        _connector_config(
+            "brandwatch",
+            config={
+                "owner": "brand@example.com",
+                "project_id": "brand-1",
+                "granted_scopes": ["read_mentions", "read_queries"],
+                "marketing_backfill": _backfill("partial"),
+            },
+            health_status="healthy",
+            last_sync_at=NOW - timedelta(days=7),
+        )
+    )
+    configs = _with_workflow(configs, "weekly_marketing_report", _workflow_config())
+
+    weekly = _workflow(_activation(configs), "weekly_marketing_report")
+
+    assert weekly["state"] == "degraded"
+    assert weekly["next_action_cta"] == "review_degraded_dependency"
+    assert any("Brand" in reason for reason in weekly["degraded_reasons"])
+    assert weekly["external_writes_allowed"] is False
+
+
+def test_accepted_partial_required_backfill_degrades_instead_of_promoting_active() -> None:
+    configs = _base_configs()
+    configs[1].config["marketing_backfill"] = _backfill("partial")
+    configs = _with_workflow(
+        configs,
+        "campaign_launch",
+        _workflow_config(accepted_partial_backfills=["google_ads"]),
+    )
+
+    campaign = _workflow(_activation(configs), "campaign_launch")
+
+    assert campaign["state"] == "degraded"
+    assert any("accepted partial backfill" in reason for reason in campaign["degraded_reasons"])
+
+
+def test_beta_brand_workflow_is_blocked_not_unavailable_without_required_connectors() -> None:
+    activation = _activation(_base_configs())
+
+    assert _workflow(activation, "social_publishing")["state"] == "promotion_blocked"
+    assert _workflow(activation, "abm_sprint")["state"] == "promotion_blocked"
+    assert _workflow(activation, "brand_crisis_response")["state"] == "promotion_blocked"
+    assert _workflow(activation, "seo_sprint")["state"] == "promotion_blocked"
+    assert "Required Brand connector" in " ".join(
+        _workflow(activation, "brand_crisis_response")["blocked_reasons"]
+    )
+    assert "Required SEO connector" in " ".join(_workflow(activation, "seo_sprint")["blocked_reasons"])
+
+
+def test_social_publishing_is_promotable_only_after_social_connector_and_gates_pass() -> None:
+    updated_at = "2026-05-01T00:00:00+00:00"
+    configs = _base_configs()
+    configs.append(
+        _connector_config(
+            "buffer",
+            config={
+                "owner": "social@example.com",
+                "account_id": "profile-123",
+                "granted_scopes": ["profile:read", "updates:create"],
+                "marketing_field_mapping": {
+                    "campaign_ids": {"campaign_id_field": "campaign_id", "updated_at": updated_at},
+                    "utm_fields": {
+                        "source": "utm_source",
+                        "medium": "utm_medium",
+                        "campaign": "utm_campaign",
+                        "updated_at": updated_at,
+                    },
+                    "timezone": {"timezone": "Asia/Kolkata", "updated_at": updated_at},
+                },
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        )
+    )
+    configs = _with_workflow(
+        configs,
+        "social_publishing",
+        _workflow_config(mode="active", promoted=True),
+    )
+
+    social = _workflow(_activation(configs), "social_publishing")
+
+    assert social["state"] == "active"
+    assert social["external_writes_allowed"] is True
+    assert social["write_connector_categories"] == ["Social"]
+
+
+def test_abm_sprint_is_promotable_only_after_abm_connector_and_gates_pass() -> None:
+    updated_at = "2026-05-01T00:00:00+00:00"
+    configs = _base_configs()
+    configs.append(
+        _connector_config(
+            "bombora",
+            config={
+                "owner": "revops@example.com",
+                "account_id": "company-123",
+                "marketing_field_mapping": {
+                    "account_domains": {"domain_field": "domain", "updated_at": updated_at},
+                    "lifecycle_stages": {
+                        "source_field": "lifecycle_stage",
+                        "stage_map": {"mql": "MQL", "sql": "SQL"},
+                        "updated_at": updated_at,
+                    },
+                    "timezone": {"timezone": "Asia/Kolkata", "updated_at": updated_at},
+                },
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        )
+    )
+    configs = _with_workflow(
+        configs,
+        "abm_sprint",
+        _workflow_config(mode="active", promoted=True),
+    )
+
+    abm = _workflow(_activation(configs), "abm_sprint")
+
+    assert abm["state"] == "active"
+    assert abm["external_writes_allowed"] is True
+    assert abm["write_connector_categories"] == ["CRM", "Ads"]
+
+
+def test_brand_crisis_response_is_promotable_only_after_brand_social_and_gates_pass() -> None:
+    updated_at = "2026-05-01T00:00:00+00:00"
+    configs = _base_configs()
+    configs.append(
+        _connector_config(
+            "brandwatch",
+            config={
+                "owner": "brand@example.com",
+                "project_id": "brand-project-123",
+                "granted_scopes": ["read_mentions", "read_queries"],
+                "marketing_field_mapping": {
+                    "timezone": {"timezone": "Asia/Kolkata", "updated_at": updated_at},
+                },
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        )
+    )
+    configs.append(
+        _connector_config(
+            "buffer",
+            config={
+                "owner": "social@example.com",
+                "account_id": "profile-123",
+                "granted_scopes": ["profile:read", "updates:create"],
+                "marketing_field_mapping": {
+                    "campaign_ids": {"campaign_id_field": "campaign_id", "updated_at": updated_at},
+                    "utm_fields": {
+                        "source": "utm_source",
+                        "medium": "utm_medium",
+                        "campaign": "utm_campaign",
+                        "updated_at": updated_at,
+                    },
+                    "timezone": {"timezone": "Asia/Kolkata", "updated_at": updated_at},
+                },
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        )
+    )
+    configs = _with_workflow(
+        configs,
+        "brand_crisis_response",
+        _workflow_config(mode="active", promoted=True),
+    )
+
+    brand = _workflow(_activation(configs), "brand_crisis_response")
+
+    assert brand["state"] == "active"
+    assert brand["external_writes_allowed"] is True
+    assert brand["write_connector_categories"] == ["Social"]
+
+
+def test_seo_sprint_is_promotable_only_after_seo_analytics_cms_and_gates_pass() -> None:
+    updated_at = "2026-05-01T00:00:00+00:00"
+    configs = _base_configs()
+    configs.append(
+        _connector_config(
+            "ahrefs",
+            config={
+                "owner": "seo@example.com",
+                "project_id": "seo-project-123",
+                "granted_scopes": ["read_keywords", "read_site_audit"],
+                "marketing_field_mapping": {
+                    "campaign_ids": {"campaign_id_field": "campaign_id", "updated_at": updated_at},
+                    "utm_fields": {
+                        "source": "utm_source",
+                        "medium": "utm_medium",
+                        "campaign": "utm_campaign",
+                        "updated_at": updated_at,
+                    },
+                    "timezone": {"timezone": "Asia/Kolkata", "updated_at": updated_at},
+                },
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        )
+    )
+    configs.append(
+        _connector_config(
+            "wordpress",
+            config={
+                "owner": "web@example.com",
+                "site_id": "site-123",
+                "granted_scopes": ["posts:read", "posts:write"],
+                "marketing_field_mapping": {
+                    "campaign_ids": {"campaign_id_field": "campaign_id", "updated_at": updated_at},
+                    "utm_fields": {
+                        "source": "utm_source",
+                        "medium": "utm_medium",
+                        "campaign": "utm_campaign",
+                        "updated_at": updated_at,
+                    },
+                    "timezone": {"timezone": "Asia/Kolkata", "updated_at": updated_at},
+                },
+                "marketing_backfill": _backfill(),
+                "marketing_connector_contract": _contract(),
+            },
+        )
+    )
+    configs = _with_workflow(
+        configs,
+        "seo_sprint",
+        _workflow_config(mode="active", promoted=True),
+    )
+
+    seo = _workflow(_activation(configs), "seo_sprint")
+
+    assert seo["state"] == "active"
+    assert seo["external_writes_allowed"] is True
+    assert seo["write_connector_categories"] == ["CMS"]
+    assert "update_page_metadata" in seo["write_actions"]

--- a/tests/unit/test_enterprise_stability_gates.py
+++ b/tests/unit/test_enterprise_stability_gates.py
@@ -587,7 +587,7 @@ def test_auth_billing_connector_target_routes_have_metadata() -> None:
     routes = gates.scan_routes(target_paths, gates.REPO_ROOT)
     findings = gates.route_metadata_findings(routes)
 
-    assert len(routes) == 41
+    assert len(routes) == 43
     assert findings == []
     assert all(route.metadata_present for route in routes)
     assert all(route.scope for route in routes)

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -52,6 +52,7 @@ const Approvals = lazyRetry(() => import("./pages/Approvals"));
 const Connectors = lazyRetry(() => import("./pages/Connectors"));
 const ConnectorCreate = lazyRetry(() => import("./pages/ConnectorCreate"));
 const ConnectorDetail = lazyRetry(() => import("./pages/ConnectorDetail"));
+const CMOVendorSandboxConnectors = lazyRetry(() => import("./pages/CMOVendorSandboxConnectors"));
 const Schemas = lazyRetry(() => import("./pages/Schemas"));
 const Audit = lazyRetry(() => import("./pages/Audit"));
 const Observatory = lazyRetry(() => import("./pages/Observatory"));
@@ -497,6 +498,16 @@ export default function App() {
           <ProtectedRoute allowedRoles={["admin"]}>
             <Layout>
               <ConnectorCreate />
+            </Layout>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/dashboard/connectors/cmo-vendor-sandbox"
+        element={
+          <ProtectedRoute allowedRoles={["admin"]}>
+            <Layout>
+              <CMOVendorSandboxConnectors />
             </Layout>
           </ProtectedRoute>
         }

--- a/ui/src/__tests__/CMODashboard.test.tsx
+++ b/ui/src/__tests__/CMODashboard.test.tsx
@@ -36,6 +36,798 @@ import CMODashboard from "@/pages/CMODashboard";
 // Test data matching current CMOKPIData interface (basic metrics shape)
 // ---------------------------------------------------------------------------
 
+const MOCK_CONNECTOR_SETUP = [
+  {
+    key: "hubspot",
+    name: "HubSpot",
+    category: "CRM",
+    required_scopes: ["crm.objects.contacts.read", "crm.objects.deals.read"],
+    required_credentials: ["client_id", "client_secret", "refresh_token"],
+    configured_status: "configured",
+    health_status: "healthy",
+    last_sync_at: "2026-05-23T07:00:00+00:00",
+    owner: "revops@example.com",
+    account_id: "portal-123",
+    data_coverage_status: "ready",
+    cta_state: "none",
+    missing_scopes: [],
+  },
+  {
+    key: "google_ads",
+    name: "Google Ads",
+    category: "Ads",
+    required_scopes: ["https://www.googleapis.com/auth/adwords"],
+    required_credentials: ["developer_token", "customer_id"],
+    configured_status: "unconfigured",
+    health_status: "missing",
+    last_sync_at: null,
+    owner: "Unassigned",
+    account_id: null,
+    data_coverage_status: "missing",
+    cta_state: "setup",
+    missing_scopes: ["https://www.googleapis.com/auth/adwords"],
+  },
+  {
+    key: "ga4",
+    name: "Google Analytics 4",
+    category: "Analytics",
+    required_scopes: ["https://www.googleapis.com/auth/analytics.readonly"],
+    required_credentials: ["property_id"],
+    configured_status: "configured",
+    health_status: "expired_auth",
+    last_sync_at: "2026-05-20T07:00:00+00:00",
+    owner: "analytics@example.com",
+    account_id: "properties/123",
+    data_coverage_status: "blocked",
+    cta_state: "reconnect",
+    missing_scopes: [],
+  },
+  {
+    key: "mailchimp",
+    name: "Mailchimp",
+    category: "Email",
+    required_scopes: ["campaigns.read", "lists.read"],
+    required_credentials: ["api_key", "audience_id"],
+    configured_status: "configured",
+    health_status: "insufficient_scope",
+    last_sync_at: "2026-05-23T07:00:00+00:00",
+    owner: "email@example.com",
+    account_id: "aud-1",
+    data_coverage_status: "blocked",
+    cta_state: "add_scope",
+    missing_scopes: ["lists.read"],
+  },
+  {
+    key: "ahrefs",
+    name: "Ahrefs",
+    category: "SEO",
+    required_scopes: [],
+    required_credentials: ["api_token", "site_url"],
+    configured_status: "configured",
+    health_status: "stale",
+    last_sync_at: "2026-05-18T07:00:00+00:00",
+    owner: "seo@example.com",
+    account_id: "agenticorg.ai",
+    data_coverage_status: "stale",
+    cta_state: "refresh",
+    missing_scopes: [],
+  },
+  {
+    key: "brandwatch",
+    name: "Brandwatch",
+    category: "Brand",
+    required_scopes: ["read_mentions"],
+    required_credentials: ["client_id", "client_secret"],
+    configured_status: "configured",
+    health_status: "degraded",
+    last_sync_at: "2026-05-23T07:00:00+00:00",
+    owner: "brand@example.com",
+    account_id: "project-9",
+    data_coverage_status: "partial",
+    cta_state: "review",
+    missing_scopes: [],
+  },
+];
+
+const MOCK_CONNECTOR_CONTRACTS = [
+  {
+    connector_key: "hubspot",
+    name: "HubSpot",
+    category: "CRM",
+    configured_status: "configured",
+    vendor_id: null,
+    account_id: "portal-123",
+    workspace_id: null,
+    read_capabilities: ["contacts", "deals", "campaigns"],
+    write_capabilities: ["update_crm"],
+    required_read_scopes: ["crm.objects.contacts.read", "crm.objects.deals.read"],
+    required_write_scopes: ["crm.objects.contacts.write"],
+    granted_scopes: ["crm.objects.contacts.read", "crm.objects.deals.read", "crm.objects.contacts.write"],
+    missing_read_scopes: [],
+    missing_write_scopes: [],
+    auth_status: "valid",
+    health_status: "healthy",
+    contract_state: "healthy",
+    read_status: "ready",
+    write_status: "ready",
+    read_ready: true,
+    write_ready: true,
+    production_ready: true,
+    mock_or_test_double: false,
+    last_sync_at: "2026-05-23T07:00:00+00:00",
+    source_objects: [{ id: "portal-123", type: "portal", url: "https://app.hubspot.com" }],
+    data_freshness: {
+      status: "fresh",
+      ttl_seconds: 86400,
+      last_sync_at: "2026-05-23T07:00:00+00:00",
+    },
+    retry_budget: {
+      max_attempts: 3,
+      attempts_used: 1,
+      remaining_attempts: 2,
+      reset_at: null,
+      next_retry_at: "2026-05-23T08:00:00+00:00",
+      idempotency_key: "hubspot-update-1",
+      idempotency_supported: true,
+    },
+    degraded_mode_reason: null,
+    idempotency_key_supported: true,
+    external_write_confirmation_status: "write_confirmed",
+    external_write_confirmations: [
+      {
+        action: "update_crm",
+        status: "write_confirmed",
+        idempotency_key: "hubspot-update-1",
+      },
+    ],
+    next_action_cta: "none",
+  },
+  {
+    connector_key: "google_ads",
+    name: "Google Ads",
+    category: "Ads",
+    configured_status: "unconfigured",
+    vendor_id: "google",
+    account_id: null,
+    workspace_id: null,
+    read_capabilities: ["campaigns", "spend"],
+    write_capabilities: ["launch_campaign", "mutate_ad_budget"],
+    required_read_scopes: ["https://www.googleapis.com/auth/adwords"],
+    required_write_scopes: ["https://www.googleapis.com/auth/adwords"],
+    granted_scopes: [],
+    missing_read_scopes: ["https://www.googleapis.com/auth/adwords"],
+    missing_write_scopes: ["https://www.googleapis.com/auth/adwords"],
+    auth_status: "missing",
+    health_status: "missing",
+    contract_state: "missing_scope",
+    read_status: "blocked",
+    write_status: "blocked",
+    read_ready: false,
+    write_ready: false,
+    production_ready: false,
+    mock_or_test_double: false,
+    last_sync_at: null,
+    source_objects: [],
+    data_freshness: {
+      status: "missing",
+      ttl_seconds: 14400,
+      last_sync_at: null,
+    },
+    retry_budget: {
+      max_attempts: 0,
+      attempts_used: 0,
+      remaining_attempts: 0,
+      reset_at: null,
+      next_retry_at: null,
+      idempotency_key: null,
+      idempotency_supported: false,
+    },
+    degraded_mode_reason: "Missing read scopes: https://www.googleapis.com/auth/adwords.",
+    idempotency_key_supported: false,
+    external_write_confirmation_status: "none",
+    external_write_confirmations: [],
+    next_action_cta: "setup",
+  },
+  {
+    connector_key: "mailchimp",
+    name: "Mailchimp",
+    category: "Email",
+    configured_status: "configured",
+    vendor_id: null,
+    account_id: "aud-1",
+    workspace_id: null,
+    read_capabilities: ["campaigns", "audiences"],
+    write_capabilities: ["send_email"],
+    required_read_scopes: ["campaigns.read", "lists.read"],
+    required_write_scopes: ["campaigns.write"],
+    granted_scopes: ["campaigns.read"],
+    missing_read_scopes: ["lists.read"],
+    missing_write_scopes: ["campaigns.write"],
+    auth_status: "valid",
+    health_status: "insufficient_scope",
+    contract_state: "missing_scope",
+    read_status: "blocked",
+    write_status: "blocked",
+    read_ready: false,
+    write_ready: false,
+    production_ready: true,
+    mock_or_test_double: false,
+    last_sync_at: "2026-05-23T07:00:00+00:00",
+    source_objects: [{ id: "aud-1", type: "audience", url: "https://mailchimp.com" }],
+    data_freshness: {
+      status: "fresh",
+      ttl_seconds: 86400,
+      last_sync_at: "2026-05-23T07:00:00+00:00",
+    },
+    retry_budget: {
+      max_attempts: 2,
+      attempts_used: 0,
+      remaining_attempts: 2,
+      reset_at: null,
+      next_retry_at: null,
+      idempotency_key: "mailchimp-send-1",
+      idempotency_supported: true,
+    },
+    degraded_mode_reason: "Missing write scopes: campaigns.write.",
+    idempotency_key_supported: true,
+    external_write_confirmation_status: "write_unconfirmed",
+    external_write_confirmations: [
+      {
+        action: "send_email",
+        status: "write_unconfirmed",
+        idempotency_key: "mailchimp-send-1",
+      },
+    ],
+    next_action_cta: "add_scope",
+  },
+];
+
+const MOCK_FIELD_MAPPING_STATUS = [
+  {
+    key: "lifecycle_stages",
+    name: "Lifecycle stages",
+    status: "valid",
+    source_categories: ["CRM"],
+    sources: ["HubSpot"],
+    required_fields: ["source_field", "stage_map"],
+    missing_fields: [],
+    affected_kpis: ["MQL", "SQL", "Pipeline contribution"],
+    missing_blocks: true,
+    last_updated_at: "2026-05-01T00:00:00+00:00",
+    blocking_reason: null,
+    next_action_cta: "none",
+  },
+  {
+    key: "opportunity_revenue",
+    name: "Opportunity revenue fields",
+    status: "unmapped",
+    source_categories: ["CRM", "Finance"],
+    sources: ["HubSpot"],
+    required_fields: ["amount_field", "close_date_field", "currency_field"],
+    missing_fields: ["amount_field", "close_date_field", "currency_field"],
+    affected_kpis: ["Pipeline contribution", "CAC", "ROAS"],
+    missing_blocks: true,
+    last_updated_at: null,
+    blocking_reason: null,
+    next_action_cta: "map_fields",
+  },
+  {
+    key: "utm_fields",
+    name: "UTM fields",
+    status: "partially_mapped",
+    source_categories: ["Ads", "Analytics", "Email", "CMS"],
+    sources: ["Google Ads", "Google Analytics 4"],
+    required_fields: ["source", "medium", "campaign"],
+    missing_fields: ["campaign"],
+    affected_kpis: ["ROAS", "CAC", "Attribution"],
+    missing_blocks: false,
+    last_updated_at: "2026-05-01T00:00:00+00:00",
+    blocking_reason: null,
+    next_action_cta: "complete_mapping",
+  },
+  {
+    key: "currency",
+    name: "Currency",
+    status: "invalid",
+    source_categories: [],
+    sources: [],
+    required_fields: ["currency"],
+    missing_fields: [],
+    affected_kpis: ["CAC", "ROAS", "Pipeline contribution"],
+    missing_blocks: true,
+    last_updated_at: "2026-05-01T00:00:00+00:00",
+    blocking_reason: "Currency 'ZZZ' is not in the supported ISO currency allowlist.",
+    next_action_cta: "fix_mapping",
+  },
+  {
+    key: "timezone",
+    name: "Timezone",
+    status: "stale",
+    source_categories: [],
+    sources: [],
+    required_fields: ["timezone"],
+    missing_fields: [],
+    affected_kpis: ["Campaign performance", "Reporting freshness"],
+    missing_blocks: true,
+    last_updated_at: "2025-01-01T00:00:00+00:00",
+    blocking_reason: null,
+    next_action_cta: "review_mapping",
+  },
+  {
+    key: "consent_unsubscribe",
+    name: "Consent and unsubscribe fields",
+    status: "blocked",
+    source_categories: ["Email", "CRM"],
+    sources: ["Mailchimp"],
+    required_fields: ["consent_field", "unsubscribe_field"],
+    missing_fields: ["consent_field"],
+    affected_kpis: ["Email performance", "Lead nurture readiness"],
+    missing_blocks: true,
+    last_updated_at: null,
+    blocking_reason: "Legal approval required before mapping consent fields.",
+    next_action_cta: "resolve_mapping_blocker",
+  },
+];
+
+const MOCK_BACKFILL_STATUS = [
+  {
+    source_connector_key: "hubspot",
+    source_name: "HubSpot",
+    category: "CRM",
+    status: "completed",
+    requested_start: "2025-05-01",
+    requested_end: "2026-05-23",
+    records_discovered: 1000,
+    records_imported: 996,
+    records_skipped: 4,
+    records_failed: 0,
+    last_run_at: "2026-05-23T10:00:00+00:00",
+    blocking_reason: null,
+    next_action_cta: "none",
+  },
+  {
+    source_connector_key: "google_ads",
+    source_name: "Google Ads",
+    category: "Ads",
+    status: "failed",
+    requested_start: "2025-05-01",
+    requested_end: "2026-05-23",
+    records_discovered: 200,
+    records_imported: 120,
+    records_skipped: 10,
+    records_failed: 70,
+    last_run_at: "2026-05-23T10:00:00+00:00",
+    blocking_reason: "Vendor export failed",
+    next_action_cta: "retry_backfill",
+  },
+  {
+    source_connector_key: "ga4",
+    source_name: "Google Analytics 4",
+    category: "Analytics",
+    status: "blocked",
+    requested_start: "2025-05-01",
+    requested_end: "2026-05-23",
+    records_discovered: null,
+    records_imported: null,
+    records_skipped: null,
+    records_failed: null,
+    last_run_at: null,
+    blocking_reason: "Connector auth is expired and must be reauthorized.",
+    next_action_cta: "resolve_blocker",
+  },
+];
+
+const MOCK_SHADOW_QUALITY = {
+  status: "passed",
+  sample_count: 5,
+  success_rate: 0.94,
+  required_sample_count: 3,
+  required_success_rate: 0.8,
+  last_run_at: "2026-05-23T09:00:00+00:00",
+  blocking_reason: null,
+  next_action_cta: "none",
+};
+
+const MOCK_WORKFLOW_ACTIVATION_STATUS = [
+  {
+    workflow_key: "weekly_marketing_report",
+    name: "Weekly Marketing Report",
+    state: "promotion_ready",
+    configured_mode: "shadow",
+    required_connectors: ["CRM", "Ads", "Analytics", "Email"],
+    optional_connectors: ["SEO", "Brand", "Finance"],
+    required_mappings: ["lifecycle_stages", "opportunity_revenue", "campaign_ids"],
+    optional_mappings: [],
+    required_backfill_categories: ["CRM", "Ads", "Analytics", "Email"],
+    optional_backfill_categories: ["SEO", "Brand", "Finance"],
+    approval_owner: "cmo@example.com",
+    policy_owner: "legal@example.com",
+    shadow_quality: MOCK_SHADOW_QUALITY,
+    blocked_reasons: [],
+    degraded_reasons: [],
+    next_action_cta: "promote_workflow",
+    external_writes_allowed: false,
+  },
+  {
+    workflow_key: "campaign_launch",
+    name: "Campaign Launch",
+    state: "promotion_blocked",
+    configured_mode: "shadow",
+    required_connectors: ["CRM", "Ads", "Analytics", "Email"],
+    optional_connectors: ["CMS", "Social"],
+    required_mappings: ["campaign_ids", "utm_fields", "consent_unsubscribe"],
+    optional_mappings: ["account_domains"],
+    required_backfill_categories: ["CRM", "Ads", "Analytics", "Email"],
+    optional_backfill_categories: ["CMS", "Social"],
+    approval_owner: null,
+    policy_owner: "legal@example.com",
+    shadow_quality: MOCK_SHADOW_QUALITY,
+    blocked_reasons: ["Required Ads connector is not healthy (missing)."],
+    degraded_reasons: [],
+    next_action_cta: "fix_required_connector",
+    external_writes_allowed: false,
+  },
+  {
+    workflow_key: "daily_spend_optimization",
+    name: "Daily Spend Optimization",
+    state: "degraded",
+    configured_mode: "active",
+    required_connectors: ["CRM", "Ads", "Analytics"],
+    optional_connectors: ["Finance"],
+    required_mappings: ["opportunity_revenue", "campaign_ids", "utm_fields"],
+    optional_mappings: [],
+    required_backfill_categories: ["CRM", "Ads", "Analytics"],
+    optional_backfill_categories: ["Finance"],
+    approval_owner: "cmo@example.com",
+    policy_owner: "finance@example.com",
+    shadow_quality: MOCK_SHADOW_QUALITY,
+    blocked_reasons: [],
+    degraded_reasons: ["Optional Finance connector Stripe is stale."],
+    next_action_cta: "review_degraded_dependency",
+    external_writes_allowed: false,
+  },
+  {
+    workflow_key: "content_pipeline",
+    name: "Content Pipeline",
+    state: "active",
+    configured_mode: "active",
+    required_connectors: ["CMS"],
+    optional_connectors: ["Analytics", "SEO", "Social"],
+    required_mappings: ["campaign_ids", "utm_fields", "timezone"],
+    optional_mappings: [],
+    required_backfill_categories: ["CMS"],
+    optional_backfill_categories: ["Analytics", "SEO", "Social"],
+    approval_owner: "content@example.com",
+    policy_owner: "brand@example.com",
+    shadow_quality: MOCK_SHADOW_QUALITY,
+    blocked_reasons: [],
+    degraded_reasons: [],
+    next_action_cta: "none",
+    external_writes_allowed: true,
+  },
+  {
+    workflow_key: "lead_nurture",
+    name: "Lead Nurture",
+    state: "shadow",
+    configured_mode: "shadow",
+    required_connectors: ["CRM", "Email"],
+    optional_connectors: ["ABM"],
+    required_mappings: ["lifecycle_stages", "consent_unsubscribe", "timezone"],
+    optional_mappings: ["account_domains"],
+    required_backfill_categories: ["CRM", "Email"],
+    optional_backfill_categories: ["ABM"],
+    approval_owner: "cmo@example.com",
+    policy_owner: "legal@example.com",
+    shadow_quality: {
+      ...MOCK_SHADOW_QUALITY,
+      status: "not_measured",
+      sample_count: 0,
+      success_rate: 0,
+      blocking_reason: "Recent shadow-run quality gate has not collected enough runs (0/3).",
+      next_action_cta: "run_shadow_quality",
+    },
+    blocked_reasons: ["Recent shadow-run quality gate has not collected enough runs (0/3)."],
+    degraded_reasons: [],
+    next_action_cta: "run_shadow_quality",
+    external_writes_allowed: false,
+  },
+  {
+    workflow_key: "abm_sprint",
+    name: "ABM Sprint",
+    state: "unavailable",
+    configured_mode: "shadow",
+    required_connectors: ["CRM", "ABM"],
+    optional_connectors: [],
+    required_mappings: ["account_domains", "lifecycle_stages", "timezone"],
+    optional_mappings: [],
+    required_backfill_categories: ["CRM", "ABM"],
+    optional_backfill_categories: [],
+    approval_owner: null,
+    policy_owner: null,
+    shadow_quality: MOCK_SHADOW_QUALITY,
+    blocked_reasons: ["First-class core marketing ABM agent is not implemented yet."],
+    degraded_reasons: [],
+    next_action_cta: "implement_first_class_agent",
+    external_writes_allowed: false,
+  },
+  {
+    workflow_key: "brand_crisis_response",
+    name: "Brand Crisis Response",
+    state: "paused",
+    configured_mode: "paused",
+    required_connectors: ["Brand"],
+    optional_connectors: ["Social"],
+    required_mappings: ["timezone"],
+    optional_mappings: [],
+    required_backfill_categories: ["Brand"],
+    optional_backfill_categories: ["Social"],
+    approval_owner: "brand@example.com",
+    policy_owner: "legal@example.com",
+    shadow_quality: MOCK_SHADOW_QUALITY,
+    blocked_reasons: [],
+    degraded_reasons: [],
+    next_action_cta: "resume_workflow",
+    external_writes_allowed: false,
+  },
+  {
+    workflow_key: "seo_sprint",
+    name: "SEO Sprint",
+    state: "unavailable",
+    configured_mode: "shadow",
+    required_connectors: ["SEO", "Analytics", "CMS"],
+    optional_connectors: [],
+    required_mappings: ["campaign_ids", "utm_fields", "timezone"],
+    optional_mappings: [],
+    required_backfill_categories: ["SEO", "Analytics", "CMS"],
+    optional_backfill_categories: [],
+    approval_owner: null,
+    policy_owner: null,
+    shadow_quality: MOCK_SHADOW_QUALITY,
+    blocked_reasons: ["SEO Strategist still wraps shared/base behavior and is not production-grade SEO execution."],
+    degraded_reasons: [],
+    next_action_cta: "implement_first_class_agent",
+    external_writes_allowed: false,
+  },
+];
+
+const MOCK_WORK_QUEUE = [
+  {
+    item_id: "cmo_wq_external_write_timeout_campaign_launch",
+    type: "external_write_failure",
+    category: "external_write",
+    severity: "critical",
+    priority_score: 1170,
+    title: "External marketing write is timeout unknown",
+    message: "Unknown vendor write state",
+    affected_workflow: "campaign_launch",
+    affected_capability: "Campaign Pilot",
+    affected_kpi: null,
+    affected_report: null,
+    affected_connector: "google_ads",
+    owner_role: "Marketing Ops",
+    due_at: "2026-05-23T12:00:00+00:00",
+    source_refs: [{ kind: "external_write", external_write_id: "write-123" }],
+    audit_refs: ["mkt_write_timeout"],
+    next_action_cta: {
+      action_key: "manual_reconcile_before_retry",
+      label: "Reconcile Before Retry",
+      path: "/dashboard/approvals",
+    },
+    next_action_label: "Reconcile Before Retry",
+    next_action_path: "/dashboard/approvals",
+    next_action_key: "manual_reconcile_before_retry",
+    status: "blocked",
+    created_at: "2026-05-23T11:45:00+00:00",
+    updated_at: "2026-05-23T11:45:00+00:00",
+  },
+  {
+    item_id: "cmo_wq_report_campaign_ad_hoc_warning",
+    type: "report_quality_gate_warning",
+    category: "report",
+    severity: "medium",
+    priority_score: 520,
+    title: "Report quality gate needs attention: Campaign Ad Hoc",
+    message: "Report is internal_only until stale optional data is reviewed.",
+    affected_workflow: "weekly_marketing_report",
+    affected_capability: null,
+    affected_kpi: null,
+    affected_report: "campaign_performance_ad_hoc",
+    affected_connector: null,
+    owner_role: "Marketing Ops",
+    due_at: null,
+    source_refs: [{ kind: "report_quality_gate", report_type: "campaign_performance_ad_hoc" }],
+    audit_refs: [],
+    next_action_cta: {
+      action_key: "review_report_warnings",
+      label: "Review Report Warnings",
+      path: "/dashboard/reports",
+    },
+    next_action_label: "Review Report Warnings",
+    next_action_path: "/dashboard/reports",
+    next_action_key: "review_report_warnings",
+    status: "open",
+    created_at: "2026-05-23T11:30:00+00:00",
+    updated_at: "2026-05-23T11:30:00+00:00",
+  },
+];
+
+const MOCK_APPROVAL_REVIEWS = [
+  {
+    approval_review_id: "cmo_approval_review_campaign",
+    approval_id: "apr-campaign-1",
+    workflow_id: "campaign_launch",
+    workflow_run_id: "run-1",
+    run_id: "run-1",
+    step_id: "launch",
+    action: "launch_campaign",
+    action_type: "campaign_launch",
+    status: "pending",
+    requester: "campaign_pilot",
+    agent_ref: "campaign_pilot",
+    assigned_approver: "cmo@example.com",
+    assigned_approver_role: "cmo",
+    created_at: "2026-05-23T10:00:00+00:00",
+    due_at: "2026-05-23T14:00:00+00:00",
+    timeout_state: "pending",
+    preview_payload: {
+      campaign_name: "Q2 Pipeline Sprint",
+      headline: "Pipeline without guesswork",
+    },
+    before_after_diff: {
+      summary: "Draft campaign becomes live Google Ads launch.",
+    },
+    budget_impact: {
+      amount: 1200,
+      currency: "USD",
+      summary: "Daily launch budget +$1,200.",
+    },
+    audience_impact: {
+      estimated_recipients: 25000,
+      summary: "Enterprise search audience.",
+    },
+    risk_flags: ["budget_change", "requires_approval"],
+    source_refs: [{ type: "campaign_brief", id: "brief-1" }],
+    connector_refs: [{ connector_key: "google_ads", write_status: "ready" }],
+    agent_rationale: "ROAS shadow runs exceeded launch threshold.",
+    policy_result: { decision: "requires_approval", reason: "Campaign launches require CMO approval." },
+    policy_result_ref: "policy:approval",
+    escalation_result: { decision: "no_escalation" },
+    escalation_result_ref: "esc:no_escalation",
+    timeout_result: { status: "pending", timed_out: false },
+    timeout_result_ref: "timeout:apr-campaign-1",
+    external_write_readiness: {
+      status: "safe",
+      reason: "Required connector contracts are write-safe.",
+    },
+    external_write_result_ref: "write:pending",
+    audit_evidence: { ready: true, audit_refs: ["audit-approval-context"] },
+    audit_refs: ["audit-approval-context"],
+    rollback_stop_plan: {
+      summary: "Pause campaign and restore previous budget cap.",
+    },
+    allowed_reviewer_actions: ["approve", "reject", "override", "request_changes", "pause"],
+    blocked_reasons: [],
+    related_work_queue_item_ids: ["cmo_wq_approval_campaign_launch"],
+    next_action_cta: {
+      action_key: "review_pending_approval",
+      label: "Review Approval",
+      path: "/dashboard/approvals",
+    },
+    evaluated_at: "2026-05-23T12:00:00+00:00",
+  },
+];
+
+const MOCK_KPI_DRILLDOWNS = [
+  {
+    drilldown_id: "cmo_kpi_drilldown:cac",
+    kpi_key: "cac",
+    display_name: "CAC",
+    description: "Customer acquisition cost for the evaluated period.",
+    status: "blocked",
+    value: null,
+    unit: "currency",
+    confidence: 0,
+    formula: "total_marketing_spend / new_customers",
+    formula_inputs: [
+      { name: "total_marketing_spend", source_key: "total_marketing_spend", value: 1000, resolved: true },
+      { name: "new_customers", source_key: "new_customers", value: 10, resolved: true },
+    ],
+    source_refs: [{ connector_key: "hubspot", object: "deals" }],
+    connector_refs: [
+      {
+        type: "connector_setup",
+        connector_key: "hubspot",
+        category: "CRM",
+        health_status: "healthy",
+        last_sync_at: "2026-05-23T07:00:00+00:00",
+      },
+      {
+        type: "connector_setup",
+        connector_key: "google_ads",
+        category: "Ads",
+        health_status: "missing",
+        last_sync_at: null,
+      },
+    ],
+    field_mappings_used: [
+      { key: "opportunity_revenue", status: "unmapped", audit_ref: "audit-mapping-opportunity_revenue" },
+      { key: "campaign_ids", status: "valid", audit_ref: "audit-mapping-campaign_ids" },
+    ],
+    backfill_state: [{ source_connector_key: "hubspot", category: "CRM", status: "completed" }],
+    reconciliation_checks: [
+      {
+        reconciliation_key: "paid_spend_totals_by_channel",
+        status: "failed",
+        severity: "high",
+        confidence_impact: 0.25,
+        next_action_cta: {
+          action_key: "resolve_spend_reconciliation",
+          label: "Resolve Spend Reconciliation",
+          path: "/dashboard/cmo?panel=reconciliation",
+        },
+      },
+    ],
+    freshness_status: "fresh",
+    freshness: { status: "fresh", last_updated_at: "2026-05-23T07:00:00+00:00" },
+    confidence_impact_reasons: ["KPI reconciliation paid_spend_totals_by_channel is failed."],
+    missing_requirements: { field_mappings: ["opportunity_revenue"] },
+    blocked_reasons: ["Required mapping opportunity_revenue is unmapped."],
+    degraded_reasons: [],
+    related_work_queue_item_ids: ["cmo_wq_kpi_cac"],
+    related_report_gate_ids: ["weekly_marketing_report"],
+    policy_refs: [],
+    audit_refs: ["audit-kpi-source"],
+    owner_role: "growth_lead",
+    next_action_cta: {
+      action_key: "fix_required_mapping",
+      label: "Fix Mapping",
+      path: "/dashboard/connectors",
+    },
+    production_lineage_ready: true,
+    production_lineage_status: "ready",
+    last_computed_at: "2026-05-23T12:00:00+00:00",
+  },
+  {
+    drilldown_id: "cmo_kpi_drilldown:roas",
+    kpi_key: "roas",
+    display_name: "ROAS",
+    description: "Return on ad spend from attributed revenue and ad spend.",
+    status: "degraded",
+    value: 5,
+    unit: "ratio",
+    confidence: 0.65,
+    formula: "attributed_revenue / ad_spend",
+    formula_inputs: [
+      { name: "attributed_revenue", source_key: "attributed_revenue", value: 5000, resolved: true },
+      { name: "ad_spend", source_key: "ad_spend", value: 1000, resolved: true },
+    ],
+    source_refs: [{ connector_key: "hubspot", object: "deals" }],
+    connector_refs: [{ type: "connector_setup", connector_key: "hubspot", category: "CRM" }],
+    field_mappings_used: [{ key: "utm_fields", status: "partially_mapped" }],
+    backfill_state: [{ source_connector_key: "hubspot", category: "CRM", status: "completed" }],
+    reconciliation_checks: [],
+    freshness_status: "stale",
+    freshness: { status: "stale", last_updated_at: "2026-05-20T07:00:00+00:00" },
+    confidence_impact_reasons: ["Source data is stale for this KPI TTL."],
+    missing_requirements: {},
+    blocked_reasons: [],
+    degraded_reasons: ["Source data is stale for this KPI TTL."],
+    related_work_queue_item_ids: [],
+    related_report_gate_ids: ["daily_ad_performance"],
+    policy_refs: [],
+    audit_refs: ["audit-kpi-source"],
+    owner_role: "growth_lead",
+    next_action_cta: {
+      action_key: "refresh_source_data",
+      label: "Refresh Source Data",
+      path: "/dashboard/connectors",
+    },
+    production_lineage_ready: true,
+    production_lineage_status: "ready",
+    last_computed_at: "2026-05-23T12:00:00+00:00",
+  },
+];
+
 const MOCK_CMO_DATA = {
   demo: true,
   company_id: "comp-001",
@@ -48,6 +840,132 @@ const MOCK_CMO_DATA = {
     { domain: "marketing", total: 54, completed: 49, failed: 5, avg_confidence: 0.91 },
     { domain: "sales", total: 35, completed: 32, failed: 3, avg_confidence: 0.87 },
   ],
+  connector_setup: MOCK_CONNECTOR_SETUP,
+  connector_setup_summary: {
+    total: 6,
+    healthy: 1,
+    missing: 1,
+    stale: 1,
+    degraded: 1,
+    auth_actions: 2,
+    needs_action: 5,
+    readiness: "setup_required",
+  },
+  connector_contracts: MOCK_CONNECTOR_CONTRACTS,
+  connector_contract_summary: {
+    total: 3,
+    configured: 2,
+    read_ready: 1,
+    write_ready: 1,
+    blocked: 1,
+    degraded: 0,
+    missing_write_scope: 1,
+    write_unconfirmed: 1,
+    write_confirmed: 1,
+    mock_or_test_double: 0,
+    readiness: "blocked",
+  },
+  field_mapping_status: MOCK_FIELD_MAPPING_STATUS,
+  field_mapping_summary: {
+    total: 6,
+    unmapped: 1,
+    partially_mapped: 1,
+    valid: 1,
+    invalid: 1,
+    stale: 1,
+    blocked: 1,
+    needs_action: 5,
+    readiness: "blocked",
+    blocking: 3,
+    degraded: 2,
+  },
+  backfill_status: MOCK_BACKFILL_STATUS,
+  backfill_summary: {
+    total: 3,
+    not_started: 0,
+    queued: 0,
+    running: 0,
+    completed: 1,
+    partial: 0,
+    failed: 1,
+    blocked: 1,
+    needs_action: 2,
+    readiness: "blocked",
+  },
+  kpi_readiness: {
+    status: "blocked",
+    historical_status: "blocked",
+    field_mapping_readiness: "blocked",
+    backfill_readiness: "blocked",
+    blocked_reasons: ["Opportunity revenue fields mapping is unmapped."],
+    degraded_reasons: ["UTM fields mapping is partially mapped."],
+    affected_kpis: ["CAC", "ROAS", "Pipeline contribution"],
+    next_action_cta: "resolve_data_readiness",
+  },
+  workflow_activation_status: MOCK_WORKFLOW_ACTIVATION_STATUS,
+  workflow_activation_summary: {
+    total: 8,
+    unavailable: 2,
+    shadow: 1,
+    promotion_blocked: 1,
+    promotion_ready: 1,
+    active: 1,
+    degraded: 1,
+    paused: 1,
+    external_writes_allowed: 1,
+    needs_action: 7,
+    readiness: "blocked",
+  },
+  cmo_work_queue: MOCK_WORK_QUEUE,
+  cmo_work_queue_summary: {
+    total: 2,
+    readiness: "blocked",
+    critical_or_high: 1,
+    needs_action: 2,
+    top_priority_score: 1170,
+    first_item_id: "cmo_wq_external_write_timeout_campaign_launch",
+    next_action_cta: {
+      action_key: "manual_reconcile_before_retry",
+      label: "Reconcile Before Retry",
+      path: "/dashboard/approvals",
+    },
+    by_severity: { critical: 1, high: 0, medium: 1, low: 0, info: 0 },
+    by_status: { open: 1, blocked: 1, waiting: 0, resolved: 0, dismissed: 0 },
+    by_category: { external_write: 1, report: 1 },
+    empty_state: null,
+  },
+  cmo_approval_reviews: MOCK_APPROVAL_REVIEWS,
+  cmo_approval_review_summary: {
+    total: 1,
+    readiness: "pending",
+    approval_ready: 1,
+    blocked: 0,
+    timed_out: 0,
+    unsafe_write: 0,
+    missing_audit: 0,
+    needs_action: 1,
+    next_action_cta: {
+      action_key: "review_pending_approval",
+      label: "Review Approval",
+      path: "/dashboard/approvals",
+    },
+  },
+  cmo_kpi_drilldowns: MOCK_KPI_DRILLDOWNS,
+  cmo_kpi_drilldown_summary: {
+    total: 2,
+    ready: 0,
+    degraded: 1,
+    blocked: 1,
+    unavailable: 0,
+    lineage_blocked: 0,
+    readiness: "blocked",
+    needs_action: 2,
+    next_action_cta: {
+      action_key: "fix_required_mapping",
+      label: "Fix Mapping",
+      path: "/dashboard/connectors",
+    },
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -133,6 +1051,242 @@ describe("CMODashboard", () => {
       expect(screen.getByText("Domain Breakdown")).toBeInTheDocument();
     });
     expect(screen.getByText("marketing")).toBeInTheDocument();
+  });
+
+  it("renders truthful CMO capability states", async () => {
+    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
+    renderCMO();
+    await waitFor(() => {
+      expect(screen.getByText("CMO Capability Status")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Campaign Pilot")).toBeInTheDocument();
+    expect(screen.getByText("Production")).toBeInTheDocument();
+    expect(screen.getByText("Content Factory")).toBeInTheDocument();
+    expect(screen.getAllByText("Beta")).toHaveLength(3);
+    expect(screen.getAllByText("Stub")).toHaveLength(2);
+    expect(screen.getAllByText("Unavailable").length).toBeGreaterThanOrEqual(3);
+    expect(screen.getByText("Demo")).toBeInTheDocument();
+    expect(screen.getByText("Do not treat this dashboard as proof of end-to-end CMO agent autonomy.")).toBeInTheDocument();
+  });
+
+  it("renders marketing connector setup states and CTAs", async () => {
+    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
+    renderCMO();
+    await waitFor(() => {
+      expect(screen.getByText("Marketing Connector Setup")).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText("HubSpot").length).toBeGreaterThan(0);
+    expect(screen.getByText("portal-123")).toBeInTheDocument();
+    expect(screen.getByText("revops@example.com")).toBeInTheDocument();
+    expect(screen.getAllByText("Healthy").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("No Action").length).toBeGreaterThan(0);
+
+    expect(screen.getAllByText("Google Ads").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Missing").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Set Up" }).length).toBeGreaterThan(0);
+
+    expect(screen.getAllByText("Google Analytics 4").length).toBeGreaterThan(0);
+    expect(screen.getByText("Expired Auth")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Reconnect" }).length).toBeGreaterThan(0);
+
+    expect(screen.getAllByText("Mailchimp").length).toBeGreaterThan(0);
+    expect(screen.getByText("Insufficient Scope")).toBeInTheDocument();
+    expect(screen.getByText("Missing: lists.read")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Add Scope" }).length).toBeGreaterThan(0);
+
+    expect(screen.getByText("Ahrefs")).toBeInTheDocument();
+    expect(screen.getByText("Stale Sync")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Refresh Sync" }).length).toBeGreaterThan(0);
+
+    expect(screen.getByText("Brandwatch")).toBeInTheDocument();
+    expect(screen.getAllByText("Degraded").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Review" }).length).toBeGreaterThan(0);
+  });
+
+  it("renders marketing connector contract read/write readiness", async () => {
+    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
+    renderCMO();
+    await waitFor(() => {
+      expect(screen.getByText("Marketing Connector Contracts")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Read access, write access, retry budgets, idempotency, and external write confirmation are evaluated separately for production CMO workflows.")).toBeInTheDocument();
+    expect(screen.getAllByText("Write Confirmed").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Write Unconfirmed").length).toBeGreaterThan(0);
+    expect(screen.getByText("2/3 left, 1 used")).toBeInTheDocument();
+    expect(screen.getAllByText("Idempotency ready").length).toBeGreaterThan(0);
+    expect(screen.getByText("Missing write scopes: campaigns.write.")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Add Scope" }).length).toBeGreaterThan(0);
+  });
+
+  it("renders marketing field mapping and backfill readiness states", async () => {
+    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
+    renderCMO();
+    await waitFor(() => {
+      expect(screen.getByText("Marketing Data Readiness")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("CMO KPI readiness is blocked by missing mappings or incomplete backfill.")).toBeInTheDocument();
+    expect(screen.getByText("Opportunity revenue fields mapping is unmapped.")).toBeInTheDocument();
+
+    expect(screen.getByText("Lifecycle stages")).toBeInTheDocument();
+    expect(screen.getByText("Valid")).toBeInTheDocument();
+
+    expect(screen.getByText("Opportunity revenue fields")).toBeInTheDocument();
+    expect(screen.getByText("Unmapped")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Map Fields" }).length).toBeGreaterThan(0);
+
+    expect(screen.getByText("UTM fields")).toBeInTheDocument();
+    expect(screen.getByText("Partially Mapped")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Complete Mapping" }).length).toBeGreaterThan(0);
+
+    expect(screen.getByText("Currency")).toBeInTheDocument();
+    expect(screen.getByText("Currency 'ZZZ' is not in the supported ISO currency allowlist.")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Fix Mapping" }).length).toBeGreaterThan(0);
+
+    expect(screen.getByText("Consent and unsubscribe fields")).toBeInTheDocument();
+    expect(screen.getByText("Legal approval required before mapping consent fields.")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Resolve Blocker" }).length).toBeGreaterThan(0);
+
+    expect(screen.getByText("Historical Backfill")).toBeInTheDocument();
+    expect(screen.getByText("996/1000 imported, 0 failed")).toBeInTheDocument();
+    expect(screen.getByText("Vendor export failed")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Retry Backfill" }).length).toBeGreaterThan(0);
+    expect(screen.getByText("Connector auth is expired and must be reauthorized.")).toBeInTheDocument();
+  });
+
+  it("renders per-workflow shadow promotion gates and write readiness", async () => {
+    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
+    renderCMO();
+    await waitFor(() => {
+      expect(screen.getByText("CMO Workflow Promotion Gates")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Weekly Marketing Report")).toBeInTheDocument();
+    expect(screen.getByText("Ready to Promote")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Promote" }).length).toBeGreaterThan(0);
+
+    expect(screen.getByText("Campaign Launch")).toBeInTheDocument();
+    expect(screen.getByText("Required Ads connector is not healthy (missing).")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Fix Connector" }).length).toBeGreaterThan(0);
+
+    expect(screen.getByText("Daily Spend Optimization")).toBeInTheDocument();
+    expect(screen.getByText("Optional Finance connector Stripe is stale.")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Review Degraded" }).length).toBeGreaterThan(0);
+
+    expect(screen.getByText("Content Pipeline")).toBeInTheDocument();
+    expect(screen.getByText("Allowed")).toBeInTheDocument();
+    expect(screen.getAllByText("Read-only").length).toBeGreaterThan(0);
+
+    expect(screen.getByText("Lead Nurture")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Run Shadow QA" }).length).toBeGreaterThan(0);
+    expect(screen.getByText("ABM Sprint")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Implement Agent" }).length).toBeGreaterThan(0);
+    expect(screen.getByText("Brand Crisis Response")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Resume" }).length).toBeGreaterThan(0);
+  });
+
+  it("renders CMO work queue items and CTAs", async () => {
+    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
+    renderCMO();
+    await waitFor(() => {
+      expect(screen.getByText("CMO Work Queue")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("External marketing write is timeout unknown")).toBeInTheDocument();
+    expect(screen.getByText("Unknown vendor write state")).toBeInTheDocument();
+    expect(document.body.textContent).toContain("google_ads");
+    expect(screen.getByRole("button", { name: "Reconcile Before Retry" })).toBeInTheDocument();
+    expect(screen.getByText("Report quality gate needs attention: Campaign Ad Hoc")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Review Report Warnings" })).toBeInTheDocument();
+  });
+
+  it("renders a non-deceptive empty CMO work queue state", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        ...MOCK_CMO_DATA,
+        cmo_work_queue: [],
+        cmo_work_queue_summary: {
+          total: 0,
+          readiness: "ready",
+          critical_or_high: 0,
+          needs_action: 0,
+          top_priority_score: 0,
+          first_item_id: null,
+          next_action_cta: null,
+          by_severity: { critical: 0, high: 0, medium: 0, low: 0, info: 0 },
+          by_status: { open: 0, blocked: 0, waiting: 0, resolved: 0, dismissed: 0 },
+          by_category: {},
+          empty_state: null,
+        },
+      },
+    });
+    renderCMO();
+    await waitFor(() => {
+      expect(screen.getByText("CMO Work Queue")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(
+        "No CMO work queue items are open. This does not make stub, unavailable, or demo capabilities production-ready.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders CMO approval review cards with safety context", async () => {
+    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
+    renderCMO();
+    await waitFor(() => {
+      expect(screen.getByText("CMO Approval Reviews")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Q2 Pipeline Sprint")).toBeInTheDocument();
+    expect(document.body.textContent).toContain("Campaign Launch / launch_campaign");
+    expect(screen.getByText("Approve enabled")).toBeInTheDocument();
+    expect(document.body.textContent).toContain("Daily launch budget +$1,200.");
+    expect(document.body.textContent).toContain("Enterprise search audience.");
+    expect(document.body.textContent).toContain("Draft campaign becomes live Google Ads launch.");
+    expect(document.body.textContent).toContain("ROAS shadow runs exceeded launch threshold.");
+    expect(document.body.textContent).toContain("Required connector contracts are write-safe.");
+    expect(document.body.textContent).toContain("Pause campaign and restore previous budget cap.");
+    expect(document.body.textContent).toContain("Allowed actions: Approve, Reject, Override, Request Changes, Pause");
+    expect(screen.getByRole("button", { name: "Review Approval" })).toBeInTheDocument();
+  });
+
+  it("renders CMO KPI drill-down lineage details", async () => {
+    mockGet.mockResolvedValue({ data: MOCK_CMO_DATA });
+    renderCMO();
+    await waitFor(() => {
+      expect(screen.getByText("CMO KPI Drill-Down")).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText("CAC").length).toBeGreaterThan(0);
+    expect(screen.getByText("total_marketing_spend / new_customers")).toBeInTheDocument();
+    expect(document.body.textContent).toContain("total_marketing_spend: 1,000");
+    expect(document.body.textContent).toContain("new_customers: 10");
+    expect(document.body.textContent).toContain("hubspot");
+    expect(document.body.textContent).toContain("Work queue: cmo_wq_kpi_cac");
+    expect(document.body.textContent).toContain("Reports: weekly_marketing_report");
+    expect(screen.getAllByRole("button", { name: "Fix Mapping" }).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Refresh Source Data" })).toBeInTheDocument();
+  });
+
+  it("shows production connector block when demo fallback is suppressed", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        ...MOCK_CMO_DATA,
+        demo: false,
+        demo_suppressed: true,
+        production_data_blocked: true,
+        message: "No real CMO KPI data is available for this production tenant.",
+      },
+    });
+    renderCMO();
+    await waitFor(() => {
+      expect(screen.getByText("No real CMO KPI data is available for this production tenant.")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Demo Data")).not.toBeInTheDocument();
   });
 
   it("shows error message when API fails", async () => {

--- a/ui/src/__tests__/CMOVendorSandboxConnectors.test.tsx
+++ b/ui/src/__tests__/CMOVendorSandboxConnectors.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+  },
+  extractApiError: (_err: unknown, fallback: string) => fallback,
+}));
+
+import CMOVendorSandboxConnectors from "@/pages/CMOVendorSandboxConnectors";
+
+function renderPage() {
+  render(
+    <MemoryRouter>
+      <CMOVendorSandboxConnectors />
+    </MemoryRouter>,
+  );
+}
+
+describe("CMOVendorSandboxConnectors", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPost.mockReset();
+    mockGet.mockResolvedValue({
+      data: {
+        categories: [],
+        missing_categories: ["CRM", "Ads", "Analytics", "Email"],
+      },
+    });
+    mockPost.mockResolvedValue({
+      data: {
+        status: "ready",
+        message: "CMO vendor-sandbox ConnectorConfig rows configured.",
+      },
+    });
+  });
+
+  it("renders the guided CMO vendor-sandbox setup flow", async () => {
+    renderPage();
+
+    expect(await screen.findByText("CMO Vendor Sandbox Connectors")).toBeInTheDocument();
+    expect(screen.getByText("Current DB Preflight Rows")).toBeInTheDocument();
+    expect(screen.getByLabelText("CRM Access Token")).toBeInTheDocument();
+    expect(screen.getByLabelText("Ads Developer Token")).toBeInTheDocument();
+    expect(screen.getByLabelText("Analytics Property ID")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email API Key")).toBeInTheDocument();
+  });
+
+  it("submits all four categories to the CMO vendor-sandbox endpoint", async () => {
+    renderPage();
+
+    await screen.findByText("CMO Vendor Sandbox Connectors");
+
+    fireEvent.change(screen.getByLabelText("CRM Access Token"), { target: { value: "hubspot-token" } });
+    fireEvent.change(screen.getByLabelText("CRM Account ID optional"), { target: { value: "246292667" } });
+
+    fireEvent.change(screen.getByLabelText("Ads Developer Token"), { target: { value: "ads-dev-token" } });
+    fireEvent.change(screen.getByLabelText("Ads Refresh Token"), { target: { value: "ads-refresh-token" } });
+    fireEvent.change(screen.getByLabelText("Ads Customer ID"), { target: { value: "1234567890" } });
+    fireEvent.change(screen.getByLabelText("Ads Client ID"), { target: { value: "ads-client-id" } });
+    fireEvent.change(screen.getByLabelText("Ads Client Secret"), { target: { value: "ads-client-secret" } });
+
+    fireEvent.change(screen.getByLabelText("Analytics Property ID"), { target: { value: "properties/123" } });
+    fireEvent.change(screen.getByLabelText("Analytics Refresh Token"), { target: { value: "ga4-refresh-token" } });
+    fireEvent.change(screen.getByLabelText("Analytics Client ID"), { target: { value: "ga4-client-id" } });
+    fireEvent.change(screen.getByLabelText("Analytics Client Secret"), { target: { value: "ga4-client-secret" } });
+
+    fireEvent.change(screen.getByLabelText("Email API Key"), { target: { value: "sendgrid-key" } });
+    fireEvent.change(screen.getByLabelText("Email Sender Identity"), { target: { value: "sender@agenticorg.ai" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /Save CMO Sandbox Connectors/i }));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+    expect(mockPost).toHaveBeenCalledWith(
+      "/connectors/cmo-vendor-sandbox",
+      expect.objectContaining({
+        connectors: expect.objectContaining({
+          CRM: expect.objectContaining({
+            connector_name: "hubspot",
+            credentials: expect.objectContaining({ access_token: "hubspot-token" }),
+            config: expect.objectContaining({ account_id: "246292667" }),
+          }),
+          Ads: expect.objectContaining({
+            connector_name: "google_ads",
+            credentials: expect.objectContaining({ customer_id: "1234567890" }),
+          }),
+          Analytics: expect.objectContaining({
+            connector_name: "ga4",
+            credentials: expect.objectContaining({ property_id: "properties/123" }),
+          }),
+          Email: expect.objectContaining({
+            connector_name: "sendgrid",
+            credentials: expect.objectContaining({ sender_identity: "sender@agenticorg.ai" }),
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -126,6 +126,354 @@
     "cooDashboard": "COO Dashboard",
     "cboDashboard": "CBO Dashboard"
   },
+  "cmoCapability": {
+    "title": "CMO Capability Status",
+    "subtitle": "Current CMO autonomy is partial: stronger operators are separated from beta, stub, unavailable, and demo surfaces.",
+    "notice": "Do not treat this dashboard as proof of end-to-end CMO agent autonomy.",
+    "capability": "Capability",
+    "state": "State",
+    "currentLimit": "Current limit",
+    "states": {
+      "production": "Production",
+      "beta": "Beta",
+      "stub": "Stub",
+      "unavailable": "Unavailable",
+      "demo": "Demo"
+    },
+    "campaignPilot": {
+      "name": "Campaign Pilot",
+      "detail": "Strongest current CMO agent: domain-specific campaign execution, budget checks, performance polling, and HITL gates."
+    },
+    "contentFactory": {
+      "name": "Content Factory",
+      "detail": "Substantial content workflow exists, including draft generation and brand checks; publish loops and QA policy are still maturing."
+    },
+    "emailMarketing": {
+      "name": "Email Marketing",
+      "detail": "Available through a separate LangGraph path and approval-gated tooling, not a complete autonomous CMO pillar yet."
+    },
+    "brandMonitor": {
+      "name": "Brand Monitor",
+      "detail": "Registered, but the core marketing implementation still wraps shared/base behavior; not production-grade brand monitoring."
+    },
+    "seoStrategist": {
+      "name": "SEO Strategist",
+      "detail": "Registered, but the core marketing implementation still wraps shared/base behavior; not production-grade SEO execution."
+    },
+    "crmIntelligence": {
+      "name": "CRM Intelligence",
+      "detail": "First-class deterministic CRM/pipeline intelligence for velocity, funnel conversion, lead scoring refresh, churn signals, segments, SQL promotion, and account health; policy/approval/audit/write-confirmation gates for CRM writes. Not production-grade without real HubSpot/Salesforce/intent connectors and pilot proof."
+    },
+    "socialMedia": {
+      "name": "Social Media",
+      "detail": "Not a first-class core marketing agent yet; any graph-level surface should be treated as experimental/demo only."
+    },
+    "abm": {
+      "name": "ABM",
+      "detail": "ABM dashboard/API surfaces exist, but a first-class core marketing ABM agent is not implemented yet."
+    },
+    "competitiveIntel": {
+      "name": "Competitive Intel",
+      "detail": "Not a first-class core marketing agent yet; any graph-level surface should be treated as experimental/demo only."
+    },
+    "kpiFeed": {
+      "name": "CMO KPI feed",
+      "demoDetail": "This dashboard is currently showing demo KPI data, not proof of end-to-end autonomous CMO operation.",
+      "liveDetail": "KPI data is not flagged as demo, but capability maturity still follows the agent states listed above."
+    }
+  },
+  "cmoConnectors": {
+    "title": "Marketing Connector Setup",
+    "subtitle": "Real-company CMO readiness depends on connected CRM, ads, analytics, CMS, email, social, SEO, brand, ABM, and finance systems.",
+    "productionBlocked": "Production CMO data is blocked until real marketing connectors are configured and synced.",
+    "summaryHealthyLabel": "healthy",
+    "summaryNeedsActionLabel": "need action",
+    "summaryMissingLabel": "missing",
+    "empty": "Connector setup status is unavailable. The dashboard cannot claim production CMO readiness without it.",
+    "system": "System",
+    "status": "Status",
+    "coverageLabel": "Coverage",
+    "owner": "Owner",
+    "account": "Account",
+    "lastSync": "Last Sync",
+    "requiredAccess": "Required Access",
+    "action": "Action",
+    "missingScopesLabel": "Missing",
+    "unassigned": "Unassigned",
+    "notAvailable": "N/A",
+    "health": {
+      "healthy": "Healthy",
+      "missing": "Missing",
+      "expiredAuth": "Expired Auth",
+      "insufficientScope": "Insufficient Scope",
+      "stale": "Stale Sync",
+      "degraded": "Degraded",
+      "unknown": "Unknown"
+    },
+    "coverage": {
+      "ready": "Ready",
+      "missing": "Missing",
+      "blocked": "Blocked",
+      "stale": "Stale",
+      "partial": "Partial",
+      "unavailable": "Unavailable"
+    },
+    "cta": {
+      "none": "No Action",
+      "setup": "Set Up",
+      "reconnect": "Reconnect",
+      "addScope": "Add Scope",
+      "refresh": "Refresh Sync",
+      "review": "Review"
+    }
+  },
+  "cmoConnectorContracts": {
+    "title": "Marketing Connector Contracts",
+    "subtitle": "Read access, write access, retry budgets, idempotency, and external write confirmation are evaluated separately for production CMO workflows.",
+    "summaryReadReadyLabel": "read-ready",
+    "summaryWriteReadyLabel": "write-ready",
+    "summaryUnconfirmedLabel": "unconfirmed",
+    "empty": "Connector contract status is unavailable. Production CMO workflows cannot treat connector access or external writes as ready without it.",
+    "system": "System",
+    "contractState": "Contract",
+    "read": "Read",
+    "write": "Write",
+    "authFreshness": "Auth / Freshness",
+    "retry": "Retry",
+    "confirmation": "Confirmation",
+    "action": "Action",
+    "noWrites": "No write capability",
+    "missingScopes": "Missing",
+    "mockProof": "Mock/test proof is not production proof.",
+    "idempotencyReady": "Idempotency ready",
+    "idempotencyMissing": "No idempotency proof",
+    "states": {
+      "healthy": "Healthy",
+      "missingScope": "Missing Scope",
+      "authExpired": "Auth Expired",
+      "rateLimited": "Rate Limited",
+      "timeout": "Timeout",
+      "vendor5xx": "Vendor 5xx",
+      "partialData": "Partial Data",
+      "staleData": "Stale Data",
+      "degraded": "Degraded",
+      "writeUnconfirmed": "Write Unconfirmed",
+      "writeConfirmed": "Write Confirmed",
+      "none": "None",
+      "unknown": "Unknown"
+    },
+    "readiness": {
+      "ready": "Ready",
+      "blocked": "Blocked",
+      "degraded": "Degraded",
+      "readOnly": "Read-only",
+      "missingScope": "Missing Scope",
+      "idempotencyMissing": "Idempotency Missing",
+      "unknown": "Unknown"
+    },
+    "cta": {
+      "none": "No Action",
+      "setup": "Set Up",
+      "reconnect": "Reconnect",
+      "addScope": "Add Scope",
+      "reviewRetryBudget": "Review Retry Budget",
+      "reviewDegraded": "Review Degraded",
+      "configureIdempotency": "Configure Idempotency"
+    }
+  },
+  "cmoDataReadiness": {
+    "title": "Marketing Data Readiness",
+    "subtitle": "Canonical CMO KPIs need validated field mappings and historical backfill before production confidence is available.",
+    "summaryMappedLabel": "mapped",
+    "summaryBackfilledLabel": "backfilled",
+    "kpiBlocked": "CMO KPI readiness is blocked by missing mappings or incomplete backfill.",
+    "kpiDegraded": "CMO KPI readiness is degraded; treat values as directional until setup is complete.",
+    "fieldMappingsTitle": "Field Mapping",
+    "backfillTitle": "Historical Backfill",
+    "emptyMappings": "Field mapping status is unavailable. Production CMO KPIs cannot be considered ready without it.",
+    "emptyBackfill": "No connected marketing source has a historical backfill projection yet.",
+    "mapping": "Mapping",
+    "status": "Status",
+    "sources": "Sources",
+    "missingFields": "Missing Fields",
+    "affectedKpis": "Affected KPIs",
+    "lastUpdated": "Last Updated",
+    "source": "Source",
+    "dateRange": "Date Range",
+    "records": "Records",
+    "lastRun": "Last Run",
+    "blocker": "Blocker",
+    "action": "Action",
+    "none": "None",
+    "readiness": {
+      "ready": "Ready",
+      "degraded": "Degraded",
+      "blocked": "Blocked"
+    },
+    "fieldStatus": {
+      "valid": "Valid",
+      "unmapped": "Unmapped",
+      "partiallyMapped": "Partially Mapped",
+      "invalid": "Invalid",
+      "stale": "Stale",
+      "blocked": "Blocked",
+      "unknown": "Unknown"
+    },
+    "backfillStatus": {
+      "completed": "Completed",
+      "notStarted": "Not Started",
+      "queued": "Queued",
+      "running": "Running",
+      "partial": "Partial",
+      "failed": "Failed",
+      "blocked": "Blocked",
+      "unknown": "Unknown"
+    },
+    "cta": {
+      "none": "No Action",
+      "connectSource": "Connect Source",
+      "mapFields": "Map Fields",
+      "completeMapping": "Complete Mapping",
+      "reviewMapping": "Review Mapping",
+      "fixMapping": "Fix Mapping",
+      "resolveMappingBlocker": "Resolve Blocker",
+      "startBackfill": "Start Backfill",
+      "monitorBackfill": "Monitor Backfill",
+      "reviewFailedRecords": "Review Failed Records",
+      "retryBackfill": "Retry Backfill",
+      "resolveBlocker": "Resolve Blocker"
+    }
+  },
+  "cmoWorkflowGates": {
+    "title": "CMO Workflow Promotion Gates",
+    "subtitle": "Workflows remain read-only until their own connector, mapping, backfill, policy, and shadow-quality gates pass.",
+    "summaryActiveLabel": "active",
+    "summaryReadyLabel": "ready",
+    "summaryBlockedLabel": "blocked",
+    "empty": "Workflow activation status is unavailable. Production CMO workflows cannot be promoted without per-workflow gates.",
+    "workflow": "Workflow",
+    "state": "State",
+    "mode": "Mode",
+    "owners": "Owners",
+    "shadowQuality": "Shadow Quality",
+    "blockers": "Blockers",
+    "externalWrites": "External Writes",
+    "action": "Action",
+    "approvalOwner": "Approval",
+    "policyOwner": "Policy",
+    "runs": "runs",
+    "writesAllowed": "Allowed",
+    "readOnly": "Read-only",
+    "states": {
+      "active": "Active",
+      "promotionReady": "Ready to Promote",
+      "shadow": "Shadow",
+      "promotionBlocked": "Blocked",
+      "degraded": "Degraded",
+      "paused": "Paused",
+      "unavailable": "Unavailable",
+      "unknown": "Unknown"
+    },
+    "cta": {
+      "none": "No Action",
+      "promoteWorkflow": "Promote",
+      "runShadowQuality": "Run Shadow QA",
+      "fixRequiredConnector": "Fix Connector",
+      "fixRequiredMapping": "Fix Mapping",
+      "completeBackfill": "Complete Backfill",
+      "configurePolicyOwner": "Configure Policy",
+      "reviewDegradedDependency": "Review Degraded",
+      "resumeWorkflow": "Resume",
+      "implementFirstClassAgent": "Implement Agent",
+      "resolvePromotionBlocker": "Resolve Blocker"
+    }
+  },
+  "cmoWorkQueue": {
+    "title": "CMO Work Queue",
+    "subtitle": "Operator-visible CMO work from approvals, escalations, connectors, data readiness, writes, policy, audit, KPIs, reconciliation, and report gates.",
+    "summaryTotalLabel": "open items",
+    "summaryCriticalHighLabel": "critical/high",
+    "empty": "No CMO work queue items are open. This does not make stub, unavailable, or demo capabilities production-ready.",
+    "priority": "Priority",
+    "item": "Item",
+    "severityLabel": "Severity",
+    "owner": "Owner",
+    "affected": "Affected",
+    "due": "Due",
+    "action": "Action",
+    "severity": {
+      "critical": "Critical",
+      "high": "High",
+      "medium": "Medium",
+      "low": "Low",
+      "info": "Info"
+    },
+    "status": {
+      "open": "Open",
+      "blocked": "Blocked",
+      "waiting": "Waiting",
+      "resolved": "Resolved",
+      "dismissed": "Dismissed"
+    }
+  },
+  "cmoApprovalReviews": {
+    "title": "CMO Approval Reviews",
+    "subtitle": "Pending and blocked marketing approvals with preview, impact, policy, timeout, write, audit, and rollback context.",
+    "summaryNeedsActionLabel": "need review",
+    "summaryBlockedLabel": "blocked",
+    "empty": "No CMO approval reviews are projected. External or customer-facing marketing actions still require policy, write-readiness, timeout, and audit evidence before approval.",
+    "safeToApprove": "Approve enabled",
+    "approvalBlocked": "Approve blocked",
+    "ownerDue": "Owner / Due",
+    "risks": "Risks",
+    "budget": "Budget",
+    "audience": "Audience",
+    "diff": "Diff",
+    "rationale": "Rationale",
+    "noRationale": "No agent rationale provided",
+    "safeguards": "Safeguards",
+    "rollback": "Rollback / Stop",
+    "blockedReasons": "Blocked",
+    "workQueueRefs": "Work queue",
+    "allowedActions": "Allowed actions",
+    "noneAllowed": "None",
+    "status": {
+      "pending": "Pending",
+      "approved": "Approved",
+      "rejected": "Rejected",
+      "overridden": "Overridden",
+      "timedOut": "Timed Out",
+      "escalated": "Escalated",
+      "blocked": "Blocked"
+    }
+  },
+  "cmoKpiLineage": {
+    "title": "CMO KPI Drill-Down",
+    "subtitle": "Formula, source, mapping, reconciliation, freshness, confidence, work queue, and report-gate lineage for canonical CMO KPIs.",
+    "summaryReadyLabel": "ready",
+    "summaryBlockedLabel": "blocked",
+    "summaryLineageBlockedLabel": "lineage blocked",
+    "empty": "KPI drill-down lineage is unavailable. Production CMO KPIs cannot be trusted without formula, source, freshness, and confidence evidence.",
+    "kpi": "KPI",
+    "statusLabel": "Status",
+    "formula": "Formula",
+    "inputs": "Inputs",
+    "sources": "Sources",
+    "confidence": "Confidence",
+    "issue": "Issue",
+    "action": "Action",
+    "notProductionProof": "Not production lineage proof",
+    "notAvailable": "N/A",
+    "freshness": "Freshness",
+    "workQueueRefs": "Work queue",
+    "reportRefs": "Reports",
+    "status": {
+      "ready": "Ready",
+      "degraded": "Degraded",
+      "blocked": "Blocked",
+      "unavailable": "Unavailable"
+    }
+  },
   "dashboard": {
     "totalAgents": "Total Agents",
     "activeAgents": "Active Agents",

--- a/ui/src/locales/hi.json
+++ b/ui/src/locales/hi.json
@@ -126,6 +126,354 @@
     "cooDashboard": "COO डैशबोर्ड",
     "cboDashboard": "CBO डैशबोर्ड"
   },
+  "cmoCapability": {
+    "title": "CMO क्षमता स्थिति",
+    "subtitle": "मौजूदा CMO स्वायत्तता आंशिक है: मजबूत ऑपरेटरों को बीटा, स्टब, अनुपलब्ध और डेमो सतहों से अलग दिखाया गया है।",
+    "notice": "इस डैशबोर्ड को end-to-end CMO agent autonomy का प्रमाण न मानें।",
+    "capability": "क्षमता",
+    "state": "स्थिति",
+    "currentLimit": "मौजूदा सीमा",
+    "states": {
+      "production": "प्रोडक्शन",
+      "beta": "बीटा",
+      "stub": "स्टब",
+      "unavailable": "अनुपलब्ध",
+      "demo": "डेमो"
+    },
+    "campaignPilot": {
+      "name": "Campaign Pilot",
+      "detail": "मौजूदा सबसे मजबूत CMO एजेंट: डोमेन-विशिष्ट अभियान निष्पादन, बजट जांच, प्रदर्शन पोलिंग और HITL गेट।"
+    },
+    "contentFactory": {
+      "name": "Content Factory",
+      "detail": "ड्राफ्ट जनरेशन और ब्रांड जांच सहित पर्याप्त कंटेंट वर्कफ़्लो मौजूद है; पब्लिश लूप और QA नीति अभी परिपक्व हो रहे हैं।"
+    },
+    "emailMarketing": {
+      "name": "Email Marketing",
+      "detail": "अलग LangGraph पथ और अनुमोदन-गेटेड टूलिंग से उपलब्ध है, पर अभी पूर्ण स्वायत्त CMO स्तंभ नहीं है।"
+    },
+    "brandMonitor": {
+      "name": "Brand Monitor",
+      "detail": "रजिस्टर्ड है, लेकिन core marketing implementation अभी shared/base behavior को wrap करता है; production-grade brand monitoring नहीं है।"
+    },
+    "seoStrategist": {
+      "name": "SEO Strategist",
+      "detail": "रजिस्टर्ड है, लेकिन core marketing implementation अभी shared/base behavior को wrap करता है; production-grade SEO execution नहीं है।"
+    },
+    "crmIntelligence": {
+      "name": "CRM Intelligence",
+      "detail": "First-class deterministic CRM/pipeline intelligence (velocity, funnel conversion, lead scoring refresh, churn signals, segments, SQL promotion, account health) policy/approval/audit/write-confirmation gates के साथ। Real HubSpot/Salesforce/intent connectors और pilot proof के बिना production नहीं।"
+    },
+    "socialMedia": {
+      "name": "Social Media",
+      "detail": "अभी first-class core marketing agent नहीं है; graph-level surface को experimental/demo ही मानें।"
+    },
+    "abm": {
+      "name": "ABM",
+      "detail": "ABM dashboard/API surfaces मौजूद हैं, लेकिन first-class core marketing ABM agent अभी implemented नहीं है।"
+    },
+    "competitiveIntel": {
+      "name": "Competitive Intel",
+      "detail": "अभी first-class core marketing agent नहीं है; graph-level surface को experimental/demo ही मानें।"
+    },
+    "kpiFeed": {
+      "name": "CMO KPI feed",
+      "demoDetail": "यह डैशबोर्ड अभी demo KPI data दिखा रहा है, end-to-end autonomous CMO operation का प्रमाण नहीं।",
+      "liveDetail": "KPI data demo के रूप में flag नहीं है, लेकिन capability maturity ऊपर सूचीबद्ध agent states के अनुसार ही है।"
+    }
+  },
+  "cmoConnectors": {
+    "title": "Marketing Connector Setup",
+    "subtitle": "Real-company CMO readiness connected CRM, ads, analytics, CMS, email, social, SEO, brand, ABM और finance systems पर निर्भर है।",
+    "productionBlocked": "Production CMO data तब तक blocked है जब तक real marketing connectors configured और synced न हों।",
+    "summaryHealthyLabel": "healthy",
+    "summaryNeedsActionLabel": "need action",
+    "summaryMissingLabel": "missing",
+    "empty": "Connector setup status unavailable है। इसके बिना dashboard production CMO readiness claim नहीं कर सकता।",
+    "system": "System",
+    "status": "Status",
+    "coverageLabel": "Coverage",
+    "owner": "Owner",
+    "account": "Account",
+    "lastSync": "Last Sync",
+    "requiredAccess": "Required Access",
+    "action": "Action",
+    "missingScopesLabel": "Missing",
+    "unassigned": "Unassigned",
+    "notAvailable": "N/A",
+    "health": {
+      "healthy": "Healthy",
+      "missing": "Missing",
+      "expiredAuth": "Expired Auth",
+      "insufficientScope": "Insufficient Scope",
+      "stale": "Stale Sync",
+      "degraded": "Degraded",
+      "unknown": "Unknown"
+    },
+    "coverage": {
+      "ready": "Ready",
+      "missing": "Missing",
+      "blocked": "Blocked",
+      "stale": "Stale",
+      "partial": "Partial",
+      "unavailable": "Unavailable"
+    },
+    "cta": {
+      "none": "No Action",
+      "setup": "Set Up",
+      "reconnect": "Reconnect",
+      "addScope": "Add Scope",
+      "refresh": "Refresh Sync",
+      "review": "Review"
+    }
+  },
+  "cmoConnectorContracts": {
+    "title": "Marketing Connector Contracts",
+    "subtitle": "Read access, write access, retry budgets, idempotency और external write confirmation production CMO workflows के लिए अलग-अलग evaluate होते हैं।",
+    "summaryReadReadyLabel": "read-ready",
+    "summaryWriteReadyLabel": "write-ready",
+    "summaryUnconfirmedLabel": "unconfirmed",
+    "empty": "Connector contract status unavailable है। इसके बिना production CMO workflows connector access या external writes को ready नहीं मान सकते।",
+    "system": "System",
+    "contractState": "Contract",
+    "read": "Read",
+    "write": "Write",
+    "authFreshness": "Auth / Freshness",
+    "retry": "Retry",
+    "confirmation": "Confirmation",
+    "action": "Action",
+    "noWrites": "No write capability",
+    "missingScopes": "Missing",
+    "mockProof": "Mock/test proof production proof नहीं है।",
+    "idempotencyReady": "Idempotency ready",
+    "idempotencyMissing": "No idempotency proof",
+    "states": {
+      "healthy": "Healthy",
+      "missingScope": "Missing Scope",
+      "authExpired": "Auth Expired",
+      "rateLimited": "Rate Limited",
+      "timeout": "Timeout",
+      "vendor5xx": "Vendor 5xx",
+      "partialData": "Partial Data",
+      "staleData": "Stale Data",
+      "degraded": "Degraded",
+      "writeUnconfirmed": "Write Unconfirmed",
+      "writeConfirmed": "Write Confirmed",
+      "none": "None",
+      "unknown": "Unknown"
+    },
+    "readiness": {
+      "ready": "Ready",
+      "blocked": "Blocked",
+      "degraded": "Degraded",
+      "readOnly": "Read-only",
+      "missingScope": "Missing Scope",
+      "idempotencyMissing": "Idempotency Missing",
+      "unknown": "Unknown"
+    },
+    "cta": {
+      "none": "No Action",
+      "setup": "Set Up",
+      "reconnect": "Reconnect",
+      "addScope": "Add Scope",
+      "reviewRetryBudget": "Review Retry Budget",
+      "reviewDegraded": "Review Degraded",
+      "configureIdempotency": "Configure Idempotency"
+    }
+  },
+  "cmoDataReadiness": {
+    "title": "Marketing Data Readiness",
+    "subtitle": "Canonical CMO KPIs need validated field mappings and historical backfill before production confidence is available.",
+    "summaryMappedLabel": "mapped",
+    "summaryBackfilledLabel": "backfilled",
+    "kpiBlocked": "CMO KPI readiness is blocked by missing mappings or incomplete backfill.",
+    "kpiDegraded": "CMO KPI readiness is degraded; treat values as directional until setup is complete.",
+    "fieldMappingsTitle": "Field Mapping",
+    "backfillTitle": "Historical Backfill",
+    "emptyMappings": "Field mapping status is unavailable. Production CMO KPIs cannot be considered ready without it.",
+    "emptyBackfill": "No connected marketing source has a historical backfill projection yet.",
+    "mapping": "Mapping",
+    "status": "Status",
+    "sources": "Sources",
+    "missingFields": "Missing Fields",
+    "affectedKpis": "Affected KPIs",
+    "lastUpdated": "Last Updated",
+    "source": "Source",
+    "dateRange": "Date Range",
+    "records": "Records",
+    "lastRun": "Last Run",
+    "blocker": "Blocker",
+    "action": "Action",
+    "none": "None",
+    "readiness": {
+      "ready": "Ready",
+      "degraded": "Degraded",
+      "blocked": "Blocked"
+    },
+    "fieldStatus": {
+      "valid": "Valid",
+      "unmapped": "Unmapped",
+      "partiallyMapped": "Partially Mapped",
+      "invalid": "Invalid",
+      "stale": "Stale",
+      "blocked": "Blocked",
+      "unknown": "Unknown"
+    },
+    "backfillStatus": {
+      "completed": "Completed",
+      "notStarted": "Not Started",
+      "queued": "Queued",
+      "running": "Running",
+      "partial": "Partial",
+      "failed": "Failed",
+      "blocked": "Blocked",
+      "unknown": "Unknown"
+    },
+    "cta": {
+      "none": "No Action",
+      "connectSource": "Connect Source",
+      "mapFields": "Map Fields",
+      "completeMapping": "Complete Mapping",
+      "reviewMapping": "Review Mapping",
+      "fixMapping": "Fix Mapping",
+      "resolveMappingBlocker": "Resolve Blocker",
+      "startBackfill": "Start Backfill",
+      "monitorBackfill": "Monitor Backfill",
+      "reviewFailedRecords": "Review Failed Records",
+      "retryBackfill": "Retry Backfill",
+      "resolveBlocker": "Resolve Blocker"
+    }
+  },
+  "cmoWorkflowGates": {
+    "title": "CMO Workflow Promotion Gates",
+    "subtitle": "Workflows तब तक read-only रहते हैं जब तक उनके connector, mapping, backfill, policy और shadow-quality gates pass न हों।",
+    "summaryActiveLabel": "active",
+    "summaryReadyLabel": "ready",
+    "summaryBlockedLabel": "blocked",
+    "empty": "Workflow activation status unavailable है। Per-workflow gates के बिना production CMO workflows promote नहीं किए जा सकते।",
+    "workflow": "Workflow",
+    "state": "State",
+    "mode": "Mode",
+    "owners": "Owners",
+    "shadowQuality": "Shadow Quality",
+    "blockers": "Blockers",
+    "externalWrites": "External Writes",
+    "action": "Action",
+    "approvalOwner": "Approval",
+    "policyOwner": "Policy",
+    "runs": "runs",
+    "writesAllowed": "Allowed",
+    "readOnly": "Read-only",
+    "states": {
+      "active": "Active",
+      "promotionReady": "Ready to Promote",
+      "shadow": "Shadow",
+      "promotionBlocked": "Blocked",
+      "degraded": "Degraded",
+      "paused": "Paused",
+      "unavailable": "Unavailable",
+      "unknown": "Unknown"
+    },
+    "cta": {
+      "none": "No Action",
+      "promoteWorkflow": "Promote",
+      "runShadowQuality": "Run Shadow QA",
+      "fixRequiredConnector": "Fix Connector",
+      "fixRequiredMapping": "Fix Mapping",
+      "completeBackfill": "Complete Backfill",
+      "configurePolicyOwner": "Configure Policy",
+      "reviewDegradedDependency": "Review Degraded",
+      "resumeWorkflow": "Resume",
+      "implementFirstClassAgent": "Implement Agent",
+      "resolvePromotionBlocker": "Resolve Blocker"
+    }
+  },
+  "cmoWorkQueue": {
+    "title": "CMO Work Queue",
+    "subtitle": "Approvals, escalations, connectors, data readiness, writes, policy, audit, KPIs, reconciliation aur report gates se operator-visible CMO work.",
+    "summaryTotalLabel": "open items",
+    "summaryCriticalHighLabel": "critical/high",
+    "empty": "No CMO work queue items are open. Isse stub, unavailable, ya demo capabilities production-ready nahi banti.",
+    "priority": "Priority",
+    "item": "Item",
+    "severityLabel": "Severity",
+    "owner": "Owner",
+    "affected": "Affected",
+    "due": "Due",
+    "action": "Action",
+    "severity": {
+      "critical": "Critical",
+      "high": "High",
+      "medium": "Medium",
+      "low": "Low",
+      "info": "Info"
+    },
+    "status": {
+      "open": "Open",
+      "blocked": "Blocked",
+      "waiting": "Waiting",
+      "resolved": "Resolved",
+      "dismissed": "Dismissed"
+    }
+  },
+  "cmoApprovalReviews": {
+    "title": "CMO Approval Reviews",
+    "subtitle": "Pending aur blocked marketing approvals with preview, impact, policy, timeout, write, audit, and rollback context.",
+    "summaryNeedsActionLabel": "need review",
+    "summaryBlockedLabel": "blocked",
+    "empty": "No CMO approval reviews are projected. External ya customer-facing marketing actions ko approval se pehle policy, write-readiness, timeout, aur audit evidence chahiye.",
+    "safeToApprove": "Approve enabled",
+    "approvalBlocked": "Approve blocked",
+    "ownerDue": "Owner / Due",
+    "risks": "Risks",
+    "budget": "Budget",
+    "audience": "Audience",
+    "diff": "Diff",
+    "rationale": "Rationale",
+    "noRationale": "No agent rationale provided",
+    "safeguards": "Safeguards",
+    "rollback": "Rollback / Stop",
+    "blockedReasons": "Blocked",
+    "workQueueRefs": "Work queue",
+    "allowedActions": "Allowed actions",
+    "noneAllowed": "None",
+    "status": {
+      "pending": "Pending",
+      "approved": "Approved",
+      "rejected": "Rejected",
+      "overridden": "Overridden",
+      "timedOut": "Timed Out",
+      "escalated": "Escalated",
+      "blocked": "Blocked"
+    }
+  },
+  "cmoKpiLineage": {
+    "title": "CMO KPI Drill-Down",
+    "subtitle": "Canonical CMO KPIs ke liye formula, source, mapping, reconciliation, freshness, confidence, work queue aur report-gate lineage.",
+    "summaryReadyLabel": "ready",
+    "summaryBlockedLabel": "blocked",
+    "summaryLineageBlockedLabel": "lineage blocked",
+    "empty": "KPI drill-down lineage unavailable hai. Formula, source, freshness aur confidence evidence ke bina production CMO KPIs trusted nahi ho sakte.",
+    "kpi": "KPI",
+    "statusLabel": "Status",
+    "formula": "Formula",
+    "inputs": "Inputs",
+    "sources": "Sources",
+    "confidence": "Confidence",
+    "issue": "Issue",
+    "action": "Action",
+    "notProductionProof": "Not production lineage proof",
+    "notAvailable": "N/A",
+    "freshness": "Freshness",
+    "workQueueRefs": "Work queue",
+    "reportRefs": "Reports",
+    "status": {
+      "ready": "Ready",
+      "degraded": "Degraded",
+      "blocked": "Blocked",
+      "unavailable": "Unavailable"
+    }
+  },
   "dashboard": {
     "totalAgents": "कुल एजेंट",
     "activeAgents": "सक्रिय एजेंट",

--- a/ui/src/pages/CMODashboard.tsx
+++ b/ui/src/pages/CMODashboard.tsx
@@ -3,6 +3,7 @@ import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import api from "@/lib/api";
 import {
   BarChart,
@@ -13,6 +14,129 @@ import {
   ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
+
+type BadgeVariant = "default" | "success" | "warning" | "destructive" | "secondary" | "outline";
+type CapabilityStatus = "production" | "beta" | "stub" | "unavailable" | "demo";
+type ConnectorHealthStatus = "healthy" | "missing" | "expired_auth" | "insufficient_scope" | "stale" | "degraded" | "unknown";
+type ConnectorCTAState = "none" | "setup" | "reconnect" | "add_scope" | "refresh" | "review";
+type ConnectorContractState =
+  | "healthy"
+  | "missing_scope"
+  | "auth_expired"
+  | "rate_limited"
+  | "timeout"
+  | "vendor_5xx"
+  | "partial_data"
+  | "stale_data"
+  | "degraded"
+  | "write_unconfirmed"
+  | "write_confirmed"
+  | "unknown";
+type FieldMappingStatus = "unmapped" | "partially_mapped" | "valid" | "invalid" | "stale" | "blocked" | "unknown";
+type BackfillStatus = "not_started" | "queued" | "running" | "completed" | "partial" | "failed" | "blocked" | "unknown";
+type WorkflowState = "unavailable" | "shadow" | "promotion_blocked" | "promotion_ready" | "active" | "degraded" | "paused" | "unknown";
+type WorkQueueSeverity = "critical" | "high" | "medium" | "low" | "info";
+type WorkQueueStatus = "open" | "blocked" | "waiting" | "resolved" | "dismissed";
+type KpiDrilldownStatus = "ready" | "degraded" | "blocked" | "unavailable";
+type ApprovalReviewStatus = "pending" | "approved" | "rejected" | "overridden" | "timed_out" | "escalated" | "blocked";
+
+const STATUS_BADGE_VARIANT: Record<CapabilityStatus, BadgeVariant> = {
+  production: "success",
+  beta: "warning",
+  stub: "secondary",
+  unavailable: "destructive",
+  demo: "outline",
+};
+
+const CONNECTOR_BADGE_VARIANT: Record<ConnectorHealthStatus, BadgeVariant> = {
+  healthy: "success",
+  missing: "secondary",
+  expired_auth: "destructive",
+  insufficient_scope: "warning",
+  stale: "warning",
+  degraded: "destructive",
+  unknown: "outline",
+};
+
+const CONNECTOR_CONTRACT_BADGE_VARIANT: Record<ConnectorContractState, BadgeVariant> = {
+  healthy: "success",
+  missing_scope: "warning",
+  auth_expired: "destructive",
+  rate_limited: "warning",
+  timeout: "warning",
+  vendor_5xx: "warning",
+  partial_data: "warning",
+  stale_data: "warning",
+  degraded: "warning",
+  write_unconfirmed: "destructive",
+  write_confirmed: "success",
+  unknown: "outline",
+};
+
+const FIELD_MAPPING_BADGE_VARIANT: Record<FieldMappingStatus, BadgeVariant> = {
+  valid: "success",
+  unmapped: "secondary",
+  partially_mapped: "warning",
+  invalid: "destructive",
+  stale: "warning",
+  blocked: "destructive",
+  unknown: "outline",
+};
+
+const BACKFILL_BADGE_VARIANT: Record<BackfillStatus, BadgeVariant> = {
+  completed: "success",
+  not_started: "secondary",
+  queued: "warning",
+  running: "warning",
+  partial: "warning",
+  failed: "destructive",
+  blocked: "destructive",
+  unknown: "outline",
+};
+
+const WORKFLOW_BADGE_VARIANT: Record<WorkflowState, BadgeVariant> = {
+  active: "success",
+  promotion_ready: "warning",
+  shadow: "secondary",
+  promotion_blocked: "destructive",
+  degraded: "warning",
+  paused: "secondary",
+  unavailable: "destructive",
+  unknown: "outline",
+};
+
+const WORK_QUEUE_SEVERITY_BADGE_VARIANT: Record<WorkQueueSeverity, BadgeVariant> = {
+  critical: "destructive",
+  high: "destructive",
+  medium: "warning",
+  low: "secondary",
+  info: "outline",
+};
+
+const WORK_QUEUE_STATUS_BADGE_VARIANT: Record<WorkQueueStatus, BadgeVariant> = {
+  open: "warning",
+  blocked: "destructive",
+  waiting: "secondary",
+  resolved: "success",
+  dismissed: "outline",
+};
+
+const KPI_DRILLDOWN_BADGE_VARIANT: Record<KpiDrilldownStatus, BadgeVariant> = {
+  ready: "success",
+  degraded: "warning",
+  blocked: "destructive",
+  unavailable: "secondary",
+};
+
+const APPROVAL_REVIEW_BADGE_VARIANT: Record<ApprovalReviewStatus, BadgeVariant> = {
+  pending: "warning",
+  approved: "success",
+  rejected: "destructive",
+  overridden: "warning",
+  timed_out: "destructive",
+  escalated: "warning",
+  blocked: "destructive",
+};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -26,8 +150,374 @@ interface DomainBreakdown {
   avg_confidence: number;
 }
 
+interface MarketingConnectorSetupItem {
+  key: string;
+  name: string;
+  category: string;
+  required_scopes: string[];
+  required_credentials: string[];
+  configured_status: "configured" | "unconfigured" | string;
+  health_status: ConnectorHealthStatus | string;
+  last_sync_at: string | null;
+  owner: string;
+  account_id: string | null;
+  data_coverage_status: string;
+  cta_state: ConnectorCTAState | string;
+  missing_scopes?: string[];
+  detail?: string;
+}
+
+interface MarketingConnectorSetupSummary {
+  total: number;
+  healthy: number;
+  missing: number;
+  stale: number;
+  degraded: number;
+  auth_actions: number;
+  needs_action: number;
+  readiness: string;
+}
+
+interface MarketingConnectorRetryBudget {
+  max_attempts: number;
+  attempts_used: number;
+  remaining_attempts: number;
+  reset_at: string | null;
+  next_retry_at: string | null;
+  idempotency_key: string | null;
+  idempotency_supported: boolean;
+}
+
+interface MarketingConnectorDataFreshness {
+  status: string;
+  ttl_seconds: number | null;
+  last_sync_at: string | null;
+}
+
+interface MarketingConnectorContractItem {
+  connector_key: string;
+  name: string;
+  category: string;
+  configured_status: string;
+  vendor_id: string | null;
+  account_id: string | null;
+  workspace_id: string | null;
+  read_capabilities: string[];
+  write_capabilities: string[];
+  required_read_scopes: string[];
+  required_write_scopes: string[];
+  granted_scopes: string[];
+  missing_read_scopes: string[];
+  missing_write_scopes: string[];
+  auth_status: string;
+  health_status: string;
+  contract_state: ConnectorContractState | string;
+  read_status: string;
+  write_status: string;
+  read_ready: boolean;
+  write_ready: boolean;
+  production_ready: boolean;
+  mock_or_test_double: boolean;
+  last_sync_at: string | null;
+  source_objects: Array<{ id?: string; url?: string; type?: string; [key: string]: unknown }>;
+  data_freshness: MarketingConnectorDataFreshness;
+  retry_budget: MarketingConnectorRetryBudget;
+  degraded_mode_reason: string | null;
+  idempotency_key_supported: boolean;
+  external_write_confirmation_status: string;
+  external_write_confirmations: Array<Record<string, unknown>>;
+  next_action_cta: string;
+}
+
+interface MarketingConnectorContractSummary {
+  total: number;
+  configured: number;
+  read_ready: number;
+  write_ready: number;
+  blocked: number;
+  degraded: number;
+  missing_write_scope: number;
+  write_unconfirmed: number;
+  write_confirmed: number;
+  mock_or_test_double: number;
+  readiness: string;
+}
+
+interface MarketingFieldMappingItem {
+  key: string;
+  name: string;
+  status: FieldMappingStatus | string;
+  source_categories: string[];
+  sources: string[];
+  required_fields: string[];
+  missing_fields: string[];
+  affected_kpis: string[];
+  missing_blocks: boolean;
+  last_updated_at: string | null;
+  blocking_reason: string | null;
+  next_action_cta: string;
+}
+
+interface MarketingFieldMappingSummary {
+  total: number;
+  unmapped: number;
+  partially_mapped: number;
+  valid: number;
+  invalid: number;
+  stale: number;
+  blocked: number;
+  needs_action: number;
+  readiness: string;
+  blocking: number;
+  degraded: number;
+}
+
+interface MarketingBackfillItem {
+  source_connector_key: string;
+  source_name: string;
+  category: string;
+  status: BackfillStatus | string;
+  requested_start: string | null;
+  requested_end: string | null;
+  records_discovered: number | null;
+  records_imported: number | null;
+  records_skipped: number | null;
+  records_failed: number | null;
+  last_run_at: string | null;
+  blocking_reason: string | null;
+  next_action_cta: string;
+}
+
+interface MarketingBackfillSummary {
+  total: number;
+  not_started: number;
+  queued: number;
+  running: number;
+  completed: number;
+  partial: number;
+  failed: number;
+  blocked: number;
+  needs_action: number;
+  readiness: string;
+}
+
+interface MarketingKPIReadiness {
+  status: "ready" | "degraded" | "blocked" | string;
+  historical_status: "ready" | "blocked" | string;
+  field_mapping_readiness: string;
+  backfill_readiness: string;
+  blocked_reasons: string[];
+  degraded_reasons: string[];
+  affected_kpis: string[];
+  next_action_cta: string;
+}
+
+interface MarketingWorkflowShadowQuality {
+  status: string;
+  sample_count: number;
+  success_rate: number;
+  required_sample_count: number;
+  required_success_rate: number;
+  last_run_at: string | null;
+  blocking_reason: string | null;
+  next_action_cta: string;
+}
+
+interface MarketingWorkflowActivationItem {
+  workflow_key: string;
+  name: string;
+  state: WorkflowState | string;
+  configured_mode: string;
+  required_connectors: string[];
+  optional_connectors: string[];
+  required_mappings: string[];
+  optional_mappings: string[];
+  required_backfill_categories: string[];
+  optional_backfill_categories: string[];
+  approval_owner: string | null;
+  policy_owner: string | null;
+  shadow_quality: MarketingWorkflowShadowQuality;
+  blocked_reasons: string[];
+  degraded_reasons: string[];
+  next_action_cta: string;
+  external_writes_allowed: boolean;
+}
+
+interface MarketingWorkflowActivationSummary {
+  total: number;
+  unavailable: number;
+  shadow: number;
+  promotion_blocked: number;
+  promotion_ready: number;
+  active: number;
+  degraded: number;
+  paused: number;
+  external_writes_allowed: number;
+  needs_action: number;
+  readiness: string;
+}
+
+interface CMOWorkQueueCTA {
+  action_key: string;
+  label: string;
+  path: string;
+}
+
+interface CMOWorkQueueItem {
+  item_id: string;
+  type: string;
+  category: string;
+  severity: WorkQueueSeverity | string;
+  priority_score: number;
+  title: string;
+  message: string;
+  affected_workflow?: string | null;
+  affected_capability?: string | null;
+  affected_kpi?: string | null;
+  affected_report?: string | null;
+  affected_connector?: string | null;
+  owner_role?: string | null;
+  due_at?: string | null;
+  source_refs?: Array<Record<string, unknown>>;
+  audit_refs?: string[];
+  next_action_cta?: CMOWorkQueueCTA | string;
+  next_action_label?: string;
+  next_action_path?: string;
+  next_action_key?: string;
+  status: WorkQueueStatus | string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+interface CMOWorkQueueSummary {
+  total: number;
+  readiness: string;
+  critical_or_high: number;
+  needs_action: number;
+  top_priority_score: number;
+  first_item_id: string | null;
+  next_action_cta?: CMOWorkQueueCTA | null;
+  by_severity?: Record<string, number>;
+  by_status?: Record<string, number>;
+  by_category?: Record<string, number>;
+  empty_state?: string | null;
+}
+
+interface CMOKpiFormulaInput {
+  name: string;
+  source_key?: string;
+  value: unknown;
+  resolved: boolean;
+}
+
+interface CMOKpiDrilldown {
+  drilldown_id: string;
+  kpi_key: string;
+  display_name: string;
+  description: string;
+  status: KpiDrilldownStatus | string;
+  value: unknown;
+  unit: string | null;
+  confidence: number;
+  formula: string | null;
+  formula_inputs: CMOKpiFormulaInput[];
+  source_refs?: Array<Record<string, unknown>>;
+  connector_refs?: Array<Record<string, unknown>>;
+  field_mappings_used?: Array<Record<string, unknown>>;
+  backfill_state?: Array<Record<string, unknown>>;
+  reconciliation_checks?: Array<Record<string, unknown>>;
+  freshness_status?: string;
+  freshness?: Record<string, unknown>;
+  confidence_impact_reasons?: string[];
+  missing_requirements?: Record<string, string[]>;
+  blocked_reasons?: string[];
+  degraded_reasons?: string[];
+  related_work_queue_item_ids?: string[];
+  related_report_gate_ids?: string[];
+  policy_refs?: string[];
+  audit_refs?: string[];
+  owner_role?: string;
+  next_action_cta?: CMOWorkQueueCTA | string;
+  production_lineage_ready?: boolean;
+  production_lineage_status?: string;
+  last_computed_at?: string;
+}
+
+interface CMOKpiDrilldownSummary {
+  total: number;
+  ready: number;
+  degraded: number;
+  blocked: number;
+  unavailable: number;
+  lineage_blocked: number;
+  readiness: string;
+  needs_action: number;
+  next_action_cta?: CMOWorkQueueCTA;
+}
+
+interface CMOApprovalReview {
+  approval_review_id: string;
+  approval_id: string;
+  workflow_id?: string | null;
+  workflow_run_id?: string | null;
+  run_id?: string | null;
+  step_id?: string | null;
+  action: string;
+  action_type: string;
+  status: ApprovalReviewStatus | string;
+  requester?: string | null;
+  agent_ref?: string | null;
+  actor_refs?: Array<Record<string, unknown>>;
+  assigned_approver?: string | null;
+  assigned_approver_role?: string | null;
+  created_at?: string | null;
+  due_at?: string | null;
+  timeout_state?: string | null;
+  preview_payload?: Record<string, unknown>;
+  before_after_diff?: Record<string, unknown> | string | null;
+  budget_impact?: Record<string, unknown> | string | null;
+  audience_impact?: Record<string, unknown> | string | null;
+  risk_flags?: string[];
+  source_refs?: Array<Record<string, unknown>>;
+  connector_refs?: Array<Record<string, unknown>>;
+  agent_rationale?: string | null;
+  policy_result?: Record<string, unknown>;
+  policy_result_ref?: string | null;
+  escalation_result?: Record<string, unknown>;
+  escalation_result_ref?: string | null;
+  timeout_result?: Record<string, unknown>;
+  timeout_result_ref?: string | null;
+  external_write_readiness?: Record<string, unknown>;
+  external_write_result_ref?: string | null;
+  audit_evidence?: Record<string, unknown>;
+  audit_refs?: string[];
+  rollback_stop_plan?: Record<string, unknown> | string | null;
+  allowed_reviewer_actions?: string[];
+  blocked_reasons?: string[];
+  related_work_queue_item_ids?: string[];
+  next_action_cta?: CMOWorkQueueCTA | string;
+  evaluated_at?: string | null;
+}
+
+interface CMOApprovalReviewSummary {
+  total: number;
+  readiness: string;
+  approval_ready: number;
+  blocked: number;
+  timed_out: number;
+  unsafe_write: number;
+  missing_audit: number;
+  needs_action: number;
+  next_action_cta?: CMOWorkQueueCTA | null;
+}
+
 interface CMOKPIData {
   demo: boolean;
+  demo_suppressed?: boolean;
+  production_data_blocked?: boolean;
+  kpi_confidence_status?: string;
+  data_coverage_status?: string;
+  message?: string;
   company_id: string;
   agent_count: number;
   total_tasks_30d: number;
@@ -35,6 +525,23 @@ interface CMOKPIData {
   hitl_interventions: number;
   total_cost_usd: number;
   domain_breakdown: DomainBreakdown[];
+  connector_setup?: MarketingConnectorSetupItem[];
+  connector_setup_summary?: MarketingConnectorSetupSummary;
+  connector_contracts?: MarketingConnectorContractItem[];
+  connector_contract_summary?: MarketingConnectorContractSummary;
+  field_mapping_status?: MarketingFieldMappingItem[];
+  field_mapping_summary?: MarketingFieldMappingSummary;
+  backfill_status?: MarketingBackfillItem[];
+  backfill_summary?: MarketingBackfillSummary;
+  kpi_readiness?: MarketingKPIReadiness;
+  workflow_activation_status?: MarketingWorkflowActivationItem[];
+  workflow_activation_summary?: MarketingWorkflowActivationSummary;
+  cmo_work_queue?: CMOWorkQueueItem[];
+  cmo_work_queue_summary?: CMOWorkQueueSummary;
+  cmo_approval_reviews?: CMOApprovalReview[];
+  cmo_approval_review_summary?: CMOApprovalReviewSummary;
+  cmo_kpi_drilldowns?: CMOKpiDrilldown[];
+  cmo_kpi_drilldown_summary?: CMOKpiDrilldownSummary;
 }
 
 // ---------------------------------------------------------------------------
@@ -49,6 +556,250 @@ const USD = new Intl.NumberFormat("en-US", {
 
 function formatNumber(n: number): string {
   return new Intl.NumberFormat("en-IN").format(n);
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return "Not synced";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "Not synced";
+  return parsed.toLocaleString();
+}
+
+function connectorActionTarget(row: MarketingConnectorSetupItem): string {
+  if (row.cta_state === "setup") {
+    return `/dashboard/connectors/cmo-vendor-sandbox?category=${encodeURIComponent(row.category)}`;
+  }
+  return "/dashboard/connectors";
+}
+
+function dataReadinessActionTarget(): string {
+  return "/dashboard/connectors";
+}
+
+function workflowActionTarget(): string {
+  return "/dashboard/workflows";
+}
+
+function workQueueActionTarget(row: CMOWorkQueueItem): string {
+  if (typeof row.next_action_cta === "object" && row.next_action_cta?.path) {
+    return row.next_action_cta.path;
+  }
+  return row.next_action_path || "/dashboard/cmo";
+}
+
+function workQueueCtaLabel(row: CMOWorkQueueItem): string {
+  if (typeof row.next_action_cta === "object" && row.next_action_cta?.label) {
+    return row.next_action_cta.label;
+  }
+  if (typeof row.next_action_cta === "string" && row.next_action_cta) {
+    return row.next_action_cta.replace(/_/g, " ");
+  }
+  return row.next_action_label || "Review";
+}
+
+function formatWorkQueueAffected(row: CMOWorkQueueItem): string {
+  const affected = [
+    row.affected_workflow,
+    row.affected_capability,
+    row.affected_kpi,
+    row.affected_report,
+    row.affected_connector,
+  ].filter(Boolean);
+  return affected.length > 0 ? affected.join(" / ") : "CMO readiness";
+}
+
+function kpiDrilldownActionTarget(row: CMOKpiDrilldown): string {
+  if (typeof row.next_action_cta === "object" && row.next_action_cta?.path) {
+    return row.next_action_cta.path;
+  }
+  return "/dashboard/cmo";
+}
+
+function kpiDrilldownCtaLabel(row: CMOKpiDrilldown): string {
+  if (typeof row.next_action_cta === "object" && row.next_action_cta?.label) {
+    return row.next_action_cta.label;
+  }
+  if (typeof row.next_action_cta === "string" && row.next_action_cta) {
+    return row.next_action_cta.replace(/_/g, " ");
+  }
+  return "Review";
+}
+
+function formatDrilldownValue(value: unknown): string {
+  if (value === null || value === undefined || value === "") return "N/A";
+  if (typeof value === "number") return new Intl.NumberFormat("en-IN").format(value);
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatFormulaInputs(row: CMOKpiDrilldown): string {
+  const inputs = row.formula_inputs ?? [];
+  if (inputs.length === 0) return "No resolved inputs";
+  return inputs
+    .slice(0, 4)
+    .map((item) => `${item.name}: ${item.resolved ? formatDrilldownValue(item.value) : "missing"}`)
+    .join(", ");
+}
+
+function formatConnectorKeys(row: CMOKpiDrilldown): string {
+  const keys = (row.connector_refs ?? [])
+    .map((ref) => ref.connector_key || ref.key || ref.category)
+    .filter(Boolean)
+    .map(String);
+  const unique = Array.from(new Set(keys));
+  return unique.length > 0 ? unique.slice(0, 4).join(", ") : "No connector refs";
+}
+
+function firstLineageReason(row: CMOKpiDrilldown): string {
+  return (
+    row.blocked_reasons?.[0] ||
+    row.degraded_reasons?.[0] ||
+    row.confidence_impact_reasons?.[0] ||
+    "No blockers"
+  );
+}
+
+function humanizeKey(value: string): string {
+  return value
+    .replace(/[_-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function safeText(value: unknown): string | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return null;
+}
+
+function recordSummary(value: Record<string, unknown> | string | null | undefined, fallback = "Not provided"): string {
+  if (typeof value === "string" && value) return value;
+  if (!value || typeof value !== "object") return fallback;
+  const directSummary =
+    safeText(value.summary) ||
+    safeText(value.description) ||
+    safeText(value.reason) ||
+    safeText(value.status) ||
+    safeText(value.decision);
+  if (directSummary) return directSummary;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function previewTitle(row: CMOApprovalReview): string {
+  const payload = row.preview_payload ?? {};
+  return (
+    safeText(payload.campaign_name) ||
+    safeText(payload.title) ||
+    safeText(payload.subject) ||
+    safeText(payload.headline) ||
+    humanizeKey(row.action)
+  );
+}
+
+function formatApprovalImpact(value: Record<string, unknown> | string | null | undefined, fallback: string): string {
+  if (typeof value === "string" && value) return value;
+  if (!value || typeof value !== "object") return fallback;
+  const summary = safeText(value.summary);
+  if (summary) return summary;
+  const amount = typeof value.amount === "number" ? value.amount : null;
+  const currency = safeText(value.currency) || "USD";
+  if (amount !== null) {
+    const formatted = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 0,
+    }).format(amount);
+    return `${formatted} ${safeText(value.direction) || "impact"}`;
+  }
+  const recipients = typeof value.estimated_recipients === "number" ? value.estimated_recipients : null;
+  if (recipients !== null) {
+    return `${formatNumber(recipients)} estimated recipients`;
+  }
+  return recordSummary(value, fallback);
+}
+
+function approvalReviewActionTarget(row: CMOApprovalReview): string {
+  if (typeof row.next_action_cta === "object" && row.next_action_cta?.path) {
+    return row.next_action_cta.path;
+  }
+  return "/dashboard/approvals";
+}
+
+function approvalReviewCtaLabel(row: CMOApprovalReview): string {
+  if (typeof row.next_action_cta === "object" && row.next_action_cta?.label) {
+    return row.next_action_cta.label;
+  }
+  if (typeof row.next_action_cta === "string" && row.next_action_cta) {
+    return humanizeKey(row.next_action_cta);
+  }
+  return "Review Approval";
+}
+
+function approvalSafeguardSummary(row: CMOApprovalReview): string {
+  const policy = recordSummary(row.policy_result, "policy missing");
+  const timeout = recordSummary(row.timeout_result, row.timeout_state || "timeout unknown");
+  const write = recordSummary(row.external_write_readiness, "write readiness unknown");
+  const auditReady = row.audit_evidence?.ready === true || (row.audit_refs ?? []).length > 0;
+  return `Policy: ${policy}; Timeout: ${timeout}; Write: ${write}; Audit: ${auditReady ? "ready" : "missing"}`;
+}
+
+function formatDateRange(start: string | null, end: string | null): string {
+  if (!start && !end) return "Not requested";
+  return `${start || "?"} to ${end || "?"}`;
+}
+
+function formatBackfillRecords(row: MarketingBackfillItem): string {
+  const imported = row.records_imported ?? 0;
+  const failed = row.records_failed ?? 0;
+  const discovered = row.records_discovered ?? 0;
+  return `${imported}/${discovered} imported, ${failed} failed`;
+}
+
+function formatContractRetryBudget(row: MarketingConnectorContractItem): string {
+  const retry = row.retry_budget || {};
+  const maxAttempts = retry.max_attempts ?? 0;
+  const remaining = retry.remaining_attempts ?? 0;
+  const used = retry.attempts_used ?? 0;
+  if (maxAttempts <= 0) {
+    return row.idempotency_key_supported ? "Idempotency only" : "No retry budget";
+  }
+  return `${remaining}/${maxAttempts} left, ${used} used`;
+}
+
+function contractStatusVariant(value?: string): BadgeVariant {
+  if (value === "ready" || value === "healthy" || value === "write_confirmed") {
+    return "success";
+  }
+  if (
+    value === "blocked" ||
+    value === "auth_expired" ||
+    value === "write_unconfirmed" ||
+    value === "idempotency_missing"
+  ) {
+    return "destructive";
+  }
+  if (
+    value === "degraded" ||
+    value === "missing_scope" ||
+    value === "rate_limited" ||
+    value === "timeout" ||
+    value === "vendor_5xx" ||
+    value === "partial_data" ||
+    value === "stale_data"
+  ) {
+    return "warning";
+  }
+  return "secondary";
 }
 
 const MARKETING_DOMAINS = new Set([
@@ -127,6 +878,292 @@ export default function CMODashboard() {
     { label: t("kpi.hitlInterventions", "HITL Interventions"), value: formatNumber(data.hitl_interventions ?? 0), color: "text-orange-600" },
     { label: t("kpi.totalCost", "Total Cost (USD)"), value: USD.format(data.total_cost_usd ?? 0), color: "text-rose-600" },
   ];
+  const statusLabels: Record<CapabilityStatus, string> = {
+    production: t("cmoCapability.states.production", "Production"),
+    beta: t("cmoCapability.states.beta", "Beta"),
+    stub: t("cmoCapability.states.stub", "Stub"),
+    unavailable: t("cmoCapability.states.unavailable", "Unavailable"),
+    demo: t("cmoCapability.states.demo", "Demo"),
+  };
+  const capabilityRows: Array<{ name: string; status: CapabilityStatus; detail: string }> = [
+    {
+      name: t("cmoCapability.campaignPilot.name", "Campaign Pilot"),
+      status: "production",
+      detail: t(
+        "cmoCapability.campaignPilot.detail",
+        "Strongest current CMO agent: domain-specific campaign execution, budget checks, performance polling, and HITL gates.",
+      ),
+    },
+    {
+      name: t("cmoCapability.contentFactory.name", "Content Factory"),
+      status: "beta",
+      detail: t(
+        "cmoCapability.contentFactory.detail",
+        "Substantial content workflow exists, including draft generation and brand checks; publish loops and QA policy are still maturing.",
+      ),
+    },
+    {
+      name: t("cmoCapability.emailMarketing.name", "Email Marketing"),
+      status: "beta",
+      detail: t(
+        "cmoCapability.emailMarketing.detail",
+        "Available through a separate LangGraph path and approval-gated tooling, not a complete autonomous CMO pillar yet.",
+      ),
+    },
+    {
+      name: t("cmoCapability.brandMonitor.name", "Brand Monitor"),
+      status: "stub",
+      detail: t(
+        "cmoCapability.brandMonitor.detail",
+        "Registered, but the core marketing implementation still wraps shared/base behavior; not production-grade brand monitoring.",
+      ),
+    },
+    {
+      name: t("cmoCapability.seoStrategist.name", "SEO Strategist"),
+      status: "stub",
+      detail: t(
+        "cmoCapability.seoStrategist.detail",
+        "Registered, but the core marketing implementation still wraps shared/base behavior; not production-grade SEO execution.",
+      ),
+    },
+    {
+      name: t("cmoCapability.crmIntelligence.name", "CRM Intelligence"),
+      status: "beta",
+      detail: t(
+        "cmoCapability.crmIntelligence.detail",
+        "First-class deterministic CRM/pipeline intelligence for velocity, funnel conversion, lead scoring refresh, churn signals, segments, SQL promotion, and account health; policy/approval/audit/write-confirmation gates for CRM writes. Not production-grade without real HubSpot/Salesforce/intent connectors and pilot proof.",
+      ),
+    },
+    {
+      name: t("cmoCapability.socialMedia.name", "Social Media"),
+      status: "unavailable",
+      detail: t(
+        "cmoCapability.socialMedia.detail",
+        "Not a first-class core marketing agent yet; any graph-level surface should be treated as experimental/demo only.",
+      ),
+    },
+    {
+      name: t("cmoCapability.abm.name", "ABM"),
+      status: "unavailable",
+      detail: t(
+        "cmoCapability.abm.detail",
+        "ABM dashboard/API surfaces exist, but a first-class core marketing ABM agent is not implemented yet.",
+      ),
+    },
+    {
+      name: t("cmoCapability.competitiveIntel.name", "Competitive Intel"),
+      status: "unavailable",
+      detail: t(
+        "cmoCapability.competitiveIntel.detail",
+        "Not a first-class core marketing agent yet; any graph-level surface should be treated as experimental/demo only.",
+      ),
+    },
+    {
+      name: t("cmoCapability.kpiFeed.name", "CMO KPI feed"),
+      status: data.demo ? "demo" : "beta",
+      detail: data.demo
+        ? t(
+            "cmoCapability.kpiFeed.demoDetail",
+            "This dashboard is currently showing demo KPI data, not proof of end-to-end autonomous CMO operation.",
+          )
+        : t(
+            "cmoCapability.kpiFeed.liveDetail",
+            "KPI data is not flagged as demo, but capability maturity still follows the agent states listed above.",
+          ),
+    },
+  ];
+  const connectorRows = data.connector_setup ?? [];
+  const connectorSummary = data.connector_setup_summary;
+  const connectorStatusLabels: Record<ConnectorHealthStatus, string> = {
+    healthy: t("cmoConnectors.health.healthy", "Healthy"),
+    missing: t("cmoConnectors.health.missing", "Missing"),
+    expired_auth: t("cmoConnectors.health.expiredAuth", "Expired Auth"),
+    insufficient_scope: t("cmoConnectors.health.insufficientScope", "Insufficient Scope"),
+    stale: t("cmoConnectors.health.stale", "Stale Sync"),
+    degraded: t("cmoConnectors.health.degraded", "Degraded"),
+    unknown: t("cmoConnectors.health.unknown", "Unknown"),
+  };
+  const coverageLabels: Record<string, string> = {
+    ready: t("cmoConnectors.coverage.ready", "Ready"),
+    missing: t("cmoConnectors.coverage.missing", "Missing"),
+    blocked: t("cmoConnectors.coverage.blocked", "Blocked"),
+    stale: t("cmoConnectors.coverage.stale", "Stale"),
+    partial: t("cmoConnectors.coverage.partial", "Partial"),
+    unavailable: t("cmoConnectors.coverage.unavailable", "Unavailable"),
+  };
+  const ctaLabels: Record<ConnectorCTAState, string> = {
+    none: t("cmoConnectors.cta.none", "No Action"),
+    setup: t("cmoConnectors.cta.setup", "Set Up"),
+    reconnect: t("cmoConnectors.cta.reconnect", "Reconnect"),
+    add_scope: t("cmoConnectors.cta.addScope", "Add Scope"),
+    refresh: t("cmoConnectors.cta.refresh", "Refresh Sync"),
+    review: t("cmoConnectors.cta.review", "Review"),
+  };
+  const contractRows = data.connector_contracts ?? [];
+  const contractSummary = data.connector_contract_summary;
+  const contractStateLabels: Record<ConnectorContractState, string> = {
+    healthy: t("cmoConnectorContracts.states.healthy", "Healthy"),
+    missing_scope: t("cmoConnectorContracts.states.missingScope", "Missing Scope"),
+    auth_expired: t("cmoConnectorContracts.states.authExpired", "Auth Expired"),
+    rate_limited: t("cmoConnectorContracts.states.rateLimited", "Rate Limited"),
+    timeout: t("cmoConnectorContracts.states.timeout", "Timeout"),
+    vendor_5xx: t("cmoConnectorContracts.states.vendor5xx", "Vendor 5xx"),
+    partial_data: t("cmoConnectorContracts.states.partialData", "Partial Data"),
+    stale_data: t("cmoConnectorContracts.states.staleData", "Stale Data"),
+    degraded: t("cmoConnectorContracts.states.degraded", "Degraded"),
+    write_unconfirmed: t("cmoConnectorContracts.states.writeUnconfirmed", "Write Unconfirmed"),
+    write_confirmed: t("cmoConnectorContracts.states.writeConfirmed", "Write Confirmed"),
+    unknown: t("cmoConnectorContracts.states.unknown", "Unknown"),
+  };
+  const contractReadinessLabels: Record<string, string> = {
+    ready: t("cmoConnectorContracts.readiness.ready", "Ready"),
+    blocked: t("cmoConnectorContracts.readiness.blocked", "Blocked"),
+    degraded: t("cmoConnectorContracts.readiness.degraded", "Degraded"),
+    read_only: t("cmoConnectorContracts.readiness.readOnly", "Read-only"),
+    missing_scope: t("cmoConnectorContracts.readiness.missingScope", "Missing Scope"),
+    idempotency_missing: t("cmoConnectorContracts.readiness.idempotencyMissing", "Idempotency Missing"),
+    unknown: t("cmoConnectorContracts.readiness.unknown", "Unknown"),
+  };
+  const contractCtaLabels: Record<string, string> = {
+    none: t("cmoConnectorContracts.cta.none", "No Action"),
+    setup: t("cmoConnectorContracts.cta.setup", "Set Up"),
+    reconnect: t("cmoConnectorContracts.cta.reconnect", "Reconnect"),
+    add_scope: t("cmoConnectorContracts.cta.addScope", "Add Scope"),
+    review_retry_budget: t("cmoConnectorContracts.cta.reviewRetryBudget", "Review Retry Budget"),
+    review_degraded: t("cmoConnectorContracts.cta.reviewDegraded", "Review Degraded"),
+    configure_idempotency: t("cmoConnectorContracts.cta.configureIdempotency", "Configure Idempotency"),
+  };
+  const connectorStatusFor = (value: string): ConnectorHealthStatus =>
+    value in CONNECTOR_BADGE_VARIANT ? (value as ConnectorHealthStatus) : "unknown";
+  const connectorCtaFor = (value: string): ConnectorCTAState =>
+    value in ctaLabels ? (value as ConnectorCTAState) : "review";
+  const connectorContractStateFor = (value: string): ConnectorContractState =>
+    value in CONNECTOR_CONTRACT_BADGE_VARIANT ? (value as ConnectorContractState) : "unknown";
+  const fieldMappingRows = data.field_mapping_status ?? [];
+  const fieldMappingSummary = data.field_mapping_summary;
+  const backfillRows = data.backfill_status ?? [];
+  const backfillSummary = data.backfill_summary;
+  const kpiReadiness = data.kpi_readiness;
+  const workflowRows = data.workflow_activation_status ?? [];
+  const workflowSummary = data.workflow_activation_summary;
+  const workQueueRows = data.cmo_work_queue ?? [];
+  const workQueueSummary = data.cmo_work_queue_summary;
+  const visibleWorkQueueRows = workQueueRows.slice(0, 8);
+  const approvalReviewRows = data.cmo_approval_reviews ?? [];
+  const approvalReviewSummary = data.cmo_approval_review_summary;
+  const visibleApprovalReviews = approvalReviewRows.slice(0, 6);
+  const kpiDrilldownRows = data.cmo_kpi_drilldowns ?? [];
+  const kpiDrilldownSummary = data.cmo_kpi_drilldown_summary;
+  const visibleKpiDrilldowns = kpiDrilldownRows.slice(0, 8);
+  const fieldStatusLabels: Record<FieldMappingStatus, string> = {
+    valid: t("cmoDataReadiness.fieldStatus.valid", "Valid"),
+    unmapped: t("cmoDataReadiness.fieldStatus.unmapped", "Unmapped"),
+    partially_mapped: t("cmoDataReadiness.fieldStatus.partiallyMapped", "Partially Mapped"),
+    invalid: t("cmoDataReadiness.fieldStatus.invalid", "Invalid"),
+    stale: t("cmoDataReadiness.fieldStatus.stale", "Stale"),
+    blocked: t("cmoDataReadiness.fieldStatus.blocked", "Blocked"),
+    unknown: t("cmoDataReadiness.fieldStatus.unknown", "Unknown"),
+  };
+  const backfillStatusLabels: Record<BackfillStatus, string> = {
+    completed: t("cmoDataReadiness.backfillStatus.completed", "Completed"),
+    not_started: t("cmoDataReadiness.backfillStatus.notStarted", "Not Started"),
+    queued: t("cmoDataReadiness.backfillStatus.queued", "Queued"),
+    running: t("cmoDataReadiness.backfillStatus.running", "Running"),
+    partial: t("cmoDataReadiness.backfillStatus.partial", "Partial"),
+    failed: t("cmoDataReadiness.backfillStatus.failed", "Failed"),
+    blocked: t("cmoDataReadiness.backfillStatus.blocked", "Blocked"),
+    unknown: t("cmoDataReadiness.backfillStatus.unknown", "Unknown"),
+  };
+  const workflowStateLabels: Record<WorkflowState, string> = {
+    active: t("cmoWorkflowGates.states.active", "Active"),
+    promotion_ready: t("cmoWorkflowGates.states.promotionReady", "Ready to Promote"),
+    shadow: t("cmoWorkflowGates.states.shadow", "Shadow"),
+    promotion_blocked: t("cmoWorkflowGates.states.promotionBlocked", "Blocked"),
+    degraded: t("cmoWorkflowGates.states.degraded", "Degraded"),
+    paused: t("cmoWorkflowGates.states.paused", "Paused"),
+    unavailable: t("cmoWorkflowGates.states.unavailable", "Unavailable"),
+    unknown: t("cmoWorkflowGates.states.unknown", "Unknown"),
+  };
+  const readinessLabels: Record<string, string> = {
+    ready: t("cmoDataReadiness.readiness.ready", "Ready"),
+    degraded: t("cmoDataReadiness.readiness.degraded", "Degraded"),
+    blocked: t("cmoDataReadiness.readiness.blocked", "Blocked"),
+  };
+  const mappingCtaLabels: Record<string, string> = {
+    none: t("cmoDataReadiness.cta.none", "No Action"),
+    connect_source: t("cmoDataReadiness.cta.connectSource", "Connect Source"),
+    map_fields: t("cmoDataReadiness.cta.mapFields", "Map Fields"),
+    complete_mapping: t("cmoDataReadiness.cta.completeMapping", "Complete Mapping"),
+    review_mapping: t("cmoDataReadiness.cta.reviewMapping", "Review Mapping"),
+    fix_mapping: t("cmoDataReadiness.cta.fixMapping", "Fix Mapping"),
+    resolve_mapping_blocker: t("cmoDataReadiness.cta.resolveMappingBlocker", "Resolve Blocker"),
+  };
+  const backfillCtaLabels: Record<string, string> = {
+    none: t("cmoDataReadiness.cta.none", "No Action"),
+    start_backfill: t("cmoDataReadiness.cta.startBackfill", "Start Backfill"),
+    monitor_backfill: t("cmoDataReadiness.cta.monitorBackfill", "Monitor Backfill"),
+    review_failed_records: t("cmoDataReadiness.cta.reviewFailedRecords", "Review Failed Records"),
+    retry_backfill: t("cmoDataReadiness.cta.retryBackfill", "Retry Backfill"),
+    resolve_blocker: t("cmoDataReadiness.cta.resolveBlocker", "Resolve Blocker"),
+  };
+  const workflowCtaLabels: Record<string, string> = {
+    none: t("cmoWorkflowGates.cta.none", "No Action"),
+    promote_workflow: t("cmoWorkflowGates.cta.promoteWorkflow", "Promote"),
+    run_shadow_quality: t("cmoWorkflowGates.cta.runShadowQuality", "Run Shadow QA"),
+    fix_required_connector: t("cmoWorkflowGates.cta.fixRequiredConnector", "Fix Connector"),
+    fix_required_mapping: t("cmoWorkflowGates.cta.fixRequiredMapping", "Fix Mapping"),
+    complete_backfill: t("cmoWorkflowGates.cta.completeBackfill", "Complete Backfill"),
+    configure_policy_owner: t("cmoWorkflowGates.cta.configurePolicyOwner", "Configure Policy"),
+    review_degraded_dependency: t("cmoWorkflowGates.cta.reviewDegradedDependency", "Review Degraded"),
+    resume_workflow: t("cmoWorkflowGates.cta.resumeWorkflow", "Resume"),
+    implement_first_class_agent: t("cmoWorkflowGates.cta.implementFirstClassAgent", "Implement Agent"),
+    resolve_promotion_blocker: t("cmoWorkflowGates.cta.resolvePromotionBlocker", "Resolve Blocker"),
+  };
+  const workQueueSeverityLabels: Record<WorkQueueSeverity, string> = {
+    critical: t("cmoWorkQueue.severity.critical", "Critical"),
+    high: t("cmoWorkQueue.severity.high", "High"),
+    medium: t("cmoWorkQueue.severity.medium", "Medium"),
+    low: t("cmoWorkQueue.severity.low", "Low"),
+    info: t("cmoWorkQueue.severity.info", "Info"),
+  };
+  const workQueueStatusLabels: Record<WorkQueueStatus, string> = {
+    open: t("cmoWorkQueue.status.open", "Open"),
+    blocked: t("cmoWorkQueue.status.blocked", "Blocked"),
+    waiting: t("cmoWorkQueue.status.waiting", "Waiting"),
+    resolved: t("cmoWorkQueue.status.resolved", "Resolved"),
+    dismissed: t("cmoWorkQueue.status.dismissed", "Dismissed"),
+  };
+  const kpiDrilldownStatusLabels: Record<KpiDrilldownStatus, string> = {
+    ready: t("cmoKpiLineage.status.ready", "Ready"),
+    degraded: t("cmoKpiLineage.status.degraded", "Degraded"),
+    blocked: t("cmoKpiLineage.status.blocked", "Blocked"),
+    unavailable: t("cmoKpiLineage.status.unavailable", "Unavailable"),
+  };
+  const approvalReviewStatusLabels: Record<ApprovalReviewStatus, string> = {
+    pending: t("cmoApprovalReviews.status.pending", "Pending"),
+    approved: t("cmoApprovalReviews.status.approved", "Approved"),
+    rejected: t("cmoApprovalReviews.status.rejected", "Rejected"),
+    overridden: t("cmoApprovalReviews.status.overridden", "Overridden"),
+    timed_out: t("cmoApprovalReviews.status.timedOut", "Timed Out"),
+    escalated: t("cmoApprovalReviews.status.escalated", "Escalated"),
+    blocked: t("cmoApprovalReviews.status.blocked", "Blocked"),
+  };
+  const fieldStatusFor = (value: string): FieldMappingStatus =>
+    value in FIELD_MAPPING_BADGE_VARIANT ? (value as FieldMappingStatus) : "unknown";
+  const backfillStatusFor = (value: string): BackfillStatus =>
+    value in BACKFILL_BADGE_VARIANT ? (value as BackfillStatus) : "unknown";
+  const workflowStateFor = (value: string): WorkflowState =>
+    value in WORKFLOW_BADGE_VARIANT ? (value as WorkflowState) : "unknown";
+  const workQueueSeverityFor = (value: string): WorkQueueSeverity =>
+    value in WORK_QUEUE_SEVERITY_BADGE_VARIANT ? (value as WorkQueueSeverity) : "medium";
+  const workQueueStatusFor = (value: string): WorkQueueStatus =>
+    value in WORK_QUEUE_STATUS_BADGE_VARIANT ? (value as WorkQueueStatus) : "open";
+  const kpiDrilldownStatusFor = (value: string): KpiDrilldownStatus =>
+    value in KPI_DRILLDOWN_BADGE_VARIANT ? (value as KpiDrilldownStatus) : "unavailable";
+  const approvalReviewStatusFor = (value: string): ApprovalReviewStatus =>
+    value in APPROVAL_REVIEW_BADGE_VARIANT ? (value as ApprovalReviewStatus) : "pending";
+  const readinessVariant = (value?: string): BadgeVariant =>
+    value === "ready" ? "success" : value === "blocked" ? "destructive" : "warning";
 
   return (
     <div className="space-y-4 p-3 md:space-y-6 md:p-6" role="main" aria-label={t("kpi.cmoDashboard", "CMO Dashboard")}>
@@ -138,7 +1175,969 @@ export default function CMODashboard() {
         {data.demo && <Badge variant="secondary">{t("kpi.demoData", "Demo Data")}</Badge>}
       </div>
 
-      {/* ── KPI Cards ── */}
+      {data.production_data_blocked && (
+        <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+          {data.message ||
+            t(
+              "cmoConnectors.productionBlocked",
+              "Production CMO data is blocked until real marketing connectors are configured and synced.",
+            )}
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+            <div>
+              <CardTitle className="text-sm font-semibold">
+                {t("cmoWorkQueue.title", "CMO Work Queue")}
+              </CardTitle>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {t(
+                  "cmoWorkQueue.subtitle",
+                  "Operator-visible CMO work from approvals, escalations, connectors, data readiness, writes, policy, audit, KPIs, reconciliation, and report gates.",
+                )}
+              </p>
+            </div>
+            {workQueueSummary && (
+              <div className="flex flex-wrap gap-2">
+                <Badge variant={workQueueSummary.total > 0 ? "warning" : "outline"}>
+                  {workQueueSummary.total} {t("cmoWorkQueue.summaryTotalLabel", "open items")}
+                </Badge>
+                <Badge variant={workQueueSummary.critical_or_high > 0 ? "destructive" : "outline"}>
+                  {workQueueSummary.critical_or_high} {t("cmoWorkQueue.summaryCriticalHighLabel", "critical/high")}
+                </Badge>
+                <Badge variant={readinessVariant(workQueueSummary.readiness)}>
+                  {workQueueSummary.readiness}
+                </Badge>
+              </div>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {visibleWorkQueueRows.length === 0 ? (
+            <div className="rounded-md border bg-muted/40 px-3 py-3 text-sm text-muted-foreground">
+              {workQueueSummary?.empty_state ||
+                t(
+                  "cmoWorkQueue.empty",
+                  "No CMO work queue items are open. This does not make stub, unavailable, or demo capabilities production-ready.",
+                )}
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[980px] text-sm">
+                <thead>
+                  <tr className="border-b text-left text-muted-foreground">
+                    <th className="pb-2 pr-4">{t("cmoWorkQueue.priority", "Priority")}</th>
+                    <th className="pb-2 pr-4">{t("cmoWorkQueue.item", "Item")}</th>
+                    <th className="pb-2 pr-4">{t("cmoWorkQueue.severityLabel", "Severity")}</th>
+                    <th className="pb-2 pr-4">{t("cmoWorkQueue.owner", "Owner")}</th>
+                    <th className="pb-2 pr-4">{t("cmoWorkQueue.affected", "Affected")}</th>
+                    <th className="pb-2 pr-4">{t("cmoWorkQueue.due", "Due")}</th>
+                    <th className="pb-2">{t("cmoWorkQueue.action", "Action")}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {visibleWorkQueueRows.map((row) => {
+                    const severity = workQueueSeverityFor(row.severity);
+                    const status = workQueueStatusFor(row.status);
+                    return (
+                      <tr key={row.item_id} className="border-b align-top last:border-0">
+                        <td className="py-2 pr-4 font-medium">{row.priority_score}</td>
+                        <td className="max-w-[360px] py-2 pr-4">
+                          <div className="font-medium">{row.title}</div>
+                          <div className="mt-1 text-xs text-muted-foreground">{row.message}</div>
+                          <div className="mt-1 flex flex-wrap gap-1">
+                            <Badge variant={WORK_QUEUE_STATUS_BADGE_VARIANT[status]}>
+                              {workQueueStatusLabels[status]}
+                            </Badge>
+                            <span className="text-xs text-muted-foreground">{row.category}</span>
+                          </div>
+                        </td>
+                        <td className="py-2 pr-4">
+                          <Badge variant={WORK_QUEUE_SEVERITY_BADGE_VARIANT[severity]}>
+                            {workQueueSeverityLabels[severity]}
+                          </Badge>
+                        </td>
+                        <td className="py-2 pr-4">
+                          {row.owner_role || t("cmoConnectors.unassigned", "Unassigned")}
+                        </td>
+                        <td className="max-w-[260px] py-2 pr-4 text-xs text-muted-foreground">
+                          {formatWorkQueueAffected(row)}
+                        </td>
+                        <td className="py-2 pr-4">{formatDateTime(row.due_at || null)}</td>
+                        <td className="py-2">
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => {
+                              window.location.href = workQueueActionTarget(row);
+                            }}
+                          >
+                            {workQueueCtaLabel(row)}
+                          </Button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+            <div>
+              <CardTitle className="text-sm font-semibold">
+                {t("cmoApprovalReviews.title", "CMO Approval Reviews")}
+              </CardTitle>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {t(
+                  "cmoApprovalReviews.subtitle",
+                  "Pending and blocked marketing approvals with preview, impact, policy, timeout, write, audit, and rollback context.",
+                )}
+              </p>
+            </div>
+            {approvalReviewSummary && (
+              <div className="flex flex-wrap gap-2">
+                <Badge variant={approvalReviewSummary.needs_action > 0 ? "warning" : "outline"}>
+                  {approvalReviewSummary.needs_action} {t("cmoApprovalReviews.summaryNeedsActionLabel", "need review")}
+                </Badge>
+                <Badge variant={approvalReviewSummary.blocked > 0 ? "destructive" : "outline"}>
+                  {approvalReviewSummary.blocked} {t("cmoApprovalReviews.summaryBlockedLabel", "blocked")}
+                </Badge>
+                <Badge variant={readinessVariant(approvalReviewSummary.readiness)}>
+                  {approvalReviewSummary.readiness}
+                </Badge>
+              </div>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {visibleApprovalReviews.length === 0 ? (
+            <div className="rounded-md border bg-muted/40 px-3 py-3 text-sm text-muted-foreground">
+              {t(
+                "cmoApprovalReviews.empty",
+                "No CMO approval reviews are projected. External or customer-facing marketing actions still require policy, write-readiness, timeout, and audit evidence before approval.",
+              )}
+            </div>
+          ) : (
+            <div className="grid gap-3 xl:grid-cols-2">
+              {visibleApprovalReviews.map((row) => {
+                const status = approvalReviewStatusFor(row.status);
+                const safeToApprove = (row.allowed_reviewer_actions ?? []).includes("approve");
+                return (
+                  <div key={row.approval_review_id} className="rounded-md border p-3 text-sm">
+                    <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                      <div>
+                        <div className="font-medium">{previewTitle(row)}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {humanizeKey(row.action_type)} / {row.action}
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap gap-1">
+                        <Badge variant={APPROVAL_REVIEW_BADGE_VARIANT[status]}>
+                          {approvalReviewStatusLabels[status]}
+                        </Badge>
+                        <Badge variant={safeToApprove ? "success" : "destructive"}>
+                          {safeToApprove
+                            ? t("cmoApprovalReviews.safeToApprove", "Approve enabled")
+                            : t("cmoApprovalReviews.approvalBlocked", "Approve blocked")}
+                        </Badge>
+                      </div>
+                    </div>
+                    <div className="mt-3 grid gap-2 md:grid-cols-2">
+                      <div>
+                        <div className="text-xs font-medium text-muted-foreground">
+                          {t("cmoApprovalReviews.ownerDue", "Owner / Due")}
+                        </div>
+                        <div>
+                          {row.assigned_approver_role || row.assigned_approver || t("cmoConnectors.unassigned", "Unassigned")}
+                        </div>
+                        <div className="text-xs text-muted-foreground">{formatDateTime(row.due_at || null)}</div>
+                      </div>
+                      <div>
+                        <div className="text-xs font-medium text-muted-foreground">
+                          {t("cmoApprovalReviews.risks", "Risks")}
+                        </div>
+                        <div>{(row.risk_flags ?? []).slice(0, 3).map(humanizeKey).join(", ") || "None listed"}</div>
+                      </div>
+                      <div>
+                        <div className="text-xs font-medium text-muted-foreground">
+                          {t("cmoApprovalReviews.budget", "Budget")}
+                        </div>
+                        <div>{formatApprovalImpact(row.budget_impact, "No budget impact provided")}</div>
+                      </div>
+                      <div>
+                        <div className="text-xs font-medium text-muted-foreground">
+                          {t("cmoApprovalReviews.audience", "Audience")}
+                        </div>
+                        <div>{formatApprovalImpact(row.audience_impact, "No audience impact provided")}</div>
+                      </div>
+                    </div>
+                    <div className="mt-3 space-y-1 text-xs text-muted-foreground">
+                      <div>
+                        <span className="font-medium text-foreground">{t("cmoApprovalReviews.diff", "Diff")}: </span>
+                        {recordSummary(row.before_after_diff, "No before/after diff provided")}
+                      </div>
+                      <div>
+                        <span className="font-medium text-foreground">{t("cmoApprovalReviews.rationale", "Rationale")}: </span>
+                        {row.agent_rationale || t("cmoApprovalReviews.noRationale", "No agent rationale provided")}
+                      </div>
+                      <div>
+                        <span className="font-medium text-foreground">
+                          {t("cmoApprovalReviews.safeguards", "Safeguards")}:{" "}
+                        </span>
+                        {approvalSafeguardSummary(row)}
+                      </div>
+                      <div>
+                        <span className="font-medium text-foreground">
+                          {t("cmoApprovalReviews.rollback", "Rollback / Stop")}:{" "}
+                        </span>
+                        {recordSummary(row.rollback_stop_plan, "No rollback or stop plan provided")}
+                      </div>
+                      {row.blocked_reasons && row.blocked_reasons.length > 0 && (
+                        <div className="text-red-700">
+                          {t("cmoApprovalReviews.blockedReasons", "Blocked")}: {row.blocked_reasons.slice(0, 2).join("; ")}
+                        </div>
+                      )}
+                      {row.related_work_queue_item_ids && row.related_work_queue_item_ids.length > 0 && (
+                        <div>
+                          {t("cmoApprovalReviews.workQueueRefs", "Work queue")}:{" "}
+                          {row.related_work_queue_item_ids.slice(0, 2).join(", ")}
+                        </div>
+                      )}
+                    </div>
+                    <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+                      <div className="text-xs text-muted-foreground">
+                        {t("cmoApprovalReviews.allowedActions", "Allowed actions")}:{" "}
+                        {(row.allowed_reviewer_actions ?? []).map(humanizeKey).join(", ") ||
+                          t("cmoApprovalReviews.noneAllowed", "None")}
+                      </div>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          window.location.href = approvalReviewActionTarget(row);
+                        }}
+                      >
+                        {approvalReviewCtaLabel(row)}
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+            <div>
+              <CardTitle className="text-sm font-semibold">
+                {t("cmoKpiLineage.title", "CMO KPI Drill-Down")}
+              </CardTitle>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {t(
+                  "cmoKpiLineage.subtitle",
+                  "Formula, source, mapping, reconciliation, freshness, confidence, work queue, and report-gate lineage for canonical CMO KPIs.",
+                )}
+              </p>
+            </div>
+            {kpiDrilldownSummary && (
+              <div className="flex flex-wrap gap-2">
+                <Badge variant={readinessVariant(kpiDrilldownSummary.readiness)}>
+                  {kpiDrilldownSummary.ready}/{kpiDrilldownSummary.total} {t("cmoKpiLineage.summaryReadyLabel", "ready")}
+                </Badge>
+                <Badge variant={kpiDrilldownSummary.blocked > 0 ? "destructive" : "outline"}>
+                  {kpiDrilldownSummary.blocked} {t("cmoKpiLineage.summaryBlockedLabel", "blocked")}
+                </Badge>
+                <Badge variant={kpiDrilldownSummary.lineage_blocked > 0 ? "destructive" : "outline"}>
+                  {kpiDrilldownSummary.lineage_blocked} {t("cmoKpiLineage.summaryLineageBlockedLabel", "lineage blocked")}
+                </Badge>
+              </div>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {visibleKpiDrilldowns.length === 0 ? (
+            <div className="rounded-md border bg-muted/40 px-3 py-3 text-sm text-muted-foreground">
+              {t(
+                "cmoKpiLineage.empty",
+                "KPI drill-down lineage is unavailable. Production CMO KPIs cannot be trusted without formula, source, freshness, and confidence evidence.",
+              )}
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[1120px] text-sm">
+                <thead>
+                  <tr className="border-b text-left text-muted-foreground">
+                    <th className="pb-2 pr-4">{t("cmoKpiLineage.kpi", "KPI")}</th>
+                    <th className="pb-2 pr-4">{t("cmoKpiLineage.statusLabel", "Status")}</th>
+                    <th className="pb-2 pr-4">{t("cmoKpiLineage.formula", "Formula")}</th>
+                    <th className="pb-2 pr-4">{t("cmoKpiLineage.inputs", "Inputs")}</th>
+                    <th className="pb-2 pr-4">{t("cmoKpiLineage.sources", "Sources")}</th>
+                    <th className="pb-2 pr-4">{t("cmoKpiLineage.confidence", "Confidence")}</th>
+                    <th className="pb-2 pr-4">{t("cmoKpiLineage.issue", "Issue")}</th>
+                    <th className="pb-2">{t("cmoKpiLineage.action", "Action")}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {visibleKpiDrilldowns.map((row) => {
+                    const status = kpiDrilldownStatusFor(row.status);
+                    return (
+                      <tr key={row.drilldown_id} className="border-b align-top last:border-0">
+                        <td className="py-2 pr-4">
+                          <div className="font-medium">{row.display_name}</div>
+                          <div className="text-xs text-muted-foreground">{row.kpi_key}</div>
+                        </td>
+                        <td className="py-2 pr-4">
+                          <Badge variant={KPI_DRILLDOWN_BADGE_VARIANT[status]}>
+                            {kpiDrilldownStatusLabels[status]}
+                          </Badge>
+                          {!row.production_lineage_ready && (
+                            <div className="mt-1 text-xs text-red-700">
+                              {t("cmoKpiLineage.notProductionProof", "Not production lineage proof")}
+                            </div>
+                          )}
+                        </td>
+                        <td className="max-w-[260px] py-2 pr-4 text-xs text-muted-foreground">
+                          {row.formula || t("cmoKpiLineage.notAvailable", "N/A")}
+                        </td>
+                        <td className="max-w-[300px] py-2 pr-4 text-xs text-muted-foreground">
+                          {formatFormulaInputs(row)}
+                        </td>
+                        <td className="max-w-[220px] py-2 pr-4 text-xs text-muted-foreground">
+                          <div>{formatConnectorKeys(row)}</div>
+                          <div>
+                            {t("cmoKpiLineage.freshness", "Freshness")}: {row.freshness_status || "unknown"}
+                          </div>
+                        </td>
+                        <td className="py-2 pr-4">
+                          {((row.confidence || 0) * 100).toFixed(0)}%
+                        </td>
+                        <td className="max-w-[300px] py-2 pr-4 text-xs text-muted-foreground">
+                          {firstLineageReason(row)}
+                          {row.related_work_queue_item_ids && row.related_work_queue_item_ids.length > 0 && (
+                            <div className="mt-1">
+                              {t("cmoKpiLineage.workQueueRefs", "Work queue")}:{" "}
+                              {row.related_work_queue_item_ids.slice(0, 2).join(", ")}
+                            </div>
+                          )}
+                          {row.related_report_gate_ids && row.related_report_gate_ids.length > 0 && (
+                            <div className="mt-1">
+                              {t("cmoKpiLineage.reportRefs", "Reports")}:{" "}
+                              {row.related_report_gate_ids.slice(0, 2).join(", ")}
+                            </div>
+                          )}
+                        </td>
+                        <td className="py-2">
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => {
+                              window.location.href = kpiDrilldownActionTarget(row);
+                            }}
+                          >
+                            {kpiDrilldownCtaLabel(row)}
+                          </Button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+            <div>
+              <CardTitle className="text-sm font-semibold">
+                {t("cmoConnectors.title", "Marketing Connector Setup")}
+              </CardTitle>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {t(
+                  "cmoConnectors.subtitle",
+                  "Real-company CMO readiness depends on connected CRM, ads, analytics, CMS, email, social, SEO, brand, ABM, and finance systems.",
+                )}
+              </p>
+            </div>
+            {connectorSummary && (
+              <div className="flex flex-wrap gap-2">
+                <Badge variant="success">
+                  {connectorSummary.healthy} {t("cmoConnectors.summaryHealthyLabel", "healthy")}
+                </Badge>
+                <Badge variant={connectorSummary.needs_action > 0 ? "warning" : "outline"}>
+                  {connectorSummary.needs_action} {t("cmoConnectors.summaryNeedsActionLabel", "need action")}
+                </Badge>
+                <Badge variant={connectorSummary.missing > 0 ? "secondary" : "outline"}>
+                  {connectorSummary.missing} {t("cmoConnectors.summaryMissingLabel", "missing")}
+                </Badge>
+              </div>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {connectorRows.length === 0 ? (
+            <div className="rounded-md border bg-muted/40 px-3 py-3 text-sm text-muted-foreground">
+              {t(
+                "cmoConnectors.empty",
+                "Connector setup status is unavailable. The dashboard cannot claim production CMO readiness without it.",
+              )}
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[980px] text-sm">
+                <thead>
+                  <tr className="border-b text-left text-muted-foreground">
+                    <th className="pb-2 pr-4">{t("cmoConnectors.system", "System")}</th>
+                    <th className="pb-2 pr-4">{t("cmoConnectors.status", "Status")}</th>
+                    <th className="pb-2 pr-4">{t("cmoConnectors.coverageLabel", "Coverage")}</th>
+                    <th className="pb-2 pr-4">{t("cmoConnectors.owner", "Owner")}</th>
+                    <th className="pb-2 pr-4">{t("cmoConnectors.account", "Account")}</th>
+                    <th className="pb-2 pr-4">{t("cmoConnectors.lastSync", "Last Sync")}</th>
+                    <th className="pb-2 pr-4">{t("cmoConnectors.requiredAccess", "Required Access")}</th>
+                    <th className="pb-2">{t("cmoConnectors.action", "Action")}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {connectorRows.map((row) => {
+                    const health = connectorStatusFor(row.health_status);
+                    const cta = connectorCtaFor(row.cta_state);
+                    const access = row.required_scopes.length > 0
+                      ? row.required_scopes.join(", ")
+                      : row.required_credentials.join(", ");
+                    return (
+                      <tr key={row.key} className="border-b align-top last:border-0">
+                        <td className="py-2 pr-4">
+                          <div className="font-medium">{row.name}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {row.key} · {row.category}
+                          </div>
+                        </td>
+                        <td className="py-2 pr-4">
+                          <Badge variant={CONNECTOR_BADGE_VARIANT[health]}>
+                            {connectorStatusLabels[health]}
+                          </Badge>
+                          {row.missing_scopes && row.missing_scopes.length > 0 && (
+                            <div className="mt-1 text-xs text-muted-foreground">
+                              {t("cmoConnectors.missingScopesLabel", "Missing")}: {row.missing_scopes.join(", ")}
+                            </div>
+                          )}
+                        </td>
+                        <td className="py-2 pr-4">
+                          {coverageLabels[row.data_coverage_status] || row.data_coverage_status}
+                        </td>
+                        <td className="py-2 pr-4">{row.owner || t("cmoConnectors.unassigned", "Unassigned")}</td>
+                        <td className="py-2 pr-4">{row.account_id || t("cmoConnectors.notAvailable", "N/A")}</td>
+                        <td className="py-2 pr-4">{formatDateTime(row.last_sync_at)}</td>
+                        <td className="max-w-[320px] py-2 pr-4 text-xs text-muted-foreground">{access}</td>
+                        <td className="py-2">
+                          {cta === "none" ? (
+                            <span className="text-xs text-muted-foreground">{ctaLabels.none}</span>
+                          ) : (
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              onClick={() => {
+                                window.location.href = connectorActionTarget(row);
+                              }}
+                            >
+                              {ctaLabels[cta]}
+                            </Button>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+            <div>
+              <CardTitle className="text-sm font-semibold">
+                {t("cmoConnectorContracts.title", "Marketing Connector Contracts")}
+              </CardTitle>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {t(
+                  "cmoConnectorContracts.subtitle",
+                  "Read access, write access, retry budgets, idempotency, and external write confirmation are evaluated separately for production CMO workflows.",
+                )}
+              </p>
+            </div>
+            {contractSummary && (
+              <div className="flex flex-wrap gap-2">
+                <Badge variant={readinessVariant(contractSummary.readiness)}>
+                  {contractSummary.read_ready}/{contractSummary.configured} {t("cmoConnectorContracts.summaryReadReadyLabel", "read-ready")}
+                </Badge>
+                <Badge variant={contractSummary.write_ready > 0 ? "success" : "secondary"}>
+                  {contractSummary.write_ready} {t("cmoConnectorContracts.summaryWriteReadyLabel", "write-ready")}
+                </Badge>
+                <Badge variant={contractSummary.write_unconfirmed > 0 ? "destructive" : "outline"}>
+                  {contractSummary.write_unconfirmed} {t("cmoConnectorContracts.summaryUnconfirmedLabel", "unconfirmed")}
+                </Badge>
+              </div>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {contractRows.length === 0 ? (
+            <div className="rounded-md border bg-muted/40 px-3 py-3 text-sm text-muted-foreground">
+              {t(
+                "cmoConnectorContracts.empty",
+                "Connector contract status is unavailable. Production CMO workflows cannot treat connector access or external writes as ready without it.",
+              )}
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[1220px] text-sm">
+                <thead>
+                  <tr className="border-b text-left text-muted-foreground">
+                    <th className="pb-2 pr-4">{t("cmoConnectorContracts.system", "System")}</th>
+                    <th className="pb-2 pr-4">{t("cmoConnectorContracts.contractState", "Contract")}</th>
+                    <th className="pb-2 pr-4">{t("cmoConnectorContracts.read", "Read")}</th>
+                    <th className="pb-2 pr-4">{t("cmoConnectorContracts.write", "Write")}</th>
+                    <th className="pb-2 pr-4">{t("cmoConnectorContracts.authFreshness", "Auth / Freshness")}</th>
+                    <th className="pb-2 pr-4">{t("cmoConnectorContracts.retry", "Retry")}</th>
+                    <th className="pb-2 pr-4">{t("cmoConnectorContracts.confirmation", "Confirmation")}</th>
+                    <th className="pb-2">{t("cmoConnectorContracts.action", "Action")}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {contractRows.map((row) => {
+                    const state = connectorContractStateFor(row.contract_state);
+                    const cta = row.next_action_cta || "none";
+                    const confirmationState = connectorContractStateFor(row.external_write_confirmation_status);
+                    const account = row.account_id || row.workspace_id || row.vendor_id || t("cmoConnectors.notAvailable", "N/A");
+                    const writeCapabilities = row.write_capabilities.length > 0
+                      ? row.write_capabilities.join(", ")
+                      : t("cmoConnectorContracts.noWrites", "No write capability");
+                    const missingScopes = [...row.missing_read_scopes, ...row.missing_write_scopes];
+                    return (
+                      <tr key={row.connector_key} className="border-b align-top last:border-0">
+                        <td className="py-2 pr-4">
+                          <div className="font-medium">{row.name}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {row.connector_key} / {row.category} / {account}
+                          </div>
+                        </td>
+                        <td className="py-2 pr-4">
+                          <Badge variant={CONNECTOR_CONTRACT_BADGE_VARIANT[state]}>
+                            {contractStateLabels[state]}
+                          </Badge>
+                          {row.degraded_mode_reason && (
+                            <div className="mt-1 max-w-[280px] text-xs text-muted-foreground">
+                              {row.degraded_mode_reason}
+                            </div>
+                          )}
+                          {row.mock_or_test_double && (
+                            <div className="mt-1 text-xs text-red-700">
+                              {t("cmoConnectorContracts.mockProof", "Mock/test proof is not production proof.")}
+                            </div>
+                          )}
+                        </td>
+                        <td className="py-2 pr-4">
+                          <Badge variant={contractStatusVariant(row.read_status)}>
+                            {contractReadinessLabels[row.read_status] || row.read_status}
+                          </Badge>
+                          <div className="mt-1 max-w-[220px] text-xs text-muted-foreground">
+                            {row.read_capabilities.join(", ")}
+                          </div>
+                        </td>
+                        <td className="py-2 pr-4">
+                          <Badge variant={contractStatusVariant(row.write_status)}>
+                            {contractReadinessLabels[row.write_status] || row.write_status}
+                          </Badge>
+                          <div className="mt-1 max-w-[260px] text-xs text-muted-foreground">
+                            {writeCapabilities}
+                          </div>
+                          {missingScopes.length > 0 && (
+                            <div className="mt-1 max-w-[260px] text-xs text-muted-foreground">
+                              {t("cmoConnectorContracts.missingScopes", "Missing")}: {missingScopes.join(", ")}
+                            </div>
+                          )}
+                        </td>
+                        <td className="py-2 pr-4">
+                          <div>{row.auth_status}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {row.data_freshness.status} / {formatDateTime(row.last_sync_at)}
+                          </div>
+                        </td>
+                        <td className="py-2 pr-4">
+                          <div>{formatContractRetryBudget(row)}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {row.idempotency_key_supported
+                              ? t("cmoConnectorContracts.idempotencyReady", "Idempotency ready")
+                              : t("cmoConnectorContracts.idempotencyMissing", "No idempotency proof")}
+                          </div>
+                        </td>
+                        <td className="py-2 pr-4">
+                          <Badge variant={contractStatusVariant(row.external_write_confirmation_status)}>
+                            {row.external_write_confirmation_status === "none"
+                              ? t("cmoConnectorContracts.states.none", "None")
+                              : contractStateLabels[confirmationState]}
+                          </Badge>
+                        </td>
+                        <td className="py-2">
+                          {cta === "none" ? (
+                            <span className="text-xs text-muted-foreground">{contractCtaLabels.none}</span>
+                          ) : (
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              onClick={() => {
+                                window.location.href = "/dashboard/connectors";
+                              }}
+                            >
+                              {contractCtaLabels[cta] || cta.replace(/_/g, " ")}
+                            </Button>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+            <div>
+              <CardTitle className="text-sm font-semibold">
+                {t("cmoDataReadiness.title", "Marketing Data Readiness")}
+              </CardTitle>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {t(
+                  "cmoDataReadiness.subtitle",
+                  "Canonical CMO KPIs need validated field mappings and historical backfill before production confidence is available.",
+                )}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {kpiReadiness && (
+                <Badge variant={readinessVariant(kpiReadiness.status)}>
+                  {readinessLabels[kpiReadiness.status] || kpiReadiness.status}
+                </Badge>
+              )}
+              {fieldMappingSummary && (
+                <Badge variant={readinessVariant(fieldMappingSummary.readiness)}>
+                  {fieldMappingSummary.valid}/{fieldMappingSummary.total} {t("cmoDataReadiness.summaryMappedLabel", "mapped")}
+                </Badge>
+              )}
+              {backfillSummary && (
+                <Badge variant={readinessVariant(backfillSummary.readiness)}>
+                  {backfillSummary.completed}/{backfillSummary.total} {t("cmoDataReadiness.summaryBackfilledLabel", "backfilled")}
+                </Badge>
+              )}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          {kpiReadiness && kpiReadiness.status !== "ready" && (
+            <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+              {kpiReadiness.status === "blocked"
+                ? t(
+                    "cmoDataReadiness.kpiBlocked",
+                    "CMO KPI readiness is blocked by missing mappings or incomplete backfill.",
+                  )
+                : t(
+                    "cmoDataReadiness.kpiDegraded",
+                    "CMO KPI readiness is degraded; treat values as directional until setup is complete.",
+                  )}
+              <div className="mt-1 text-xs">
+                {(kpiReadiness.blocked_reasons[0] || kpiReadiness.degraded_reasons[0] || "").trim()}
+              </div>
+            </div>
+          )}
+
+          <div>
+            <h3 className="mb-2 text-sm font-semibold">{t("cmoDataReadiness.fieldMappingsTitle", "Field Mapping")}</h3>
+            {fieldMappingRows.length === 0 ? (
+              <div className="rounded-md border bg-muted/40 px-3 py-3 text-sm text-muted-foreground">
+                {t(
+                  "cmoDataReadiness.emptyMappings",
+                  "Field mapping status is unavailable. Production CMO KPIs cannot be considered ready without it.",
+                )}
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[920px] text-sm">
+                  <thead>
+                    <tr className="border-b text-left text-muted-foreground">
+                      <th className="pb-2 pr-4">{t("cmoDataReadiness.mapping", "Mapping")}</th>
+                      <th className="pb-2 pr-4">{t("cmoDataReadiness.status", "Status")}</th>
+                      <th className="pb-2 pr-4">{t("cmoDataReadiness.sources", "Sources")}</th>
+                      <th className="pb-2 pr-4">{t("cmoDataReadiness.missingFields", "Missing Fields")}</th>
+                      <th className="pb-2 pr-4">{t("cmoDataReadiness.affectedKpis", "Affected KPIs")}</th>
+                      <th className="pb-2 pr-4">{t("cmoDataReadiness.lastUpdated", "Last Updated")}</th>
+                      <th className="pb-2">{t("cmoDataReadiness.action", "Action")}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {fieldMappingRows.map((row) => {
+                      const status = fieldStatusFor(row.status);
+                      const cta = row.next_action_cta || "none";
+                      return (
+                        <tr key={row.key} className="border-b align-top last:border-0">
+                          <td className="py-2 pr-4">
+                            <div className="font-medium">{row.name}</div>
+                            <div className="text-xs text-muted-foreground">{row.key}</div>
+                          </td>
+                          <td className="py-2 pr-4">
+                            <Badge variant={FIELD_MAPPING_BADGE_VARIANT[status]}>
+                              {fieldStatusLabels[status]}
+                            </Badge>
+                            {row.blocking_reason && (
+                              <div className="mt-1 text-xs text-muted-foreground">{row.blocking_reason}</div>
+                            )}
+                          </td>
+                          <td className="py-2 pr-4">{row.sources.length > 0 ? row.sources.join(", ") : row.source_categories.join(", ")}</td>
+                          <td className="py-2 pr-4">{row.missing_fields.length > 0 ? row.missing_fields.join(", ") : t("cmoDataReadiness.none", "None")}</td>
+                          <td className="max-w-[260px] py-2 pr-4 text-xs text-muted-foreground">{row.affected_kpis.join(", ")}</td>
+                          <td className="py-2 pr-4">{formatDateTime(row.last_updated_at)}</td>
+                          <td className="py-2">
+                            {cta === "none" ? (
+                              <span className="text-xs text-muted-foreground">{mappingCtaLabels.none}</span>
+                            ) : (
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() => {
+                                  window.location.href = dataReadinessActionTarget();
+                                }}
+                              >
+                                {mappingCtaLabels[cta] || cta.replace(/_/g, " ")}
+                              </Button>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+
+          <div>
+            <h3 className="mb-2 text-sm font-semibold">{t("cmoDataReadiness.backfillTitle", "Historical Backfill")}</h3>
+            {backfillRows.length === 0 ? (
+              <div className="rounded-md border bg-muted/40 px-3 py-3 text-sm text-muted-foreground">
+                {t(
+                  "cmoDataReadiness.emptyBackfill",
+                  "No connected marketing source has a historical backfill projection yet.",
+                )}
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[920px] text-sm">
+                  <thead>
+                    <tr className="border-b text-left text-muted-foreground">
+                      <th className="pb-2 pr-4">{t("cmoDataReadiness.source", "Source")}</th>
+                      <th className="pb-2 pr-4">{t("cmoDataReadiness.status", "Status")}</th>
+                      <th className="pb-2 pr-4">{t("cmoDataReadiness.dateRange", "Date Range")}</th>
+                      <th className="pb-2 pr-4">{t("cmoDataReadiness.records", "Records")}</th>
+                      <th className="pb-2 pr-4">{t("cmoDataReadiness.lastRun", "Last Run")}</th>
+                      <th className="pb-2 pr-4">{t("cmoDataReadiness.blocker", "Blocker")}</th>
+                      <th className="pb-2">{t("cmoDataReadiness.action", "Action")}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {backfillRows.map((row) => {
+                      const status = backfillStatusFor(row.status);
+                      const cta = row.next_action_cta || "none";
+                      return (
+                        <tr key={row.source_connector_key} className="border-b align-top last:border-0">
+                          <td className="py-2 pr-4">
+                            <div className="font-medium">{row.source_name}</div>
+                            <div className="text-xs text-muted-foreground">{row.source_connector_key} Â· {row.category}</div>
+                          </td>
+                          <td className="py-2 pr-4">
+                            <Badge variant={BACKFILL_BADGE_VARIANT[status]}>
+                              {backfillStatusLabels[status]}
+                            </Badge>
+                          </td>
+                          <td className="py-2 pr-4">{formatDateRange(row.requested_start, row.requested_end)}</td>
+                          <td className="py-2 pr-4">{formatBackfillRecords(row)}</td>
+                          <td className="py-2 pr-4">{formatDateTime(row.last_run_at)}</td>
+                          <td className="max-w-[240px] py-2 pr-4 text-xs text-muted-foreground">
+                            {row.blocking_reason || t("cmoDataReadiness.none", "None")}
+                          </td>
+                          <td className="py-2">
+                            {cta === "none" ? (
+                              <span className="text-xs text-muted-foreground">{backfillCtaLabels.none}</span>
+                            ) : (
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() => {
+                                  window.location.href = dataReadinessActionTarget();
+                                }}
+                              >
+                                {backfillCtaLabels[cta] || cta.replace(/_/g, " ")}
+                              </Button>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+            <div>
+              <CardTitle className="text-sm font-semibold">
+                {t("cmoWorkflowGates.title", "CMO Workflow Promotion Gates")}
+              </CardTitle>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {t(
+                  "cmoWorkflowGates.subtitle",
+                  "Workflows remain read-only until their own connector, mapping, backfill, policy, and shadow-quality gates pass.",
+                )}
+              </p>
+            </div>
+            {workflowSummary && (
+              <div className="flex flex-wrap gap-2">
+                <Badge variant="success">
+                  {workflowSummary.active}/{workflowSummary.total} {t("cmoWorkflowGates.summaryActiveLabel", "active")}
+                </Badge>
+                <Badge variant="warning">
+                  {workflowSummary.promotion_ready} {t("cmoWorkflowGates.summaryReadyLabel", "ready")}
+                </Badge>
+                <Badge variant={workflowSummary.promotion_blocked || workflowSummary.unavailable ? "destructive" : "secondary"}>
+                  {workflowSummary.promotion_blocked + workflowSummary.unavailable} {t("cmoWorkflowGates.summaryBlockedLabel", "blocked")}
+                </Badge>
+              </div>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {workflowRows.length === 0 ? (
+            <div className="rounded-md border bg-muted/40 px-3 py-3 text-sm text-muted-foreground">
+              {t(
+                "cmoWorkflowGates.empty",
+                "Workflow activation status is unavailable. Production CMO workflows cannot be promoted without per-workflow gates.",
+              )}
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[1040px] text-sm">
+                <thead>
+                  <tr className="border-b text-left text-muted-foreground">
+                    <th className="pb-2 pr-4">{t("cmoWorkflowGates.workflow", "Workflow")}</th>
+                    <th className="pb-2 pr-4">{t("cmoWorkflowGates.state", "State")}</th>
+                    <th className="pb-2 pr-4">{t("cmoWorkflowGates.mode", "Mode")}</th>
+                    <th className="pb-2 pr-4">{t("cmoWorkflowGates.owners", "Owners")}</th>
+                    <th className="pb-2 pr-4">{t("cmoWorkflowGates.shadowQuality", "Shadow Quality")}</th>
+                    <th className="pb-2 pr-4">{t("cmoWorkflowGates.blockers", "Blockers")}</th>
+                    <th className="pb-2 pr-4">{t("cmoWorkflowGates.externalWrites", "External Writes")}</th>
+                    <th className="pb-2">{t("cmoWorkflowGates.action", "Action")}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {workflowRows.map((row) => {
+                    const state = workflowStateFor(row.state);
+                    const cta = row.next_action_cta || "none";
+                    const firstReason = row.blocked_reasons[0] || row.degraded_reasons[0] || "";
+                    const quality = row.shadow_quality;
+                    return (
+                      <tr key={row.workflow_key} className="border-b align-top last:border-0">
+                        <td className="py-2 pr-4">
+                          <div className="font-medium">{row.name}</div>
+                          <div className="text-xs text-muted-foreground">{row.workflow_key}</div>
+                        </td>
+                        <td className="py-2 pr-4">
+                          <Badge variant={WORKFLOW_BADGE_VARIANT[state]}>
+                            {workflowStateLabels[state]}
+                          </Badge>
+                        </td>
+                        <td className="py-2 pr-4">{row.configured_mode}</td>
+                        <td className="max-w-[220px] py-2 pr-4 text-xs text-muted-foreground">
+                          <div>
+                            {t("cmoWorkflowGates.approvalOwner", "Approval")}:{" "}
+                            {row.approval_owner || t("cmoConnectors.unassigned", "Unassigned")}
+                          </div>
+                          <div>
+                            {t("cmoWorkflowGates.policyOwner", "Policy")}:{" "}
+                            {row.policy_owner || t("cmoConnectors.unassigned", "Unassigned")}
+                          </div>
+                        </td>
+                        <td className="py-2 pr-4">
+                          <div>{quality.status.replace(/_/g, " ")}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {quality.sample_count}/{quality.required_sample_count} {t("cmoWorkflowGates.runs", "runs")} ·{" "}
+                            {(quality.success_rate * 100).toFixed(0)}%
+                          </div>
+                        </td>
+                        <td className="max-w-[320px] py-2 pr-4 text-xs text-muted-foreground">
+                          {firstReason || t("cmoDataReadiness.none", "None")}
+                        </td>
+                        <td className="py-2 pr-4">
+                          <Badge variant={row.external_writes_allowed ? "success" : "secondary"}>
+                            {row.external_writes_allowed
+                              ? t("cmoWorkflowGates.writesAllowed", "Allowed")
+                              : t("cmoWorkflowGates.readOnly", "Read-only")}
+                          </Badge>
+                        </td>
+                        <td className="py-2">
+                          {cta === "none" ? (
+                            <span className="text-xs text-muted-foreground">{workflowCtaLabels.none}</span>
+                          ) : (
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              onClick={() => {
+                                window.location.href = workflowActionTarget();
+                              }}
+                            >
+                              {workflowCtaLabels[cta] || cta.replace(/_/g, " ")}
+                            </Button>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
       <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
         {kpiCards.map((m) => (
           <Card key={m.label}>
@@ -151,6 +2150,48 @@ export default function CMODashboard() {
           </Card>
         ))}
       </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-semibold">{t("cmoCapability.title", "CMO Capability Status")}</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            {t(
+              "cmoCapability.subtitle",
+              "Current CMO autonomy is partial: stronger operators are separated from beta, stub, unavailable, and demo surfaces.",
+            )}
+          </p>
+        </CardHeader>
+        <CardContent>
+          <div className="mb-3 rounded-md border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+            {t(
+              "cmoCapability.notice",
+              "Do not treat this dashboard as proof of end-to-end CMO agent autonomy.",
+            )}
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-muted-foreground">
+                  <th className="pb-2 pr-4">{t("cmoCapability.capability", "Capability")}</th>
+                  <th className="pb-2 pr-4">{t("cmoCapability.state", "State")}</th>
+                  <th className="pb-2">{t("cmoCapability.currentLimit", "Current limit")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {capabilityRows.map((row) => (
+                  <tr key={row.name} className="border-b last:border-0">
+                    <td className="py-2 pr-4 font-medium">{row.name}</td>
+                    <td className="py-2 pr-4">
+                      <Badge variant={STATUS_BADGE_VARIANT[row.status]}>{statusLabels[row.status]}</Badge>
+                    </td>
+                    <td className="py-2 text-muted-foreground">{row.detail}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
 
       {/* ── Domain Breakdown ── */}
       {displayDomains.length === 0 ? (

--- a/ui/src/pages/CMOVendorSandboxConnectors.tsx
+++ b/ui/src/pages/CMOVendorSandboxConnectors.tsx
@@ -1,0 +1,412 @@
+import { useEffect, useMemo, useState } from "react";
+import { ArrowLeft, CheckCircle2, RefreshCw, Save } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import api, { extractApiError } from "@/lib/api";
+
+type Category = "CRM" | "Ads" | "Analytics" | "Email";
+
+interface ProviderOption {
+  connectorName: string;
+  label: string;
+  authType: "oauth2" | "api_key";
+  requiredCredentials: string[];
+  configFields?: string[];
+}
+
+interface CategoryStatus {
+  category: Category;
+  connector_name: string;
+  display_name: string;
+  source: string;
+  readiness_state: string;
+  proof_scope: string;
+  environment_type: string;
+  local_test_only: boolean;
+  mock_or_test_double: boolean;
+  credential_values_redacted: boolean;
+}
+
+interface FormState {
+  connectorName: string;
+  credentials: Record<string, string>;
+  config: Record<string, string>;
+}
+
+const CATEGORY_ORDER: Category[] = ["CRM", "Ads", "Analytics", "Email"];
+
+const PROVIDERS: Record<Category, ProviderOption[]> = {
+  CRM: [
+    {
+      connectorName: "hubspot",
+      label: "HubSpot Sandbox",
+      authType: "oauth2",
+      requiredCredentials: ["access_token"],
+      configFields: ["account_id"],
+    },
+    {
+      connectorName: "salesforce",
+      label: "Salesforce Sandbox",
+      authType: "oauth2",
+      requiredCredentials: ["instance_url", "refresh_token", "client_id", "client_secret"],
+    },
+  ],
+  Ads: [
+    {
+      connectorName: "google_ads",
+      label: "Google Ads Test Customer",
+      authType: "oauth2",
+      requiredCredentials: [
+        "developer_token",
+        "refresh_token",
+        "customer_id",
+        "client_id",
+        "client_secret",
+      ],
+    },
+    {
+      connectorName: "meta_ads",
+      label: "Meta Ads Sandbox",
+      authType: "oauth2",
+      requiredCredentials: ["access_token", "ad_account_id"],
+    },
+    {
+      connectorName: "linkedin_ads",
+      label: "LinkedIn Ads Sandbox",
+      authType: "oauth2",
+      requiredCredentials: ["refresh_token", "account_id", "client_id", "client_secret"],
+    },
+  ],
+  Analytics: [
+    {
+      connectorName: "ga4",
+      label: "GA4 Sandbox Property",
+      authType: "oauth2",
+      requiredCredentials: ["property_id", "refresh_token", "client_id", "client_secret"],
+    },
+  ],
+  Email: [
+    {
+      connectorName: "sendgrid",
+      label: "SendGrid Sandbox",
+      authType: "api_key",
+      requiredCredentials: ["api_key", "sender_identity"],
+    },
+    {
+      connectorName: "mailchimp",
+      label: "Mailchimp Test Account",
+      authType: "api_key",
+      requiredCredentials: ["api_key", "server_prefix", "audience_id"],
+    },
+  ],
+};
+
+const FIELD_LABELS: Record<string, string> = {
+  access_token: "Access Token",
+  account_id: "Account ID",
+  ad_account_id: "Ad Account ID",
+  api_key: "API Key",
+  audience_id: "Audience ID",
+  client_id: "Client ID",
+  client_secret: "Client Secret",
+  customer_id: "Customer ID",
+  developer_token: "Developer Token",
+  instance_url: "Instance URL",
+  property_id: "Property ID",
+  refresh_token: "Refresh Token",
+  sender_identity: "Sender Identity",
+  server_prefix: "Server Prefix",
+};
+
+function initialState(): Record<Category, FormState> {
+  return Object.fromEntries(
+    CATEGORY_ORDER.map((category) => [
+      category,
+      {
+        connectorName: PROVIDERS[category][0].connectorName,
+        credentials: {},
+        config: {},
+      },
+    ]),
+  ) as Record<Category, FormState>;
+}
+
+function fieldLabel(field: string): string {
+  return FIELD_LABELS[field] || field.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function providerFor(category: Category, connectorName: string): ProviderOption {
+  return PROVIDERS[category].find((provider) => provider.connectorName === connectorName) || PROVIDERS[category][0];
+}
+
+function credentialInputType(field: string): string {
+  return field.includes("url") || field === "instance_url" ? "url" : "password";
+}
+
+function compactValues(values: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(values)
+      .map(([key, value]) => [key, value.trim()])
+      .filter(([, value]) => value),
+  );
+}
+
+export default function CMOVendorSandboxConnectors() {
+  const navigate = useNavigate();
+  const [forms, setForms] = useState<Record<Category, FormState>>(() => initialState());
+  const [statusRows, setStatusRows] = useState<CategoryStatus[]>([]);
+  const [missingCategories, setMissingCategories] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [feedback, setFeedback] = useState<{ type: "success" | "error"; message: string } | null>(null);
+
+  const statusByCategory = useMemo(
+    () => new Map(statusRows.map((row) => [row.category, row])),
+    [statusRows],
+  );
+
+  async function fetchStatus() {
+    setLoading(true);
+    try {
+      const { data } = await api.get("/connectors/cmo-vendor-sandbox");
+      setStatusRows(Array.isArray(data?.categories) ? data.categories : []);
+      setMissingCategories(Array.isArray(data?.missing_categories) ? data.missing_categories : []);
+    } catch (err: unknown) {
+      setFeedback({ type: "error", message: extractApiError(err, "Failed to load CMO connector status") });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void fetchStatus();
+  }, []);
+
+  function updateProvider(category: Category, connectorName: string) {
+    setForms((current) => ({
+      ...current,
+      [category]: {
+        connectorName,
+        credentials: {},
+        config: {},
+      },
+    }));
+  }
+
+  function updateCredential(category: Category, key: string, value: string) {
+    setForms((current) => ({
+      ...current,
+      [category]: {
+        ...current[category],
+        credentials: { ...current[category].credentials, [key]: value },
+      },
+    }));
+  }
+
+  function updateConfig(category: Category, key: string, value: string) {
+    setForms((current) => ({
+      ...current,
+      [category]: {
+        ...current[category],
+        config: { ...current[category].config, [key]: value },
+      },
+    }));
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setFeedback(null);
+
+    const missing = CATEGORY_ORDER.flatMap((category) => {
+      const provider = providerFor(category, forms[category].connectorName);
+      return provider.requiredCredentials
+        .filter((field) => !forms[category].credentials[field]?.trim())
+        .map((field) => `${category}: ${fieldLabel(field)}`);
+    });
+    if (missing.length > 0) {
+      setFeedback({ type: "error", message: `Missing required fields: ${missing.join(", ")}` });
+      return;
+    }
+
+    const connectors = Object.fromEntries(
+      CATEGORY_ORDER.map((category) => {
+        const provider = providerFor(category, forms[category].connectorName);
+        return [
+          category,
+          {
+            connector_name: provider.connectorName,
+            display_name: provider.label,
+            auth_type: provider.authType,
+            credentials: compactValues(forms[category].credentials),
+            config: compactValues(forms[category].config),
+          },
+        ];
+      }),
+    );
+
+    setSaving(true);
+    try {
+      const { data } = await api.post("/connectors/cmo-vendor-sandbox", { connectors });
+      setFeedback({
+        type: "success",
+        message: data?.message || "CMO vendor-sandbox connectors saved",
+      });
+      setForms(initialState());
+      await fetchStatus();
+    } catch (err: unknown) {
+      setFeedback({ type: "error", message: extractApiError(err, "Failed to save CMO connectors") });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">CMO Vendor Sandbox Connectors</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Configure the tenant CRM, ads, analytics, and email connector rows used by the CMO weekly report preflight.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" variant="outline" onClick={() => navigate("/dashboard/connectors")}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Connectors
+          </Button>
+          <Button type="button" variant="outline" onClick={() => fetchStatus()} disabled={loading}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      {feedback && (
+        <div
+          className={`rounded-md border px-4 py-3 text-sm ${
+            feedback.type === "success"
+              ? "border-green-200 bg-green-50 text-green-800"
+              : "border-red-200 bg-red-50 text-red-800"
+          }`}
+        >
+          {feedback.message}
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-semibold">Current DB Preflight Rows</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <p className="text-sm text-muted-foreground">Loading status...</p>
+          ) : (
+            <div className="grid gap-3 md:grid-cols-4">
+              {CATEGORY_ORDER.map((category) => {
+                const row = statusByCategory.get(category);
+                const ready = row?.source === "db" && row.readiness_state === "ready";
+                return (
+                  <div key={category} className="rounded-md border p-3">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-medium">{category}</span>
+                      <Badge variant={ready ? "success" : "secondary"}>
+                        {ready ? "DB ready" : "Missing"}
+                      </Badge>
+                    </div>
+                    <div className="mt-2 space-y-1 text-xs text-muted-foreground">
+                      <p>{row?.display_name || "No ConnectorConfig row"}</p>
+                      {row && <p>{row.proof_scope} | {row.environment_type}</p>}
+                      {row && <p>local={String(row.local_test_only)} mock={String(row.mock_or_test_double)}</p>}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          {missingCategories.length > 0 && (
+            <p className="mt-3 text-xs text-muted-foreground">
+              Missing categories: {missingCategories.join(", ")}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid gap-4 xl:grid-cols-2">
+          {CATEGORY_ORDER.map((category) => {
+            const state = forms[category];
+            const selectedProvider = providerFor(category, state.connectorName);
+            return (
+              <Card key={category}>
+                <CardHeader>
+                  <div className="flex items-center justify-between gap-3">
+                    <CardTitle className="text-sm font-semibold">{category}</CardTitle>
+                    <Badge variant="outline">{selectedProvider.authType}</Badge>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div>
+                    <label className="text-sm font-medium">{category} Provider</label>
+                    <select
+                      value={state.connectorName}
+                      onChange={(event) => updateProvider(category, event.target.value)}
+                      className="mt-1 w-full rounded border px-3 py-2 text-sm"
+                      aria-label={`${category} Provider`}
+                    >
+                      {PROVIDERS[category].map((provider) => (
+                        <option key={provider.connectorName} value={provider.connectorName}>
+                          {provider.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {selectedProvider.requiredCredentials.map((field) => (
+                      <div key={field}>
+                        <label className="text-sm font-medium">{fieldLabel(field)}</label>
+                        <input
+                          type={credentialInputType(field)}
+                          value={state.credentials[field] || ""}
+                          onChange={(event) => updateCredential(category, field, event.target.value)}
+                          className="mt-1 w-full rounded border px-3 py-2 text-sm"
+                          autoComplete="off"
+                          aria-label={`${category} ${fieldLabel(field)}`}
+                        />
+                      </div>
+                    ))}
+                    {(selectedProvider.configFields || []).map((field) => (
+                      <div key={field}>
+                        <label className="text-sm font-medium">{fieldLabel(field)}</label>
+                        <input
+                          type="text"
+                          value={state.config[field] || ""}
+                          onChange={(event) => updateConfig(category, field, event.target.value)}
+                          className="mt-1 w-full rounded border px-3 py-2 text-sm"
+                          aria-label={`${category} ${fieldLabel(field)} optional`}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-wrap items-center justify-end gap-3">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <CheckCircle2 className="h-4 w-4" />
+            Values are encrypted server-side and never returned by the API.
+          </div>
+          <Button type="submit" disabled={saving}>
+            <Save className="mr-2 h-4 w-4" />
+            {saving ? "Saving..." : "Save CMO Sandbox Connectors"}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/ui/src/pages/Connectors.tsx
+++ b/ui/src/pages/Connectors.tsx
@@ -210,7 +210,12 @@ export default function Connectors() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <h2 className="text-2xl font-bold">Connectors</h2>
-        <Button onClick={() => navigate("/dashboard/connectors/new")}>Register Connector</Button>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" onClick={() => navigate("/dashboard/connectors/cmo-vendor-sandbox")}>
+            CMO Sandbox Setup
+          </Button>
+          <Button onClick={() => navigate("/dashboard/connectors/new")}>Register Connector</Button>
+        </div>
       </div>
 
       {/* Tab System */}

--- a/workflows/step_results.py
+++ b/workflows/step_results.py
@@ -94,6 +94,42 @@ class NotifySideEffectNotConfiguredError(WorkflowStepError):
         )
 
 
+class ExternalWriteConfirmationMissingError(WorkflowStepError):
+    def __init__(
+        self,
+        *,
+        step_id: str,
+        action: str,
+        connector: str | None,
+        mode: str | None,
+        reason: str,
+        final_state: str | None = None,
+        next_action: str | None = None,
+        audit_reference: str | None = None,
+        code: str = "external_write_confirmation_missing",
+    ) -> None:
+        details: dict[str, Any] = {
+            "step_id": step_id,
+            "action": action,
+            "reason": reason,
+        }
+        if connector:
+            details["connector"] = connector
+        if mode:
+            details["mode"] = mode
+        if final_state:
+            details["final_state"] = final_state
+        if next_action:
+            details["next_action"] = next_action
+        if audit_reference:
+            details["audit_reference"] = audit_reference
+        super().__init__(
+            code,
+            "External marketing write step cannot complete without write confirmation.",
+            details,
+        )
+
+
 class ParallelChildError(WorkflowStepError):
     def __init__(self, *, step_id: str, failed_children: list[dict[str, Any]]) -> None:
         super().__init__(

--- a/workflows/step_types.py
+++ b/workflows/step_types.py
@@ -8,12 +8,16 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from core.config import external_keys, is_relaxed_env, is_strict_runtime_env, settings
+from core.marketing.approval_timeouts import timeout_policy_for_action
+from core.marketing.external_writes import evaluate_marketing_external_write_result
+from core.marketing.workflow_activation import EXTERNAL_WRITE_ACTIONS
 from workflows.condition_evaluator import evaluate_condition
 from workflows.event_waits import WorkflowEventWaitStore
 from workflows.parallel_executor import execute_parallel
 from workflows.step_results import (
     ALLOWED_STEP_STATUSES,
     AgentExecutionError,
+    ExternalWriteConfirmationMissingError,
     MissingAgentConfigError,
     MissingLLMProviderConfigError,
     NotifySideEffectNotConfiguredError,
@@ -27,6 +31,30 @@ from workflows.step_results import (
 
 TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
 logger = logging.getLogger(__name__)
+MARKETING_AGENT_TYPES = {
+    "abm_agent",
+    "brand_monitor",
+    "campaign_pilot",
+    "competitive_intel",
+    "content_factory",
+    "crm_intelligence",
+    "email_marketing",
+    "seo_strategist",
+    "social_media",
+}
+MARKETING_WRITE_ACTION_HINTS = (
+    "activate",
+    "add_to_drip",
+    "launch",
+    "mutate",
+    "publish",
+    "schedule",
+    "send",
+    "setup",
+    "spend",
+    "start_nurture",
+    "update_crm",
+)
 
 
 def _env_flag(name: str) -> bool:
@@ -96,6 +124,152 @@ def _missing_llm_result(step: dict, agent_type: str, action: str) -> dict[str, A
         step_id=step_id,
         step_type="agent",
         failure=MissingLLMProviderConfigError(agent=agent_type, step_id=step_id),
+    )
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _state_lookup(state: dict, *keys: str) -> Any:
+    containers = [
+        state,
+        state.get("context") if isinstance(state.get("context"), dict) else {},
+        state.get("definition") if isinstance(state.get("definition"), dict) else {},
+    ]
+    for container in containers:
+        if not isinstance(container, dict):
+            continue
+        for key in keys:
+            value = container.get(key)
+            if value is not None:
+                return value
+    return None
+
+
+def _workflow_mode(step: dict, state: dict, output: dict[str, Any]) -> str:
+    return _normalize_key(
+        step.get("workflow_mode")
+        or step.get("mode")
+        or output.get("workflow_mode")
+        or output.get("mode")
+        or _state_lookup(state, "workflow_mode", "cmo_workflow_mode", "configured_mode", "mode")
+    )
+
+
+def _marketing_context(step: dict, state: dict, agent_type: str) -> bool:
+    domain = _normalize_key(step.get("domain") or _state_lookup(state, "domain"))
+    return domain == "marketing" or _normalize_key(agent_type) in MARKETING_AGENT_TYPES
+
+
+def _requires_marketing_write_confirmation(
+    step: dict,
+    state: dict,
+    *,
+    agent_type: str,
+    action: str,
+) -> bool:
+    if step.get("external_write_required") is False or step.get("requires_external_write") is False:
+        return False
+    if step.get("external_write_required") is True or step.get("requires_external_write") is True:
+        return True
+    if not _marketing_context(step, state, agent_type):
+        return False
+    normalized_action = _normalize_key(action)
+    if normalized_action in EXTERNAL_WRITE_ACTIONS:
+        return True
+    return any(hint in normalized_action for hint in MARKETING_WRITE_ACTION_HINTS)
+
+
+def _connector_key(step: dict, output: dict[str, Any]) -> str | None:
+    value = (
+        step.get("connector_key")
+        or step.get("connector")
+        or output.get("connector_key")
+        or output.get("connector")
+    )
+    return str(value).strip().lower() if value else None
+
+
+def _connector_contracts_from_state(state: dict) -> list[dict[str, Any]]:
+    value = _state_lookup(
+        state,
+        "connector_contracts",
+        "marketing_connector_contracts",
+        "cmo_connector_contracts",
+    )
+    return value if isinstance(value, list) else []
+
+
+def _external_write_decision(
+    step: dict,
+    state: dict,
+    *,
+    agent_type: str,
+    action: str,
+    output: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not _requires_marketing_write_confirmation(
+        step,
+        state,
+        agent_type=agent_type,
+        action=action,
+    ):
+        return None
+
+    mode = _workflow_mode(step, state, output)
+    connector_key = _connector_key(step, output)
+    return evaluate_marketing_external_write_result(
+        _connector_contracts_from_state(state),
+        connector_key=connector_key,
+        action=action,
+        workflow_mode=mode or "active",
+        output=output,
+        step=step,
+        state=state,
+    )
+
+
+def _output_with_external_write_decision(
+    output: Any,
+    decision: dict[str, Any],
+) -> dict[str, Any]:
+    base = dict(output) if isinstance(output, dict) else {"result": output}
+    base["external_write_state"] = decision.get("final_state")
+    base["external_write_reason"] = decision.get("reason")
+    base["external_write_next_action"] = decision.get("next_action")
+    base["external_write_attempt"] = decision.get("attempt")
+    base["external_write_confirmation"] = decision.get("confirmation")
+    base["external_write_retry_plan"] = decision.get("retry_plan")
+    base["external_write_audit"] = decision.get("audit_events") or []
+    base["external_write_audit_reference"] = decision.get("audit_reference")
+    base["decision_audit"] = decision.get("decision_audit")
+    base["decision_audit_ref"] = decision.get("decision_audit_ref")
+    if decision.get("escalation_decision") is not None:
+        base["external_write_escalation_decision"] = decision.get("escalation_decision")
+        base["external_write_escalation_evidence"] = decision.get("escalation_evidence")
+    if decision.get("marketing_policy_decision") is not None:
+        base["marketing_policy_decision"] = decision.get("marketing_policy_decision")
+    return base
+
+
+def _external_write_failure(
+    step: dict,
+    action: str,
+    connector_key: str | None,
+    mode: str,
+    decision: dict[str, Any],
+) -> ExternalWriteConfirmationMissingError:
+    return ExternalWriteConfirmationMissingError(
+        step_id=str(step.get("id", "")),
+        action=action,
+        connector=connector_key,
+        mode=mode or None,
+        reason=str(decision.get("reason") or "External write confirmation is missing."),
+        final_state=str(decision.get("final_state") or ""),
+        next_action=str(decision.get("next_action") or ""),
+        audit_reference=str(decision.get("audit_reference") or ""),
+        code=str(decision.get("error_code") or "external_write_confirmation_missing"),
     )
 
 
@@ -193,6 +367,7 @@ async def _execute_agent(step: dict, state: dict) -> dict[str, Any]:
 
         result = await agent_instance.execute(task)
         result_status = result.status
+        final_output = result.output
         if result_status == "hitl_triggered":
             result_status = "waiting_hitl"
         if result_status not in ALLOWED_STEP_STATUSES:
@@ -224,11 +399,54 @@ async def _execute_agent(step: dict, state: dict) -> dict[str, Any]:
                 output=result.output,
             )
 
+        if result_status == "completed":
+            output = result.output if isinstance(result.output, dict) else {}
+            write_decision = _external_write_decision(
+                step,
+                state,
+                agent_type=agent_type,
+                action=action,
+                output=output,
+            )
+            if write_decision:
+                augmented_output = _output_with_external_write_decision(result.output, write_decision)
+                step_status = str(write_decision.get("step_status") or "failed")
+                if step_status == "failed":
+                    mode = _workflow_mode(step, state, output)
+                    connector_key = _connector_key(step, output)
+                    confirmation_failure = _external_write_failure(
+                        step,
+                        action,
+                        connector_key,
+                        mode,
+                        write_decision,
+                    )
+                    return failure_result(
+                        step_id=step["id"],
+                        step_type="agent",
+                        failure=confirmation_failure,
+                        output=augmented_output,
+                    )
+                if step_status == "waiting_delay":
+                    return {
+                        "step_id": step["id"],
+                        "type": "agent",
+                        "status": "waiting_delay",
+                        "output": augmented_output,
+                        "resume_at": write_decision.get("resume_at"),
+                        "confidence": result.confidence,
+                        "reasoning_trace": result.reasoning_trace,
+                        "tool_calls": [tc.model_dump() for tc in result.tool_calls],
+                        "agent": agent_type,
+                        "action": action,
+                    }
+                final_output = augmented_output
+
         return {
             "step_id": step["id"],
             "type": "agent",
             "status": result_status,
-            "output": result.output,
+            "output": final_output,
             "confidence": result.confidence,
             "reasoning_trace": result.reasoning_trace,
             "tool_calls": [tc.model_dump() for tc in result.tool_calls],
@@ -264,12 +482,25 @@ async def _execute_condition(step: dict, state: dict) -> dict[str, Any]:
 
 
 async def _execute_hitl(step: dict, state: dict) -> dict[str, Any]:
+    action = (
+        step.get("approval_action")
+        or step.get("action")
+        or _state_lookup(state, "action", "approval_action", "blocked_action")
+    )
+    timeout_policy = timeout_policy_for_action(action, step) if action else None
+    timeout_hours = (
+        timeout_policy.get("default_sla_hours")
+        if isinstance(timeout_policy, dict)
+        else step.get("timeout_hours", 4)
+    )
     return {
         "step_id": step["id"],
         "type": "human_in_loop",
         "status": "waiting_hitl",
         "assignee_role": step.get("assignee_role", ""),
-        "timeout_hours": step.get("timeout_hours", 4),
+        "timeout_hours": timeout_hours,
+        "approval_action": action,
+        "approval_timeout_policy": timeout_policy,
     }
 
 


### PR DESCRIPTION
Summary:
- Add admin-only CMO vendor sandbox connector setup API and UI for CRM, Ads, Analytics, and Email.
- Store encrypted credentials with vendor_sandbox proof metadata and safe status-only responses.
- Add weekly report sandbox pilot support, proof persistence, QA flow docs, and focused regression tests.

Validation:
- python -m pytest tests/unit/test_cmo_vendor_sandbox_connector_config.py tests/unit/test_cmo_weekly_report_sandbox_runner.py tests/unit/test_cmo_weekly_report_pilot_persistence.py tests/unit/test_cmo_weekly_report_pilot_proof.py tests/unit/test_api_endpoints.py::TestConnectorsEndpoints --no-cov -q
- python -m ruff check api/v1/connectors.py core/marketing/weekly_report_sandbox_pilot.py core/marketing/weekly_report_pilot_persistence.py scripts/run_weekly_report_sandbox_pilot.py scripts/configure_cmo_vendor_sandbox_connectors.py tests/unit/test_cmo_vendor_sandbox_connector_config.py
- python -m compileall api/v1/connectors.py core/marketing/weekly_report_sandbox_pilot.py core/marketing/weekly_report_pilot_persistence.py scripts/run_weekly_report_sandbox_pilot.py scripts/configure_cmo_vendor_sandbox_connectors.py tests/unit/test_cmo_vendor_sandbox_connector_config.py
- npm --prefix ui test -- CMOVendorSandboxConnectors
- npm --prefix ui test -- CMODashboard
- npm --prefix ui run typecheck
- npm --prefix ui run build
- git diff --check