### PR TITLE
[codex] docs(commerce): explain merchant self-serve interoperability

### DIFF
--- a/docs/commerce-agent-agentic-commerce-implementation-prd.md
+++ b/docs/commerce-agent-agentic-commerce-implementation-prd.md
@@ -53,6 +53,55 @@ AgenticOrg must not hold provider credentials, call Plural/Stripe/Pine/payment
 providers directly, call private merchant commerce APIs directly, or become the
 canonical catalog/order/refund system.
 
+### End-To-End Flow Summary
+
+The complete product flow is documented in
+`docs/commerce-agent-end-to-end-agentic-commerce-flow.md`. That guide is the
+plain-language operating model for buyers, sellers, and implementation owners.
+
+Buyer one-time setup:
+
+1. Buyer chooses an approved channel such as ChatGPT, Claude, Gemini, WhatsApp,
+   Telegram, web/mobile, or a future agent surface.
+2. AgenticOrg creates or resumes a buyer-agent session and binds it to the
+   channel identity without exposing tokens.
+3. Buyer sets safe preferences such as locale, currency, delivery region,
+   notification route, and accessibility needs.
+4. Buyer sees what the channel can do: browse, compare, draft cart, request
+   checkout, read status, or hand off to support.
+5. Payment-affecting actions still require Grantex consent and Commerce
+   Passport evidence every time.
+
+Seller one-time setup:
+
+1. Seller creates the merchant workspace in Grantex.
+2. Seller verifies identity and stores private approval artifacts outside repos.
+3. Seller connects existing systems to Grantex: storefront, catalog, ERP/PIM,
+   inventory/WMS, OMS, logistics, payment provider, CRM/support, or CSV/API.
+4. Grantex normalizes catalog, inventory, price, policy, consent, payment,
+   order, fulfillment, support, audit, and protocol-publishing state.
+5. Seller selects allowed agent actions and channels.
+6. Grantex runs scans, readiness checks, human review gates, smoke tests, and
+   rollback checks before any production capability is approved.
+
+Regular transaction:
+
+1. Buyer asks in their chosen chat channel.
+2. AgenticOrg starts the session and asks Grantex for approved merchant/channel
+   capabilities.
+3. AgenticOrg searches catalog, checks inventory, and drafts carts only through
+   Grantex.
+4. Grantex returns grounded facts, totals, policy, inventory freshness, and
+   blocker codes.
+5. Buyer approves or denies Grantex consent.
+6. Grantex issues scoped Commerce Passport status only if consent and policy
+   pass.
+7. AgenticOrg requests payment intent and checkout handoff only through
+   Grantex.
+8. Grantex owns provider interaction, webhook reconciliation, audit, order,
+   fulfillment, support, return, refund, settlement, and rollback state.
+9. AgenticOrg shows buyer-safe status and refuses unsupported claims.
+
 ## 2. Current Implementation Snapshot
 
 | Area | Current evidence | Current state |
@@ -299,6 +348,7 @@ Avoid these claims until separately approved:
 | Surface | Required AgenticOrg update |
 | --- | --- |
 | `docs/commerce-agent-overview.md` | Keep architecture, merchant journey, standards fit, and gap summary current. |
+| `docs/commerce-agent-end-to-end-agentic-commerce-flow.md` | Keep buyer one-time setup, seller one-time setup, regular transaction, exception paths, and source-of-truth rules current. |
 | `docs/commerce-agent-developer-guide.md` | Keep safe extension rules, direct-provider bans, and future alias requirements current. |
 | Channel adapter docs | Maintain per-channel setup/runbooks for ChatGPT, Claude, Gemini, WhatsApp, Telegram, web/mobile, and future agent surfaces. |
 | C5 planning reports | Continue using C5-series docs for implementation slices and evidence packets. |

--- a/docs/commerce-agent-agentic-commerce-implementation-prd.md
+++ b/docs/commerce-agent-agentic-commerce-implementation-prd.md
@@ -80,7 +80,105 @@ The target AgenticOrg buyer journey should be:
 9. Agent refuses unsupported refunds, returns, discounts, delivery promises,
    live-provider claims, and certification claims unless Grantex provides them.
 
-## 4. Merchant Education Journey
+## 4. Buyer Agent Launch From Existing Chat Interfaces
+
+This is a critical product requirement: buyers should not need to learn a new
+shopping interface just to use agentic commerce. A buyer should be able to start
+from the chat surface they already use, such as ChatGPT, Claude, Gemini,
+WhatsApp, Telegram, a merchant website chat widget, voice assistant, or a future
+agent marketplace.
+
+The current implementation does not yet provide full channel launch coverage.
+The PRD therefore requires an AgenticOrg channel adapter layer that makes each
+interface feel simple while keeping commerce execution inside Grantex.
+
+```mermaid
+flowchart LR
+  chat["Buyer chat surface"]
+  adapter["AgenticOrg channel adapter"]
+  session["Buyer agent session"]
+  tools["Grantex-only commerce aliases"]
+  grantex["Grantex Commerce"]
+
+  chat --> adapter
+  adapter --> session
+  session --> tools
+  tools --> grantex
+```
+
+Channel adapter principles:
+
+- One buyer prompt should create or resume a buyer-agent session.
+- The user should not need to understand MCP, UCP, ACP, AP2, passports, or
+  provider details.
+- Each channel must normalize user identity, locale, currency, consent state,
+  conversation ID, channel message limits, attachment handling, and handoff URLs.
+- Every commerce action must still go through Grantex-only tools.
+- Channel adapters must never store provider credentials or private merchant
+  integration credentials.
+- Payment and checkout actions must require Grantex consent and Commerce
+  Passport evidence, even if the chat interface has its own confirmation UX.
+
+| Buyer interface | Launch path AgenticOrg should support | Current platform reality to design around | Required AgenticOrg work |
+| --- | --- | --- | --- |
+| ChatGPT | Publish an AgenticOrg/Grantex Commerce app using remote MCP-backed tools and Apps SDK packaging. | ChatGPT apps can be connected and invoked in chat, and custom apps use MCP-backed tools. Workspace admins can control actions. OpenAI docs also state that ChatGPT Agent Mode does not use custom apps today, and Deep Research custom-app usage is read/fetch only. | Build remote MCP app manifest, OAuth/account linking, read vs write action labels, confirmation copy, app review checklist, frozen-tool-version update workflow, and fallback to read-only discovery when write actions are unavailable. |
+| Claude | Expose a remote MCP connector for Claude-compatible clients. | MCP is the primary official integration path for Claude and other clients; remote MCP gives Claude access to external tools and data. | Build remote MCP endpoint, auth, tool descriptions, least-privilege scopes, connector test harness, and refusal behavior for missing Grantex approval. |
+| Gemini | Support a Gemini API or Vertex/ADK wrapper using function declarations that call AgenticOrg channel tools. | Gemini API function calling lets a model call declared functions and return structured parameters; consumer Gemini app distribution for arbitrary third-party commerce actions is not the same as a public MCP app directory. | Build Gemini function-declaration schema, tool execution loop, response normalization, user consent handoff, and clear "supported via AgenticOrg-hosted Gemini channel" vs "native Gemini app support pending" labels. |
+| WhatsApp | Provide a WhatsApp Business Platform channel adapter backed by webhooks. | WhatsApp Cloud API uses WABA/business phone numbers, permissions, approved templates, inbound message webhooks, and delivery-status webhooks. | Build WABA setup guide, webhook receiver, message template policy, session window handling, identity binding, consent link handoff, rate-limit handling, opt-out, and human support escalation. |
+| Telegram | Provide a Telegram bot channel adapter. | Telegram Bot API is HTTPS-based, uses bot tokens, and receives updates through polling or webhooks; webhooks can include a secret token header. | Build BotFather setup guide, webhook receiver, secret validation, chat/user identity mapping, inline buttons, consent link handoff, rate limits, and bot token secret handling. |
+| Merchant website or mobile app | Embed AgenticOrg buyer chat or deep-link into an AgenticOrg hosted session. | This is the most controllable first-party channel. | Build web/mobile SDK or embeddable widget, session resume, Grantex merchant selector, consent redirect, and analytics attribution. |
+| Other agent/chat surfaces | Use remote MCP, A2A handoff, REST, or webhook adapter depending on platform support. | Capability support differs by platform and changes over time. | Maintain a channel certification matrix with supported actions, auth, consent, message constraints, and known limitations. |
+
+Do not describe this as "flawless across every chat app" until each channel has:
+
+- one-click or low-friction user launch;
+- account/channel identity binding;
+- approved Grantex merchant and capability discovery;
+- Grantex-only tool execution;
+- consent and Commerce Passport handoff;
+- payment/checkout confirmation wording;
+- refusal and recovery UX;
+- telemetry, audit, and redacted evidence;
+- regression tests and channel-specific smoke tests;
+- a documented fallback when the platform does not allow write actions.
+
+### Buyer Agent Launch Acceptance Criteria
+
+A channel is launch-ready only when all of these pass:
+
+1. A real user can start with a natural prompt such as "help me buy a sofa from
+   this merchant" and reach the AgenticOrg buyer agent without manual developer
+   setup.
+2. The channel creates or resumes a stable AgenticOrg buyer-agent session.
+3. The session is bound to channel user identity without exposing private tokens.
+4. Merchant discovery comes from Grantex, not from model guesses.
+5. Product, price, inventory, delivery, return, and checkout facts are grounded
+   in Grantex responses.
+6. The channel shows clear consent and checkout handoff copy before any
+   payment-affecting action.
+7. If the channel cannot support write actions, the agent offers read-only
+   discovery and a safe handoff link instead of pretending checkout is possible.
+8. The agent refuses unsupported claims and logs redacted evidence.
+9. A merchant can see channel attribution and failure reasons in operational
+   reporting.
+10. Channel launch is disabled by default until Grantex approves merchant
+    read-only discovery and any checkout scope separately.
+
+Implementation must re-check current platform documentation before build because
+chat-platform capabilities and approval rules change. Current reference inputs:
+
+- OpenAI ChatGPT custom apps and remote MCP developer-mode documentation:
+  <https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt>
+- Anthropic Claude MCP connector documentation:
+  <https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector>
+- Google Gemini API function-calling documentation:
+  <https://ai.google.dev/gemini-api/docs/function-calling>
+- Meta WhatsApp Business Platform / Cloud API documentation:
+  <https://developers.facebook.com/docs/whatsapp/cloud-api/>
+- Telegram Bot API documentation:
+  <https://core.telegram.org/bots/api>
+
+## 5. Merchant Education Journey
 
 AgenticOrg should help merchants understand the journey without creating false
 production confidence:
