### PR TITLE
C6U5 public discovery state contract

### DIFF
--- a/core/commerce/buyer_discovery.py
+++ b/core/commerce/buyer_discovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from core.commerce.public_discovery_state import public_discovery_decision_from_payload
 from core.commerce.sales_guardrails import inventory_caution
 
 C6G_PREVIEW_ENDPOINT = "/v1/commerce/merchants/{merchant_id}/agenticorg-buyer-discovery-preview"
@@ -143,6 +144,7 @@ def build_buyer_discovery_response(
     intent = classify_buyer_discovery_request(request_text)
     safe_preview = sanitize_buyer_discovery_preview(grantex_payload)
     source_reference = safe_preview.get("source_reference", {})
+    public_discovery_state = safe_preview.get("public_discovery_state", {})
 
     if intent != "read_only_discovery":
         return _refusal_for_intent(intent, source_reference)
@@ -169,6 +171,7 @@ def build_buyer_discovery_response(
             "remediation_items": _string_list(safe_preview.get("remediation_items")),
             "blocked_capabilities": _string_list(safe_preview.get("blocked_capabilities")),
             "safety_labels": safe_preview.get("safety_labels", {}),
+            "public_discovery_state": public_discovery_state,
             "source_reference": source_reference,
         }
 
@@ -201,6 +204,7 @@ def build_buyer_discovery_response(
         "allowed_capabilities": safe_preview.get("allowed_capabilities", []),
         "blocked_capabilities": safe_preview.get("blocked_capabilities", []),
         "safety_labels": safety_labels,
+        "public_discovery_state": public_discovery_state,
         "source_reference": source_reference,
     }
 
@@ -253,6 +257,7 @@ def sanitize_buyer_discovery_preview(grantex_payload: Mapping[str, Any] | None) 
             "audit_event_id": _safe_text(data.get("audit_event_id")),
         }
     )
+    public_discovery_state = public_discovery_decision_from_payload(data)
 
     return {
         "status": "available",
@@ -268,6 +273,7 @@ def sanitize_buyer_discovery_preview(grantex_payload: Mapping[str, Any] | None) 
         "blockers": _string_list(data.get("blockers")),
         "remediation_items": _string_list(data.get("remediation_items")),
         "safety_labels": safety_labels,
+        "public_discovery_state": public_discovery_state,
         "source_reference": source_reference,
     }
 

