### PR TITLE
fix(connectors): stabilize Zoho organization regressions

### DIFF
--- a/connectors/finance/zoho_books.py
+++ b/connectors/finance/zoho_books.py
@@ -924,6 +924,17 @@ class ZohoBooksConnector(BaseConnector):
                     "in the authenticated account."
                 )
         else:
+            configured_org_id = _normalise_org_id(
+                self._org_id or self.config.get("organization_id")
+            )
+            if configured_org_id:
+                configured_orgs = [
+                    org
+                    for org in orgs
+                    if str(org.get("organization_id") or "") == str(configured_org_id)
+                ]
+                if configured_orgs:
+                    orgs = configured_orgs
             self._set_org_id(orgs[0].get("organization_id"))
         return {"organizations": [self._normalize_organization(orgs[0])]}
 

--- a/connectors/finance/zoho_books.py
+++ b/connectors/finance/zoho_books.py
@@ -840,10 +840,8 @@ class ZohoBooksConnector(BaseConnector):
                 "Use the GSTN connector for statutory GST reports; use "
                 "list_invoices only when you explicitly need invoice source data."
             )
-        data = await self._get(
-            "/reports/gstsummary",
-            params=self._org_params(qp, source_params=params),
-        )
+        query = self._org_params(qp, source_params=params)
+        data = await self._get("/reports/gstsummary", params=query)
         return self._unwrap(data, "gst_summary")
 
     async def calculate_tds(self, **params) -> dict[str, Any]:
