### PR TITLE
[codex] feat(commerce): add buyer discovery session orchestration

### DIFF
--- a/core/agents/prompts/commerce_sales_agent.prompt.txt
+++ b/core/agents/prompts/commerce_sales_agent.prompt.txt
@@ -16,16 +16,18 @@ Use only the grantex_commerce tools exposed to you:
 Never call payment providers directly. Do not call or request Stripe, Plural, Pine Labs, Pine, provider credentials, webhook secrets, or live payment settings. This agent does not mint Commerce Passports; it only receives passport outputs from Grantex after a successful consent exchange.
 
 Responsibilities:
-1. Discover merchants and products with Grantex read-only preview/catalog tools.
-2. Answer product questions only from Grantex tool data.
-3. Create cart drafts only through Grantex.
-4. Request user consent through Grantex before checkout/payment.
-5. Exchange granted consent for a Grantex Commerce Passport.
-6. Create payment intents and checkout handoff only through Grantex.
-7. Poll payment status only through Grantex.
+1. Start buyer discovery with the AgenticOrg buyer discovery session workflow around `buyer_discovery_preview`; use the channel-neutral session response as the buyer-facing contract.
+2. Discover merchants and products with Grantex read-only preview/catalog tools.
+3. Answer product questions only from Grantex tool data.
+4. Create cart drafts only through Grantex.
+5. Request user consent through Grantex before checkout/payment.
+6. Exchange granted consent for a Grantex Commerce Passport.
+7. Create payment intents and checkout handoff only through Grantex.
+8. Poll payment status only through Grantex.
 
 Guardrails:
 - Treat buyer_discovery_preview output as sandbox-only, read-only, preview-only evidence unless Grantex explicitly says otherwise.
+- Buyer discovery session responses must be channel-neutral JSON that includes status, message, merchant_preview, catalog_samples, allowed_capabilities, blocked_capabilities, source_reference, refusal_code, and evidence_summary.
 - If Grantex says public discovery is disabled, AgenticOrg public discovery is disabled, production approval is not granted, or live mode is not live, surface a preview-only response or refusal. Do not imply launch.
 - Refuse checkout/payment, live provider, live Plural, fulfillment, returns, refunds, or unsupported channel actions when the user asks for them during read-only discovery.
 - Refuse checkout or payment without granted consent and a valid checkout Commerce Passport.

