### PR TITLE
[codex] Add C6W4 OACP adapter preview consumption

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -30,6 +30,14 @@ ArtifactType = Literal[
     "revocation",
     "protocol_adapter",
 ]
+AdapterPreviewSurface = Literal[
+    "schema_org_jsonld",
+    "ucp_capability_profile",
+    "acp_commerce_capability",
+    "ap2_evidence_intent_summary",
+    "a2a_agent_card_task_capability",
+    "mcp_tool_resource_capability",
+]
 OfflineAction = Literal[
     "browse",
     "compare",
@@ -143,6 +151,50 @@ OACP_FIRST_E2E_BRIDGES: dict[str, str] = {
     "gemini_style": "a2a_task_bridge_with_openapi_fallback",
     "perplexity_style": "hosted_answer_search_bridge_with_openapi_read_and_commit_preflight",
 }
+
+OACP_C6W4_PROTOCOL_ADAPTER_SURFACES: tuple[AdapterPreviewSurface, ...] = (
+    "schema_org_jsonld",
+    "ucp_capability_profile",
+    "acp_commerce_capability",
+    "ap2_evidence_intent_summary",
+    "a2a_agent_card_task_capability",
+    "mcp_tool_resource_capability",
+)
+
+OACP_C6W4_BLOCKED_ADAPTER_ACTIONS: frozenset[str] = frozenset(
+    {
+        "checkout_create",
+        "payment_authorize",
+        "payment_capture",
+        "refund_execute",
+        "settlement_execute",
+        "payout_execute",
+        "fulfillment_start",
+        "merchant_approval",
+        "public_discovery_publish",
+        "public_discovery_unpublish",
+        "live_provider_call",
+        "live_plural_call",
+        "provider_call",
+        "carrier_call",
+        "shipping_provider_call",
+        "merchant_private_api_call",
+        "protocol_publication",
+    }
+)
+
+OACP_C6W4_NON_BINDING_ADAPTER_ACTIONS: frozenset[str] = frozenset(
+    {
+        "browse",
+        "compare",
+        "draft_cart",
+        "quote_preview",
+        "policy_explain",
+        "seller_card_display",
+        "agent_route",
+        "tool_discovery",
+    }
+)
 
 OACP_REQUIRED_ENVELOPE_FIELDS = (
     "artifact_id",
@@ -1009,6 +1061,92 @@ def evaluate_agenticorg_artifact_runtime_use(
             "refusal_code": "artifact_not_commerce_authority",
         }
     return {"allowed": True, "status": "allowed"}
+
+
+def _string_list(value: Any) -> list[str]:
+    return [item for item in value if isinstance(item, str)] if isinstance(value, list) else []
+
+
+def _adapter_preview_refusal(code: str, message: str) -> dict[str, Any]:
+    return {
+        "allowed": False,
+        "status": "refused",
+        "refusal_code": code,
+        "message": message,
+    }
+
+
+def evaluate_agenticorg_oacp_adapter_preview_use(
+    *,
+    preview: dict[str, Any],
+    action: str,
+) -> dict[str, Any]:
+    """Evaluate local use of a Grantex adapter preview without granting authority."""
+
+    if preview.get("generated") is not True or preview.get("status") != "preview_only":
+        return _adapter_preview_refusal("adapter_preview_invalid", "Adapter preview is not valid.")
+    if preview.get("surface") not in OACP_C6W4_PROTOCOL_ADAPTER_SURFACES:
+        return _adapter_preview_refusal("adapter_surface_unknown", "Adapter preview surface is unsupported.")
+
+    safety_flags = (
+        preview.get("non_authoritative_for_transaction") is True
+        and preview.get("no_checkout_payment_enablement") is True
+        and preview.get("no_live_provider_enablement") is True
+        and preview.get("no_public_discovery_enablement") is True
+    )
+    if not safety_flags:
+        return _adapter_preview_refusal(
+            "adapter_preview_not_buyer_safe",
+            "Adapter preview is missing required safety flags.",
+        )
+
+    source_ids = _string_list(preview.get("source_artifact_ids"))
+    source_families = _string_list(preview.get("source_artifact_families"))
+    if (
+        not source_ids
+        or not source_families
+        or preview.get("source_authority") != "grantex_canonical_oacp_artifact_authority"
+    ):
+        return _adapter_preview_refusal("adapter_source_missing", "Adapter preview must cite Grantex source artifacts.")
+
+    unsupported = set(_string_list(preview.get("unsupported_capabilities")))
+    blocked = OACP_C6W4_BLOCKED_ADAPTER_ACTIONS | unsupported
+    if action in blocked or action not in OACP_C6W4_NON_BINDING_ADAPTER_ACTIONS:
+        return _adapter_preview_refusal(
+            "adapter_not_transaction_authority",
+            "Adapter previews can route or display sourced facts, not approve commerce actions.",
+        )
+
+    return {
+        "allowed": True,
+        "status": "allowed",
+        "action": action,
+        "source_artifact_ids": source_ids,
+        "source_artifact_families": source_families,
+        "freshness_tier": preview.get("freshness_tier"),
+        "unsupported_capabilities": sorted(blocked),
+        "commerce_facts_invented": False,
+    }
+
+
+def summarize_oacp_adapter_preview_for_buyer(preview: dict[str, Any]) -> dict[str, Any]:
+    """Return channel-safe wording for buyer/seller surfaces."""
+
+    evaluation = evaluate_agenticorg_oacp_adapter_preview_use(preview=preview, action="browse")
+    if not evaluation["allowed"]:
+        return evaluation
+
+    return {
+        "allowed": True,
+        "status": "allowed",
+        "wording": "Preview facts are sourced from Grantex OACP artifacts and are not purchase approval.",
+        "source_artifact_ids": evaluation["source_artifact_ids"],
+        "source_artifact_families": evaluation["source_artifact_families"],
+        "freshness_tier": evaluation["freshness_tier"],
+        "unsupported_capabilities": evaluation["unsupported_capabilities"],
+        "non_authoritative_for_transaction": True,
+        "commerce_facts_invented": False,
+    }
 
 
 def verify_oacp_artifact(input_data: OacpArtifactVerificationInput) -> dict[str, Any]:

--- a/docs/reports/commerce-agent-c6w4-oacp-adapter-preview-consumption.md
+++ b/docs/reports/commerce-agent-c6w4-oacp-adapter-preview-consumption.md
@@ -1,0 +1,105 @@
+# Commerce Agent C6W4 - OACP Adapter Preview Consumption
+
+Status: implementation foundation, internal-only, non-enabling.
+
+## Scope
+
+C6W4 adds local AgenticOrg handling rules for Grantex OACP adapter previews.
+
+This slice adds:
+
+- Local preview-use checks for schema.org JSON-LD style discovery, UCP-style capability profiles, ACP-style commerce capability shapes, AP2-style evidence and intent summaries, A2A-style agent card/task capabilities, and MCP-style tool/resource capabilities.
+- Channel-safe summary output that preserves source artifact IDs, artifact families, freshness tier, and unsupported capabilities.
+- Focused tests proving adapter previews remain non-binding and buyer-safe.
+
+AgenticOrg does not invent commerce facts. It consumes Grantex-sourced preview metadata and must keep source/freshness wording visible to buyer and seller surfaces.
+
+adapter previews are not transaction authority. They can route or display sourced facts, but cannot approve commerce actions.
+
+No endpoint, migration, workflow, provider adapter, public discovery, checkout/payment, live provider, merchant private API, allowlist, cloud, deploy, or external protocol publication behavior is added.
+
+## Buyer-Agent Handling
+
+Buyer agents may use adapter previews for:
+
+- Browse.
+- Compare.
+- Draft-cart explanation.
+- Quote-preview explanation.
+- Policy explanation.
+- Seller-card display.
+- Agent routing.
+- Tool discovery.
+
+Buyer agents must preserve:
+
+- Source artifact IDs.
+- Source artifact families.
+- Source authority.
+- Freshness tier.
+- Unsupported capability wording.
+- Explicit non-authoritative transaction wording.
+
+## Seller-Agent Handling
+
+Seller agents may use adapter previews to explain:
+
+- Which Grantex artifacts supplied the preview facts.
+- Which surfaces can display non-binding facts.
+- Which capabilities are unsupported or blocked.
+- Which remediation still requires merchant systems or provider rails.
+
+Seller agents must not treat adapter previews as merchant approval, payment approval, checkout approval, public discovery approval, or provider execution authority.
+
+## Third-Party Agent Cards
+
+Third-party agent cards are bounded by the preview safety contract:
+
+- The preview surface must be one of the C6W4 surfaces.
+- The preview must cite Grantex source artifacts.
+- non_authoritative_for_transaction must be true.
+- no_checkout_payment_enablement, no_live_provider_enablement, and no_public_discovery_enablement must be true.
+- Missing flags or missing source references fail closed.
+
+## Blocked Actions
+
+Adapter previews refuse:
+
+- Checkout creation.
+- Payment authorization or capture.
+- Refund execution.
+- Settlement, payout, fulfillment start, or merchant approval.
+- Public discovery publish or unpublish.
+- Live provider or live Plural use.
+- Provider, carrier, shipping provider, or merchant private API calls.
+- Protocol publication or external submission.
+
+## What This Does Not Enable
+
+C6W4 does not enable:
+
+- Public discovery.
+- Production Commerce V1.
+- Checkout/payment creation.
+- Payment capture or debit.
+- Live payments.
+- Live provider use.
+- Live Plural use.
+- Provider calls.
+- Carrier or shipping provider calls.
+- Merchant private API calls.
+- Connector credential export.
+- Production allowlists.
+- Public OACP publication.
+- External protocol submission.
+- Certification, compliance, conformance, standardization, production readiness, public-launch readiness, merchant approval, checkout approval, payment approval, live provider readiness, or OACP public readiness claims.
+
+## Stop Conditions
+
+Stop later implementation if:
+
+- Adapter previews are used as final commerce authority.
+- Buyer-facing text drops source/freshness/unsupported capability wording.
+- AgenticOrg creates checkout/payment, live provider, live Plural, public discovery, or external protocol publication behavior from a preview.
+- AgenticOrg calls provider, carrier, shipping provider, or merchant private APIs from a preview.
+- AgenticOrg receives raw credentials, raw connector payloads, raw provider payloads, private merchant API values, or production allowlists.

--- a/tests/unit/test_oacp_adapter_previews.py
+++ b/tests/unit/test_oacp_adapter_previews.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.commerce.oacp_artifacts import (
+    OACP_C6W4_PROTOCOL_ADAPTER_SURFACES,
+    evaluate_agenticorg_oacp_adapter_preview_use,
+    summarize_oacp_adapter_preview_for_buyer,
+)
+
+C6W4_DOC_PATH = Path("docs/reports/commerce-agent-c6w4-oacp-adapter-preview-consumption.md")
+
+
+def _preview(surface: str = "a2a_agent_card_task_capability") -> dict[str, object]:
+    return {
+        "generated": True,
+        "status": "preview_only",
+        "surface": surface,
+        "source_artifact_ids": ["merchant_capability_C6W3", "seller_agent_capability_C6W3", "protocol_adapter_C6W3"],
+        "source_artifact_families": ["merchant_capability", "seller_agent_capability", "protocol_adapter"],
+        "source_authority": "grantex_canonical_oacp_artifact_authority",
+        "generated_at": "2026-06-11T00:01:00.000Z",
+        "expires_at": "2026-06-11T00:05:00.000Z",
+        "max_ttl_seconds": 240,
+        "freshness_tier": "fresh",
+        "unsupported_capabilities": [
+            "checkout_create",
+            "payment_authorize",
+            "payment_capture",
+            "live_provider_call",
+            "merchant_private_api_call",
+            "protocol_publication",
+        ],
+        "blocked_capabilities": ["checkout_create", "payment_authorize", "payment_capture"],
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "surface_payload": {
+            "preview_only": True,
+            "internal_only": True,
+            "non_publication": True,
+            "source_refs": [
+                {"artifact_id": "merchant_capability_C6W3", "artifact_type": "merchant_capability"},
+                {"artifact_id": "seller_agent_capability_C6W3", "artifact_type": "seller_agent_capability"},
+            ],
+            "tasks": [
+                {
+                    "task": "answer_policy_question",
+                    "mode": "non_binding_preview",
+                    "transaction_authority": False,
+                }
+            ],
+        },
+    }
+
+
+def test_c6w4_agenticorg_accepts_valid_preview_surfaces_for_non_binding_use() -> None:
+    for surface in OACP_C6W4_PROTOCOL_ADAPTER_SURFACES:
+        result = evaluate_agenticorg_oacp_adapter_preview_use(preview=_preview(surface), action="browse")
+        assert result["allowed"] is True
+        assert result["commerce_facts_invented"] is False
+        assert result["freshness_tier"] == "fresh"
+        assert "protocol_adapter_C6W3" in result["source_artifact_ids"]
+
+
+def test_c6w4_refuses_adapter_previews_as_transaction_or_provider_authority() -> None:
+    preview = _preview()
+
+    for action in (
+        "checkout_create",
+        "payment_authorize",
+        "payment_intent",
+        "payment_capture",
+        "live_provider_call",
+        "merchant_private_api_call",
+        "protocol_publication",
+    ):
+        result = evaluate_agenticorg_oacp_adapter_preview_use(preview=preview, action=action)
+        assert result["allowed"] is False
+        assert result["refusal_code"] == "adapter_not_transaction_authority"
+
+
+def test_c6w4_refuses_preview_missing_safety_source_or_known_surface() -> None:
+    missing_flag = {**_preview(), "no_checkout_payment_enablement": False}
+    assert evaluate_agenticorg_oacp_adapter_preview_use(
+        preview=missing_flag,
+        action="browse",
+    )["refusal_code"] == "adapter_preview_not_buyer_safe"
+
+    missing_source = {**_preview(), "source_artifact_ids": []}
+    assert evaluate_agenticorg_oacp_adapter_preview_use(
+        preview=missing_source,
+        action="browse",
+    )["refusal_code"] == "adapter_source_missing"
+
+    unknown_surface = {**_preview(), "surface": "third_party_unbounded_card"}
+    assert evaluate_agenticorg_oacp_adapter_preview_use(
+        preview=unknown_surface,
+        action="browse",
+    )["refusal_code"] == "adapter_surface_unknown"
+
+
+def test_c6w4_buyer_summary_preserves_source_freshness_and_unsupported_wording() -> None:
+    summary = summarize_oacp_adapter_preview_for_buyer(_preview("mcp_tool_resource_capability"))
+
+    assert summary["allowed"] is True
+    assert "sourced from Grantex OACP artifacts" in summary["wording"]
+    assert summary["freshness_tier"] == "fresh"
+    assert "merchant_capability_C6W3" in summary["source_artifact_ids"]
+    assert "checkout_create" in summary["unsupported_capabilities"]
+    assert summary["non_authoritative_for_transaction"] is True
+    assert summary["commerce_facts_invented"] is False
+
+
+def test_c6w4_agenticorg_doc_captures_preview_consumption_boundaries() -> None:
+    doc = C6W4_DOC_PATH.read_text(encoding="utf-8")
+
+    for heading in (
+        "Scope",
+        "Buyer-Agent Handling",
+        "Seller-Agent Handling",
+        "Third-Party Agent Cards",
+        "Blocked Actions",
+        "What This Does Not Enable",
+    ):
+        assert f"## {heading}" in doc
+
+    assert "AgenticOrg does not invent commerce facts" in doc
+    assert "adapter previews are not transaction authority" in doc


### PR DESCRIPTION
## Summary
- Adds local C6W4 adapter preview consumer helpers for AgenticOrg buyer/seller runtime use.
- Refuses transaction, provider, private API, publication, and unsupported actions from adapter previews.
- Adds focused tests and internal docs for buyer-safe preview consumption without invented commerce facts.

## Validation
- python -m pytest tests/unit/test_oacp_artifact_schemas.py tests/unit/test_oacp_adapter_previews.py --no-cov
- python -m ruff check core/commerce/oacp_artifacts.py tests/unit/test_oacp_artifact_schemas.py tests/unit/test_oacp_adapter_previews.py
- python -m mypy core/commerce/oacp_artifacts.py tests/unit/test_oacp_artifact_schemas.py tests/unit/test_oacp_adapter_previews.py
- git diff --cached --check
- ASCII and focused guardrail scans