### PR TITLE
[codex] Update OACP agent PRD and content plan

### DIFF
--- a/docs/commerce-agent-agentic-commerce-implementation-prd.md
+++ b/docs/commerce-agent-agentic-commerce-implementation-prd.md
@@ -8,10 +8,11 @@ The consolidated cross-repo PRD lives in the Grantex repo at
 buyer-agent implementation companion and must stay aligned with that canonical
 source.
 
-AgenticOrg is not the merchant system of record. It is the buyer-agent and
-workflow layer. It helps users discover products, compare options, draft carts,
-request consent, and follow checkout/order status only through Grantex-approved
-commerce tools.
+AgenticOrg is not the merchant system of record and not the provider/payment
+rail. It is the buyer and seller AI-agent runtime. It helps merchants create
+seller commerce agents, initiate connector sync jobs, maintain local OACP
+artifact cache, run buyer conversations, request refresh/confirmation, and
+verify provider-owned mandate capability where approved.
 
 This document is planning and documentation only. It does not deploy, change
 production configuration, enable public commerce discovery, approve a merchant,
@@ -22,41 +23,54 @@ enable checkout/payment creation, enable live payments, or enable live Plural.
 ```mermaid
 flowchart LR
   merchant["Merchant systems"]
-  grantex["Grantex Commerce"]
-  agenticorg["AgenticOrg Commerce Sales Agent"]
+  selleragent["AgenticOrg Seller Commerce Agent"]
+  grantex["Grantex OACP Authority"]
+  cache["AgenticOrg artifact cache"]
+  buyeragent["AgenticOrg Buyer Agent"]
+  provider["Provider/fintech rails"]
   buyer["Buyer or buyer-side AI agent"]
 
-  merchant --> grantex
-  grantex --> agenticorg
-  agenticorg --> buyer
+  merchant --> selleragent
+  selleragent --> grantex
+  grantex --> cache
+  cache --> buyeragent
+  buyeragent --> buyer
+  buyeragent -. "capability verification" .-> provider
 ```
 
 Grantex owns:
 
-- merchant profile and tenant boundary;
-- catalog, inventory, pricing, tax, warranty, and return-policy truth;
+- authority-side merchant approval state and tenant boundary;
+- public-safe catalog, inventory, pricing, tax, warranty, and return-policy
+  artifact validation;
 - policy and approval gates;
-- Commerce Passport consent;
-- provider credentials and provider webhooks;
-- payment intent, checkout handoff, reconciliation, settlement, audit, and
-  rollback;
-- native API, MCP, UCP-style, ACP-style, schema.org, and future AP2 evidence
-  publishing.
+- Commerce Passport and revocation posture;
+- OACP artifact families, adapter previews, refusal semantics, source/freshness
+  TTLs, and non-sensitive evidence reference rules;
+- native API, MCP-style, UCP-style, ACP-style, schema.org, A2A-style, and
+  AP2-style preview authority.
 
 AgenticOrg owns:
 
 - the Commerce Sales Agent pack;
-- Grantex-only connector aliases;
+- seller-agent self-serve onboarding;
+- merchant-approved connector sync initiation;
+- OACP artifact cache scoped by buyer agent, seller agent, tenant, and merchant;
+- Grantex/OACP connector aliases;
 - buyer-facing workflow orchestration;
 - safe refusal behavior;
 - synthetic/demo walkthroughs;
 - evals proving agents do not invent seller, price, inventory, checkout,
   refund, delivery, or payment facts;
-- public discovery gating until Grantex approves a real surface.
+- public discovery gating until Grantex approves a real surface;
+- ChatGPT-style, Claude/MCP-style, Gemini-style, Perplexity/search-style, web,
+  and messaging channel bridges.
 
-AgenticOrg must not hold provider credentials, call Plural/Stripe/Pine/payment
-providers directly, call private merchant commerce APIs directly, or become the
-canonical catalog/order/refund system.
+AgenticOrg must not hold raw provider credentials by default, execute payments,
+or become the canonical catalog/order/refund system. It may verify
+provider-owned mandate capability directly where approved and may initiate
+merchant-approved connector sync jobs; those paths must remain separate from
+payment execution and must not leak raw credentials or private payloads.
 
 ### End-To-End Flow Summary
 
@@ -79,12 +93,13 @@ Buyer one-time setup:
 
 Seller one-time setup:
 
-1. Seller creates the merchant workspace in Grantex.
-2. Seller verifies identity and stores private approval artifacts outside repos.
-3. Seller connects existing systems to Grantex: storefront, catalog, ERP/PIM,
-   inventory/WMS, OMS, logistics, payment provider, CRM/support, or CSV/API.
-4. Grantex normalizes catalog, inventory, price, policy, consent, payment,
-   order, fulfillment, support, audit, and protocol-publishing state.
+1. Seller starts in AgenticOrg Seller Commerce Agent.
+2. Seller creates an onboarding packet for Grantex authority review.
+3. Seller connects existing systems through AgenticOrg seller-agent connector
+   workflows, merchant-owned connector platforms, approved external integration
+   providers, or CSV/API.
+4. Grantex validates public-safe facts, source/freshness evidence, policy,
+   consent posture, and protocol adapter state into OACP artifacts.
 5. Seller selects allowed agent actions and channels.
 6. Grantex runs scans, readiness checks, human review gates, smoke tests, and
    rollback checks before any production capability is approved.
@@ -92,46 +107,71 @@ Seller one-time setup:
 Regular transaction:
 
 1. Buyer asks in their chosen chat channel.
-2. AgenticOrg starts the session and asks Grantex for approved merchant/channel
-   capabilities.
-3. AgenticOrg searches catalog, checks inventory, and drafts carts only through
-   Grantex.
-4. Grantex returns grounded facts, totals, policy, inventory freshness, and
-   blocker codes.
-5. Buyer approves or denies Grantex consent.
-6. Grantex issues scoped Commerce Passport status only if consent and policy
-   pass.
-7. AgenticOrg requests payment intent and checkout handoff only through
-   Grantex.
-8. Grantex owns provider interaction, webhook reconciliation, audit, order,
-   fulfillment, support, return, refund, settlement, and rollback state.
-9. AgenticOrg shows buyer-safe status and refuses unsupported claims.
+2. AgenticOrg starts the session and reads valid cached OACP artifacts when TTL,
+   revocation, and risk rules allow.
+3. AgenticOrg refreshes or verifies with Grantex when artifacts are missing,
+   stale, revoked, high risk, or ambiguous.
+4. AgenticOrg presents grounded facts, source/freshness labels, and blocker
+   codes without inventing facts.
+5. Commitment-bound actions use prepared envelopes, response reconciliation,
+   eligibility packets, and dry-run verification before any future handoff.
+6. Merchant confirmation goes through approved connector handoff or
+   merchant-owned systems.
+7. Provider-owned mandate/payment capability verification stays with providers
+   and may be verified directly by AgenticOrg where approved.
+8. AgenticOrg shows buyer-safe status and refuses unsupported claims.
 
 ## 2. Current Implementation Snapshot
 
 | Area | Current evidence | Current state |
 | --- | --- | --- |
-| Grantex-only connector | `connectors/commerce/grantex_commerce.py` exposes `merchant_get_profile`, `catalog_search`, `catalog_get_item`, `inventory_check`, `cart_create`, `consent_request`, `consent_exchange`, `buyer_discovery_preview`, `payment_create_intent`, `checkout_create`, and `payment_get_status`. | Correct boundary exists. C6H adds a GET-only sandbox buyer discovery preview consumer; it is not a handoff request, public discovery, checkout/payment, or live provider path. |
+| Grantex/OACP connector | `connectors/commerce/grantex_commerce.py` exposes `merchant_get_profile`, `catalog_search`, `catalog_get_item`, `inventory_check`, `cart_create`, `consent_request`, `consent_exchange`, `buyer_discovery_preview`, `payment_create_intent`, `checkout_create`, and `payment_get_status`. | Existing aliases remain useful, but OACP artifact cache and approved provider/connector verifiers must be added so AgenticOrg is not merely a thin Grantex client. |
 | Payment guardrails | `core/commerce/sales_guardrails.py` blocks missing consent/passport, amount-cap breach, disabled merchant/agent, policy denial, and non-mock provider choices. | Good local fail-closed behavior; must expand as Grantex adds order/refund/fulfillment. |
 | Demo and evals | `demos/commerce_sales_agent_demo.py`, golden commerce evals, no-provider-call regression tests, real-staging and hosted smoke tests. | Strong demo/smoke foundation. |
 | Public discovery gate | Commerce metadata is fail-closed behind `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED`. | Safe posture. |
 | Docs-only CI guard | `.github/workflows/deploy.yml` classifies docs-only changes and skips cloud auth/build/push/deploy-adjacent jobs. | Correct for future planning docs merges. |
 | Merchant education docs | C5O-C5X docs cover self-onboarding, architecture, API/data model proposals, UI wireframes, validator, review workflow, rollout automation, demo merchant, and launch rehearsal. | Good planning foundation; runtime implementation still pending. |