@@ -95,7 +193,7 @@ production confidence:
 7. Show a launch rehearsal that ends in "request rollout", not automatic
    production enablement.
 
-## 5. Standards And Protocol Fit
+## 6. Standards And Protocol Fit
 
 AgenticOrg should treat standards as surfaces published by Grantex, not as
 separate sources of truth.
@@ -103,8 +201,8 @@ separate sources of truth.
 | Surface | AgenticOrg behavior |
 | --- | --- |
 | Native Grantex tools | Primary runtime path for all commerce actions. |
-| MCP | Use tool aliases backed by Grantex policy and audit. Do not add direct provider tools. |
-| UCP-style profile | Consume only Grantex-published capability profiles after approval. |
+| MCP | Use tool aliases backed by Grantex policy and audit. Do not add direct provider tools. This is the primary bridge for ChatGPT custom apps, Claude-compatible connectors, and other MCP-capable clients. |
+| UCP-style profile | Consume only Grantex-published capability profiles after approval. Use it to explain merchant capabilities to channel adapters. |
 | ACP-style checkout | Render checkout state and buyer messages from Grantex; do not complete checkout outside Grantex. |
 | AP2-style evidence | Present mandate/consent status only when Grantex provides deterministic signed evidence. |
 | schema.org | Use public-safe product/offer/shipping/return metadata generated by Grantex. |
@@ -112,10 +210,11 @@ separate sources of truth.
 Do not claim UCP, ACP, AP2, A2A, MPP, schema.org production, or live-provider
 compliance unless Grantex implementation and conformance evidence exist.
 
-## 6. AgenticOrg Gap Register
+## 7. AgenticOrg Gap Register
 
 | Gap | Why it matters | Required AgenticOrg work | Dependency |
 | --- | --- | --- | --- |
+| Buyer-agent creation and launch | Real buyers should start from familiar chat interfaces without developer setup. | Channel adapter layer for ChatGPT, Claude, Gemini, WhatsApp, Telegram, web/mobile, and future agent surfaces. | Platform-specific app/bot/API approval plus Grantex capability approval. |
 | Buyer-facing commerce UX | Buyers need a safe, understandable flow. | Product comparison, grounded cart draft, consent handoff, checkout status, refusal copy. | Grantex catalog/consent/payment APIs. |
 | Merchant-facing demo UX | Merchants need to understand how publishing works. | Demo Home Goods Store walkthrough, launch rehearsal, status labels, blocked-path examples. | Grantex demo packet and self-serve docs. |
 | Order and fulfillment reads | Buyers ask "where is my order?" | Add Grantex-only aliases and UI copy after Grantex order/fulfillment APIs exist. | Grantex order/fulfillment implementation. |
@@ -129,20 +228,24 @@ compliance unless Grantex implementation and conformance evidence exist.
 | Landing page copy | Prospects need clear positioning without overclaiming. | Add future public copy only after approval: "Agentic commerce readiness through Grantex"; no live/certification claims. | Product/web approval. |
 | GitHub workflows | Docs-only changes should not push images or deploy. | Keep docs-only guard current and treat workflow changes as non-docs-only. | Existing CI guard. |
 
-## 7. Fast-Track AgenticOrg Plan
+## 8. Fast-Track AgenticOrg Plan
 
 | Slice | Goal | AgenticOrg output | Guardrail |
 | --- | --- | --- | --- |
 | A. Merchant education pack | Explain the self-serve journey. | Demo script, screenshots/walkthrough, blocked-path labels. | Synthetic/demo only. |
 | B. Buyer read-only discovery UX | Let a user ask product questions safely. | Grantex-only product comparison and inventory caution copy. | No checkout or payment. |
