### PR TITLE
test(commerce): cover Grantex alias refusal parity

### DIFF
--- a/connectors/commerce/grantex_commerce.py
+++ b/connectors/commerce/grantex_commerce.py
@@ -172,6 +172,9 @@ class GrantexCommerceConnector(BaseConnector):
 
     async def payment_get_status(self, **params: Any) -> dict[str, Any]:
         """Poll payment status through Grantex Commerce only."""
+        guardrail = validate_payment_action("payment_get_status", params)
+        if not guardrail.get("allowed"):
+            return guardrail
         return await self._call_mcp_alias("payment_get_status", params)
 
     def _require_idempotency_key(self, alias: str, params: dict[str, Any]) -> dict[str, Any] | None:

--- a/core/commerce/buyer_discovery.py
+++ b/core/commerce/buyer_discovery.py
@@ -22,8 +22,22 @@ LIVE_PROVIDER_TERMS = (
     "live commerce",
     "plural",
     "pine labs",
+    "direct provider",
+    "payment provider",
+    "provider api",
+    "provider call",
     "provider credential",
     "provider secret",
+)
+MERCHANT_PRIVATE_API_TERMS = (
+    "merchant private api",
+    "merchant private endpoint",
+    "merchant private system",
+    "merchant existing system",
+    "merchant backend",
+    "merchant internal api",
+    "private merchant api",
+    "private merchant endpoint",
 )
 FULFILLMENT_TERMS = (
     "fulfillment",
@@ -76,6 +90,8 @@ NON_ENABLING_CONTROL_FIELDS = (
 def classify_buyer_discovery_request(request_text: str) -> str:
     """Classify requests that C6H must refuse before any write-like behavior."""
     text = str(request_text or "").strip().lower()
+    if _contains_any(text, MERCHANT_PRIVATE_API_TERMS):
+        return "merchant_private_api"
     if _contains_any(text, LIVE_PROVIDER_TERMS):
         return "live_provider"
     if _contains_any(text, CHECKOUT_PAYMENT_TERMS):
@@ -235,6 +251,10 @@ def _refusal_for_intent(intent: str, source_reference: Mapping[str, Any]) -> dic
             "Live payment/provider access is not enabled in this read-only discovery slice. "
             "I cannot request provider access or live routing."
         ),
+        "merchant_private_api": (
+            "Merchant private APIs and merchant existing systems are not available to AgenticOrg. "
+            "Commerce requests must go through Grantex-owned contracts."
+        ),
         "fulfillment": (
             "Fulfillment, shipment, delivery, and order-status execution are not enabled in this slice."
         ),
@@ -243,7 +263,9 @@ def _refusal_for_intent(intent: str, source_reference: Mapping[str, Any]) -> dic
     return {
         "status": "refused",
         "refusal": True,
-        "refusal_code": f"{intent}_not_enabled",
+        "refusal_code": "merchant_private_api_not_allowed"
+        if intent == "merchant_private_api"
+        else f"{intent}_not_enabled",
         "message": messages[intent],
         "source_reference": dict(source_reference),
     }

--- a/core/commerce/buyer_session.py
+++ b/core/commerce/buyer_session.py
@@ -10,6 +10,7 @@ from core.commerce.buyer_discovery import (
     CHECKOUT_PAYMENT_TERMS,
     FULFILLMENT_TERMS,
     LIVE_PROVIDER_TERMS,
+    MERCHANT_PRIVATE_API_TERMS,
     REFUND_RETURN_TERMS,
     build_buyer_discovery_response,
 )
@@ -71,6 +72,11 @@ BLOCKED_CAPABILITIES_BY_INTENT = {
         "provider_credential_access",
         "provider_private_api",
     ),
+    "merchant_private_api": (
+        "merchant_private_api",
+        "merchant_existing_system",
+        "direct_merchant_system_access",
+    ),
     "fulfillment": (
         "order_fulfillment",
         "shipping_delivery",
@@ -89,6 +95,8 @@ BLOCKED_CAPABILITIES_BY_INTENT = {
 def classify_buyer_session_intent(request_text: str) -> str:
     """Classify buyer intent before any Grantex call or side-effect path."""
     text = str(request_text or "").strip().lower()
+    if _contains_any(text, MERCHANT_PRIVATE_API_TERMS):
+        return "merchant_private_api"
     if _contains_any(text, LIVE_PROVIDER_TERMS):
         return "live_provider"
     if _contains_any(text, CHECKOUT_PAYMENT_TERMS):
@@ -159,6 +167,10 @@ def _intent_refusal(intent: str) -> dict[str, Any]:
         "live_provider": (
             "Live providers, live Plural, provider credentials, and provider APIs are blocked in this session."
         ),
+        "merchant_private_api": (
+            "Merchant private APIs and merchant existing systems are blocked in this session. "
+            "Commerce requests must use Grantex-owned contracts."
+        ),
         "fulfillment": (
             "Fulfillment, shipping, delivery, dispatch, tracking, and order-status execution are blocked here."
         ),
@@ -168,7 +180,9 @@ def _intent_refusal(intent: str) -> dict[str, Any]:
     return {
         "status": "refused",
         "refusal": True,
-        "refusal_code": f"{intent}_not_enabled",
+        "refusal_code": "merchant_private_api_not_allowed"
+        if intent == "merchant_private_api"
+        else f"{intent}_not_enabled",
         "message": messages[intent],
         "allowed_capabilities": list(READ_ONLY_ALLOWED_CAPABILITIES),
         "blocked_capabilities": list(BLOCKED_CAPABILITIES_BY_INTENT[intent]),

--- a/core/commerce/sales_guardrails.py
+++ b/core/commerce/sales_guardrails.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Mapping
 from typing import Any
 
@@ -38,12 +39,17 @@ PAYMENT_REFUSAL_ERROR_CODES = frozenset(
         "amount_cap_exceeded",
         "checkout_amount_exceeds_passport",
         "checkout_passport_required",
+        "checkout_not_enabled",
+        "checkout_payment_not_enabled",
         "commerce_disabled",
         "consent_denied",
         "consent_expired",
         "consent_not_granted",
         "emergency_disabled",
+        "live_payment_not_enabled",
         "live_provider_blocked",
+        "live_provider_not_enabled",
+        "merchant_private_api_not_allowed",
         "merchant_agentic_commerce_disabled",
         "merchant_disabled",
         "merchant_emergency_disabled",
@@ -55,8 +61,28 @@ PAYMENT_REFUSAL_ERROR_CODES = frozenset(
         "policy_decision_deny",
         "policy_denied",
         "provider_blocked",
+        "provider_call_not_allowed",
         "provider_unavailable",
+        "public_discovery_disabled",
+        "public_discovery_not_enabled",
+        "stale_inventory",
     }
+)
+
+SENSITIVE_ERROR_PATTERNS = (
+    re.compile(r"-----BEGIN [A-Z ]+PRIVATE KEY-----.*?-----END [A-Z ]+PRIVATE KEY-----", re.I | re.S),
+    re.compile(r"\b(?:postgresql?|redis)://[^\s'\"<>]+", re.I),
+    re.compile(r"\bhttps?://[^\s'\"<>]*(?:private|internal|merchant|provider)[^\s'\"<>]*", re.I),
+    re.compile(
+        r"\b(?:bearer|token|jwt|passport|secret|api[_-]?key|webhook[_-]?secret|"
+        r"client[_-]?secret|password)\s*[:=]\s*[^\s,'\"{}]+",
+        re.I,
+    ),
+    re.compile(
+        r"\b(?:raw[_-]?payload|provider[_-]?(?:payload|metadata|credential|credentials))"
+        r"\b\s*[:=]\s*\{[^{}]*\}",
+        re.I,
+    ),
 )
 
 UNSUPPORTED_CLAIM_TERMS: dict[str, tuple[str, ...]] = {
@@ -178,10 +204,15 @@ def validate_payment_action(action: str, params: dict[str, Any]) -> dict[str, An
     if policy_decision in POLICY_DENIALS:
         return refusal("policy_denied", "Grantex policy denied this checkout/payment action.")
 
-    if action in {"checkout_create", "payment_create_intent"}:
+    if action in {"checkout_create", "payment_create_intent", "payment_get_status"}:
         passport_jwt = _lookup(params, "passport_jwt", "passport.jwt", "commerce_passport.jwt")
         if not passport_jwt:
-            return refusal("consent_required", "Checkout/payment requires a granted Grantex Commerce Passport.")
+            message = (
+                "Payment status requires a Grantex Commerce Passport."
+                if action == "payment_get_status"
+                else "Checkout/payment requires a granted Grantex Commerce Passport."
+            )
+            return refusal("consent_required", message)
 
     amount_minor_units = _as_int(_lookup(params, "amount_minor_units", "amount", "total_amount_minor_units"))
     passport_cap = _as_int(
@@ -216,6 +247,20 @@ def validate_payment_action(action: str, params: dict[str, Any]) -> dict[str, An
         )
 
     return allowed()
+
+
+def _sanitize_grantex_error_message(value: Any) -> str:
+    message = str(value or "").replace("\x00", "").strip()
+    if not message:
+        return "Grantex Commerce request failed."
+    for pattern in SENSITIVE_ERROR_PATTERNS:
+        message = pattern.sub("[redacted]", message)
+    if "[redacted]" in message:
+        return (
+            "Grantex Commerce refused the request. Private provider, merchant, "
+            "credential, or raw payload details were redacted."
+        )
+    return message[:500].rstrip()
 
 
 def _inventory_records(inventory: Any) -> list[Mapping[str, Any]]:
@@ -326,7 +371,7 @@ def normalize_grantex_error(payload: Any, status_code: int | None = None) -> dic
         code = "grantex_jsonrpc_error"
 
     raw_message = error_obj.get("message") if isinstance(error_obj, Mapping) else None
-    message = str(raw_message).strip() if raw_message else "Grantex Commerce request failed."
+    message = _sanitize_grantex_error_message(raw_message)
 
     retryable = bool(error_obj.get("retryable")) if isinstance(error_obj, Mapping) else False
     normalized: dict[str, Any] = {
@@ -337,9 +382,13 @@ def normalize_grantex_error(payload: Any, status_code: int | None = None) -> dic
         "refusal": code in PAYMENT_REFUSAL_ERROR_CODES,
     }
 
-    for field in ("decision_id", "audit_event_id", "remediation"):
+    for field in ("decision_id", "audit_event_id"):
         value = error_obj.get(field) if isinstance(error_obj, Mapping) else None
         if value:
             normalized[field] = value
+
+    remediation = error_obj.get("remediation") if isinstance(error_obj, Mapping) else None
+    if isinstance(remediation, str):
+        normalized["remediation"] = _sanitize_grantex_error_message(remediation)
 
     return normalized

--- a/docs/reports/commerce-agent-c6u3-alias-refusal-parity-tests.md
+++ b/docs/reports/commerce-agent-c6u3-alias-refusal-parity-tests.md
@@ -1,0 +1,116 @@
+# Commerce Agent C6U3 Alias And Refusal Parity Tests
+
+Status: internal test coverage and release-control report only.
+
+This report does not approve production launch, real merchants, public
+discovery, checkout/payment creation, live payments, live Plural, provider
+calls, merchant private API calls, production config, production allowlists,
+cloud resources, protocol publication, external submission, certification,
+compliance, conformance, standardization, public-launch readiness, merchant
+approval, or production readiness.
+
+## Purpose
+
+C6U3 converts the C6U2 cross-contract parity risks into narrow executable
+AgenticOrg tests. The tests prove that AgenticOrg commerce aliases continue to
+depend on Grantex-owned commerce contracts, that unsupported buyer actions fail
+closed before side effects, and that Grantex errors are translated without
+copying private provider, merchant, credential, or raw payload details into
+buyer-facing output.
+
+## Tested Parity
+
+| Area | Test coverage | Result |
+| --- | --- | --- |
+| Alias inventory | `test_c6u3_alias_inventory_is_grantex_only` pins every AgenticOrg commerce alias to a Grantex MCP or REST path. | AgenticOrg commerce tools remain `grantex_commerce:*` aliases only. |
+| Payment status passport gate | `test_payment_status_missing_passport_refuses_before_grantex_call` proves missing passport input is refused locally. | `payment_get_status` no longer relies only on Grantex for the first missing-passport refusal. |
+| Payment status transport | `test_payment_status_with_passport_uses_grantex_mcp_only` proves status polling calls `/mcp` with `payment.get_status`. | Status polling stays on the Grantex MCP contract. |
+| Blocked buyer intents | `test_blocked_buyer_session_intents_never_call_grantex` covers checkout/payment, live provider, merchant private API, fulfillment, and refund requests. | These intents are refused before any Grantex preview call and before any non-Grantex path can exist. |
+| Public discovery gate | `test_public_discovery_hides_commerce_agent_tools_when_gate_is_absent` verifies the default public discovery gate hides commerce tools. | Public discovery remains hidden by default. |
+| Stale inventory | `test_stale_inventory_is_translated_to_buyer_safe_caution` verifies stale or unknown inventory becomes cautious buyer-safe wording. | AgenticOrg does not promise stock when freshness is missing. |
+| Error redaction | `test_grantex_error_translation_redacts_private_details` verifies private URLs, raw payload markers, credentials, and passport-like values are redacted. | Buyer-safe errors do not echo private implementation details. |
+| Future channels | `test_channel_targets_are_documented_only_not_live_exposure` verifies future channel labels remain non-enabling response metadata. | ChatGPT, Claude, Gemini, WhatsApp, and Telegram remain future target labels only. |
+
+## Grantex-Only Boundary
+
+The executable alias inventory covers:
+
+- `merchant_get_profile` -> `merchant.get_profile`
+- `catalog_search` -> `catalog.search`
+- `catalog_get_item` -> `catalog.get_item`
+- `inventory_check` -> `inventory.check`
+- `cart_create` -> `cart.create`
+- `payment_create_intent` -> `payment.create_intent`
+- `checkout_create` -> `checkout.create`
+- `payment_get_status` -> `payment.get_status`
+- `consent_request` -> `/v1/commerce/passports/consent-requests`
+- `consent_exchange` -> `/v1/commerce/passports/exchange`
+- `buyer_discovery_preview` -> `/v1/commerce/merchants/{merchant_id}/agenticorg-buyer-discovery-preview`
+
+AgenticOrg still must not call payment providers, Plural, provider credential
+routes, merchant private APIs, merchant existing systems, or merchant private
+connectors directly for commerce.
+
+## Refusal Behavior
+
+| Request class | AgenticOrg result | Grantex call attempted? |
+| --- | --- | --- |
+| Missing passport for `payment_get_status` | `consent_required` local refusal | No |
+| Checkout/payment request in read-only buyer session | `checkout_payment_not_enabled` | No |
+| Live provider or live Plural request | `live_provider_not_enabled` | No |
+| Merchant private API or merchant existing-system request | `merchant_private_api_not_allowed` | No |
+| Fulfillment, shipment, delivery, or tracking execution | `fulfillment_not_enabled` | No |
+| Refund, return, replacement, or chargeback execution | `refund_return_not_enabled` | No |
+| Public discovery with no explicit AgenticOrg gate | Commerce tools hidden | No public commerce exposure |
+| Stale or unknown inventory | Buyer-safe caution | No stock promise |
+
+## Buyer-Safe Error Translation
+
+The C6U3 guardrail keeps Grantex error codes, status, retryability, audit event
+references, and decision references when they are safe to show. Error messages
+and remediation text are redacted when they contain private URLs, raw payload
+markers, credential-like values, passport-like values, database URLs, Redis URLs,
+provider credential references, or webhook-secret markers.
+
+## Remaining Gaps
+
+| Gap | Owner | Priority | Next slice |
+| --- | --- | --- | --- |
+| Source/freshness projection | Grantex + AgenticOrg | P0 | C6U4 buyer-safe catalog, source, freshness, price, tax, warranty, and return projection. |
+| Shared public discovery state contract | Grantex + AgenticOrg | P0 | C6U5 cross-repo public discovery state parity. |
+| Consent/session/passport revocation propagation | Grantex + AgenticOrg | P0 | C6U6 durable session and revocation propagation. |
+| Channel-specific refusal packs | AgenticOrg | P1 | Channel slices after C6U5 and C6U6. |
+| schema.org/UCP-style/ACP-style/AP2-style posture | Grantex + AgenticOrg | P2 | C6U10 internal adapter packaging without external publication claims. |
+| Order, fulfillment, refund, support, settlement, and payout contracts | Grantex first, AgenticOrg consumer later | P0 | C6U7 and C6U8 post-purchase contracts. |
+| AgenticOrg CI/CD cloud-build guard follow-up after PR #723 cancellation | AgenticOrg | P0 | Separate release-control slice, not C6U3. |
+
+## Stop Conditions
+
+- Any AgenticOrg commerce path calls a payment provider, Plural, provider
+  credential route, merchant private API, or merchant existing system directly.
+- Any buyer-facing output includes raw provider payloads, private merchant URLs,
+  secrets, passport/JWT values, database URLs, Redis URLs, production config, or
+  production allowlist values.
+- Any public A2A, MCP, API, web, ChatGPT, Claude, Gemini, WhatsApp, or Telegram
+  metadata exposes commerce tools before explicit Grantex and AgenticOrg
+  approval gates exist.
+- Any wording claims production launch, public discovery, checkout/payment, live
+  provider, live Plural, certification, compliance, conformance,
+  standardization, merchant approval, public-launch readiness, or production
+  readiness.
+
+## Validation
+
+Expected focused validation:
+
+- `python -m pytest tests/regression/test_commerce_c6u3_alias_refusal_parity.py`
+- `python -m pytest tests/unit/test_grantex_commerce_connector.py tests/unit/test_commerce_buyer_session.py tests/unit/test_commerce_buyer_discovery.py tests/unit/test_commerce_sales_agent_guardrails.py`
+- `python -m ruff check connectors/commerce/grantex_commerce.py core/commerce/sales_guardrails.py core/commerce/buyer_discovery.py core/commerce/buyer_session.py tests/regression/test_commerce_c6u3_alias_refusal_parity.py`
+- `git diff --check origin/main...HEAD`
+- Focused secret, private-detail, production config, public discovery, checkout/payment, live provider, direct provider, Plural, merchant private API, and overclaim scans.
+
+This slice adds no runtime API, migration, workflow, dependency, cloud resource,
+production config, secret, provider integration, merchant private API path,
+production allowlist, public discovery enablement, checkout/payment enablement,
+live provider enablement, live Plural enablement, or external protocol
+publication/submission action.

--- a/tests/regression/test_commerce_c6u3_alias_refusal_parity.py
+++ b/tests/regression/test_commerce_c6u3_alias_refusal_parity.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from connectors.commerce.grantex_commerce import (
+    REST_CONSENT_ENDPOINTS,
+    REST_READ_ONLY_ENDPOINTS,
+    TOOL_ALIAS_TO_GRANTEX,
+    GrantexCommerceConnector,
+)
+from core.commerce.buyer_session import (
+    build_channel_neutral_buyer_response,
+    start_buyer_discovery_session,
+)
+from core.commerce.discovery_gate import iter_public_discovery_agent_tools
+from core.commerce.sales_guardrails import (
+    GRANTEX_COMMERCE_DEFAULT_TOOLS,
+    inventory_caution,
+    normalize_grantex_error,
+)
+
+
+def _json_response(payload: dict[str, Any], status_code: int = 200) -> httpx.Response:
+    return httpx.Response(status_code, json=payload)
+
+
+async def _connector(handler) -> GrantexCommerceConnector:
+    connector = GrantexCommerceConnector(
+        {"base_url": "https://grantex.test", "bearer_token": "gx_agent_test_token"}
+    )
+    connector._auth_headers = {
+        "Authorization": "Bearer gx_agent_test_token",
+        "Accept": "application/json",
+    }
+    connector._client = httpx.AsyncClient(
+        base_url=connector.base_url,
+        headers=connector._auth_headers,
+        transport=httpx.MockTransport(handler),
+    )
+    return connector
+
+
+def test_c6u3_alias_inventory_is_grantex_only() -> None:
+    expected_mcp_aliases = {
+        "merchant_get_profile": "merchant.get_profile",
+        "catalog_search": "catalog.search",
+        "catalog_get_item": "catalog.get_item",
+        "inventory_check": "inventory.check",
+        "cart_create": "cart.create",
+        "payment_create_intent": "payment.create_intent",
+        "checkout_create": "checkout.create",
+        "payment_get_status": "payment.get_status",
+    }
+
+    assert TOOL_ALIAS_TO_GRANTEX == expected_mcp_aliases
+    assert REST_CONSENT_ENDPOINTS == {
+        "consent_request": "/v1/commerce/passports/consent-requests",
+        "consent_exchange": "/v1/commerce/passports/exchange",
+    }
+    assert REST_READ_ONLY_ENDPOINTS == {
+        "buyer_discovery_preview": (
+            "/v1/commerce/merchants/{merchant_id}/agenticorg-buyer-discovery-preview"
+        )
+    }
+    assert set(GRANTEX_COMMERCE_DEFAULT_TOOLS) == {
+        "grantex_commerce:merchant_get_profile",
+        "grantex_commerce:catalog_search",
+        "grantex_commerce:catalog_get_item",
+        "grantex_commerce:inventory_check",
+        "grantex_commerce:cart_create",
+        "grantex_commerce:consent_request",
+        "grantex_commerce:consent_exchange",
+        "grantex_commerce:buyer_discovery_preview",
+        "grantex_commerce:payment_create_intent",
+        "grantex_commerce:checkout_create",
+        "grantex_commerce:payment_get_status",
+    }
+
+    serialized = json.dumps(
+        {
+            "mcp": TOOL_ALIAS_TO_GRANTEX,
+            "rest": REST_CONSENT_ENDPOINTS | REST_READ_ONLY_ENDPOINTS,
+            "tools": GRANTEX_COMMERCE_DEFAULT_TOOLS,
+        },
+        sort_keys=True,
+    ).lower()
+    assert "stripe" not in serialized
+    assert "pinelabs" not in serialized
+    assert "provider_credential" not in serialized
+    assert "merchant_private" not in serialized
+
+
+async def test_payment_status_missing_passport_refuses_before_grantex_call() -> None:
+    connector = GrantexCommerceConnector({})
+
+    result = await connector.payment_get_status(payment_intent_id="pi_synthetic_c6u3")
+
+    assert result["allowed"] is False
+    assert result["status"] == "refused"
+    assert result["error"] == "consent_required"
+
+
+async def test_payment_status_with_passport_uses_grantex_mcp_only() -> None:
+    captured: dict[str, Any] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["body"] = json.loads(request.content)
+        return _json_response(
+            {
+                "jsonrpc": "2.0",
+                "id": captured["body"]["id"],
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps({"data": {"status": "authorized"}}),
+                        }
+                    ]
+                },
+            }
+        )
+
+    connector = await _connector(handler)
+    try:
+        result = await connector.payment_get_status(
+            payment_intent_id="pi_synthetic_c6u3",
+            passport_jwt="passport.synthetic.value",
+        )
+    finally:
+        await connector.disconnect()
+
+    assert captured["path"] == "/mcp"
+    assert captured["body"]["method"] == "tools/call"
+    assert captured["body"]["params"]["name"] == "payment.get_status"
+    assert captured["body"]["params"]["arguments"] == {
+        "payment_intent_id": "pi_synthetic_c6u3",
+        "passport_jwt": "passport.synthetic.value",
+    }
+    assert result["data"]["status"] == "authorized"
+
+
+@pytest.mark.parametrize(
+    ("request_text", "refusal_code"),
+    [
+        ("Checkout and pay for this item.", "checkout_payment_not_enabled"),
+        ("Use live provider routing for this buyer.", "live_provider_not_enabled"),
+        ("Call the merchant private API endpoint.", "merchant_private_api_not_allowed"),
+        ("Track delivery for this order.", "fulfillment_not_enabled"),
+        ("Start a refund.", "refund_return_not_enabled"),
+    ],
+)
+async def test_blocked_buyer_session_intents_never_call_grantex(
+    request_text: str,
+    refusal_code: str,
+) -> None:
+    class FakeConnector:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def buyer_discovery_preview(self, **params: str) -> dict[str, Any]:
+            self.calls += 1
+            raise AssertionError("blocked buyer intents must not call Grantex preview")
+
+    connector = FakeConnector()
+
+    response = await start_buyer_discovery_session(
+        connector,
+        merchant_id="merchant_synthetic_c6u3",
+        request_text=request_text,
+        channel="future_channel",
+    )
+
+    assert connector.calls == 0
+    assert response["status"] == "refused"
+    assert response["refusal_code"] == refusal_code
+    assert response["evidence_summary"]["grantex_call_status"] == "not_attempted"
+
+
+def test_public_discovery_hides_commerce_agent_tools_when_gate_is_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED", raising=False)
+
+    visible = dict(
+        iter_public_discovery_agent_tools(
+            {
+                "commerce_sales_agent": GRANTEX_COMMERCE_DEFAULT_TOOLS,
+                "support_triage": ["create_ticket"],
+            }
+        )
+    )
+
+    assert "commerce_sales_agent" not in visible
+    assert visible == {"support_triage": ["create_ticket"]}
+
+
+def test_stale_inventory_is_translated_to_buyer_safe_caution() -> None:
+    result = inventory_caution(
+        {
+            "items": [
+                {
+                    "variant_id": "variant_synthetic_c6u3",
+                    "availability_status": "unknown",
+                    "stale": True,
+                    "source_system": "synthetic_fixture",
+                }
+            ]
+        }
+    )
+
+    assert result["caution_required"] is True
+    assert "Do not guarantee availability" in result["message"]
+    serialized = json.dumps(result, sort_keys=True).lower()
+    assert "raw_payload" not in serialized
+    assert "provider" not in serialized
+    assert "merchant private" not in serialized
+
+
+def test_grantex_error_translation_redacts_private_details() -> None:
+    db_url = "postgres" + "://user:pass@merchant-private.internal/db"
+    private_url = "https://" + "merchant-private.internal/orders/123"
+    error_payload = {
+        "error": {
+            "code": "provider_unavailable",
+            "message": (
+                "Provider failure contained raw_payload={token=synthetic-token} "
+                f"{db_url} {private_url} passport=passport.synthetic.value"
+            ),
+            "audit_event_id": "audit_synthetic_c6u3",
+            "decision_id": "decision_synthetic_c6u3",
+            "remediation": "Do not retry with webhook_secret=synthetic-webhook-token.",
+        }
+    }
+
+    normalized = normalize_grantex_error(error_payload, 502)
+    serialized = json.dumps(normalized, sort_keys=True)
+
+    assert normalized["error"] == "provider_unavailable"
+    assert normalized["refusal"] is True
+    assert normalized["audit_event_id"] == "audit_synthetic_c6u3"
+    assert normalized["decision_id"] == "decision_synthetic_c6u3"
+    assert "postgres://" not in serialized
+    assert "merchant-private.internal" not in serialized
+    assert "synthetic-token" not in serialized
+    assert "passport.synthetic.value" not in serialized
+    assert "webhook_secret" not in serialized
+
+
+def test_channel_targets_are_documented_only_not_live_exposure() -> None:
+    response = build_channel_neutral_buyer_response(
+        None,
+        request_text="Show merchant preview.",
+        channel="chatgpt",
+    )
+
+    assert response["channel_neutral"] is True
+    assert response["status"] == "unavailable"
+    assert response["refusal_code"] == "grantex_discovery_unavailable"
+    assert response["evidence_summary"]["non_enabling"] is True
+    assert response["evidence_summary"]["preview_only"] is True
+    for target in ("chatgpt", "claude", "gemini", "whatsapp", "telegram"):
+        assert target in response["supported_channel_targets"]


### PR DESCRIPTION
C6U3 AgenticOrg alias/refusal parity tests, report, and tiny fail-closed guardrails for payment status preflight, merchant-private intent refusal, and buyer-safe Grantex error redaction. No deploy, workflow, production config, public discovery, checkout/payment enablement, live provider, live Plural, production allowlist, direct provider call, merchant private API call, or protocol publication change.