### PR TITLE
C6X2 OACP artifact cache helper

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -153,6 +153,19 @@ OfflineAction = Literal[
     "emergency_disable",
 ]
 IssuerKeyState = Literal["active", "retired", "revoked"]
+PersistentCacheScopeKind = Literal["buyer_agent", "seller_agent", "tenant", "merchant"]
+PersistentCacheActionIntent = Literal["non_binding_preview", "prepare_only", "final_commitment"]
+PersistentCacheEvaluationStatus = Literal[
+    "usable_for_non_binding_cache",
+    "prepared_only_for_commitment_boundary",
+    "blocked",
+    "stale",
+    "expired",
+    "revoked",
+    "mismatched",
+    "unsafe",
+    "unsupported",
+]
 
 OACP_ARTIFACT_SIGNATURE_PROFILE: dict[str, Any] = {
     "payload_format": "canonical_json",
@@ -874,6 +887,39 @@ class OacpCachedArtifact:
     envelope: dict[str, Any]
     payload: Any
     verified_at: str
+
+
+@dataclass(frozen=True)
+class OacpPersistentArtifactCacheRecord:
+    cache_record_id: str
+    artifact_id: str
+    artifact_type: ArtifactType
+    authority: str
+    issuer: str
+    scope_kind: PersistentCacheScopeKind
+    tenant_id: str | None
+    merchant_id: str | None
+    seller_agent_id: str | None
+    buyer_agent_id: str | None
+    source_refs: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+    generated_at: str
+    cached_at: str
+    expires_at: str
+    freshness_status: str
+    revocation_snapshot_status: str
+    revocation_snapshot_observed_at: str | None
+    ttl_policy_seconds: int
+    risk_tier: RiskTier
+    blocked_capabilities: tuple[str, ...] = field(default_factory=tuple)
+    unsupported_capabilities: tuple[str, ...] = field(default_factory=tuple)
+    verifier_result_ref: str | None = None
+    revocation_snapshot_age_seconds: int | None = None
+    allowed_to_execute: bool = False
+    non_authoritative_for_transaction: bool = True
+    no_checkout_payment_enablement: bool = True
+    no_live_provider_enablement: bool = True
+    no_public_discovery_enablement: bool = True
 
 
 def canonicalize_oacp_payload(payload: Any) -> str:
@@ -3804,6 +3850,316 @@ def verify_oacp_artifact(input_data: OacpArtifactVerificationInput) -> dict[str,
         "cache_key": cache_key,
         "payload_hash": payload_hash,
         "expires_at": _string_field(envelope, "expires_at"),
+    }
+
+
+C6X2_PRIVATE_REF_MARKERS = (
+    "raw_jwt",
+    "bearer ",
+    "private_key",
+    "api_key",
+    "access_token",
+    "refresh_token",
+    "password",
+    "secret",
+    "db_url",
+    "redis_url",
+    "merchant_private_api",
+    "raw_provider_payload",
+    "raw_connector_payload",
+    "production_allowlist",
+)
+C6X2_ENABLEMENT_REF_MARKERS = (
+    "checkout_payment_enabled",
+    "live_provider_enabled",
+    "public_discovery_enabled",
+    "order_created",
+    "payment_captured",
+    "provider_executed",
+    "shipping_created",
+    "hold_created",
+    "refund_created",
+    "return_created",
+)
+C6X2_ARTIFACTS_NOT_TRANSACTION_AUTHORITY = frozenset(
+    {"protocol_adapter", "seller_agent_capability", "public_discovery"}
+)
+
+
+def _c6x2_cache_refusal(
+    *,
+    status: PersistentCacheEvaluationStatus,
+    refusal_code: str,
+    message: str,
+    record: OacpPersistentArtifactCacheRecord | None = None,
+) -> dict[str, Any]:
+    return {
+        "evaluated": False,
+        "status": status,
+        "refusal_code": refusal_code,
+        "message": message,
+        "cache_record_id": None if record is None else record.cache_record_id,
+        "artifact_id": None if record is None else record.artifact_id,
+        "allowed_to_preview": False,
+        "allowed_to_prepare": False,
+        "allowed_to_execute": False,
+        "prepared_only": True,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "commerce_facts_invented": False,
+        "grantex_runtime_required": False,
+    }
+
+
+def _c6x2_scope_present(record: OacpPersistentArtifactCacheRecord) -> bool:
+    if not record.tenant_id:
+        return False
+    if record.scope_kind == "merchant":
+        return bool(record.merchant_id)
+    if record.scope_kind == "seller_agent":
+        return bool(record.merchant_id and record.seller_agent_id)
+    if record.scope_kind == "buyer_agent":
+        return bool(record.merchant_id and record.seller_agent_id and record.buyer_agent_id)
+    return record.scope_kind == "tenant"
+
+
+def _c6x2_scope_matches(
+    record: OacpPersistentArtifactCacheRecord,
+    expected_scope: dict[str, str | None] | None,
+) -> bool:
+    if expected_scope is None:
+        return True
+    actual: dict[str, str | None] = {
+        "tenant_id": record.tenant_id,
+        "merchant_id": record.merchant_id,
+        "seller_agent_id": record.seller_agent_id,
+        "buyer_agent_id": record.buyer_agent_id,
+    }
+    return all(value is None or actual.get(key) == value for key, value in expected_scope.items())
+
+
+def _c6x2_refs_safe(values: tuple[str, ...]) -> bool:
+    for value in values:
+        normalized = value.strip().lower()
+        if not normalized:
+            return False
+        if any(marker in normalized for marker in C6X2_PRIVATE_REF_MARKERS):
+            return False
+        if any(marker in normalized for marker in C6X2_ENABLEMENT_REF_MARKERS):
+            return False
+    return True
+
+
+def _c6x2_non_enablement_flags_intact(record: OacpPersistentArtifactCacheRecord) -> bool:
+    return (
+        record.allowed_to_execute is False
+        and record.non_authoritative_for_transaction is True
+        and record.no_checkout_payment_enablement is True
+        and record.no_live_provider_enablement is True
+        and record.no_public_discovery_enablement is True
+    )
+
+
+def evaluate_oacp_persistent_artifact_cache_record(
+    *,
+    record: OacpPersistentArtifactCacheRecord | None,
+    action_intent: PersistentCacheActionIntent,
+    now_iso: str,
+    grantex_available: bool,
+    expected_scope: dict[str, str | None] | None = None,
+) -> dict[str, Any]:
+    if record is None:
+        return _c6x2_cache_refusal(
+            status="blocked",
+            refusal_code="cache_record_missing",
+            message="C6X2 requires a local persistent OACP artifact cache record.",
+        )
+
+    if not record.cache_record_id or not record.artifact_id or not record.authority or not record.issuer:
+        return _c6x2_cache_refusal(
+            status="blocked",
+            refusal_code="cache_record_identity_missing",
+            message="C6X2 cache records require local id, artifact id, authority, and issuer.",
+            record=record,
+        )
+    if not _c6x2_scope_present(record):
+        return _c6x2_cache_refusal(
+            status="blocked",
+            refusal_code="cache_scope_missing",
+            message="C6X2 cache records require tenant, merchant, seller, or buyer scope as applicable.",
+            record=record,
+        )
+    if not _c6x2_scope_matches(record, expected_scope):
+        return _c6x2_cache_refusal(
+            status="mismatched",
+            refusal_code="cache_scope_mismatch",
+            message="C6X2 refuses cache records outside the requesting agent or tenant scope.",
+            record=record,
+        )
+    if not _c6x2_non_enablement_flags_intact(record):
+        return _c6x2_cache_refusal(
+            status="unsafe",
+            refusal_code="non_enablement_flags_missing",
+            message="C6X2 refuses cache records with missing or false non-enablement flags.",
+            record=record,
+        )
+
+    now = _parse_iso(now_iso)
+    generated_at = _parse_iso(record.generated_at)
+    cached_at = _parse_iso(record.cached_at)
+    expires_at = _parse_iso(record.expires_at)
+    if now is None or generated_at is None or cached_at is None or expires_at is None:
+        return _c6x2_cache_refusal(
+            status="stale",
+            refusal_code="cache_freshness_missing",
+            message="C6X2 cache records require generated, cached, and expiry timestamps.",
+            record=record,
+        )
+    if now >= expires_at:
+        return _c6x2_cache_refusal(
+            status="expired",
+            refusal_code="cache_record_expired",
+            message="C6X2 refuses expired persistent OACP artifact cache records.",
+            record=record,
+        )
+    if record.ttl_policy_seconds <= 0 or record.ttl_policy_seconds > OACP_ARTIFACT_TTLS_SECONDS[record.artifact_type]:
+        return _c6x2_cache_refusal(
+            status="stale",
+            refusal_code="cache_ttl_policy_invalid",
+            message="C6X2 refuses cache records with missing or excessive TTL policy.",
+            record=record,
+        )
+    if record.freshness_status not in {"fresh", "provisional"}:
+        return _c6x2_cache_refusal(
+            status="stale",
+            refusal_code="cache_freshness_stale",
+            message="C6X2 cache records must be fresh or provisional for preview and prepare use.",
+            record=record,
+        )
+
+    max_revocation_age = OACP_REVOCATION_SNAPSHOT_MAX_AGE_SECONDS[record.risk_tier]
+    if record.revocation_snapshot_status == "revoked":
+        return _c6x2_cache_refusal(
+            status="revoked",
+            refusal_code="cache_record_revoked",
+            message="C6X2 refuses revoked persistent OACP artifact cache records.",
+            record=record,
+        )
+    if (
+        max_revocation_age is None
+        or record.revocation_snapshot_status != "fresh"
+        or record.revocation_snapshot_observed_at is None
+        or _parse_iso(record.revocation_snapshot_observed_at) is None
+        or record.revocation_snapshot_age_seconds is None
+        or record.revocation_snapshot_age_seconds > max_revocation_age
+    ):
+        return _c6x2_cache_refusal(
+            status="stale",
+            refusal_code="cache_revocation_snapshot_ambiguous",
+            message="C6X2 requires a fresh local revocation snapshot before cached artifact use.",
+            record=record,
+        )
+
+    refs_to_check = (
+        *record.source_refs,
+        *record.evidence_refs,
+        *(() if record.verifier_result_ref is None else (record.verifier_result_ref,)),
+    )
+    if not record.source_refs or not record.evidence_refs or not _c6x2_refs_safe(refs_to_check):
+        return _c6x2_cache_refusal(
+            status="unsafe",
+            refusal_code="cache_refs_missing_or_private",
+            message="C6X2 refuses missing, private, raw, or enabling cache refs.",
+            record=record,
+        )
+
+    if record.risk_tier == "critical":
+        return _c6x2_cache_refusal(
+            status="unsupported",
+            refusal_code="critical_risk_cache_use_blocked",
+            message="C6X2 blocks critical-risk cache use in offline or prepared-only mode.",
+            record=record,
+        )
+
+    if action_intent == "final_commitment" and record.artifact_type in C6X2_ARTIFACTS_NOT_TRANSACTION_AUTHORITY:
+        return _c6x2_cache_refusal(
+            status="blocked",
+            refusal_code="artifact_not_transaction_authority",
+            message="C6X2 refuses adapter previews, seller cards, or discovery records as transaction authority.",
+            record=record,
+        )
+    if action_intent == "final_commitment" and record.verifier_result_ref is None:
+        return _c6x2_cache_refusal(
+            status="blocked",
+            refusal_code="stronger_commitment_evidence_missing",
+            message=(
+                "C6X2 final commitment requests require stronger cached verifier evidence "
+                "and remain non-executing."
+            ),
+            record=record,
+        )
+
+    status: PersistentCacheEvaluationStatus = (
+        "usable_for_non_binding_cache"
+        if action_intent == "non_binding_preview"
+        else "prepared_only_for_commitment_boundary"
+    )
+    allowed_to_prepare = action_intent != "non_binding_preview"
+    offline_mode_status = (
+        "grantex_available"
+        if grantex_available
+        else "grantex_unavailable_valid_cache_prepared_only"
+    )
+    buyer_safe_message = (
+        "Cached OACP artifact may support non-binding preview without routing this turn through Grantex."
+        if action_intent == "non_binding_preview"
+        else "C6X2 can prepare a source-aware handoff from valid cache only; no execution occurs."
+    )
+
+    return {
+        "evaluated": True,
+        "status": status,
+        "cache_record_id": record.cache_record_id,
+        "artifact_id": record.artifact_id,
+        "artifact_type": record.artifact_type,
+        "authority": record.authority,
+        "issuer": record.issuer,
+        "scope_kind": record.scope_kind,
+        "tenant_id": record.tenant_id,
+        "merchant_id": record.merchant_id,
+        "seller_agent_id": record.seller_agent_id,
+        "buyer_agent_id": record.buyer_agent_id,
+        "source_refs": list(record.source_refs),
+        "evidence_refs": list(record.evidence_refs),
+        "generated_at": record.generated_at,
+        "cached_at": record.cached_at,
+        "expires_at": record.expires_at,
+        "freshness_status": record.freshness_status,
+        "revocation_snapshot_status": record.revocation_snapshot_status,
+        "revocation_snapshot_observed_at": record.revocation_snapshot_observed_at,
+        "ttl_policy_seconds": record.ttl_policy_seconds,
+        "risk_tier": record.risk_tier,
+        "blocked_capabilities": list(record.blocked_capabilities),
+        "unsupported_capabilities": list(record.unsupported_capabilities),
+        "verifier_result_ref": record.verifier_result_ref,
+        "offline_mode_status": offline_mode_status,
+        "allowed_to_preview": True,
+        "allowed_to_prepare": allowed_to_prepare,
+        "allowed_to_execute": False,
+        "prepared_only": True,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "commerce_facts_invented": False,
+        "grantex_runtime_required": False,
+        "buyer_safe_message": buyer_safe_message,
+        "seller_safe_message": (
+            "Seller-side use remains source-aware and prepared-only; merchant systems remain the operational source of "
+            "record."
+        ),
     }
 
 

--- a/docs/reports/commerce-agent-c6x2-oacp-artifact-cache-runtime.md
+++ b/docs/reports/commerce-agent-c6x2-oacp-artifact-cache-runtime.md
@@ -1,0 +1,53 @@
+# Commerce Agent C6X2 OACP Artifact Cache Runtime
+
+## Scope
+
+C6X2 adds an internal AgenticOrg persistent OACP artifact cache helper/model boundary. The helper evaluates local cache records for non-binding preview and prepared-only handoff behavior. It is internal, non-publication, non-certifying, non-production, and non-executing.
+
+## Correct Ownership Model
+
+AgenticOrg remains the buyer and seller AI-agent runtime. AgenticOrg owns buyer agents, seller agents, channel UX, local and persistent OACP artifact cache behavior, seller-agent initiated connector sync intent, and runtime consumption of OACP artifacts. Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. Merchant systems remain operational sources of record. Provider and fintech rails own mandate and payment execution where separately approved.
+
+The cache model supports valid cached OACP artifacts without routing every non-binding turn through Grantex. It does not make cached artifacts, adapter previews, or seller cards transaction authority.
+
+## Persistent Cache Record Model
+
+The internal record model includes cache record id, artifact id, artifact family/type, authority, issuer, buyer-agent/seller-agent/tenant/merchant scope ids where applicable, source refs, evidence refs, generated_at, cached_at, expires_at, freshness status, revocation snapshot status and timestamp, TTL policy, risk tier, blocked capabilities, unsupported capabilities, verifier result reference, and non-enablement flags.
+
+The four cache scopes are buyer agent, seller agent, tenant, and merchant. Each scope must carry the required local ids before cache evaluation can continue.
+
+## Cache Evaluation Helper
+
+The helper evaluates one local record at a time. It returns a deterministic local decision with allowed_to_preview, allowed_to_prepare, allowed_to_execute, prepared_only, non_authoritative_for_transaction, no_checkout_payment_enablement, no_live_provider_enablement, no_public_discovery_enablement, buyer-safe message, seller-safe message, source refs, evidence refs, freshness, revocation, and risk metadata.
+
+`allowed_to_execute` is always false in C6X2. The helper does not call Grantex, providers, merchant private APIs, checkout/payment systems, public discovery services, or any external system.
+
+## Freshness, Revocation, And TTL
+
+Valid cached records may support non-binding preview or answer flows while TTL and revocation snapshot posture are acceptable. Freshness must be fresh or provisional, timestamps must parse, expires_at must be in the future, and TTL policy must not exceed the internal OACP artifact defaults. Revocation snapshot posture must be fresh and within the risk-tier maximum age.
+
+## Non-Binding Versus Commitment-Bound Use
+
+Non-binding preview can continue from valid cache even when Grantex is unavailable. Prepare-only handoff can continue from valid cache and source-aware metadata. Final commitment requests remain prepared-only or refused; C6X2 does not execute, approve, create, hold, refund, return, ship, publish, or settle anything.
+
+Adapter previews, seller cards, and public discovery records cannot override missing, expired, revoked, or stale canonical artifacts and cannot become transaction authority.
+
+## Persistence And Migration Decision
+
+C6X2 implements a pure internal model/helper boundary and focused tests only. It adds no DB migration. A later migration proposal is required before durable production storage, including table fields, indexes, tenant boundaries, retention, rollback, tests, and risk review.
+
+## Fail-Closed Rules
+
+The helper fails closed for missing cache records, missing artifact id, missing authority or issuer, missing scope ids, stale or expired timestamps, stale or ambiguous revocation snapshots, revoked records, mismatched scope, missing evidence/source refs, private/raw refs, secrets or token-like refs, false non-enablement flags, critical risk tier, final commitment against adapter/seller-card/discovery records, and final commitment without stronger verifier evidence.
+
+## Guardrails
+
+C6X2 adds no public endpoint, public OpenAPI runtime contract, migration, workflow, cloud resource, production config, secret, production allowlist assignment, public discovery enablement, no checkout or payment enablement, no live provider rail enablement, no merchant private API execution, carrier/shipping path, provider call, raw connector/provider/private payload exposure, or external OACP publication/submission.
+
+## What C6X2 Does Not Enable
+
+C6X2 does not make OACP public. It does not create checkout, payment, provider, mandate, order, hold, refund, return, shipping, public discovery, production Commerce V1, or live rail behavior. It does not approve merchant, checkout, payment, mandate, provider, public launch, production, or future execution use.
+
+## Future Work
+
+Future slices can propose durable cache storage, cache eviction, tenant indexes, revocation refresh, source sync scheduling, and controlled handoff integration. Those slices must stay separate from live execution until a future product decision explicitly approves the necessary runtime, security, and operational changes.

--- a/tests/unit/test_oacp_c6x2_artifact_cache.py
+++ b/tests/unit/test_oacp_c6x2_artifact_cache.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from core.commerce.oacp_artifacts import (
+    OacpPersistentArtifactCacheRecord,
+    evaluate_oacp_persistent_artifact_cache_record,
+)
+
+C6X2_DOC_PATH = Path("docs/reports/commerce-agent-c6x2-oacp-artifact-cache-runtime.md")
+
+
+def _doc() -> str:
+    return C6X2_DOC_PATH.read_text(encoding="utf-8")
+
+
+def _record(**overrides: object) -> OacpPersistentArtifactCacheRecord:
+    base = OacpPersistentArtifactCacheRecord(
+        cache_record_id="cache_price_C6X2",
+        artifact_id="price_C6W3",
+        artifact_type="price",
+        authority="grantex_canonical_oacp_artifact_authority",
+        issuer="grantex",
+        scope_kind="buyer_agent",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+        source_refs=("source_ref_price_C6X2",),
+        evidence_refs=("evidence_price_C6X2_redacted",),
+        generated_at="2026-06-11T00:00:00.000Z",
+        cached_at="2026-06-11T00:00:10.000Z",
+        expires_at="2026-06-11T00:05:00.000Z",
+        freshness_status="fresh",
+        revocation_snapshot_status="fresh",
+        revocation_snapshot_observed_at="2026-06-11T00:00:30.000Z",
+        revocation_snapshot_age_seconds=30,
+        ttl_policy_seconds=300,
+        risk_tier="low",
+        blocked_capabilities=("checkout_payment_creation", "live_provider_call"),
+        unsupported_capabilities=("transaction_authority_from_adapter_preview",),
+        verifier_result_ref="verifier_result_price_C6X2",
+    )
+    return replace(base, **overrides)
+
+
+def test_c6x2_persistent_cache_supports_all_internal_scopes_without_grantex_toll_booth() -> None:
+    records = [
+        _record(scope_kind="buyer_agent"),
+        _record(
+            cache_record_id="cache_seller_C6X2",
+            scope_kind="seller_agent",
+            buyer_agent_id=None,
+            artifact_id="seller_agent_capability_C6X2",
+            artifact_type="seller_agent_capability",
+            ttl_policy_seconds=6 * 60 * 60,
+        ),
+        _record(
+            cache_record_id="cache_tenant_C6X2",
+            scope_kind="tenant",
+            merchant_id=None,
+            seller_agent_id=None,
+            buyer_agent_id=None,
+            artifact_id="policy_C6X2",
+            artifact_type="policy",
+            ttl_policy_seconds=6 * 60 * 60,
+        ),
+        _record(
+            cache_record_id="cache_merchant_C6X2",
+            scope_kind="merchant",
+            seller_agent_id=None,
+            buyer_agent_id=None,
+            artifact_id="merchant_capability_C6X2",
+            artifact_type="merchant_capability",
+            ttl_policy_seconds=24 * 60 * 60,
+        ),
+    ]
+
+    for record in records:
+        result = evaluate_oacp_persistent_artifact_cache_record(
+            record=record,
+            action_intent="non_binding_preview",
+            now_iso="2026-06-11T00:01:00.000Z",
+            grantex_available=False,
+            expected_scope={"tenant_id": "cten_C6W3"},
+        )
+
+        assert result["evaluated"] is True
+        assert result["status"] == "usable_for_non_binding_cache"
+        assert result["allowed_to_preview"] is True
+        assert result["allowed_to_prepare"] is False
+        assert result["allowed_to_execute"] is False
+        assert result["non_authoritative_for_transaction"] is True
+        assert result["no_checkout_payment_enablement"] is True
+        assert result["no_live_provider_enablement"] is True
+        assert result["no_public_discovery_enablement"] is True
+        assert result["grantex_runtime_required"] is False
+        assert result["commerce_facts_invented"] is False
+
+
+def test_c6x2_final_commitment_remains_prepared_only_for_valid_cache() -> None:
+    result = evaluate_oacp_persistent_artifact_cache_record(
+        record=_record(),
+        action_intent="final_commitment",
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=False,
+        expected_scope={
+            "tenant_id": "cten_C6W3",
+            "merchant_id": "mch_C6W3",
+            "seller_agent_id": "seller_C6W3",
+            "buyer_agent_id": "buyer_C6W3",
+        },
+    )
+
+    assert result["evaluated"] is True
+    assert result["status"] == "prepared_only_for_commitment_boundary"
+    assert result["allowed_to_prepare"] is True
+    assert result["allowed_to_execute"] is False
+    assert result["prepared_only"] is True
+    assert "no execution occurs" in result["buyer_safe_message"]
+
+
+def test_c6x2_cache_evaluation_fails_closed_for_unsafe_or_ambiguous_states() -> None:
+    cases = [
+        (_record(expires_at="2026-06-11T00:00:30.000Z"), "expired", "cache_record_expired"),
+        (_record(freshness_status="stale"), "stale", "cache_freshness_stale"),
+        (_record(revocation_snapshot_status="revoked"), "revoked", "cache_record_revoked"),
+        (_record(evidence_refs=("raw_jwt_ref",)), "unsafe", "cache_refs_missing_or_private"),
+        (_record(no_live_provider_enablement=False), "unsafe", "non_enablement_flags_missing"),
+    ]
+
+    for record, status, refusal_code in cases:
+        result = evaluate_oacp_persistent_artifact_cache_record(
+            record=record,
+            action_intent="non_binding_preview",
+            now_iso="2026-06-11T00:01:00.000Z",
+            grantex_available=True,
+            expected_scope={"tenant_id": "cten_C6W3"},
+        )
+
+        assert result["evaluated"] is False
+        assert result["status"] == status
+        assert result["refusal_code"] == refusal_code
+        assert result["allowed_to_execute"] is False
+
+
+def test_c6x2_cache_rejects_scope_mismatch_and_non_authority_artifacts_for_commitment() -> None:
+    mismatch = evaluate_oacp_persistent_artifact_cache_record(
+        record=_record(),
+        action_intent="prepare_only",
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+        expected_scope={"merchant_id": "other_merchant"},
+    )
+    assert mismatch["status"] == "mismatched"
+    assert mismatch["refusal_code"] == "cache_scope_mismatch"
+
+    adapter = evaluate_oacp_persistent_artifact_cache_record(
+        record=_record(
+            artifact_id="protocol_adapter_C6X2",
+            artifact_type="protocol_adapter",
+            ttl_policy_seconds=24 * 60 * 60,
+        ),
+        action_intent="final_commitment",
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+        expected_scope={"tenant_id": "cten_C6W3"},
+    )
+    assert adapter["status"] == "blocked"
+    assert adapter["refusal_code"] == "artifact_not_transaction_authority"
+    assert adapter["allowed_to_execute"] is False
+
+
+def test_c6x2_docs_capture_runtime_cache_boundary_and_guardrails() -> None:
+    doc = _doc()
+    for heading in (
+        "Scope",
+        "Correct Ownership Model",
+        "Persistent Cache Record Model",
+        "Cache Evaluation Helper",
+        "Freshness, Revocation, And TTL",
+        "Non-Binding Versus Commitment-Bound Use",
+        "Persistence And Migration Decision",
+        "Fail-Closed Rules",
+        "Guardrails",
+        "What C6X2 Does Not Enable",
+        "Future Work",
+    ):
+        assert f"## {heading}" in doc
+
+    assert "AgenticOrg remains the buyer and seller AI-agent runtime" in doc
+    assert "Grantex remains the trust, protocol, policy, and canonical OACP artifact authority" in doc
+    assert "without routing every non-binding turn through Grantex" in doc
+    assert "no DB migration" in doc
+    assert "no checkout or payment enablement" in doc
+    assert "no live provider rail enablement" in doc
+    assert "no merchant private API execution" in doc


### PR DESCRIPTION
Adds the C6X2 internal persistent OACP artifact cache helper/model boundary, focused tests, and runtime planning report. Scope remains internal-only, cache-evaluation-only, prepared-only for commitment boundaries, non-publication, non-certifying, non-production, and non-executing. No endpoints, migrations, workflows, config, provider calls, merchant private API calls, checkout/payment enablement, public discovery enablement, live rails, allowlists, or external OACP publication are added.