-| C. Cart and consent UX | Rehearse safe checkout. | Cart draft and Grantex consent handoff. | No passport displayed or logged. |
-| D. Sandbox checkout demo | Show end-to-end sandbox flow. | Checkout status and payment status rendering. | Mock/sandbox provider only. |
-| E. Order/fulfillment support | Answer post-purchase questions. | Grantex-only order and fulfillment aliases after Grantex ships them. | No invented status. |
-| F. Returns/refunds support | Guide support safely. | Refusal/manual handoff now; Grantex-only request/status later. | No refund execution. |
-| G. Protocol display | Show standard capability status. | UCP/ACP/schema.org/AP2 readiness labels from Grantex. | No unsupported compliance claims. |
-| H. Real merchant pilot support | Assist one approved merchant rollout. | Controlled agent workflow and eval evidence. | Separate Grantex rollout approval. |
+| C. First-party web/mobile buyer channel | Prove low-friction session creation. | AgenticOrg hosted buyer-agent session and embeddable merchant link/widget. | Still Grantex-only; no public discovery unless approved. |
+| D. ChatGPT and Claude MCP channels | Reach major AI chat surfaces through remote MCP. | Remote MCP app/connector, auth, action labels, confirmation copy, smoke tests. | Respect platform limits; no unsupported write-action claims. |
+| E. WhatsApp and Telegram bot channels | Reach common messaging surfaces. | Webhook adapters, identity binding, consent links, opt-out, human escalation. | Tokens/webhook secrets never logged or committed. |
+| F. Gemini channel | Support Gemini-powered buyer-agent sessions. | Gemini function declarations or hosted wrapper calling AgenticOrg tools. | Label native Gemini app support as pending unless approved. |
+| G. Cart and consent UX | Rehearse safe checkout. | Cart draft and Grantex consent handoff. | No passport displayed or logged. |
+| H. Sandbox checkout demo | Show end-to-end sandbox flow. | Checkout status and payment status rendering. | Mock/sandbox provider only. |
+| I. Order/fulfillment support | Answer post-purchase questions. | Grantex-only order and fulfillment aliases after Grantex ships them. | No invented status. |
+| J. Returns/refunds support | Guide support safely. | Refusal/manual handoff now; Grantex-only request/status later. | No refund execution. |
+| K. Protocol display | Show standard capability status. | UCP/ACP/schema.org/AP2 readiness labels from Grantex. | No unsupported compliance claims. |
+| L. Real merchant pilot support | Assist one approved merchant rollout. | Controlled agent workflow and eval evidence. | Separate Grantex rollout approval. |
 
-## 8. Release Acceptance Criteria
+## 9. Release Acceptance Criteria
 
 Before AgenticOrg can participate in a real merchant pilot:
 
@@ -150,6 +253,9 @@ Before AgenticOrg can participate in a real merchant pilot:
 - AgenticOrg public commerce discovery remains disabled until Grantex read-only
   discovery is approved.
 - Every commerce tool alias maps to a Grantex API or MCP tool.
+- Each approved buyer channel has a documented launch path, auth model, consent
+  handoff, write-action support status, fallback behavior, telemetry, and smoke
+  evidence.
 - No commerce code imports or calls direct provider SDKs, Plural, Stripe, Pine,
   or merchant private checkout APIs.
 - Buyer-facing copy distinguishes "known", "unknown", "stale", "blocked", and
@@ -161,7 +267,7 @@ Before AgenticOrg can participate in a real merchant pilot:
   blocker codes, and non-secret references.
 - Docs-only PRs skip cloud build/push/deploy-adjacent jobs by policy.
 
-## 9. Public Landing Page Copy Draft
+## 10. Public Landing Page Copy Draft
 
 If product/web owners update the AgenticOrg landing page later, use safe
 positioning like this:
@@ -188,19 +294,20 @@ Avoid these claims until separately approved:
 - "Agents can refund customers."
 - "Agents can call merchant systems directly."
 
-## 10. Documentation And Workflow Coverage
+## 11. Documentation And Workflow Coverage
 
 | Surface | Required AgenticOrg update |
 | --- | --- |
 | `docs/commerce-agent-overview.md` | Keep architecture, merchant journey, standards fit, and gap summary current. |
 | `docs/commerce-agent-developer-guide.md` | Keep safe extension rules, direct-provider bans, and future alias requirements current. |
+| Channel adapter docs | Maintain per-channel setup/runbooks for ChatGPT, Claude, Gemini, WhatsApp, Telegram, web/mobile, and future agent surfaces. |
 | C5 planning reports | Continue using C5-series docs for implementation slices and evidence packets. |
 | Demo docs | Keep Demo Home Goods Store explicitly synthetic/demo-only. |
 | Evals and regressions | Add tests whenever new commerce aliases or refusal cases are added. |
 | `.github/workflows/deploy.yml` | Preserve docs-only guard so planning merges skip cloud build/push/deploy-adjacent jobs. |
 | Product landing page | Future copy must be reviewed before runtime/UI change and must not imply production readiness. |
 
-## 11. Stop Conditions
+## 12. Stop Conditions
 
 Stop AgenticOrg work if any of these occur:
 
@@ -215,5 +322,8 @@ Stop AgenticOrg work if any of these occur:
   discovery is approved.
 - The agent invents seller details, prices, discounts, availability, delivery
   dates, refund eligibility, order status, or payment status.
+- A channel claims to support checkout, payment, order, refund, or live commerce
+  when that platform only supports read/fetch actions or when Grantex has not
+  approved the merchant capability.
 - A docs-only change triggers cloud build/push/deploy-adjacent work without an
   explicit policy decision.

--- a/docs/commerce-agent-agentic-commerce-implementation-prd.md
+++ b/docs/commerce-agent-agentic-commerce-implementation-prd.md
@@ -3,6 +3,11 @@
 This document explains what AgenticOrg must provide so merchants can safely join
 agentic commerce through Grantex.
 
+The consolidated cross-repo PRD lives in the Grantex repo at
+`docs/guides/commerce-v1-agentic-commerce-prd.md`. This AgenticOrg PRD is the
+buyer-agent implementation companion and must stay aligned with that canonical
+source.
+
 AgenticOrg is not the merchant system of record. It is the buyer-agent and
 workflow layer. It helps users discover products, compare options, draft carts,
 request consent, and follow checkout/order status only through Grantex-approved