+| OACP consumer foundation | C6W3-C6W9 helper/tests/docs consume artifact schemas, adapter previews, commitment boundaries, prepared envelopes, response reconciliations, eligibility packets, and dry-run verifier results. | Internal only; no execution, public protocol publication, certification, or production readiness. |
+
+### 2.1 Current OACP Status Through C6W9
+
+AgenticOrg currently has local consumer behavior for:
+
+- public-safe OACP artifact family validation;
+- adapter preview consumption for schema.org, UCP-style, ACP-style,
+  AP2-style, A2A-style, and MCP-style surfaces;
+- commitment-boundary classification over cached artifacts;
+- prepared envelope consumption;
+- response evidence reconciliation;
+- eligibility packet handling;
+- execution-controller dry-run verifier consumption.
+
+Still missing:
+
+- persistent cache scoped by buyer agent, seller agent, tenant, and merchant;
+- seller-agent onboarding UI/runtime for OACP;
+- real Shopify/WooCommerce/ERP connector sync initiation;
+- provider-owned mandate capability verifier runtime;
+- channel bridges for ChatGPT-style, Claude/MCP-style, Gemini-style,
+  Perplexity/search-style, web, and messaging surfaces;
+- public seller cards and third-party agent cards with risk controls;
+- execution-controller ownership and implementation;
+- production audit persistence and live merchant pilot workflows.
 
 ## 3. Buyer-Agent Journey
 
 The target AgenticOrg buyer journey should be:
 
 1. User asks an agent to find or compare products.
-2. Agent reads only Grantex merchant/catalog/inventory tools.
+2. Agent reads valid cached OACP artifacts when TTL, revocation, and risk rules
+   allow; otherwise it refreshes/verifies with Grantex.
 3. Agent explains uncertainty when stock, price, delivery, or return data is
    stale or unavailable.
-4. Agent creates a cart draft only from grounded Grantex variant IDs.
-5. Agent asks the user for consent through Grantex.
-6. Grantex issues a scoped Commerce Passport only if consent and policy pass.
-7. Agent requests payment intent and checkout handoff through Grantex.
-8. Agent polls payment/order status only through Grantex.
-9. Agent refuses unsupported refunds, returns, discounts, delivery promises,
+4. Agent asks for seller/source confirmation through approved connector handoff
+   when commitment-bound facts need refresh.
+5. Agent verifies provider-owned mandate capability directly only where approved.
+6. Agent prepares non-executing handoff artifacts when C6W5-C6W9 rules pass.
+7. Agent refuses unsupported refunds, returns, discounts, delivery promises,
    live-provider claims, and certification claims unless Grantex provides them.
 
 ## 4. Buyer Agent Launch From Existing Chat Interfaces
@@ -144,20 +184,23 @@ agent marketplace.
 
 The current implementation does not yet provide full channel launch coverage.
 The PRD therefore requires an AgenticOrg channel adapter layer that makes each
-interface feel simple while keeping commerce execution inside Grantex.
+interface feel simple while preserving OACP artifact rules and keeping execution
+with the correct owner.
 
 ```mermaid
 flowchart LR
   chat["Buyer chat surface"]
   adapter["AgenticOrg channel adapter"]
   session["Buyer agent session"]
-  tools["Grantex-only commerce aliases"]
-  grantex["Grantex Commerce"]
+  cache["OACP artifact cache"]
+  grantex["Grantex OACP authority"]
+  provider["Provider/fintech rail"]
 
   chat --> adapter
   adapter --> session
-  session --> tools
-  tools --> grantex
+  session --> cache
+  cache --> grantex
+  session -. "approved capability verification" .-> provider
 ```
 
 Channel adapter principles:
@@ -167,11 +210,15 @@ Channel adapter principles:
   provider details.
 - Each channel must normalize user identity, locale, currency, consent state,
   conversation ID, channel message limits, attachment handling, and handoff URLs.
-- Every commerce action must still go through Grantex-only tools.
+- Non-binding browse/compare/explain actions may continue from valid cached
+  artifacts.
+- Commitment-bound actions require refresh, refusal, or prepared handoff
+  depending on risk tier and artifact freshness.
 - Channel adapters must never store provider credentials or private merchant
   integration credentials.
-- Payment and checkout actions must require Grantex consent and Commerce
-  Passport evidence, even if the chat interface has its own confirmation UX.
+- Payment and mandate setup must remain provider-owned. AgenticOrg may verify
+  provider capability only through approved provider flows and must not execute
+  payments.
 
 | Buyer interface | Launch path AgenticOrg should support | Current platform reality to design around | Required AgenticOrg work |
 | --- | --- | --- | --- |
@@ -181,14 +228,14 @@ Channel adapter principles:
 | WhatsApp | Provide a WhatsApp Business Platform channel adapter backed by webhooks. | WhatsApp Cloud API uses WABA/business phone numbers, permissions, approved templates, inbound message webhooks, and delivery-status webhooks. | Build WABA setup guide, webhook receiver, message template policy, session window handling, identity binding, consent link handoff, rate-limit handling, opt-out, and human support escalation. |
 | Telegram | Provide a Telegram bot channel adapter. | Telegram Bot API is HTTPS-based, uses bot tokens, and receives updates through polling or webhooks; webhooks can include a secret token header. | Build BotFather setup guide, webhook receiver, secret validation, chat/user identity mapping, inline buttons, consent link handoff, rate limits, and bot token secret handling. |
 | Merchant website or mobile app | Embed AgenticOrg buyer chat or deep-link into an AgenticOrg hosted session. | This is the most controllable first-party channel. | Build web/mobile SDK or embeddable widget, session resume, Grantex merchant selector, consent redirect, and analytics attribution. |
-| Other agent/chat surfaces | Use remote MCP, A2A handoff, REST, or webhook adapter depending on platform support. | Capability support differs by platform and changes over time. | Maintain a channel certification matrix with supported actions, auth, consent, message constraints, and known limitations. |
+| Other agent/chat surfaces | Use remote MCP, A2A handoff, REST, or webhook adapter depending on platform support. | Capability support differs by platform and changes over time. | Maintain a channel readiness matrix with supported actions, auth, consent, message constraints, and known limitations. |
 
 Do not describe this as "flawless across every chat app" until each channel has:
 
 - one-click or low-friction user launch;
 - account/channel identity binding;
 - approved Grantex merchant and capability discovery;
-- Grantex-only tool execution;
+- OACP artifact consumption and authority-checked refresh behavior;
 - consent and Commerce Passport handoff;
 - payment/checkout confirmation wording;
 - refusal and recovery UX;
@@ -242,23 +289,27 @@ production confidence:
 3. Show blocked paths: direct provider calls, live payments, live Plural,
    checkout without consent, refund execution, stale inventory promises.
 4. Show the Grantex onboarding checklist and approval gates.
-5. Show how existing merchant systems connect to Grantex, not AgenticOrg.
+5. Show how existing merchant systems connect through AgenticOrg seller-agent
+   workflows, merchant-owned connector platforms, or approved external
+   integration providers, while Grantex validates public-safe OACP artifacts.
 6. Show how AgenticOrg responds when Grantex says no.
 7. Show a launch rehearsal that ends in "request rollout", not automatic
    production enablement.
 
 ## 6. Standards And Protocol Fit
 
