### PR TITLE
docs(commerce): add demo home goods merchant packet

### DIFF
--- a/docs/examples/commerce-agent-c5w-demo-home-goods-store-packet.json
+++ b/docs/examples/commerce-agent-c5w-demo-home-goods-store-packet.json
@@ -1,0 +1,75 @@
+{
+  "packet_type": "synthetic_realistic_merchant_demo_packet",
+  "packet_version": "c5w-demo-v1",
+  "decision_state": "demo_ready_not_production",
+  "production_rollout_permitted": false,
+  "merchant_identity": {
+    "merchant_id": "mch_demo_readonly_homegoods_0001",
+    "tenant_reference": "cten_demo_readonly_homegoods_0001",
+    "agent_reference": "cag_demo_readonly_sales_0001",
+    "display_name": "Demo Home Goods Store",
+    "category": "Home and Kitchen",
+    "discovery_description": "Demo read-only discovery profile for a synthetic home goods merchant. This profile is for internal walkthroughs only and is not production approval.",
+    "country_code": "IN",
+    "default_currency": "INR",
+    "legal_entity_reference": "DEMO_REFERENCE_ONLY_NOT_REAL"
+  },
+  "approval_references": {
+    "merchant_owner": "DEMO_APPROVAL_REF_MERCHANT_OWNER_0001",
+    "legal_compliance": "DEMO_APPROVAL_REF_LEGAL_0001",
+    "product_wording": "DEMO_APPROVAL_REF_PRODUCT_0001",
+    "security": "DEMO_APPROVAL_REF_SECURITY_0001",
+    "ops_on_call_support": "DEMO_APPROVAL_REF_OPS_0001",
+    "backup_rpo": "DEMO_APPROVAL_REF_BACKUP_RPO_0001",
+    "agenticorg_dependency": "DEMO_APPROVAL_REF_AGENTICORG_0001"
+  },
+  "owners": {
+    "rollback_owner": "DEMO_ROLE_ROLLBACK_OWNER",
+    "read_only_smoke_owner": "DEMO_ROLE_READ_ONLY_SMOKE_OWNER",
+    "evidence_retention_owner": "DEMO_ROLE_EVIDENCE_RETENTION_OWNER"
+  },
+  "public_payload_preview": {
+    "merchant_id": "mch_demo_readonly_homegoods_0001",
+    "display_name": "Demo Home Goods Store",
+    "category": "Home and Kitchen",
+    "discovery_description": "Demo read-only discovery profile for a synthetic home goods merchant. This profile is for internal walkthroughs only and is not production approval.",
+    "issuer_reference": "https://api.demo.grantex.invalid",
+    "jwks_uri_reference": "https://api.demo.grantex.invalid/.well-known/jwks.json",
+    "supported_read_only_capabilities": [
+      "merchant_profile_read",
+      "catalog_summary_read",
+      "policy_summary_read"
+    ],
+    "blocked_capabilities": [
+      "checkout_creation",
+      "payment_intent_creation",
+      "live_payment_processing",
+      "live_plural_access",
+      "provider_credential_access"
+    ],
+    "posture": {
+      "non_secret_metadata_only": true,
+      "no_checkout_or_payment_creation": true,
+      "no_live_payment_path": true,
+      "no_live_plural_path": true,
+      "no_provider_credentials": true,
+      "no_certification_or_readiness_claim": true
+    }
+  },
+  "validation_summary": {
+    "secret_private_detail_scan": "demo_pass",
+    "overclaim_scan": "demo_pass",
+    "merchant_id_name_review": "demo_pass_demo_name_only",
+    "synthetic_id_production_candidate_scan": "demo_pass_not_candidate",
+    "config_allowlist_value_scan": "demo_pass"
+  },
+  "safety_assertions": {
+    "synthetic_demo_only": true,
+    "not_real_merchant_approval": true,
+    "not_production_allowlist_value": true,
+    "not_public_discovery_enablement": true,
+    "grantex_remains_fail_closed": true,
+    "agenticorg_remains_gated": true,
+    "no_checkout_payment_or_live_provider": true
+  }
+}