--- a/docs/commerce-agent-agentic-commerce-implementation-prd.md
+++ b/docs/commerce-agent-agentic-commerce-implementation-prd.md
@@ -1,0 +1,219 @@
+# AgenticOrg Agentic Commerce Implementation PRD
+
+This document explains what AgenticOrg must provide so merchants can safely join
+agentic commerce through Grantex.
+
+AgenticOrg is not the merchant system of record. It is the buyer-agent and
+workflow layer. It helps users discover products, compare options, draft carts,
+request consent, and follow checkout/order status only through Grantex-approved
+commerce tools.
+
+This document is planning and documentation only. It does not deploy, change
+production configuration, enable public commerce discovery, approve a merchant,
+enable checkout/payment creation, enable live payments, or enable live Plural.
+
+## 1. Product Boundary
+
+```mermaid
+flowchart LR
+  merchant["Merchant systems"]
+  grantex["Grantex Commerce"]
+  agenticorg["AgenticOrg Commerce Sales Agent"]
+  buyer["Buyer or buyer-side AI agent"]
+
+  merchant --> grantex
+  grantex --> agenticorg
+  agenticorg --> buyer
+```
+
+Grantex owns:
+
+- merchant profile and tenant boundary;
+- catalog, inventory, pricing, tax, warranty, and return-policy truth;
+- policy and approval gates;
+- Commerce Passport consent;
+- provider credentials and provider webhooks;
+- payment intent, checkout handoff, reconciliation, settlement, audit, and
+  rollback;
+- native API, MCP, UCP-style, ACP-style, schema.org, and future AP2 evidence
+  publishing.
+
+AgenticOrg owns:
+
+- the Commerce Sales Agent pack;
+- Grantex-only connector aliases;
+- buyer-facing workflow orchestration;
+- safe refusal behavior;
+- synthetic/demo walkthroughs;
+- evals proving agents do not invent seller, price, inventory, checkout,
+  refund, delivery, or payment facts;
+- public discovery gating until Grantex approves a real surface.
+
+AgenticOrg must not hold provider credentials, call Plural/Stripe/Pine/payment
+providers directly, call private merchant commerce APIs directly, or become the
+canonical catalog/order/refund system.
+
+## 2. Current Implementation Snapshot
+
+| Area | Current evidence | Current state |
+| --- | --- | --- |
+| Grantex-only connector | `connectors/commerce/grantex_commerce.py` exposes `merchant_get_profile`, `catalog_search`, `catalog_get_item`, `inventory_check`, `cart_create`, `consent_request`, `consent_exchange`, `payment_create_intent`, `checkout_create`, and `payment_get_status`. | Correct boundary exists. |
+| Payment guardrails | `core/commerce/sales_guardrails.py` blocks missing consent/passport, amount-cap breach, disabled merchant/agent, policy denial, and non-mock provider choices. | Good local fail-closed behavior; must expand as Grantex adds order/refund/fulfillment. |
+| Demo and evals | `demos/commerce_sales_agent_demo.py`, golden commerce evals, no-provider-call regression tests, real-staging and hosted smoke tests. | Strong demo/smoke foundation. |
+| Public discovery gate | Commerce metadata is fail-closed behind `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED`. | Safe posture. |
+| Docs-only CI guard | `.github/workflows/deploy.yml` classifies docs-only changes and skips cloud auth/build/push/deploy-adjacent jobs. | Correct for future planning docs merges. |
+| Merchant education docs | C5O-C5X docs cover self-onboarding, architecture, API/data model proposals, UI wireframes, validator, review workflow, rollout automation, demo merchant, and launch rehearsal. | Good planning foundation; runtime implementation still pending. |
+
+## 3. Buyer-Agent Journey
+
+The target AgenticOrg buyer journey should be:
+
+1. User asks an agent to find or compare products.
+2. Agent reads only Grantex merchant/catalog/inventory tools.
+3. Agent explains uncertainty when stock, price, delivery, or return data is
+   stale or unavailable.
+4. Agent creates a cart draft only from grounded Grantex variant IDs.
+5. Agent asks the user for consent through Grantex.
+6. Grantex issues a scoped Commerce Passport only if consent and policy pass.
+7. Agent requests payment intent and checkout handoff through Grantex.
+8. Agent polls payment/order status only through Grantex.
+9. Agent refuses unsupported refunds, returns, discounts, delivery promises,
+   live-provider claims, and certification claims unless Grantex provides them.
+
+## 4. Merchant Education Journey
+
+AgenticOrg should help merchants understand the journey without creating false
+production confidence:
+
+1. Show a synthetic merchant demo such as Demo Home Goods Store.
+2. Show what the buyer-side agent can see.
+3. Show blocked paths: direct provider calls, live payments, live Plural,
+   checkout without consent, refund execution, stale inventory promises.
+4. Show the Grantex onboarding checklist and approval gates.
+5. Show how existing merchant systems connect to Grantex, not AgenticOrg.
+6. Show how AgenticOrg responds when Grantex says no.
+7. Show a launch rehearsal that ends in "request rollout", not automatic
+   production enablement.
+
+## 5. Standards And Protocol Fit
+
+AgenticOrg should treat standards as surfaces published by Grantex, not as
+separate sources of truth.
+
+| Surface | AgenticOrg behavior |
+| --- | --- |
+| Native Grantex tools | Primary runtime path for all commerce actions. |
+| MCP | Use tool aliases backed by Grantex policy and audit. Do not add direct provider tools. |
+| UCP-style profile | Consume only Grantex-published capability profiles after approval. |
+| ACP-style checkout | Render checkout state and buyer messages from Grantex; do not complete checkout outside Grantex. |
+| AP2-style evidence | Present mandate/consent status only when Grantex provides deterministic signed evidence. |
+| schema.org | Use public-safe product/offer/shipping/return metadata generated by Grantex. |
+
+Do not claim UCP, ACP, AP2, A2A, MPP, schema.org production, or live-provider
+compliance unless Grantex implementation and conformance evidence exist.
+
+## 6. AgenticOrg Gap Register
+
+| Gap | Why it matters | Required AgenticOrg work | Dependency |
+| --- | --- | --- | --- |
+| Buyer-facing commerce UX | Buyers need a safe, understandable flow. | Product comparison, grounded cart draft, consent handoff, checkout status, refusal copy. | Grantex catalog/consent/payment APIs. |
+| Merchant-facing demo UX | Merchants need to understand how publishing works. | Demo Home Goods Store walkthrough, launch rehearsal, status labels, blocked-path examples. | Grantex demo packet and self-serve docs. |
+| Order and fulfillment reads | Buyers ask "where is my order?" | Add Grantex-only aliases and UI copy after Grantex order/fulfillment APIs exist. | Grantex order/fulfillment implementation. |
+| Return/refund request reads | Buyers ask for returns and refunds. | Refuse or hand off until Grantex request APIs exist; later add request/status aliases. | Grantex return/refund workflow. |
+| Delivery promise safety | Agents must not invent shipping dates. | Add stale/unknown delivery refusal logic and verified delivery status rendering. | Grantex logistics/fulfillment fields. |
+| Discounts/offers/EMI safety | Agents must not invent promotions. | Require Grantex-sourced offer metadata and tests for unsupported offer claims. | Grantex pricing/offer/provider metadata. |
+| Existing-system explanation | Merchants need to know they can keep Shopify/ERP/OMS/etc. | Docs and UI copy that point all integrations to Grantex. | Grantex connector framework. |
+| Protocol discovery UX | Users and platforms need capability clarity. | Display capabilities only from Grantex-published profiles and approved metadata. | Grantex UCP/ACP/MCP/schema.org/AP2 adapters. |
+| Eval coverage | Regression tests must catch unsafe agent behavior. | Add evals for order, fulfillment, refund, delivery, offer, stale data, direct-provider import attempts. | New Grantex capabilities. |
+| Public discovery policy | Public surfaces must stay fail-closed until approved. | Keep `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED` disabled by default and tested. | Grantex read-only production approval. |
+| Landing page copy | Prospects need clear positioning without overclaiming. | Add future public copy only after approval: "Agentic commerce readiness through Grantex"; no live/certification claims. | Product/web approval. |
+| GitHub workflows | Docs-only changes should not push images or deploy. | Keep docs-only guard current and treat workflow changes as non-docs-only. | Existing CI guard. |
+
+## 7. Fast-Track AgenticOrg Plan
+
+| Slice | Goal | AgenticOrg output | Guardrail |
+| --- | --- | --- | --- |
+| A. Merchant education pack | Explain the self-serve journey. | Demo script, screenshots/walkthrough, blocked-path labels. | Synthetic/demo only. |
+| B. Buyer read-only discovery UX | Let a user ask product questions safely. | Grantex-only product comparison and inventory caution copy. | No checkout or payment. |
+| C. Cart and consent UX | Rehearse safe checkout. | Cart draft and Grantex consent handoff. | No passport displayed or logged. |
+| D. Sandbox checkout demo | Show end-to-end sandbox flow. | Checkout status and payment status rendering. | Mock/sandbox provider only. |
+| E. Order/fulfillment support | Answer post-purchase questions. | Grantex-only order and fulfillment aliases after Grantex ships them. | No invented status. |
+| F. Returns/refunds support | Guide support safely. | Refusal/manual handoff now; Grantex-only request/status later. | No refund execution. |
+| G. Protocol display | Show standard capability status. | UCP/ACP/schema.org/AP2 readiness labels from Grantex. | No unsupported compliance claims. |
+| H. Real merchant pilot support | Assist one approved merchant rollout. | Controlled agent workflow and eval evidence. | Separate Grantex rollout approval. |
+
+## 8. Release Acceptance Criteria
+
+Before AgenticOrg can participate in a real merchant pilot:
+
+- Grantex has approved the merchant, capability surface, and rollout scope.
+- AgenticOrg public commerce discovery remains disabled until Grantex read-only
+  discovery is approved.
+- Every commerce tool alias maps to a Grantex API or MCP tool.
+- No commerce code imports or calls direct provider SDKs, Plural, Stripe, Pine,
+  or merchant private checkout APIs.
+- Buyer-facing copy distinguishes "known", "unknown", "stale", "blocked", and
+  "requires consent" states.
+- AgenticOrg evals cover stale inventory, missing consent, denied policy,
+  disabled merchant, unsupported offer, no direct provider call, and no
+  invented refund/delivery/order facts.
+- Evidence reports contain only statuses, synthetic IDs, redacted hashes,
+  blocker codes, and non-secret references.
+- Docs-only PRs skip cloud build/push/deploy-adjacent jobs by policy.
+
+## 9. Public Landing Page Copy Draft
+
+If product/web owners update the AgenticOrg landing page later, use safe
+positioning like this:
+
+> AgenticOrg can demonstrate buyer-side agentic commerce workflows powered by
+> Grantex. Merchants connect their existing systems to Grantex, preview the
+> agent-facing surface, and launch only after explicit approval. AgenticOrg
+> agents use Grantex-approved tools; they do not hold payment credentials or
+> invent prices, stock, discounts, refunds, or delivery promises.
+
+Safe bullets:
+
+- Show merchants how AI agents will discover and explain their products.
+- Demonstrate cart drafting, consent handoff, and checkout status in sandbox.
+- Refuse unsafe or unsupported commerce actions.
+- Keep merchant data, credentials, policy, consent, and audit in Grantex.
+- Keep public discovery gated until Grantex approves it.
+
+Avoid these claims until separately approved:
+
+- "Production commerce enabled."
+- "Live payments ready."
+- "Certified UCP/ACP/AP2 compliant."
+- "Agents can refund customers."
+- "Agents can call merchant systems directly."
+
+## 10. Documentation And Workflow Coverage
+
+| Surface | Required AgenticOrg update |
+| --- | --- |
+| `docs/commerce-agent-overview.md` | Keep architecture, merchant journey, standards fit, and gap summary current. |
+| `docs/commerce-agent-developer-guide.md` | Keep safe extension rules, direct-provider bans, and future alias requirements current. |
+| C5 planning reports | Continue using C5-series docs for implementation slices and evidence packets. |
+| Demo docs | Keep Demo Home Goods Store explicitly synthetic/demo-only. |
+| Evals and regressions | Add tests whenever new commerce aliases or refusal cases are added. |
+| `.github/workflows/deploy.yml` | Preserve docs-only guard so planning merges skip cloud build/push/deploy-adjacent jobs. |
+| Product landing page | Future copy must be reviewed before runtime/UI change and must not imply production readiness. |
+
+## 11. Stop Conditions
+
+Stop AgenticOrg work if any of these occur:
+
+- A direct Stripe, Plural, Pine, provider, or merchant private commerce API path
+  is introduced for commerce execution.
+- AgenticOrg stores provider credentials, raw payment data, Commerce Passport
+  values, JWTs, idempotency keys, webhook secrets, DB/Redis URLs, private keys,
+  or private merchant artifacts.
+- AgenticOrg claims a merchant, protocol, payment provider, checkout, refund, or
+  live path is approved when Grantex has not approved it.
+- AgenticOrg public discovery is enabled before Grantex read-only production
+  discovery is approved.
+- The agent invents seller details, prices, discounts, availability, delivery
+  dates, refund eligibility, order status, or payment status.
+- A docs-only change triggers cloud build/push/deploy-adjacent work without an
+  explicit policy decision.

