### PR TITLE
[codex] Add C6W7 response reconciliation

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -81,6 +81,23 @@ PreparedEnvelopeKind = Literal[
     "mandate_capability_evidence_request",
     "support_escalation_preparation",
 ]
+ResponseEvidenceKind = Literal[
+    "buyer_confirmation_response",
+    "seller_source_refresh_response",
+    "merchant_confirmation_response",
+    "mandate_capability_evidence_response",
+    "support_escalation_response",
+]
+ReconciliationStatus = Literal[
+    "accepted_for_preparation",
+    "rejected",
+    "needs_source_refresh",
+    "needs_human_review",
+    "expired",
+    "stale",
+    "mismatched",
+    "blocked",
+]
 OfflineAction = Literal[
     "browse",
     "compare",
@@ -363,6 +380,41 @@ OACP_C6W6_MANDATE_EVIDENCE_ACTIONS: frozenset[str] = frozenset(
 OACP_C6W6_SUPPORT_PREPARATION_ACTIONS: frozenset[str] = frozenset(
     {"support_escalation_sla_promise", "refund_request", "return_authorization", "cancellation"}
 )
+OACP_C6W7_RESPONSE_EVIDENCE_KINDS: frozenset[str] = frozenset(
+    {
+        "buyer_confirmation_response",
+        "seller_source_refresh_response",
+        "merchant_confirmation_response",
+        "mandate_capability_evidence_response",
+        "support_escalation_response",
+    }
+)
+OACP_C6W7_RECONCILIATION_STATUSES: frozenset[str] = frozenset(
+    {
+        "accepted_for_preparation",
+        "rejected",
+        "needs_source_refresh",
+        "needs_human_review",
+        "expired",
+        "stale",
+        "mismatched",
+        "blocked",
+    }
+)
+OACP_C6W7_RESPONSE_TTL_SECONDS: dict[str, int] = {
+    "buyer_confirmation_response": 15 * 60,
+    "seller_source_refresh_response": 30 * 60,
+    "merchant_confirmation_response": 10 * 60,
+    "mandate_capability_evidence_response": 2 * 60,
+    "support_escalation_response": 10 * 60,
+}
+OACP_C6W7_RESPONSE_KIND_BY_ENVELOPE_KIND: dict[str, str] = {
+    "buyer_confirmation_request": "buyer_confirmation_response",
+    "seller_source_refresh_request": "seller_source_refresh_response",
+    "merchant_confirmation_request": "merchant_confirmation_response",
+    "mandate_capability_evidence_request": "mandate_capability_evidence_response",
+    "support_escalation_preparation": "support_escalation_response",
+}
 
 OACP_REQUIRED_ENVELOPE_FIELDS = (
     "artifact_id",
@@ -1979,6 +2031,456 @@ def prepare_agenticorg_c6w6_commitment_envelope(
             blocked_envelope,
         )
     return {"generated": True, "status": "prepared_only", "envelope": envelope}
+
+
+_C6W7_PRIVATE_VALUE_MARKERS = (
+    "http://",
+    "https://",
+    "postgres://",
+    "redis://",
+    "mongodb://",
+    "private_key",
+    "raw_jwt",
+    "passport",
+    "access_token",
+    "api_key",
+    "password",
+    "secret",
+    "credential",
+    "allowlist",
+    "customer_data",
+    "customer_identifier",
+    "customer_email",
+    "customer_phone",
+    "customer_address",
+    "raw_provider_payload",
+    "raw_connector_payload",
+)
+_C6W7_FORBIDDEN_EXECUTION_MARKERS = (
+    "execute",
+    "executed",
+    "execution",
+    "checkout",
+    "payment",
+    "order_create",
+    "order_created",
+    "order_placed",
+    "hold_created",
+    "refund_created",
+    "return_created",
+    "shipment",
+    "shipping",
+    "carrier",
+    "provider_call",
+    "merchant_private_api",
+    "public_discovery_enable",
+    "public_discovery_publish",
+    "protocol_publication",
+    "protocol_submission",
+    "certification",
+    "conformance",
+    "standardization",
+    "production_ready",
+    "live_provider",
+    "live_rail",
+    "live_payment",
+    "mandate_created",
+)
+
+
+def _c6w7_safe_evidence_refs(evidence_refs: list[str] | None) -> list[str] | None:
+    refs: list[str] = []
+    for value in evidence_refs or []:
+        if not isinstance(value, str) or not value:
+            continue
+        normalized = value.lower()
+        if any(marker in normalized for marker in _C6W7_PRIVATE_VALUE_MARKERS):
+            return None
+        if value not in refs:
+            refs.append(value)
+    return refs[:20]
+
+
+def _c6w7_ttl(response_kind: str, created_at: str, envelope: dict[str, Any]) -> dict[str, Any] | None:
+    created = _parse_iso(created_at)
+    envelope_expiry = _parse_iso(_string_field(envelope, "expires_at"))
+    if created is None or envelope_expiry is None:
+        return None
+    default_expiry = created.timestamp() + OACP_C6W7_RESPONSE_TTL_SECONDS[response_kind]
+    expires_timestamp = min(default_expiry, envelope_expiry.timestamp())
+    if expires_timestamp <= created.timestamp():
+        return None
+    expires_at = datetime.fromtimestamp(expires_timestamp, tz=UTC).isoformat(timespec="milliseconds")
+    return {
+        "expires_at": expires_at.replace("+00:00", "Z"),
+        "max_ttl_seconds": int(expires_timestamp - created.timestamp()),
+    }
+
+
+def _c6w7_risk_context_missing(
+    *,
+    envelope: dict[str, Any],
+    currency: str | None,
+    amount_minor_units: int | None,
+    total_quantity: int | None,
+) -> bool:
+    if (
+        envelope.get("envelope_kind") == "seller_source_refresh_request"
+        or envelope.get("action_class") != "commitment_bound"
+    ):
+        return False
+    return (
+        currency not in {"INR", "USD"}
+        or amount_minor_units is None
+        or amount_minor_units < 0
+        or total_quantity is None
+        or total_quantity <= 0
+    )
+
+
+def _c6w7_mandate_evidence_stale(
+    *,
+    response_kind: str,
+    response_status: str,
+    created_at: str,
+    response_evidence_issued_at: str | None,
+) -> bool:
+    if response_kind != "mandate_capability_evidence_response" or response_status != "accepted_for_preparation":
+        return False
+    created = _parse_iso(created_at)
+    issued = _parse_iso(response_evidence_issued_at)
+    if created is None or issued is None or issued > created:
+        return True
+    return created.timestamp() - issued.timestamp() > OACP_ARTIFACT_TTLS_SECONDS["mandate_capability"]
+
+
+def _c6w7_response_conflicts_with_envelope(
+    *,
+    envelope: dict[str, Any],
+    response_claimed_envelope_id: str | None,
+    response_claimed_action: str | None,
+) -> bool:
+    if response_claimed_envelope_id is not None and response_claimed_envelope_id != envelope.get("envelope_id"):
+        return True
+    if response_claimed_action is not None and response_claimed_action != envelope.get("requested_action"):
+        return True
+    return False
+
+
+def _c6w7_response_indicates_forbidden_execution(response_flags: list[str] | None) -> bool:
+    for value in response_flags or []:
+        if not isinstance(value, str):
+            continue
+        normalized = value.lower()
+        if any(marker in normalized for marker in _C6W7_FORBIDDEN_EXECUTION_MARKERS):
+            return True
+    return False
+
+
+def _c6w7_next_human_step(status: str, envelope: dict[str, Any]) -> str:
+    action = str(envelope.get("requested_action"))
+    if status == "accepted_for_preparation":
+        return f"Review reconciled {action} evidence before any separate execution handoff exists."
+    if status == "rejected":
+        return f"Stop {action} preparation and keep source evidence attached for audit."
+    if status in {"needs_source_refresh", "stale", "expired"}:
+        return "Refresh source artifacts before preparing another envelope."
+    if status in {"needs_human_review", "mismatched"}:
+        return "Route the response to a human reviewer with source and freshness labels."
+    return "Do not proceed; the response is blocked by C6W7 fail-closed policy."
+
+
+def _c6w7_next_system_step_label(status: str) -> str:
+    if status == "accepted_for_preparation":
+        return "local_reconciled_preparation_handoff_label"
+    if status in {"needs_source_refresh", "stale", "expired"}:
+        return "source_refresh_reconciliation_label"
+    if status in {"needs_human_review", "mismatched"}:
+        return "human_review_reconciliation_label"
+    if status == "rejected":
+        return "local_rejection_record_label"
+    return "blocked_reconciliation_label"
+
+
+def _c6w7_buyer_safe_message(status: str, envelope: dict[str, Any]) -> str:
+    action = str(envelope.get("requested_action"))
+    if status == "accepted_for_preparation":
+        return (
+            f"Response accepted for preparation only for {action}; no order, hold, checkout, "
+            "payment, mandate, refund, return, shipment, or provider action occurred."
+        )
+    if status == "rejected":
+        return f"Response rejected {action} preparation; no execution occurred."
+    if status in {"needs_source_refresh", "stale", "expired"}:
+        return (
+            "Source evidence is missing, stale, or expired. A refreshed source artifact is required "
+            "before preparation continues."
+        )
+    if status in {"needs_human_review", "mismatched"}:
+        return "The response needs human review because source or envelope evidence is ambiguous."
+    return "The response is blocked. C6W7 does not execute or approve live transaction actions."
+
+
+def _c6w7_seller_safe_message(status: str, envelope: dict[str, Any]) -> str:
+    if status == "accepted_for_preparation":
+        return (
+            f"Evidence for {envelope.get('envelope_kind')} was reconciled locally as prepared-only; "
+            "keep merchant systems and provider rails as operational authorities."
+        )
+    if status == "rejected":
+        return "Seller response is recorded as rejected and does not create operational obligations."
+    if status in {"needs_source_refresh", "stale", "expired"}:
+        return "Seller or source owner must provide refreshed cached evidence without private payloads or credentials."
+    if status in {"needs_human_review", "mismatched"}:
+        return (
+            "Seller response conflicts with local envelope metadata and must be reviewed before another "
+            "prepared handoff."
+        )
+    return "Seller response is blocked and must not be treated as transaction authority."
+
+
+def _c6w7_reconciliation_id(
+    *,
+    envelope_id: str,
+    response_kind: str,
+    response_status: str,
+    created_at: str,
+    response_evidence_refs: list[str],
+) -> str:
+    payload = {
+        "envelope_id": envelope_id,
+        "response_kind": response_kind,
+        "response_status": response_status,
+        "created_at": created_at,
+        "response_evidence_refs": response_evidence_refs,
+    }
+    digest = hashlib.sha256(canonicalize_oacp_payload(payload).encode("utf-8")).hexdigest()
+    return f"oacp_c6w7_reconciliation_{digest[:20]}"
+
+
+def _c6w7_reconciliation(
+    *,
+    envelope: dict[str, Any],
+    response_kind: str,
+    response_status: str,
+    created_at: str,
+    expires_at: str,
+    max_ttl_seconds: int,
+    response_evidence_refs: list[str],
+) -> dict[str, Any]:
+    allowed = response_status == "accepted_for_preparation"
+    envelope_id = str(envelope.get("envelope_id"))
+    return {
+        "reconciliation_id": _c6w7_reconciliation_id(
+            envelope_id=envelope_id,
+            response_kind=response_kind,
+            response_status=response_status,
+            created_at=created_at,
+            response_evidence_refs=response_evidence_refs,
+        ),
+        "envelope_id": envelope_id,
+        "envelope_kind": envelope.get("envelope_kind"),
+        "response_kind": response_kind,
+        "response_status": response_status,
+        "created_at": created_at,
+        "expires_at": expires_at,
+        "max_ttl_seconds": max_ttl_seconds,
+        "action_class": envelope.get("action_class"),
+        "requested_action": envelope.get("requested_action"),
+        "risk_tier": envelope.get("risk_tier"),
+        "source_artifact_ids": _string_list(envelope.get("source_artifact_ids")),
+        "source_artifact_families": _string_list(envelope.get("source_artifact_families")),
+        "source_authority": envelope.get("source_authority"),
+        "response_evidence_refs": response_evidence_refs,
+        "freshness_summary": envelope.get("freshness_summary"),
+        "decision_summary": {
+            "source_resolver_decision_id": envelope.get("source_resolver_decision_id"),
+            "action_class": envelope.get("action_class"),
+            "offline_mode_status": envelope.get("offline_mode_status"),
+            "allowed_to_prepare_from_envelope": envelope.get("allowed_to_prepare") is True,
+            "non_authoritative_for_transaction": True,
+        },
+        "unsupported_capabilities": _string_list(envelope.get("unsupported_capabilities")),
+        "blocked_capabilities": _string_list(envelope.get("blocked_capabilities")),
+        "required_next_artifact_families": _string_list(envelope.get("required_fresh_artifact_families")),
+        "buyer_safe_message": _c6w7_buyer_safe_message(response_status, envelope),
+        "seller_safe_message": _c6w7_seller_safe_message(response_status, envelope),
+        "next_human_step": _c6w7_next_human_step(response_status, envelope),
+        "next_system_step_label": _c6w7_next_system_step_label(response_status),
+        "allowed_to_preview": envelope.get("allowed_to_preview") is True,
+        "allowed_to_prepare": allowed and envelope.get("allowed_to_prepare") is True,
+        "allowed_to_execute": False,
+        "prepared_only": True,
+        "reconciled_only": True,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "commerce_facts_invented": False,
+    }
+
+
+def _c6w7_refusal(
+    refusal_code: str,
+    message: str,
+    blocked_reconciliation: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "reconciled": False,
+        "status": "blocked",
+        "refusal_code": refusal_code,
+        "message": message,
+    }
+    if blocked_reconciliation is not None:
+        result["blocked_reconciliation"] = blocked_reconciliation
+    return result
+
+
+def reconcile_agenticorg_c6w7_prepared_response(
+    *,
+    envelope: dict[str, Any] | None,
+    response_kind: ResponseEvidenceKind,
+    response_status: ReconciliationStatus,
+    created_at: str,
+    response_evidence_refs: list[str] | None = None,
+    response_flags: list[str] | None = None,
+    response_claimed_envelope_id: str | None = None,
+    response_claimed_action: str | None = None,
+    response_evidence_issued_at: str | None = None,
+    amount_minor_units: int | None = None,
+    currency: str | None = None,
+    total_quantity: int | None = None,
+) -> dict[str, Any]:
+    """Reconcile cached C6W7 response evidence against a C6W6 prepared envelope."""
+
+    if envelope is None:
+        return _c6w7_refusal(
+            "prepared_envelope_missing",
+            "C6W7 requires a C6W6 prepared envelope before response reconciliation.",
+        )
+
+    evidence_refs = _c6w7_safe_evidence_refs(response_evidence_refs)
+    ttl = _c6w7_ttl(response_kind, created_at, envelope)
+    blocked_reconciliation = None
+    if ttl is not None and evidence_refs:
+        blocked_reconciliation = _c6w7_reconciliation(
+            envelope=envelope,
+            response_kind=response_kind,
+            response_status="blocked",
+            created_at=created_at,
+            expires_at=str(ttl["expires_at"]),
+            max_ttl_seconds=int(ttl["max_ttl_seconds"]),
+            response_evidence_refs=evidence_refs,
+        )
+
+    if envelope.get("allowed_to_execute") is not False:
+        return _c6w7_refusal(
+            "prepared_envelope_allows_execution",
+            "C6W7 refuses executable envelope input.",
+            blocked_reconciliation,
+        )
+    if envelope.get("prepared_only") is not True or envelope.get("envelope_status") != "prepared_only":
+        return _c6w7_refusal(
+            "prepared_envelope_not_prepared_only",
+            "C6W7 reconciles prepared-only envelopes only.",
+            blocked_reconciliation,
+        )
+
+    freshness = envelope.get("freshness_summary")
+    if (
+        not _string_list(envelope.get("source_artifact_ids"))
+        or not _string_list(envelope.get("source_artifact_families"))
+        or not isinstance(freshness, dict)
+        or freshness.get("earliest_expires_at") is None
+        or freshness.get("freshness_tier") in {"stale", "unknown"}
+        or ttl is None
+    ):
+        return _c6w7_refusal(
+            "source_freshness_missing_or_stale",
+            "C6W7 requires fresh envelope source metadata and a live TTL.",
+            blocked_reconciliation,
+        )
+    if OACP_C6W7_RESPONSE_KIND_BY_ENVELOPE_KIND.get(str(envelope.get("envelope_kind"))) != response_kind:
+        return _c6w7_refusal(
+            "response_kind_envelope_mismatch",
+            "Response kind does not match the prepared envelope kind.",
+            blocked_reconciliation,
+        )
+    if response_status not in OACP_C6W7_RECONCILIATION_STATUSES:
+        return _c6w7_refusal(
+            "response_status_attempts_execution",
+            "Response status is not an allowed C6W7 fail-closed status.",
+            blocked_reconciliation,
+        )
+    if evidence_refs is None:
+        return _c6w7_refusal(
+            "private_or_forbidden_response_field",
+            "Response evidence refs contain private or enabling fields.",
+            blocked_reconciliation,
+        )
+    if not evidence_refs:
+        return _c6w7_refusal(
+            "response_evidence_refs_missing",
+            "C6W7 requires local cached response evidence refs.",
+            blocked_reconciliation,
+        )
+    if _c6w7_response_indicates_forbidden_execution(response_flags):
+        return _c6w7_refusal(
+            "response_indicates_forbidden_execution",
+            "Response evidence implies forbidden live execution or publication behavior.",
+            blocked_reconciliation,
+        )
+    if _c6w7_risk_context_missing(
+        envelope=envelope,
+        currency=currency,
+        amount_minor_units=amount_minor_units,
+        total_quantity=total_quantity,
+    ):
+        return _c6w7_refusal(
+            "risk_context_missing_or_ambiguous",
+            "Commitment-bound reconciliation requires amount, currency, and quantity context.",
+            blocked_reconciliation,
+        )
+    if _c6w7_mandate_evidence_stale(
+        response_kind=response_kind,
+        response_status=response_status,
+        created_at=created_at,
+        response_evidence_issued_at=response_evidence_issued_at,
+    ):
+        return _c6w7_refusal(
+            "mandate_evidence_stale",
+            "Mandate capability evidence is older than the commitment-boundary TTL.",
+            blocked_reconciliation,
+        )
+    if _c6w7_response_conflicts_with_envelope(
+        envelope=envelope,
+        response_claimed_envelope_id=response_claimed_envelope_id,
+        response_claimed_action=response_claimed_action,
+    ):
+        return _c6w7_refusal(
+            "response_conflicts_with_envelope",
+            "Response evidence conflicts with C6W6 envelope metadata.",
+            blocked_reconciliation,
+        )
+
+    reconciliation = _c6w7_reconciliation(
+        envelope=envelope,
+        response_kind=response_kind,
+        response_status=response_status,
+        created_at=created_at,
+        expires_at=str(ttl["expires_at"]),
+        max_ttl_seconds=int(ttl["max_ttl_seconds"]),
+        response_evidence_refs=evidence_refs,
+    )
+    try:
+        assert_no_forbidden_oacp_artifact_fields(reconciliation)
+    except ValueError:
+        return _c6w7_refusal(
+            "private_or_forbidden_response_field",
+            "Prepared response reconciliation contains private or enabling fields.",
+            blocked_reconciliation,
+        )
+    return {"reconciled": True, "status": response_status, "reconciliation": reconciliation}
 
 
 def verify_oacp_artifact(input_data: OacpArtifactVerificationInput) -> dict[str, Any]:

--- a/docs/reports/commerce-agent-c6w7-response-reconciliation.md
+++ b/docs/reports/commerce-agent-c6w7-response-reconciliation.md
@@ -1,0 +1,98 @@
+# Commerce Agent C6W7 - Response Reconciliation
+
+Status: implementation foundation, internal-only, non-enabling.
+
+## Scope
+
+C6W7 adds AgenticOrg-local prepared commitment response intake and evidence reconciliation over C6W6 prepared envelopes. Reconciliation results are local evidence records. They are not execution instructions and are not transaction authority.
+
+This slice adds helper logic, tests, and internal documentation only. It does not add endpoints, migrations, workflows, provider adapters, public discovery, checkout/payment, live provider rail behavior, merchant private API behavior, carrier or shipping behavior, allowlists, cloud, deploy, or external protocol publication behavior.
+
+AgenticOrg remains the buyer/seller agent runtime. Grantex remains the trust, protocol, policy, and canonical-artifact authority. Merchant systems remain operational sources of record. Provider and fintech rails own payment and mandate execution.
+
+## Response Evidence Kinds
+
+AgenticOrg can reconcile five internal response evidence kinds:
+
+- buyer_confirmation_response for local buyer confirmation, rejection, clarification, or refresh requests.
+- seller_source_refresh_response for refreshed, unchanged, missing, stale, or ambiguous seller/source facts.
+- merchant_confirmation_response for merchant or source-owner confirm, reject, expire, or manual-review responses.
+- mandate_capability_evidence_response for cached provider-owned mandate capability evidence states.
+- support_escalation_response for support acknowledgment, rejection, or manual-review states.
+
+## Reconciliation Output
+
+Every reconciliation includes reconciliation_id, envelope_id, envelope_kind, response_kind, response_status, created_at, expires_at, max_ttl_seconds, action_class, requested_action, risk_tier, source artifact IDs and families, source authority, response evidence refs, freshness summary, decision summary, unsupported capabilities, blocked capabilities, required next artifact families, buyer-safe message, seller-safe message, next_human_step, next_system_step_label, and non-authoritative transaction flags.
+
+allowed_to_execute remains false. prepared_only remains true. reconciled_only remains true. next_system_step_label is a label, not an executable endpoint.
+
+## Status Enum
+
+C6W7 uses a small fail-closed status enum:
+
+- accepted_for_preparation
+- rejected
+- needs_source_refresh
+- needs_human_review
+- expired
+- stale
+- mismatched
+- blocked
+
+accepted_for_preparation means cached evidence may continue as preparation only. It does not mean checkout, payment, order, hold, refund, return, shipment, provider rail use, mandate creation, or merchant private API execution.
+
+## Fail-Closed Rules
+
+Response reconciliation fails closed when:
+
+- the C6W6 envelope is missing.
+- the envelope allows execution.
+- the envelope is not prepared_only.
+- source artifact IDs, families, freshness, or TTL metadata is missing, stale, expired, or ambiguous.
+- response kind does not match envelope kind.
+- response status or flags try to execute or approve live action.
+- response evidence refs are missing.
+- response evidence contains private credentials, raw JWTs, private URLs, raw provider payloads, private customer data, DB/Redis URLs, private keys, or allowlist values.
+- response evidence indicates checkout, payment, order, hold, refund, return, shipping, provider call, carrier call, merchant private API use, public discovery enablement, protocol publication/submission, certification, or production readiness.
+- commitment-bound amount, currency, or quantity context is ambiguous.
+- mandate capability evidence is older than the mandate TTL at the commitment boundary.
+- merchant or source responses conflict with the C6W5 decision or C6W6 envelope metadata.
+
+## Human And Source Responses
+
+Buyer-safe messages tell the buyer that response intake is reconciled locally and remains prepared-only. Seller-safe messages preserve source, freshness, unsupported capability, blocked capability, and non-authoritative wording. Seller refresh responses can carry new artifact IDs only as evidence references. Merchant confirmation responses do not create orders, holds, payments, refunds, returns, or shipments. Mandate evidence responses do not verify live mandates or call provider rails. Support responses do not promise SLA, refund, return, replacement, settlement, or payout.
+
+## Toll Booth Boundary
+
+Grantex does not become a synchronous toll booth for non-binding agent interactions. AgenticOrg can reconcile cached responses locally from C6W6 envelopes and Grantex-authoritative metadata while preserving source authority and remaining fail-closed.
+
+## What This Does Not Enable
+
+C6W7 does not enable:
+
+- Public discovery.
+- Production Commerce V1.
+- Checkout/payment creation.
+- Order creation.
+- Inventory holds.
+- Payment capture or debit.
+- Mandate creation.
+- Refund or return execution.
+- Shipping or carrier calls.
+- Live provider rail use.
+- Provider calls.
+- Merchant private API calls.
+- Connector credential export.
+- Production allowlists.
+- Public OACP publication.
+- External protocol submission.
+- Certification, compliance, conformance, standardization, production readiness, public-launch readiness, merchant approval, checkout approval, payment approval, live provider readiness, or OACP public readiness claims.
+
+## Future Slices
+
+Future slices must add separate controls before any execution handoff:
+
+- Human confirmation audit storage.
+- Merchant-system source response ingestion from source-owned channels.
+- Provider-owned mandate verification outside C6W7.
+- Explicit controlled execution handoff outside local preview and reconciliation helpers.

--- a/tests/unit/test_oacp_response_reconciliation.py
+++ b/tests/unit/test_oacp_response_reconciliation.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.commerce.oacp_artifacts import (
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES,
+    evaluate_agenticorg_c6w5_commitment_boundary,
+    prepare_agenticorg_c6w6_commitment_envelope,
+    reconcile_agenticorg_c6w7_prepared_response,
+)
+
+C6W7_DOC_PATH = Path("docs/reports/commerce-agent-c6w7-response-reconciliation.md")
+
+
+def _artifacts() -> list[dict[str, object]]:
+    return [
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["merchant_capability"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["seller_agent_capability"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["catalog_snapshot"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["offer"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["price"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["inventory"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["policy"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["mandate_capability"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["commitment_evidence"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["protocol_adapter"],
+    ]
+
+
+def _preview() -> dict[str, object]:
+    return {
+        "generated": True,
+        "status": "preview_only",
+        "surface": "mcp_tool_resource_capability",
+        "source_artifact_ids": [artifact["envelope"]["artifact_id"] for artifact in _artifacts()],
+        "source_artifact_families": [artifact["envelope"]["artifact_type"] for artifact in _artifacts()],
+        "source_authority": "grantex_canonical_oacp_artifact_authority",
+        "generated_at": "2026-06-11T00:00:30.000Z",
+        "expires_at": "2026-06-11T00:02:00.000Z",
+        "max_ttl_seconds": 90,
+        "freshness_tier": "fresh",
+        "unsupported_capabilities": [
+            "checkout_create",
+            "payment_authorize",
+            "payment_capture",
+            "live_provider_call",
+            "merchant_private_api_call",
+            "protocol_publication",
+        ],
+        "blocked_capabilities": ["checkout_create", "payment_authorize", "payment_capture"],
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "surface_payload": {
+            "preview_only": True,
+            "internal_only": True,
+            "non_publication": True,
+            "source_refs": [
+                {
+                    "artifact_id": artifact["envelope"]["artifact_id"],
+                    "artifact_type": artifact["envelope"]["artifact_type"],
+                }
+                for artifact in _artifacts()
+            ],
+        },
+    }
+
+
+def _decision(action: str = "price_lock") -> dict[str, object]:
+    return evaluate_agenticorg_c6w5_commitment_boundary(
+        action=action,
+        cached_artifacts=_artifacts(),
+        adapter_preview=_preview(),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=False,
+        revocation_snapshot_age_seconds=30,
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+        max_quantity_per_sku=1,
+    )
+
+
+def _envelope(kind: str = "buyer_confirmation_request") -> dict[str, object]:
+    prepared = prepare_agenticorg_c6w6_commitment_envelope(
+        envelope_kind=kind,  # type: ignore[arg-type]
+        resolver_decision=_decision(),
+        created_at="2026-06-11T00:01:15.000Z",
+        evidence_refs=["prepared-price-ref"],
+        unsupported_capabilities=["checkout_create", "payment_authorize"],
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+    )
+    assert prepared["generated"] is True
+    return prepared["envelope"]  # type: ignore[return-value]
+
+
+def test_c6w7_reconciles_buyer_and_merchant_responses_as_prepared_only() -> None:
+    buyer = reconcile_agenticorg_c6w7_prepared_response(
+        envelope=_envelope(),
+        response_kind="buyer_confirmation_response",
+        response_status="accepted_for_preparation",
+        created_at="2026-06-11T00:01:30.000Z",
+        response_evidence_refs=["buyer-confirmation-cache-ref"],
+        response_claimed_action="price_lock",
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+    )
+    assert buyer["reconciled"] is True
+    reconciliation = buyer["reconciliation"]
+    assert reconciliation["response_kind"] == "buyer_confirmation_response"
+    assert reconciliation["response_status"] == "accepted_for_preparation"
+    assert reconciliation["requested_action"] == "price_lock"
+    assert reconciliation["allowed_to_execute"] is False
+    assert reconciliation["prepared_only"] is True
+    assert reconciliation["reconciled_only"] is True
+    assert reconciliation["non_authoritative_for_transaction"] is True
+    assert reconciliation["no_checkout_payment_enablement"] is True
+    assert reconciliation["no_live_provider_enablement"] is True
+    assert reconciliation["no_public_discovery_enablement"] is True
+    assert "price_C6W3" in reconciliation["source_artifact_ids"]
+    assert "buyer-confirmation-cache-ref" in reconciliation["response_evidence_refs"]
+    assert "http" not in reconciliation["next_system_step_label"]
+    assert "no order, hold, checkout, payment" in reconciliation["buyer_safe_message"]
+    assert reconciliation["commerce_facts_invented"] is False
+
+    merchant_prepared = prepare_agenticorg_c6w6_commitment_envelope(
+        envelope_kind="merchant_confirmation_request",
+        resolver_decision=_decision(),
+        created_at="2026-06-11T00:01:15.000Z",
+        evidence_refs=["prepared-price-ref"],
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+    )
+    assert merchant_prepared["generated"] is True
+    merchant = reconcile_agenticorg_c6w7_prepared_response(
+        envelope=merchant_prepared["envelope"],
+        response_kind="merchant_confirmation_response",
+        response_status="needs_human_review",
+        created_at="2026-06-11T00:01:30.000Z",
+        response_evidence_refs=["merchant-confirmation-cache-ref"],
+        response_claimed_envelope_id=merchant_prepared["envelope"]["envelope_id"],
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+    )
+    assert merchant["reconciled"] is True
+    assert merchant["reconciliation"]["allowed_to_prepare"] is False
+    assert merchant["reconciliation"]["next_system_step_label"] == "human_review_reconciliation_label"
+
+
+def test_c6w7_reconciles_refresh_mandate_and_support_response_kinds() -> None:
+    refresh_decision = evaluate_agenticorg_c6w5_commitment_boundary(
+        action="ask_refresh_source_facts",
+        cached_artifacts=_artifacts(),
+        adapter_preview=_preview(),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+        revocation_snapshot_age_seconds=30,
+    )
+    refresh_prepared = prepare_agenticorg_c6w6_commitment_envelope(
+        envelope_kind="seller_source_refresh_request",
+        resolver_decision=refresh_decision,
+        created_at="2026-06-11T00:01:15.000Z",
+        evidence_refs=["refresh-request-ref"],
+    )
+    assert refresh_prepared["generated"] is True
+    refresh = reconcile_agenticorg_c6w7_prepared_response(
+        envelope=refresh_prepared["envelope"],
+        response_kind="seller_source_refresh_response",
+        response_status="needs_source_refresh",
+        created_at="2026-06-11T00:01:30.000Z",
+        response_evidence_refs=["refreshed-artifact-id-only-ref"],
+    )
+    assert refresh["reconciled"] is True
+    assert refresh["reconciliation"]["response_status"] == "needs_source_refresh"
+
+    mandate_decision = evaluate_agenticorg_c6w5_commitment_boundary(
+        action="prepare_mandate_capability_check_request",
+        cached_artifacts=_artifacts(),
+        adapter_preview=_preview(),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+        revocation_snapshot_age_seconds=30,
+    )
+    mandate_prepared = prepare_agenticorg_c6w6_commitment_envelope(
+        envelope_kind="mandate_capability_evidence_request",
+        resolver_decision=mandate_decision,
+        created_at="2026-06-11T00:01:15.000Z",
+        evidence_refs=["mandate-request-ref"],
+    )
+    assert mandate_prepared["generated"] is True
+    mandate = reconcile_agenticorg_c6w7_prepared_response(
+        envelope=mandate_prepared["envelope"],
+        response_kind="mandate_capability_evidence_response",
+        response_status="accepted_for_preparation",
+        created_at="2026-06-11T00:01:30.000Z",
+        response_evidence_refs=["mandate-capability-cache-ref"],
+        response_evidence_issued_at="2026-06-11T00:00:45.000Z",
+    )
+    assert mandate["reconciled"] is True
+    assert mandate["reconciliation"]["max_ttl_seconds"] <= 120
+
+    support_decision = evaluate_agenticorg_c6w5_commitment_boundary(
+        action="support_escalation_sla_promise",
+        cached_artifacts=_artifacts(),
+        adapter_preview=_preview(),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+        revocation_snapshot_age_seconds=30,
+        currency="USD",
+        amount_minor_units=5000,
+        total_quantity=1,
+    )
+    support_prepared = prepare_agenticorg_c6w6_commitment_envelope(
+        envelope_kind="support_escalation_preparation",
+        resolver_decision=support_decision,
+        created_at="2026-06-11T00:01:15.000Z",
+        evidence_refs=["support-request-ref"],
+        currency="USD",
+        amount_minor_units=5000,
+        total_quantity=1,
+    )
+    assert support_prepared["generated"] is True
+    support = reconcile_agenticorg_c6w7_prepared_response(
+        envelope=support_prepared["envelope"],
+        response_kind="support_escalation_response",
+        response_status="rejected",
+        created_at="2026-06-11T00:01:30.000Z",
+        response_evidence_refs=["support-response-ref"],
+        currency="USD",
+        amount_minor_units=5000,
+        total_quantity=1,
+    )
+    assert support["reconciled"] is True
+    assert "does not create operational obligations" in support["reconciliation"]["seller_safe_message"]
+
+
+def test_c6w7_fails_closed_for_unsafe_or_mismatched_response_evidence() -> None:
+    prepared = _envelope()
+    missing = reconcile_agenticorg_c6w7_prepared_response(
+        envelope=None,
+        response_kind="buyer_confirmation_response",
+        response_status="accepted_for_preparation",
+        created_at="2026-06-11T00:01:30.000Z",
+        response_evidence_refs=["buyer-ref"],
+    )
+    assert missing["reconciled"] is False
+    assert missing["refusal_code"] == "prepared_envelope_missing"
+
+    executable = reconcile_agenticorg_c6w7_prepared_response(
+        envelope={**prepared, "allowed_to_execute": True},
+        response_kind="buyer_confirmation_response",
+        response_status="accepted_for_preparation",
+        created_at="2026-06-11T00:01:30.000Z",
+        response_evidence_refs=["buyer-ref"],
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+    )
+    assert executable["reconciled"] is False
+    assert executable["refusal_code"] == "prepared_envelope_allows_execution"
+
+    mismatch = reconcile_agenticorg_c6w7_prepared_response(
+        envelope=prepared,
+        response_kind="merchant_confirmation_response",
+        response_status="accepted_for_preparation",
+        created_at="2026-06-11T00:01:30.000Z",
+        response_evidence_refs=["merchant-ref"],
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+    )
+    assert mismatch["reconciled"] is False
+    assert mismatch["refusal_code"] == "response_kind_envelope_mismatch"
+
+    private_ref = reconcile_agenticorg_c6w7_prepared_response(
+        envelope=prepared,
+        response_kind="buyer_confirmation_response",
+        response_status="accepted_for_preparation",
+        created_at="2026-06-11T00:01:30.000Z",
+        response_evidence_refs=["https://private.example/customer/address"],
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+    )
+    assert private_ref["reconciled"] is False
+    assert private_ref["refusal_code"] == "private_or_forbidden_response_field"
+
+    execution = reconcile_agenticorg_c6w7_prepared_response(
+        envelope=prepared,
+        response_kind="buyer_confirmation_response",
+        response_status="accepted_for_preparation",
+        created_at="2026-06-11T00:01:30.000Z",
+        response_evidence_refs=["buyer-ref"],
+        response_flags=["payment_executed"],
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+    )
+    assert execution["reconciled"] is False
+    assert execution["refusal_code"] == "response_indicates_forbidden_execution"
+
+
+def test_c6w7_fails_closed_for_stale_ambiguous_old_mandate_and_conflicting_evidence() -> None:
+    prepared = _envelope()
+    stale = reconcile_agenticorg_c6w7_prepared_response(
+        envelope=prepared,
+        response_kind="buyer_confirmation_response",
+        response_status="accepted_for_preparation",
+        created_at="2026-06-11T00:10:30.000Z",
+        response_evidence_refs=["buyer-ref"],
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+    )
+    assert stale["reconciled"] is False
+    assert stale["refusal_code"] == "source_freshness_missing_or_stale"
+
+    ambiguous = reconcile_agenticorg_c6w7_prepared_response(
+        envelope=prepared,
+        response_kind="buyer_confirmation_response",
+        response_status="accepted_for_preparation",
+        created_at="2026-06-11T00:01:30.000Z",
+        response_evidence_refs=["buyer-ref"],
+    )
+    assert ambiguous["reconciled"] is False
+    assert ambiguous["refusal_code"] == "risk_context_missing_or_ambiguous"
+
+    conflict = reconcile_agenticorg_c6w7_prepared_response(
+        envelope=prepared,
+        response_kind="buyer_confirmation_response",
+        response_status="accepted_for_preparation",
+        created_at="2026-06-11T00:01:30.000Z",
+        response_evidence_refs=["buyer-ref"],
+        response_claimed_action="inventory_hold",
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+    )
+    assert conflict["reconciled"] is False
+    assert conflict["refusal_code"] == "response_conflicts_with_envelope"
+
+    mandate_decision = evaluate_agenticorg_c6w5_commitment_boundary(
+        action="prepare_mandate_capability_check_request",
+        cached_artifacts=_artifacts(),
+        adapter_preview=_preview(),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+        revocation_snapshot_age_seconds=30,
+    )
+    mandate_prepared = prepare_agenticorg_c6w6_commitment_envelope(
+        envelope_kind="mandate_capability_evidence_request",
+        resolver_decision=mandate_decision,
+        created_at="2026-06-11T00:01:15.000Z",
+        evidence_refs=["mandate-request-ref"],
+    )
+    assert mandate_prepared["generated"] is True
+    old_mandate = reconcile_agenticorg_c6w7_prepared_response(
+        envelope=mandate_prepared["envelope"],
+        response_kind="mandate_capability_evidence_response",
+        response_status="accepted_for_preparation",
+        created_at="2026-06-11T00:01:30.000Z",
+        response_evidence_refs=["mandate-cache-ref"],
+        response_evidence_issued_at="2026-06-10T23:58:00.000Z",
+    )
+    assert old_mandate["reconciled"] is False
+    assert old_mandate["refusal_code"] == "mandate_evidence_stale"
+
+
+def test_c6w7_documents_response_reconciliation_boundaries() -> None:
+    doc = C6W7_DOC_PATH.read_text(encoding="utf-8")
+    for heading in (
+        "Scope",
+        "Response Evidence Kinds",
+        "Reconciliation Output",
+        "Status Enum",
+        "Fail-Closed Rules",
+        "Human And Source Responses",
+        "Toll Booth Boundary",
+        "What This Does Not Enable",
+        "Future Slices",
+    ):
+        assert f"## {heading}" in doc
+    assert "allowed_to_execute remains false" in doc
+    assert "reconciled_only remains true" in doc


### PR DESCRIPTION
## Summary

- Adds internal C6W7 runtime response evidence kinds and reconciliation statuses.
- Adds AgenticOrg-local response reconciliation over C6W6 prepared envelopes and cached response refs.
- Adds focused C6W7 tests and internal report documentation.

## Guardrails

- Internal-only, non-publication, non-certifying, non-production, prepared-only, and non-executing.
- Keeps allowed_to_execute false, prepared_only true, reconciled_only true, and non_authoritative_for_transaction true.
- Adds no endpoints, migrations, workflows, config, secrets, external calls, provider calls, merchant private API calls, checkout/payment behavior, public discovery behavior, or live rail behavior.
- AgenticOrg remains buyer/seller agent runtime and does not invent commerce facts from response evidence.

## Validation

- python -m pytest tests/unit/test_oacp_artifact_schemas.py tests/unit/test_oacp_adapter_previews.py tests/unit/test_oacp_commitment_boundary.py tests/unit/test_oacp_prepared_envelopes.py tests/unit/test_oacp_response_reconciliation.py --no-cov
- python -m ruff check core/commerce/oacp_artifacts.py tests/unit/test_oacp_response_reconciliation.py
- python -m mypy core/commerce/oacp_artifacts.py tests/unit/test_oacp_response_reconciliation.py
- git diff --check origin/main...HEAD
- ASCII and focused guardrail scans on touched files
