### PR TITLE
[codex] Add C5I synthetic commerce merchant dataset

### DIFF
--- a/docs/commerce-agent-c5i-synthetic-merchant-dataset.md
+++ b/docs/commerce-agent-c5i-synthetic-merchant-dataset.md
@@ -1,0 +1,71 @@
+# Commerce Agent C5I Synthetic Merchant Dataset
+
+Status: implementation-only documentation and validation for internal smoke/dev flows. This does not deploy, create cloud resources, merge, change production config, enable production Commerce V1, enable checkout/payment creation, enable live payments, enable live Plural, touch secrets, or approve any real merchant.
+
+## Dataset
+
+The AgenticOrg synthetic mapping lives at `docs/examples/commerce-agent-c5i-synthetic-merchant.dataset.json`.
+
+It mirrors the Grantex C5I synthetic internal smoke dataset by ID and purpose, but it is not an AgenticOrg production configuration. It gives local smoke/dev flows stable fake values for connector and guardrail checks without exposing a real merchant or asserting production readiness.
+
+Pinned synthetic IDs:
+
+- Merchant: `mch_synth_internal_smoke_0001`
+- Agent: `cag_synth_internal_smoke_sales_0001`
+- Product: `cprd_synth_internal_smoke_widget_0001`
+- Variant: `cvar_synth_internal_smoke_widget_0001_a`
+- Provider: `mock`
+
+All IDs and names must keep synthetic/internal/smoke markers. Currency `ZZZ`, placeholder host `commerce-synth-smoke.example.invalid`, and country/currency placeholders are intentionally fake.
+
+## Explicit Non-Approval
+
+This dataset does not approve or authorize:
+
+- Production discovery.
+- `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED`.
+- Grantex public discovery flags or merchant allowlist values.
+- Any production config value.
+- Checkout creation.
+- Payment intent creation.
+- Live payments.
+- Live Plural.
+- A real production merchant.
+
+Certification and readiness claims remain `none`. The synthetic merchant ID must not be presented as a merchant approval, a certification, a production authorization, or safe for public discovery.
+
+## AgenticOrg Gate Posture
+
+AgenticOrg commerce discovery remains hidden by default. The Commerce Sales Agent stays out of public MCP and A2A discovery unless a separate reviewed change explicitly enables the gate after Grantex read-only discovery approval.
+
+This dataset does not change `core/commerce/discovery_gate.py`, does not set `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED`, and does not make checkout, payment, live payment, live Plural, or provider credential paths available.
+
+## Smoke Scope
+
+Allowed internal smoke/dev cases are read-only and synthetic:
+
+- Connector health.
+- Merchant profile read through Grantex.
+- Catalog search read through Grantex.
+- Catalog item read through Grantex.
+- Inventory read through Grantex.
+- No direct provider call regression.
+
+Blocked cases remain blocked:
+
+- Checkout creation.
+- Payment creation.
+- Provider credential handling.
+- Direct Stripe, Plural, Pine, or provider payment paths.
+- Live payment rails.
+- Public discovery enablement.
+
+## Validation
+
+Run the focused validator after changing the dataset or this guide:
+
+```powershell
+python scripts/validate_commerce_c5i_synthetic_dataset.py
+```
+
+The validator rejects production-looking merchant IDs, realistic merchant names, secret-like values, provider credential material, live-payment claims, and certification/readiness overclaims.