--- a/docs/commerce-agent-developer-guide.md
+++ b/docs/commerce-agent-developer-guide.md
@@ -145,3 +145,20 @@ When adding commerce behavior:
    new commerce files are added.
 4. Keep all payment-affecting work on Grantex tools.
 5. Update evidence docs only with scrubbed, non-secret summaries.
+
+## Future Commerce Alias Requirements
+
+Do not add new AgenticOrg commerce aliases until the corresponding Grantex
+runtime API, policy gate, audit event, and tests exist. Planned future aliases
+must remain Grantex-only:
+
+| Future area | AgenticOrg behavior before Grantex ships it | Required behavior after Grantex ships it |
+| --- | --- | --- |
+| Order status | Refuse or explain that order status is unavailable. | Read order status through Grantex only. |
+| Fulfillment and shipment | Refuse delivery promises unless Grantex provides verified data. | Read fulfillment, tracking, pickup, and delivery fields through Grantex only. |
+| Returns and refunds | Refuse refund execution and route to merchant support/manual handoff. | Request/read return or refund status through Grantex only, with policy and audit. |
+| Offers, discounts, EMI, rewards | Do not invent promotions or affordability. | Show only Grantex-provided offer metadata and eligibility. |
+| UCP/ACP/schema.org/AP2 readiness | Do not claim compliance or certification. | Display only Grantex-published capability and evidence states. |
+
+See `docs/commerce-agent-agentic-commerce-implementation-prd.md` for the full
+gap register and fast-track plan.

--- a/docs/commerce-agent-developer-guide.md
+++ b/docs/commerce-agent-developer-guide.md
@@ -162,3 +162,27 @@ must remain Grantex-only:
 
 See `docs/commerce-agent-agentic-commerce-implementation-prd.md` for the full
 gap register and fast-track plan.
+
+## Future Channel Adapter Requirements
+
+Buyer channels such as ChatGPT, Claude, Gemini, WhatsApp, Telegram, web/mobile,
+and future agent marketplaces must be implemented as thin AgenticOrg channel
+adapters. They may translate message formats and session identity, but they must
+not implement commerce execution outside Grantex.
+
+Each channel adapter must define:
+
+- channel type and platform capability limits;
+- auth/account-linking model;
+- buyer session creation and resume behavior;
+- message, attachment, locale, currency, and identity normalization;
+- which actions are read-only, consent-required, checkout-capable, or blocked;
+- Grantex-only tool mapping;
+- consent and checkout handoff copy;
+- redacted evidence fields;
+- rate-limit, retry, and human escalation behavior;
+- smoke tests and regression tests.
+
+Do not mark a channel launch-ready until a real user can start from that channel
+without developer setup and the channel has documented fallback behavior when it
+cannot perform write actions.

--- a/docs/commerce-agent-end-to-end-agentic-commerce-flow.md
+++ b/docs/commerce-agent-end-to-end-agentic-commerce-flow.md
@@ -5,6 +5,10 @@ commerce journey in plain English. It is documentation only. It does not enable
 public discovery, production Commerce V1, checkout/payment creation, live
 payments, live Plural, merchant approval, or any production allowlist.
 
