### PR TITLE
docs(commerce): add real merchant artifact collection template

### DIFF
--- a/docs/reports/commerce-agent-c5m-real-merchant-artifact-intake-status.md
+++ b/docs/reports/commerce-agent-c5m-real-merchant-artifact-intake-status.md
@@ -1,0 +1,155 @@
+# Commerce Agent C5M Real Merchant Artifact Intake Status
+
+Status: planning only
+Date: 2026-05-26
+Scope: current repo-safe AgenticOrg dependency status for real merchant
+artifact collection
+Production changes made by this status record: none
+AgenticOrg public commerce discovery changed by this status record: no
+Grantex production Commerce V1 changed by this status record: no
+Merchant allowlist value approved by this status record: no
+Checkout or payment creation changed by this status record: no
+Live payment path changed by this status record: no
+Live Plural path changed by this status record: no
+Named merchant approved by this status record: no
+Secrets inspected or changed: no
+
+This status record tracks C5M AgenticOrg dependency intake readiness only. It
+does not approve a merchant, approve AgenticOrg public commerce discovery,
+approve a Grantex production allowlist value, or authorize any runtime change.
+
+## Current State
+
+- Grantex C5L intake checklist is merged at
+  `e5ec94da5ca3d0865f9e54be21124294f797fedb`.
+- AgenticOrg C5L intake checklist is merged at
+  `743c76e2c3687e309e83f9b6a8021425541f5dd3`.
+- No real named merchant is approved.
+- No production allowlist value is approved.
+- No AgenticOrg public commerce discovery is enabled.
+- Grantex production read-only discovery remains fail-closed.
+- AgenticOrg public commerce discovery remains gated.
+- C5I and C5J synthetic data remains internal, local, and smoke-only.
+- Synthetic data is not production approval.
+
+## Intake Status
+
+| Field | Current state | Notes |
+| --- | --- | --- |
+| Merchant identity status | Not ready | `merchant_id`, display name, category, and discovery description remain placeholders. |
+| Approval artifact status | Not ready | No human approval artifacts are recorded in repo. |
+| Payload preview status | Not ready | No reviewed AgenticOrg public payload preview exists. |
+| Safety scan status | Not ready | Future scans are required after humans provide public-safe summaries. |
+| Owner assignment status | Not ready | Rollback, read-only smoke, and evidence retention owners remain placeholders. |
+| Decision state | Not ready | Missing artifacts block intake and AgenticOrg rollout proposal preparation. |
+
+## Current Placeholder Values
+
+| Field | Current value |
+| --- | --- |
+| Merchant ID | `<MERCHANT_ID_PENDING_APPROVAL>` |
+| Merchant public name | `<MERCHANT_PUBLIC_NAME_PENDING_APPROVAL>` |
+| Merchant category | `<MERCHANT_CATEGORY_PENDING_APPROVAL>` |
+| Merchant discovery description | `<MERCHANT_DISCOVERY_DESCRIPTION_PENDING_APPROVAL>` |
+| Legal/entity reference | `<LEGAL_ENTITY_REFERENCE_PENDING_APPROVAL>` |
+| Private approval reference | `<PRIVATE_APPROVAL_REFERENCE_PENDING>` |
+| Grantex verification reference | `<GRANTEX_VERIFICATION_REFERENCE_PENDING>` |
+| Rollback owner | `<ROLLBACK_OWNER_PENDING>` |
+| Read-only smoke owner | `<READ_ONLY_SMOKE_OWNER_PENDING>` |
+| Evidence retention owner | `<EVIDENCE_RETENTION_OWNER_PENDING>` |
+
+## Human Approval Checklist
+
+| Approval | Current status |
+| --- | --- |
+| Merchant owner | Pending |
+| Legal/compliance | Pending |
+| Product wording | Pending |
+| Security | Pending |
+| Ops/on-call/support | Pending |
+| Backup/RPO | Pending |
+| AgenticOrg dependency | Pending |
+| Rollback owner | Pending |
+| Read-only smoke owner | Pending |
+| Evidence retention owner | Pending |
+
+## Public Payload Preview Placeholder Schema
+
+```yaml
+merchant_id: "<MERCHANT_ID_PENDING_APPROVAL>"
+display_name: "<MERCHANT_PUBLIC_NAME_PENDING_APPROVAL>"
+category: "<MERCHANT_CATEGORY_PENDING_APPROVAL>"
+discovery_description: "<MERCHANT_DISCOVERY_DESCRIPTION_PENDING_APPROVAL>"
+agent_card_commerce_summary: "<AGENT_CARD_COMMERCE_SUMMARY_PENDING_APPROVAL>"
+mcp_tool_discovery_summary: "<MCP_TOOL_DISCOVERY_SUMMARY_PENDING_APPROVAL>"
+issuer_reference: "<ISSUER_REFERENCE_PENDING_APPROVAL>"
+jwks_uri_reference: "<JWKS_REFERENCE_PENDING_APPROVAL>"
+grantex_verification_reference: "<GRANTEX_VERIFICATION_REFERENCE_PENDING>"
+supported_read_only_capabilities:
+  - "<READ_ONLY_CAPABILITY_PENDING_APPROVAL>"
+posture:
+  non_secret_metadata_only: true
+  no_checkout_or_payment_creation: true
+  no_live_payment_path: true
+  no_live_plural_path: true
+  no_provider_credentials: true
+  no_direct_provider_calls: true
+  no_certification_or_readiness_claim: true
+cache_and_headers:
+  cache_header_posture: "<CACHE_HEADER_POSTURE_PENDING_APPROVAL>"
+  rate_limit_posture: "<RATE_LIMIT_POSTURE_PENDING_APPROVAL>"
+owners:
+  rollback_owner: "<ROLLBACK_OWNER_PENDING>"
+  read_only_smoke_owner: "<READ_ONLY_SMOKE_OWNER_PENDING>"
+  evidence_retention_owner: "<EVIDENCE_RETENTION_OWNER_PENDING>"
+```
+
+## Explicit Rejected Material
+
+- Private contracts.
+- Private contacts.
+- Signed approval records.
+- Pricing terms.
+- Customer data.
+- Secrets.
+- Tokens, passports, or JWTs.
+- Provider credentials.
+- Raw payloads.
+- DB or Redis URLs.
+- Production config values.
+- Live-payment or live-Plural claims.
+- Certification or readiness claims.
+
+## Stop Conditions
+
+- Real merchant approval is missing.
+- Any private material appears in repo.
+- Any secret appears in repo.
+- Any production config or allowlist value appears.
+- Any synthetic ID is proposed for production.
+- Any broad runtime, live, payment, checkout, or provider path is requested.
+- AgenticOrg public discovery is requested before Grantex read-only smoke
+  passes.
+
+## Next Action
+
+Humans may collect approval artifacts outside the repository using
+`docs/templates/commerce-agent-real-merchant-artifact-collection-template.md`.
+Only public-safe summaries and non-secret private reference labels may be
+proposed for a future readiness review.
+
+## Explicit Non-Approval
+
+- This status record does not approve a merchant.
+- This status record does not approve production discovery.
+- This status record does not approve a Grantex production allowlist value.
+- This status record does not enable AgenticOrg public commerce discovery.
+- This status record does not enable `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED`.
+- This status record does not enable `COMMERCE_PUBLIC_DISCOVERY_ENABLED`.
+- This status record does not set `COMMERCE_PUBLIC_DISCOVERY_MERCHANT_ALLOWLIST`.
+- This status record does not enable Commerce V1.
+- This status record does not enable checkout or payment creation.
+- This status record does not enable live payments.
+- This status record does not enable live Plural.
+- This status record does not add a direct provider path.
+- This status record does not treat synthetic data as production approval.

