### PR TITLE
test(commerce): cover buyer-safe source freshness projection

### DIFF
--- a/core/commerce/buyer_discovery.py
+++ b/core/commerce/buyer_discovery.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from core.commerce.sales_guardrails import inventory_caution
+
 C6G_PREVIEW_ENDPOINT = "/v1/commerce/merchants/{merchant_id}/agenticorg-buyer-discovery-preview"
 
 CHECKOUT_PAYMENT_TERMS = (
@@ -69,6 +71,35 @@ PRIVATE_OUTPUT_KEYS = {
     "redis_url",
     "raw_payload",
     "allowlist",
+}
+
+PRIVATE_SOURCE_MARKERS = (
+    "private",
+    "internal",
+    "provider",
+    "credential",
+    "secret",
+    "token",
+    "jwt",
+    "passport",
+    "raw",
+    "payload",
+    "postgres://",
+    "postgresql://",
+    "redis://",
+    "http://",
+    "https://",
+)
+
+SOURCE_STATUS_VALUES = {
+    "current",
+    "fresh",
+    "preview",
+    "stale",
+    "unknown",
+    "not_checked",
+    "unverified",
+    "blocked",
 }
 
 NON_ENABLING_CONTROL_FIELDS = (
@@ -322,23 +353,221 @@ def _safe_evidence_checklist(value: Any) -> list[dict[str, str]]:
     return entries
 
 
-def _safe_catalog_samples(value: Any) -> list[dict[str, str]]:
+def _safe_catalog_samples(value: Any) -> list[dict[str, Any]]:
     if not isinstance(value, Sequence) or isinstance(value, str):
         return []
-    samples: list[dict[str, str]] = []
+    samples: list[dict[str, Any]] = []
     for item in value[:3]:
         if not isinstance(item, Mapping):
             continue
-        samples.append(
-            _drop_empty(
-                {
-                    "title": _safe_text(item.get("title"), limit=160),
-                    "brand": _safe_text(item.get("brand"), limit=120),
-                    "category": _safe_text(item.get("category_preset") or item.get("category"), limit=120),
-                }
-            )
+        sample = _drop_empty(
+            {
+                "title": _safe_public_text(item.get("title"), limit=160),
+                "brand": _safe_public_text(item.get("brand"), limit=120),
+                "category": _safe_public_text(item.get("category_preset") or item.get("category"), limit=120),
+            }
         )
+        commercial_facts = _buyer_safe_commercial_facts(item)
+        if commercial_facts:
+            sample["commercial_facts"] = commercial_facts
+        source_summary = _buyer_safe_source_summary(item)
+        if source_summary:
+            sample["source_summary"] = source_summary
+        samples.append(sample)
     return samples
+
+
+def _buyer_safe_commercial_facts(item: Mapping[str, Any]) -> dict[str, Any]:
+    variant = _first_mapping(item.get("variants"))
+    fact_source = variant or item
+    price_amount = _first_value(fact_source, item, keys=("price_amount", "price", "amount", "amount_minor_units"))
+    currency = _safe_currency(_first_value(fact_source, item, keys=("currency", "price_currency")))
+    availability = _safe_status(
+        _first_value(
+            fact_source,
+            item,
+            keys=("availability_status", "inventory_status", "stock_status", "freshness"),
+        )
+    )
+    warranty = _safe_public_text(_first_value(fact_source, item, keys=("warranty_summary", "warranty")), limit=240)
+    return_policy = _safe_public_text(
+        _first_value(fact_source, item, keys=("return_policy_summary", "return_policy")),
+        limit=240,
+    )
+    tax_value = _first_value(
+        fact_source,
+        item,
+        keys=("tax_inclusive", "tax_rate", "tax_amount_minor_units", "gst_slab", "hsn_code", "tax"),
+    )
+
+    inventory = inventory_caution({"items": [fact_source]})
+    facts: dict[str, Any] = {
+        "price": _drop_empty(
+            {
+                "status": "preview_only" if price_amount not in (None, "") and currency else "unknown",
+                "display": f"{currency} {_safe_text(price_amount, limit=60)}"
+                if price_amount not in (None, "") and currency
+                else "",
+                "final_price_confirmed": False,
+                "message": (
+                    "Preview price only. Final tax, fees, discounts, delivery charges, "
+                    "and checkout totals are not confirmed."
+                    if price_amount not in (None, "") and currency
+                    else "Price is not confirmed by Grantex for this preview."
+                ),
+            }
+        ),
+        "tax": _drop_empty(
+            {
+                "status": "provided_by_grantex" if tax_value not in (None, "") else "unknown",
+                "final_tax_confirmed": False,
+                "message": "Final tax/GST is not confirmed for checkout."
+                if tax_value in (None, "")
+                else "Tax metadata is present, but final checkout tax is not confirmed here.",
+            }
+        ),
+        "warranty": _drop_empty(
+            {
+                "status": "provided_by_grantex" if warranty else "unknown",
+                "summary": warranty,
+                "message": "Warranty terms are not confirmed by Grantex for this preview." if not warranty else "",
+            }
+        ),
+        "return_policy": _drop_empty(
+            {
+                "status": "provided_by_grantex" if return_policy else "unknown",
+                "summary": return_policy,
+                "message": "Return or refund handling is not confirmed by Grantex for this preview."
+                if not return_policy
+                else "",
+            }
+        ),
+        "inventory": _drop_empty(
+            {
+                "status": "unknown_or_stale"
+                if inventory.get("caution_required")
+                else availability or "preview_bucket",
+                "preview_availability": availability,
+                "caution_required": bool(inventory.get("caution_required")),
+                "stock_promise": False,
+                "message": inventory.get("message")
+                or "Availability is a Grantex preview bucket, not a reserved quantity.",
+            }
+        ),
+        "unsupported": [
+            "discounts",
+            "coupons",
+            "emi",
+            "delivery",
+            "support",
+            "fulfillment",
+            "refunds",
+            "settlement",
+            "payout",
+        ],
+    }
+    return facts
+
+
+def _buyer_safe_source_summary(item: Mapping[str, Any]) -> dict[str, Any]:
+    variant = _first_mapping(item.get("variants"))
+    fact_source = variant or item
+    source_label = _safe_source_label(
+        _first_value(
+            fact_source,
+            item,
+            keys=("source_label", "source_system", "connector_source", "source", "source_type"),
+        )
+    )
+    freshness = _safe_status(
+        _first_value(
+            fact_source,
+            item,
+            keys=("freshness", "freshness_status", "sync_status", "health_state"),
+        )
+    )
+    stale = _truthy(_first_value(fact_source, item, keys=("stale", "is_stale")))
+    if stale:
+        freshness = "stale"
+    last_checked_at = _safe_timestamp(
+        _first_value(
+            fact_source,
+            item,
+            keys=("last_synced_at", "last_successful_sync_at", "source_snapshot_at", "generated_at"),
+        )
+    )
+    return _drop_empty(
+        {
+            "source": source_label or "grantex_preview",
+            "freshness_status": freshness or ("unknown" if not last_checked_at else "preview"),
+            "last_checked_at": last_checked_at,
+        }
+    )
+
+
+def _first_mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        for item in value:
+            if isinstance(item, Mapping):
+                return item
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _first_value(*mappings: Mapping[str, Any], keys: Sequence[str]) -> Any:
+    for mapping in mappings:
+        for key in keys:
+            value = mapping.get(key)
+            if value not in (None, ""):
+                return value
+    return None
+
+
+def _safe_public_text(value: Any, *, limit: int = 240) -> str:
+    text = _safe_text(value, limit=limit)
+    if not text:
+        return ""
+    lowered = text.lower()
+    if any(marker in lowered for marker in PRIVATE_SOURCE_MARKERS):
+        return ""
+    return text
+
+
+def _safe_source_label(value: Any) -> str:
+    text = _safe_text(value, limit=80)
+    if not text:
+        return ""
+    lowered = text.lower()
+    if any(marker in lowered for marker in PRIVATE_SOURCE_MARKERS):
+        return "grantex_controlled_source"
+    return text
+
+
+def _safe_currency(value: Any) -> str:
+    text = _safe_text(value, limit=3).upper()
+    return text if len(text) == 3 and text.isalpha() else ""
+
+
+def _safe_status(value: Any) -> str:
+    text = _safe_text(value, limit=40).lower().replace(" ", "_").replace("-", "_")
+    safe_availability = {"in_stock", "out_of_stock", "pre_order", "back_order"}
+    return text if text in SOURCE_STATUS_VALUES or text in safe_availability else ""
+
+
+def _safe_timestamp(value: Any) -> str:
+    text = _safe_text(value, limit=40)
+    if len(text) >= 10 and "://" not in text and not any(marker in text.lower() for marker in PRIVATE_SOURCE_MARKERS):
+        return text
+    return ""
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value in (None, ""):
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "stale", "expired", "blocked"}
 
 
 def _string_list(value: Any, *, limit: int = 20) -> list[str]:

--- a/core/commerce/buyer_session.py
+++ b/core/commerce/buyer_session.py
@@ -318,6 +318,8 @@ def _is_safe_value(value: Any) -> bool:
         return bool(_safe_text(value))
     if isinstance(value, int | float | bool):
         return True
+    if isinstance(value, Mapping):
+        return all(isinstance(key, str) and _is_safe_value(nested) for key, nested in value.items())
     if isinstance(value, Sequence) and not isinstance(value, str):
-        return all(isinstance(item, str | int | float | bool) for item in value)
+        return all(_is_safe_value(item) for item in value)
     return False

--- a/core/commerce/sales_guardrails.py
+++ b/core/commerce/sales_guardrails.py
@@ -86,18 +86,32 @@ SENSITIVE_ERROR_PATTERNS = (
 )
 
 UNSUPPORTED_CLAIM_TERMS: dict[str, tuple[str, ...]] = {
+    "final_price": ("final price", "final payable", "payable amount", "checkout total", "all taxes included"),
     "emi": ("emi", "installment", "instalment", "no-cost emi", "no cost emi"),
     "discount": ("discount", "coupon", "promo", "cashback", "deal", "sale price"),
     "offer": ("offer", "promotion", "bundle"),
+    "inventory": ("guaranteed in stock", "in stock", "available now", "reserved stock"),
+    "delivery": ("delivery", "deliver", "shipping", "ship by", "delivery tomorrow"),
+    "fulfillment": ("fulfillment", "dispatch", "tracking", "order status"),
+    "refund": ("refund", "chargeback"),
+    "settlement": ("settlement", "payout", "reconciliation"),
+    "support": ("support promise", "service center", "customer support"),
     "return_policy": ("return policy", "returns", "refund", "replacement"),
     "tax": ("tax", "gst", "vat"),
     "warranty": ("warranty", "guarantee"),
 }
 
 TOOL_DATA_CLAIM_KEYS: dict[str, tuple[str, ...]] = {
+    "final_price": ("final_price", "final_amount", "payable_amount", "checkout_total"),
     "emi": ("emi", "installment", "instalment", "financing"),
     "discount": ("discount", "coupon", "promo", "cashback"),
     "offer": ("offer", "promotion", "bundle"),
+    "inventory": ("inventory_confirmed", "reserved_stock"),
+    "delivery": ("delivery", "serviceability", "shipping"),
+    "fulfillment": ("fulfillment", "dispatch", "tracking", "order_status"),
+    "refund": ("refund", "chargeback"),
+    "settlement": ("settlement", "payout", "reconciliation"),
+    "support": ("support", "service_center"),
     "return_policy": ("return", "refund", "replacement"),
     "tax": ("tax", "gst", "vat"),
     "warranty": ("warranty", "guarantee"),

--- a/docs/reports/commerce-agent-c6u4-source-freshness-commercial-fact-projection.md
+++ b/docs/reports/commerce-agent-c6u4-source-freshness-commercial-fact-projection.md
@@ -1,0 +1,91 @@
+# C6U4 Source/Freshness and Buyer-Safe Commercial Fact Projection
+
+Status: internal implementation report only. This does not approve production launch, real merchants, public discovery, checkout/payment, live providers, live Plural, production config, production allowlists, cloud resources, provider calls, merchant private API calls, protocol publication, external submission, certification, compliance, conformance, standardization, public-launch readiness, merchant approval, or production readiness.
+
+## Summary
+
+C6U4 adds a buyer-safe commercial fact projection for AgenticOrg read-only commerce previews. AgenticOrg still treats Grantex as the only source of truth. The projection qualifies preview price, inventory, source, and freshness facts and refuses or marks unsupported facts when Grantex does not provide buyer-safe evidence.
+
+No public discovery, checkout/payment, live provider, live Plural, provider call, merchant private API call, production config, production allowlist, workflow, migration, dependency, cloud resource, or protocol publication behavior is added.
+
+## Projection Model
+
+| Fact | Buyer-safe projection |
+| --- | --- |
+| Preview price | Shown as preview-only when Grantex provides amount and currency. `final_price_confirmed` remains false. |
+| Tax/GST | Marked unknown unless Grantex provides explicit tax metadata. Final checkout tax is not confirmed here. |
+| Warranty | Summary may be shown only when Grantex provides a public-safe summary. Missing summary stays unknown. |
+| Return/refund | Return summary may be shown only when Grantex provides a public-safe summary. Refund execution remains unsupported. |
+| Inventory | Availability is a preview bucket only. Unknown or stale data becomes caution, not a stock promise. |
+| Source/freshness | Shows a safe source label, freshness status, and optional timestamp. Private labels become `grantex_controlled_source`. |
+| Delivery/support/fulfillment | Unsupported until Grantex provides explicit buyer-safe contracts. |
+| Settlement/payout/reconciliation | Unsupported in buyer discovery. |
+| Discounts/coupons/EMI | Unsupported unless Grantex provides explicit buyer-safe facts in a later slice. |
+
+## Runtime Scope
+
+Changed runtime behavior is defensive only:
+
+- `buyer_discovery.py` now projects `commercial_facts` and `source_summary` for capped Grantex catalog samples.
+- `buyer_session.py` preserves nested safe projection fields in channel-neutral responses.
+- `sales_guardrails.py` expands unsupported claim detection for final price, inventory, delivery, fulfillment, refund, settlement, payout, support, discount, coupon, and EMI language.
+
+These helpers do not call a provider, Plural, a merchant private API, or any new Grantex endpoint. They do not enable writes or public discovery.
+
+## Refusal Rules
+
+AgenticOrg must refuse or qualify:
+
+- Final price, checkout total, or tax-inclusive claims without Grantex final-price facts.
+- Tax/GST claims without Grantex tax facts.
+- Warranty claims without Grantex warranty facts.
+- Return/refund claims without Grantex return/refund facts.
+- Delivery, fulfillment, tracking, support, settlement, payout, discount, coupon, and EMI claims without Grantex source facts.
+- Any stale or unknown inventory as an availability guarantee.
+- Any private source label, private URL, raw connector payload, credential, token, passport/JWT value, DB/Redis URL, webhook secret, or merchant-private identifier.
+
+## Safe Buyer Wording
+
+- "This is a Grantex preview price, not a final checkout total."
+- "Final tax, fees, discounts, delivery charges, and checkout totals are not confirmed."
+- "Inventory is stale or unknown, so I cannot confirm availability."
+- "Warranty and return terms are unknown unless Grantex provides summaries."
+- "Delivery, refunds, settlement, payout, and support execution are not enabled in this slice."
+
+## Unsafe Buyer Wording
+
+The guardrails must refuse or rewrite:
+
+- "This is the final price with all taxes included."
+- "Guaranteed in stock."
+- "Guaranteed delivery tomorrow."
+- "Guaranteed refund."
+- "I checked the merchant private system."
+- "The provider approved this payment."
+
+## Tests
+
+The C6U4 regression test covers:
+
+- Preview price projected as non-final when final tax is missing.
+- Missing warranty, return, delivery, support, fulfillment, refund, settlement, and payout facts are not invented.
+- Stale inventory becomes caution and never a stock promise.
+- Private source metadata, raw payload markers, credentials, internal tenant/merchant IDs, and private URLs are omitted or redacted.
+- Channel-neutral buyer responses preserve the safe projection while public discovery stays hidden.
+- Unsupported commercial claims are refused when Grantex source facts are missing.
+
+Nearby buyer discovery/session tests were updated to assert the new nested safe shape without relaxing redaction.
+
+## Remaining Gaps
+
+- Shared public discovery state contract.
+- Consent/session/passport revocation propagation.
+- Channel-specific refusal packs.
+- Order, fulfillment, refund, support, settlement, and payout contracts.
+- Sandbox checkout E2E.
+- Live provider readiness.
+- AgenticOrg CI/CD cloud-build guard follow-up.
+
+## Stop Conditions
+
+Stop any C6U4 follow-up if it adds public discovery enablement, checkout/payment enablement, live payment, live Plural, provider calls, merchant private API calls, production config, production allowlists, cloud resources, secrets, workflow changes, migrations, protocol publication, external submission, certification, compliance, conformance, standardization, merchant approval, or production readiness claims.

--- a/tests/regression/test_commerce_c6u4_source_freshness_projection.py
+++ b/tests/regression/test_commerce_c6u4_source_freshness_projection.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from core.commerce.buyer_discovery import build_buyer_discovery_response
+from core.commerce.buyer_session import build_channel_neutral_buyer_response
+from core.commerce.sales_guardrails import validate_claims_against_tool_data
+
+
+def _preview_payload(sample: dict[str, Any], **overrides: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "merchant_id": "merchant_private_c6u4",
+        "tenant_id": "tenant_private_c6u4",
+        "merchant_reference": "merchant_synthetic_c6u4",
+        "display_name": "Synthetic Appliance Preview",
+        "integration_status": "sandbox_handoff_requested",
+        "generated_at": "2026-06-09T00:00:00Z",
+        "audit_event_id": "audit_synthetic_c6u4",
+        "merchant": {
+            "merchant_reference": "merchant_synthetic_c6u4",
+            "display_name": "Synthetic Appliance Preview",
+            "category_preset": "electronics_appliances",
+            "country_code": "IN",
+            "default_currency": "INR",
+            "public_discovery_description_draft": "Synthetic public-safe appliance preview.",
+        },
+        "readiness_summary": {
+            "overall_status": "ready",
+            "catalog_status": "ready",
+        },
+        "agent_facing_preview_summary": {
+            "preview_status": "ready",
+            "sample_product_count": 1,
+        },
+        "rollout_proposal_summary": {
+            "proposal_status": "dry_run_passed",
+        },
+        "evidence_checklist": [
+            {"key": "source_freshness", "label": "Source freshness checked", "status": "pass"}
+        ],
+        "sample_products": [sample],
+        "allowed_buyer_agent_capabilities": ["read_only_catalog_discovery_preview"],
+        "blocked_buyer_agent_capabilities": [
+            "public_discovery",
+            "checkout_payment_creation",
+            "live_payment",
+            "live_plural",
+            "provider_credentials",
+            "order_fulfillment",
+            "refunds_returns_execution",
+            "production_allowlist",
+        ],
+        "blockers": [],
+        "remediation_items": [],
+        "sandbox_only": True,
+        "buyer_agent_discovery_is_public": False,
+        "agenticorg_public_discovery_enabled": False,
+        "public_discovery_enabled": False,
+        "checkout_payment_enabled": False,
+        "live_provider_enabled": False,
+        "live_plural_enabled": False,
+        "production_approval_status": "not_approved",
+        "live_mode_status": "not_live",
+    }
+    data.update(overrides)
+    return {"data": data}
+
+
+def _sample_product(**overrides: Any) -> dict[str, Any]:
+    sample = {
+        "title": "Synthetic Lamp",
+        "brand": "SyntheticBrand",
+        "category_preset": "electronics_appliances",
+        "source_system": "manual_upload",
+        "last_synced_at": "2026-06-09T00:00:00Z",
+        "variants": [
+            {
+                "sku": "variant_synthetic_c6u4",
+                "price_amount": 1299,
+                "currency": "INR",
+                "availability_status": "in_stock",
+                "warranty_summary": "Synthetic one-year limited warranty summary.",
+                "return_policy_summary": "Synthetic seven-day unopened return summary.",
+            }
+        ],
+    }
+    sample.update(overrides)
+    return sample
+
+
+def test_preview_price_is_projected_as_non_final_when_tax_is_missing() -> None:
+    response = build_buyer_discovery_response(_preview_payload(_sample_product()))
+
+    assert response["status"] == "preview_only"
+    facts = response["catalog_samples"][0]["commercial_facts"]
+    assert facts["price"]["status"] == "preview_only"
+    assert facts["price"]["display"] == "INR 1299"
+    assert facts["price"]["final_price_confirmed"] is False
+    assert "Final tax" in facts["tax"]["message"]
+    assert facts["tax"]["status"] == "unknown"
+    assert "delivery" in facts["unsupported"]
+    assert "settlement" in facts["unsupported"]
+
+
+def test_missing_warranty_return_delivery_and_support_are_not_invented() -> None:
+    response = build_buyer_discovery_response(
+        _preview_payload(
+            _sample_product(
+                variants=[
+                    {
+                        "sku": "variant_synthetic_c6u4_missing",
+                        "price_amount": 799,
+                        "currency": "INR",
+                        "availability_status": "in_stock",
+                    }
+                ]
+            )
+        )
+    )
+
+    facts = response["catalog_samples"][0]["commercial_facts"]
+    assert facts["warranty"]["status"] == "unknown"
+    assert facts["return_policy"]["status"] == "unknown"
+    for unsupported in ("delivery", "support", "fulfillment", "refunds", "payout"):
+        assert unsupported in facts["unsupported"]
+
+
+def test_stale_inventory_and_private_source_metadata_are_buyer_safe() -> None:
+    response = build_buyer_discovery_response(
+        _preview_payload(
+            _sample_product(
+                source_system="https://merchant-private.internal/pim",
+                raw_payload={"token": "synthetic-secret"},
+                variants=[
+                    {
+                        "sku": "variant_synthetic_c6u4_stale",
+                        "price_amount": 799,
+                        "currency": "INR",
+                        "availability_status": "unknown",
+                        "stale": True,
+                        "last_synced_at": "2026-06-01T00:00:00Z",
+                        "source_system": "merchant-private-pim",
+                    }
+                ],
+            )
+        )
+    )
+
+    sample = response["catalog_samples"][0]
+    assert sample["commercial_facts"]["inventory"]["status"] == "unknown_or_stale"
+    assert sample["commercial_facts"]["inventory"]["caution_required"] is True
+    assert sample["commercial_facts"]["inventory"]["stock_promise"] is False
+    assert sample["source_summary"]["source"] == "grantex_controlled_source"
+    assert sample["source_summary"]["freshness_status"] == "stale"
+
+    serialized = json.dumps(response, sort_keys=True).lower()
+    assert "merchant-private.internal" not in serialized
+    assert "raw_payload" not in serialized
+    assert "synthetic-secret" not in serialized
+    assert "merchant_private_c6u4" not in serialized
+    assert "tenant_private_c6u4" not in serialized
+
+
+def test_channel_response_preserves_projection_but_keeps_public_discovery_hidden() -> None:
+    response = build_channel_neutral_buyer_response(
+        _preview_payload(_sample_product()),
+        request_text="Show product price and availability.",
+        channel="web_chat",
+    )
+
+    assert response["status"] == "preview_only"
+    assert response["evidence_summary"]["preview_only"] is True
+    assert response["evidence_summary"]["safety_labels"]["public_discovery_enabled"] is False
+    sample = response["catalog_samples"][0]
+    assert sample["commercial_facts"]["price"]["final_price_confirmed"] is False
+    assert sample["commercial_facts"]["inventory"]["stock_promise"] is False
+
+
+def test_unsupported_commercial_claims_are_refused_without_grantex_source_facts() -> None:
+    result = validate_claims_against_tool_data(
+        (
+            "This is the final price with all taxes included, guaranteed in stock, "
+            "delivery tomorrow, customer support, refund, settlement, payout, "
+            "tracking, discount, coupon, and no-cost EMI."
+        ),
+        {"catalog_samples": [{"title": "Synthetic Lamp"}]},
+    )
+
+    assert result["allowed"] is False
+    unsupported = set(result["details"]["unsupported_claims"])
+    assert {
+        "final_price",
+        "inventory",
+        "delivery",
+        "support",
+        "refund",
+        "settlement",
+        "fulfillment",
+        "discount",
+        "emi",
+    }.issubset(unsupported)

--- a/tests/unit/test_commerce_buyer_discovery.py
+++ b/tests/unit/test_commerce_buyer_discovery.py
@@ -118,11 +118,15 @@ def test_sanitizer_parses_valid_read_only_discovery_handoff() -> None:
         "currency": "INR",
         "discovery_description": "Preview-only appliance catalog for buyer-agent tests.",
     }
-    assert safe["catalog_samples"] == [
-        {"title": "Countertop Mixer", "brand": "TestBrand", "category": "electronics_appliances"},
-        {"title": "Rice Cooker", "brand": "TestBrand"},
-        {"title": "Induction Cooktop", "brand": "TestBrand"},
+    assert [sample["title"] for sample in safe["catalog_samples"]] == [
+        "Countertop Mixer",
+        "Rice Cooker",
+        "Induction Cooktop",
     ]
+    assert safe["catalog_samples"][0]["brand"] == "TestBrand"
+    assert safe["catalog_samples"][0]["category"] == "electronics_appliances"
+    assert safe["catalog_samples"][0]["commercial_facts"]["price"]["status"] == "unknown"
+    assert safe["catalog_samples"][0]["source_summary"]["source"] == "grantex_preview"
     assert "buyer_agent_readiness_context" in safe["allowed_capabilities"]
     assert "checkout_payment_creation" in safe["blocked_capabilities"]
 

--- a/tests/unit/test_commerce_buyer_session.py
+++ b/tests/unit/test_commerce_buyer_session.py
@@ -145,10 +145,13 @@ async def test_buyer_session_calls_grantex_for_read_only_discovery() -> None:
     assert response["contract"] == BUYER_SESSION_CONTRACT
     assert response["status"] == "preview_only"
     assert response["merchant_preview"]["display_name"] == "Grounded Preview Store"
-    assert response["catalog_samples"] == [
-        {"title": "Grounded Mixer", "brand": "SafeBrand", "category": "electronics_appliances"},
-        {"title": "Grounded Cooker", "brand": "SafeBrand"},
+    assert [sample["title"] for sample in response["catalog_samples"]] == [
+        "Grounded Mixer",
+        "Grounded Cooker",
     ]
+    assert response["catalog_samples"][0]["brand"] == "SafeBrand"
+    assert response["catalog_samples"][0]["category"] == "electronics_appliances"
+    assert response["catalog_samples"][0]["commercial_facts"]["price"]["status"] == "unknown"
     assert response["allowed_capabilities"] == ["read_only_profile_discovery_preview"]
     assert "checkout_payment_creation" in response["blocked_capabilities"]
     assert response["source_reference"]["system"] == "grantex"
@@ -198,8 +201,8 @@ def test_buyer_session_redacts_private_fields_and_stays_grounded() -> None:
     assert "secret" not in serialized
     assert "raw_payload" not in serialized
     assert "999" not in serialized
-    assert "discount" not in serialized.lower()
-    assert "delivery" not in serialized.lower()
+    assert "discount promise" not in serialized.lower()
+    assert "delivery promise" not in serialized.lower()
     assert "refund promise" not in serialized.lower()
 
 


### PR DESCRIPTION
C6U4 AgenticOrg buyer-safe source/freshness and commercial fact projection. Adds defensive projection of Grantex preview facts, preserves nested safe projection in buyer sessions, expands unsupported commercial-claim refusals, updates nearby expectations, and adds an internal report plus regression tests. The projection marks preview price as non-final, tax/warranty/return/delivery/support/fulfillment/refund/settlement/payout/discount/EMI as unknown or unsupported without Grantex facts, redacts private source details, and keeps public discovery hidden. Validation: focused C6U4 regression, nearby buyer discovery/session/guardrail/C6U3 tests, ruff, mypy, diff checks, ASCII check, and guardrail scans. No workflow, migration, dependency, config, cloud, provider, merchant-private API, public discovery, checkout/payment, live provider, live Plural, allowlist, or protocol behavior added.