+The consolidated cross-repo PRD is maintained in the Grantex repo at
+`docs/guides/commerce-v1-agentic-commerce-prd.md`. This document is the
+AgenticOrg buyer-agent companion view of that PRD.
+
 ## The Simple Mental Model
 
 AgenticOrg is the buyer-agent layer. A buyer can start from a familiar chat

--- a/docs/commerce-agent-end-to-end-agentic-commerce-flow.md
+++ b/docs/commerce-agent-end-to-end-agentic-commerce-flow.md
@@ -1,0 +1,174 @@
+# End-To-End Agentic Commerce Flow
+
+This document explains the AgenticOrg side of the Grantex-powered agentic
+commerce journey in plain English. It is documentation only. It does not enable
+public discovery, production Commerce V1, checkout/payment creation, live
+payments, live Plural, merchant approval, or any production allowlist.
+
+## The Simple Mental Model
+
+AgenticOrg is the buyer-agent layer. A buyer can start from a familiar chat
+surface, such as ChatGPT, Claude, Gemini, WhatsApp, Telegram, a merchant website
+chat widget, or an AgenticOrg-hosted session. AgenticOrg turns that buyer request
+into safe Grantex-only commerce tool calls.
+
+Grantex remains the merchant control plane. It owns merchant identity, catalog,
+inventory, price, policy, consent, Commerce Passport, payment intent, order,
+fulfillment, refund handoff, settlement, audit, and rollback.
+
+```mermaid
+flowchart LR
+  buyer["Buyer"]
+  chat["Chat surface"]
+  adapter["AgenticOrg channel adapter"]
+  session["AgenticOrg buyer-agent session"]
+  aliases["Grantex-only tool aliases"]
+  grantex["Grantex Commerce"]
+  merchant["Merchant systems"]
+
+  buyer --> chat
+  chat --> adapter
+  adapter --> session
+  session --> aliases
+  aliases --> grantex
+  merchant --> grantex
+```
+
+## One-Time Buyer Setup
+
+A buyer should not need to understand MCP, UCP, ACP, AP2, schema.org, Commerce
+Passports, provider adapters, or merchant backends. The one-time buyer setup
+should feel like normal account linking and permission setup.
+
+| Step | Buyer sees | AgenticOrg does | Grantex does |
+| --- | --- | --- | --- |
+| 1. Pick a channel | "Use AgenticOrg in ChatGPT/Claude/Gemini/WhatsApp/Telegram/web." | Starts the correct channel adapter. | Provides approved merchant/tool capability metadata. |
+| 2. Sign in or link account | "Continue with AgenticOrg" or channel-specific account linking. | Creates or resumes a buyer-agent session and binds the channel user to that session. | Does not expose private merchant or provider data. |
+| 3. Set basic preferences | Preferred locale, currency, delivery region, notification path, and optional spending comfort. | Stores only safe session preferences needed for conversation and handoff. | Uses preferences only for policy checks, consent copy, and supported commerce flows. |
+| 4. Understand permissions | Buyer sees that the agent can browse, draft carts, request consent, and hand off checkout only when approved. | Shows channel-specific action labels and limitations. | Provides capability state and blocks unsupported actions. |
+| 5. Payment readiness | Buyer may use a provider wallet, hosted checkout, or approved payment handoff later. | Does not store raw cards, provider credentials, Commerce Passport values, JWTs, or secrets. | Owns consent, Commerce Passport issuance, payment intent, and checkout state. |
+| 6. Revocation and history | Buyer can revoke permissions or ask what happened. | Shows redacted session/evidence status. | Owns revocation, audit evidence, and protected action history. |
+
+Buyer setup is not a blanket authorization. Every payment-affecting action still
+requires fresh Grantex consent and policy approval.
+
+## One-Time Seller Setup
+
+The seller setup happens in Grantex. AgenticOrg should explain and preview it,
+but must not approve the seller or connect directly to private merchant systems.
+
+| Step | Seller does in Grantex | AgenticOrg responsibility |
+| --- | --- | --- |
+| 1. Create merchant workspace | Create tenant, merchant profile, owner roles, sandbox/live split, and category preset. | Explain status labels and show that the merchant is not live yet. |
+| 2. Verify business | Provide private legal/compliance artifacts outside the repo and record non-secret references. | Never display private contracts, contacts, pricing terms, or signed approvals. |
+| 3. Connect existing systems | Connect storefront, catalog, ERP/PIM, inventory/WMS, OMS, logistics, payment provider, and support systems as needed. | Consume only Grantex-approved public-safe capability output. |
+| 4. Prepare catalog | Normalize products, variants, images, price, tax, warranty, return summary, availability, and category data. | Show only grounded product facts returned by Grantex. |
+| 5. Configure permissions | Choose whether agents may browse, draft carts, request checkout, read order status, or request support. | Render those capabilities to buyers only after Grantex approval. |
+| 6. Run scans | Validate secrets, private data, stale inventory, overclaims, production-looking test IDs, and config/allowlist values. | Add refusal/eval coverage for unsafe claims and unsupported actions. |
+| 7. Review gates | Legal, product, security, ops/support, rollback, smoke, and evidence owners approve. | Do not treat demo data or synthetic IDs as approval. |
+| 8. Rehearse launch | Run sandbox/demo flows and confirm rollback, support, and evidence handling. | Provide demo scripts, buyer-agent walkthroughs, and blocked-path examples. |
+| 9. Request rollout | Ask Grantex for the smallest approved surface, usually read-only discovery first. | Keep public discovery gated until Grantex approves the surface. |
+
+## Regular Agentic Commerce Transaction
+
+This is the intended transaction flow after a seller and buyer have completed
+the relevant one-time setup and a specific merchant capability is approved.
+
+```mermaid
+sequenceDiagram
+  participant B as Buyer
+  participant C as Chat surface
+  participant A as AgenticOrg
+  participant G as Grantex
+  participant M as Merchant systems
+  participant P as Provider or checkout handoff
+
+  B->>C: "Find a sofa under my budget"
+  C->>A: Start or resume buyer-agent session
+  A->>G: merchant_get_profile
+  G-->>A: Approved merchant and capability state
+  A->>G: catalog_search / catalog_get_item
+  G->>M: Use synced catalog truth
+  G-->>A: Products, prices, policies, freshness
+  A->>G: inventory_check
+  G-->>A: Availability and stale/unknown warnings
+  A-->>B: Grounded options and caveats
+  B->>A: "Prepare this one"
+  A->>G: cart_create with exact variant IDs
+  G-->>A: Cart draft and totals
+  A-->>B: Consent explanation and checkout handoff
+  B->>G: Approve or deny consent
+  G-->>A: Commerce Passport only if consent and policy pass
+  A->>G: payment_create_intent / checkout_create
+  G->>P: Provider-neutral sandbox/live-approved path
+  P-->>G: Payment status webhook or handoff status
+  G-->>A: Payment/order status
+  A-->>B: Status, next step, or safe refusal
+```
+
+## Normal Happy Path
+
+1. Buyer asks for help in an existing chat interface.
+2. AgenticOrg creates or resumes a buyer-agent session.
+3. AgenticOrg asks Grantex which merchant capabilities are approved for that
+   channel.
+4. AgenticOrg searches catalog and checks inventory through Grantex only.
+5. AgenticOrg explains options with grounded product IDs, prices, stock state,
+   delivery caveats, return summary, and unknowns.
+6. Buyer chooses an item or asks for a comparison.
+7. AgenticOrg creates a cart draft in Grantex using exact variant IDs.
+8. Grantex recalculates totals, policy, amount caps, eligibility, and supported
+   checkout state.
+9. AgenticOrg asks the buyer for consent using Grantex-provided copy.
+10. Buyer approves or denies in the Grantex consent/checkout handoff.
+11. Grantex issues a scoped Commerce Passport only if consent and policy pass.
+12. AgenticOrg asks Grantex to create the payment intent and checkout handoff.
+13. Provider interaction happens through Grantex, not AgenticOrg.
+14. Grantex receives provider webhooks, reconciles status, and writes audit.
+15. AgenticOrg shows buyer-safe status and next steps.
+16. Post-purchase status, fulfillment, support, return, or refund answers come
+    only from Grantex once those APIs exist and are approved.
+
+## Failure And Recovery Paths
+
+| Situation | AgenticOrg must do | Grantex must do |
+| --- | --- | --- |
+| Merchant not approved | Refuse public discovery or checkout and explain that the merchant is not live. | Keep capability fail-closed. |
+| Channel cannot perform write actions | Offer read-only discovery and a safe handoff link. | Publish channel capability limits. |
+| Product not found | Ask clarifying questions or show no-results response. | Return empty grounded search, not guessed products. |
+| Price changed | Re-fetch item/cart, explain changed totals, request buyer confirmation again. | Recalculate and audit the change. |
+| Inventory stale or unknown | Warn or refuse checkout promise. | Provide freshness timestamp and stale/unknown status. |
+| Policy denied | Explain the safe blocker without leaking private policy. | Return blocker code and audit event. |
+| Consent denied or expired | Stop checkout and offer browse/cart edit only. | Revoke or expire passport material. |
+| Payment failed or pending | Show status and next supported step only. | Reconcile provider webhook and expose safe status. |
+| Delivery/fulfillment unavailable | Refuse delivery promise. | Require verified logistics/OMS data before exposing status. |
+| Return/refund requested | Use manual support handoff now; later call Grantex request/status APIs. | Own refund policy, provider handoff, and audit. |
+
+## What AgenticOrg Must Never Do
+
+- Do not call Plural, Stripe, Pine, Shopify, WooCommerce, Magento, ERP, OMS,
+  WMS, logistics, support, or merchant private APIs directly for commerce
+  execution.
+- Do not store provider credentials, raw payment data, Commerce Passport values,
+  JWTs, idempotency key values, webhook secrets, DB/Redis URLs, private keys, or
+  private merchant artifacts.
+- Do not invent products, sellers, prices, discounts, stock, delivery promises,
+  return eligibility, order status, payment status, or refund outcomes.
+- Do not claim a buyer channel is launch-ready until account linking, session
+  creation, Grantex capability discovery, consent handoff, fallback behavior,
+  telemetry, smoke tests, and approval state exist.
+- Do not treat synthetic/demo merchants or synthetic IDs as production approval.
+
+## Implementation Backlog
+
+| Slice | AgenticOrg output | Dependency |
+| --- | --- | --- |
+| Buyer session core | Stable buyer-agent session creation/resume across channels. | AgenticOrg auth/session model. |
+| Web/mobile channel | Hosted buyer-agent session and embeddable merchant link/widget. | Grantex read-only approval. |
+| ChatGPT/Claude channel | Remote MCP connector/app with scopes, action labels, and smoke tests. | Platform approval plus Grantex capabilities. |
+| Gemini channel | Function-calling wrapper or approved native launch path. | Gemini platform design and Grantex capabilities. |
+| WhatsApp/Telegram channel | Bot/webhook adapters, identity mapping, opt-out, consent links. | Channel credentials and webhook secret handling outside Git. |
+| Buyer UX | Grounded comparison, cart draft, consent copy, checkout status, refusal copy. | Grantex catalog/cart/consent/payment APIs. |
+| Post-purchase UX | Order/fulfillment/support/return/refund status display. | Grantex order, fulfillment, support, and refund APIs. |
+| Merchant demo UX | Demo launch rehearsal and blocked-path explanations. | Grantex merchant onboarding/readiness docs. |
+| Evals | Regression tests for no invention, stale data, policy denial, direct-provider attempts, and unsafe claims. | New channel and Grantex capability slices. |