-AgenticOrg should treat standards as surfaces published by Grantex, not as
-separate sources of truth.
+AgenticOrg should treat OACP artifacts as the internal source for protocol
+surfaces. Standards-style adapters are previews derived from Grantex authority
+artifacts, not separate sources of truth and not transaction authority.
 
 | Surface | AgenticOrg behavior |
 | --- | --- |
-| Native Grantex tools | Primary runtime path for all commerce actions. |
-| MCP | Use tool aliases backed by Grantex policy and audit. Do not add direct provider tools. This is the primary bridge for ChatGPT custom apps, Claude-compatible connectors, and other MCP-capable clients. |
-| UCP-style profile | Consume only Grantex-published capability profiles after approval. Use it to explain merchant capabilities to channel adapters. |
-| ACP-style checkout | Render checkout state and buyer messages from Grantex; do not complete checkout outside Grantex. |
-| AP2-style evidence | Present mandate/consent status only when Grantex provides deterministic signed evidence. |
+| OACP artifacts | Primary internal trust input for non-binding agent interactions and future commitment handoffs. |
+| Native Grantex tools | Authority refresh/verification path for artifacts and policy; not required for every valid cached non-binding turn. |
+| MCP | Use tool aliases backed by OACP artifacts and Grantex authority. Do not add payment-execution tools. This is the primary bridge for ChatGPT custom apps, Claude-compatible connectors, and other MCP-capable clients. |
+| UCP-style profile | Consume only Grantex-authorized capability profiles. Use it to explain merchant capabilities to channel adapters. |
+| ACP-style checkout | Render only prepared or blocked checkout state; do not complete checkout outside an approved future execution path. |
+| AP2-style evidence | Present provider-owned mandate/consent evidence refs only when deterministic signed evidence exists. |
 | schema.org | Use public-safe product/offer/shipping/return metadata generated by Grantex. |
 
 Do not claim UCP, ACP, AP2, A2A, MPP, schema.org production, or live-provider
@@ -268,15 +319,18 @@ compliance unless Grantex implementation and conformance evidence exist.
 
 | Gap | Why it matters | Required AgenticOrg work | Dependency |
 | --- | --- | --- | --- |
-| Buyer-agent creation and launch | Real buyers should start from familiar chat interfaces without developer setup. | Channel adapter layer for ChatGPT, Claude, Gemini, WhatsApp, Telegram, web/mobile, and future agent surfaces. | Platform-specific app/bot/API approval plus Grantex capability approval. |
+| Buyer-agent creation and launch | Real buyers should start from familiar chat interfaces without developer setup. | Channel adapter layer for ChatGPT-style, Claude/MCP-style, Gemini-style, Perplexity/search-style, WhatsApp, Telegram, web/mobile, and future agent surfaces. | Platform-specific app/bot/API approval plus Grantex capability approval. |
+| Seller Commerce Agent onboarding | Merchants should self-serve inside AgenticOrg. | Seller agent creates onboarding packet, connector plan, source/freshness evidence, and Grantex authority request. | Grantex authority APIs and product approval. |
+| Artifact cache persistence | Non-binding interactions should continue without Grantex in every turn. | Cache OACP artifacts per buyer agent, seller agent, tenant, and merchant with TTL, revocation snapshot, risk tier, and refresh/refusal UX. | Grantex artifact issuance/verification contract. |
 | Buyer-facing commerce UX | Buyers need a safe, understandable flow. | Product comparison, grounded cart draft, consent handoff, checkout status, refusal copy. | Grantex catalog/consent/payment APIs. |
 | Merchant-facing demo UX | Merchants need to understand how publishing works. | Demo Home Goods Store walkthrough, launch rehearsal, status labels, blocked-path examples. | Grantex demo packet and self-serve docs. |
-| Order and fulfillment reads | Buyers ask "where is my order?" | Add Grantex-only aliases and UI copy after Grantex order/fulfillment APIs exist. | Grantex order/fulfillment implementation. |
+| Order and fulfillment reads | Buyers ask "where is my order?" | Add OACP status artifact consumption, connector handoff, and buyer-safe UI copy after order/fulfillment sources exist. | Merchant OMS/logistics evidence and Grantex artifact policy. |
 | Return/refund request reads | Buyers ask for returns and refunds. | Refuse or hand off until Grantex request APIs exist; later add request/status aliases. | Grantex return/refund workflow. |
 | Delivery promise safety | Agents must not invent shipping dates. | Add stale/unknown delivery refusal logic and verified delivery status rendering. | Grantex logistics/fulfillment fields. |
 | Discounts/offers/EMI safety | Agents must not invent promotions. | Require Grantex-sourced offer metadata and tests for unsupported offer claims. | Grantex pricing/offer/provider metadata. |
-| Existing-system explanation | Merchants need to know they can keep Shopify/ERP/OMS/etc. | Docs and UI copy that point all integrations to Grantex. | Grantex connector framework. |
-| Protocol discovery UX | Users and platforms need capability clarity. | Display capabilities only from Grantex-published profiles and approved metadata. | Grantex UCP/ACP/MCP/schema.org/AP2 adapters. |
+| Existing-system connectors | Merchants need to keep Shopify/WooCommerce/ERP/OMS/etc. | Seller-agent connector sync initiation, credential-custody selection, source evidence, and stale/conflict UX. | Merchant/external connector custody and Grantex artifact policy. |
+| Provider mandate capability verification | Buyers may need provider-owned mandates before autonomous commitments. | Approved provider verifier flow, buyer-safe status, non-sensitive evidence refs, and no payment execution. | Provider/fintech rail approval. |
+| Protocol discovery UX | Users and platforms need capability clarity. | Display capabilities only from OACP artifacts and Grantex-authorized profiles. | Grantex OACP/UCP/ACP/MCP/schema.org/AP2 adapter previews. |
 | Eval coverage | Regression tests must catch unsafe agent behavior. | Add evals for order, fulfillment, refund, delivery, offer, stale data, direct-provider import attempts. | New Grantex capabilities. |
 | Public discovery policy | Public surfaces must stay fail-closed until approved. | Keep `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED` disabled by default and tested. | Grantex read-only production approval. |
 | Landing page copy | Prospects need clear positioning without overclaiming. | Add future public copy only after approval: "Agentic commerce readiness through Grantex"; no live/certification claims. | Product/web approval. |
@@ -286,16 +340,17 @@ compliance unless Grantex implementation and conformance evidence exist.
 
 | Slice | Goal | AgenticOrg output | Guardrail |
 | --- | --- | --- | --- |
-| A. Merchant education pack | Explain the self-serve journey. | Demo script, screenshots/walkthrough, blocked-path labels. | Synthetic/demo only. |
-| B. Buyer read-only discovery UX | Let a user ask merchant/product questions safely. | Grantex C6G read-only buyer discovery preview consumer plus product comparison and inventory caution copy. | No public discovery, checkout/payment, fulfillment, refunds, live Plural, live provider paths, or invented merchant/product claims. |
-| C. First-party web/mobile buyer channel | Prove low-friction session creation. | AgenticOrg hosted buyer-agent session and embeddable merchant link/widget. | Still Grantex-only; no public discovery unless approved. |
-| D. ChatGPT and Claude MCP channels | Reach major AI chat surfaces through remote MCP. | Remote MCP app/connector, auth, action labels, confirmation copy, smoke tests. | Respect platform limits; no unsupported write-action claims. |
+| A. Seller Commerce Agent education pack | Explain the self-serve journey. | Demo script, screenshots/walkthrough, blocked-path labels, connector-custody choices. | Synthetic/demo only. |
+| A1. Seller Commerce Agent runtime | Let merchant start onboarding in AgenticOrg. | Onboarding packet, connector plan, source evidence status, authority request. | No live enablement. |
+| B. Buyer read-only discovery UX | Let a user ask merchant/product questions safely. | OACP artifact-backed discovery plus product comparison and inventory caution copy. | No public discovery, checkout/payment, fulfillment, refunds, live Plural, live provider paths, or invented merchant/product claims. |
+| C. First-party web/mobile buyer channel | Prove low-friction session creation. | AgenticOrg hosted buyer-agent session and embeddable merchant link/widget. | OACP-backed and fail-closed; no public discovery unless approved. |
+| D. ChatGPT-style and Claude/MCP-style channels | Reach major AI chat surfaces through remote MCP or equivalent hosted bridge. | Remote MCP app/connector, auth, action labels, confirmation copy, smoke tests. | Respect platform limits; no unsupported write-action claims. |
 | E. WhatsApp and Telegram bot channels | Reach common messaging surfaces. | Webhook adapters, identity binding, consent links, opt-out, human escalation. | Tokens/webhook secrets never logged or committed. |
 | F. Gemini channel | Support Gemini-powered buyer-agent sessions. | Gemini function declarations or hosted wrapper calling AgenticOrg tools. | Label native Gemini app support as pending unless approved. |
