### PR TITLE
C6X3 OACP cache repository port

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -13,7 +13,7 @@ import json
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any, Literal, cast
+from typing import Any, Literal, Protocol, cast
 
 RiskTier = Literal["informational", "low", "medium", "high", "critical"]
 ArtifactType = Literal[
@@ -920,6 +920,43 @@ class OacpPersistentArtifactCacheRecord:
     no_checkout_payment_enablement: bool = True
     no_live_provider_enablement: bool = True
     no_public_discovery_enablement: bool = True
+
+
+@dataclass(frozen=True)
+class OacpArtifactCacheRepositoryQuery:
+    scope_kind: PersistentCacheScopeKind | None = None
+    tenant_id: str | None = None
+    merchant_id: str | None = None
+    seller_agent_id: str | None = None
+    buyer_agent_id: str | None = None
+    artifact_type: ArtifactType | None = None
+    authority: str | None = None
+
+
+class OacpArtifactCacheRepositoryPort(Protocol):
+    def upsert(self, record: OacpPersistentArtifactCacheRecord) -> dict[str, Any]:
+        """Store or replace a local cache record without external calls."""
+        ...
+
+    def get(self, cache_record_id: str) -> OacpPersistentArtifactCacheRecord | None:
+        """Read one local cache record by deterministic local id."""
+        ...
+
+    def list_for_scope(self, query: OacpArtifactCacheRepositoryQuery) -> tuple[OacpPersistentArtifactCacheRecord, ...]:
+        """List local cache records that match a tenant, merchant, seller, or buyer scope."""
+        ...
+
+    def evaluate(
+        self,
+        *,
+        cache_record_id: str,
+        action_intent: PersistentCacheActionIntent,
+        now_iso: str,
+        grantex_available: bool,
+        expected_scope: dict[str, str | None] | None = None,
+    ) -> dict[str, Any]:
+        """Evaluate one stored record using the C6X2 fail-closed cache policy."""
+        ...
 
 
 def canonicalize_oacp_payload(payload: Any) -> str:
@@ -4161,6 +4198,138 @@ def evaluate_oacp_persistent_artifact_cache_record(
             "record."
         ),
     }
+
+
+def _c6x3_repository_refusal(
+    *,
+    status: PersistentCacheEvaluationStatus,
+    refusal_code: str,
+    message: str,
+    record: OacpPersistentArtifactCacheRecord | None = None,
+) -> dict[str, Any]:
+    return {
+        "stored": False,
+        "status": status,
+        "refusal_code": refusal_code,
+        "message": message,
+        "cache_record_id": None if record is None else record.cache_record_id,
+        "artifact_id": None if record is None else record.artifact_id,
+        "allowed_to_execute": False,
+        "repository_only": True,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "grantex_runtime_required": False,
+    }
+
+
+def _c6x3_record_safe_for_repository(record: OacpPersistentArtifactCacheRecord) -> dict[str, Any]:
+    if not record.cache_record_id or not record.artifact_id or not record.authority or not record.issuer:
+        return _c6x3_repository_refusal(
+            status="blocked",
+            refusal_code="cache_record_identity_missing",
+            message="C6X3 repository records require local id, artifact id, authority, and issuer.",
+            record=record,
+        )
+    if not _c6x2_scope_present(record):
+        return _c6x3_repository_refusal(
+            status="blocked",
+            refusal_code="cache_scope_missing",
+            message="C6X3 repository records require the expected tenant, merchant, seller, or buyer scope.",
+            record=record,
+        )
+    if not _c6x2_non_enablement_flags_intact(record):
+        return _c6x3_repository_refusal(
+            status="unsafe",
+            refusal_code="non_enablement_flags_missing",
+            message="C6X3 repository refuses records with executable or enabling flags.",
+            record=record,
+        )
+    refs_to_check = (
+        *record.source_refs,
+        *record.evidence_refs,
+        *(() if record.verifier_result_ref is None else (record.verifier_result_ref,)),
+    )
+    if not record.source_refs or not record.evidence_refs or not _c6x2_refs_safe(refs_to_check):
+        return _c6x3_repository_refusal(
+            status="unsafe",
+            refusal_code="cache_refs_missing_or_private",
+            message="C6X3 repository refuses missing, private, raw, or enabling refs.",
+            record=record,
+        )
+    return {
+        "stored": True,
+        "status": "stored",
+        "cache_record_id": record.cache_record_id,
+        "artifact_id": record.artifact_id,
+        "artifact_type": record.artifact_type,
+        "scope_kind": record.scope_kind,
+        "allowed_to_execute": False,
+        "repository_only": True,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "grantex_runtime_required": False,
+    }
+
+
+def _c6x3_query_matches(
+    record: OacpPersistentArtifactCacheRecord,
+    query: OacpArtifactCacheRepositoryQuery,
+) -> bool:
+    return (
+        (query.scope_kind is None or record.scope_kind == query.scope_kind)
+        and (query.tenant_id is None or record.tenant_id == query.tenant_id)
+        and (query.merchant_id is None or record.merchant_id == query.merchant_id)
+        and (query.seller_agent_id is None or record.seller_agent_id == query.seller_agent_id)
+        and (query.buyer_agent_id is None or record.buyer_agent_id == query.buyer_agent_id)
+        and (query.artifact_type is None or record.artifact_type == query.artifact_type)
+        and (query.authority is None or record.authority == query.authority)
+    )
+
+
+class InMemoryOacpArtifactCacheRepository:
+    """Internal test adapter for the cache repository port; it is not durable storage."""
+
+    def __init__(self) -> None:
+        self._records: dict[str, OacpPersistentArtifactCacheRecord] = {}
+
+    def upsert(self, record: OacpPersistentArtifactCacheRecord) -> dict[str, Any]:
+        store_result = _c6x3_record_safe_for_repository(record)
+        if store_result["stored"] is not True:
+            return store_result
+        self._records[record.cache_record_id] = record
+        return store_result
+
+    def get(self, cache_record_id: str) -> OacpPersistentArtifactCacheRecord | None:
+        return self._records.get(cache_record_id)
+
+    def list_for_scope(self, query: OacpArtifactCacheRepositoryQuery) -> tuple[OacpPersistentArtifactCacheRecord, ...]:
+        return tuple(
+            sorted(
+                (record for record in self._records.values() if _c6x3_query_matches(record, query)),
+                key=lambda record: record.cache_record_id,
+            )
+        )
+
+    def evaluate(
+        self,
+        *,
+        cache_record_id: str,
+        action_intent: PersistentCacheActionIntent,
+        now_iso: str,
+        grantex_available: bool,
+        expected_scope: dict[str, str | None] | None = None,
+    ) -> dict[str, Any]:
+        return evaluate_oacp_persistent_artifact_cache_record(
+            record=self.get(cache_record_id),
+            action_intent=action_intent,
+            now_iso=now_iso,
+            grantex_available=grantex_available,
+            expected_scope=expected_scope,
+        )
 
 
 class OacpArtifactCache:

--- a/docs/reports/commerce-agent-c6x3-oacp-cache-repository.md
+++ b/docs/reports/commerce-agent-c6x3-oacp-cache-repository.md
@@ -1,0 +1,45 @@
+# Commerce Agent C6X3 OACP Cache Repository
+
+## Scope
+
+C6X3 adds an internal AgenticOrg OACP artifact cache repository port and a non-durable in-memory adapter for tests. The repository stores, reads, lists, and evaluates local cache records already shaped by C6X2. It is internal, non-publication, non-certifying, non-production, and non-executing.
+
+## Correct Ownership Model
+
+AgenticOrg remains the buyer and seller AI-agent runtime and owns local/persistent OACP artifact cache behavior. Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. Merchant systems remain operational sources of record. Provider and fintech rails own mandate and payment execution where separately approved.
+
+The repository allows valid cached OACP artifacts to support non-binding preview and prepare flows without routing every non-binding turn through Grantex. It does not turn cached artifacts, adapter previews, or seller cards into transaction authority.
+
+## Repository Port
+
+The internal port supports `upsert`, `get`, `list_for_scope`, and `evaluate`. It stores only local cache records that preserve artifact id/type, authority/issuer, buyer-agent/seller-agent/tenant/merchant scope, source refs, evidence refs, generated_at, cached_at, expires_at, freshness, revocation snapshot posture, TTL policy, risk tier, blocked capabilities, unsupported capabilities, verifier result refs, and non-enablement flags.
+
+The in-memory adapter is a test adapter only. It makes no external calls and does not persist production records.
+
+## Repository Query
+
+Queries can filter by cache scope kind, tenant id, merchant id, seller agent id, buyer agent id, artifact type, and authority. The query model keeps buyer-agent, seller-agent, tenant, and merchant cache boundaries explicit.
+
+## Evaluation Behavior
+
+Repository evaluation delegates to the C6X2 fail-closed cache evaluator. Valid cached records may support non-binding preview from local cache while TTL and revocation snapshot posture remain acceptable. Final commitment requests are prepared-only or refused. Every evaluation keeps `allowed_to_execute = false`, `non_authoritative_for_transaction = true`, `no_checkout_payment_enablement = true`, `no_live_provider_enablement = true`, and `no_public_discovery_enablement = true`.
+
+## Persistence And Migration Decision
+
+C6X3 adds no DB migration. The repository port defines the runtime boundary for a future durable implementation, but production storage requires a later explicit migration proposal with table fields, tenant indexes, retention, rollback, and tests.
+
+## Fail-Closed Rules
+
+The repository refuses records with missing local id, artifact id, authority, issuer, required scope ids, missing refs, private/raw refs, false non-enablement flags, executable posture, or unsafe labels. Missing records evaluate as blocked. Scope mismatches, stale records, expired records, revoked records, and ambiguous revocation posture remain fail-closed in the C6X2 evaluator.
+
+## Guardrails
+
+C6X3 adds no public endpoint, public OpenAPI runtime contract, migration, workflow, cloud resource, production config, secret, production allowlist assignment, public discovery enablement, no checkout or payment enablement, no live provider rail enablement, no merchant private API execution, carrier/shipping path, provider call, raw connector/provider/private payload exposure, or external OACP publication/submission.
+
+## What C6X3 Does Not Enable
+
+C6X3 does not make OACP public. It does not create checkout, payment, provider, mandate, order, hold, refund, return, shipping, public discovery, production Commerce V1, or live rail behavior. It does not approve merchant, checkout, payment, mandate, provider, public launch, production, or future execution use.
+
+## Future Work
+
+Future slices may propose a durable repository implementation, cache compaction, cache eviction, refresh scheduling, or tenant-indexed storage. Any durable storage work must be explicitly approved as a migration slice before production persistence is introduced.

