### PR TITLE
[codex] Add C6W9 dry-run verifier

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -115,6 +115,24 @@ EligibilityStatus = Literal[
     "mismatched",
     "unsupported",
 ]
+DryRunVerificationKind = Literal[
+    "execution_controller_handoff_dry_run",
+    "audit_readiness_verification",
+    "missing_contract_requirement",
+    "blocked_handoff_verification",
+    "manual_review_required_verification",
+]
+DryRunVerificationStatus = Literal[
+    "dry_run_accepted_for_future_controller",
+    "missing_contract_requirement",
+    "needs_human_review",
+    "blocked",
+    "stale",
+    "expired",
+    "mismatched",
+    "unsupported",
+    "unsafe",
+]
 OfflineAction = Literal[
     "browse",
     "compare",
@@ -459,6 +477,60 @@ OACP_C6W8_PACKET_TTL_SECONDS: dict[str, int] = {
     "missing_evidence_packet": 10 * 60,
     "blocked_execution_packet": 10 * 60,
     "manual_review_packet": 15 * 60,
+}
+OACP_C6W9_DRY_RUN_VERIFICATION_KINDS: frozenset[str] = frozenset(
+    {
+        "execution_controller_handoff_dry_run",
+        "audit_readiness_verification",
+        "missing_contract_requirement",
+        "blocked_handoff_verification",
+        "manual_review_required_verification",
+    }
+)
+OACP_C6W9_VERIFIER_STATUSES: frozenset[str] = frozenset(
+    {
+        "dry_run_accepted_for_future_controller",
+        "missing_contract_requirement",
+        "needs_human_review",
+        "blocked",
+        "stale",
+        "expired",
+        "mismatched",
+        "unsupported",
+        "unsafe",
+    }
+)
+OACP_C6W9_CONTRACT_CHECKS: tuple[str, ...] = (
+    "packet_kind_recognized",
+    "eligibility_status_acceptable",
+    "reconciliation_lineage_present",
+    "envelope_lineage_present",
+    "source_artifact_refs_present",
+    "evidence_refs_redacted_and_non_private",
+    "required_confirmations_present",
+    "freshness_ttl_valid",
+    "mandate_evidence_valid",
+    "action_class_risk_tier_consistent",
+    "commitment_risk_context_present",
+    "non_enablement_flags_intact",
+    "no_executable_url_or_target",
+    "no_raw_private_labels_or_payloads",
+    "no_publication_certification_readiness_claims",
+)
+OACP_C6W9_AUDIT_READINESS_CHECKS: tuple[str, ...] = (
+    "audit_lineage_refs_present",
+    "audit_refs_redacted",
+    "decision_lineage_complete",
+    "source_refs_carried_forward",
+    "evidence_refs_carried_forward",
+    "messages_safe_and_non_executing",
+)
+OACP_C6W9_VERIFICATION_TTL_SECONDS: dict[str, int] = {
+    "execution_controller_handoff_dry_run": 5 * 60,
+    "audit_readiness_verification": 10 * 60,
+    "missing_contract_requirement": 5 * 60,
+    "blocked_handoff_verification": 5 * 60,
+    "manual_review_required_verification": 10 * 60,
 }
 
 OACP_REQUIRED_ENVELOPE_FIELDS = (
@@ -3038,6 +3110,571 @@ def prepare_agenticorg_c6w8_eligibility_packet(
             "C6W8 eligibility packet contains private or enabling fields.",
         )
     return {"prepared": True, "status": status, "packet": packet}
+
+
+_C6W9_FORBIDDEN_TARGET_MARKERS = (
+    "http://",
+    "https://",
+    "endpoint",
+    "checkout_url",
+    "payment_url",
+    "order_target",
+    "provider_target",
+    "merchant_private",
+    "live_rail",
+    "carrier_target",
+    "shipping_target",
+)
+_C6W9_PUBLICATION_CLAIM_MARKERS = (
+    "protocol_publication",
+    "protocol_submission",
+    "certification",
+    "compliance",
+    "conformance",
+    "standardization",
+    "production_ready",
+    "execution_ready",
+)
+
+
+def _c6w9_blank_contract_checks(value: bool = False) -> dict[str, bool]:
+    return dict.fromkeys(OACP_C6W9_CONTRACT_CHECKS, value)
+
+
+def _c6w9_blank_audit_checks(value: bool = False) -> dict[str, bool]:
+    return dict.fromkeys(OACP_C6W9_AUDIT_READINESS_CHECKS, value)
+
+
+def _c6w9_safe_refs(values: list[str] | None) -> list[str] | None:
+    return _c6w8_safe_refs(values)
+
+
+def _c6w9_values_safe(values: list[str] | None) -> bool:
+    refs = _c6w9_safe_refs(values)
+    if refs is None:
+        return False
+    for value in refs:
+        normalized = value.lower().replace("-", "_")
+        if any(marker in normalized for marker in _C6W9_FORBIDDEN_TARGET_MARKERS):
+            return False
+    return True
+
+
+def _c6w9_values_do_not_claim_publication_or_readiness(values: list[str] | None) -> bool:
+    for value in values or []:
+        normalized = value.lower().replace("-", "_")
+        if any(marker in normalized for marker in _C6W9_PUBLICATION_CLAIM_MARKERS):
+            return False
+    return True
+
+
+def _c6w9_ttl(
+    verification_kind: str,
+    created_at: str,
+    packet: dict[str, Any],
+) -> dict[str, Any] | None:
+    created = _parse_iso(created_at)
+    packet_expiry = _parse_iso(_string_field(packet, "expires_at"))
+    if created is None or packet_expiry is None:
+        return None
+    default_expiry = datetime.fromtimestamp(
+        created.timestamp() + OACP_C6W9_VERIFICATION_TTL_SECONDS[verification_kind],
+        tz=UTC,
+    )
+    expires_at = min(default_expiry, packet_expiry)
+    if expires_at <= created:
+        return {"expires_at": created_at, "max_ttl_seconds": 0, "expired": True}
+    return {
+        "expires_at": expires_at.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        "max_ttl_seconds": int((expires_at - created).total_seconds()),
+        "expired": False,
+    }
+
+
+def _c6w9_provided_confirmations_present(required: list[str], provided: list[str] | None) -> bool:
+    if not required:
+        return False
+    safe_provided = _c6w9_safe_refs(provided)
+    if safe_provided is None:
+        return False
+    provided_set = set(safe_provided)
+    return all(confirmation in provided_set for confirmation in required)
+
+
+def _c6w9_risk_context_missing(
+    *,
+    packet: dict[str, Any],
+    currency: str | None,
+    amount_minor_units: int | None,
+    total_quantity: int | None,
+) -> bool:
+    action = str(packet.get("requested_action"))
+    action_class = cast(ActionClass, str(packet.get("action_class")))
+    if not _c6w5_requires_risk_context(action, action_class):
+        return False
+    return (
+        amount_minor_units is None
+        or amount_minor_units <= 0
+        or currency is None
+        or not currency.strip()
+        or total_quantity is None
+        or total_quantity <= 0
+    )
+
+
+def _c6w9_mandate_evidence_stale(
+    *,
+    packet: dict[str, Any],
+    created_at: str,
+    mandate_evidence_issued_at: str | None,
+) -> bool:
+    requested_action = str(packet.get("requested_action"))
+    if requested_action not in {
+        "payment_intent",
+        "mandate_setup_use",
+        "prepare_mandate_capability_check_request",
+    }:
+        return False
+    if mandate_evidence_issued_at is None:
+        return True
+    issued = _parse_iso(mandate_evidence_issued_at)
+    created = _parse_iso(created_at)
+    if issued is None or created is None:
+        return True
+    return (created - issued).total_seconds() > 120
+
+
+def _c6w9_action_risk_consistent(packet: dict[str, Any]) -> bool:
+    action_class = str(packet.get("action_class"))
+    risk_tier = str(packet.get("risk_tier"))
+    if action_class == "always_blocked" or risk_tier == "critical":
+        return False
+    if action_class == "commitment_bound":
+        return risk_tier in {"medium", "high"}
+    if action_class == "commitment_adjacent":
+        return risk_tier in {"low", "medium"}
+    return risk_tier in {"informational", "low"}
+
+
+def _c6w9_freshness_valid(
+    *,
+    packet: dict[str, Any],
+    created_at: str,
+    ttl: dict[str, Any] | None,
+) -> bool:
+    freshness = packet.get("freshness_summary")
+    if not isinstance(freshness, dict):
+        return False
+    earliest_expires_at = freshness.get("earliest_expires_at")
+    earliest_expiry = _parse_iso(str(earliest_expires_at)) if earliest_expires_at is not None else None
+    created = _parse_iso(created_at)
+    return (
+        ttl is not None
+        and ttl.get("expired") is not True
+        and int(packet.get("max_ttl_seconds") or 0) > 0
+        and freshness.get("freshness_tier") not in {"stale", "unknown"}
+        and earliest_expiry is not None
+        and created is not None
+        and earliest_expiry > created
+    )
+
+
+def _c6w9_non_enablement_flags_intact(packet: dict[str, Any]) -> bool:
+    return (
+        packet.get("allowed_to_execute") is False
+        and packet.get("prepared_only") is True
+        and packet.get("reconciled_only") is True
+        and packet.get("eligibility_only") is True
+        and packet.get("non_authoritative_for_transaction") is True
+        and packet.get("no_checkout_payment_enablement") is True
+        and packet.get("no_live_provider_enablement") is True
+        and packet.get("no_public_discovery_enablement") is True
+    )
+
+
+def _c6w9_no_executable_target(packet: dict[str, Any], verification_flags: list[str] | None) -> bool:
+    return (
+        _c6w9_values_safe(verification_flags)
+        and _c6w9_values_safe([str(packet.get("next_system_step_label", ""))])
+        and _c6w9_values_safe(_string_list(packet.get("audit_lineage_refs")))
+        and _c6w9_values_safe(_string_list(packet.get("response_evidence_refs")))
+    )
+
+
+def _c6w9_no_publication_or_readiness_claims(packet: dict[str, Any], verification_flags: list[str] | None) -> bool:
+    return (
+        _c6w9_values_do_not_claim_publication_or_readiness(verification_flags)
+        and _c6w9_values_do_not_claim_publication_or_readiness([str(packet.get("next_system_step_label", ""))])
+        and _c6w9_values_do_not_claim_publication_or_readiness(_string_list(packet.get("audit_lineage_refs")))
+        and _c6w9_values_do_not_claim_publication_or_readiness(_string_list(packet.get("response_evidence_refs")))
+    )
+
+
+def _c6w9_claimed_lineage_matches(
+    *,
+    packet: dict[str, Any],
+    claimed_packet_id: str | None,
+    claimed_reconciliation_id: str | None,
+    claimed_envelope_id: str | None,
+) -> bool:
+    return (
+        (claimed_packet_id is None or claimed_packet_id == packet.get("packet_id"))
+        and (claimed_reconciliation_id is None or claimed_reconciliation_id == packet.get("reconciliation_id"))
+        and (claimed_envelope_id is None or claimed_envelope_id == packet.get("envelope_id"))
+    )
+
+
+def _c6w9_status_from_packet(packet: dict[str, Any]) -> str:
+    eligibility_status = str(packet.get("eligibility_status"))
+    if eligibility_status == "eligible_for_future_handoff":
+        return "dry_run_accepted_for_future_controller"
+    if eligibility_status == "missing_evidence":
+        return "missing_contract_requirement"
+    if eligibility_status == "needs_human_review":
+        return "needs_human_review"
+    return eligibility_status
+
+
+def _c6w9_kind_matches_status(verification_kind: str, status: str) -> bool:
+    if status == "dry_run_accepted_for_future_controller":
+        return verification_kind in {"execution_controller_handoff_dry_run", "audit_readiness_verification"}
+    if status == "missing_contract_requirement":
+        return verification_kind == "missing_contract_requirement"
+    if status == "needs_human_review":
+        return verification_kind == "manual_review_required_verification"
+    return verification_kind == "blocked_handoff_verification"
+
+
+def _c6w9_operator_message(status: str) -> str:
+    if status == "dry_run_accepted_for_future_controller":
+        return (
+            "C6W9 dry-run accepted the local packet contract shape for a future controller review. "
+            "This is not execution readiness and does not execute."
+        )
+    if status == "missing_contract_requirement":
+        return "C6W9 found missing contract evidence, freshness, risk, or confirmation requirements."
+    if status == "needs_human_review":
+        return "C6W9 requires human review labels only and does not approve merchant, payment, or rail behavior."
+    if status in {"stale", "expired"}:
+        return "C6W9 found stale or expired packet lineage; refresh source artifacts before another dry run."
+    if status == "mismatched":
+        return "C6W9 found mismatched packet, reconciliation, envelope, or lineage references."
+    if status == "unsupported":
+        return "C6W9 marks this handoff contract unsupported under the internal non-executing policy."
+    if status == "unsafe":
+        return "C6W9 blocked unsafe private, executable, or publication-oriented packet content."
+    return "C6W9 blocks the future handoff path and keeps the request non-executing."
+
+
+def _c6w9_verification_id(
+    *,
+    verification_kind: str,
+    verification_status: str,
+    eligibility_packet_id: str,
+    created_at: str,
+    audit_lineage_refs: list[str],
+) -> str:
+    payload = {
+        "verification_kind": verification_kind,
+        "verification_status": verification_status,
+        "eligibility_packet_id": eligibility_packet_id,
+        "created_at": created_at,
+        "audit_lineage_refs": audit_lineage_refs,
+    }
+    digest = hashlib.sha256(canonicalize_oacp_payload(payload).encode("utf-8")).hexdigest()
+    return f"oacp_c6w9_verification_{digest[:20]}"
+
+
+def _c6w9_verification(
+    *,
+    verification_kind: str,
+    packet: dict[str, Any],
+    status: str,
+    created_at: str,
+    ttl: dict[str, Any],
+    contract_checks: dict[str, bool],
+    audit_readiness_checks: dict[str, bool],
+    missing_requirements: list[str],
+) -> dict[str, Any]:
+    allowed_for_future_handoff = (
+        status == "dry_run_accepted_for_future_controller" and packet.get("allowed_for_future_handoff") is True
+    )
+    audit_refs = _string_list(packet.get("audit_lineage_refs"))
+    return {
+        "verification_id": _c6w9_verification_id(
+            verification_kind=verification_kind,
+            verification_status=status,
+            eligibility_packet_id=str(packet.get("packet_id")),
+            created_at=created_at,
+            audit_lineage_refs=audit_refs,
+        ),
+        "verification_kind": verification_kind,
+        "verification_status": status,
+        "created_at": created_at,
+        "expires_at": ttl["expires_at"],
+        "max_ttl_seconds": ttl["max_ttl_seconds"],
+        "eligibility_packet_id": packet.get("packet_id"),
+        "packet_kind": packet.get("packet_kind"),
+        "eligibility_status": packet.get("eligibility_status"),
+        "reconciliation_id": packet.get("reconciliation_id"),
+        "envelope_id": packet.get("envelope_id"),
+        "requested_action": packet.get("requested_action"),
+        "action_class": packet.get("action_class"),
+        "risk_tier": packet.get("risk_tier"),
+        "source_artifact_ids": _string_list(packet.get("source_artifact_ids")),
+        "source_artifact_families": _string_list(packet.get("source_artifact_families")),
+        "response_evidence_refs": _string_list(packet.get("response_evidence_refs")),
+        "audit_lineage_refs": audit_refs,
+        "required_confirmations": _string_list(packet.get("required_confirmations")),
+        "missing_requirements": missing_requirements,
+        "freshness_summary": packet.get("freshness_summary"),
+        "contract_checks": contract_checks,
+        "audit_readiness_checks": audit_readiness_checks,
+        "unsupported_capabilities": _string_list(packet.get("unsupported_capabilities")),
+        "blocked_capabilities": _string_list(packet.get("blocked_capabilities")),
+        "buyer_safe_message": packet.get("buyer_safe_message"),
+        "seller_safe_message": packet.get("seller_safe_message"),
+        "operator_safe_message": _c6w9_operator_message(status),
+        "next_human_step": packet.get("next_human_step"),
+        "next_system_step_label": packet.get("next_system_step_label"),
+        "allowed_to_preview": packet.get("allowed_to_preview") is True,
+        "allowed_to_prepare": allowed_for_future_handoff and packet.get("allowed_to_prepare") is True,
+        "allowed_for_future_handoff": allowed_for_future_handoff,
+        "allowed_to_execute": False,
+        "dry_run_only": True,
+        "eligibility_only": True,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "commerce_facts_invented": False,
+    }
+
+
+def _c6w9_refusal(
+    refusal_code: str,
+    message: str,
+    status: str = "blocked",
+    blocked_verification: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "verified": False,
+        "status": status,
+        "refusal_code": refusal_code,
+        "message": message,
+    }
+    if blocked_verification is not None:
+        result["blocked_verification"] = blocked_verification
+    return result
+
+
+def verify_agenticorg_c6w9_execution_handoff_dry_run(
+    *,
+    verification_kind: DryRunVerificationKind,
+    eligibility_packet: dict[str, Any] | None,
+    created_at: str,
+    provided_confirmations: list[str] | None = None,
+    verification_flags: list[str] | None = None,
+    claimed_packet_id: str | None = None,
+    claimed_reconciliation_id: str | None = None,
+    claimed_envelope_id: str | None = None,
+    mandate_evidence_issued_at: str | None = None,
+    amount_minor_units: int | None = None,
+    currency: str | None = None,
+    total_quantity: int | None = None,
+) -> dict[str, Any]:
+    """Dry-run verify a local C6W8 eligibility packet for future controller review only."""
+
+    if eligibility_packet is None:
+        return _c6w9_refusal(
+            "packet_missing",
+            "C6W9 requires a C6W8 eligibility packet before dry-run verification.",
+        )
+
+    packet = eligibility_packet
+    if _c6w9_safe_refs(provided_confirmations) is None or _c6w9_safe_refs(verification_flags) is None:
+        return _c6w9_refusal(
+            "private_or_forbidden_verification_field",
+            "C6W9 verifier input contains private, raw, or unredacted fields.",
+            "unsafe",
+        )
+    if packet.get("allowed_to_execute") is not False:
+        return _c6w9_refusal(
+            "packet_allows_execution",
+            "C6W9 refuses eligibility packets that allow execution.",
+            "unsafe",
+        )
+    if (
+        packet.get("prepared_only") is not True
+        or packet.get("reconciled_only") is not True
+        or packet.get("eligibility_only") is not True
+    ):
+        return _c6w9_refusal(
+            "packet_not_prepared_reconciled_or_eligibility_only",
+            "C6W9 accepts prepared-only, reconciled-only, eligibility-only packets only.",
+        )
+
+    ttl = _c6w9_ttl(verification_kind, created_at, packet)
+    contract_checks = _c6w9_blank_contract_checks()
+    audit_checks = _c6w9_blank_audit_checks()
+    source_ids = _string_list(packet.get("source_artifact_ids"))
+    source_families = _string_list(packet.get("source_artifact_families"))
+    response_refs = _string_list(packet.get("response_evidence_refs"))
+    audit_refs = _string_list(packet.get("audit_lineage_refs"))
+    required_confirmations = _string_list(packet.get("required_confirmations"))
+    refs_safe = _c6w9_safe_refs(response_refs) is not None and _c6w9_safe_refs(audit_refs) is not None
+    confirmations_present = _c6w9_provided_confirmations_present(required_confirmations, provided_confirmations)
+    freshness_valid = _c6w9_freshness_valid(packet=packet, created_at=created_at, ttl=ttl)
+    mandate_evidence_valid = not _c6w9_mandate_evidence_stale(
+        packet=packet,
+        created_at=created_at,
+        mandate_evidence_issued_at=mandate_evidence_issued_at,
+    )
+    risk_context_present = not _c6w9_risk_context_missing(
+        packet=packet,
+        currency=currency,
+        amount_minor_units=amount_minor_units,
+        total_quantity=total_quantity,
+    )
+    lineage_matches = _c6w9_claimed_lineage_matches(
+        packet=packet,
+        claimed_packet_id=claimed_packet_id,
+        claimed_reconciliation_id=claimed_reconciliation_id,
+        claimed_envelope_id=claimed_envelope_id,
+    )
+    no_executable_target = _c6w9_no_executable_target(packet, verification_flags)
+    no_publication_claims = _c6w9_no_publication_or_readiness_claims(packet, verification_flags)
+    non_enablement_flags_intact = _c6w9_non_enablement_flags_intact(packet)
+    source_refs_present = bool(source_ids and source_families)
+    evidence_refs_present = bool(response_refs)
+    audit_lineage_present = bool(audit_refs)
+    reconciliation_id = _string_field(packet, "reconciliation_id") or ""
+    envelope_id = _string_field(packet, "envelope_id") or ""
+    decision_lineage_complete = (
+        audit_lineage_present
+        and reconciliation_id in audit_refs
+        and envelope_id in audit_refs
+        and lineage_matches
+    )
+    status = _c6w9_status_from_packet(packet)
+
+    contract_checks["packet_kind_recognized"] = str(packet.get("packet_kind")) in OACP_C6W8_ELIGIBILITY_PACKET_KINDS
+    contract_checks["eligibility_status_acceptable"] = packet.get("eligibility_status") == "eligible_for_future_handoff"
+    contract_checks["reconciliation_lineage_present"] = bool(reconciliation_id) and lineage_matches
+    contract_checks["envelope_lineage_present"] = bool(envelope_id) and lineage_matches
+    contract_checks["source_artifact_refs_present"] = source_refs_present
+    contract_checks["evidence_refs_redacted_and_non_private"] = refs_safe and evidence_refs_present
+    contract_checks["required_confirmations_present"] = confirmations_present
+    contract_checks["freshness_ttl_valid"] = freshness_valid
+    contract_checks["mandate_evidence_valid"] = mandate_evidence_valid
+    contract_checks["action_class_risk_tier_consistent"] = _c6w9_action_risk_consistent(packet)
+    contract_checks["commitment_risk_context_present"] = risk_context_present
+    contract_checks["non_enablement_flags_intact"] = non_enablement_flags_intact
+    contract_checks["no_executable_url_or_target"] = no_executable_target
+    contract_checks["no_raw_private_labels_or_payloads"] = refs_safe and no_executable_target
+    contract_checks["no_publication_certification_readiness_claims"] = no_publication_claims
+
+    audit_checks["audit_lineage_refs_present"] = audit_lineage_present
+    audit_checks["audit_refs_redacted"] = refs_safe
+    audit_checks["decision_lineage_complete"] = decision_lineage_complete
+    audit_checks["source_refs_carried_forward"] = source_refs_present
+    audit_checks["evidence_refs_carried_forward"] = evidence_refs_present
+    audit_checks["messages_safe_and_non_executing"] = _c6w9_values_safe(
+        [
+            str(packet.get("buyer_safe_message", "")),
+            str(packet.get("seller_safe_message", "")),
+            str(packet.get("next_human_step", "")),
+            str(packet.get("next_system_step_label", "")),
+        ]
+    )
+
+    missing_requirements = set(_string_list(packet.get("missing_requirements")))
+    if not contract_checks["reconciliation_lineage_present"] or not contract_checks["envelope_lineage_present"]:
+        status = "mismatched"
+        missing_requirements.add("complete_packet_reconciliation_envelope_lineage")
+    if not decision_lineage_complete:
+        status = "mismatched"
+        missing_requirements.add("complete_packet_reconciliation_envelope_lineage")
+    if not source_refs_present or not evidence_refs_present or not audit_lineage_present:
+        status = "missing_contract_requirement"
+        missing_requirements.add("source_evidence_and_audit_refs")
+    if not confirmations_present:
+        status = "missing_contract_requirement"
+        for confirmation in required_confirmations:
+            missing_requirements.add(f"confirmation:{confirmation}")
+    if not risk_context_present:
+        status = "missing_contract_requirement"
+        missing_requirements.add("amount_currency_quantity_context")
+    if not mandate_evidence_valid:
+        status = "stale"
+        missing_requirements.add("fresh_mandate_capability_evidence")
+    if not freshness_valid:
+        status = "expired" if ttl is None or ttl.get("expired") is True else "stale"
+        missing_requirements.add("fresh_source_artifacts")
+    if not contract_checks["action_class_risk_tier_consistent"]:
+        status = "unsupported" if packet.get("risk_tier") == "critical" else "mismatched"
+        missing_requirements.add("consistent_action_class_and_risk_tier")
+    if (
+        not contract_checks["non_enablement_flags_intact"]
+        or not contract_checks["no_executable_url_or_target"]
+        or not contract_checks["no_raw_private_labels_or_payloads"]
+        or not contract_checks["no_publication_certification_readiness_claims"]
+    ):
+        status = "unsafe"
+        missing_requirements.add("non_enablement_and_private_target_controls")
+
+    if not non_enablement_flags_intact:
+        return _c6w9_refusal(
+            "non_enablement_flags_missing",
+            "C6W9 refuses packets with missing or false non-enablement flags.",
+            "unsafe",
+        )
+    if not no_executable_target or not no_publication_claims or not refs_safe:
+        return _c6w9_refusal(
+            "private_or_forbidden_verification_field",
+            "C6W9 refuses private refs, executable targets, publication claims, or readiness claims.",
+            "unsafe",
+        )
+    if not _c6w9_kind_matches_status(verification_kind, status):
+        blocked_verification = None
+        if ttl is not None:
+            blocked_verification = _c6w9_verification(
+                verification_kind=verification_kind,
+                packet=packet,
+                status="mismatched",
+                created_at=created_at,
+                ttl=ttl,
+                contract_checks=contract_checks,
+                audit_readiness_checks=audit_checks,
+                missing_requirements=[*sorted(missing_requirements), "verification_kind_status_mismatch"],
+            )
+        return _c6w9_refusal(
+            "verification_kind_status_mismatch",
+            "C6W9 verification kind does not match the derived dry-run status.",
+            "blocked",
+            blocked_verification,
+        )
+
+    verification_ttl = ttl or {"expires_at": created_at, "max_ttl_seconds": 0}
+    verification = _c6w9_verification(
+        verification_kind=verification_kind,
+        packet=packet,
+        status=status,
+        created_at=created_at,
+        ttl=verification_ttl,
+        contract_checks=contract_checks,
+        audit_readiness_checks=audit_checks,
+        missing_requirements=sorted(missing_requirements),
+    )
+    try:
+        assert_no_forbidden_oacp_artifact_fields(verification)
+    except ValueError:
+        return _c6w9_refusal(
+            "private_or_forbidden_verification_field",
+            "C6W9 dry-run verification contains private or enabling fields.",
+            "unsafe",
+        )
+    return {"verified": True, "status": status, "verification": verification}
 
 
 def verify_oacp_artifact(input_data: OacpArtifactVerificationInput) -> dict[str, Any]:

--- a/docs/reports/commerce-agent-c6w9-dry-run-verifier.md
+++ b/docs/reports/commerce-agent-c6w9-dry-run-verifier.md
@@ -1,0 +1,135 @@
+# Commerce Agent C6W9 Dry-Run Verifier
+
+## Scope
+
+C6W9 adds an internal AgenticOrg dry-run verifier over C6W8 eligibility packets. The verifier checks whether a local packet has enough lineage, freshness, evidence refs, confirmations, risk context, and non-enablement flags for a future gated controller review.
+
+The verifier produces local dry-run results only. It does not create an execution controller, execute a transaction, call Grantex live, call providers, call merchant private APIs, create checkout or payment objects, enable public discovery, or persist production audit events.
+
+## Dry-Run Result Kinds
+
+- `execution_controller_handoff_dry_run`
+- `audit_readiness_verification`
+- `missing_contract_requirement`
+- `blocked_handoff_verification`
+- `manual_review_required_verification`
+
+Each result kind is internal and non-executing. AgenticOrg can use the result to explain what is complete, missing, blocked, or routed to human review.
+
+## Verifier Statuses
+
+- `dry_run_accepted_for_future_controller`
+- `missing_contract_requirement`
+- `needs_human_review`
+- `blocked`
+- `stale`
+- `expired`
+- `mismatched`
+- `unsupported`
+- `unsafe`
+
+Only `dry_run_accepted_for_future_controller` means the local packet contract shape is complete enough for a future controller review. It is still not execution readiness and does not approve live behavior.
+
+## Required Fields
+
+Verifier results include:
+
+- deterministic `verification_id`
+- `verification_kind` and `verification_status`
+- `created_at`, `expires_at`, and `max_ttl_seconds`
+- `eligibility_packet_id`, `packet_kind`, and `eligibility_status`
+- `reconciliation_id` and `envelope_id`
+- `requested_action`, `action_class`, and `risk_tier`
+- source artifact IDs and families
+- redacted response evidence refs and audit lineage refs
+- required confirmations and missing requirements
+- freshness summary
+- contract checks and audit-readiness checks
+- unsupported and blocked capabilities
+- buyer, seller, and operator-safe messages
+- label-only next human and next system steps
+- `allowed_to_execute remains false`
+- `dry_run_only remains true`
+- `eligibility_only remains true`
+- `non_authoritative_for_transaction remains true`
+- no checkout/payment, live-provider, or public-discovery enablement
+
+AgenticOrg does not invent commerce facts from packet data. The verifier preserves source and blocked wording from the packet.
+
+## Contract Checks
+
+The runtime verifier checks:
+
+- packet kind recognition
+- eligibility status acceptability for the requested verifier kind
+- reconciliation and envelope lineage
+- source artifact refs
+- redacted, non-private evidence refs
+- required confirmations
+- freshness and TTL
+- mandate evidence freshness when relevant
+- action class and risk tier consistency
+- amount, currency, and quantity context for commitment-bound actions
+- non-enablement flags
+- absence of executable URLs, endpoint targets, provider targets, merchant private targets, or live rail targets
+- absence of raw private labels or payloads
+- absence of publication, submission, certification, compliance, conformance, production-readiness, or execution-readiness claims
+
+## Audit Readiness
+
+Audit-readiness verification confirms that the local packet carries:
+
+- audit lineage refs
+- redacted audit refs
+- reconciliation and envelope lineage
+- source refs
+- response evidence refs
+- buyer, seller, and operator-safe messages
+
+C6W9 does not persist production audit records. It prepares local audit-readiness facts for a later gated slice.
+
+## Fail-Closed Rules
+
+The verifier blocks or marks unsafe when:
+
+- the C6W8 packet is missing
+- the packet allows execution
+- the packet is not prepared-only, reconciled-only, and eligibility-only
+- the eligibility status does not match the verifier kind
+- lineage is missing or mismatched
+- evidence refs are missing, raw, private, or unredacted
+- required confirmations are missing
+- freshness or TTL is stale or expired
+- risk context is missing or inconsistent
+- mandate evidence is stale or missing at the boundary
+- non-enablement flags are missing or false
+- executable URLs, endpoint targets, provider targets, merchant private targets, or live rail targets appear
+- the packet implies checkout, payment, order, hold, refund, return, shipping, provider execution, public discovery enablement, publication, or readiness claims
+- secrets, raw JWTs, private keys, raw provider payloads, private merchant URLs, DB or Redis URLs, private customer data, or production allowlist values appear
+
+## Dry-Run Acceptance Is Not Execution
+
+Dry-run acceptance is a local contract check. It is not execution readiness, merchant approval, checkout approval, payment approval, live-provider readiness, public-launch readiness, certification, compliance, conformance, or standardization.
+
+## Toll Booth Boundary
+
+AgenticOrg can continue non-binding and prepare-only flows from valid cached artifacts without routing every interaction through Grantex. Grantex remains the artifact and policy authority; AgenticOrg remains the agent runtime. Merchant systems and provider rails remain the operational execution authorities.
+
+## What This Does Not Enable
+
+C6W9 does not enable:
+
+- public discovery
+- checkout or payment
+- live providers or live rails
+- live Plural behavior
+- production Commerce V1
+- merchant private API calls
+- provider, carrier, or shipping calls
+- production audit persistence
+- protocol publication or submission
+- certification, compliance, conformance, standardization, production-readiness, or execution-readiness claims
+
+## Future Slices
+
+Future slices would need separately gated execution-controller ownership, merchant-system handoff contracts, provider-owned payment and mandate behavior, production audit persistence, human approval flows, rollback handling, and operational controls. Those are outside C6W9.

--- a/tests/unit/test_oacp_dry_run_verifier.py
+++ b/tests/unit/test_oacp_dry_run_verifier.py
@@ -1,0 +1,441 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from core.commerce.oacp_artifacts import (
+    OACP_C6W3_VALID_ARTIFACT_FIXTURES,
+    OACP_C6W9_DRY_RUN_VERIFICATION_KINDS,
+    OACP_C6W9_VERIFIER_STATUSES,
+    EligibilityPacketKind,
+    PreparedEnvelopeKind,
+    ReconciliationStatus,
+    ResponseEvidenceKind,
+    evaluate_agenticorg_c6w5_commitment_boundary,
+    prepare_agenticorg_c6w6_commitment_envelope,
+    prepare_agenticorg_c6w8_eligibility_packet,
+    reconcile_agenticorg_c6w7_prepared_response,
+    verify_agenticorg_c6w9_execution_handoff_dry_run,
+)
+
+C6W9_DOC_PATH = Path("docs/reports/commerce-agent-c6w9-dry-run-verifier.md")
+
+
+def _artifacts() -> list[dict[str, object]]:
+    return [
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["merchant_capability"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["seller_agent_capability"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["catalog_snapshot"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["offer"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["price"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["inventory"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["policy"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["mandate_capability"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["commitment_evidence"],
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES["protocol_adapter"],
+    ]
+
+
+def _preview() -> dict[str, object]:
+    return {
+        "generated": True,
+        "status": "preview_only",
+        "surface": "mcp_tool_resource_capability",
+        "source_artifact_ids": [artifact["envelope"]["artifact_id"] for artifact in _artifacts()],
+        "source_artifact_families": [artifact["envelope"]["artifact_type"] for artifact in _artifacts()],
+        "source_authority": "grantex_canonical_oacp_artifact_authority",
+        "generated_at": "2026-06-11T00:00:30.000Z",
+        "expires_at": "2026-06-11T00:02:00.000Z",
+        "max_ttl_seconds": 90,
+        "freshness_tier": "fresh",
+        "unsupported_capabilities": [
+            "checkout_create",
+            "payment_authorize",
+            "payment_capture",
+            "live_provider_call",
+            "merchant_private_api_call",
+            "protocol_publication",
+        ],
+        "blocked_capabilities": ["checkout_create", "payment_authorize", "payment_capture"],
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "surface_payload": {
+            "preview_only": True,
+            "internal_only": True,
+            "non_publication": True,
+            "source_refs": [
+                {
+                    "artifact_id": artifact["envelope"]["artifact_id"],
+                    "artifact_type": artifact["envelope"]["artifact_type"],
+                }
+                for artifact in _artifacts()
+            ],
+        },
+    }
+
+
+def _decision(action: str = "price_lock") -> dict[str, object]:
+    return evaluate_agenticorg_c6w5_commitment_boundary(
+        action=action,
+        cached_artifacts=_artifacts(),
+        adapter_preview=_preview(),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=False,
+        revocation_snapshot_age_seconds=30,
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+        max_quantity_per_sku=1,
+    )
+
+
+def _envelope(kind: PreparedEnvelopeKind = "buyer_confirmation_request") -> dict[str, object]:
+    prepared = prepare_agenticorg_c6w6_commitment_envelope(
+        envelope_kind=kind,
+        resolver_decision=_decision(),
+        created_at="2026-06-11T00:01:15.000Z",
+        evidence_refs=["prepared-price-ref"],
+        unsupported_capabilities=["checkout_create", "payment_authorize"],
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+    )
+    assert prepared["generated"] is True
+    return cast(dict[str, object], prepared["envelope"])
+
+
+def _reconciliation(
+    *,
+    response_status: ReconciliationStatus = "accepted_for_preparation",
+    response_kind: ResponseEvidenceKind = "buyer_confirmation_response",
+    envelope_kind: PreparedEnvelopeKind = "buyer_confirmation_request",
+) -> dict[str, object]:
+    reconciled = reconcile_agenticorg_c6w7_prepared_response(
+        envelope=_envelope(envelope_kind),
+        response_kind=response_kind,
+        response_status=response_status,
+        created_at="2026-06-11T00:01:30.000Z",
+        response_evidence_refs=["buyer-confirmation-cache-ref"],
+        response_claimed_action="price_lock",
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+    )
+    assert reconciled["reconciled"] is True
+    return cast(dict[str, object], reconciled["reconciliation"])
+
+
+def _mandate_reconciliation() -> dict[str, object]:
+    mandate_decision = evaluate_agenticorg_c6w5_commitment_boundary(
+        action="prepare_mandate_capability_check_request",
+        cached_artifacts=_artifacts(),
+        adapter_preview=_preview(),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+        revocation_snapshot_age_seconds=30,
+    )
+    prepared = prepare_agenticorg_c6w6_commitment_envelope(
+        envelope_kind="mandate_capability_evidence_request",
+        resolver_decision=mandate_decision,
+        created_at="2026-06-11T00:01:15.000Z",
+        evidence_refs=["mandate-request-ref"],
+    )
+    assert prepared["generated"] is True
+    reconciled = reconcile_agenticorg_c6w7_prepared_response(
+        envelope=prepared["envelope"],
+        response_kind="mandate_capability_evidence_response",
+        response_status="accepted_for_preparation",
+        created_at="2026-06-11T00:01:30.000Z",
+        response_evidence_refs=["mandate-capability-cache-ref"],
+        response_evidence_issued_at="2026-06-11T00:00:45.000Z",
+    )
+    assert reconciled["reconciled"] is True
+    return cast(dict[str, object], reconciled["reconciliation"])
+
+
+def _eligibility_packet(
+    *,
+    packet_kind: EligibilityPacketKind = "execution_handoff_eligibility_packet",
+    reconciliation: dict[str, object] | None = None,
+) -> dict[str, object]:
+    prepared = prepare_agenticorg_c6w8_eligibility_packet(
+        packet_kind=packet_kind,
+        reconciliation=reconciliation or _reconciliation(),
+        created_at="2026-06-11T00:01:45.000Z",
+        provided_confirmations=["buyer_confirmation"],
+        amount_minor_units=200000,
+        currency="INR",
+        total_quantity=1,
+    )
+    assert prepared["prepared"] is True
+    return cast(dict[str, object], prepared["packet"])
+
+
+def test_c6w9_verifies_accepted_handoff_and_audit_contracts() -> None:
+    packet = _eligibility_packet()
+    dry_run = verify_agenticorg_c6w9_execution_handoff_dry_run(
+        verification_kind="execution_controller_handoff_dry_run",
+        eligibility_packet=packet,
+        created_at="2026-06-11T00:02:00.000Z",
+        provided_confirmations=["buyer_confirmation"],
+        amount_minor_units=200000,
+        currency="INR",
+        total_quantity=1,
+    )
+    assert dry_run["verified"] is True
+    assert dry_run["status"] == "dry_run_accepted_for_future_controller"
+    verification = dry_run["verification"]
+    assert verification["verification_kind"] == "execution_controller_handoff_dry_run"
+    assert verification["verification_status"] == "dry_run_accepted_for_future_controller"
+    assert verification["eligibility_packet_id"] == packet["packet_id"]
+    assert verification["packet_kind"] == "execution_handoff_eligibility_packet"
+    assert verification["requested_action"] == "price_lock"
+    assert verification["allowed_for_future_handoff"] is True
+    assert verification["allowed_to_execute"] is False
+    assert verification["dry_run_only"] is True
+    assert verification["eligibility_only"] is True
+    assert verification["non_authoritative_for_transaction"] is True
+    assert verification["no_checkout_payment_enablement"] is True
+    assert verification["no_live_provider_enablement"] is True
+    assert verification["no_public_discovery_enablement"] is True
+    assert "price_C6W3" in verification["source_artifact_ids"]
+    assert "buyer-confirmation-cache-ref" in verification["response_evidence_refs"]
+    assert packet["reconciliation_id"] in verification["audit_lineage_refs"]
+    assert verification["contract_checks"]["non_enablement_flags_intact"] is True
+    assert verification["contract_checks"]["no_executable_url_or_target"] is True
+    assert verification["audit_readiness_checks"]["decision_lineage_complete"] is True
+    assert "not execution readiness" in verification["operator_safe_message"]
+    assert verification["commerce_facts_invented"] is False
+
+    audit_packet = _eligibility_packet(packet_kind="audit_trail_preparation_packet")
+    audit = verify_agenticorg_c6w9_execution_handoff_dry_run(
+        verification_kind="audit_readiness_verification",
+        eligibility_packet=audit_packet,
+        created_at="2026-06-11T00:02:00.000Z",
+        provided_confirmations=["buyer_confirmation"],
+        amount_minor_units=200000,
+        currency="INR",
+        total_quantity=1,
+    )
+    assert audit["verified"] is True
+    assert audit["verification"]["verification_kind"] == "audit_readiness_verification"
+    assert audit["verification"]["allowed_to_execute"] is False
+
+
+def test_c6w9_reports_non_accepted_statuses_without_handoff_permission() -> None:
+    missing = verify_agenticorg_c6w9_execution_handoff_dry_run(
+        verification_kind="missing_contract_requirement",
+        eligibility_packet=_eligibility_packet(
+            packet_kind="missing_evidence_packet",
+            reconciliation=_reconciliation(response_status="needs_source_refresh"),
+        ),
+        created_at="2026-06-11T00:02:00.000Z",
+        provided_confirmations=["buyer_confirmation"],
+        amount_minor_units=200000,
+        currency="INR",
+        total_quantity=1,
+    )
+    assert missing["verified"] is True
+    assert missing["status"] == "missing_contract_requirement"
+    assert missing["verification"]["allowed_for_future_handoff"] is False
+
+    review = verify_agenticorg_c6w9_execution_handoff_dry_run(
+        verification_kind="manual_review_required_verification",
+        eligibility_packet=_eligibility_packet(
+            packet_kind="manual_review_packet",
+            reconciliation=_reconciliation(response_status="needs_human_review"),
+        ),
+        created_at="2026-06-11T00:02:00.000Z",
+        provided_confirmations=["buyer_confirmation"],
+        amount_minor_units=200000,
+        currency="INR",
+        total_quantity=1,
+    )
+    assert review["verified"] is True
+    assert review["status"] == "needs_human_review"
+
+    for response_status in ("rejected", "stale", "mismatched"):
+        blocked = verify_agenticorg_c6w9_execution_handoff_dry_run(
+            verification_kind="blocked_handoff_verification",
+            eligibility_packet=_eligibility_packet(
+                packet_kind="blocked_execution_packet",
+                reconciliation=_reconciliation(response_status=cast(ReconciliationStatus, response_status)),
+            ),
+            created_at="2026-06-11T00:02:00.000Z",
+            provided_confirmations=["buyer_confirmation"],
+            amount_minor_units=200000,
+            currency="INR",
+            total_quantity=1,
+        )
+        assert blocked["verified"] is True
+        assert blocked["verification"]["allowed_to_execute"] is False
+        assert blocked["verification"]["allowed_for_future_handoff"] is False
+
+    expired = verify_agenticorg_c6w9_execution_handoff_dry_run(
+        verification_kind="blocked_handoff_verification",
+        eligibility_packet=_eligibility_packet(),
+        created_at="2026-06-11T00:12:01.000Z",
+        provided_confirmations=["buyer_confirmation"],
+        amount_minor_units=200000,
+        currency="INR",
+        total_quantity=1,
+    )
+    assert expired["verified"] is True
+    assert expired["status"] == "expired"
+
+    mismatched = verify_agenticorg_c6w9_execution_handoff_dry_run(
+        verification_kind="blocked_handoff_verification",
+        eligibility_packet=_eligibility_packet(),
+        created_at="2026-06-11T00:02:00.000Z",
+        provided_confirmations=["buyer_confirmation"],
+        claimed_packet_id="wrong-packet-id",
+        amount_minor_units=200000,
+        currency="INR",
+        total_quantity=1,
+    )
+    assert mismatched["verified"] is True
+    assert mismatched["status"] == "mismatched"
+
+    unsupported = verify_agenticorg_c6w9_execution_handoff_dry_run(
+        verification_kind="blocked_handoff_verification",
+        eligibility_packet=_eligibility_packet(
+            packet_kind="blocked_execution_packet",
+            reconciliation={**_reconciliation(), "risk_tier": "critical"},
+        ),
+        created_at="2026-06-11T00:02:00.000Z",
+        provided_confirmations=["buyer_confirmation"],
+        amount_minor_units=200000,
+        currency="INR",
+        total_quantity=1,
+    )
+    assert unsupported["verified"] is True
+    assert unsupported["status"] == "unsupported"
+
+    assert "blocked_handoff_verification" in OACP_C6W9_DRY_RUN_VERIFICATION_KINDS
+    assert "unsafe" in OACP_C6W9_VERIFIER_STATUSES
+
+
+def test_c6w9_fails_closed_for_unsafe_or_mismatched_verifier_input() -> None:
+    packet = _eligibility_packet()
+    missing = verify_agenticorg_c6w9_execution_handoff_dry_run(
+        verification_kind="execution_controller_handoff_dry_run",
+        eligibility_packet=None,
+        created_at="2026-06-11T00:02:00.000Z",
+    )
+    assert missing["verified"] is False
+    assert missing["refusal_code"] == "packet_missing"
+
+    executable = verify_agenticorg_c6w9_execution_handoff_dry_run(
+        verification_kind="execution_controller_handoff_dry_run",
+        eligibility_packet={**packet, "allowed_to_execute": True},
+        created_at="2026-06-11T00:02:00.000Z",
+        provided_confirmations=["buyer_confirmation"],
+        amount_minor_units=200000,
+        currency="INR",
+        total_quantity=1,
+    )
+    assert executable["verified"] is False
+    assert executable["refusal_code"] == "packet_allows_execution"
+
+    non_eligibility = verify_agenticorg_c6w9_execution_handoff_dry_run(
+        verification_kind="execution_controller_handoff_dry_run",
+        eligibility_packet={**packet, "eligibility_only": False},
+        created_at="2026-06-11T00:02:00.000Z",
+        provided_confirmations=["buyer_confirmation"],
+        amount_minor_units=200000,
+        currency="INR",
+        total_quantity=1,
+    )
+    assert non_eligibility["verified"] is False
+    assert non_eligibility["refusal_code"] == "packet_not_prepared_reconciled_or_eligibility_only"
+
+    unsafe_ref = verify_agenticorg_c6w9_execution_handoff_dry_run(
+        verification_kind="execution_controller_handoff_dry_run",
+        eligibility_packet={**packet, "response_evidence_refs": ["raw_jwt_private_ref"]},
+        created_at="2026-06-11T00:02:00.000Z",
+        provided_confirmations=["buyer_confirmation"],
+        amount_minor_units=200000,
+        currency="INR",
+        total_quantity=1,
+    )
+    assert unsafe_ref["verified"] is False
+    assert unsafe_ref["refusal_code"] == "private_or_forbidden_verification_field"
+
+    missing_confirmation = verify_agenticorg_c6w9_execution_handoff_dry_run(
+        verification_kind="missing_contract_requirement",
+        eligibility_packet=packet,
+        created_at="2026-06-11T00:02:00.000Z",
+        amount_minor_units=200000,
+        currency="INR",
+        total_quantity=1,
+    )
+    assert missing_confirmation["verified"] is True
+    assert missing_confirmation["status"] == "missing_contract_requirement"
+    assert "confirmation:buyer_confirmation" in missing_confirmation["verification"]["missing_requirements"]
+
+    ambiguous_risk = verify_agenticorg_c6w9_execution_handoff_dry_run(
+        verification_kind="missing_contract_requirement",
+        eligibility_packet=packet,
+        created_at="2026-06-11T00:02:00.000Z",
+        provided_confirmations=["buyer_confirmation"],
+    )
+    assert ambiguous_risk["verified"] is True
+    assert ambiguous_risk["status"] == "missing_contract_requirement"
+
+    kind_mismatch = verify_agenticorg_c6w9_execution_handoff_dry_run(
+        verification_kind="execution_controller_handoff_dry_run",
+        eligibility_packet=_eligibility_packet(
+            packet_kind="manual_review_packet",
+            reconciliation=_reconciliation(response_status="needs_human_review"),
+        ),
+        created_at="2026-06-11T00:02:00.000Z",
+        provided_confirmations=["buyer_confirmation"],
+        amount_minor_units=200000,
+        currency="INR",
+        total_quantity=1,
+    )
+    assert kind_mismatch["verified"] is False
+    assert kind_mismatch["refusal_code"] == "verification_kind_status_mismatch"
+
+
+def test_c6w9_fails_closed_for_stale_mandate_evidence() -> None:
+    prepared = prepare_agenticorg_c6w8_eligibility_packet(
+        packet_kind="execution_handoff_eligibility_packet",
+        reconciliation=_mandate_reconciliation(),
+        created_at="2026-06-11T00:01:45.000Z",
+        provided_confirmations=["mandate_capability_evidence"],
+        mandate_evidence_issued_at="2026-06-11T00:00:45.000Z",
+    )
+    assert prepared["prepared"] is True
+    stale_mandate = verify_agenticorg_c6w9_execution_handoff_dry_run(
+        verification_kind="blocked_handoff_verification",
+        eligibility_packet=cast(dict[str, object], prepared["packet"]),
+        created_at="2026-06-11T00:01:55.000Z",
+        provided_confirmations=["mandate_capability_evidence"],
+        mandate_evidence_issued_at="2026-06-10T23:58:00.000Z",
+    )
+    assert stale_mandate["verified"] is True
+    assert stale_mandate["status"] == "stale"
+    assert stale_mandate["verification"]["allowed_to_execute"] is False
+
+
+def test_c6w9_documents_dry_run_verifier_boundaries() -> None:
+    doc = C6W9_DOC_PATH.read_text(encoding="utf-8")
+    for heading in (
+        "Scope",
+        "Dry-Run Result Kinds",
+        "Verifier Statuses",
+        "Required Fields",
+        "Contract Checks",
+        "Audit Readiness",
+        "Fail-Closed Rules",
+        "Dry-Run Acceptance Is Not Execution",
+        "Toll Booth Boundary",
+        "What This Does Not Enable",
+        "Future Slices",
+    ):
+        assert f"## {heading}" in doc
+    assert "allowed_to_execute remains false" in doc
+    assert "dry_run_only remains true" in doc


### PR DESCRIPTION
## Summary

Adds the internal AgenticOrg C6W9 execution-controller handoff dry-run verifier over C6W8 eligibility packets.

The verifier consumes local cached eligibility packets and produces buyer, seller, and operator-safe dry-run verification results only. It does not call Grantex live, providers, merchant private APIs, checkout/payment systems, public discovery, or external systems.

## Scope

- Added runtime-side C6W9 dry-run verifier helper in `core/commerce/oacp_artifacts.py`
- Added focused C6W9 unit tests over the C6W3-C6W8 cached artifact flow
- Added internal C6W9 report documentation

## Non-Enablement

- `allowed_to_execute` remains false
- `dry_run_only` remains true
- `non_authoritative_for_transaction` remains true
- No checkout/payment enablement
- No live provider or live rail enablement
- No public discovery enablement
- No production audit persistence
- No protocol publication or submission

## Validation

- `python -m pytest tests/unit/test_oacp_artifact_schemas.py tests/unit/test_oacp_adapter_previews.py tests/unit/test_oacp_commitment_boundary.py tests/unit/test_oacp_prepared_envelopes.py tests/unit/test_oacp_response_reconciliation.py tests/unit/test_oacp_eligibility_packets.py tests/unit/test_oacp_dry_run_verifier.py --no-cov`
- `python -m ruff check core/commerce/oacp_artifacts.py tests/unit/test_oacp_dry_run_verifier.py`
- `python -m mypy core/commerce/oacp_artifacts.py tests/unit/test_oacp_dry_run_verifier.py`
- `git diff --check origin/main...HEAD`
- ASCII check on touched files