-| G. Cart and consent UX | Rehearse safe checkout. | Cart draft and Grantex consent handoff. | No passport displayed or logged. |
-| H. Sandbox checkout demo | Show end-to-end sandbox flow. | Checkout status and payment status rendering. | Mock/sandbox provider only. |
-| I. Order/fulfillment support | Answer post-purchase questions. | Grantex-only order and fulfillment aliases after Grantex ships them. | No invented status. |
-| J. Returns/refunds support | Guide support safely. | Refusal/manual handoff now; Grantex-only request/status later. | No refund execution. |
+| G. Prepared commitment UX | Rehearse safe commitment handoff. | C6W5-C6W9 boundary, envelope, reconciliation, eligibility, and dry-run status in buyer-safe copy. | No execution. |
+| H. Provider mandate verifier | Show provider-owned capability verification where approved. | First approved provider verifier and non-sensitive evidence refs. | No payment execution. |
+| I. Order/fulfillment support | Answer post-purchase questions. | OACP status artifacts and connector handoff after merchant order/fulfillment sources exist. | No invented status. |
+| J. Returns/refunds support | Guide support safely. | Refusal/manual handoff now; OACP request/status artifacts later. | No refund execution. |
 | K. Protocol display | Show standard capability status. | UCP/ACP/schema.org/AP2 readiness labels from Grantex. | No unsupported compliance claims. |
 | L. Real merchant pilot support | Assist one approved merchant rollout. | Controlled agent workflow and eval evidence. | Separate Grantex rollout approval. |
 
@@ -306,12 +361,15 @@ Before AgenticOrg can participate in a real merchant pilot:
 - Grantex has approved the merchant, capability surface, and rollout scope.
 - AgenticOrg public commerce discovery remains disabled until Grantex read-only
   discovery is approved.
-- Every commerce tool alias maps to a Grantex API or MCP tool.
+- Every commerce tool alias maps to an OACP artifact, Grantex authority API, or
+  explicitly approved provider/connector verifier.
 - Each approved buyer channel has a documented launch path, auth model, consent
   handoff, write-action support status, fallback behavior, telemetry, and smoke
   evidence.
-- No commerce code imports or calls direct provider SDKs, Plural, Stripe, Pine,
-  or merchant private checkout APIs.
+- No commerce code executes payments, creates live checkout/payment, or calls
+  merchant private APIs outside approved connector sync workflows.
+- Provider capability verification, if added, is separated from payment
+  execution and logs only non-sensitive evidence refs.
 - Buyer-facing copy distinguishes "known", "unknown", "stale", "blocked", and
   "requires consent" states.
 - AgenticOrg evals cover stale inventory, missing consent, denied policy,
@@ -321,24 +379,45 @@ Before AgenticOrg can participate in a real merchant pilot:
   blocker codes, and non-secret references.
 - Docs-only PRs skip cloud build/push/deploy-adjacent jobs by policy.
 
-## 10. Public Landing Page Copy Draft
+## 10. Public Landing Page And Blog Plan
 
 If product/web owners update the AgenticOrg landing page later, use safe
-positioning like this:
+positioning like this. This PRD update is planning only and does not publish
+runtime UI.
 
-> AgenticOrg can demonstrate buyer-side agentic commerce workflows powered by
-> Grantex. Merchants connect their existing systems to Grantex, preview the
-> agent-facing surface, and launch only after explicit approval. AgenticOrg
-> agents use Grantex-approved tools; they do not hold payment credentials or
-> invent prices, stock, discounts, refunds, or delivery promises.
+> AgenticOrg runs seller and buyer AI agents for commerce workflows. Seller
+> agents help merchants connect existing systems and prepare Grantex authority
+> requests. Buyer agents consume signed OACP artifacts, show source/freshness,
+> and refuse unsupported commitments. Provider and fintech rails own mandate and
+> payment execution.
 
-Safe bullets:
+AgenticOrg landing page planning blocks:
 
-- Show merchants how AI agents will discover and explain their products.
-- Demonstrate cart drafting, consent handoff, and checkout status in sandbox.
-- Refuse unsafe or unsupported commerce actions.
-- Keep merchant data, credentials, policy, consent, and audit in Grantex.
-- Keep public discovery gated until Grantex approves it.
+- Hero: "Seller And Buyer Agents For Safe Agentic Commerce"
+- Section 1: Seller Commerce Agent - onboarding packet, connector plan,
+  source/freshness evidence, Grantex authority request.
+- Section 2: Buyer Agent Runtime - channel UX, comparison, source labels,
+  refusal, refresh, and prepared handoff.
+- Section 3: Artifact Cache - cached per buyer agent, seller agent, tenant, and
+  merchant with TTL/risk rules.
+- Section 4: Connector Workflows - Shopify, WooCommerce, ERP/PIM, OMS/WMS,
+  logistics, support, CSV/API.
+- Section 5: Provider Mandate Boundary - provider-owned setup and execution,
+  approved capability verification, non-sensitive evidence refs only.
+- Section 6: OACP Status - internal C6W9 foundation, no public standard or live
+  execution claim.
+
+Blog series plan:
+
+| Blog | Audience | Visual workflow |
+| --- | --- | --- |
+| Seller Commerce Agents: Where Merchant Self-Serve Begins | Merchants | Seller agent -> connector setup -> Grantex authority request. |
+| Buyer Agents With Source And Freshness Labels | Product and UX | Buyer question -> cache check -> refresh/refuse -> answer. |
+| Artifact Cache Across Buyer, Seller, Tenant, And Merchant | Engineers | Four-scope cache key and TTL/risk tiers. |
+| Shopify And WooCommerce In Agentic Commerce | Integrators | Connector custody and sync evidence flow. |
+| Provider-Owned Mandates Without Payment Execution In The Agent | Fintech and risk teams | Provider mandate setup -> capability verification -> evidence ref. |
+| ChatGPT, Claude, Gemini, And Search-Style Channels | GTM and engineering | Channel bridge matrix and supported action labels. |
+| What Is Still Missing Before Autonomous Commerce | Leadership | C6W9 complete vs runtime gaps. |
 
 Avoid these claims until separately approved:
 
@@ -346,7 +425,11 @@ Avoid these claims until separately approved:
 - "Live payments ready."
 - "Certified UCP/ACP/AP2 compliant."
 - "Agents can refund customers."
-- "Agents can call merchant systems directly."
+- "Agents can execute payments."
+- "Agents can call merchant systems without approved connector policy."
+
+Detailed page and blog plan lives in
+`docs/reports/commerce-agent-oacp-landing-blog-plan.md`.
 
 ## 11. Documentation And Workflow Coverage
 
@@ -367,7 +450,7 @@ Avoid these claims until separately approved:
 Stop AgenticOrg work if any of these occur:
 
 - A direct Stripe, Plural, Pine, provider, or merchant private commerce API path
-  is introduced for commerce execution.
+  is introduced for payment execution or unapproved merchant execution.
 - AgenticOrg stores provider credentials, raw payment data, Commerce Passport
   values, JWTs, idempotency keys, webhook secrets, DB/Redis URLs, private keys,
   or private merchant artifacts.

--- a/docs/commerce-agent-agentic-commerce-implementation-prd.md
+++ b/docs/commerce-agent-agentic-commerce-implementation-prd.md
@@ -419,14 +419,14 @@ Blog series plan:
 | ChatGPT, Claude, Gemini, And Search-Style Channels | GTM and engineering | Channel bridge matrix and supported action labels. |
 | What Is Still Missing Before Autonomous Commerce | Leadership | C6W9 complete vs runtime gaps. |
 
