### PR TITLE
[codex] Add C6W5 commitment boundary resolver

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -38,6 +38,42 @@ AdapterPreviewSurface = Literal[
     "a2a_agent_card_task_capability",
     "mcp_tool_resource_capability",
 ]
+CommitmentBoundaryAction = Literal[
+    "browse_merchant_profile",
+    "inspect_seller_card",
+    "compare_catalog_summaries",
+    "explain_policy",
+    "explain_available_capabilities",
+    "show_source_freshness_labels",
+    "prepare_buyer_question",
+    "prepare_seller_agent_remediation_suggestion",
+    "prepare_draft_quote",
+    "prepare_draft_cart",
+    "ask_refresh_source_facts",
+    "prepare_non_binding_reservation_request",
+    "prepare_mandate_capability_check_request",
+    "prepare_human_confirmation_prompt",
+    "price_lock",
+    "inventory_hold",
+    "reservation",
+    "order_placement",
+    "payment_intent",
+    "mandate_setup_use",
+    "cancellation",
+    "refund_request",
+    "return_authorization",
+    "support_escalation_sla_promise",
+    "live_payment_execution",
+    "live_plural_provider_call",
+    "public_discovery_enablement",
+    "production_checkout_payment_creation",
+    "merchant_private_api_call",
+    "provider_private_api_call",
+    "protocol_publication_submission",
+    "certification_conformance_claim",
+    "final_delivery_refund_settlement_payout_promise",
+]
+ActionClass = Literal["non_binding_preview", "commitment_adjacent", "commitment_bound", "always_blocked"]
 OfflineAction = Literal[
     "browse",
     "compare",
@@ -195,6 +231,105 @@ OACP_C6W4_NON_BINDING_ADAPTER_ACTIONS: frozenset[str] = frozenset(
         "tool_discovery",
     }
 )