@@ -897,7 +895,14 @@ class ZohoBooksConnector(BaseConnector):
         If a caller supplies organization_id, the connector records that
         as the active org for later calls in the same session.
         """
-        data = await super()._get("/organizations")
+        explicit_org_id = ""
+        query: dict[str, Any] | None = None
+        if any(key in params for key in _ORG_ID_KEYS):
+            explicit_org_id, _source = self._org_id_from_params(params)
+            if explicit_org_id:
+                query = {"organization_id": explicit_org_id}
+
+        data = await super()._get("/organizations", query)
         self._raise_for_zoho_error(data, "/organizations")
         orgs = data.get("organizations", []) if isinstance(data, dict) else []
         if not orgs:
@@ -906,22 +911,19 @@ class ZohoBooksConnector(BaseConnector):
                 "refresh_token, client_id, client_secret, and organization_id "
                 "are configured."
             )
-        explicit_org_id, _source = self._org_id_from_params(params)
         if explicit_org_id:
             self._set_org_id(explicit_org_id)
-        selected_org_id = explicit_org_id or self._org_id
-        if selected_org_id:
             orgs = [
                 org
                 for org in orgs
-                if str(org.get("organization_id") or "") == str(selected_org_id)
+                if str(org.get("organization_id") or "") == str(explicit_org_id)
             ]
             if not orgs:
                 raise RuntimeError(
-                    f"Zoho Books organization_id {selected_org_id} was not found "
+                    f"Zoho Books organization_id {explicit_org_id} was not found "
                     "in the authenticated account."
                 )
-        elif not self._org_id:
+        else:
             self._set_org_id(orgs[0].get("organization_id"))
         return {"organizations": [self._normalize_organization(orgs[0])]}
 

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -86,7 +86,7 @@
     "public_exempt_reason": null,
     "rate_limit": "a2a-task-read",
     "scope": "a2a.task.sensitive.read",
-    "source_line": 349,
+    "source_line": 374,
     "tenant_required": true
   },
   {
@@ -410,7 +410,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.list",
-    "source_line": 1304,
+    "source_line": 1330,
     "tenant_required": true
   },
   {
@@ -428,7 +428,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 1049,
+    "source_line": 1075,
     "tenant_required": true
   },
   {
@@ -446,7 +446,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.tools.sensitive.read",
-    "source_line": 1003,
+    "source_line": 1029,
     "tenant_required": true
   },
   {
@@ -464,7 +464,7 @@
     "public_exempt_reason": null,
     "rate_limit": "ai-generation",
     "scope": "agents.generate",
-    "source_line": 1718,
+    "source_line": 1744,
     "tenant_required": true
   },
   {
@@ -482,7 +482,7 @@
     "public_exempt_reason": null,
     "rate_limit": "file-upload",
     "scope": "agents.import",
-    "source_line": 1561,
+    "source_line": 1587,
     "tenant_required": true
   },
   {
@@ -500,7 +500,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.org_tree",
-    "source_line": 1424,
+    "source_line": 1450,
     "tenant_required": true
   },
   {
@@ -518,7 +518,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 3793,
+    "source_line": 3829,
     "tenant_required": true
   },
   {
@@ -536,7 +536,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.read",
-    "source_line": 1840,
+    "source_line": 1866,
     "tenant_required": true
   },
   {
@@ -554,7 +554,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 2010,
+    "source_line": 2036,
     "tenant_required": true
   },
   {
@@ -572,7 +572,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 1870,
+    "source_line": 1896,
     "tenant_required": true
   },
   {
@@ -590,7 +590,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.amendments.read",
-    "source_line": 3752,
+    "source_line": 3788,
     "tenant_required": true
   },
   {
@@ -608,7 +608,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.budget.read",
-    "source_line": 3466,
+    "source_line": 3502,
     "tenant_required": true
   },
   {
@@ -626,7 +626,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 3311,
+    "source_line": 3347,
     "tenant_required": true
   },
   {
@@ -644,7 +644,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.delegate",
-    "source_line": 1485,
+    "source_line": 1511,
     "tenant_required": true
   },
   {
@@ -662,7 +662,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.explanation.read",
-    "source_line": 3612,
+    "source_line": 3648,
     "tenant_required": true
   },
   {
@@ -680,7 +680,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.feedback.list",
-    "source_line": 3584,
+    "source_line": 3620,
     "tenant_required": true
   },
   {
@@ -698,7 +698,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-feedback",
     "scope": "agents.feedback.write",
-    "source_line": 3538,
+    "source_line": 3574,
     "tenant_required": true
   },
   {
@@ -716,7 +716,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.feedback.analyze",
-    "source_line": 3728,
+    "source_line": 3764,
     "tenant_required": true
   },
   {
@@ -734,7 +734,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 2821,
+    "source_line": 2857,
     "tenant_required": true
   },
   {
@@ -752,7 +752,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 2956,
+    "source_line": 2992,
     "tenant_required": true
   },
   {
@@ -770,7 +770,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.prompt_history",
-    "source_line": 3424,
+    "source_line": 3460,
     "tenant_required": true
   },
   {
@@ -788,7 +788,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 2869,
+    "source_line": 2905,
     "tenant_required": true
   },
   {
@@ -806,7 +806,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3126,
+    "source_line": 3162,
     "tenant_required": true
   },
   {
@@ -824,7 +824,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3075,
+    "source_line": 3111,
     "tenant_required": true
   },
   {
@@ -842,7 +842,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3187,
+    "source_line": 3223,
     "tenant_required": true
   },
   {
@@ -860,7 +860,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-execution",
     "scope": "agents.execute",
-    "source_line": 2171,
+    "source_line": 2197,
     "tenant_required": true
   },
   {
@@ -1671,7 +1671,7 @@
     "public_exempt_reason": null,
     "rate_limit": "chat-history-read",
     "scope": "chat.history.sensitive.read",
-    "source_line": 850,
+    "source_line": 854,
     "tenant_required": true
   },
   {
@@ -3327,7 +3327,7 @@
     "public_exempt_reason": null,
     "rate_limit": "mcp-tool-call",
     "scope": "mcp.external_agent_execution.sensitive.write",
-    "source_line": 109,
+    "source_line": 110,
     "tenant_required": true
   },
   {
@@ -3345,7 +3345,7 @@
     "public_exempt_reason": "public-tool-discovery-no-tenant-data",
     "rate_limit": "mcp-discovery",
     "scope": "public:mcp.tool_discovery.read",
-    "source_line": 43,
+    "source_line": 44,
     "tenant_required": false
   },
   {


### PR DESCRIPTION
## Summary

- Fix Zoho Books `get_organization()` so stale configured organization IDs do not filter `/organizations` discovery unless the caller explicitly supplies an organization ID.
- Preserve explicit numeric organization ID handling for `/organizations` requests.
- Keep the India GST report guard compatible with the existing regression and refresh generated route inventory metadata required by the enterprise stability gate.

## Validation

- `python -m pytest tests/regression/test_ca_firms_uday25_zoho_crm_tools.py::test_zoho_get_organization_lists_without_stale_org_injection tests/regression/test_ca_firms_uday25_zoho_crm_tools.py::test_zoho_get_organization_accepts_numeric_explicit_org_id tests/regression/test_may05_github_issue_closures.py::test_zoho_india_gst_report_refuses_invoice_fallback -q`
- `python -m pytest tests/regression/test_ca_firms_uday25_zoho_crm_tools.py tests/regression/test_may05_github_issue_closures.py -q`
- `python -m ruff check connectors/finance/zoho_books.py tests/regression/test_ca_firms_uday25_zoho_crm_tools.py tests/regression/test_may05_github_issue_closures.py`
- `python scripts/check_enterprise_stability_gates.py`
- focused secret scan on changed files
- `git diff --check`

No deploy, cloud command, production config change, secret change, Commerce V1 enablement, public discovery enablement, checkout/payment creation, live payment, or live Plural path is included.