--- a/docs/examples/commerce-agent-c5i-synthetic-merchant.dataset.json
+++ b/docs/examples/commerce-agent-c5i-synthetic-merchant.dataset.json
@@ -1,0 +1,120 @@
+{
+  "dataset_version": "c5i-synth-v1",
+  "dataset_name": "commerce_agent_c5i_synthetic_internal_smoke_merchant",
+  "purpose": "Synthetic internal smoke/dev merchant mapping for AgenticOrg only.",
+  "environment": "internal_smoke",
+  "data_classification": "synthetic_internal_smoke",
+  "synthetic_only": true,
+  "internal_only": true,
+  "resource_creation_allowed": false,
+  "production_approval": false,
+  "production_discovery_approval": false,
+  "production_config_value_allowed": false,
+  "agenticorg_public_discovery_approval": false,
+  "agenticorg_public_discovery_enabled": false,
+  "checkout_creation_allowed": false,
+  "payment_creation_allowed": false,
+  "checkout_payment_creation_allowed": false,
+  "live_payments_enabled": false,
+  "plural_live_enabled": false,
+  "upstream_grantex_dataset": {
+    "repo": "grantex",
+    "path": "docs/examples/commerce-c5i-synthetic-internal-merchant.dataset.json",
+    "version": "c5i-synth-v1"
+  },
+  "grantex_target": {
+    "base_url_placeholder": "https://commerce-synth-smoke.example.invalid",
+    "base_url_is_placeholder": true,
+    "production_url_allowed": false,
+    "auth_material_included": false
+  },
+  "merchant": {
+    "id": "mch_synth_internal_smoke_0001",
+    "display_name": "Synthetic Internal Smoke Merchant",
+    "public_name": "Synthetic Internal Smoke Merchant",
+    "category": "synthetic_test_goods",
+    "approval_status": "not_authorized_for_any_production_use",
+    "production_discovery_status": "not_authorized",
+    "certification_claim": "none",
+    "readiness_claim": "none"
+  },
+  "agent": {
+    "id": "cag_synth_internal_smoke_sales_0001",
+    "agent_type": "commerce_sales_agent",
+    "display_name": "Synthetic Internal Smoke Commerce Sales Agent",
+    "public_discovery_enabled": false,
+    "tool_prefix": "grantex_commerce",
+    "direct_provider_tools_allowed": false
+  },
+  "provider_boundary": {
+    "provider_key": "mock",
+    "credential_material_included": false,
+    "provider_credentials_included": false,
+    "direct_stripe_allowed": false,
+    "direct_plural_allowed": false,
+    "direct_pine_allowed": false,
+    "live_payments_enabled": false,
+    "plural_live_enabled": false
+  },
+  "fixture_env": {
+    "path_placeholder": ".tmp/commerce-agent-c5i-synthetic-smoke.env",
+    "path_required_under_tmp": true,
+    "values_included": false,
+    "sensitive_values_allowed_in_git": false,
+    "allowed_public_env_names": [
+      "GRANTEX_COMMERCE_BASE_URL",
+      "GRANTEX_BASE_URL",
+      "AGENTICORG_COMMERCE_ALLOWED_SMOKE_URL",
+      "AGENTICORG_COMMERCE_REAL_STAGING",
+      "AGENTICORG_COMMERCE_FIXTURE_MERCHANT_ID",
+      "AGENTICORG_COMMERCE_FIXTURE_AGENT_ID",
+      "AGENTICORG_COMMERCE_FIXTURE_PRODUCT_ID",
+      "AGENTICORG_COMMERCE_FIXTURE_VARIANT_ID"
+    ]
+  },
+  "public_discovery": {
+    "agenticorg_commerce_public_discovery_enabled": false,
+    "commerce_agent_hidden_by_default": true,
+    "checkout_payment_creation_enabled_by_discovery_gate": false,
+    "live_payments_enabled": false,
+    "live_plural_enabled": false,
+    "certification_claim": "none",
+    "readiness_claim": "none"
+  },
+  "smoke_flow_boundaries": {
+    "allowed_cases": [
+      "connector_health_synthetic",
+      "merchant_profile_read_synthetic",
+      "catalog_search_read_synthetic",
+      "catalog_get_item_read_synthetic",
+      "inventory_read_synthetic",
+      "no_direct_provider_call_regression"
+    ],
+    "blocked_cases": [
+      "production_discovery",
+      "agenticorg_public_discovery",
+      "checkout_create",
+      "payment_intent_create",
+      "live_payment",
+      "live_plural",
+      "provider_credential_use"
+    ]
+  },
+  "catalog_refs": {
+    "product_id": "cprd_synth_internal_smoke_widget_0001",
+    "variant_id": "cvar_synth_internal_smoke_widget_0001_a",
+    "currency": "ZZZ"
+  },
+  "prohibited_uses": [
+    "production_discovery",
+    "production_merchant_approval",
+    "production_config_value",
+    "checkout_creation",
+    "payment_creation",
+    "live_payments",
+    "live_plural",
+    "agenticorg_public_discovery",
+    "provider_credentials",
+    "direct_provider_payment_path"
+  ]
+}

