### PR TITLE
fix: harden security scan findings

### DIFF
--- a/connectors/comms/s3.py
+++ b/connectors/comms/s3.py
@@ -15,7 +15,8 @@ from connectors.framework.base_connector import BaseConnector
 class S3Connector(BaseConnector):
     name = "s3"
     category = "comms"
-    auth_type = "service_account"
+    # Literal auth-mode label, not a credential or service-account key.
+    auth_type = "service_account"  # nosemgrep
     base_url = "https://storage.googleapis.com"
     rate_limit_rpm = 1000
 

--- a/connectors/finance/tally.py
+++ b/connectors/finance/tally.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 
 import uuid
 from typing import Any
-from xml.etree.ElementTree import Element, SubElement, tostring
+
+# stdlib ElementTree is used only to construct outbound XML envelopes.
+# All untrusted Tally responses are parsed through defusedxml below.
+from xml.etree.ElementTree import Element, SubElement, tostring  # nosemgrep
 
 import structlog
 from defusedxml.ElementTree import ParseError as XMLParseError

--- a/connectors/framework/base_connector.py
+++ b/connectors/framework/base_connector.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import abc
 import re
 from typing import Any
-from xml.etree.ElementTree import Element
 
 import httpx
 import structlog
@@ -312,7 +311,7 @@ class BaseConnector(abc.ABC):
             return body["value"] if isinstance(body["value"], list) else body
         return body
 
-    async def _post_xml(self, xml_body: str) -> Element:
+    async def _post_xml(self, xml_body: str) -> Any:
         """POST an XML body and return the parsed XML response.
 
         Used by connectors that speak XML over HTTP (e.g. Tally TDL).

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -31,7 +31,7 @@ DOMAINS = ["finance", "hr", "marketing", "ops", "commerce"]
 
 def _deterministic_seed(case_id: str) -> int:
     """Produce a stable integer seed from a case id (no randomness)."""
-    return int(hashlib.md5(case_id.encode()).hexdigest()[:8], 16)  # noqa: S324
+    return int(hashlib.md5(case_id.encode(), usedforsecurity=False).hexdigest()[:8], 16)
 
 
 def _perturb_value(value: Any, seed: int) -> Any:

--- a/migrations/versions/v4_1_0_company_model.py
+++ b/migrations/versions/v4_1_0_company_model.py
@@ -117,7 +117,7 @@ def upgrade():
     # Table names are hardcoded — not user input.
     for tbl in ["agents", "workflow_definitions", "workflow_runs", "audit_log"]:
         policy_sql = (
-            f"CREATE POLICY company_isolation ON {tbl} USING ("  # noqa: S608
+            f"CREATE POLICY company_isolation ON {tbl} USING ("  # noqa: S608  # nosec B608
             f"  company_id IS NULL"
             f"  OR company_id IN ("
             f"    SELECT id FROM companies"

--- a/scripts/check_enterprise_stability_gates.py
+++ b/scripts/check_enterprise_stability_gates.py
@@ -365,7 +365,7 @@ def _bool_value(value: str | None) -> bool | None:
 
 
 def _finding(category: str, path: str, line: int, code: str, message: str) -> Finding:
-    digest = hashlib.sha1(f"{category}:{path}:{line}:{code}".encode()).hexdigest()[:12]
+    digest = hashlib.sha256(f"{category}:{path}:{line}:{code}".encode()).hexdigest()[:12]
     return Finding(category=category, path=path, line=line, code=code, message=message, key=f"{category}:{path}:{line}:{digest}")
 
 

--- a/scripts/gcp_billing_mtd.py
+++ b/scripts/gcp_billing_mtd.py
@@ -56,7 +56,7 @@ def run_query(sql: str) -> list[dict]:
         },
         method="POST",
     )
-    with urllib.request.urlopen(req) as resp:  # noqa: S310  # nosec B310
+    with urllib.request.urlopen(req) as resp:  # noqa: S310  # nosec B310  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
         body = json.loads(resp.read())
     if not body.get("jobComplete"):
         sys.exit("Query did not complete synchronously; rerun.")
@@ -81,7 +81,7 @@ def find_billing_table() -> str:
         url,
         headers={"Authorization": f"Bearer {token}"},
     )
-    with urllib.request.urlopen(req) as resp:  # noqa: S310  # nosec B310
+    with urllib.request.urlopen(req) as resp:  # noqa: S310  # nosec B310  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
         body = json.loads(resp.read())
     tables = [t["tableReference"]["tableId"] for t in body.get("tables", [])]
     standard = [t for t in tables if t.startswith("gcp_billing_export_v1_")]
@@ -119,7 +119,7 @@ def main() -> None:
     WHERE EXTRACT(YEAR FROM usage_start_time) = {year}
       AND EXTRACT(MONTH FROM usage_start_time) = {month}
     GROUP BY currency
-    """  # noqa: S608
+    """  # noqa: S608  # nosec B608
     by_service_sql = f"""
     SELECT
       service.description AS service,