+
+OACP_C6W5_NON_BINDING_PREVIEW_ACTIONS: frozenset[str] = frozenset(
+    {
+        "browse_merchant_profile",
+        "inspect_seller_card",
+        "compare_catalog_summaries",
+        "explain_policy",
+        "explain_available_capabilities",
+        "show_source_freshness_labels",
+        "prepare_buyer_question",
+        "prepare_seller_agent_remediation_suggestion",
+    }
+)
+OACP_C6W5_COMMITMENT_ADJACENT_ACTIONS: frozenset[str] = frozenset(
+    {
+        "prepare_draft_quote",
+        "prepare_draft_cart",
+        "ask_refresh_source_facts",
+        "prepare_non_binding_reservation_request",
+        "prepare_mandate_capability_check_request",
+        "prepare_human_confirmation_prompt",
+    }
+)
+OACP_C6W5_COMMITMENT_BOUND_ACTIONS: frozenset[str] = frozenset(
+    {
+        "price_lock",
+        "inventory_hold",
+        "reservation",
+        "order_placement",
+        "payment_intent",
+        "mandate_setup_use",
+        "cancellation",
+        "refund_request",
+        "return_authorization",
+        "support_escalation_sla_promise",
+    }
+)
+OACP_C6W5_ALWAYS_BLOCKED_ACTIONS: frozenset[str] = frozenset(
+    {
+        "live_payment_execution",
+        "live_plural_provider_call",
+        "public_discovery_enablement",
+        "production_checkout_payment_creation",
+        "merchant_private_api_call",
+        "provider_private_api_call",
+        "protocol_publication_submission",
+        "certification_conformance_claim",
+        "final_delivery_refund_settlement_payout_promise",
+    }
+)
+
+_C6W5_BASE_PREVIEW_ARTIFACTS: frozenset[ArtifactType] = frozenset(
+    {"merchant_capability", "seller_agent_capability", "policy", "protocol_adapter"}
+)
+OACP_C6W5_REQUIRED_FRESH_ARTIFACT_FAMILIES: dict[str, frozenset[ArtifactType]] = {
+    "browse_merchant_profile": _C6W5_BASE_PREVIEW_ARTIFACTS,
+    "inspect_seller_card": _C6W5_BASE_PREVIEW_ARTIFACTS,
+    "compare_catalog_summaries": _C6W5_BASE_PREVIEW_ARTIFACTS | frozenset({"catalog_snapshot"}),
+    "explain_policy": _C6W5_BASE_PREVIEW_ARTIFACTS,
+    "explain_available_capabilities": _C6W5_BASE_PREVIEW_ARTIFACTS,
+    "show_source_freshness_labels": _C6W5_BASE_PREVIEW_ARTIFACTS,
+    "prepare_buyer_question": _C6W5_BASE_PREVIEW_ARTIFACTS,
+    "prepare_seller_agent_remediation_suggestion": _C6W5_BASE_PREVIEW_ARTIFACTS,
+    "prepare_draft_quote": _C6W5_BASE_PREVIEW_ARTIFACTS | frozenset({"catalog_snapshot", "price"}),
+    "prepare_draft_cart": _C6W5_BASE_PREVIEW_ARTIFACTS | frozenset({"catalog_snapshot", "price", "inventory"}),
+    "ask_refresh_source_facts": _C6W5_BASE_PREVIEW_ARTIFACTS,
+    "prepare_non_binding_reservation_request": _C6W5_BASE_PREVIEW_ARTIFACTS | frozenset({"offer", "inventory"}),
+    "prepare_mandate_capability_check_request": _C6W5_BASE_PREVIEW_ARTIFACTS | frozenset({"mandate_capability"}),
+    "prepare_human_confirmation_prompt": _C6W5_BASE_PREVIEW_ARTIFACTS,
+    "price_lock": _C6W5_BASE_PREVIEW_ARTIFACTS | frozenset({"offer", "price"}),
+    "inventory_hold": _C6W5_BASE_PREVIEW_ARTIFACTS | frozenset({"inventory"}),
+    "reservation": _C6W5_BASE_PREVIEW_ARTIFACTS | frozenset({"offer", "inventory"}),
+    "order_placement": _C6W5_BASE_PREVIEW_ARTIFACTS | frozenset({"offer", "price", "inventory"}),
+    "payment_intent": _C6W5_BASE_PREVIEW_ARTIFACTS | frozenset({"price", "mandate_capability"}),
+    "mandate_setup_use": _C6W5_BASE_PREVIEW_ARTIFACTS | frozenset({"mandate_capability"}),
+    "cancellation": _C6W5_BASE_PREVIEW_ARTIFACTS | frozenset({"commitment_evidence"}),
+    "refund_request": _C6W5_BASE_PREVIEW_ARTIFACTS | frozenset({"commitment_evidence"}),
+    "return_authorization": _C6W5_BASE_PREVIEW_ARTIFACTS | frozenset({"commitment_evidence"}),
+    "support_escalation_sla_promise": _C6W5_BASE_PREVIEW_ARTIFACTS,
+    **{action: frozenset() for action in OACP_C6W5_ALWAYS_BLOCKED_ACTIONS},
+}
+OACP_C6W5_ACTION_RISK_TIERS: dict[str, RiskTier] = dict.fromkeys(
+    OACP_C6W5_NON_BINDING_PREVIEW_ACTIONS,
+    cast(RiskTier, "informational"),
+)
+OACP_C6W5_ACTION_RISK_TIERS.update(dict.fromkeys(OACP_C6W5_COMMITMENT_ADJACENT_ACTIONS, cast(RiskTier, "low")))
+OACP_C6W5_ACTION_RISK_TIERS.update({
+    "price_lock": "medium",
+    "inventory_hold": "medium",
+    "reservation": "medium",
+    "order_placement": "high",
+    "payment_intent": "high",
+    "mandate_setup_use": "high",
+    "cancellation": "high",
+    "refund_request": "high",
+    "return_authorization": "high",
+    "support_escalation_sla_promise": "medium",
+})
+OACP_C6W5_ACTION_RISK_TIERS.update(dict.fromkeys(OACP_C6W5_ALWAYS_BLOCKED_ACTIONS, cast(RiskTier, "critical")))
 
 OACP_REQUIRED_ENVELOPE_FIELDS = (
     "artifact_id",
@@ -1147,6 +1282,329 @@ def summarize_oacp_adapter_preview_for_buyer(preview: dict[str, Any]) -> dict[st
         "non_authoritative_for_transaction": True,
         "commerce_facts_invented": False,
     }
+
+
+def _c6w5_action_class(action: str) -> ActionClass:
+    if action in OACP_C6W5_NON_BINDING_PREVIEW_ACTIONS:
+        return "non_binding_preview"
+    if action in OACP_C6W5_COMMITMENT_ADJACENT_ACTIONS:
+        return "commitment_adjacent"
+    if action in OACP_C6W5_COMMITMENT_BOUND_ACTIONS:
+        return "commitment_bound"
+    return "always_blocked"
+
+
+def _c6w5_blocked_capabilities(preview: dict[str, Any]) -> list[str]:
+    blocked = set(OACP_C6W4_BLOCKED_ADAPTER_ACTIONS) | set(OACP_C6W5_ALWAYS_BLOCKED_ACTIONS)
+    blocked.update(_string_list(preview.get("blocked_capabilities")))
+    blocked.update(_string_list(preview.get("unsupported_capabilities")))
+    return sorted(blocked)
+
+
+def _artifact_type_from_cached(artifact: dict[str, Any]) -> ArtifactType | None:
+    envelope = artifact.get("envelope")
+    if not isinstance(envelope, dict):
+        return None
+    artifact_type = envelope.get("artifact_type")
+    return cast(ArtifactType, artifact_type) if artifact_type in OACP_ARTIFACT_TTLS_SECONDS else None
+
+
+def _c6w5_freshness_summary(artifacts: list[dict[str, Any]]) -> dict[str, Any]:
+    artifact_freshness: dict[str, str] = {}
+    expires: list[datetime] = []
+    freshness_values: set[str] = set()
+    for artifact in artifacts:
+        envelope = artifact.get("envelope")
+        if not isinstance(envelope, dict):
+            continue
+        artifact_id = _string_field(envelope, "artifact_id")
+        freshness = _string_field(envelope, "freshness_class")
+        expires_at = _parse_iso(_string_field(envelope, "expires_at"))
+        if artifact_id is not None and freshness is not None:
+            artifact_freshness[artifact_id] = freshness
+            freshness_values.add(freshness)
+        if expires_at is not None:
+            expires.append(expires_at)
+    tier = next(iter(freshness_values)) if len(freshness_values) == 1 else "mixed"
+    earliest = min(expires).isoformat(timespec="milliseconds").replace("+00:00", "Z") if expires else None
+    return {
+        "freshness_tier": tier,
+        "artifact_freshness": artifact_freshness,
+        "earliest_expires_at": earliest,
+    }
+
+
+def _c6w5_decision(
+    *,
+    action: str,
+    action_class: ActionClass,
+    allowed_to_preview: bool,
+    allowed_to_prepare: bool,
+    reason: str | None,
+    required: frozenset[ArtifactType],
+    source_artifacts: list[dict[str, Any]],
+    risk_tier: RiskTier,
+    offline_mode_status: str,
+    buyer_safe_message: str,
+    blocked_capabilities: list[str],
+) -> dict[str, Any]:
+    source_ids: list[str] = []
+    source_families: list[str] = []
+    for artifact in source_artifacts:
+        envelope = artifact.get("envelope")
+        if not isinstance(envelope, dict):
+            continue
+        artifact_id = _string_field(envelope, "artifact_id")
+        artifact_type = _string_field(envelope, "artifact_type")
+        if artifact_id is not None:
+            source_ids.append(artifact_id)
+        if artifact_type is not None:
+            source_families.append(artifact_type)
+    return {
+        "action": action,
+        "action_class": action_class,
+        "allowed_to_preview": allowed_to_preview,
+        "allowed_to_prepare": allowed_to_prepare,
+        "allowed_to_execute": False,
+        "refusal_or_escalation_reason": reason,
+        "required_fresh_artifact_families": sorted(required),
+        "source_artifact_ids": source_ids,
+        "source_artifact_families": source_families,
+        "source_authority": "grantex_canonical_oacp_artifact_authority",
+        "freshness_summary": _c6w5_freshness_summary(source_artifacts),
+        "risk_tier": risk_tier,
+        "offline_mode_status": offline_mode_status,
+        "buyer_safe_message": buyer_safe_message,
+        "blocked_capabilities": blocked_capabilities,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "commerce_facts_invented": False,
+    }
+
+
+def _c6w5_requires_risk_context(action: str, action_class: ActionClass) -> bool:
+    return action_class not in {"non_binding_preview", "always_blocked"} and action not in {
+        "ask_refresh_source_facts",
+        "prepare_human_confirmation_prompt",
+        "prepare_mandate_capability_check_request",
+    }
+
+
+def _c6w5_risk_context_reason(
+    *,
+    risk_tier: RiskTier,
+    currency: str | None,
+    amount_minor_units: int | None,
+    total_quantity: int | None,
+    max_quantity_per_sku: int | None,
+) -> str | None:
+    if currency not in {"INR", "USD"} or amount_minor_units is None or amount_minor_units < 0:
+        return "risk_context_missing_or_ambiguous"
+    if total_quantity is None or total_quantity <= 0:
+        return "risk_context_missing_or_ambiguous"
+    cap = OACP_FIRST_RELEASE_RISK_CAPS[risk_tier]
+    amount_cap = cap["currency_caps"].get(currency)
+    if amount_cap is None or amount_minor_units > amount_cap:
+        return "risk_cap_exceeded"
+    total_cap = cap["total_quantity_cap"]
+    per_sku_cap = cap["per_sku_quantity_cap"]
+    if total_cap is not None and total_quantity > total_cap:
+        return "quantity_cap_exceeded"
+    if max_quantity_per_sku is not None and per_sku_cap is not None and max_quantity_per_sku > per_sku_cap:
+        return "quantity_cap_exceeded"
+    return None
+
+
+def evaluate_agenticorg_c6w5_commitment_boundary(
+    *,
+    action: str,
+    cached_artifacts: list[dict[str, Any]],
+    adapter_preview: dict[str, Any],
+    now_iso: str,
+    grantex_available: bool,
+    revocation_snapshot_age_seconds: int | None = None,
+    currency: str | None = None,
+    amount_minor_units: int | None = None,
+    total_quantity: int | None = None,
+    max_quantity_per_sku: int | None = None,
+) -> dict[str, Any]:
+    """Resolve C6W5 preview/prepare boundaries from local artifacts only."""
+
+    action_class = _c6w5_action_class(action)
+    risk_tier = OACP_C6W5_ACTION_RISK_TIERS.get(action, "critical")
+    required = OACP_C6W5_REQUIRED_FRESH_ARTIFACT_FAMILIES.get(action, frozenset())
+    blocked_capabilities = _c6w5_blocked_capabilities(adapter_preview)
+    source_artifacts = [artifact for artifact in cached_artifacts if _artifact_type_from_cached(artifact) is not None]
+    by_type = {_artifact_type_from_cached(artifact): artifact for artifact in source_artifacts}
+    offline_mode_status = (
+        "online_policy_available"
+        if grantex_available
+        else "offline_prepared_not_executed"
+        if action_class == "commitment_bound"
+        else "offline_cache_valid"
+    )
+
+    if action_class == "always_blocked":
+        return _c6w5_decision(
+            action=action,
+            action_class=action_class,
+            allowed_to_preview=False,
+            allowed_to_prepare=False,
+            reason="blocked_in_c6w5",
+            required=required,
+            source_artifacts=source_artifacts,
+            risk_tier=risk_tier,
+            offline_mode_status="offline_blocked",
+            buyer_safe_message="This C6W5 action is blocked and cannot be prepared or executed from adapter previews.",
+            blocked_capabilities=blocked_capabilities,
+        )
+
+    preview_check = evaluate_agenticorg_oacp_adapter_preview_use(preview=adapter_preview, action="browse")
+    preview_expires_at = _parse_iso(_string_field(adapter_preview, "expires_at"))
+    now = _parse_iso(now_iso)
+    if (
+        not preview_check["allowed"]
+        or preview_expires_at is None
+        or now is None
+        or now > preview_expires_at
+    ):
+        return _c6w5_decision(
+            action=action,
+            action_class=action_class,
+            allowed_to_preview=False,
+            allowed_to_prepare=False,
+            reason="adapter_preview_missing_safety_or_freshness",
+            required=required,
+            source_artifacts=source_artifacts,
+            risk_tier=risk_tier,
+            offline_mode_status="online_policy_available" if grantex_available else "offline_blocked",
+            buyer_safe_message="Adapter previews cannot override missing safety flags or expired metadata.",
+            blocked_capabilities=blocked_capabilities,
+        )
+
+    missing = sorted(required - {artifact_type for artifact_type in by_type if artifact_type is not None})
+    if missing:
+        return _c6w5_decision(
+            action=action,
+            action_class=action_class,
+            allowed_to_preview=action_class == "non_binding_preview",
+            allowed_to_prepare=False,
+            reason=f"required_artifact_missing:{','.join(missing)}",
+            required=required,
+            source_artifacts=source_artifacts,
+            risk_tier=risk_tier,
+            offline_mode_status="online_policy_available" if grantex_available else "offline_blocked",
+            buyer_safe_message="Required source artifacts are missing, so the action can only remain non-executing.",
+            blocked_capabilities=blocked_capabilities,
+        )
+
+    required_artifacts = [by_type[artifact_type] for artifact_type in required if artifact_type in by_type]
+    for artifact in required_artifacts:
+        envelope = artifact["envelope"]
+        payload = artifact["payload"]
+        validation = validate_oacp_artifact_family(envelope=envelope, payload=payload, now_iso=now_iso)
+        if not validation["valid"]:
+            return _c6w5_decision(
+                action=action,
+                action_class=action_class,
+                allowed_to_preview=False,
+                allowed_to_prepare=False,
+                reason=str(validation["refusal_code"]),
+                required=required,
+                source_artifacts=required_artifacts,
+                risk_tier=risk_tier,
+                offline_mode_status="online_policy_available" if grantex_available else "offline_blocked",
+                buyer_safe_message="A required OACP artifact is invalid, stale, revoked, or ambiguous.",
+                blocked_capabilities=blocked_capabilities,
+            )
+        freshness = _string_field(envelope, "freshness_class")
+        if freshness in {"stale", "unknown"} or (action_class != "non_binding_preview" and freshness != "fresh"):
+            return _c6w5_decision(
+                action=action,
+                action_class=action_class,
+                allowed_to_preview=action_class == "non_binding_preview",
+                allowed_to_prepare=False,
+                reason="artifact_freshness_missing_stale_or_ambiguous",
+                required=required,
+                source_artifacts=required_artifacts,
+                risk_tier=risk_tier,
+                offline_mode_status="online_policy_available" if grantex_available else "offline_blocked",
+                buyer_safe_message="Source facts must be fresh enough before a commitment-bound request is prepared.",
+                blocked_capabilities=blocked_capabilities,
+            )
+
+    max_revocation_age = OACP_REVOCATION_SNAPSHOT_MAX_AGE_SECONDS[risk_tier]
+    if action_class != "non_binding_preview" and (
+        revocation_snapshot_age_seconds is None
+        or max_revocation_age is None
+        or revocation_snapshot_age_seconds > max_revocation_age
+    ):
+        return _c6w5_decision(
+            action=action,
+            action_class=action_class,
+            allowed_to_preview=True,
+            allowed_to_prepare=False,
+            reason="revocation_snapshot_missing_or_stale",
+            required=required,
+            source_artifacts=required_artifacts,
+            risk_tier=risk_tier,
+            offline_mode_status="online_policy_available" if grantex_available else "offline_blocked",
+            buyer_safe_message="The local revocation posture is too stale for a commitment-bound preparation.",
+            blocked_capabilities=blocked_capabilities,
+        )
+
+    if _c6w5_requires_risk_context(action, action_class):
+        risk_reason = _c6w5_risk_context_reason(
+            risk_tier=risk_tier,
+            currency=currency,
+            amount_minor_units=amount_minor_units,
+            total_quantity=total_quantity,
+            max_quantity_per_sku=max_quantity_per_sku,
+        )
+        if risk_reason is not None:
+            return _c6w5_decision(
+                action=action,
+                action_class=action_class,
+                allowed_to_preview=True,
+                allowed_to_prepare=False,
+                reason=risk_reason,
+                required=required,
+                source_artifacts=required_artifacts,
+                risk_tier=risk_tier,
+                offline_mode_status="online_policy_available" if grantex_available else "offline_blocked",
+                buyer_safe_message=(
+                    "Amount, currency, or quantity is missing or outside the conservative C6W5 risk caps."
+                ),
+                blocked_capabilities=blocked_capabilities,
+            )
+
+    allowed_to_prepare = action_class != "non_binding_preview"
+    if action_class == "non_binding_preview":
+        message = "Preview can continue from sourced OACP artifacts; this is not purchase approval."
+        reason = None
+    elif action_class == "commitment_adjacent":
+        message = (
+            "Prepared request only; no checkout, payment, provider call, or merchant private API call is executed."
+        )
+        reason = None
+    else:
+        message = "Prepared, not executed. C6W5 does not grant transaction authority from adapter previews."
+        reason = "prepared_not_executed_c6w5"
+    return _c6w5_decision(
+        action=action,
+        action_class=action_class,
+        allowed_to_preview=True,
+        allowed_to_prepare=allowed_to_prepare,
+        reason=reason,
+        required=required,
+        source_artifacts=required_artifacts,
+        risk_tier=risk_tier,
+        offline_mode_status=offline_mode_status,
+        buyer_safe_message=message,
+        blocked_capabilities=blocked_capabilities,
+    )
 
 
 def verify_oacp_artifact(input_data: OacpArtifactVerificationInput) -> dict[str, Any]:

--- a/docs/reports/commerce-agent-c6w5-commitment-boundary-resolver.md
+++ b/docs/reports/commerce-agent-c6w5-commitment-boundary-resolver.md
@@ -1,0 +1,91 @@
+# Commerce Agent C6W5 - Commitment Boundary Resolver
+
+Status: implementation foundation, internal-only, non-enabling.
+
+## Scope
+
+C6W5 adds a local AgenticOrg resolver for commitment-boundary decisions over cached signed Grantex OACP artifacts and C6W4 adapter previews.
+
+This slice adds pure helper logic, tests, and internal documentation only. It does not add endpoints, migrations, workflows, provider adapters, public discovery, checkout/payment, live provider, live Plural, merchant private API, allowlist, cloud, deploy, or external protocol publication behavior.
+
+AgenticOrg remains the buyer/seller agent runtime. Grantex remains the trust, protocol, policy, and canonical-artifact authority. Merchant systems remain operational sources of record. Provider and fintech rails own payment and mandate execution.
+
+## Commitment Boundary Model
+
+The resolver classifies actions into:
+
+- Non-binding preview: browse merchant profile, inspect seller card, compare catalog summaries, explain policy, explain available capabilities, show source/freshness labels, prepare buyer question, and prepare seller-agent remediation suggestion.
+- Commitment-adjacent: prepare draft quote, prepare draft cart, ask merchant/seller agent to refresh source facts, prepare non-binding reservation request, prepare mandate capability check request, and prepare human confirmation prompt.
+- Commitment-bound: price lock, inventory hold, reservation, order placement, payment intent, mandate setup/use, cancellation, refund request, return authorization, and support escalation with merchant SLA promise.
+- Always blocked in C6W5: live payment execution, live Plural/provider calls, public discovery enablement, production checkout/payment creation, merchant or provider private API calls, protocol publication/submission, certification/conformance claims, and final delivery/refund/settlement/payout promises without source artifact authority.
+
+Every result includes action_class, allowed_to_preview, allowed_to_prepare, allowed_to_execute, refusal_or_escalation_reason, required_fresh_artifact_families, source_artifact_ids, freshness_summary, risk_tier, offline_mode_status, buyer_safe_message, blocked_capabilities, and non-authoritative transaction flags.
+
+allowed_to_execute is always false in C6W5.
+
+## Offline Commitment Mode
+
+Non-binding preview may continue from valid cached artifacts and a valid adapter preview. Commitment-adjacent and commitment-bound actions require the local artifact set to be present, scoped, fresh, in TTL, and within revocation/risk posture before AgenticOrg may prepare a request.
+
+If Grantex is unavailable but cached TTL is valid, AgenticOrg may continue preview and prepare requests. If a buyer asks for final commitment while Grantex is unavailable, the resolver returns buyer-safe prepared-not-executed wording. Critical actions are blocked offline.
+
+Adapter previews cannot override expired, revoked, missing, stale, or ambiguous OACP artifacts. Seller cards and protocol adapters are never transaction authority.
+
+## TTL And Risk Defaults
+
+Artifact TTL defaults:
+
+- merchant capability: 24h.
+- seller agent capability: 6h.
+- policy: 6h.
+- catalog: 6h.
+- offer: 15m.
+- price: 5m, or 60s for dynamic price.
+- inventory: 60s, or 30s for high-velocity goods.
+- public discovery: 15m display/read only.
+- mandate capability: 2m at commitment boundary.
+- protocol adapter: 24h max and never longer than referenced artifacts.
+
+Risk defaults:
+
+- Low: up to INR 25,000 / USD 300 equivalent, non-binding draft/quote only.
+- Medium: up to INR 10,000 / USD 125 equivalent for price-lock, inventory-hold, reservation, and support preparation with source confirmation.
+- High: up to INR 5,000 / USD 60 equivalent for order/payment/cancel/refund/return preparation, still non-executing in C6W5.
+- Critical: blocked offline.
+
+Missing or ambiguous amount, currency, or quantity fails closed for preparation.
+
+## Toll Booth Boundary
+
+Grantex does not become a synchronous toll booth for browse, comparison, education, recommendation, or other non-binding messages. AgenticOrg can use cached valid Grantex artifacts locally subject to TTL, freshness, revocation, unsupported capability, and scope rules.
+
+AgenticOrg does not invent commerce facts from adapter previews. Channel messages must preserve source, freshness, unsupported capability, and non-authoritative wording.
+
+## What This Does Not Enable
+
+C6W5 does not enable:
+
+- Public discovery.
+- Production Commerce V1.
+- Checkout/payment creation.
+- Payment capture or debit.
+- Live payments.
+- Live provider use.
+- Live Plural use.
+- Provider calls.
+- Carrier or shipping provider calls.
+- Merchant private API calls.
+- Connector credential export.
+- Production allowlists.
+- Public OACP publication.
+- External protocol submission.
+- Certification, compliance, conformance, standardization, production readiness, public-launch readiness, merchant approval, checkout approval, payment approval, live provider readiness, or OACP public readiness claims.
+
+## Future Slices
+
+Future slices must add separate evidence and approval paths before any real execution:
+
+- Commitment evidence reconciliation with merchant systems.
+- Provider-owned mandate verification with non-production evidence first.
+- Human confirmation prompts and audit records.
+- Explicit execution rails outside C6W5 with provider and merchant system authority.

--- a/tests/unit/test_oacp_commitment_boundary.py
+++ b/tests/unit/test_oacp_commitment_boundary.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.commerce.oacp_artifacts import (
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES,
+    evaluate_agenticorg_c6w5_commitment_boundary,
+)
+
+C6W5_DOC_PATH = Path("docs/reports/commerce-agent-c6w5-commitment-boundary-resolver.md")
+
+
+def _artifacts() -> list[dict[str, object]]:
+    return [
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["merchant_capability"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["seller_agent_capability"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["catalog_snapshot"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["offer"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["price"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["inventory"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["policy"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["mandate_capability"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["commitment_evidence"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["protocol_adapter"],
+    ]
+
+
+def _preview() -> dict[str, object]:
+    return {
+        "generated": True,
+        "status": "preview_only",
+        "surface": "mcp_tool_resource_capability",
+        "source_artifact_ids": [artifact["envelope"]["artifact_id"] for artifact in _artifacts()],
+        "source_artifact_families": [artifact["envelope"]["artifact_type"] for artifact in _artifacts()],
+        "source_authority": "grantex_canonical_oacp_artifact_authority",
+        "generated_at": "2026-06-11T00:00:30.000Z",
+        "expires_at": "2026-06-11T00:02:00.000Z",
+        "max_ttl_seconds": 90,
+        "freshness_tier": "fresh",
+        "unsupported_capabilities": [
+            "checkout_create",
+            "payment_authorize",
+            "payment_capture",
+            "live_provider_call",
+            "merchant_private_api_call",
+            "protocol_publication",
+        ],
+        "blocked_capabilities": ["checkout_create", "payment_authorize", "payment_capture"],
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "surface_payload": {
+            "preview_only": True,
+            "internal_only": True,
+            "non_publication": True,
+            "source_refs": [
+                {
+                    "artifact_id": artifact["envelope"]["artifact_id"],
+                    "artifact_type": artifact["envelope"]["artifact_type"],
+                }
+                for artifact in _artifacts()
+            ],
+        },
+    }
+
+
+def test_c6w5_allows_non_binding_preview_with_source_and_freshness_labels() -> None:
+    result = evaluate_agenticorg_c6w5_commitment_boundary(
+        action="compare_catalog_summaries",
+        cached_artifacts=_artifacts(),
+        adapter_preview=_preview(),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+    )
+
+    assert result["action_class"] == "non_binding_preview"
+    assert result["allowed_to_preview"] is True
+    assert result["allowed_to_prepare"] is False
+    assert result["allowed_to_execute"] is False
+    assert result["risk_tier"] == "informational"
+    assert result["source_authority"] == "grantex_canonical_oacp_artifact_authority"
+    assert "catalog_snapshot_C6W3" in result["source_artifact_ids"]
+    assert "checkout_create" in result["blocked_capabilities"]
+    assert result["commerce_facts_invented"] is False
+    assert "not purchase approval" in result["buyer_safe_message"]
+
+
+def test_c6w5_prepares_commitment_bound_actions_offline_without_execution() -> None:
+    result = evaluate_agenticorg_c6w5_commitment_boundary(
+        action="price_lock",
+        cached_artifacts=_artifacts(),
+        adapter_preview=_preview(),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=False,
+        revocation_snapshot_age_seconds=30,
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+        max_quantity_per_sku=1,
+    )
+
+    assert result["action_class"] == "commitment_bound"
+    assert result["allowed_to_preview"] is True
+    assert result["allowed_to_prepare"] is True
+    assert result["allowed_to_execute"] is False
+    assert result["refusal_or_escalation_reason"] == "prepared_not_executed_c6w5"
+    assert result["offline_mode_status"] == "offline_prepared_not_executed"
+    assert "price" in result["required_fresh_artifact_families"]
+
+
+def test_c6w5_fails_closed_for_missing_stale_or_ambiguous_commitment_inputs() -> None:
+    without_price = [artifact for artifact in _artifacts() if artifact["envelope"]["artifact_type"] != "price"]
+    missing = evaluate_agenticorg_c6w5_commitment_boundary(
+        action="price_lock",
+        cached_artifacts=without_price,
+        adapter_preview=_preview(),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+        revocation_snapshot_age_seconds=30,
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+    )
+    assert missing["allowed_to_prepare"] is False
+    assert missing["refusal_or_escalation_reason"] == "required_artifact_missing:price"
+
+    price = OACP_C6W3_VALID_ARTIFACT_FIXTURES["price"]
+    stale_price = {"envelope": {**price["envelope"], "freshness_class": "stale"}, "payload": price["payload"]}
+    stale = evaluate_agenticorg_c6w5_commitment_boundary(
+        action="price_lock",
+        cached_artifacts=[artifact for artifact in _artifacts() if artifact["envelope"]["artifact_type"] != "price"]
+        + [stale_price],
+        adapter_preview=_preview(),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+        revocation_snapshot_age_seconds=30,
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+    )
+    assert stale["allowed_to_prepare"] is False
+    assert stale["refusal_or_escalation_reason"] == "artifact_freshness_missing_stale_or_ambiguous"
+
+    ambiguous = evaluate_agenticorg_c6w5_commitment_boundary(
+        action="price_lock",
+        cached_artifacts=_artifacts(),
+        adapter_preview=_preview(),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+        revocation_snapshot_age_seconds=30,
+    )
+    assert ambiguous["allowed_to_prepare"] is False
+    assert ambiguous["refusal_or_escalation_reason"] == "risk_context_missing_or_ambiguous"
+
+
+def test_c6w5_blocks_live_and_publication_actions_and_documents_boundaries() -> None:
+    blocked = evaluate_agenticorg_c6w5_commitment_boundary(
+        action="live_payment_execution",
+        cached_artifacts=_artifacts(),
+        adapter_preview=_preview(),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=False,
+    )
+
+    assert blocked["action_class"] == "always_blocked"
+    assert blocked["allowed_to_preview"] is False
+    assert blocked["allowed_to_prepare"] is False
+    assert blocked["allowed_to_execute"] is False
+    assert blocked["offline_mode_status"] == "offline_blocked"
+
+    doc = C6W5_DOC_PATH.read_text(encoding="utf-8")
+    for heading in (
+        "Scope",
+        "Commitment Boundary Model",
+        "Offline Commitment Mode",
+        "TTL And Risk Defaults",
+        "What This Does Not Enable",
+        "Future Slices",
+    ):
+        assert f"## {heading}" in doc
+    assert "AgenticOrg does not invent commerce facts" in doc
+    assert "Grantex does not become a synchronous toll booth" in doc


### PR DESCRIPTION
Summary: Adds internal AgenticOrg C6W5 commitment-boundary resolver over local cached OACP artifacts and C6W4 adapter previews, with focused tests and internal documentation. Validation: focused OACP C6W4 C6W5 pytest passed, ruff passed, mypy passed, git diff check passed, ASCII check passed, guardrail scans passed. Guardrails: no endpoints, routes, migrations, workflows, production config, secrets, provider adapters, public discovery enablement, checkout or payment enablement, live provider or Plural enablement, cloud or deploy behavior, allowlists, private API calls, or external protocol publication behavior added. C6W5 remains internal, preview-only, non-public, non-production, non-executing, and fail-closed.