--- a/core/commerce/buyer_session.py
+++ b/core/commerce/buyer_session.py
@@ -242,6 +242,9 @@ def _evidence_summary(
         summary["refusal_code"] = _safe_refusal_code(response.get("refusal_code"))
     if safety_labels:
         summary["safety_labels"] = safety_labels
+    public_discovery_state = _mapping(response.get("public_discovery_state"))
+    if public_discovery_state:
+        summary["public_discovery_state"] = public_discovery_state
     for source_key, target_key in (
         ("readiness_summary", "readiness"),
         ("agent_facing_preview_summary", "agent_preview"),

--- a/core/commerce/public_discovery_state.py
+++ b/core/commerce/public_discovery_state.py
@@ -1,0 +1,263 @@
+"""Fail-closed shared public discovery state decisions for Agentic Commerce."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Any
+
+PUBLIC_DISCOVERY_STATE_CONTRACT = "agenticorg.commerce.public_discovery_state.v1"
+
+PUBLIC_DISCOVERY_STATES = frozenset(
+    {
+        "hidden",
+        "draft",
+        "sandbox_review",
+        "approved_for_sandbox_preview",
+        "blocked",
+        "rejected",
+        "expired",
+        "production_pending",
+        "future_public_enabled",
+    }
+)
+
+PRIVATE_STATE_MARKERS = (
+    "private",
+    "internal",
+    "provider",
+    "credential",
+    "secret",
+    "token",
+    "jwt",
+    "passport",
+    "raw",
+    "payload",
+    "postgres://",
+    "postgresql://",
+    "redis://",
+    "http://",
+    "https://",
+)
+
+REQUIRED_FUTURE_EVIDENCE = (
+    "grantex_review_decision",
+    "agenticorg_exposure_decision",
+    "source_freshness",
+    "rollback_owner",
+)
+
+
+def public_discovery_decision_from_payload(
+    grantex_payload: Mapping[str, Any] | None,
+    *,
+    now: datetime | str | None = None,
+) -> dict[str, Any]:
+    """Return a buyer-safe fail-closed decision from Grantex and AgenticOrg state."""
+    data = _data_object(grantex_payload)
+    state_payload = _mapping(data.get("public_discovery_state"))
+    grantex_state = _normalize_state(
+        _first_value(
+            state_payload,
+            data,
+            keys=("grantex_state", "grantex_public_discovery_state", "public_discovery_state"),
+        )
+    )
+    agenticorg_state = _normalize_state(
+        _first_value(
+            state_payload,
+            data,
+            keys=("agenticorg_state", "agenticorg_public_discovery_state"),
+        )
+    )
+
+    evidence_keys = _safe_evidence_keys(
+        state_payload.get("evidence") or data.get("public_discovery_evidence") or data.get("evidence_checklist")
+    )
+    blockers = _state_blockers(
+        grantex_state=grantex_state,
+        agenticorg_state=agenticorg_state,
+        evidence_keys=evidence_keys,
+        state_payload=state_payload,
+        data=data,
+        now=_parse_datetime(now),
+    )
+    internal_preview_allowed = not blockers and grantex_state == agenticorg_state == "approved_for_sandbox_preview"
+    refusal_code = (
+        "public_discovery_not_enabled"
+        if internal_preview_allowed
+        else blockers[0]
+        if blockers
+        else "public_discovery_not_enabled"
+    )
+
+    return {
+        "contract": PUBLIC_DISCOVERY_STATE_CONTRACT,
+        "grantex_state": grantex_state,
+        "agenticorg_state": agenticorg_state,
+        "buyer_visibility": "internal_preview" if internal_preview_allowed else "hidden",
+        "public_discovery_visible": False,
+        "public_discovery_refusal": True,
+        "internal_preview_allowed": internal_preview_allowed,
+        "future_public_enabled_active": False,
+        "refusal_code": refusal_code,
+        "reason": _buyer_safe_reason(refusal_code),
+        "required_evidence_missing": [
+            key for key in REQUIRED_FUTURE_EVIDENCE if key not in set(evidence_keys)
+        ],
+        "evidence_keys": evidence_keys,
+    }
+
+
+def _state_blockers(
+    *,
+    grantex_state: str,
+    agenticorg_state: str,
+    evidence_keys: Sequence[str],
+    state_payload: Mapping[str, Any],
+    data: Mapping[str, Any],
+    now: datetime,
+) -> list[str]:
+    blockers: list[str] = []
+    if grantex_state == "missing" or agenticorg_state == "missing":
+        blockers.append("public_discovery_state_missing")
+    if grantex_state == "unsupported" or agenticorg_state == "unsupported":
+        blockers.append("public_discovery_state_unsupported")
+    if grantex_state in PUBLIC_DISCOVERY_STATES and agenticorg_state in PUBLIC_DISCOVERY_STATES:
+        if grantex_state != agenticorg_state:
+            blockers.append("public_discovery_state_mismatch")
+    if grantex_state in {"blocked", "rejected", "expired"}:
+        blockers.append(f"grantex_state_{grantex_state}")
+    if agenticorg_state in {"blocked", "rejected", "expired"}:
+        blockers.append(f"agenticorg_state_{agenticorg_state}")
+    if grantex_state == "future_public_enabled" or agenticorg_state == "future_public_enabled":
+        blockers.append("future_public_enabled_not_enabled_by_c6u5")
+    if _is_stale_or_expired(state_payload, data, now=now):
+        blockers.append("public_discovery_state_expired_or_stale")
+    if _truthy(_first_value(state_payload, data, keys=("synthetic_data", "synthetic_demo", "demo_data"))):
+        blockers.append("synthetic_demo_not_production_approval")
+
+    if grantex_state == agenticorg_state == "approved_for_sandbox_preview":
+        missing = [key for key in REQUIRED_FUTURE_EVIDENCE if key not in set(evidence_keys)]
+        if missing:
+            blockers.append("public_discovery_evidence_missing")
+    return _unique(blockers)
+
+
+def _is_stale_or_expired(
+    state_payload: Mapping[str, Any],
+    data: Mapping[str, Any],
+    *,
+    now: datetime,
+) -> bool:
+    freshness = _safe_token(
+        _first_value(state_payload, data, keys=("freshness_status", "state_freshness", "source_freshness"))
+    )
+    if freshness in {"stale", "expired", "blocked"}:
+        return True
+    expires_at = _parse_datetime(_first_value(state_payload, data, keys=("expires_at", "state_expires_at")))
+    return expires_at <= now
+
+
+def _safe_evidence_keys(value: Any) -> list[str]:
+    entries: list[str] = []
+    if isinstance(value, Mapping):
+        iterable: Sequence[Any] = list(value.values())
+    elif isinstance(value, Sequence) and not isinstance(value, str):
+        iterable = value
+    else:
+        return []
+
+    for item in iterable[:16]:
+        if isinstance(item, str):
+            token = _safe_token(item)
+        elif isinstance(item, Mapping):
+            token = _safe_token(item.get("key") or item.get("evidence_key") or item.get("type"))
+            status = _safe_token(item.get("status"))
+            if status and status not in {"pass", "passed", "available", "fresh", "current"}:
+                continue
+        else:
+            continue
+        if token and token not in entries:
+            entries.append(token)
+    return entries
+
+
+def _buyer_safe_reason(code: str) -> str:
+    messages = {
+        "public_discovery_state_missing": "Public discovery state is incomplete, so discovery remains hidden.",
+        "public_discovery_state_unsupported": "Public discovery state is unsupported, so discovery remains hidden.",
+        "public_discovery_state_mismatch": "Grantex and AgenticOrg discovery states do not match.",
+        "public_discovery_state_expired_or_stale": "Public discovery evidence is stale or expired.",
+        "public_discovery_evidence_missing": "Required public discovery evidence is missing.",
+        "synthetic_demo_not_production_approval": "Synthetic or demo data cannot approve public discovery.",
+        "future_public_enabled_not_enabled_by_c6u5": "Future public discovery state is not active in C6U5.",
+    }
+    return messages.get(code, "Public discovery is not enabled for this merchant.")
+
+
+def _data_object(payload: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    if not isinstance(payload, Mapping):
+        return {}
+    data = payload.get("data")
+    return data if isinstance(data, Mapping) else payload
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _first_value(*mappings: Mapping[str, Any], keys: Sequence[str]) -> Any:
+    for mapping in mappings:
+        for key in keys:
+            value = mapping.get(key)
+            if value not in (None, ""):
+                return value
+    return None
+
+
+def _normalize_state(value: Any) -> str:
+    token = _safe_token(value)
+    if not token:
+        return "missing"
+    return token if token in PUBLIC_DISCOVERY_STATES else "unsupported"
+
+
+def _safe_token(value: Any) -> str:
+    if value in (None, ""):
+        return ""
+    text = str(value).strip().lower().replace("-", "_").replace(" ", "_")
+    if not text or len(text) > 80:
+        return ""
+    if any(marker in text for marker in PRIVATE_STATE_MARKERS):
+        return ""
+    return "".join(ch for ch in text if ch.isalnum() or ch == "_")
+
+
+def _parse_datetime(value: datetime | str | Any | None) -> datetime:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, str) and value.strip():
+        text = value.strip().replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(text)
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+        except ValueError:
+            return datetime.max.replace(tzinfo=UTC)
+    return datetime.now(UTC)
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value in (None, ""):
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "demo", "synthetic"}
+
+
+def _unique(values: Sequence[str]) -> list[str]:
+    result: list[str] = []
+    for value in values:
+        if value and value not in result:
+            result.append(value)
+    return result

--- a/docs/reports/commerce-agent-c6u5-public-discovery-state-contract.md
+++ b/docs/reports/commerce-agent-c6u5-public-discovery-state-contract.md
@@ -1,0 +1,86 @@
+# C6U5 Agentic Commerce Public Discovery State Contract
+
+Status: internal implementation report only. This document does not approve production launch, real merchants, public discovery, checkout/payment, live providers, live Plural, production config, production allowlists, cloud resources, provider calls, merchant private API calls, protocol publication, external submission, certification, compliance, conformance, standardization, public-launch readiness, merchant approval, or production readiness.
+
+## Executive summary
+
+C6U5 defines how AgenticOrg consumes Grantex public discovery state. AgenticOrg remains fail-closed: public buyer discovery stays hidden or refused unless a future separately approved slice proves compatible Grantex and AgenticOrg approval, fresh source evidence, rollback ownership, and safe channel exposure.
+
+This PR does not enable public discovery. It adds a defensive, non-enabling state decision helper and tests that preserve hidden/refused behavior.
+
+## Shared state table
+
+| State | AgenticOrg behavior |
+| --- | --- |
+| `hidden` | Hide/refuse public discovery. |
+| `draft` | Hide/refuse public discovery. |
+| `sandbox_review` | Hide/refuse public discovery. |
+| `approved_for_sandbox_preview` | Allow only internal preview context; public discovery remains hidden. |
+| `blocked` | Hide/refuse public discovery. |
+| `rejected` | Hide/refuse public discovery. |
+| `expired` | Hide/refuse public discovery. |
+| `production_pending` | Hide/refuse public discovery. |
+| `future_public_enabled` | Future enum only; still hidden/refused in C6U5. |
+
+## Grantex-owned responsibilities
+
+Grantex owns merchant readiness, discovery review, rollout proposal, source/freshness facts, preview conformance, production allowlist decisions, and audit evidence. AgenticOrg treats Grantex as the only commerce source and does not call providers, Plural, or merchant private APIs.
+
+## AgenticOrg-owned responsibilities
+
+AgenticOrg owns buyer-agent exposure, channel-safe discovery behavior, public metadata hiding, buyer-facing refusal wording, and future channel rollback. AgenticOrg must fail closed when Grantex state is missing, unsupported, stale, expired, blocked, rejected, mismatched, or demo-only.
+
+## Defensive helper behavior
+
+`core/commerce/public_discovery_state.py` returns a buyer-safe decision with:
+
+- Grantex state.
+- AgenticOrg state.
+- Buyer visibility: `hidden` or `internal_preview`.
+- `public_discovery_visible: false`.
+- `public_discovery_refusal: true`.
+- Required evidence gaps.
+- Redacted evidence keys only.
+
+The helper never returns active public discovery in C6U5. Even `future_public_enabled` is treated as a non-active future enum.
+
+## Mismatch, expiry, and rollback
+
+State mismatch refuses public discovery. Missing state refuses public discovery. Unsupported state refuses public discovery. Expired or stale evidence refuses public discovery. Synthetic or demo state refuses public discovery. Rollback from either owner must hide public metadata in all buyer channels before any future public exposure can be considered.
+
+## Buyer-safe wording
+
+Allowed:
+
+- "Public discovery is not enabled for this merchant."
+- "This is an internal sandbox preview only."
+- "Grantex and AgenticOrg discovery state is not aligned, so discovery remains hidden."
+
+Unsafe:
+
+- "Public discovery is approved."
+- "This merchant is production ready."
+- "This merchant is certified or compliant."
+- "Checkout or payment is enabled."
+- "Live provider or live Plural is available."
+
+## Private-only fields
+
+AgenticOrg must not show raw state evidence, real tenant or merchant IDs, private source labels, provider internals, URLs, credentials, tokens, JWTs, passports, DB/Redis URLs, webhook secrets, raw payloads, production config values, concrete allowlists, or private reviewer notes.
+
+## Stop conditions
+
+Stop C6U5 work if it adds public discovery enablement, checkout/payment enablement, live payment, live Plural, provider calls, merchant private API calls, production config, production allowlists, cloud resources, secrets, workflow changes, migrations, protocol publication, external submission, certification, compliance, conformance, standardization, merchant approval, public-launch readiness, or production readiness claims.
+
+## Remaining gaps
+
+- Consent/session/passport revocation propagation.
+- Channel-specific refusal packs.
+- Order, fulfillment, refund, support, settlement, and payout contracts.
+- Sandbox checkout E2E.
+- Live provider readiness.
+- AgenticOrg CI/CD cloud-build guard follow-up.
+
+## Validation plan
+
+C6U5 validation should run the focused state contract regression, nearby commerce discovery/refusal/session tests, lint/type checks for touched Python files, diff whitespace check, ASCII check, secret/private scan, production config/allowlist scan, public discovery enablement scan, checkout/payment/live-provider scan, direct provider/Plural scan, merchant private API scan, raw connector/private payload scan, and overclaim scan.

--- a/tests/regression/test_commerce_c6u5_public_discovery_state_contract.py
+++ b/tests/regression/test_commerce_c6u5_public_discovery_state_contract.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from core.commerce.buyer_discovery import build_buyer_discovery_response
+from core.commerce.buyer_session import build_channel_neutral_buyer_response
+from core.commerce.public_discovery_state import public_discovery_decision_from_payload
+
+NOW = datetime(2026, 6, 9, tzinfo=UTC)
+
+CANONICAL_STATES = (
+    "hidden",
+    "draft",
+    "sandbox_review",
+    "approved_for_sandbox_preview",
+    "blocked",
+    "rejected",
+    "expired",
+    "production_pending",
+    "future_public_enabled",
+)
+
+
+def _state_payload(grantex_state: str, agenticorg_state: str | None = None, **overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "grantex_state": grantex_state,
+        "agenticorg_state": agenticorg_state or grantex_state,
+        "freshness_status": "fresh",
+        "expires_at": "2026-06-10T00:00:00Z",
+        "evidence": [
+            {"key": "grantex_review_decision", "status": "pass"},
+            {"key": "agenticorg_exposure_decision", "status": "pass"},
+            {"key": "source_freshness", "status": "pass"},
+            {"key": "rollback_owner", "status": "pass"},
+        ],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _preview_payload(public_state: dict[str, Any] | None = None, **overrides: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "merchant_id": "merchant_private_c6u5",
+        "tenant_id": "tenant_private_c6u5",
+        "merchant_reference": "merchant_synthetic_c6u5",
+        "display_name": "Synthetic Discovery Preview",
+        "integration_status": "sandbox_handoff_requested",
+        "generated_at": "2026-06-09T00:00:00Z",
+        "audit_event_id": "audit_synthetic_c6u5",
+        "public_discovery_state": public_state,
+        "merchant": {
+            "merchant_reference": "merchant_synthetic_c6u5",
+            "display_name": "Synthetic Discovery Preview",
+            "category_preset": "electronics_appliances",
+            "country_code": "IN",
+            "default_currency": "INR",
+            "public_discovery_description_draft": "Synthetic public-safe discovery preview.",
+        },
+        "readiness_summary": {"overall_status": "ready", "catalog_status": "ready"},
+        "agent_facing_preview_summary": {"preview_status": "ready", "sample_product_count": 1},
+        "rollout_proposal_summary": {"proposal_status": "dry_run_passed", "dry_run_result": "passed"},
+        "evidence_checklist": [{"key": "source_freshness", "label": "Source freshness", "status": "pass"}],
+        "sample_products": [{"title": "Synthetic Lamp", "brand": "SyntheticBrand"}],
+        "allowed_buyer_agent_capabilities": ["read_only_catalog_discovery_preview"],
+        "blocked_buyer_agent_capabilities": [
+            "public_discovery",
+            "checkout_payment_creation",
+            "live_payment",
+            "live_plural",
+            "provider_credentials",
+            "direct_merchant_system_access",
+        ],
+        "blockers": [],
+        "remediation_items": [],
+        "sandbox_only": True,
+        "buyer_agent_discovery_is_public": False,
+        "agenticorg_public_discovery_enabled": False,
+        "public_discovery_enabled": False,
+        "checkout_payment_enabled": False,
+        "live_provider_enabled": False,
+        "live_plural_enabled": False,
+        "production_approval_status": "not_approved",
+        "live_mode_status": "not_live",
+    }
+    data.update(overrides)
+    return {"data": data}
+
+
+@pytest.mark.parametrize("state", CANONICAL_STATES)
+def test_canonical_states_never_enable_public_discovery_in_c6u5(state: str) -> None:
+    decision = public_discovery_decision_from_payload(
+        _preview_payload(_state_payload(state)),
+        now=NOW,
+    )
+
+    assert decision["grantex_state"] == state
+    assert decision["agenticorg_state"] == state
+    assert decision["public_discovery_visible"] is False
+    assert decision["public_discovery_refusal"] is True
+    assert decision["future_public_enabled_active"] is False
+    if state == "approved_for_sandbox_preview":
+        assert decision["buyer_visibility"] == "internal_preview"
+        assert decision["internal_preview_allowed"] is True
+    else:
+        assert decision["buyer_visibility"] == "hidden"
+        assert decision["internal_preview_allowed"] is False
+    if state == "future_public_enabled":
+        assert decision["refusal_code"] == "future_public_enabled_not_enabled_by_c6u5"
+
+
+@pytest.mark.parametrize(
+    ("public_state", "refusal_code"),
+    [
+        (None, "public_discovery_state_missing"),
+        (_state_payload("not_a_real_state"), "public_discovery_state_unsupported"),
+        (_state_payload("approved_for_sandbox_preview", "hidden"), "public_discovery_state_mismatch"),
+        (
+            _state_payload("approved_for_sandbox_preview", expires_at="2026-06-08T00:00:00Z"),
+            "public_discovery_state_expired_or_stale",
+        ),
+        (
+            _state_payload("approved_for_sandbox_preview", synthetic_data=True),
+            "synthetic_demo_not_production_approval",
+        ),
+        (
+            _state_payload("approved_for_sandbox_preview", evidence=[]),
+            "public_discovery_evidence_missing",
+        ),
+    ],
+)
+def test_missing_mismatched_stale_or_demo_state_fails_closed(
+    public_state: dict[str, Any] | None,
+    refusal_code: str,
+) -> None:
+    decision = public_discovery_decision_from_payload(_preview_payload(public_state), now=NOW)
+
+    assert decision["buyer_visibility"] == "hidden"
+    assert decision["public_discovery_visible"] is False
+    assert decision["public_discovery_refusal"] is True
+    assert decision["refusal_code"] == refusal_code
+
+
+def test_buyer_discovery_response_carries_hidden_state_without_enabling_public_discovery() -> None:
+    response = build_buyer_discovery_response(
+        _preview_payload(_state_payload("approved_for_sandbox_preview")),
+        request_text="Show this merchant preview.",
+    )
+
+    assert response["status"] == "preview_only"
+    assert response["public_discovery_state"]["buyer_visibility"] == "internal_preview"
+    assert response["public_discovery_state"]["public_discovery_visible"] is False
+    assert response["safety_labels"]["public_discovery_enabled"] is False
+    assert response["safety_labels"]["agenticorg_public_discovery_enabled"] is False
+    assert "public discovery" in response["message"].lower()
+
+
+def test_channel_response_preserves_public_discovery_refusal_state() -> None:
+    response = build_channel_neutral_buyer_response(
+        _preview_payload(_state_payload("sandbox_review")),
+        request_text="Show this merchant preview.",
+        channel="chatgpt",
+    )
+
+    state = response["evidence_summary"]["public_discovery_state"]
+    assert response["status"] == "preview_only"
+    assert response["channel"] == "chatgpt"
+    assert state["grantex_state"] == "sandbox_review"
+    assert state["agenticorg_state"] == "sandbox_review"
+    assert state["buyer_visibility"] == "hidden"
+    assert state["public_discovery_visible"] is False
+    assert state["public_discovery_refusal"] is True
+
+
+def test_private_state_evidence_is_redacted_from_buyer_safe_response() -> None:
+    response = build_buyer_discovery_response(
+        _preview_payload(
+            _state_payload(
+                "approved_for_sandbox_preview",
+                evidence=[
+                    {"key": "grantex_review_decision", "status": "pass"},
+                    {"key": "https://merchant-private.internal/state", "status": "pass"},
+                    {"key": "provider_credentials", "status": "pass"},
+                    {"key": "source_freshness", "status": "pass"},
+                    {"key": "rollback_owner", "status": "pass"},
+                ],
+                raw_payload={"token": "synthetic-secret"},
+                private_url="https://merchant-private.internal/state",
+                webhook_secret="synthetic-webhook-secret",
+            )
+        )
+    )
+
+    serialized = json.dumps(response, sort_keys=True).lower()
+    state_serialized = json.dumps(response["public_discovery_state"], sort_keys=True).lower()
+    assert "synthetic discovery preview" in serialized
+    assert "merchant-private.internal" not in serialized
+    assert "provider_credentials" not in state_serialized
+    assert "raw_payload" not in serialized
+    assert "synthetic-secret" not in serialized
+    assert "webhook_secret" not in serialized
+    assert "merchant_private_c6u5" not in serialized
+    assert "tenant_private_c6u5" not in serialized
+
+
+def test_public_discovery_state_refusal_does_not_open_checkout_or_provider_paths() -> None:
+    response = build_buyer_discovery_response(
+        _preview_payload(_state_payload("future_public_enabled")),
+        request_text="Show public discovery and create checkout.",
+    )
+
+    assert response["status"] == "refused"
+    assert response["refusal_code"] == "checkout_payment_not_enabled"
+    serialized = json.dumps(response, sort_keys=True).lower()
+    assert "live_plural_enabled\": true" not in serialized
+    assert "live_provider_enabled\": true" not in serialized
+    assert "checkout_payment_enabled\": true" not in serialized
+    assert "provider call" not in serialized


### PR DESCRIPTION
## Summary
- add fail-closed AgenticOrg public discovery state decision helper
- project buyer-safe public_discovery_state into discovery and buyer-session evidence summaries
- add regression coverage for hidden/refused behavior, stale/mismatched/synthetic states, redaction, and no checkout/provider exposure

## Validation
- python -m pytest tests/regression/test_commerce_c6u5_public_discovery_state_contract.py
- python -m pytest tests/unit/test_commerce_buyer_discovery.py tests/unit/test_commerce_buyer_session.py tests/unit/test_commerce_sales_agent_guardrails.py tests/regression/test_commerce_c6u4_source_freshness_projection.py tests/regression/test_commerce_c6u5_public_discovery_state_contract.py
- python -m ruff check core/commerce/public_discovery_state.py core/commerce/buyer_discovery.py core/commerce/buyer_session.py tests/regression/test_commerce_c6u5_public_discovery_state_contract.py
- python -m mypy core/commerce/public_discovery_state.py core/commerce/buyer_discovery.py core/commerce/buyer_session.py
- git diff --check origin/main...HEAD

## Guardrails
Defensive/non-enabling runtime helper only. No public discovery enablement, checkout/payment, live provider, live Plural, cloud, config, secret, allowlist, provider call, merchant private API, or protocol publication behavior added.