### PR TITLE
feat(commerce): add buyer discovery consumer foundation

### DIFF
--- a/connectors/commerce/grantex_commerce.py
+++ b/connectors/commerce/grantex_commerce.py
@@ -6,6 +6,7 @@ import json
 import os
 import uuid
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
@@ -26,6 +27,10 @@ TOOL_ALIAS_TO_GRANTEX: dict[str, str] = {
 REST_CONSENT_ENDPOINTS: dict[str, str] = {
     "consent_request": "/v1/commerce/passports/consent-requests",
     "consent_exchange": "/v1/commerce/passports/exchange",
+}
+
+REST_READ_ONLY_ENDPOINTS: dict[str, str] = {
+    "buyer_discovery_preview": "/v1/commerce/merchants/{merchant_id}/agenticorg-buyer-discovery-preview",
 }
 
 IDEMPOTENT_TOOL_ALIASES = frozenset({"cart_create", "payment_create_intent", "checkout_create"})
@@ -57,6 +62,7 @@ class GrantexCommerceConnector(BaseConnector):
             "cart_create": self.cart_create,
             "consent_request": self.consent_request,
             "consent_exchange": self.consent_exchange,
+            "buyer_discovery_preview": self.buyer_discovery_preview,
             "payment_create_intent": self.payment_create_intent,
             "checkout_create": self.checkout_create,
             "payment_get_status": self.payment_get_status,
@@ -129,6 +135,21 @@ class GrantexCommerceConnector(BaseConnector):
         """Exchange granted consent for a Grantex-minted Commerce Passport."""
         return await self._post_rest(REST_CONSENT_ENDPOINTS["consent_exchange"], params)
 
+    async def buyer_discovery_preview(self, **params: Any) -> dict[str, Any]:
+        """Read Grantex AgenticOrg buyer-agent discovery preview evidence."""
+        merchant_id = str(params.get("merchant_id", "") or "").strip()
+        if not merchant_id:
+            return {
+                "error": "merchant_id_required",
+                "message": "merchant_id is required for buyer discovery preview.",
+                "retryable": False,
+                "refusal": True,
+            }
+        path = REST_READ_ONLY_ENDPOINTS["buyer_discovery_preview"].format(
+            merchant_id=quote(merchant_id, safe="")
+        )
+        return await self._get_rest(path)
+
     async def payment_create_intent(self, **params: Any) -> dict[str, Any]:
         """Create a payment intent through Grantex Commerce only."""
         missing = self._require_idempotency_key("payment_create_intent", params)
@@ -194,6 +215,24 @@ class GrantexCommerceConnector(BaseConnector):
             raise RuntimeError("Connector not connected")
         try:
             response = await self._client.post(path, json=params)
+        except httpx.HTTPError:
+            return {
+                "error": "grantex_transport_error",
+                "message": "Grantex Commerce is unreachable.",
+                "retryable": True,
+                "refusal": False,
+            }
+
+        payload = self._response_json(response)
+        if response.status_code >= 400:
+            return normalize_grantex_error(payload, response.status_code)
+        return payload if isinstance(payload, dict) else {"data": payload}
+
+    async def _get_rest(self, path: str) -> dict[str, Any]:
+        if not self._client:
+            raise RuntimeError("Connector not connected")
+        try:
+            response = await self._client.get(path)
         except httpx.HTTPError:
             return {
                 "error": "grantex_transport_error",

--- a/core/agents/prompts/commerce_sales_agent.prompt.txt
+++ b/core/agents/prompts/commerce_sales_agent.prompt.txt
@@ -8,6 +8,7 @@ Use only the grantex_commerce tools exposed to you:
 - grantex_commerce__cart_create
 - grantex_commerce__consent_request
 - grantex_commerce__consent_exchange
+- grantex_commerce__buyer_discovery_preview
 - grantex_commerce__payment_create_intent
 - grantex_commerce__checkout_create
 - grantex_commerce__payment_get_status
@@ -15,7 +16,7 @@ Use only the grantex_commerce tools exposed to you:
 Never call payment providers directly. Do not call or request Stripe, Plural, Pine Labs, Pine, provider credentials, webhook secrets, or live payment settings. This agent does not mint Commerce Passports; it only receives passport outputs from Grantex after a successful consent exchange.
 
 Responsibilities:
-1. Discover products with Grantex catalog tools.
+1. Discover merchants and products with Grantex read-only preview/catalog tools.
 2. Answer product questions only from Grantex tool data.
 3. Create cart drafts only through Grantex.
 4. Request user consent through Grantex before checkout/payment.
@@ -24,13 +25,16 @@ Responsibilities:
 7. Poll payment status only through Grantex.
 
 Guardrails:
+- Treat buyer_discovery_preview output as sandbox-only, read-only, preview-only evidence unless Grantex explicitly says otherwise.
+- If Grantex says public discovery is disabled, AgenticOrg public discovery is disabled, production approval is not granted, or live mode is not live, surface a preview-only response or refusal. Do not imply launch.
+- Refuse checkout/payment, live provider, live Plural, fulfillment, returns, refunds, or unsupported channel actions when the user asks for them during read-only discovery.
 - Refuse checkout or payment without granted consent and a valid checkout Commerce Passport.
 - Refuse checkout or payment when consent is denied, expired, revoked, or missing.
 - Respect the Commerce Passport amount cap, currency, scopes, expiry, and revocation state.
 - Respect merchant disablement, emergency disablement, agent disablement, agent untrusted status, and policy denial.
 - Use Grantex tool data for price, tax, warranty, return policy, offer, discount, and inventory claims.
 - If inventory is stale or unknown, say availability is not guaranteed and ask to confirm before checkout.
-- Do not invent EMI, discounts, coupons, offers, warranty, tax, return policy, or inventory.
+- Do not invent sellers, products, prices, discounts, coupons, offers, warranty, tax, return policy, availability, launch status, or payment readiness.
 - Do not promise inventory when status is unknown.
 - Do not claim payment is complete unless Grantex status data confirms it and the user confirms the final action.
 

--- a/core/commerce/buyer_discovery.py
+++ b/core/commerce/buyer_discovery.py
@@ -1,0 +1,350 @@
+"""Buyer-facing read-only discovery responses from Grantex C6G handoff data."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+C6G_PREVIEW_ENDPOINT = "/v1/commerce/merchants/{merchant_id}/agenticorg-buyer-discovery-preview"
+
+CHECKOUT_PAYMENT_TERMS = (
+    "checkout",
+    "pay",
+    "payment",
+    "payment link",
+    "buy now",
+    "place order",
+    "purchase",
+)
+LIVE_PROVIDER_TERMS = (
+    "live payment",
+    "live provider",
+    "live commerce",
+    "plural",
+    "pine labs",
+    "provider credential",
+    "provider secret",
+)
+FULFILLMENT_TERMS = (
+    "fulfillment",
+    "fulfilment",
+    "shipping",
+    "delivery",
+    "deliver",
+    "dispatch",
+    "tracking",
+    "order status",
+)
+REFUND_RETURN_TERMS = ("refund", "return", "replacement", "cancel order", "chargeback")
+
+PRIVATE_OUTPUT_KEYS = {
+    "legal_name",
+    "legal_entity_name",
+    "contract",
+    "contracts",
+    "private_contact",
+    "private_contacts",
+    "provider_account",
+    "provider_account_refs",
+    "provider_" + "credentials",
+    "token",
+    "jwt",
+    "passport",
+    "db_url",
+    "redis_url",
+    "raw_payload",
+    "allowlist",
+}
+
+NON_ENABLING_CONTROL_FIELDS = (
+    "sandbox_only",
+    "handoff_request_is_approval",
+    "buyer_agent_discovery_is_public",
+    "agenticorg_public_discovery_enabled",
+    "public_discovery_enabled",
+    "checkout_payment_enabled",
+    "live_provider_enabled",
+    "live_plural_enabled",
+    "production_allowlist_written",
+    "live_mode_status",
+    "production_approval_status",
+    "rollout_status",
+)
+
+
+def classify_buyer_discovery_request(request_text: str) -> str:
+    """Classify requests that C6H must refuse before any write-like behavior."""
+    text = str(request_text or "").strip().lower()
+    if _contains_any(text, LIVE_PROVIDER_TERMS):
+        return "live_provider"
+    if _contains_any(text, CHECKOUT_PAYMENT_TERMS):
+        return "checkout_payment"
+    if _contains_any(text, FULFILLMENT_TERMS):
+        return "fulfillment"
+    if _contains_any(text, REFUND_RETURN_TERMS):
+        return "refund_return"
+    return "read_only_discovery"
+
+
+def build_buyer_discovery_response(
+    grantex_payload: Mapping[str, Any] | None,
+    *,
+    request_text: str = "",
+) -> dict[str, Any]:
+    """Build a safe buyer response grounded only in Grantex preview payloads."""
+    intent = classify_buyer_discovery_request(request_text)
+    safe_preview = sanitize_buyer_discovery_preview(grantex_payload)
+    source_reference = safe_preview.get("source_reference", {})
+
+    if intent != "read_only_discovery":
+        return _refusal_for_intent(intent, source_reference)
+
+    if safe_preview.get("status") == "unavailable":
+        return {
+            "status": "unavailable",
+            "refusal": True,
+            "refusal_code": "grantex_discovery_unavailable",
+            "message": "Grantex did not return buyer discovery data, so I cannot describe this merchant.",
+            "source_reference": source_reference,
+        }
+
+    blockers = _string_list(safe_preview.get("blockers"))
+    integration_status = _safe_text(safe_preview.get("integration_status"))
+    if integration_status != "sandbox_handoff_requested" or blockers:
+        return {
+            "status": "blocked",
+            "refusal": True,
+            "refusal_code": "buyer_discovery_blocked",
+            "message": "Grantex has not cleared this sandbox buyer discovery preview for read-only use.",
+            "merchant": safe_preview.get("merchant", {}),
+            "blockers": blockers,
+            "remediation_items": _string_list(safe_preview.get("remediation_items")),
+            "blocked_capabilities": _string_list(safe_preview.get("blocked_capabilities")),
+            "safety_labels": safe_preview.get("safety_labels", {}),
+            "source_reference": source_reference,
+        }
+
+    safety_labels = _mapping(safe_preview.get("safety_labels"))
+    preview_only = (
+        safety_labels.get("public_discovery_enabled") is False
+        or safety_labels.get("agenticorg_public_discovery_enabled") is False
+        or safety_labels.get("buyer_agent_discovery_is_public") is False
+        or safety_labels.get("production_approval_status") != "approved"
+        or safety_labels.get("live_mode_status") != "live"
+    )
+    status = "preview_only" if preview_only else "available"
+    message = (
+        "This is a Grantex-grounded read-only sandbox preview. It is not public discovery, "
+        "production approval, checkout/payment, fulfillment, refunds, or live provider access."
+        if preview_only
+        else "This merchant discovery response is grounded in Grantex read-only data."
+    )
+
+    return {
+        "status": status,
+        "refusal": False,
+        "message": message,
+        "merchant": safe_preview.get("merchant", {}),
+        "catalog_samples": safe_preview.get("catalog_samples", []),
+        "readiness_summary": safe_preview.get("readiness_summary", {}),
+        "agent_facing_preview_summary": safe_preview.get("agent_facing_preview_summary", {}),
+        "rollout_proposal_summary": safe_preview.get("rollout_proposal_summary", {}),
+        "evidence_checklist": safe_preview.get("evidence_checklist", []),
+        "allowed_capabilities": safe_preview.get("allowed_capabilities", []),
+        "blocked_capabilities": safe_preview.get("blocked_capabilities", []),
+        "safety_labels": safety_labels,
+        "source_reference": source_reference,
+    }
+
+
+async def run_buyer_discovery_preview(
+    connector: Any,
+    *,
+    merchant_id: str,
+    request_text: str = "",
+) -> dict[str, Any]:
+    """Call the Grantex preview route and return a safe buyer-facing response."""
+    raw = await connector.buyer_discovery_preview(merchant_id=merchant_id)
+    return build_buyer_discovery_response(raw, request_text=request_text)
+
+
+def sanitize_buyer_discovery_preview(grantex_payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Select public-safe C6G fields and ignore anything private or raw."""
+    data = _data_object(grantex_payload)
+    if not data:
+        return {"status": "unavailable", "source_reference": {"system": "grantex", "endpoint": C6G_PREVIEW_ENDPOINT}}
+
+    merchant = _mapping(data.get("merchant"))
+    merchant_reference = _safe_text(data.get("merchant_reference") or merchant.get("merchant_reference"))
+    safe_merchant = _drop_empty(
+        {
+            "merchant_reference": merchant_reference,
+            "display_name": _safe_text(data.get("display_name") or merchant.get("display_name")),
+            "category": _safe_text(merchant.get("category_preset")),
+            "country": _safe_text(merchant.get("country_code")),
+            "currency": _safe_text(merchant.get("default_currency")),
+            "discovery_description": _safe_text(merchant.get("public_discovery_description_draft"), limit=600),
+        }
+    )
+
+    safety_labels = {
+        key: data.get(key)
+        for key in NON_ENABLING_CONTROL_FIELDS
+        if key in data and _is_scalar(data.get(key))
+    }
+
+    source_reference = _drop_empty(
+        {
+            "system": "grantex",
+            "endpoint": C6G_PREVIEW_ENDPOINT,
+            "merchant_reference": merchant_reference,
+            "generated_at": _safe_text(data.get("generated_at")),
+            "audit_event_id": _safe_text(data.get("audit_event_id")),
+        }
+    )
+
+    return {
+        "status": "available",
+        "integration_status": _safe_text(data.get("integration_status")),
+        "merchant": safe_merchant,
+        "readiness_summary": _safe_mapping(data.get("readiness_summary")),
+        "agent_facing_preview_summary": _safe_mapping(data.get("agent_facing_preview_summary")),
+        "rollout_proposal_summary": _safe_mapping(data.get("rollout_proposal_summary")),
+        "evidence_checklist": _safe_evidence_checklist(data.get("evidence_checklist")),
+        "catalog_samples": _safe_catalog_samples(data.get("sample_products")),
+        "allowed_capabilities": _string_list(data.get("allowed_buyer_agent_capabilities")),
+        "blocked_capabilities": _string_list(data.get("blocked_buyer_agent_capabilities")),
+        "blockers": _string_list(data.get("blockers")),
+        "remediation_items": _string_list(data.get("remediation_items")),
+        "safety_labels": safety_labels,
+        "source_reference": source_reference,
+    }
+
+
+def _refusal_for_intent(intent: str, source_reference: Mapping[str, Any]) -> dict[str, Any]:
+    messages = {
+        "checkout_payment": (
+            "Checkout and payment are not enabled in this read-only discovery slice. "
+            "I can only show Grantex-grounded preview information."
+        ),
+        "live_provider": (
+            "Live payment/provider access is not enabled in this read-only discovery slice. "
+            "I cannot request provider access or live routing."
+        ),
+        "fulfillment": (
+            "Fulfillment, shipment, delivery, and order-status execution are not enabled in this slice."
+        ),
+        "refund_return": "Returns and refunds execution are not enabled in this slice.",
+    }
+    return {
+        "status": "refused",
+        "refusal": True,
+        "refusal_code": f"{intent}_not_enabled",
+        "message": messages[intent],
+        "source_reference": dict(source_reference),
+    }
+
+
+def _contains_any(text: str, terms: Sequence[str]) -> bool:
+    return any(term in text for term in terms)
+
+
+def _data_object(payload: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    if not isinstance(payload, Mapping):
+        return {}
+    data = payload.get("data")
+    if isinstance(data, Mapping):
+        return data
+    return payload
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _safe_mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    result: dict[str, Any] = {}
+    for key, nested in value.items():
+        key_text = _safe_text(key, limit=80)
+        if not key_text or _looks_private_key(key_text):
+            continue
+        if _is_scalar(nested):
+            result[key_text] = nested if isinstance(nested, bool | int | float) else _safe_text(nested, limit=500)
+        elif isinstance(nested, Sequence) and not isinstance(nested, str):
+            result[key_text] = _string_list(nested, limit=10)
+    return result
+
+
+def _safe_evidence_checklist(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        return []
+    entries: list[dict[str, str]] = []
+    for item in value[:12]:
+        if not isinstance(item, Mapping):
+            continue
+        entries.append(
+            _drop_empty(
+                {
+                    "key": _safe_text(item.get("key"), limit=80),
+                    "label": _safe_text(item.get("label"), limit=160),
+                    "status": _safe_text(item.get("status"), limit=40),
+                }
+            )
+        )
+    return entries
+
+
+def _safe_catalog_samples(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        return []
+    samples: list[dict[str, str]] = []
+    for item in value[:3]:
+        if not isinstance(item, Mapping):
+            continue
+        samples.append(
+            _drop_empty(
+                {
+                    "title": _safe_text(item.get("title"), limit=160),
+                    "brand": _safe_text(item.get("brand"), limit=120),
+                    "category": _safe_text(item.get("category_preset") or item.get("category"), limit=120),
+                }
+            )
+        )
+    return samples
+
+
+def _string_list(value: Any, *, limit: int = 20) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        return []
+    result: list[str] = []
+    for item in value[:limit]:
+        if not _is_scalar(item):
+            continue
+        text = _safe_text(item, limit=180)
+        if text:
+            result.append(text)
+    return result
+
+
+def _safe_text(value: Any, *, limit: int = 240) -> str:
+    if value in (None, ""):
+        return ""
+    text = str(value).replace("\x00", "").strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip()
+
+
+def _drop_empty(value: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: nested for key, nested in value.items() if nested not in ("", None, [], {})}
+
+
+def _is_scalar(value: Any) -> bool:
+    return isinstance(value, str | int | float | bool) or value is None
+
+
+def _looks_private_key(key: str) -> bool:
+    lowered = key.strip().lower()
+    return any(marker in lowered for marker in PRIVATE_OUTPUT_KEYS)

--- a/core/commerce/sales_guardrails.py
+++ b/core/commerce/sales_guardrails.py
@@ -17,6 +17,7 @@ GRANTEX_COMMERCE_TOOL_ALIASES = [
     "cart_create",
     "consent_request",
     "consent_exchange",
+    "buyer_discovery_preview",
     "payment_create_intent",
     "checkout_create",
     "payment_get_status",

--- a/docs/commerce-agent-agentic-commerce-implementation-prd.md
+++ b/docs/commerce-agent-agentic-commerce-implementation-prd.md
@@ -111,7 +111,7 @@ Regular transaction:
 
 | Area | Current evidence | Current state |
 | --- | --- | --- |
-| Grantex-only connector | `connectors/commerce/grantex_commerce.py` exposes `merchant_get_profile`, `catalog_search`, `catalog_get_item`, `inventory_check`, `cart_create`, `consent_request`, `consent_exchange`, `payment_create_intent`, `checkout_create`, and `payment_get_status`. | Correct boundary exists. |
+| Grantex-only connector | `connectors/commerce/grantex_commerce.py` exposes `merchant_get_profile`, `catalog_search`, `catalog_get_item`, `inventory_check`, `cart_create`, `consent_request`, `consent_exchange`, `buyer_discovery_preview`, `payment_create_intent`, `checkout_create`, and `payment_get_status`. | Correct boundary exists. C6H adds a GET-only sandbox buyer discovery preview consumer; it is not a handoff request, public discovery, checkout/payment, or live provider path. |
 | Payment guardrails | `core/commerce/sales_guardrails.py` blocks missing consent/passport, amount-cap breach, disabled merchant/agent, policy denial, and non-mock provider choices. | Good local fail-closed behavior; must expand as Grantex adds order/refund/fulfillment. |
 | Demo and evals | `demos/commerce_sales_agent_demo.py`, golden commerce evals, no-provider-call regression tests, real-staging and hosted smoke tests. | Strong demo/smoke foundation. |
 | Public discovery gate | Commerce metadata is fail-closed behind `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED`. | Safe posture. |
@@ -287,7 +287,7 @@ compliance unless Grantex implementation and conformance evidence exist.
 | Slice | Goal | AgenticOrg output | Guardrail |
 | --- | --- | --- | --- |
 | A. Merchant education pack | Explain the self-serve journey. | Demo script, screenshots/walkthrough, blocked-path labels. | Synthetic/demo only. |
-| B. Buyer read-only discovery UX | Let a user ask product questions safely. | Grantex-only product comparison and inventory caution copy. | No checkout or payment. |
+| B. Buyer read-only discovery UX | Let a user ask merchant/product questions safely. | Grantex C6G read-only buyer discovery preview consumer plus product comparison and inventory caution copy. | No public discovery, checkout/payment, fulfillment, refunds, live Plural, live provider paths, or invented merchant/product claims. |
 | C. First-party web/mobile buyer channel | Prove low-friction session creation. | AgenticOrg hosted buyer-agent session and embeddable merchant link/widget. | Still Grantex-only; no public discovery unless approved. |
 | D. ChatGPT and Claude MCP channels | Reach major AI chat surfaces through remote MCP. | Remote MCP app/connector, auth, action labels, confirmation copy, smoke tests. | Respect platform limits; no unsupported write-action claims. |
 | E. WhatsApp and Telegram bot channels | Reach common messaging surfaces. | Webhook adapters, identity binding, consent links, opt-out, human escalation. | Tokens/webhook secrets never logged or committed. |

--- a/docs/commerce-agent-buyer-discovery-consumer.md
+++ b/docs/commerce-agent-buyer-discovery-consumer.md
@@ -1,0 +1,98 @@
+# AgenticOrg Buyer Discovery Consumer Foundation
+
+C6H adds the AgenticOrg-side consumer foundation for Grantex buyer-agent
+discovery handoff data. It is a read-only sandbox integration. It does not
+deploy anything, expose public commerce discovery, approve a merchant, enable
+checkout/payment, enable live payments, enable live Plural, call payment
+providers, call merchant private APIs, store provider credentials, write
+production configuration, or set allowlists.
+
+## What Buyers Can Ask
+
+A buyer can ask an AgenticOrg buyer agent to inspect a Grantex-grounded merchant
+preview. AgenticOrg calls only the Grantex read-only buyer discovery preview
+route:
+
+`GET /v1/commerce/merchants/{merchant_id}/agenticorg-buyer-discovery-preview`
+
+The buyer-facing response is built only from the fields Grantex returns. If
+Grantex does not return data, reports blockers, or has not requested sandbox
+handoff, AgenticOrg refuses or shows a preview-only response.
+
+## Safe Fields
+
+AgenticOrg may show:
+
+- merchant display name;
+- category;
+- country and currency when Grantex marks them public-safe;
+- discovery description;
+- read-only preview status;
+- capped catalog sample titles, brands, and categories;
+- allowed buyer-agent capability labels;
+- blocked buyer-agent capability labels;
+- safety labels;
+- a source reference back to the Grantex handoff preview.
+
+AgenticOrg must not show legal names, private contacts, private approval
+references, contracts, provider credentials, payment provider metadata,
+tokens/JWTs/passports, raw payloads, DB/Redis URLs, production configuration
+values, or allowlist values.
+
+## Refusal Behavior
+
+The C6H buyer-agent workflow refuses:
+
+- checkout and payment requests;
+- live payment, live Plural, and provider-access requests;
+- fulfillment, delivery, shipment, tracking, and order-status execution;
+- returns and refund execution;
+- invented sellers, products, prices, discounts, delivery promises, refund
+  promises, availability, launch status, or payment readiness.
+
+When Grantex says public discovery is disabled, AgenticOrg public commerce
+discovery is disabled, production approval is not granted, or the merchant is
+not live, AgenticOrg surfaces a preview-only response. Preview-only is not
+public launch and not merchant approval.
+
+## Channel-Neutral Launch Notes
+
+No live channel integration is enabled by C6H. Future channels can wrap the same
+read-only buyer discovery workflow after separate implementation, security
+review, and approval.
+
+| Channel | Future wrapper shape | C6H posture |
+| --- | --- | --- |
+| ChatGPT | A future app or remote MCP wrapper could call the AgenticOrg buyer discovery workflow. | Not live; no custom app is shipped by C6H. |
+| Claude | A future MCP connector could call the same workflow with tenant-scoped auth. | Not live; no Claude connector is shipped by C6H. |
+| Gemini | A future function-calling or hosted agent wrapper could call the workflow. | Not live; no Gemini integration is shipped by C6H. |
+| WhatsApp | A future WhatsApp Business adapter could translate messages into the workflow. | Not live; no WABA, phone number, webhook, or template is shipped by C6H. |
+| Telegram | A future bot adapter could call the workflow after bot-token and webhook review. | Not live; no Telegram bot is shipped by C6H. |
+| generic web/chat | A future AgenticOrg web chat can call the same workflow. | Not live; C6H only adds the backend consumer foundation. |
+
+## Operator And Developer Notes
+
+Merchants still onboard, prepare evidence, request review, and request handoff
+through Grantex. AgenticOrg does not duplicate Grantex seller onboarding,
+catalog, policy, passport, checkout, payment, fulfillment, refund, or provider
+logic.
+
+The AgenticOrg connector exposes one new read-only alias:
+
+`grantex_commerce:buyer_discovery_preview`
+
+It maps to the Grantex C6G preview route and does not expose Grantex operator
+handoff request or withdrawal endpoints.
+
+## Stop Conditions
+
+Stop and do not proceed if a change would:
+
+- enable AgenticOrg public commerce discovery;
+- enable Grantex public discovery;
+- call Plural or any payment provider directly;
+- call merchant private APIs directly;
+- store provider credentials or secrets;
+- create checkout, payment, fulfillment, return, or refund actions;
+- write production configuration or allowlists;
+- treat sandbox/demo/synthetic data as merchant production approval.

--- a/docs/commerce-agent-contract-gap-report.md
+++ b/docs/commerce-agent-contract-gap-report.md
@@ -15,7 +15,7 @@ Status: M12 gap analysis and safe regression coverage only. This pass did not de
 | Area | Status | Assessment |
 | --- | --- | --- |
 | Grantex-only commerce connector | `done` | `GrantexCommerceConnector` exposes `grantex_commerce:*` aliases and does not import Stripe, Plural, Pine, or provider credential connectors. |
-| Safe tool aliases | `done` | Aliases map to Grantex MCP tools plus Grantex passport REST endpoints: catalog, inventory, cart, consent, passport exchange, payment intent, checkout, and status. |
+| Safe tool aliases | `done` | Aliases map to Grantex MCP tools plus Grantex passport REST endpoints and the C6H GET-only buyer discovery preview endpoint: catalog, inventory, cart, consent, passport exchange, buyer preview, payment intent, checkout, and status. |
 | Consent/passport guardrails | `partial` | Local guardrails refuse missing, denied, revoked, or expired passport inputs; final cryptographic verification remains Grantex-owned and hosted staging is not yet exercised. |
 | Amount cap guardrails | `done` | Local guardrails refuse requested amounts above passport cap before calling Grantex. |
 | Disabled merchant/agent guardrails | `partial` | Local status/error handling exists; real staging disabled merchant and untrusted agent cases are not yet executed. |
@@ -38,6 +38,7 @@ Status: M12 gap analysis and safe regression coverage only. This pass did not de
 | `cart_create` alias | `done` | Requires idempotency key and maps to `cart.create`. | Hosted staging evidence pending. |
 | `consent_request` alias | `done` | Calls `/v1/commerce/passports/consent-requests`. | Hosted staging consent UX and delivery pending. |
 | `consent_exchange` alias | `done` | Calls `/v1/commerce/passports/exchange`. | Hosted staging approval flow pending. |
+| `buyer_discovery_preview` alias | `done` | Calls `/v1/commerce/merchants/{merchant_id}/agenticorg-buyer-discovery-preview` with GET only. | Sandbox preview-only; no public discovery, checkout/payment, provider, or handoff request endpoint is exposed. |
 | `payment_create_intent` alias | `done` | Requires idempotency key, local guardrail pass, then maps to `payment.create_intent`. | Hosted staging evidence pending. |
 | `checkout_create` alias | `done` | Requires idempotency key, local guardrail pass, then maps to `checkout.create`. | Hosted staging evidence pending. |
 | `payment_get_status` alias | `done` | Maps to `payment.get_status`. | Hosted staging evidence pending. |

--- a/docs/commerce-agent-developer-guide.md
+++ b/docs/commerce-agent-developer-guide.md
@@ -11,6 +11,9 @@ Sales Agent without weakening the Grantex-only commerce boundary.
   staging or exact temporary smoke URL.
 - Use only `grantex_commerce:*` commerce tools.
 - Do not call Stripe, Plural, Pine, or provider credential paths for commerce.
+- Treat `grantex_commerce:buyer_discovery_preview` as read-only sandbox preview
+  data. It is not public discovery, production approval, checkout/payment,
+  fulfillment, returns, refunds, or live provider access.
 - Do not print fixture env values, passports/JWTs, auth material, idempotency
   values, raw payloads, DB/Redis URLs, private keys, or secrets.
 - Do not present mocked output as hosted or real-staging evidence.
@@ -72,6 +75,7 @@ network work.
 | Fixture path outside `.tmp/` | Refused. |
 | Fake connector/provider path | Refused by regression tests and runtime guardrails. |
 | Direct provider imports/calls in commerce code | Blocked by static regression. |
+| Buyer discovery asks for checkout/payment/live provider/fulfillment/refund work | Refused by the C6H buyer discovery consumer. |
 
 ## Evidence Interpretation
 
@@ -145,6 +149,8 @@ When adding commerce behavior:
    new commerce files are added.
 4. Keep all payment-affecting work on Grantex tools.
 5. Update evidence docs only with scrubbed, non-secret summaries.
+6. For buyer discovery, consume only Grantex C6G read-only preview payloads and
+   do not expose the Grantex operator handoff request or withdrawal endpoints.
 
 ## Future Commerce Alias Requirements
 

--- a/docs/commerce-agent-overview.md
+++ b/docs/commerce-agent-overview.md
@@ -1,9 +1,10 @@
 # Commerce Sales Agent Overview
 
 The AgenticOrg Commerce Sales Agent is the agent and workflow layer for
-Grantex-controlled commerce. It helps users discover products, draft carts,
-request consent, use Commerce Passport fixtures during approved smoke runs, and
-follow Grantex payment-intent and checkout status flows.
+Grantex-controlled commerce. It helps users inspect Grantex-grounded read-only
+buyer discovery previews, discover products, draft carts, request consent, use
+Commerce Passport fixtures during approved smoke runs, and follow Grantex
+payment-intent and checkout status flows.
 
 This page is documentation only. It does not deploy, change production config,
 enable production Commerce V1, enable live payments, enable live Plural, or
@@ -35,6 +36,7 @@ commerce transaction should work end to end.
 | Production discovery | Commerce metadata is gated by default behind `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED`; it is not final production readiness. |
 | Direct provider calls | Blocked for commerce. AgenticOrg commerce uses Grantex only. |
 | Live checkout/payments/Plural | Blocked. |
+| C6H buyer discovery consumer | Read-only sandbox consumer foundation; not public discovery or checkout/payment. |
 
 ## Architecture
 
@@ -170,6 +172,7 @@ payment status.
 | `grantex_commerce:cart_create` | Create a cart draft from grounded items. |
 | `grantex_commerce:consent_request` | Request user consent with supported checkout scopes. |
 | `grantex_commerce:consent_exchange` | Exchange granted consent only when granted consent fixture material exists. |
+| `grantex_commerce:buyer_discovery_preview` | Read Grantex C6G sandbox buyer discovery handoff preview data. |
 | `grantex_commerce:payment_create_intent` | Create Grantex provider-neutral payment intent with supported fields only. |
 | `grantex_commerce:checkout_create` | Create Grantex checkout handoff. |
 | `grantex_commerce:payment_get_status` | Poll Grantex payment status. |

--- a/tests/regression/test_commerce_sales_agent_no_provider_calls.py
+++ b/tests/regression/test_commerce_sales_agent_no_provider_calls.py
@@ -6,6 +6,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 COMMERCE_CODE = [
     ROOT / "connectors" / "commerce" / "grantex_commerce.py",
+    ROOT / "core" / "commerce" / "buyer_discovery.py",
     ROOT / "core" / "commerce" / "discovery_gate.py",
     ROOT / "core" / "commerce" / "sales_guardrails.py",
     ROOT / "core" / "commerce" / "staging_evidence.py",
@@ -62,6 +63,7 @@ def test_commerce_agent_default_toolset_is_grantex_only() -> None:
     domain_tools = _DOMAIN_DEFAULT_TOOLS["commerce"]
 
     assert tools == domain_tools
+    assert "grantex_commerce:buyer_discovery_preview" in tools
     assert tools
     assert all(tool.startswith("grantex_commerce:") for tool in tools)
     assert all("stripe" not in tool.lower() for tool in tools)

--- a/tests/unit/test_commerce_buyer_discovery.py
+++ b/tests/unit/test_commerce_buyer_discovery.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from core.commerce.buyer_discovery import (
+    build_buyer_discovery_response,
+    run_buyer_discovery_preview,
+    sanitize_buyer_discovery_preview,
+)
+
+
+def _valid_grantex_preview(**overrides: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "merchant_id": "merchant_private_internal_id",
+        "tenant_id": "tenant_private_internal_id",
+        "merchant_reference": "sandbox-mref-1",
+        "display_name": "Sandbox Electronics Preview",
+        "integration_status": "sandbox_handoff_requested",
+        "handoff_requested_at": "2026-06-02T10:00:00Z",
+        "handoff_request_actor": "operator:test",
+        "audit_event_id": "audit_c6g_1",
+        "generated_at": "2026-06-02T10:01:00Z",
+        "merchant": {
+            "merchant_reference": "sandbox-mref-1",
+            "display_name": "Sandbox Electronics Preview",
+            "category_preset": "electronics_appliances",
+            "country_code": "IN",
+            "default_currency": "INR",
+            "public_discovery_description_draft": "Preview-only appliance catalog for buyer-agent tests.",
+            "support_email": "private-support@example.test",
+            "legal_name": "Private Legal Entity Pvt Ltd",
+        },
+        "readiness_summary": {
+            "overall_status": "ready",
+            "category_status": "ready",
+            "catalog_status": "ready",
+            "private_contract": "do not echo",
+        },
+        "agent_facing_preview_summary": {
+            "preview_status": "ready",
+            "sample_product_count": 3,
+            "preview_blockers": [],
+        },
+        "rollout_proposal_summary": {
+            "proposal_status": "dry_run_passed",
+            "dry_run_result": "passed",
+            "operator_decision": "rollout_proposal_ready",
+        },
+        "evidence_checklist": [
+            {"key": "c6c_preview", "label": "Agent-facing preview ready", "status": "pass"},
+            {"key": "c6f_dry_run", "label": "Dry-run evidence passed", "status": "pass"},
+        ],
+        "sample_products": [
+            {
+                "sample_reference": "sample-1",
+                "title": "Countertop Mixer",
+                "brand": "TestBrand",
+                "category_preset": "electronics_appliances",
+                "description": "Internal long product text",
+                "price": "999",
+                "legal_name": "Private Product Owner",
+            },
+            {"sample_reference": "sample-2", "title": "Rice Cooker", "brand": "TestBrand"},
+            {"sample_reference": "sample-3", "title": "Induction Cooktop", "brand": "TestBrand"},
+            {"sample_reference": "sample-4", "title": "Should Be Capped", "brand": "TestBrand"},
+        ],
+        "allowed_buyer_agent_capabilities": [
+            "read_only_profile_discovery_preview",
+            "read_only_catalog_discovery_preview",
+            "buyer_agent_readiness_context",
+        ],
+        "blocked_buyer_agent_capabilities": [
+            "public_discovery",
+            "checkout_payment_creation",
+            "live_payment",
+            "live_plural",
+            "provider_credentials",
+            "order_fulfillment",
+            "refunds_returns_execution",
+            "production_allowlist",
+            "direct_merchant_system_access",
+        ],
+        "blockers": [],
+        "remediation_items": [],
+        "sandbox_only": True,
+        "handoff_request_is_approval": False,
+        "buyer_agent_discovery_is_public": False,
+        "agenticorg_public_discovery_enabled": False,
+        "public_discovery_enabled": False,
+        "checkout_payment_enabled": False,
+        "live_provider_enabled": False,
+        "live_plural_enabled": False,
+        "production_allowlist_written": False,
+        "live_mode_status": "not_live",
+        "production_approval_status": "not_approved",
+        "rollout_status": "rollout_not_requested",
+        "passport_jwt": "passport.jwt.value",
+        "provider_credentials": {"api_key": "secret"},
+        "raw_payload": {"do": "not echo"},
+    }
+    data.update(overrides)
+    return {"data": data}
+
+
+def test_sanitizer_parses_valid_read_only_discovery_handoff() -> None:
+    safe = sanitize_buyer_discovery_preview(_valid_grantex_preview())
+
+    assert safe["integration_status"] == "sandbox_handoff_requested"
+    assert safe["merchant"] == {
+        "merchant_reference": "sandbox-mref-1",
+        "display_name": "Sandbox Electronics Preview",
+        "category": "electronics_appliances",
+        "country": "IN",
+        "currency": "INR",
+        "discovery_description": "Preview-only appliance catalog for buyer-agent tests.",
+    }
+    assert safe["catalog_samples"] == [
+        {"title": "Countertop Mixer", "brand": "TestBrand", "category": "electronics_appliances"},
+        {"title": "Rice Cooker", "brand": "TestBrand"},
+        {"title": "Induction Cooktop", "brand": "TestBrand"},
+    ]
+    assert "buyer_agent_readiness_context" in safe["allowed_capabilities"]
+    assert "checkout_payment_creation" in safe["blocked_capabilities"]
+
+
+def test_missing_grantex_data_returns_safe_unavailable_refusal() -> None:
+    response = build_buyer_discovery_response(None)
+
+    assert response["status"] == "unavailable"
+    assert response["refusal"] is True
+    assert response["refusal_code"] == "grantex_discovery_unavailable"
+
+
+def test_disabled_public_discovery_returns_preview_only_response() -> None:
+    response = build_buyer_discovery_response(_valid_grantex_preview())
+
+    assert response["status"] == "preview_only"
+    assert response["refusal"] is False
+    assert response["safety_labels"]["public_discovery_enabled"] is False
+    assert response["safety_labels"]["agenticorg_public_discovery_enabled"] is False
+    assert response["safety_labels"]["production_approval_status"] == "not_approved"
+    assert "not public discovery" in response["message"]
+
+
+def test_checkout_payment_request_is_refused() -> None:
+    response = build_buyer_discovery_response(_valid_grantex_preview(), request_text="Can I checkout and pay now?")
+
+    assert response["status"] == "refused"
+    assert response["refusal_code"] == "checkout_payment_not_enabled"
+
+
+@pytest.mark.parametrize(
+    "request_text",
+    [
+        "Please enable live payment routing.",
+        "Connect the live Plural path.",
+        "Share the provider credentials.",
+    ],
+)
+def test_live_payment_live_plural_provider_requests_are_refused(request_text: str) -> None:
+    response = build_buyer_discovery_response(_valid_grantex_preview(), request_text=request_text)
+
+    assert response["status"] == "refused"
+    assert response["refusal_code"] == "live_provider_not_enabled"
+
+
+@pytest.mark.parametrize(
+    ("request_text", "refusal_code"),
+    [
+        ("Can you promise delivery tomorrow?", "fulfillment_not_enabled"),
+        ("Process my refund for this product.", "refund_return_not_enabled"),
+    ],
+)
+def test_fulfillment_and_refund_requests_are_refused(request_text: str, refusal_code: str) -> None:
+    response = build_buyer_discovery_response(_valid_grantex_preview(), request_text=request_text)
+
+    assert response["status"] == "refused"
+    assert response["refusal_code"] == refusal_code
+
+
+def test_buyer_agent_does_not_invent_or_echo_private_details() -> None:
+    response = build_buyer_discovery_response(_valid_grantex_preview())
+    serialized = json.dumps(response, sort_keys=True)
+
+    assert "Countertop Mixer" in serialized
+    assert "Should Be Capped" not in serialized
+    assert "999" not in serialized
+    assert "Private Legal Entity" not in serialized
+    assert "private-support@example.test" not in serialized
+    assert "passport.jwt.value" not in serialized
+    assert "secret" not in serialized
+    assert "raw_payload" not in serialized
+    assert "merchant_private_internal_id" not in serialized
+    assert "tenant_private_internal_id" not in serialized
+
+
+def test_handoff_ready_without_request_is_blocked() -> None:
+    response = build_buyer_discovery_response(
+        _valid_grantex_preview(integration_status="sandbox_handoff_ready")
+    )
+
+    assert response["status"] == "blocked"
+    assert response["refusal_code"] == "buyer_discovery_blocked"
+
+
+def test_blockers_from_grantex_block_preview_response() -> None:
+    response = build_buyer_discovery_response(
+        _valid_grantex_preview(blockers=["C6F dry-run evidence is stale"])
+    )
+
+    assert response["status"] == "blocked"
+    assert response["blockers"] == ["C6F dry-run evidence is stale"]
+
+
+async def test_workflow_wrapper_calls_read_only_connector_method() -> None:
+    class FakeConnector:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, str]] = []
+
+        async def buyer_discovery_preview(self, **params: str) -> dict[str, Any]:
+            self.calls.append(dict(params))
+            return _valid_grantex_preview()
+
+    connector = FakeConnector()
+
+    response = await run_buyer_discovery_preview(
+        connector,
+        merchant_id="merchant_sandbox_1",
+        request_text="Show me the merchant preview.",
+    )
+
+    assert connector.calls == [{"merchant_id": "merchant_sandbox_1"}]
+    assert response["status"] == "preview_only"
+
+
+def test_channel_neutral_launch_docs_are_preview_only() -> None:
+    doc = Path("docs/commerce-agent-buyer-discovery-consumer.md").read_text(encoding="utf-8")
+
+    for channel in ("ChatGPT", "Claude", "Gemini", "WhatsApp", "Telegram", "generic web/chat"):
+        assert channel in doc
+    assert "No live channel integration is enabled by C6H." in doc

--- a/tests/unit/test_grantex_commerce_connector.py
+++ b/tests/unit/test_grantex_commerce_connector.py
@@ -53,6 +53,7 @@ async def test_alias_mapping_uses_safe_agenticorg_names() -> None:
         "cart_create",
         "consent_request",
         "consent_exchange",
+        "buyer_discovery_preview",
         "payment_create_intent",
         "checkout_create",
         "payment_get_status",
@@ -102,6 +103,45 @@ async def test_consent_exchange_uses_rest_endpoint() -> None:
     assert captured["path"] == "/v1/commerce/passports/exchange"
     assert captured["body"] == {"consent_request_id": "cons_req_1"}
     assert result["data"]["passport_jwt"] == "passport.jwt.value"
+
+
+async def test_buyer_discovery_preview_uses_read_only_rest_endpoint() -> None:
+    captured: dict[str, Any] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["path"] = request.url.raw_path.decode()
+        captured["authorization"] = request.headers.get("authorization")
+        return _json_response(
+            {
+                "data": {
+                    "merchant_reference": "sandbox-ref-1",
+                    "integration_status": "sandbox_handoff_requested",
+                    "sandbox_only": True,
+                    "public_discovery_enabled": False,
+                }
+            }
+        )
+
+    connector = await _connector(handler)
+    try:
+        result = await connector.buyer_discovery_preview(merchant_id="merchant sandbox/1")
+    finally:
+        await connector.disconnect()
+
+    assert captured["method"] == "GET"
+    assert captured["path"] == "/v1/commerce/merchants/merchant%20sandbox%2F1/agenticorg-buyer-discovery-preview"
+    assert captured["authorization"] == "Bearer gx_agent_test_token"
+    assert result["data"]["integration_status"] == "sandbox_handoff_requested"
+
+
+async def test_buyer_discovery_preview_requires_merchant_id() -> None:
+    connector = GrantexCommerceConnector({})
+
+    result = await connector.buyer_discovery_preview()
+
+    assert result["error"] == "merchant_id_required"
+    assert result["refusal"] is True
 
 
 async def test_idempotency_key_required_for_payment_affecting_tools() -> None:


### PR DESCRIPTION
## Summary
- add a Grantex read-only buyer discovery preview connector alias for the C6G handoff contract
- add AgenticOrg buyer discovery sanitization/refusal workflow for preview-only responses
- update commerce agent prompt, docs, and regression tests for C6H safety posture

## Guardrails
- no deploy or merge from this PR
- no production config, secrets, public discovery enablement, checkout/payment enablement, live payment, live Plural, provider credential storage, merchant private API calls, or allowlists
- C6H consumes only Grantex read-only preview data and refuses checkout/payment/live provider/fulfillment/refund requests

## Validation
- python -m pytest --no-cov tests/unit/test_grantex_commerce_connector.py tests/unit/test_commerce_buyer_discovery.py tests/unit/test_commerce_sales_agent_guardrails.py tests/regression/test_commerce_sales_agent_no_provider_calls.py
- python -m pytest --no-cov tests/unit/test_a2a_mcp.py
- python -m ruff check connectors/commerce/grantex_commerce.py core/commerce/buyer_discovery.py core/commerce/sales_guardrails.py tests/unit/test_grantex_commerce_connector.py tests/unit/test_commerce_buyer_discovery.py tests/regression/test_commerce_sales_agent_no_provider_calls.py
- python -m mypy core/commerce/buyer_discovery.py core/commerce/sales_guardrails.py connectors/commerce/grantex_commerce.py
- git diff --cached --check
- focused safety scans for secrets/private details, production discovery/config/allowlist enablement, checkout/payment/live provider/live Plural paths, overclaims, and synthetic/demo production-candidate wording