--- a/docs/templates/commerce-agent-real-merchant-artifact-collection-template.md
+++ b/docs/templates/commerce-agent-real-merchant-artifact-collection-template.md
@@ -1,0 +1,159 @@
+# Commerce Agent Real Merchant Artifact Collection Template
+
+Status: template only
+Date: 2026-05-26
+Scope: repo-safe placeholder template for AgenticOrg dependency artifacts
+before any future public commerce discovery proposal
+Production changes made by this template: none
+AgenticOrg public commerce discovery changed by this template: no
+Grantex production Commerce V1 changed by this template: no
+Merchant allowlist value approved by this template: no
+Checkout or payment creation changed by this template: no
+Live payment path changed by this template: no
+Live Plural path changed by this template: no
+Named merchant approved by this template: no
+Secrets inspected or changed: no
+
+Use this template to request and track human approval artifacts outside the
+repository. Commit only public-safe summaries and non-secret reference labels.
+Do not commit raw approvals, private contracts, private contacts, pricing
+terms, customer data, provider credentials, secrets, raw payloads, production
+config values, or sensitive business details.
+
+## Placeholder Rules
+
+- Keep every pending value as an explicit placeholder.
+- Replace placeholders only after a separate human artifact review confirms
+  the value is public-safe for repository use.
+- A completed template is still not an AgenticOrg rollout approval.
+- Synthetic merchant IDs, names, and payloads are never production candidates.
+- AgenticOrg may reference only reviewed Grantex-controlled public metadata.
+
+Required placeholders:
+
+- `<MERCHANT_ID_PENDING_APPROVAL>`
+- `<MERCHANT_PUBLIC_NAME_PENDING_APPROVAL>`
+- `<MERCHANT_CATEGORY_PENDING_APPROVAL>`
+- `<MERCHANT_DISCOVERY_DESCRIPTION_PENDING_APPROVAL>`
+- `<LEGAL_ENTITY_REFERENCE_PENDING_APPROVAL>`
+- `<PRIVATE_APPROVAL_REFERENCE_PENDING>`
+- `<APPROVER_ROLE_PENDING>`
+- `<APPROVER_NAME_PENDING>`
+- `<APPROVAL_DATE_PENDING>`
+- `<ROLLBACK_OWNER_PENDING>`
+- `<READ_ONLY_SMOKE_OWNER_PENDING>`
+- `<EVIDENCE_RETENTION_OWNER_PENDING>`
+
+## Merchant Identity
+
+| Field | Placeholder value | Repository safety rule |
+| --- | --- | --- |
+| Approved public merchant ID | `<MERCHANT_ID_PENDING_APPROVAL>` | Must be human-approved in Grantex before any future allowlist or AgenticOrg public discovery proposal; never use a synthetic ID. |
+| Approved public display name | `<MERCHANT_PUBLIC_NAME_PENDING_APPROVAL>` | Must be approved public wording, not a private alias. |
+| Approved public category | `<MERCHANT_CATEGORY_PENDING_APPROVAL>` | Must be approved public wording. |
+| Approved public discovery description | `<MERCHANT_DISCOVERY_DESCRIPTION_PENDING_APPROVAL>` | Must avoid checkout, payment, live-provider, certification, and readiness claims. |
+| Legal/entity reference | `<LEGAL_ENTITY_REFERENCE_PENDING_APPROVAL>` | Use only a public-safe or reference-only label; do not commit contracts. |
+| Support/escalation posture | `<SUPPORT_ESCALATION_POSTURE_PENDING_APPROVAL>` | Describe posture only; do not commit private contacts. |
+
+## Human Approval Checklist
+
+| Approval | Approver role | Approver name | Approval date | Private artifact reference | Status |
+| --- | --- | --- | --- | --- | --- |
+| Merchant owner | `<APPROVER_ROLE_PENDING>` | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | `<PRIVATE_APPROVAL_REFERENCE_PENDING>` | Pending |
+| Legal/compliance | `<APPROVER_ROLE_PENDING>` | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | `<PRIVATE_APPROVAL_REFERENCE_PENDING>` | Pending |
+| Product wording | `<APPROVER_ROLE_PENDING>` | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | `<PRIVATE_APPROVAL_REFERENCE_PENDING>` | Pending |
+| Security | `<APPROVER_ROLE_PENDING>` | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | `<PRIVATE_APPROVAL_REFERENCE_PENDING>` | Pending |
+| Ops/on-call/support | `<APPROVER_ROLE_PENDING>` | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | `<PRIVATE_APPROVAL_REFERENCE_PENDING>` | Pending |
+| Backup/RPO | `<APPROVER_ROLE_PENDING>` | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | `<PRIVATE_APPROVAL_REFERENCE_PENDING>` | Pending |
+| AgenticOrg dependency | `<APPROVER_ROLE_PENDING>` | `<APPROVER_NAME_PENDING>` | `<APPROVAL_DATE_PENDING>` | `<PRIVATE_APPROVAL_REFERENCE_PENDING>` | Pending |
+| Rollback owner | `<APPROVER_ROLE_PENDING>` | `<ROLLBACK_OWNER_PENDING>` | `<APPROVAL_DATE_PENDING>` | `<PRIVATE_APPROVAL_REFERENCE_PENDING>` | Pending |
+| Read-only smoke owner | `<APPROVER_ROLE_PENDING>` | `<READ_ONLY_SMOKE_OWNER_PENDING>` | `<APPROVAL_DATE_PENDING>` | `<PRIVATE_APPROVAL_REFERENCE_PENDING>` | Pending |
+| Evidence retention owner | `<APPROVER_ROLE_PENDING>` | `<EVIDENCE_RETENTION_OWNER_PENDING>` | `<APPROVAL_DATE_PENDING>` | `<PRIVATE_APPROVAL_REFERENCE_PENDING>` | Pending |
+
+## Public Payload Preview Placeholder Schema
+
+```yaml
+merchant_id: "<MERCHANT_ID_PENDING_APPROVAL>"
+display_name: "<MERCHANT_PUBLIC_NAME_PENDING_APPROVAL>"
+category: "<MERCHANT_CATEGORY_PENDING_APPROVAL>"
+discovery_description: "<MERCHANT_DISCOVERY_DESCRIPTION_PENDING_APPROVAL>"
+agent_card_commerce_summary: "<AGENT_CARD_COMMERCE_SUMMARY_PENDING_APPROVAL>"
+mcp_tool_discovery_summary: "<MCP_TOOL_DISCOVERY_SUMMARY_PENDING_APPROVAL>"
+issuer_reference: "<ISSUER_REFERENCE_PENDING_APPROVAL>"
+jwks_uri_reference: "<JWKS_REFERENCE_PENDING_APPROVAL>"
+grantex_verification_reference: "<GRANTEX_VERIFICATION_REFERENCE_PENDING>"
+supported_read_only_capabilities:
+  - "<READ_ONLY_CAPABILITY_PENDING_APPROVAL>"
+posture:
+  non_secret_metadata_only: true
+  no_checkout_or_payment_creation: true
+  no_live_payment_path: true
+  no_live_plural_path: true
+  no_provider_credentials: true
+  no_direct_provider_calls: true
+  no_certification_or_readiness_claim: true
+cache_and_headers:
+  cache_header_posture: "<CACHE_HEADER_POSTURE_PENDING_APPROVAL>"
+  rate_limit_posture: "<RATE_LIMIT_POSTURE_PENDING_APPROVAL>"
+owners:
+  rollback_owner: "<ROLLBACK_OWNER_PENDING>"
+  read_only_smoke_owner: "<READ_ONLY_SMOKE_OWNER_PENDING>"
+  evidence_retention_owner: "<EVIDENCE_RETENTION_OWNER_PENDING>"
+```
+
+## Repo-Safe Intake Status Fields
+
+| Field | Allowed values | Current template value |
+| --- | --- | --- |
+| Merchant identity status | pending, reviewed, rejected | pending |
+| Approval artifact status | pending, complete, rejected | pending |
+| Payload preview status | pending, reviewed, rejected | pending |
+| Safety scan status | pending, passed, failed | pending |
+| Owner assignment status | pending, complete, rejected | pending |
+| Decision state | not ready, intake ready, rollout proposal ready, rejected | not ready |
+
+## Explicit Rejected Material
+
+Do not place any of this material in the repository:
+
+- Private contracts.
+- Private contacts.
+- Signed approval records.
+- Pricing terms.
+- Customer data.
+- Secrets.
+- Tokens, passports, or JWTs.
+- Provider credentials.
+- Raw payloads.
+- DB or Redis URLs.
+- Production config values.
+- Live-payment or live-Plural claims.
+- Certification or readiness claims.
+- Realistic private merchant details.
+- Synthetic IDs proposed as production candidates.
+
+## Stop Conditions
+
+Stop collection and do not prepare a future proposal if any condition below is
+true:
+
+- Real merchant approval is missing.
+- Any private material appears in the repository.
+- Any secret appears in the repository.
+- Any production config or allowlist value appears.
+- Any synthetic ID is proposed for production.
+- Any broad runtime, live payment, checkout, payment creation, or provider path
+  is requested.
+- AgenticOrg public discovery is requested before Grantex read-only smoke
+  passes and separate AgenticOrg approval exists.
+
+## Non-Approval
+
+- This template does not approve a merchant.
+- This template does not approve an allowlist value.
+- This template does not enable AgenticOrg public commerce discovery.
+- This template does not enable Commerce V1.
+- This template does not enable checkout or payment creation.
+- This template does not enable live payments or live Plural.
+- This template does not add a direct provider path.
+- This template does not treat synthetic data as production approval.


### PR DESCRIPTION
Docs-only C5M planning change. Adds a repo-safe AgenticOrg real merchant artifact collection template and current intake status record using placeholder-only values. Current state remains not ready: no merchant approved, no allowlist value approved, no AgenticOrg public discovery enabled, and synthetic data remains internal/local/smoke-only and not production approval. This PR does not deploy, change production config, touch secrets, approve or invent a merchant, set allowlists, enable Commerce V1, enable AgenticOrg public discovery, enable checkout/payment creation, enable live payments, or enable live Plural. Validation run locally: focused secret/private-detail scan, focused overclaim scan, production-looking merchant ID/name scan, synthetic-ID production-candidate scan, and git diff --cached --check.