--- a/docs/reports/commerce-agent-c5w-demo-home-goods-store-walkthrough.md
+++ b/docs/reports/commerce-agent-c5w-demo-home-goods-store-walkthrough.md
@@ -1,0 +1,97 @@
+# Commerce Agent C5W Demo Home Goods Store Walkthrough
+
+Status: docs/examples only
+Date: 2026-05-27
+Scope: synthetic merchant demo packet for AgenticOrg read-only discovery
+walkthroughs
+Production changes made by this record: none
+Production rollout approved by this record: no
+Production allowlist value approved by this record: no
+AgenticOrg public commerce discovery enabled by this record: no
+Checkout or payment creation enabled by this record: no
+Live payment or live Plural enabled by this record: no
+Secrets inspected or changed: no
+
+This walkthrough explains how to present
+`docs/examples/commerce-agent-c5w-demo-home-goods-store-packet.json` in an
+internal demo. "Demo Home Goods Store" is a synthetic/demo-only merchant
+profile. It is not a real merchant, not onboarding approval, not production
+approval, and not an allowlist candidate.
+
+## Demo Purpose
+
+The demo may show how AgenticOrg could display a Grantex-controlled,
+read-only merchant discovery preview after review gates. It remains an
+internal walkthrough only and does not enable AgenticOrg public commerce
+discovery.
+
+## What The Demo May Show
+
+- Merchant identity preview for `Demo Home Goods Store`.
+- Public payload preview with non-secret metadata only.
+- Demo approval reference placeholders.
+- Demo owner assignment placeholders.
+- Demo scan summary placeholders.
+- Read-only discovery posture.
+- Blocked checkout, payment, live Plural, live provider, and provider
+  credential paths.
+
+## What The Demo Must Not Imply
+
+- No real merchant approval.
+- No production allowlist.
+- No public discovery enablement.
+- No production Commerce V1 enablement.
+- No checkout or payment creation.
+- No live payments.
+- No live Plural.
+- No provider credentials.
+- No certification or readiness claim.
+
+## Suggested UI Labels
+
+| Field | Demo label |
+| --- | --- |
+| Display name | Demo Home Goods Store |
+| Status | Demo-ready, not production-approved |
+| Allowed | Read-only discovery preview |
+| Blocked | Checkout, payments, live Plural, provider credentials, production allowlist |
+
+## Demo Packet Summary
+
+- Merchant ID: `mch_demo_readonly_homegoods_0001`.
+- Tenant reference: `cten_demo_readonly_homegoods_0001`.
+- Agent reference: `cag_demo_readonly_sales_0001`.
+- Decision state: `demo_ready_not_production`.
+- Production rollout permitted: `false`.
+- Grantex production read-only discovery remains fail-closed.
+- AgenticOrg public commerce discovery remains gated.
+
+## Public-Safe Boundary
+
+The packet contains only synthetic identifiers, demo approval references,
+role-label owner placeholders, non-secret payload preview fields, and demo scan
+summaries. It must not be expanded with private contracts, private contacts,
+signed approvals, pricing terms, customer data, real addresses, phone numbers,
+emails, PAN or GST IDs, provider credentials, tokens, raw payloads, DB or Redis
+URLs, private keys, or production config values.
+
+## Stop Conditions
+
+Stop the demo and keep AgenticOrg gated if any condition appears:
+
+- Any real private merchant artifact appears.
+- Any production config or allowlist value appears.
+- Any claim says the demo merchant is approved.
+- Any request asks to enable public discovery.
+- Any request asks to enable checkout or payment creation.
+- Any request asks to enable live payment or live Plural.
+- Any provider credential path is introduced.
+
+## Explicit Non-Approval
+
+This walkthrough and packet do not approve a merchant, do not approve a
+production allowlist value, do not enable public discovery, do not enable
+Commerce V1, do not enable checkout or payment creation, do not enable live
+payments, do not enable live Plural, do not add provider credential access, and
+do not approve AgenticOrg public commerce discovery.


### PR DESCRIPTION
## Summary
- Add a synthetic/demo-only Demo Home Goods Store packet for AgenticOrg read-only discovery walkthroughs.
- Add a walkthrough documenting allowed demo surfaces, blocked production/payment/provider paths, AgenticOrg gated posture, and stop conditions.

## Safety
- Demo/synthetic data only; not real merchant approval.
- No production allowlist value, public discovery enablement, production Commerce V1 enablement, checkout/payment creation, live payments, live Plural, or provider credential path.
- Grantex production read-only discovery remains fail-closed and AgenticOrg remains gated.

## Validation
- Parsed JSON packet with ConvertFrom-Json.
- Ran focused secret/private-detail scan.
- Ran focused overclaim scan; hits are explicit negative/safety contexts only.
- Ran merchant ID/name scan; only allowed demo ID/name present.
- Ran synthetic production-candidate and config/allowlist assignment scans.
- Ran git diff --check.