--- a/core/commerce/buyer_discovery.py
+++ b/core/commerce/buyer_discovery.py
@@ -28,6 +28,7 @@ LIVE_PROVIDER_TERMS = (
 FULFILLMENT_TERMS = (
     "fulfillment",
     "fulfilment",
+    "ship",
     "shipping",
     "delivery",
     "deliver",
@@ -170,6 +171,9 @@ async def run_buyer_discovery_preview(
 
 def sanitize_buyer_discovery_preview(grantex_payload: Mapping[str, Any] | None) -> dict[str, Any]:
     """Select public-safe C6G fields and ignore anything private or raw."""
+    if isinstance(grantex_payload, Mapping) and grantex_payload.get("error") and not grantex_payload.get("data"):
+        return {"status": "unavailable", "source_reference": {"system": "grantex", "endpoint": C6G_PREVIEW_ENDPOINT}}
+
     data = _data_object(grantex_payload)
     if not data:
         return {"status": "unavailable", "source_reference": {"system": "grantex", "endpoint": C6G_PREVIEW_ENDPOINT}}

--- a/core/commerce/buyer_session.py
+++ b/core/commerce/buyer_session.py
@@ -1,0 +1,309 @@
+"""Channel-neutral buyer discovery session orchestration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from core.commerce.buyer_discovery import (
+    C6G_PREVIEW_ENDPOINT,
+    CHECKOUT_PAYMENT_TERMS,
+    FULFILLMENT_TERMS,
+    LIVE_PROVIDER_TERMS,
+    REFUND_RETURN_TERMS,
+    build_buyer_discovery_response,
+)
+
+BUYER_SESSION_CONTRACT = "agenticorg.commerce.buyer_discovery_session.v1"
+
+READ_ONLY_DISCOVERY_TERMS = (
+    "merchant",
+    "seller",
+    "store",
+    "catalog",
+    "catalogue",
+    "product",
+    "products",
+    "item",
+    "items",
+    "preview",
+    "discover",
+    "discovery",
+    "show",
+    "search",
+    "browse",
+    "compare",
+    "detail",
+    "details",
+    "brand",
+    "category",
+    "price",
+    "inventory",
+    "availability",
+)
+
+CHANNEL_NEUTRAL_TARGETS = (
+    "chatgpt",
+    "claude",
+    "gemini",
+    "whatsapp",
+    "telegram",
+    "web_chat",
+    "future_channel",
+)
+
+READ_ONLY_ALLOWED_CAPABILITIES = (
+    "read_only_profile_discovery_preview",
+    "read_only_catalog_discovery_preview",
+    "buyer_agent_readiness_context",
+)
+
+BLOCKED_CAPABILITIES_BY_INTENT = {
+    "checkout_payment": (
+        "checkout_payment_creation",
+        "cart_checkout_handoff",
+        "payment_intent_creation",
+        "live_payment",
+    ),
+    "live_provider": (
+        "live_provider_access",
+        "live_plural",
+        "provider_credential_access",
+        "provider_private_api",
+    ),
+    "fulfillment": (
+        "order_fulfillment",
+        "shipping_delivery",
+        "dispatch_tracking",
+        "order_status_execution",
+    ),
+    "refund_return": (
+        "refunds_returns_execution",
+        "replacement_execution",
+        "chargeback_execution",
+    ),
+    "unsupported": ("unsupported_non_discovery_request",),
+}
+
+
+def classify_buyer_session_intent(request_text: str) -> str:
+    """Classify buyer intent before any Grantex call or side-effect path."""
+    text = str(request_text or "").strip().lower()
+    if _contains_any(text, LIVE_PROVIDER_TERMS):
+        return "live_provider"
+    if _contains_any(text, CHECKOUT_PAYMENT_TERMS):
+        return "checkout_payment"
+    if _contains_any(text, FULFILLMENT_TERMS):
+        return "fulfillment"
+    if _contains_any(text, REFUND_RETURN_TERMS):
+        return "refund_return"
+    if not text or _contains_any(text, READ_ONLY_DISCOVERY_TERMS):
+        return "read_only_discovery"
+    return "unsupported"
+
+
+async def start_buyer_discovery_session(
+    connector: Any,
+    *,
+    merchant_id: str,
+    request_text: str = "",
+    channel: str = "future_channel",
+) -> dict[str, Any]:
+    """Start a safe read-only buyer session around Grantex preview data."""
+    intent = classify_buyer_session_intent(request_text)
+    if intent != "read_only_discovery":
+        return _channel_response(
+            _intent_refusal(intent),
+            intent=intent,
+            channel=channel,
+            grantex_call_status="not_attempted",
+        )
+
+    raw = await connector.buyer_discovery_preview(merchant_id=merchant_id)
+    response = build_buyer_discovery_response(raw, request_text=request_text)
+    return _channel_response(
+        response,
+        intent=intent,
+        channel=channel,
+        grantex_call_status="completed",
+    )
+
+
+def build_channel_neutral_buyer_response(
+    grantex_payload: Mapping[str, Any] | None,
+    *,
+    request_text: str = "",
+    channel: str = "future_channel",
+) -> dict[str, Any]:
+    """Build the session response shape from an already fetched Grantex payload."""
+    intent = classify_buyer_session_intent(request_text)
+    response = (
+        build_buyer_discovery_response(grantex_payload, request_text=request_text)
+        if intent == "read_only_discovery"
+        else _intent_refusal(intent)
+    )
+    return _channel_response(
+        response,
+        intent=intent,
+        channel=channel,
+        grantex_call_status="completed" if intent == "read_only_discovery" else "not_attempted",
+    )
+
+
+def _intent_refusal(intent: str) -> dict[str, Any]:
+    messages = {
+        "checkout_payment": (
+            "Checkout and payment are blocked in this read-only buyer discovery session. "
+            "I can only show Grantex-grounded preview information."
+        ),
+        "live_provider": (
+            "Live providers, live Plural, provider credentials, and provider APIs are blocked in this session."
+        ),
+        "fulfillment": (
+            "Fulfillment, shipping, delivery, dispatch, tracking, and order-status execution are blocked here."
+        ),
+        "refund_return": "Refund, return, replacement, and chargeback execution are blocked here.",
+        "unsupported": "This buyer session only supports Grantex-grounded read-only merchant and catalog discovery.",
+    }
+    return {
+        "status": "refused",
+        "refusal": True,
+        "refusal_code": f"{intent}_not_enabled",
+        "message": messages[intent],
+        "allowed_capabilities": list(READ_ONLY_ALLOWED_CAPABILITIES),
+        "blocked_capabilities": list(BLOCKED_CAPABILITIES_BY_INTENT[intent]),
+        "source_reference": _default_source_reference(),
+    }
+
+
+def _channel_response(
+    response: Mapping[str, Any],
+    *,
+    intent: str,
+    channel: str,
+    grantex_call_status: str,
+) -> dict[str, Any]:
+    return {
+        "contract": BUYER_SESSION_CONTRACT,
+        "channel": _safe_channel(channel),
+        "channel_neutral": True,
+        "supported_channel_targets": list(CHANNEL_NEUTRAL_TARGETS),
+        "intent": intent,
+        "status": _safe_text(response.get("status") or "refused"),
+        "message": _safe_text(response.get("message"), limit=800),
+        "merchant_preview": _mapping(response.get("merchant")),
+        "catalog_samples": _safe_list_of_mappings(response.get("catalog_samples")),
+        "allowed_capabilities": _string_list(
+            response.get("allowed_capabilities") or READ_ONLY_ALLOWED_CAPABILITIES
+        ),
+        "blocked_capabilities": _string_list(response.get("blocked_capabilities")),
+        "source_reference": _mapping(response.get("source_reference")) or _default_source_reference(),
+        "refusal_code": _safe_refusal_code(response.get("refusal_code")),
+        "evidence_summary": _evidence_summary(
+            response,
+            intent=intent,
+            grantex_call_status=grantex_call_status,
+        ),
+    }
+
+
+def _evidence_summary(
+    response: Mapping[str, Any],
+    *,
+    intent: str,
+    grantex_call_status: str,
+) -> dict[str, Any]:
+    status = _safe_text(response.get("status") or "refused")
+    safety_labels = _mapping(response.get("safety_labels"))
+    summary: dict[str, Any] = {
+        "intent": intent,
+        "grantex_call_status": grantex_call_status,
+        "grantex_grounded": grantex_call_status == "completed" and intent == "read_only_discovery",
+        "read_only": True,
+        "preview_only": status in {"preview_only", "blocked", "unavailable", "refused"},
+        "non_enabling": True,
+    }
+
+    if response.get("refusal_code"):
+        summary["refusal_code"] = _safe_refusal_code(response.get("refusal_code"))
+    if safety_labels:
+        summary["safety_labels"] = safety_labels
+    for source_key, target_key in (
+        ("readiness_summary", "readiness"),
+        ("agent_facing_preview_summary", "agent_preview"),
+        ("rollout_proposal_summary", "rollout"),
+    ):
+        value = _mapping(response.get(source_key))
+        if value:
+            summary[target_key] = value
+    checklist = _safe_list_of_mappings(response.get("evidence_checklist"))
+    if checklist:
+        summary["evidence_checklist"] = checklist
+    return summary
+
+
+def _default_source_reference() -> dict[str, str]:
+    return {
+        "system": "grantex",
+        "endpoint": C6G_PREVIEW_ENDPOINT,
+    }
+
+
+def _contains_any(text: str, terms: Sequence[str]) -> bool:
+    return any(term in text for term in terms)
+
+
+def _safe_channel(channel: str) -> str:
+    value = _safe_text(channel, limit=60).lower().replace("-", "_").replace(" ", "_")
+    return value or "future_channel"
+
+
+def _safe_refusal_code(value: Any) -> str | None:
+    text = _safe_text(value, limit=120)
+    return text or None
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): nested for key, nested in value.items() if _is_safe_value(nested)}
+
+
+def _safe_list_of_mappings(value: Any, *, limit: int = 20) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        return []
+    result: list[dict[str, Any]] = []
+    for item in value[:limit]:
+        if isinstance(item, Mapping):
+            result.append(_mapping(item))
+    return result
+
+
+def _string_list(value: Any, *, limit: int = 20) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        return []
+    result: list[str] = []
+    for item in value[:limit]:
+        text = _safe_text(item, limit=180)
+        if text:
+            result.append(text)
+    return result
+
+
+def _safe_text(value: Any, *, limit: int = 240) -> str:
+    if value in (None, ""):
+        return ""
+    text = str(value).replace("\x00", "").strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip()
+
+
+def _is_safe_value(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(_safe_text(value))
+    if isinstance(value, int | float | bool):
+        return True
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return all(isinstance(item, str | int | float | bool) for item in value)
+    return False

--- a/docs/commerce-agent-buyer-discovery-consumer.md
+++ b/docs/commerce-agent-buyer-discovery-consumer.md
@@ -19,6 +19,18 @@ The buyer-facing response is built only from the fields Grantex returns. If
 Grantex does not return data, reports blockers, or has not requested sandbox
 handoff, AgenticOrg refuses or shows a preview-only response.
 
+C6I adds a buyer discovery session wrapper around that route. The wrapper first
+classifies intent as read-only discovery, checkout/payment, live provider,
+fulfillment, refund/return, or unsupported. Only read-only discovery proceeds to
+the Grantex preview call. Blocked intents return a refusal without calling a
+provider, merchant private API, checkout, payment, fulfillment, or refund path.
+
+The session response is channel-neutral for ChatGPT, Claude, Gemini, WhatsApp,
+Telegram, web chat, and future channels. Every response includes `status`,
+`message`, `merchant_preview`, `catalog_samples`, `allowed_capabilities`,
+`blocked_capabilities`, `source_reference`, `refusal_code`, and
+`evidence_summary`.
+
 ## Safe Fields
 
 AgenticOrg may show:
@@ -83,6 +95,19 @@ The AgenticOrg connector exposes one new read-only alias:
 
 It maps to the Grantex C6G preview route and does not expose Grantex operator
 handoff request or withdrawal endpoints.
+
+Application and channel adapters should call
+`core.commerce.buyer_session.start_buyer_discovery_session(...)` instead of
+formatting the raw preview directly. The session wrapper keeps the response
+shape stable and prevents checkout/payment/live-provider/fulfillment/refund
+requests from reaching any non-read-only path.
+
+## Rollback Notes
+
+Rollback is code-only: remove or disable usage of the C6I session wrapper and
+return callers to the C6H read-only consumer. No production config, public
+discovery flag, allowlist, provider credential, checkout/payment, fulfillment,
+refund, or merchant-system state is changed by this slice.
 
 ## Stop Conditions
 

--- a/docs/commerce-agent-developer-guide.md
+++ b/docs/commerce-agent-developer-guide.md
@@ -14,6 +14,10 @@ Sales Agent without weakening the Grantex-only commerce boundary.
 - Treat `grantex_commerce:buyer_discovery_preview` as read-only sandbox preview
   data. It is not public discovery, production approval, checkout/payment,
   fulfillment, returns, refunds, or live provider access.
+- Use `core.commerce.buyer_session.start_buyer_discovery_session(...)` for
+  buyer-facing discovery. It returns the channel-neutral C6I response contract
+  for ChatGPT, Claude, Gemini, WhatsApp, Telegram, web chat, and future channel
+  wrappers.
 - Do not print fixture env values, passports/JWTs, auth material, idempotency
   values, raw payloads, DB/Redis URLs, private keys, or secrets.
 - Do not present mocked output as hosted or real-staging evidence.
@@ -75,7 +79,8 @@ network work.
 | Fixture path outside `.tmp/` | Refused. |
 | Fake connector/provider path | Refused by regression tests and runtime guardrails. |
 | Direct provider imports/calls in commerce code | Blocked by static regression. |
-| Buyer discovery asks for checkout/payment/live provider/fulfillment/refund work | Refused by the C6H buyer discovery consumer. |
+| Buyer discovery asks for checkout/payment/live provider/fulfillment/refund work | Refused by the C6I buyer discovery session wrapper before any non-read-only path. |
+| Buyer discovery asks for unrelated unsupported work | Refused by the C6I buyer discovery session wrapper. |
 
 ## Evidence Interpretation
 
@@ -151,6 +156,13 @@ When adding commerce behavior:
 5. Update evidence docs only with scrubbed, non-secret summaries.
 6. For buyer discovery, consume only Grantex C6G read-only preview payloads and
    do not expose the Grantex operator handoff request or withdrawal endpoints.
+
+## C6I Rollback
+
+C6I adds only local AgenticOrg orchestration, prompt, docs, and tests. Roll back
+by reverting the buyer session wrapper usage. No production config, public
+discovery setting, allowlist, provider credential, checkout/payment state,
+fulfillment state, refund state, or merchant private API integration is changed.
 
 ## Future Commerce Alias Requirements
 

--- a/docs/commerce-agent-overview.md
+++ b/docs/commerce-agent-overview.md
@@ -34,6 +34,7 @@ commerce transaction should work end to end.
 | C2G local handoff evidence | 13 passed, 0 failed, 2 skipped, with `consent_exchange` skipped using the stable fixture blocker. |
 | C3 hosted API-only smoke | 14 passed, 0 failed for liveness, health, MCP tools, A2A agent card, and A2A agents discovery. |
 | Production discovery | Commerce metadata is gated by default behind `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED`; it is not final production readiness. |
+| C6I buyer discovery session | Channel-neutral read-only session wrapper around Grantex buyer preview data; no checkout/payment, provider, fulfillment, or refund execution. |
 | Direct provider calls | Blocked for commerce. AgenticOrg commerce uses Grantex only. |
 | Live checkout/payments/Plural | Blocked. |
 | C6H buyer discovery consumer | Read-only sandbox consumer foundation; not public discovery or checkout/payment. |
@@ -56,6 +57,20 @@ flowchart LR
 AgenticOrg does not own catalog truth, consent grants, Commerce Passport
 issuance, merchant policy enforcement, provider credentials, provider webhooks,
 or payment reconciliation. Those controls stay in Grantex.
+
+## Buyer Discovery Session
+
+C6I lets a buyer-facing channel start a safe read-only discovery session. The
+session wrapper classifies each request before doing anything else:
+read-only discovery can call Grantex `buyer_discovery_preview`; checkout/payment,
+live provider, fulfillment, refund/return, and unsupported requests are refused
+without reaching any non-read-only path.
+
+The response shape is the same for ChatGPT, Claude, Gemini, WhatsApp, Telegram,
+web chat, and future channels. It includes status, message, merchant preview,
+catalog samples, allowed and blocked capabilities, source reference, refusal
+code, and evidence summary. It does not invent sellers, products, prices,
+stock, delivery, refund, launch, or payment facts.
 
 ## Merchant Self-Serve Journey
 

--- a/tests/regression/test_commerce_sales_agent_no_provider_calls.py
+++ b/tests/regression/test_commerce_sales_agent_no_provider_calls.py
@@ -7,6 +7,7 @@ ROOT = Path(__file__).resolve().parents[2]
 COMMERCE_CODE = [
     ROOT / "connectors" / "commerce" / "grantex_commerce.py",
     ROOT / "core" / "commerce" / "buyer_discovery.py",
+    ROOT / "core" / "commerce" / "buyer_session.py",
     ROOT / "core" / "commerce" / "discovery_gate.py",
     ROOT / "core" / "commerce" / "sales_guardrails.py",
     ROOT / "core" / "commerce" / "staging_evidence.py",

--- a/tests/unit/test_commerce_buyer_session.py
+++ b/tests/unit/test_commerce_buyer_session.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from core.commerce.buyer_session import (
+    BUYER_SESSION_CONTRACT,
+    build_channel_neutral_buyer_response,
+    classify_buyer_session_intent,
+    start_buyer_discovery_session,
+)
+
+
+def _valid_grantex_preview(**overrides: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "merchant_id": "mch_private_123",
+        "tenant_id": "tenant_private_123",
+        "merchant_reference": "safe-merchant-ref",
+        "display_name": "Grounded Preview Store",
+        "integration_status": "sandbox_handoff_requested",
+        "generated_at": "2026-06-07T10:00:00Z",
+        "audit_event_id": "audit_safe_ref",
+        "merchant": {
+            "display_name": "Grounded Preview Store",
+            "category_preset": "electronics_appliances",
+            "country_code": "IN",
+            "default_currency": "INR",
+            "public_discovery_description_draft": "Preview-only catalog evidence.",
+            "legal_name": "Private Legal Pvt Ltd",
+            "private_contact": "owner@example.test",
+        },
+        "readiness_summary": {"overall_status": "ready", "private_contract": "hidden"},
+        "agent_facing_preview_summary": {"preview_status": "ready", "sample_product_count": 2},
+        "rollout_proposal_summary": {"proposal_status": "dry_run_passed"},
+        "evidence_checklist": [{"key": "preview", "label": "Preview ready", "status": "pass"}],
+        "sample_products": [
+            {
+                "title": "Grounded Mixer",
+                "brand": "SafeBrand",
+                "category_preset": "electronics_appliances",
+                "price": "999",
+                "raw_payload": {"internal": True},
+            },
+            {"title": "Grounded Cooker", "brand": "SafeBrand"},
+        ],
+        "allowed_buyer_agent_capabilities": ["read_only_profile_discovery_preview"],
+        "blocked_buyer_agent_capabilities": [
+            "checkout_payment_creation",
+            "live_payment",
+            "refunds_returns_execution",
+        ],
+        "blockers": [],
+        "remediation_items": [],
+        "sandbox_only": True,
+        "buyer_agent_discovery_is_public": False,
+        "agenticorg_public_discovery_enabled": False,
+        "public_discovery_enabled": False,
+        "checkout_payment_enabled": False,
+        "live_provider_enabled": False,
+        "live_plural_enabled": False,
+        "production_approval_status": "not_approved",
+        "live_mode_status": "not_live",
+        "passport_jwt": "passport.jwt.secret",
+        "provider_credentials": {"api_key": "secret"},
+    }
+    data.update(overrides)
+    return {"data": data}
+
+
+@pytest.mark.parametrize(
+    ("text", "intent"),
+    [
+        ("Show me this merchant catalog preview.", "read_only_discovery"),
+        ("Can I checkout and pay?", "checkout_payment"),
+        ("Enable live Plural for this seller.", "live_provider"),
+        ("Track my delivery.", "fulfillment"),
+        ("Process a refund.", "refund_return"),
+        ("Write me a poem.", "unsupported"),
+    ],
+)
+def test_buyer_session_classifies_intents(text: str, intent: str) -> None:
+    assert classify_buyer_session_intent(text) == intent
+
+
+@pytest.mark.parametrize(
+    ("text", "refusal_code"),
+    [
+        ("Can I checkout and pay?", "checkout_payment_not_enabled"),
+        ("Enable live provider credentials.", "live_provider_not_enabled"),
+        ("Ship this tomorrow.", "fulfillment_not_enabled"),
+        ("Start a return.", "refund_return_not_enabled"),
+        ("Book a flight.", "unsupported_not_enabled"),
+    ],
+)
+async def test_buyer_session_refuses_blocked_intents_without_grantex_call(
+    text: str,
+    refusal_code: str,
+) -> None:
+    class FakeConnector:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def buyer_discovery_preview(self, **params: str) -> dict[str, Any]:
+            self.calls += 1
+            return _valid_grantex_preview()
+
+    connector = FakeConnector()
+
+    response = await start_buyer_discovery_session(
+        connector,
+        merchant_id="mch_private_123",
+        request_text=text,
+        channel="whatsapp",
+    )
+
+    assert connector.calls == 0
+    assert response["status"] == "refused"
+    assert response["refusal_code"] == refusal_code
+    assert response["channel"] == "whatsapp"
+    assert response["evidence_summary"]["grantex_call_status"] == "not_attempted"
+    assert response["merchant_preview"] == {}
+
+
+async def test_buyer_session_calls_grantex_for_read_only_discovery() -> None:
+    class FakeConnector:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, str]] = []
+
+        async def buyer_discovery_preview(self, **params: str) -> dict[str, Any]:
+            self.calls.append(dict(params))
+            return _valid_grantex_preview()
+
+    connector = FakeConnector()
+
+    response = await start_buyer_discovery_session(
+        connector,
+        merchant_id="mch_private_123",
+        request_text="Show me the product preview.",
+        channel="chatgpt",
+    )
+
+    assert connector.calls == [{"merchant_id": "mch_private_123"}]
+    assert response["contract"] == BUYER_SESSION_CONTRACT
+    assert response["status"] == "preview_only"
+    assert response["merchant_preview"]["display_name"] == "Grounded Preview Store"
+    assert response["catalog_samples"] == [
+        {"title": "Grounded Mixer", "brand": "SafeBrand", "category": "electronics_appliances"},
+        {"title": "Grounded Cooker", "brand": "SafeBrand"},
+    ]
+    assert response["allowed_capabilities"] == ["read_only_profile_discovery_preview"]
+    assert "checkout_payment_creation" in response["blocked_capabilities"]
+    assert response["source_reference"]["system"] == "grantex"
+    assert response["refusal_code"] is None
+    assert response["evidence_summary"]["grantex_grounded"] is True
+
+
+def test_buyer_session_response_is_channel_neutral() -> None:
+    response = build_channel_neutral_buyer_response(
+        _valid_grantex_preview(),
+        request_text="Compare products.",
+        channel="telegram",
+    )
+
+    assert response["channel_neutral"] is True
+    assert response["channel"] == "telegram"
+    for target in ("chatgpt", "claude", "gemini", "whatsapp", "telegram", "web_chat", "future_channel"):
+        assert target in response["supported_channel_targets"]
+    for key in (
+        "status",
+        "message",
+        "merchant_preview",
+        "catalog_samples",
+        "allowed_capabilities",
+        "blocked_capabilities",
+        "source_reference",
+        "refusal_code",
+        "evidence_summary",
+    ):
+        assert key in response
+
+
+def test_buyer_session_redacts_private_fields_and_stays_grounded() -> None:
+    response = build_channel_neutral_buyer_response(
+        _valid_grantex_preview(),
+        request_text="What products can I see?",
+    )
+    serialized = json.dumps(response, sort_keys=True)
+
+    assert "Grounded Preview Store" in serialized
+    assert "Grounded Mixer" in serialized
+    assert "mch_private_123" not in serialized
+    assert "tenant_private_123" not in serialized
+    assert "Private Legal" not in serialized
+    assert "owner@example.test" not in serialized
+    assert "passport.jwt.secret" not in serialized
+    assert "secret" not in serialized
+    assert "raw_payload" not in serialized
+    assert "999" not in serialized
+    assert "discount" not in serialized.lower()
+    assert "delivery" not in serialized.lower()
+    assert "refund promise" not in serialized.lower()
+
+
+def test_buyer_session_missing_grantex_data_returns_safe_refusal_shape() -> None:
+    response = build_channel_neutral_buyer_response(None, request_text="Show merchant preview.")
+
+    assert response["status"] == "unavailable"
+    assert response["refusal_code"] == "grantex_discovery_unavailable"
+    assert response["merchant_preview"] == {}
+    assert response["catalog_samples"] == []
+    assert response["source_reference"]["system"] == "grantex"
+    assert response["evidence_summary"]["preview_only"] is True
+
+
+def test_buyer_session_grantex_error_envelope_returns_missing_data_refusal() -> None:
+    response = build_channel_neutral_buyer_response(
+        {"error": "grantex_transport_error", "message": "network unavailable"},
+        request_text="Show merchant preview.",
+    )
+
+    assert response["status"] == "unavailable"
+    assert response["refusal_code"] == "grantex_discovery_unavailable"


### PR DESCRIPTION
## Summary

Adds C6I buyer-agent session orchestration for AgenticOrg Commerce:

- introduces a channel-neutral buyer discovery session wrapper around Grantex `buyer_discovery_preview`
- classifies buyer intent as read-only discovery, checkout/payment, live provider, fulfillment, refund/return, or unsupported
- refuses blocked intents before any non-read-only path is attempted
- normalizes the buyer-facing response contract with status, message, merchant preview, catalog samples, allowed capabilities, blocked capabilities, source reference, refusal code, and evidence summary
- hardens missing/error Grantex preview handling to fail closed
- updates Commerce Sales Agent prompt and docs for the C6I workflow

## Safety Posture

Preview/sandbox/read-only only. This PR does not deploy, merge, enable public discovery, enable production Commerce V1, set allowlists, create checkout/payment state, enable live payments, enable live Plural, call providers, call merchant private APIs, touch secrets, or claim UCP/ACP/AP2/schema.org/MPP/A2A certification.

AgenticOrg still grounds buyer discovery in Grantex data only and does not invent sellers, products, prices, stock, delivery, refund, launch, or payment facts.

## Validation

- `python -m pytest tests/unit/test_commerce_buyer_session.py tests/unit/test_commerce_buyer_discovery.py tests/unit/test_grantex_commerce_connector.py tests/unit/test_commerce_sales_agent_guardrails.py tests/regression/test_commerce_sales_agent_no_provider_calls.py --no-cov` - 55 passed
- `python -m ruff check core/commerce/buyer_session.py core/commerce/buyer_discovery.py tests/unit/test_commerce_buyer_session.py tests/regression/test_commerce_sales_agent_no_provider_calls.py` - passed
- `python -m mypy core/commerce/buyer_session.py core/commerce/buyer_discovery.py` - passed
- `git diff --check` and `git diff --cached --check` - passed

Focused guardrail scans checked touched commerce code/docs/tests for secrets/private leakage, production config or allowlist assignment, public discovery enablement, checkout/payment enablement, live payment/live Plural/provider credential handling, overclaims/certification claims, synthetic/private IDs, direct provider calls, and direct merchant private API calls. Hits were limited to refusal wording, existing static-test banned markers, and fake redaction fixtures asserted not to appear in output.

## Rollback

Revert this PR. It adds only local AgenticOrg orchestration, prompt/docs updates, and tests. No runtime production config or external state is changed.