--- a/tests/unit/test_oacp_c6x3_cache_repository.py
+++ b/tests/unit/test_oacp_c6x3_cache_repository.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from core.commerce.oacp_artifacts import (
+    InMemoryOacpArtifactCacheRepository,
+    OacpArtifactCacheRepositoryPort,
+    OacpArtifactCacheRepositoryQuery,
+    OacpPersistentArtifactCacheRecord,
+)
+
+C6X3_DOC_PATH = Path("docs/reports/commerce-agent-c6x3-oacp-cache-repository.md")
+
+
+def _doc() -> str:
+    return C6X3_DOC_PATH.read_text(encoding="utf-8")
+
+
+def _record(**overrides: object) -> OacpPersistentArtifactCacheRecord:
+    base = OacpPersistentArtifactCacheRecord(
+        cache_record_id="cache_price_C6X3",
+        artifact_id="price_C6W3",
+        artifact_type="price",
+        authority="grantex_canonical_oacp_artifact_authority",
+        issuer="grantex",
+        scope_kind="buyer_agent",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+        source_refs=("source_ref_price_C6X3",),
+        evidence_refs=("evidence_price_C6X3_redacted",),
+        generated_at="2026-06-11T00:00:00.000Z",
+        cached_at="2026-06-11T00:00:10.000Z",
+        expires_at="2026-06-11T00:05:00.000Z",
+        freshness_status="fresh",
+        revocation_snapshot_status="fresh",
+        revocation_snapshot_observed_at="2026-06-11T00:00:30.000Z",
+        revocation_snapshot_age_seconds=30,
+        ttl_policy_seconds=300,
+        risk_tier="low",
+        blocked_capabilities=("checkout_payment_creation", "live_provider_call"),
+        unsupported_capabilities=("transaction_authority_from_adapter_preview",),
+        verifier_result_ref="verifier_result_price_C6X3",
+    )
+    return replace(base, **overrides)
+
+
+def test_c6x3_repository_port_stores_and_lists_all_cache_scopes() -> None:
+    repository: OacpArtifactCacheRepositoryPort = InMemoryOacpArtifactCacheRepository()
+    records = (
+        _record(scope_kind="buyer_agent"),
+        _record(
+            cache_record_id="cache_seller_C6X3",
+            artifact_id="seller_agent_capability_C6X3",
+            artifact_type="seller_agent_capability",
+            scope_kind="seller_agent",
+            buyer_agent_id=None,
+            ttl_policy_seconds=6 * 60 * 60,
+        ),
+        _record(
+            cache_record_id="cache_tenant_C6X3",
+            artifact_id="policy_C6X3",
+            artifact_type="policy",
+            scope_kind="tenant",
+            merchant_id=None,
+            seller_agent_id=None,
+            buyer_agent_id=None,
+            ttl_policy_seconds=6 * 60 * 60,
+        ),
+        _record(
+            cache_record_id="cache_merchant_C6X3",
+            artifact_id="merchant_capability_C6X3",
+            artifact_type="merchant_capability",
+            scope_kind="merchant",
+            seller_agent_id=None,
+            buyer_agent_id=None,
+            ttl_policy_seconds=24 * 60 * 60,
+        ),
+    )
+
+    for record in records:
+        assert repository.upsert(record) == {
+            "stored": True,
+            "status": "stored",
+            "cache_record_id": record.cache_record_id,
+            "artifact_id": record.artifact_id,
+            "artifact_type": record.artifact_type,
+            "scope_kind": record.scope_kind,
+            "allowed_to_execute": False,
+            "repository_only": True,
+            "non_authoritative_for_transaction": True,
+            "no_checkout_payment_enablement": True,
+            "no_live_provider_enablement": True,
+            "no_public_discovery_enablement": True,
+            "grantex_runtime_required": False,
+        }
+
+    tenant_records = repository.list_for_scope(OacpArtifactCacheRepositoryQuery(tenant_id="cten_C6W3"))
+    assert {record.scope_kind for record in tenant_records} == {"buyer_agent", "seller_agent", "tenant", "merchant"}
+
+    buyer_records = repository.list_for_scope(
+        OacpArtifactCacheRepositoryQuery(
+            scope_kind="buyer_agent",
+            tenant_id="cten_C6W3",
+            merchant_id="mch_C6W3",
+            seller_agent_id="seller_C6W3",
+            buyer_agent_id="buyer_C6W3",
+        )
+    )
+    assert [record.cache_record_id for record in buyer_records] == ["cache_price_C6X3"]
+
+
+def test_c6x3_repository_evaluates_cached_records_without_grantex_toll_booth() -> None:
+    repository = InMemoryOacpArtifactCacheRepository()
+    repository.upsert(_record())
+
+    preview = repository.evaluate(
+        cache_record_id="cache_price_C6X3",
+        action_intent="non_binding_preview",
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=False,
+        expected_scope={"tenant_id": "cten_C6W3", "merchant_id": "mch_C6W3"},
+    )
+    assert preview["status"] == "usable_for_non_binding_cache"
+    assert preview["allowed_to_preview"] is True
+    assert preview["allowed_to_prepare"] is False
+    assert preview["allowed_to_execute"] is False
+    assert preview["grantex_runtime_required"] is False
+
+    commitment = repository.evaluate(
+        cache_record_id="cache_price_C6X3",
+        action_intent="final_commitment",
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=False,
+        expected_scope={
+            "tenant_id": "cten_C6W3",
+            "merchant_id": "mch_C6W3",
+            "seller_agent_id": "seller_C6W3",
+            "buyer_agent_id": "buyer_C6W3",
+        },
+    )
+    assert commitment["status"] == "prepared_only_for_commitment_boundary"
+    assert commitment["allowed_to_prepare"] is True
+    assert commitment["allowed_to_execute"] is False
+    assert commitment["non_authoritative_for_transaction"] is True
+
+
+def test_c6x3_repository_fails_closed_for_unsafe_store_and_missing_records() -> None:
+    repository = InMemoryOacpArtifactCacheRepository()
+
+    unsafe = repository.upsert(_record(evidence_refs=("raw_jwt_ref",)))
+    assert unsafe["stored"] is False
+    assert unsafe["status"] == "unsafe"
+    assert unsafe["refusal_code"] == "cache_refs_missing_or_private"
+
+    executable = repository.upsert(_record(cache_record_id="cache_exec_C6X3", allowed_to_execute=True))
+    assert executable["stored"] is False
+    assert executable["status"] == "unsafe"
+    assert executable["refusal_code"] == "non_enablement_flags_missing"
+
+    missing = repository.evaluate(
+        cache_record_id="missing_C6X3",
+        action_intent="non_binding_preview",
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+    )
+    assert missing["evaluated"] is False
+    assert missing["status"] == "blocked"
+    assert missing["allowed_to_execute"] is False
+
+
+def test_c6x3_repository_docs_capture_no_migration_and_guardrails() -> None:
+    doc = _doc()
+    for heading in (
+        "Scope",
+        "Correct Ownership Model",
+        "Repository Port",
+        "Repository Query",
+        "Evaluation Behavior",
+        "Persistence And Migration Decision",
+        "Fail-Closed Rules",
+        "Guardrails",
+        "What C6X3 Does Not Enable",
+        "Future Work",
+    ):
+        assert f"## {heading}" in doc
+
+    assert "AgenticOrg remains the buyer and seller AI-agent runtime" in doc
+    assert "without routing every non-binding turn through Grantex" in doc
+    assert "no DB migration" in doc
+    assert "allowed_to_execute = false" in doc
+    assert "no checkout or payment enablement" in doc
+    assert "no live provider rail enablement" in doc
+    assert "no merchant private API execution" in doc


### PR DESCRIPTION
Adds C6X3 AgenticOrg internal OACP artifact cache repository port, non-durable in-memory test adapter, focused tests, and internal documentation. Scope remains internal-only, repository-only, non-publication, non-certifying, non-production, and non-executing. No DB migration, endpoints, workflows, config, provider calls, merchant private API calls, checkout/payment enablement, public discovery enablement, live rails, allowlists, or external OACP publication are added.