-Avoid these claims until separately approved:
+Avoid claims that imply:
 
-- "Production commerce enabled."
-- "Live payments ready."
-- "Certified UCP/ACP/AP2 compliant."
-- "Agents can refund customers."
-- "Agents can execute payments."
-- "Agents can call merchant systems without approved connector policy."
+- production commerce is already enabled;
+- live payments are ready;
+- UCP, ACP, or AP2 certification already exists;
+- agents can refund customers;
+- agents can execute payments;
+- agents can call merchant systems without approved connector policy.
 
 Detailed page and blog plan lives in
 `docs/reports/commerce-agent-oacp-landing-blog-plan.md`.

--- a/docs/commerce-agent-end-to-end-agentic-commerce-flow.md
+++ b/docs/commerce-agent-end-to-end-agentic-commerce-flow.md
@@ -1,6 +1,6 @@
 # End-To-End Agentic Commerce Flow
 
-This document explains the AgenticOrg side of the Grantex-powered agentic
+This document explains the AgenticOrg side of the OACP-powered agentic
 commerce journey in plain English. It is documentation only. It does not enable
 public discovery, production Commerce V1, checkout/payment creation, live
 payments, live Plural, merchant approval, or any production allowlist.
@@ -11,14 +11,16 @@ AgenticOrg buyer-agent companion view of that PRD.
 
 ## The Simple Mental Model
 
-AgenticOrg is the buyer-agent layer. A buyer can start from a familiar chat
-surface, such as ChatGPT, Claude, Gemini, WhatsApp, Telegram, a merchant website
-chat widget, or an AgenticOrg-hosted session. AgenticOrg turns that buyer request
-into safe Grantex-only commerce tool calls.
+AgenticOrg is the buyer and seller AI-agent runtime. A seller starts in Seller
+Commerce Agent and connects existing systems through approved connector custody.
+A buyer starts from a familiar chat surface, such as ChatGPT, Claude, Gemini,
+WhatsApp, Telegram, a merchant website chat widget, or an AgenticOrg-hosted
+session. AgenticOrg turns those requests into OACP artifact-backed answers,
+refreshes, refusals, and prepared handoffs.
 
-Grantex remains the merchant control plane. It owns merchant identity, catalog,
-inventory, price, policy, consent, Commerce Passport, payment intent, order,
-fulfillment, refund handoff, settlement, audit, and rollback.
+Grantex remains the trust, protocol, policy, and canonical-artifact authority.
+Merchant systems remain operational sources of record. Provider and fintech
+rails own mandate and payment execution.
 
 ```mermaid
 flowchart LR
@@ -26,16 +28,18 @@ flowchart LR
   chat["Chat surface"]
   adapter["AgenticOrg channel adapter"]
   session["AgenticOrg buyer-agent session"]
-  aliases["Grantex-only tool aliases"]
-  grantex["Grantex Commerce"]
+  cache["OACP artifact cache"]
+  grantex["Grantex OACP authority"]
   merchant["Merchant systems"]
+  provider["Provider/fintech rail"]
 
   buyer --> chat
   chat --> adapter
   adapter --> session
-  session --> aliases
-  aliases --> grantex
+  session --> cache
+  cache --> grantex
   merchant --> grantex
+  session -. "approved capability verification" .-> provider
 ```
 
 ## One-Time Buyer Setup
@@ -50,23 +54,25 @@ should feel like normal account linking and permission setup.
 | 2. Sign in or link account | "Continue with AgenticOrg" or channel-specific account linking. | Creates or resumes a buyer-agent session and binds the channel user to that session. | Does not expose private merchant or provider data. |
 | 3. Set basic preferences | Preferred locale, currency, delivery region, notification path, and optional spending comfort. | Stores only safe session preferences needed for conversation and handoff. | Uses preferences only for policy checks, consent copy, and supported commerce flows. |
 | 4. Understand permissions | Buyer sees that the agent can browse, draft carts, request consent, and hand off checkout only when approved. | Shows channel-specific action labels and limitations. | Provides capability state and blocks unsupported actions. |
-| 5. Payment readiness | Buyer may use a provider wallet, hosted checkout, or approved payment handoff later. | Does not store raw cards, provider credentials, Commerce Passport values, JWTs, or secrets. | Owns consent, Commerce Passport issuance, payment intent, and checkout state. |
+| 5. Mandate/payment readiness | Buyer may use a provider wallet, hosted checkout, or approved payment handoff later. | Does not store raw cards, provider credentials, Commerce Passport values, JWTs, or secrets; may verify provider-owned capability where approved. | Owns policy/artifact evidence rules, not provider mandate setup. |
 | 6. Revocation and history | Buyer can revoke permissions or ask what happened. | Shows redacted session/evidence status. | Owns revocation, audit evidence, and protected action history. |
 
-Buyer setup is not a blanket authorization. Every payment-affecting action still
-requires fresh Grantex consent and policy approval.
+Buyer setup is not a blanket authorization. Every commitment-bound action still
+requires fresh policy, source/freshness, revocation, provider capability,
+consent, and audit evidence.
 
 ## One-Time Seller Setup
 
-The seller setup happens in Grantex. AgenticOrg should explain and preview it,
-but must not approve the seller or connect directly to private merchant systems.
+Seller setup begins in AgenticOrg Seller Commerce Agent and flows into Grantex
+authority review. AgenticOrg must not approve the seller or bypass connector
+custody rules.
 
-| Step | Seller does in Grantex | AgenticOrg responsibility |
+| Step | Seller action | AgenticOrg responsibility |
 | --- | --- | --- |
-| 1. Create merchant workspace | Create tenant, merchant profile, owner roles, sandbox/live split, and category preset. | Explain status labels and show that the merchant is not live yet. |
+| 1. Create seller agent | Create seller commerce agent, onboarding packet, and authority request. | Explain status labels and show that the merchant is not live yet. |
 | 2. Verify business | Provide private legal/compliance artifacts outside the repo and record non-secret references. | Never display private contracts, contacts, pricing terms, or signed approvals. |
-| 3. Connect existing systems | Connect storefront, catalog, ERP/PIM, inventory/WMS, OMS, logistics, payment provider, and support systems as needed. | Consume only Grantex-approved public-safe capability output. |
-| 4. Prepare catalog | Normalize products, variants, images, price, tax, warranty, return summary, availability, and category data. | Show only grounded product facts returned by Grantex. |
+| 3. Connect existing systems | Connect storefront, catalog, ERP/PIM, inventory/WMS, OMS, logistics, payment provider, and support systems through approved connector custody. | Initiate approved connector sync jobs and capture source/freshness evidence. |
+| 4. Prepare catalog | Normalize products, variants, images, price, tax, warranty, return summary, availability, and category data. | Show only grounded product facts from OACP artifacts and approved evidence. |
 | 5. Configure permissions | Choose whether agents may browse, draft carts, request checkout, read order status, or request support. | Render those capabilities to buyers only after Grantex approval. |
 | 6. Run scans | Validate secrets, private data, stale inventory, overclaims, production-looking test IDs, and config/allowlist values. | Add refusal/eval coverage for unsafe claims and unsupported actions. |
 | 7. Review gates | Legal, product, security, ops/support, rollback, smoke, and evidence owners approve. | Do not treat demo data or synthetic IDs as approval. |
@@ -85,53 +91,41 @@ sequenceDiagram
   participant A as AgenticOrg
   participant G as Grantex
   participant M as Merchant systems
-  participant P as Provider or checkout handoff
+  participant P as Provider/fintech rail
 
   B->>C: "Find a sofa under my budget"
   C->>A: Start or resume buyer-agent session
-  A->>G: merchant_get_profile
-  G-->>A: Approved merchant and capability state
-  A->>G: catalog_search / catalog_get_item
-  G->>M: Use synced catalog truth
-  G-->>A: Products, prices, policies, freshness
-  A->>G: inventory_check
-  G-->>A: Availability and stale/unknown warnings
+  A->>A: Check cached OACP artifacts
+  A->>G: Refresh/verify when stale, missing, revoked, or high risk
+  G-->>A: Artifacts and blocker codes
   A-->>B: Grounded options and caveats
   B->>A: "Prepare this one"