--- a/docs/commerce-agent-overview.md
+++ b/docs/commerce-agent-overview.md
@@ -9,6 +9,11 @@ This page is documentation only. It does not deploy, change production config,
 enable production Commerce V1, enable live payments, enable live Plural, or
 approve production discovery.
 
+For the full implementation gap plan, read
+`docs/commerce-agent-agentic-commerce-implementation-prd.md`. That companion
+PRD maps the current AgenticOrg implementation to the merchant self-serve gaps
+that Grantex must close before real merchant launch.
+
 ## Current Posture
 
 | Area | Status |
@@ -95,6 +100,11 @@ Grantex closing these gaps first:
 - Live provider approval, webhook signature verification, reconciliation, and
   rollback readiness.
 - UCP/ACP/schema.org adapter generation from one canonical Grantex model.
+- Order, fulfillment, delivery/pickup, cancellation, support, return, refund,
+  settlement, and payout surfaces that agents can read without inventing facts.
+- Product/landing copy that explains "agentic commerce readiness" without
+  implying public discovery, checkout, payment, live provider, or certification
+  approval.
 
 Until those gaps close, AgenticOrg must refuse to invent sellers, products,
 prices, discounts, delivery promises, return promises, checkout status, or
@@ -169,6 +179,7 @@ gate for production until Grantex read-only production discovery is approved.
 
 ## Evidence Links
 
+- `docs/commerce-agent-agentic-commerce-implementation-prd.md`
 - `docs/reports/commerce-agent-real-staging-evidence.md`
 - `docs/reports/commerce-agent-hosted-smoke-evidence.md`
 - `docs/reports/commerce-agent-production-discovery-readiness.md`

--- a/docs/commerce-agent-overview.md
+++ b/docs/commerce-agent-overview.md
@@ -14,6 +14,11 @@ For the full implementation gap plan, read
 PRD maps the current AgenticOrg implementation to the merchant self-serve gaps
 that Grantex must close before real merchant launch.
 
+The consolidated cross-repo PRD is maintained in the Grantex repo at
+`docs/guides/commerce-v1-agentic-commerce-prd.md`. AgenticOrg docs should treat
+that file as the product source of truth and this repo's docs as the buyer-agent
+execution companion.
+
 For a plain-language buyer and seller walkthrough, read
 `docs/commerce-agent-end-to-end-agentic-commerce-flow.md`. It explains what a
 buyer does once, what a seller does once in Grantex, and how a normal agentic

--- a/docs/commerce-agent-overview.md
+++ b/docs/commerce-agent-overview.md
@@ -14,6 +14,11 @@ For the full implementation gap plan, read
 PRD maps the current AgenticOrg implementation to the merchant self-serve gaps
 that Grantex must close before real merchant launch.
 
+For a plain-language buyer and seller walkthrough, read
+`docs/commerce-agent-end-to-end-agentic-commerce-flow.md`. It explains what a
+buyer does once, what a seller does once in Grantex, and how a normal agentic
+commerce transaction should work end to end.
+
 ## Current Posture
 
 | Area | Status |