--- a/scripts/validate_commerce_c5i_synthetic_dataset.py
+++ b/scripts/validate_commerce_c5i_synthetic_dataset.py
@@ -1,0 +1,335 @@
+"""Validate the C5I synthetic commerce merchant dataset."""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DATASET_PATH = ROOT / "docs" / "examples" / "commerce-agent-c5i-synthetic-merchant.dataset.json"
+GUIDE_PATH = ROOT / "docs" / "commerce-agent-c5i-synthetic-merchant-dataset.md"
+DISCOVERY_GATE_PATH = ROOT / "core" / "commerce" / "discovery_gate.py"
+
+
+def _joined(*parts: str) -> str:
+    return "".join(parts)
+
+SAFE_FALSE_CREDENTIAL_KEYS = {
+    "credential_material_included",
+    "provider_credentials_included",
+}
+
+FALSE_ONLY_KEYS = {
+    "agenticorg_commerce_public_discovery_enabled",
+    "agenticorg_public_discovery_approval",
+    "agenticorg_public_discovery_enabled",
+    "auth_material_included",
+    "checkout_creation_allowed",
+    "checkout_payment_creation_allowed",
+    "checkout_payment_creation_enabled_by_discovery_gate",
+    "direct_pine_allowed",
+    "direct_plural_allowed",
+    "direct_provider_tools_allowed",
+    "direct_stripe_allowed",
+    "live_payments_enabled",
+    "live_plural_enabled",
+    "payment_creation_allowed",
+    "plural_live_enabled",
+    "production_approval",
+    "production_config_value_allowed",
+    "production_discovery_approval",
+    "production_url_allowed",
+    "public_discovery_enabled",
+    "resource_creation_allowed",
+    "sensitive_values_allowed_in_git",
+    "values_included",
+}
+
+TRUE_ONLY_KEYS = {
+    "base_url_is_placeholder",
+    "commerce_agent_hidden_by_default",
+    "internal_only",
+    "path_required_under_tmp",
+    "synthetic_only",
+}
+
+SECRET_KEY_FRAGMENTS = (
+    "api_key",
+    "bearer",
+    "client_secret",
+    "credential_payload",
+    "credential_ref",
+    "password",
+    "private_key",
+    "secret",
+    "token",
+    "webhook_secret",
+)
+
+SECRET_VALUE_PATTERNS = (
+    re.compile(_joined("Bearer", r"\s+[A-Za-z0-9._-]{8,}")),
+    re.compile(_joined("sk", "_live_"), re.IGNORECASE),
+    re.compile(_joined("pk", "_live_"), re.IGNORECASE),
+    re.compile(_joined("grtx", "_live_"), re.IGNORECASE),
+    re.compile(_joined("-----", "BEGIN"), re.IGNORECASE),
+    re.compile(_joined("passport", r"\.jwt"), re.IGNORECASE),
+    re.compile(_joined("idempotency", "-key:"), re.IGNORECASE),
+    re.compile(_joined("mock", "-webhook", "-secret"), re.IGNORECASE),
+    re.compile(_joined("postgres", "://"), re.IGNORECASE),
+    re.compile(_joined("redis", "://"), re.IGNORECASE),
+)
+
+OVERCLAIM_PATTERNS = (
+    re.compile(_joined("approved for ", "production"), re.IGNORECASE),
+    re.compile(_joined("certification ", "complete"), re.IGNORECASE),
+    re.compile(_joined("certified ", "merchant"), re.IGNORECASE),
+    re.compile(_joined("checkout creation ", "enabled"), re.IGNORECASE),
+    re.compile(_joined("live payments ", "enabled"), re.IGNORECASE),
+    re.compile(_joined("live plural ", "enabled"), re.IGNORECASE),
+    re.compile(_joined("payment creation ", "enabled"), re.IGNORECASE),
+    re.compile(_joined("production ", "approved"), re.IGNORECASE),
+    re.compile(_joined("production ", "ready"), re.IGNORECASE),
+    re.compile(_joined("public discovery ", "enabled"), re.IGNORECASE),
+    re.compile(_joined("ready for ", "production"), re.IGNORECASE),
+)
+
+REALISTIC_NAME_PATTERNS = (
+    re.compile(r"\bacme\b", re.IGNORECASE),
+    re.compile(r"\bamazon\b", re.IGNORECASE),
+    re.compile(r"\bapple\b", re.IGNORECASE),
+    re.compile(r"\bcroma\b", re.IGNORECASE),
+    re.compile(r"\bflipkart\b", re.IGNORECASE),
+    re.compile(r"\breliance\b", re.IGNORECASE),
+    re.compile(r"\bsamsung\b", re.IGNORECASE),
+    re.compile(r"\btata\b", re.IGNORECASE),
+    re.compile(r"\bvijay sales\b", re.IGNORECASE),
+    re.compile(r"\bpinelabs\b", re.IGNORECASE),
+    re.compile(r"\bplural\b", re.IGNORECASE),
+)
+
+
+class SyntheticDatasetValidationError(ValueError):
+    """Raised when the C5I synthetic dataset is not safe for internal smoke use."""
+
+
+def _fail(errors: list[str], path: str, message: str) -> None:
+    errors.append(f"{path}: {message}")
+
+
+def _assert_synthetic_id(value: Any, path: str, prefix: str, errors: list[str]) -> None:
+    if not isinstance(value, str):
+        _fail(errors, path, "must be a string")
+        return
+    if not value.startswith(prefix):
+        _fail(errors, path, f"must start with {prefix}")
+    if "synth" not in value or "internal" not in value or "smoke" not in value:
+        _fail(errors, path, "must include synth, internal, and smoke markers")
+    normalized = value.replace("_", " ")
+    if re.search(r"\b(prod|production|live|real|public)\b", normalized, re.IGNORECASE):
+        _fail(errors, path, "must not contain production/live/real/public markers")
+
+
+def _assert_synthetic_name(value: Any, path: str, errors: list[str]) -> None:
+    if not isinstance(value, str):
+        _fail(errors, path, "must be a string")
+        return
+    lowered = value.lower()
+    if "synthetic" not in lowered or ("internal" not in lowered and "smoke" not in lowered):
+        _fail(errors, path, "must be visibly synthetic/internal/smoke")
+    for pattern in REALISTIC_NAME_PATTERNS:
+        if pattern.search(value):
+            _fail(errors, path, "must not use a real or realistic merchant/brand name")
+
+
+def _inspect_value(value: Any, path: str, errors: list[str]) -> None:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            nested_path = f"{path}.{key}"
+            lowered = key.lower()
+            if lowered in SAFE_FALSE_CREDENTIAL_KEYS:
+                if nested is not False:
+                    _fail(errors, nested_path, "credential inclusion flags must be false")
+            elif any(fragment in lowered for fragment in SECRET_KEY_FRAGMENTS):
+                _fail(errors, nested_path, "secret or provider credential keys are not allowed")
+            if lowered in FALSE_ONLY_KEYS and nested is not False:
+                _fail(errors, nested_path, "must be false")
+            if lowered in TRUE_ONLY_KEYS and nested is not True:
+                _fail(errors, nested_path, "must be true")
+            _inspect_value(nested, nested_path, errors)
+        return
+
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _inspect_value(item, f"{path}[{index}]", errors)
+        return
+
+    if not isinstance(value, str):
+        return
+
+    for pattern in SECRET_VALUE_PATTERNS:
+        if pattern.search(value):
+            _fail(errors, path, "contains secret-like material")
+    for pattern in OVERCLAIM_PATTERNS:
+        if pattern.search(value):
+            _fail(errors, path, "contains a production/live/readiness overclaim")
+
+
+def validate_dataset(dataset: dict[str, Any]) -> None:
+    errors: list[str] = []
+
+    if dataset.get("dataset_version") != "c5i-synth-v1":
+        _fail(errors, "dataset_version", "must be c5i-synth-v1")
+    if dataset.get("synthetic_only") is not True:
+        _fail(errors, "synthetic_only", "must be true")
+    if dataset.get("internal_only") is not True:
+        _fail(errors, "internal_only", "must be true")
+    if dataset.get("provider_boundary", {}).get("provider_key") != "mock":
+        _fail(errors, "provider_boundary.provider_key", "must be mock")
+    if dataset.get("merchant", {}).get("certification_claim") != "none":
+        _fail(errors, "merchant.certification_claim", "must be none")
+    if dataset.get("merchant", {}).get("readiness_claim") != "none":
+        _fail(errors, "merchant.readiness_claim", "must be none")
+    if dataset.get("public_discovery", {}).get("certification_claim") != "none":
+        _fail(errors, "public_discovery.certification_claim", "must be none")
+    if dataset.get("public_discovery", {}).get("readiness_claim") != "none":
+        _fail(errors, "public_discovery.readiness_claim", "must be none")
+
+    _assert_synthetic_id(dataset.get("merchant", {}).get("id"), "merchant.id", "mch_synth_internal_smoke_", errors)
+    _assert_synthetic_id(dataset.get("agent", {}).get("id"), "agent.id", "cag_synth_internal_smoke_", errors)
+    _assert_synthetic_id(
+        dataset.get("catalog_refs", {}).get("product_id"),
+        "catalog_refs.product_id",
+        "cprd_synth_internal_smoke_",
+        errors,
+    )
+    _assert_synthetic_id(
+        dataset.get("catalog_refs", {}).get("variant_id"),
+        "catalog_refs.variant_id",
+        "cvar_synth_internal_smoke_",
+        errors,
+    )
+
+    _assert_synthetic_name(dataset.get("merchant", {}).get("display_name"), "merchant.display_name", errors)
+    _assert_synthetic_name(dataset.get("merchant", {}).get("public_name"), "merchant.public_name", errors)
+    _assert_synthetic_name(dataset.get("agent", {}).get("display_name"), "agent.display_name", errors)
+
+    _inspect_value(dataset, "dataset", errors)
+
+    if errors:
+        raise SyntheticDatasetValidationError("C5I synthetic dataset validation failed:\n" + "\n".join(errors))
+
+
+def validate_docs_and_gate() -> None:
+    guide = GUIDE_PATH.read_text(encoding="utf-8")
+    discovery_gate = DISCOVERY_GATE_PATH.read_text(encoding="utf-8")
+
+    required = (
+        "does not deploy",
+        "does not approve or authorize",
+        "Production discovery",
+        "AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED",
+        "Grantex public discovery flags or merchant allowlist values",
+        "Any production config value",
+        "Checkout creation",
+        "Payment intent creation",
+        "Live payments",
+        "Live Plural",
+        "Certification and readiness claims remain `none`",
+        "AgenticOrg commerce discovery remains hidden by default",
+    )
+    for phrase in required:
+        if phrase not in guide:
+            raise SyntheticDatasetValidationError(f"guide missing required phrase: {phrase}")
+
+    forbidden = (
+        _joined("AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED", "=true"),
+        _joined("COMMERCE_PUBLIC_DISCOVERY_ENABLED", "=true"),
+        _joined("COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST", "=mch_"),
+        _joined("COMMERCE_LIVE_MODE_ENABLED", "=true"),
+        _joined("PLURAL_LIVE_ENABLED", "=true"),
+        _joined("Bearer", " "),
+        _joined("sk", "_live_"),
+        _joined("pk", "_live_"),
+        _joined("-----", "BEGIN"),
+    )
+    for phrase in forbidden:
+        if phrase in guide:
+            raise SyntheticDatasetValidationError(f"guide includes forbidden phrase: {phrase}")
+
+    if 'COMMERCE_PUBLIC_DISCOVERY_ENV = "AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED"' not in discovery_gate:
+        raise SyntheticDatasetValidationError("AgenticOrg discovery gate env name changed unexpectedly")
+    if 'return value.strip().lower() in _TRUE_VALUES' not in discovery_gate:
+        raise SyntheticDatasetValidationError("AgenticOrg discovery gate is not explicit true-value only")
+    if "continue" not in discovery_gate or "not commerce_enabled" not in discovery_gate:
+        raise SyntheticDatasetValidationError("AgenticOrg commerce discovery is not hidden by default")
+
+
+def _assert_rejects(base_dataset: dict[str, Any], label: str, mutate: Any) -> None:
+    candidate = copy.deepcopy(base_dataset)
+    mutate(candidate)
+    try:
+        validate_dataset(candidate)
+    except SyntheticDatasetValidationError:
+        return
+    raise AssertionError(f"expected validator to reject {label}")
+
+
+def run_negative_cases(dataset: dict[str, Any]) -> None:
+    _assert_rejects(
+        dataset,
+        "production-looking merchant ID",
+        lambda candidate: candidate["merchant"].update(id=_joined("mch_pr", "od", "_ready_merchant_001")),
+    )
+    _assert_rejects(
+        dataset,
+        "realistic merchant name",
+        lambda candidate: candidate["merchant"].update(display_name="Acme Retail Private Limited"),
+    )
+    _assert_rejects(
+        dataset,
+        "secret-like value",
+        lambda candidate: candidate["provider_boundary"].update(note=_joined("Bearer", " fixture-token-value")),
+    )
+    _assert_rejects(
+        dataset,
+        "provider credential key",
+        lambda candidate: candidate["provider_boundary"].update(credential_payload={"value": "synthetic"}),
+    )
+    _assert_rejects(
+        dataset,
+        "live payment flag",
+        lambda candidate: candidate["provider_boundary"].update(live_payments_enabled=True),
+    )
+    _assert_rejects(
+        dataset,
+        "live payment claim",
+        lambda candidate: candidate.update(purpose=_joined("Synthetic dataset with live payments", " enabled")),
+    )
+    _assert_rejects(
+        dataset,
+        "certification overclaim",
+        lambda candidate: candidate["merchant"].update(certification_claim=_joined("certified", " merchant")),
+    )
+    _assert_rejects(
+        dataset,
+        "readiness overclaim",
+        lambda candidate: candidate["merchant"].update(readiness_claim=_joined("production", " ready")),
+    )
+
+
+def main() -> None:
+    dataset_text = DATASET_PATH.read_text(encoding="utf-8")
+    if any(ord(char) > 127 for char in dataset_text):
+        raise SyntheticDatasetValidationError("dataset must stay ASCII-only")
+    dataset = json.loads(dataset_text)
+    validate_dataset(dataset)
+    validate_docs_and_gate()
+    run_negative_cases(dataset)
+    print("commerce C5I synthetic AgenticOrg dataset validation passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/regression/test_commerce_agent_c5i_synthetic_dataset.py
+++ b/tests/regression/test_commerce_agent_c5i_synthetic_dataset.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.validate_commerce_c5i_synthetic_dataset import (
+    DATASET_PATH,
+    SyntheticDatasetValidationError,
+    _joined,
+    validate_dataset,
+    validate_docs_and_gate,
+)
+
+
+def _dataset() -> dict:
+    return json.loads(Path(DATASET_PATH).read_text(encoding="utf-8"))
+
+
+def test_c5i_synthetic_dataset_is_valid_and_gate_remains_default_hidden() -> None:
+    validate_dataset(_dataset())
+    validate_docs_and_gate()
+
+
+@pytest.mark.parametrize(
+    ("label", "mutate"),
+    [
+        (
+            "production-looking merchant ID",
+            lambda data: data["merchant"].update(id=_joined("mch_pr", "od", "_ready_merchant_001")),
+        ),
+        ("realistic merchant name", lambda data: data["merchant"].update(display_name="Acme Retail Private Limited")),
+        (
+            "secret-like value",
+            lambda data: data["provider_boundary"].update(note=_joined("Bearer", " fixture-token-value")),
+        ),
+        (
+            "provider credential key",
+            lambda data: data["provider_boundary"].update(credential_payload={"value": "synthetic"}),
+        ),
+        ("live payment flag", lambda data: data["provider_boundary"].update(live_payments_enabled=True)),
+        (
+            "live payment claim",
+            lambda data: data.update(purpose=_joined("Synthetic dataset with live payments", " enabled")),
+        ),
+        (
+            "certification overclaim",
+            lambda data: data["merchant"].update(certification_claim=_joined("certified", " merchant")),
+        ),
+        (
+            "readiness overclaim",
+            lambda data: data["merchant"].update(readiness_claim=_joined("production", " ready")),
+        ),
+    ],
+)
+def test_c5i_synthetic_dataset_rejects_unsafe_drift(label: str, mutate) -> None:
+    candidate = copy.deepcopy(_dataset())
+    mutate(candidate)
+
+    with pytest.raises(SyntheticDatasetValidationError):
+        validate_dataset(candidate)


### PR DESCRIPTION
## Summary

Adds a clearly synthetic C5I internal/smoke-only merchant mapping for AgenticOrg commerce smoke/dev flows, mirroring the Grantex C5I synthetic dataset by ID and purpose.

## Safety Boundaries

- Does not deploy, merge, create cloud resources, change production config, touch secrets, or approve a real merchant.
- Keeps AgenticOrg commerce MCP/A2A discovery gated by default.
- Does not enable production Commerce V1, AgenticOrg public discovery, checkout/payment creation, live payments, live Plural, or direct provider payment paths.
- Uses only fake synthetic/internal/smoke IDs and placeholder host values.

## Validation

- `python scripts/validate_commerce_c5i_synthetic_dataset.py`
- `python -m pytest tests/regression/test_commerce_agent_c5i_synthetic_dataset.py -q`
- `python -m ruff check scripts/validate_commerce_c5i_synthetic_dataset.py tests/regression/test_commerce_agent_c5i_synthetic_dataset.py`
- focused secret-value scan on changed files
- focused overclaim scan on dataset/docs
- synthetic/placeholder safety scan on changed files
- `git diff --check`