@@ -131,7 +131,7 @@ def main() -> None:
     HAVING net_cost > 0
     ORDER BY net_cost DESC
     LIMIT 15
-    """  # noqa: S608
+    """  # noqa: S608  # nosec B608
 
     print(f"=== {year}-{month:02d} (project: {PROJECT}) ===\n")
     totals = run_query(total_sql)

--- a/scripts/qa_audit.py
+++ b/scripts/qa_audit.py
@@ -184,7 +184,7 @@ def _check_url_health(paths: set[str], base: str, head_cache: dict[str, int]) ->
             # nosec B310 — base scheme validated above; URL is built
             # from a trusted config + a path the audit script controls.
             req = urllib.request.Request(url, method="HEAD")  # noqa: S310
-            with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310  # nosec B310
+            with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310  # nosec B310  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
                 head_cache[path] = resp.status
                 out[path] = resp.status
         except urllib.error.HTTPError as e:

--- a/scripts/run_beat.py
+++ b/scripts/run_beat.py
@@ -70,7 +70,7 @@ def _run_celery_beat() -> int:
     # at /tmp (writable tmpfs on Cloud Run) so the scheduler can
     # persist its last-run state for the lifetime of the revision.
     schedule_path = os.environ.get(
-        "AGENTICORG_BEAT_SCHEDULE_PATH", "/tmp/celerybeat-schedule"  # noqa: S108
+        "AGENTICORG_BEAT_SCHEDULE_PATH", "/tmp/celerybeat-schedule"  # noqa: S108  # nosec B108
     )
     sys.argv = [
         "celery",

--- a/tests/security/test_agent_scaling_full.py
+++ b/tests/security/test_agent_scaling_full.py
@@ -484,7 +484,7 @@ class TestFTSCALE011:
         for i in range(total):
             request_id = f"req-{i}"
             # Hash-based deterministic split
-            h = int(hashlib.md5(request_id.encode()).hexdigest(), 16)
+            h = int(hashlib.md5(request_id.encode(), usedforsecurity=False).hexdigest(), 16)
             bucket = h % 100
             if bucket < variant_b_pct:
                 variant_b_count += 1

--- a/ui/nginx.cloudrun.conf.template
+++ b/ui/nginx.cloudrun.conf.template
@@ -22,7 +22,7 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    rewrite ^(.+)/$ $1 permanent;
+    rewrite ^(.+)/$ https://$host$1 permanent;
 
     error_page 502 503 504 /index.html;
 

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -33,7 +33,7 @@ server {
     index index.html;
 
     # ── Strip trailing slashes (fixes GSC "Alternative page with canonical") ─
-    rewrite ^(.+)/$ $1 permanent;
+    rewrite ^(.+)/$ https://$host$1 permanent;
 
     # ── Custom error pages — serve SPA instead of nginx default ──────────────
     error_page 502 503 504 /index.html;

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -3300,9 +3300,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -46,7 +46,8 @@
   "overrides": {
     "dompurify": ">=3.4.0",
     "lodash": ">=4.18.0",
-    "follow-redirects": ">=1.16.0"
+    "follow-redirects": ">=1.16.0",
+    "brace-expansion": ">=5.0.6"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
Security hardening from the June 9, 2026 full scan. Fixes UI brace-expansion advisory, hardens HTTPS canonical redirects, clears Semgrep security findings, removes non-test Bandit high/medium findings, and documents scanner false positives where guards already exist. Local verification: npm audit clean for ui/mcp-server/sdk-ts; Semgrep p/security-audit+p/secrets 0 findings; Bandit 0 high and 0 non-test medium; Ruff touched files passed; enterprise stability gates passed; tests/security/test_agent_scaling_full.py passed; ui npm ci and npm run build passed.