-  A->>G: cart_create with exact variant IDs
-  G-->>A: Cart draft and totals
-  A-->>B: Consent explanation and checkout handoff
-  B->>G: Approve or deny consent
-  G-->>A: Commerce Passport only if consent and policy pass
-  A->>G: payment_create_intent / checkout_create
-  G->>P: Provider-neutral sandbox/live-approved path
-  P-->>G: Payment status webhook or handoff status
-  G-->>A: Payment/order status
-  A-->>B: Status, next step, or safe refusal
+  A->>G: C6W5-C6W9 boundary and dry-run checks
+  G-->>A: Non-executing eligibility or blocker
+  A->>M: Request source confirmation through approved connector handoff
+  M-->>A: Confirmation evidence or refusal
+  A->>P: Verify provider-owned mandate capability when approved
+  P-->>A: Capability evidence or refusal
+  A-->>B: Prepared handoff, next step, or safe refusal
 ```
 
 ## Normal Happy Path
 
 1. Buyer asks for help in an existing chat interface.
 2. AgenticOrg creates or resumes a buyer-agent session.
-3. AgenticOrg asks Grantex which merchant capabilities are approved for that
-   channel.
-4. AgenticOrg searches catalog and checks inventory through Grantex only.
-5. AgenticOrg explains options with grounded product IDs, prices, stock state,
+3. AgenticOrg reads valid cached OACP artifacts or refreshes/verifies with
+   Grantex when required.
+4. AgenticOrg explains options with grounded product IDs, prices, stock state,
    delivery caveats, return summary, and unknowns.
-6. Buyer chooses an item or asks for a comparison.
-7. AgenticOrg creates a cart draft in Grantex using exact variant IDs.
-8. Grantex recalculates totals, policy, amount caps, eligibility, and supported
-   checkout state.
-9. AgenticOrg asks the buyer for consent using Grantex-provided copy.
-10. Buyer approves or denies in the Grantex consent/checkout handoff.
-11. Grantex issues a scoped Commerce Passport only if consent and policy pass.
-12. AgenticOrg asks Grantex to create the payment intent and checkout handoff.
-13. Provider interaction happens through Grantex, not AgenticOrg.
-14. Grantex receives provider webhooks, reconciles status, and writes audit.
-15. AgenticOrg shows buyer-safe status and next steps.
-16. Post-purchase status, fulfillment, support, return, or refund answers come
-    only from Grantex once those APIs exist and are approved.
+5. Buyer chooses an item or asks for a comparison.
+6. Commitment-bound requests go through C6W5-C6W9 boundary, prepared envelope,
+   response reconciliation, eligibility, and dry-run verifier checks.
+7. Merchant confirmation uses approved connector handoff or merchant-owned
+   systems.
+8. Provider-owned mandate/payment capability verification stays with the
+   provider/fintech rail and may be verified directly by AgenticOrg where
+   approved.
+9. Current OACP work remains prepared-only and non-executing.
 
 ## Failure And Recovery Paths
 
@@ -150,9 +144,9 @@ sequenceDiagram
 
 ## What AgenticOrg Must Never Do
 
-- Do not call Plural, Stripe, Pine, Shopify, WooCommerce, Magento, ERP, OMS,
-  WMS, logistics, support, or merchant private APIs directly for commerce
-  execution.
+- Do not call Plural, Stripe, Pine, or another provider for payment execution.
+- Do not call Shopify, WooCommerce, Magento, ERP, OMS, WMS, logistics, support,
+  or merchant private APIs outside approved connector sync workflows.
 - Do not store provider credentials, raw payment data, Commerce Passport values,
   JWTs, idempotency key values, webhook secrets, DB/Redis URLs, private keys, or
   private merchant artifacts.
@@ -172,7 +166,7 @@ sequenceDiagram
 | ChatGPT/Claude channel | Remote MCP connector/app with scopes, action labels, and smoke tests. | Platform approval plus Grantex capabilities. |
 | Gemini channel | Function-calling wrapper or approved native launch path. | Gemini platform design and Grantex capabilities. |
 | WhatsApp/Telegram channel | Bot/webhook adapters, identity mapping, opt-out, consent links. | Channel credentials and webhook secret handling outside Git. |
-| Buyer UX | Grounded comparison, cart draft, consent copy, checkout status, refusal copy. | Grantex catalog/cart/consent/payment APIs. |
+| Buyer UX | Grounded comparison, source/freshness labels, prepared handoff, consent copy, refusal copy. | OACP artifacts, Grantex authority, connector evidence, provider capability verifier. |
 | Post-purchase UX | Order/fulfillment/support/return/refund status display. | Grantex order, fulfillment, support, and refund APIs. |
 | Merchant demo UX | Demo launch rehearsal and blocked-path explanations. | Grantex merchant onboarding/readiness docs. |
 | Evals | Regression tests for no invention, stale data, policy denial, direct-provider attempts, and unsafe claims. | New channel and Grantex capability slices. |

--- a/docs/commerce-agent-overview.md
+++ b/docs/commerce-agent-overview.md
@@ -1,10 +1,10 @@
 # Commerce Sales Agent Overview
 
-The AgenticOrg Commerce Sales Agent is the agent and workflow layer for
-Grantex-controlled commerce. It helps users inspect Grantex-grounded read-only
-buyer discovery previews, discover products, draft carts, request consent, use
-Commerce Passport fixtures during approved smoke runs, and follow Grantex
-payment-intent and checkout status flows.
+The AgenticOrg Commerce Sales Agent is the buyer and seller AI-agent runtime for
+OACP commerce. It helps merchants prepare seller agents and connector workflows,
+helps buyers inspect artifact-grounded discovery previews, and consumes
+Grantex-authorized OACP artifacts without becoming the merchant system of record
+or the payment execution rail.
 
 This page is documentation only. It does not deploy, change production config,
 enable production Commerce V1, enable live payments, enable live Plural, or
@@ -35,7 +35,8 @@ commerce transaction should work end to end.
 | C3 hosted API-only smoke | 14 passed, 0 failed for liveness, health, MCP tools, A2A agent card, and A2A agents discovery. |
 | Production discovery | Commerce metadata is gated by default behind `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED`; it is not final production readiness. |
 | C6I buyer discovery session | Channel-neutral read-only session wrapper around Grantex buyer preview data; no checkout/payment, provider, fulfillment, or refund execution. |
-| Direct provider calls | Blocked for commerce. AgenticOrg commerce uses Grantex only. |
+| C6W3-C6W9 OACP consumer foundation | Internal artifact schema, adapter preview, commitment boundary, prepared envelope, reconciliation, eligibility, and dry-run verifier consumer behavior. |
+| Payment execution | Blocked. AgenticOrg may verify provider-owned mandate capability only through separately approved verifier flows. |
 | Live checkout/payments/Plural | Blocked. |
 | C6H buyer discovery consumer | Read-only sandbox consumer foundation; not public discovery or checkout/payment. |
 
@@ -43,20 +44,19 @@ commerce transaction should work end to end.
 
 ```mermaid
 flowchart LR