@@ -66,6 +71,25 @@ layer, not the merchant system of record. If a merchant already uses Shopify,
 WooCommerce, Magento, a custom store, an ERP, an OMS, a WMS, a payment provider,
 or a support desk, those systems should connect to Grantex. AgenticOrg should
 receive only the Grantex-approved, public-safe, policy-checked view.
+
+## End-To-End Flow
+
+The operational flow is:
+
+1. Seller completes one-time setup in Grantex: workspace, verification,
+   connected systems, catalog, inventory, policy, payment path, approvals,
+   smoke evidence, and rollback ownership.
+2. Buyer completes one-time setup in their preferred channel: account/session
+   linking, safe preferences, and understanding that checkout requires Grantex
+   consent.
+3. Buyer asks the agent to find, compare, or buy.
+4. AgenticOrg calls only Grantex aliases for merchant profile, catalog,
+   inventory, cart, consent, payment intent, checkout, and status.
+5. Grantex enforces source-of-truth, policy, consent, Commerce Passport,
+   provider handoff, audit, order/fulfillment state, support/refund handoff, and
+   rollback.
+6. AgenticOrg explains the result to the buyer and refuses anything Grantex has
+   not approved or cannot verify.
 
 ## Buyer Agent Launch Surfaces
 

--- a/docs/commerce-agent-overview.md
+++ b/docs/commerce-agent-overview.md
@@ -40,6 +40,66 @@ AgenticOrg does not own catalog truth, consent grants, Commerce Passport
 issuance, merchant policy enforcement, provider credentials, provider webhooks,
 or payment reconciliation. Those controls stay in Grantex.
 
+## Merchant Self-Serve Journey
+
+For merchants, the intended product experience should be simple:
+
+1. The merchant signs up in Grantex Commerce.
+2. The merchant connects an existing store, catalog, ERP, inventory, OMS,
+   payment provider, or support system.
+3. Grantex normalizes that data into safe merchant profile, catalog, inventory,
+   policy, consent, checkout, order, audit, and protocol-publishing records.
+4. The merchant previews exactly what an AI agent can see.
+5. The merchant chooses which actions agents may request, such as browse,
+   cart draft, checkout request, order status, or support handoff.
+6. Grantex runs validation scans and review gates.
+7. AgenticOrg agents use only the approved Grantex tools.
+8. Live discovery or checkout is enabled only after a separate approved rollout.
+
+AgenticOrg should feel like the buyer-facing assistant and merchant-facing demo
+layer, not the merchant system of record. If a merchant already uses Shopify,
+WooCommerce, Magento, a custom store, an ERP, an OMS, a WMS, a payment provider,
+or a support desk, those systems should connect to Grantex. AgenticOrg should
+receive only the Grantex-approved, public-safe, policy-checked view.
+
+## Standards And Protocol Fit
+
+AgenticOrg should be ready to work with the standards ecosystem without claiming
+unsupported certification:
+
+| Surface | How AgenticOrg should use it |
+| --- | --- |
+| Native Grantex tools | Primary integration path for merchant profile, catalog, inventory, cart, consent, payment intent, checkout, and payment status. |
+| MCP | Agent tool surface for safe commerce actions backed by Grantex policy and audit. |
+| UCP | Future capability discovery and shopping capability mapping. AgenticOrg should consume Grantex-published UCP-style profiles only after Grantex approves them. |
+| ACP | Future checkout/session compatibility. AgenticOrg may render checkout state, but Grantex remains the seller/control-plane endpoint. |
+| AP2 | Future signed checkout/payment mandate evidence. AgenticOrg may present mandate status only when Grantex provides deterministic evidence. |
+| schema.org | Public product, offer, shipping, and return-policy metadata generated from Grantex-approved merchant data. |
+
+Do not claim UCP, ACP, AP2, A2A, or live-provider compliance unless the
+corresponding Grantex implementation, conformance tests, approvals, and rollout
+evidence exist.
+
+## Pending Gaps Before Real Merchant Launch
+
+AgenticOrg can demo the buyer-agent journey, but real merchant launch depends on
+Grantex closing these gaps first:
+
+- Self-serve merchant onboarding and approval workflow.
+- Existing-system connectors for catalog, inventory, orders, fulfillment,
+  payment status, and support.
+- Hardened large catalog import jobs.
+- Fresh inventory, stock holds, and delivery/pickup promise handling.
+- Production order, fulfillment, shipment, cancellation, and return status APIs.
+- Refund/return request workflow before any refund execution.
+- Live provider approval, webhook signature verification, reconciliation, and
+  rollback readiness.
+- UCP/ACP/schema.org adapter generation from one canonical Grantex model.
+
+Until those gaps close, AgenticOrg must refuse to invent sellers, products,
+prices, discounts, delivery promises, return promises, checkout status, or
+payment status.
+
 ## Tool Aliases
 
 | Alias | Purpose |

--- a/docs/commerce-agent-overview.md
+++ b/docs/commerce-agent-overview.md
@@ -67,6 +67,26 @@ WooCommerce, Magento, a custom store, an ERP, an OMS, a WMS, a payment provider,
 or a support desk, those systems should connect to Grantex. AgenticOrg should
 receive only the Grantex-approved, public-safe, policy-checked view.
 
+## Buyer Agent Launch Surfaces
+
+The buyer agent must be easy to start from the places buyers already chat. The
+current implementation does not yet make every surface launch-ready; this is a
+tracked PRD gap.
+
+| Surface | Intended launch model | Current readiness posture |
+| --- | --- | --- |
+| ChatGPT | Custom app/remote MCP backed by Grantex-only tools. | Planned; must respect ChatGPT app approval, action controls, and current write-action limits. |
+| Claude | Remote MCP connector backed by Grantex-only tools. | Planned; must include auth, scopes, and smoke evidence. |
+| Gemini | AgenticOrg-hosted Gemini API/function-calling wrapper or approved future native channel. | Planned; native consumer Gemini launch support must not be claimed until available and approved. |
+| WhatsApp | WhatsApp Business Platform bot/webhook adapter. | Planned; requires WABA, phone number, templates, opt-out, webhook, and consent-link handling. |
+| Telegram | Telegram Bot API webhook adapter. | Planned; requires bot token, webhook secret validation, chat identity mapping, and consent-link handling. |
+| Web/mobile | AgenticOrg-hosted buyer-agent session or embedded merchant widget. | Best first controllable channel after Grantex approval. |
+
+Every channel must create or resume a buyer-agent session, call only Grantex
+commerce aliases, show clear consent/checkout handoff, and fall back to
+read-only discovery when the platform or approval state does not allow write
+actions.
+
 ## Standards And Protocol Fit
 
 AgenticOrg should be ready to work with the standards ecosystem without claiming


### PR DESCRIPTION
## Summary
- Updates the Commerce Sales Agent overview with the merchant self-serve journey and standards fit.
- Clarifies how AgenticOrg should use Grantex-approved data and avoid direct merchant/provider calls.
- Lists the remaining Grantex-dependent gaps before real merchant launch.

## Validation
- `git diff --check`
- Focused diff scan for secrets/private details
- Focused diff scan for overclaims
- Focused diff scan for merchant IDs/names and production-candidate language
- Focused diff scan for production config/allowlist assignments

## Safety
Docs only. No runtime code, config, cloud resources, deploy, secrets, Commerce V1 enablement, public discovery enablement, checkout/payment enablement, live payments, or live Plural changes.