-  user[User] --> agent[Commerce Sales Agent]
-  agent --> aliases[grantex_commerce:* aliases]
-  aliases --> grantex[Grantex Commerce REST/MCP]
-  grantex --> catalog[Catalog and inventory]
-  grantex --> consent[Consent request and passport]
-  grantex --> policy[Policy and amount caps]
-  grantex --> payment[Provider-neutral payment intent]
-  payment --> mock[Mock provider smoke evidence]
-  payment -. blocked .-> providers[Live providers / Plural]
+  user[User] --> buyer[AgenticOrg Buyer Agent]
+  merchant[Merchant] --> seller[AgenticOrg Seller Agent]
+  seller --> systems[Merchant systems]
+  seller --> grantex[Grantex OACP Authority]
+  grantex --> artifacts[Signed artifacts]
+  artifacts --> buyer
+  buyer -. approved capability verification .-> provider[Provider/fintech rail]
 ```
 
-AgenticOrg does not own catalog truth, consent grants, Commerce Passport
-issuance, merchant policy enforcement, provider credentials, provider webhooks,
-or payment reconciliation. Those controls stay in Grantex.
+AgenticOrg does not own catalog truth, provider payment execution, settlement,
+or merchant operational state. Grantex owns artifact authority, policy and
+refusal semantics, and evidence requirements. Merchant systems own operational
+facts. Provider and fintech rails own mandates and payments.
 
 ## Buyer Discovery Session
 
@@ -76,42 +76,43 @@ stock, delivery, refund, launch, or payment facts.
 
 For merchants, the intended product experience should be simple:
 
-1. The merchant signs up in Grantex Commerce.
+1. The merchant starts in AgenticOrg Seller Commerce Agent.
 2. The merchant connects an existing store, catalog, ERP, inventory, OMS,
-   payment provider, or support system.
-3. Grantex normalizes that data into safe merchant profile, catalog, inventory,
-   policy, consent, checkout, order, audit, and protocol-publishing records.
+   payment provider, or support system through approved connector custody.
+3. Grantex validates public-safe facts, source/freshness, policy, and evidence
+   references into OACP artifacts.
 4. The merchant previews exactly what an AI agent can see.
 5. The merchant chooses which actions agents may request, such as browse,
    cart draft, checkout request, order status, or support handoff.
 6. Grantex runs validation scans and review gates.
-7. AgenticOrg agents use only the approved Grantex tools.
+7. AgenticOrg agents use valid OACP artifacts, approved authority refresh, and
+   approved provider/connector verifier flows.
 8. Live discovery or checkout is enabled only after a separate approved rollout.
 
-AgenticOrg should feel like the buyer-facing assistant and merchant-facing demo
-layer, not the merchant system of record. If a merchant already uses Shopify,
-WooCommerce, Magento, a custom store, an ERP, an OMS, a WMS, a payment provider,
-or a support desk, those systems should connect to Grantex. AgenticOrg should
-receive only the Grantex-approved, public-safe, policy-checked view.
+AgenticOrg should feel like the seller-agent and buyer-agent product, not the
+merchant system of record. If a merchant already uses Shopify, WooCommerce,
+Magento, a custom store, an ERP, an OMS, a WMS, a payment provider, or a support
+desk, those systems should connect through approved connector custody and
+produce public-safe evidence for Grantex/OACP validation.
 
 ## End-To-End Flow
 
 The operational flow is:
 
-1. Seller completes one-time setup in Grantex: workspace, verification,
-   connected systems, catalog, inventory, policy, payment path, approvals,
-   smoke evidence, and rollback ownership.
+1. Seller completes one-time setup in AgenticOrg Seller Commerce Agent and
+   Grantex authority review: onboarding packet, connected systems, catalog,
+   inventory, policy, payment/mandate path, approvals, smoke evidence, and
+   rollback ownership.
 2. Buyer completes one-time setup in their preferred channel: account/session
    linking, safe preferences, and understanding that checkout requires Grantex
    consent.
 3. Buyer asks the agent to find, compare, or buy.
-4. AgenticOrg calls only Grantex aliases for merchant profile, catalog,
-   inventory, cart, consent, payment intent, checkout, and status.
-5. Grantex enforces source-of-truth, policy, consent, Commerce Passport,
-   provider handoff, audit, order/fulfillment state, support/refund handoff, and
-   rollback.
-6. AgenticOrg explains the result to the buyer and refuses anything Grantex has
-   not approved or cannot verify.
+4. AgenticOrg reads valid cached OACP artifacts when TTL, revocation, and risk
+   rules allow; otherwise it asks Grantex for authority refresh.
+5. Commitment-bound actions require C6W5-C6W9 boundary, prepared envelope,
+   reconciliation, eligibility, and dry-run checks.
+6. AgenticOrg explains the result to the buyer and refuses anything artifacts,
+   source evidence, provider capability, or policy cannot verify.
 
 ## Buyer Agent Launch Surfaces
 
@@ -121,17 +122,17 @@ tracked PRD gap.
 
 | Surface | Intended launch model | Current readiness posture |
 | --- | --- | --- |
-| ChatGPT | Custom app/remote MCP backed by Grantex-only tools. | Planned; must respect ChatGPT app approval, action controls, and current write-action limits. |
-| Claude | Remote MCP connector backed by Grantex-only tools. | Planned; must include auth, scopes, and smoke evidence. |
+| ChatGPT | Custom app/remote MCP backed by OACP artifacts and authority refresh. | Planned; must respect ChatGPT app approval, action controls, and current write-action limits. |
+| Claude | Remote MCP connector backed by OACP artifacts and authority refresh. | Planned; must include auth, scopes, and smoke evidence. |
 | Gemini | AgenticOrg-hosted Gemini API/function-calling wrapper or approved future native channel. | Planned; native consumer Gemini launch support must not be claimed until available and approved. |
 | WhatsApp | WhatsApp Business Platform bot/webhook adapter. | Planned; requires WABA, phone number, templates, opt-out, webhook, and consent-link handling. |
 | Telegram | Telegram Bot API webhook adapter. | Planned; requires bot token, webhook secret validation, chat identity mapping, and consent-link handling. |
 | Web/mobile | AgenticOrg-hosted buyer-agent session or embedded merchant widget. | Best first controllable channel after Grantex approval. |
 
-Every channel must create or resume a buyer-agent session, call only Grantex
-commerce aliases, show clear consent/checkout handoff, and fall back to
-read-only discovery when the platform or approval state does not allow write
-actions.
+Every channel must create or resume a buyer-agent session, use OACP artifacts or
+authority refresh, show clear source/freshness and consent/handoff copy, and
+fall back to read-only discovery when the platform or approval state does not
+allow write actions.
 
 ## Standards And Protocol Fit
 
@@ -140,11 +141,12 @@ unsupported certification:
 
 | Surface | How AgenticOrg should use it |
 | --- | --- |
-| Native Grantex tools | Primary integration path for merchant profile, catalog, inventory, cart, consent, payment intent, checkout, and payment status. |
-| MCP | Agent tool surface for safe commerce actions backed by Grantex policy and audit. |
+| OACP artifacts | Primary internal trust input for source/freshness, refusal, prepared handoff, and future controller checks. |
+| Native Grantex tools | Authority refresh path for merchant profile, catalog, inventory, policy, and artifact verification. |
+| MCP | Agent tool surface for safe commerce actions backed by OACP artifacts and Grantex authority. |
 | UCP | Future capability discovery and shopping capability mapping. AgenticOrg should consume Grantex-published UCP-style profiles only after Grantex approves them. |
-| ACP | Future checkout/session compatibility. AgenticOrg may render checkout state, but Grantex remains the seller/control-plane endpoint. |
-| AP2 | Future signed checkout/payment mandate evidence. AgenticOrg may present mandate status only when Grantex provides deterministic evidence. |
+| ACP | Future checkout/session compatibility. AgenticOrg may render prepared or blocked checkout state, but execution remains separately gated. |
+| AP2 | Future signed checkout/payment mandate evidence. AgenticOrg may present provider-owned mandate status only when deterministic evidence exists. |
 | schema.org | Public product, offer, shipping, and return-policy metadata generated from Grantex-approved merchant data. |
 
 Do not claim UCP, ACP, AP2, A2A, or live-provider compliance unless the

--- a/docs/reports/commerce-agent-oacp-landing-blog-plan.md
+++ b/docs/reports/commerce-agent-oacp-landing-blog-plan.md
@@ -1,0 +1,175 @@
+# AgenticOrg OACP Landing Page And Blog Plan
+
+Status: internal planning only.
+
+This document plans how AgenticOrg should explain Open Agentic Commerce Protocol
+work without publishing a protocol, enabling public discovery, enabling
+checkout/payment, enabling live provider rails, changing production
+configuration, or claiming certification/compliance/conformance.
+
+## Corrected Public Position
+
+AgenticOrg is the AI-agent runtime for commerce:
+
+- Seller Commerce Agents onboard merchants and start connector workflows.
+- Buyer agents run chat/channel experiences and use OACP artifacts.
+- Artifact cache is scoped by buyer agent, seller agent, tenant, and merchant.
+- Non-binding discovery can continue from valid cached artifacts.
+- Commitment-bound actions require refresh, refusal, or prepared handoff.
+
+Grantex is the trust, protocol, policy, and canonical-artifact authority.
+Merchant systems remain operational sources of record. Provider and fintech
+rails own mandate and payment execution.
+
+## Current Implementation Summary
+
+AgenticOrg has internal C6W3-C6W9 consumer behavior:
+
+| Slice | AgenticOrg behavior | Public posture |
+| --- | --- | --- |
+| C6W3 | Consumes OACP artifact schemas and public-safe fixtures. | Internal only. |
+| C6W4 | Consumes adapter previews without treating them as transaction authority. | Preview only. |
+| C6W5 | Classifies non-binding, adjacent, bound, and blocked actions. | Non-executing. |
+| C6W6 | Consumes prepared-only envelopes. | Prepared only. |
+| C6W7 | Reconciles local/cached response evidence. | Reconciled only. |
+| C6W8 | Consumes eligibility/audit packets. | Eligibility only. |
+| C6W9 | Consumes dry-run verifier results. | Dry-run only. |
+
+## Landing Page Plan
+
+Recommended first viewport:
+
+- H1: "Seller And Buyer Agents For Safe Agentic Commerce"
+- Supporting line: "AgenticOrg runs commerce agents that connect merchant
+  systems, consume Grantex-signed OACP artifacts, and show source/freshness
+  before any commitment."
+- Primary CTA: "Explore Seller Commerce Agent"
+- Secondary CTA: "Read the OACP trust model"
+
+Sections:
+
+1. Seller Commerce Agent
+   - merchant self-serve starts here;
+   - connector setup;
+   - source/freshness evidence;
+   - Grantex authority request.
+2. Buyer Agent Runtime
+   - ChatGPT-style, Claude/MCP-style, Gemini-style, Perplexity/search-style,
+     WhatsApp, Telegram, web, and mobile channel bridges;
+   - source/freshness labels;
+   - refusal and refresh behavior.
+3. Artifact Cache
+   - cache per buyer agent, seller agent, tenant, and merchant;
+   - TTL and revocation snapshot;
+   - risk-tier action gating.
+4. Connector Workflows
+   - Shopify;
+   - WooCommerce;
+   - ERP/PIM;
+   - OMS/WMS;
+   - logistics;
+   - support;
+   - CSV/API.
+5. Mandate Boundary
+   - mandates and payment execution belong to provider/fintech rails;
+   - AgenticOrg may verify capability where approved;
+   - Grantex receives non-sensitive evidence refs only when needed.
+6. Current Status
+   - C6W9 internal foundation complete;
+   - no public discovery, live checkout/payment, or protocol certification.
+
+## Landing Page Visual
+
+```mermaid
+flowchart LR
+  merchant["Merchant"]
+  seller["AgenticOrg Seller Commerce Agent"]
+  systems["Shopify / WooCommerce / ERP / OMS"]
+  grantex["Grantex OACP Authority"]
+  cache["AgenticOrg Artifact Cache"]
+  buyer["AgenticOrg Buyer Agent"]
+  channel["ChatGPT / Claude / Gemini / Search / Web"]
+  provider["Provider / Fintech Rail"]
+
+  merchant --> seller
+  seller --> systems
+  systems --> seller
+  seller --> grantex
+  grantex --> cache
+  cache --> buyer
+  buyer --> channel
+  buyer -. "verify capability when approved" .-> provider
+```
+
+## Blog Series
+
+| Blog | Core message | Visual |
+| --- | --- | --- |
+| Seller Commerce Agents: Where Merchant Self-Serve Begins | Merchant onboarding should start in the agent runtime and flow into Grantex authority. | Seller-agent onboarding sequence. |
+| Buyer Agents With Source And Freshness Labels | Buyers can trust answers only when agents show where facts came from and when they expire. | Cache/refresh/refusal state machine. |
+| Artifact Cache Across Four Scopes | Cache must be scoped by buyer agent, seller agent, tenant, and merchant to avoid cross-context leakage. | Four-scope cache key diagram. |
+| Connecting Shopify, WooCommerce, And ERP For Agents | Existing systems stay source of record; seller agents initiate approved sync jobs. | Connector custody and evidence flow. |
+| Provider-Owned Mandates | Payment mandates belong with fintech rails; AgenticOrg verifies capability where approved. | Provider capability verification sequence. |
+| Channels For ChatGPT, Claude, Gemini, And Search | Different surfaces need different bridges and action labels. | Channel bridge matrix. |
+| The Remaining Gap To Autonomous Commerce | C6W9 is a contract dry run, not live execution. | Gap ladder to controlled pilot. |
+
+## Blog Visuals
+
+### Seller Onboarding
+
+```mermaid
+sequenceDiagram
+  participant Merchant
+  participant SellerAgent as AgenticOrg Seller Agent
+  participant Connector as Connector Platform
+  participant Grantex
+
+  Merchant->>SellerAgent: Start commerce onboarding
+  SellerAgent->>Connector: Initiate approved sync setup
+  Connector-->>SellerAgent: Source facts and evidence refs
+  SellerAgent->>Grantex: Request artifact authority review
+  Grantex-->>SellerAgent: Signed artifacts or blockers
+  SellerAgent-->>Merchant: Readiness, gaps, next step
+```
+
+### Buyer Cache Decision
+
+```mermaid
+stateDiagram-v2
+  [*] --> Prompt
+  Prompt --> CacheCheck
+  CacheCheck --> Answer: valid artifact and low risk
+  CacheCheck --> Refresh: missing / stale / revoked / high risk
+  Refresh --> Answer: refreshed artifact
+  Refresh --> Refuse: blocked or unsupported
+  Prompt --> Commitment: commitment-bound request
+  Commitment --> PreparedOnly: C6W5-C6W9 pass
+  Commitment --> Refuse: missing evidence
+```
+
+### Provider Mandate Capability
+
+```mermaid
+sequenceDiagram
+  participant Buyer
+  participant Provider
+  participant AgenticOrg
+  participant Grantex
+
+  Buyer->>Provider: Human-approved mandate setup
+  Provider-->>AgenticOrg: Capability/evidence reference
+  AgenticOrg->>Provider: Verify capability when approved
+  AgenticOrg->>Grantex: Send non-sensitive ref if required
+  Grantex-->>AgenticOrg: Artifact lineage accepted/refused
+```
+
+## Approval Checklist
+
+- Product approves page copy.
+- Legal approves OACP naming and non-standardization language.
+- Security verifies no secret, private merchant data, production ID, or raw
+  provider payload appears.
+- Engineering confirms C6W9 implementation status.
+- No claim implies production readiness, public discovery, live checkout/payment,
+  live provider rails, certification, compliance, conformance, or merchant
+  approval.


### PR DESCRIPTION
## Summary
- Updates the AgenticOrg Agentic Commerce PRD, overview, and end-to-end flow to reflect the corrected OACP architecture.
- Positions AgenticOrg as the buyer/seller agent runtime with seller-agent onboarding, connector sync initiation, local OACP artifact cache, channel bridges, and approved provider capability verification.
- Adds an internal landing page and blog plan with visual workflows for AgenticOrg public positioning.

## Current status captured
- AgenticOrg consumer behavior is documented through C6W9.
- C6W3-C6W9 remain internal, non-publication, non-certifying, non-production, non-executing, and fail-closed.
- Pending work is called out for persistent artifact cache, seller-agent onboarding runtime, real connector sync initiation, provider-owned mandate verifier runtime, channel bridges, third-party seller cards, execution-controller ownership, production audit persistence, and live merchant pilot workflows.

## Guardrails
- Docs only.
- No runtime, endpoint, migration, workflow, config, secret, provider, payment, public discovery, allowlist, deploy, or protocol-publication behavior changed.
- No claim of certification, compliance, conformance, standardization, production readiness, public launch readiness, merchant approval, checkout approval, payment approval, or live provider readiness.

## Validation
- `git diff --cached --check` passed before commit.
- ASCII check on touched/new files passed.
- Focused contradiction scan for old all-through-Grantex wording passed.
- Secret literal scan passed.
- Enablement/overclaim scan hits were expected negative or blocked-positioning language only.