### PR TITLE
C6X4 durable OACP artifact cache repository

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -13,7 +13,10 @@ import json
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any, Literal, Protocol, cast
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
 
 RiskTier = Literal["informational", "low", "medium", "high", "critical"]
 ArtifactType = Literal[
@@ -4325,6 +4328,238 @@ class InMemoryOacpArtifactCacheRepository:
     ) -> dict[str, Any]:
         return evaluate_oacp_persistent_artifact_cache_record(
             record=self.get(cache_record_id),
+            action_intent=action_intent,
+            now_iso=now_iso,
+            grantex_available=grantex_available,
+            expected_scope=expected_scope,
+        )
+
+
+def _c6x4_durable_repository_refusal(
+    *,
+    status: PersistentCacheEvaluationStatus,
+    refusal_code: str,
+    message: str,
+    record: OacpPersistentArtifactCacheRecord | None = None,
+) -> dict[str, Any]:
+    return {
+        "stored": False,
+        "status": status,
+        "refusal_code": refusal_code,
+        "message": message,
+        "cache_record_id": None if record is None else record.cache_record_id,
+        "artifact_id": None if record is None else record.artifact_id,
+        "durable_repository": True,
+        "allowed_to_execute": False,
+        "repository_only": True,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "grantex_runtime_required": False,
+    }
+
+
+def _c6x4_durable_record_safe_for_storage(record: OacpPersistentArtifactCacheRecord) -> dict[str, Any]:
+    base_result = _c6x3_record_safe_for_repository(record)
+    if base_result["stored"] is not True:
+        result = dict(base_result)
+        result["durable_repository"] = True
+        return result
+
+    generated_at = _parse_iso(record.generated_at)
+    cached_at = _parse_iso(record.cached_at)
+    expires_at = _parse_iso(record.expires_at)
+    revocation_observed_at = _parse_iso(record.revocation_snapshot_observed_at)
+    if (
+        generated_at is None
+        or cached_at is None
+        or expires_at is None
+        or revocation_observed_at is None
+        or generated_at > cached_at
+        or cached_at >= expires_at
+    ):
+        return _c6x4_durable_repository_refusal(
+            status="stale",
+            refusal_code="cache_timestamps_invalid",
+            message="C6X4 durable cache records require ordered generated, cached, revocation, and expiry timestamps.",
+            record=record,
+        )
+
+    if record.ttl_policy_seconds <= 0 or record.ttl_policy_seconds > OACP_ARTIFACT_TTLS_SECONDS[record.artifact_type]:
+        return _c6x4_durable_repository_refusal(
+            status="stale",
+            refusal_code="cache_ttl_policy_invalid",
+            message="C6X4 durable cache records require a positive TTL not exceeding the artifact family default.",
+            record=record,
+        )
+    if record.freshness_status not in {"fresh", "provisional"}:
+        return _c6x4_durable_repository_refusal(
+            status="stale",
+            refusal_code="cache_freshness_stale",
+            message="C6X4 durable cache records must be fresh or provisional at storage time.",
+            record=record,
+        )
+    if record.revocation_snapshot_status != "fresh" or record.revocation_snapshot_age_seconds is None:
+        return _c6x4_durable_repository_refusal(
+            status="stale",
+            refusal_code="cache_revocation_snapshot_ambiguous",
+            message="C6X4 durable cache records require a fresh local revocation snapshot.",
+            record=record,
+        )
+
+    return {
+        **base_result,
+        "durable_repository": True,
+    }
+
+
+def _c6x4_record_ttl_policy(record: OacpPersistentArtifactCacheRecord) -> dict[str, Any]:
+    return {
+        "ttl_policy_seconds": record.ttl_policy_seconds,
+        "artifact_family": record.artifact_type,
+        "source": "grantex_oacp_cached_artifact_verifier_result",
+    }
+
+
+def _c6x4_row_to_record(row: Any) -> OacpPersistentArtifactCacheRecord:
+    return OacpPersistentArtifactCacheRecord(
+        cache_record_id=str(row.cache_record_id),
+        artifact_id=str(row.artifact_id),
+        artifact_type=cast(ArtifactType, row.artifact_type),
+        authority=str(row.authority),
+        issuer=str(row.issuer),
+        scope_kind=cast(PersistentCacheScopeKind, row.scope_kind),
+        tenant_id=row.tenant_id,
+        merchant_id=row.merchant_id,
+        seller_agent_id=row.seller_agent_id,
+        buyer_agent_id=row.buyer_agent_id,
+        source_refs=tuple(row.source_refs or ()),
+        evidence_refs=tuple(row.evidence_refs or ()),
+        generated_at=row.generated_at.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        cached_at=row.cached_at.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        expires_at=row.expires_at.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        freshness_status=str(row.freshness_status),
+        revocation_snapshot_status=str(row.revocation_snapshot_status),
+        revocation_snapshot_observed_at=(
+            None
+            if row.revocation_snapshot_observed_at is None
+            else row.revocation_snapshot_observed_at.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+        ),
+        ttl_policy_seconds=int(row.ttl_policy_seconds),
+        risk_tier=cast(RiskTier, row.risk_tier),
+        blocked_capabilities=tuple(row.blocked_capabilities or ()),
+        unsupported_capabilities=tuple(row.unsupported_capabilities or ()),
+        verifier_result_ref=row.verifier_result_ref,
+        revocation_snapshot_age_seconds=row.revocation_snapshot_age_seconds,
+        allowed_to_execute=bool(row.allowed_to_execute),
+        non_authoritative_for_transaction=bool(row.non_authoritative_for_transaction),
+        no_checkout_payment_enablement=bool(row.no_checkout_payment_enablement),
+        no_live_provider_enablement=bool(row.no_live_provider_enablement),
+        no_public_discovery_enablement=bool(row.no_public_discovery_enablement),
+    )
+
+
+def _c6x4_apply_record_to_row(row: Any, record: OacpPersistentArtifactCacheRecord) -> None:
+    row.artifact_id = record.artifact_id
+    row.artifact_type = record.artifact_type
+    row.artifact_family = record.artifact_type
+    row.authority = record.authority
+    row.issuer = record.issuer
+    row.scope_kind = record.scope_kind
+    row.tenant_id = record.tenant_id
+    row.merchant_id = record.merchant_id
+    row.seller_agent_id = record.seller_agent_id
+    row.buyer_agent_id = record.buyer_agent_id
+    row.source_refs = list(record.source_refs)
+    row.evidence_refs = list(record.evidence_refs)
+    row.generated_at = _parse_iso(record.generated_at)
+    row.issued_at = _parse_iso(record.generated_at)
+    row.cached_at = _parse_iso(record.cached_at)
+    row.expires_at = _parse_iso(record.expires_at)
+    row.freshness_status = record.freshness_status
+    row.revocation_snapshot_status = record.revocation_snapshot_status
+    row.revocation_snapshot_age_seconds = record.revocation_snapshot_age_seconds
+    row.revocation_snapshot_observed_at = _parse_iso(record.revocation_snapshot_observed_at)
+    row.ttl_policy = _c6x4_record_ttl_policy(record)
+    row.ttl_policy_seconds = record.ttl_policy_seconds
+    row.risk_tier = record.risk_tier
+    row.blocked_capabilities = list(record.blocked_capabilities)
+    row.unsupported_capabilities = list(record.unsupported_capabilities)
+    row.verifier_result_ref = record.verifier_result_ref
+    row.allowed_to_execute = False
+    row.non_authoritative_for_transaction = True
+    row.no_checkout_payment_enablement = True
+    row.no_live_provider_enablement = True
+    row.no_public_discovery_enablement = True
+
+
+class DurableOacpArtifactCacheRepository:
+    """Async SQLAlchemy-backed OACP cache repository; it performs no external calls."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def upsert(self, record: OacpPersistentArtifactCacheRecord) -> dict[str, Any]:
+        from core.models.oacp_artifact_cache import OacpArtifactCacheRecordRow
+
+        store_result = _c6x4_durable_record_safe_for_storage(record)
+        if store_result["stored"] is not True:
+            return store_result
+
+        row = await self._session.get(OacpArtifactCacheRecordRow, record.cache_record_id)
+        if row is None:
+            row = OacpArtifactCacheRecordRow(cache_record_id=record.cache_record_id)
+            self._session.add(row)
+        _c6x4_apply_record_to_row(row, record)
+        await self._session.flush()
+        return store_result
+
+    async def get(self, cache_record_id: str) -> OacpPersistentArtifactCacheRecord | None:
+        from core.models.oacp_artifact_cache import OacpArtifactCacheRecordRow
+
+        row = await self._session.get(OacpArtifactCacheRecordRow, cache_record_id)
+        return None if row is None else _c6x4_row_to_record(row)
+
+    async def list_for_scope(
+        self,
+        query: OacpArtifactCacheRepositoryQuery,
+    ) -> tuple[OacpPersistentArtifactCacheRecord, ...]:
+        from sqlalchemy import select
+
+        from core.models.oacp_artifact_cache import OacpArtifactCacheRecordRow
+
+        statement = select(OacpArtifactCacheRecordRow)
+        if query.scope_kind is not None:
+            statement = statement.where(OacpArtifactCacheRecordRow.scope_kind == query.scope_kind)
+        if query.tenant_id is not None:
+            statement = statement.where(OacpArtifactCacheRecordRow.tenant_id == query.tenant_id)
+        if query.merchant_id is not None:
+            statement = statement.where(OacpArtifactCacheRecordRow.merchant_id == query.merchant_id)
+        if query.seller_agent_id is not None:
+            statement = statement.where(OacpArtifactCacheRecordRow.seller_agent_id == query.seller_agent_id)
+        if query.buyer_agent_id is not None:
+            statement = statement.where(OacpArtifactCacheRecordRow.buyer_agent_id == query.buyer_agent_id)
+        if query.artifact_type is not None:
+            statement = statement.where(OacpArtifactCacheRecordRow.artifact_type == query.artifact_type)
+        if query.authority is not None:
+            statement = statement.where(OacpArtifactCacheRecordRow.authority == query.authority)
+
+        rows = (await self._session.scalars(statement.order_by(OacpArtifactCacheRecordRow.cache_record_id))).all()
+        records = tuple(_c6x4_row_to_record(row) for row in rows)
+        return tuple(record for record in records if _c6x3_query_matches(record, query))
+
+    async def evaluate(
+        self,
+        *,
+        cache_record_id: str,
+        action_intent: PersistentCacheActionIntent,
+        now_iso: str,
+        grantex_available: bool,
+        expected_scope: dict[str, str | None] | None = None,
+    ) -> dict[str, Any]:
+        return evaluate_oacp_persistent_artifact_cache_record(
+            record=await self.get(cache_record_id),
             action_intent=action_intent,
             now_iso=now_iso,
             grantex_available=grantex_available,

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -56,6 +56,7 @@ from core.models.invoice import Invoice as Invoice
 from core.models.kpi_cache import KPICache as KPICache
 from core.models.lead_pipeline import EmailSequence as EmailSequence
 from core.models.lead_pipeline import LeadPipeline as LeadPipeline
+from core.models.oacp_artifact_cache import OacpArtifactCacheRecordRow as OacpArtifactCacheRecordRow
 from core.models.organization import CostCenter as CostCenter
 from core.models.organization import Department as Department
 from core.models.professional_tax import ProfessionalTaxRegistration as ProfessionalTaxRegistration

--- a/core/models/oacp_artifact_cache.py
+++ b/core/models/oacp_artifact_cache.py
@@ -1,0 +1,80 @@
+"""Durable OACP artifact cache record model.
+
+The table stores only public-safe artifact and evidence references used by
+AgenticOrg local cache evaluation. It is not transaction authority.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, TIMESTAMP, Boolean, Index, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.models.base import BaseModel
+
+OACP_CACHE_JSON = JSONB().with_variant(JSON(), "sqlite")
+
+
+class OacpArtifactCacheRecordRow(BaseModel):
+    __tablename__ = "oacp_artifact_cache_records"
+    __table_args__ = (
+        Index("ix_oacp_cache_tenant_id", "tenant_id"),
+        Index("ix_oacp_cache_merchant_id", "merchant_id"),
+        Index("ix_oacp_cache_seller_agent_id", "seller_agent_id"),
+        Index("ix_oacp_cache_buyer_agent_id", "buyer_agent_id"),
+        Index("ix_oacp_cache_artifact_id", "artifact_id"),
+        Index("ix_oacp_cache_artifact_type", "artifact_type"),
+        Index("ix_oacp_cache_expires_at", "expires_at"),
+        Index("ix_oacp_cache_freshness_status", "freshness_status"),
+        Index("ix_oacp_cache_revocation_status", "revocation_snapshot_status"),
+    )
+
+    cache_record_id: Mapped[str] = mapped_column(String(160), primary_key=True)
+    artifact_id: Mapped[str] = mapped_column(String(160), nullable=False)
+    artifact_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    artifact_family: Mapped[str] = mapped_column(String(64), nullable=False)
+    authority: Mapped[str] = mapped_column(String(255), nullable=False)
+    issuer: Mapped[str] = mapped_column(String(255), nullable=False)
+    scope_kind: Mapped[str] = mapped_column(String(32), nullable=False)
+    tenant_id: Mapped[str] = mapped_column(String(160), nullable=False)
+    merchant_id: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    seller_agent_id: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    buyer_agent_id: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    source_refs: Mapped[list[str]] = mapped_column(OACP_CACHE_JSON, nullable=False, default=list)
+    evidence_refs: Mapped[list[str]] = mapped_column(OACP_CACHE_JSON, nullable=False, default=list)
+    generated_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    issued_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    cached_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    freshness_status: Mapped[str] = mapped_column(String(32), nullable=False)
+    revocation_snapshot_status: Mapped[str] = mapped_column(String(32), nullable=False)
+    revocation_snapshot_age_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    revocation_snapshot_observed_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+    ttl_policy: Mapped[dict[str, Any]] = mapped_column(OACP_CACHE_JSON, nullable=False, default=dict)
+    ttl_policy_seconds: Mapped[int] = mapped_column(Integer, nullable=False)
+    risk_tier: Mapped[str] = mapped_column(String(32), nullable=False)
+    blocked_capabilities: Mapped[list[str]] = mapped_column(
+        OACP_CACHE_JSON,
+        nullable=False,
+        default=list,
+    )
+    unsupported_capabilities: Mapped[list[str]] = mapped_column(
+        OACP_CACHE_JSON,
+        nullable=False,
+        default=list,
+    )
+    verifier_result_ref: Mapped[str | None] = mapped_column(Text, nullable=True)
+    allowed_to_execute: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    non_authoritative_for_transaction: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    no_checkout_payment_enablement: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    no_live_provider_enablement: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    no_public_discovery_enablement: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
+    updated_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=True,
+        onupdate=func.now(),
+    )

--- a/docs/reports/commerce-agent-c6x4-durable-oacp-cache-repository.md
+++ b/docs/reports/commerce-agent-c6x4-durable-oacp-cache-repository.md
@@ -1,0 +1,37 @@
+# Commerce Agent C6X4 Durable OACP Cache Repository
+
+## Scope
+
+C6X4 adds the first durable AgenticOrg OACP artifact cache repository foundation. It stores local cache records shaped by C6X2/C6X3 after fail-closed validation and keeps evaluation local for non-binding preview, answer, and prepare flows.
+
+## Correct Ownership Model
+
+AgenticOrg remains the buyer and seller AI-agent runtime and owns local/durable OACP artifact cache behavior. Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. Merchant systems remain operational sources of record. Provider and fintech rails own mandate and payment execution where separately approved.
+
+## Durable Repository Contract
+
+The durable repository exposes async `upsert`, `get`, `list_for_scope`, and `evaluate` methods. It stores buyer agent, seller agent, tenant, and merchant scoped cache records without calling Grantex for every non-binding turn. Evaluation delegates to the C6X2 fail-closed cache evaluator.
+
+## Stored Fields
+
+The table stores `cache_record_id`, artifact identity and family, issuer and authority, tenant, merchant, seller-agent, and buyer-agent scope ids, source refs, redacted evidence refs, generated, issued, cached, expiry, freshness, revocation snapshot, TTL, risk, blocked and unsupported capabilities, verifier result refs, non-enablement flags, and created/updated timestamps.
+
+## Migration Decision
+
+C6X4 adds a narrow Alembic migration, `v6x4_oacp_cache`, because durable persistence is explicitly required for this slice and the repo has an established Alembic migration convention. The migration creates only `oacp_artifact_cache_records`, tenant-safe indexes, a duplicate artifact/scope uniqueness guard, timestamp checks, non-execution flag checks, and tenant RLS. Rollback drops only this cache table and indexes.
+
+## Fail-Closed Storage And Evaluation
+
+The repository refuses missing local ids, missing artifact ids, missing issuer or authority, missing scope, invalid timestamps, unsafe refs, executable flags, false non-enablement flags, stale freshness, ambiguous revocation snapshots, or invalid TTL policy. Final commitment actions remain prepared-only or refused, and `allowed_to_execute = false` is preserved.
+
+## Guardrails
+
+C6X4 stores only public-safe, non-sensitive refs. It stores no raw provider payloads, raw connector payloads, raw JWTs, credentials, tokens, private keys, bank or card data, private customer data, private merchant API values, secrets, production allowlists, or executable targets.
+
+## What C6X4 Does Not Enable
+
+C6X4 adds no public endpoint, public OpenAPI runtime contract, workflow, cloud resource, production config, secret, public discovery enablement, checkout, payment, order, hold, refund, return, shipping execution, no live provider rail enablement, merchant private API execution, external OACP publication, or approval/readiness claim.
+
+## Future Work
+
+Future slices may add cache eviction, refresh scheduling, and tenant-indexed maintenance jobs. Those must remain separate from checkout, payment, provider rail, merchant private API, and public OACP publication behavior unless separately approved.

--- a/migrations/versions/v6_x4_oacp_artifact_cache.py
+++ b/migrations/versions/v6_x4_oacp_artifact_cache.py
@@ -1,0 +1,128 @@
+"""C6X4 durable OACP artifact cache records.
+
+Revision ID: v6x4_oacp_cache
+Revises: v4918_merge_ca_weekly_heads
+Create Date: 2026-06-13
+
+This table is an AgenticOrg-owned local cache for Grantex-issued OACP
+artifact verifier results. It stores only non-sensitive artifact metadata and
+redacted evidence references; it is not transaction authority and does not
+enable checkout, payment, provider, merchant private API, or public discovery
+execution.
+
+Rollback: drop the cache table and its indexes. No source-of-record merchant,
+provider, payment, or canonical Grantex artifact state is stored here.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v6x4_oacp_cache"
+down_revision = "v4918_merge_ca_weekly_heads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS oacp_artifact_cache_records (
+            cache_record_id VARCHAR(160) PRIMARY KEY,
+            artifact_id VARCHAR(160) NOT NULL,
+            artifact_type VARCHAR(64) NOT NULL,
+            artifact_family VARCHAR(64) NOT NULL,
+            authority VARCHAR(255) NOT NULL,
+            issuer VARCHAR(255) NOT NULL,
+            scope_kind VARCHAR(32) NOT NULL,
+            tenant_id VARCHAR(160) NOT NULL,
+            merchant_id VARCHAR(160),
+            seller_agent_id VARCHAR(160),
+            buyer_agent_id VARCHAR(160),
+            source_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+            evidence_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+            generated_at TIMESTAMPTZ NOT NULL,
+            issued_at TIMESTAMPTZ NOT NULL,
+            cached_at TIMESTAMPTZ NOT NULL,
+            expires_at TIMESTAMPTZ NOT NULL,
+            freshness_status VARCHAR(32) NOT NULL,
+            revocation_snapshot_status VARCHAR(32) NOT NULL,
+            revocation_snapshot_age_seconds INTEGER,
+            revocation_snapshot_observed_at TIMESTAMPTZ,
+            ttl_policy JSONB NOT NULL DEFAULT '{}'::jsonb,
+            ttl_policy_seconds INTEGER NOT NULL,
+            risk_tier VARCHAR(32) NOT NULL,
+            blocked_capabilities JSONB NOT NULL DEFAULT '[]'::jsonb,
+            unsupported_capabilities JSONB NOT NULL DEFAULT '[]'::jsonb,
+            verifier_result_ref TEXT,
+            allowed_to_execute BOOLEAN NOT NULL DEFAULT FALSE,
+            non_authoritative_for_transaction BOOLEAN NOT NULL DEFAULT TRUE,
+            no_checkout_payment_enablement BOOLEAN NOT NULL DEFAULT TRUE,
+            no_live_provider_enablement BOOLEAN NOT NULL DEFAULT TRUE,
+            no_public_discovery_enablement BOOLEAN NOT NULL DEFAULT TRUE,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ,
+            CONSTRAINT ck_oacp_cache_scope_kind
+                CHECK (scope_kind IN ('buyer_agent', 'seller_agent', 'tenant', 'merchant')),
+            CONSTRAINT ck_oacp_cache_risk_tier
+                CHECK (risk_tier IN ('informational', 'low', 'medium', 'high', 'critical')),
+            CONSTRAINT ck_oacp_cache_ttl_positive CHECK (ttl_policy_seconds > 0),
+            CONSTRAINT ck_oacp_cache_ordered_timestamps CHECK (generated_at <= cached_at AND cached_at < expires_at),
+            CONSTRAINT ck_oacp_cache_non_execution_flags CHECK (
+                allowed_to_execute IS FALSE
+                AND non_authoritative_for_transaction IS TRUE
+                AND no_checkout_payment_enablement IS TRUE
+                AND no_live_provider_enablement IS TRUE
+                AND no_public_discovery_enablement IS TRUE
+            )
+        );
+    """)
+    op.execute("CREATE INDEX IF NOT EXISTS ix_oacp_cache_tenant_id ON oacp_artifact_cache_records (tenant_id);")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_oacp_cache_merchant_id ON oacp_artifact_cache_records (merchant_id);")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_oacp_cache_seller_agent_id ON oacp_artifact_cache_records (seller_agent_id);")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_oacp_cache_buyer_agent_id ON oacp_artifact_cache_records (buyer_agent_id);")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_oacp_cache_artifact_id ON oacp_artifact_cache_records (artifact_id);")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_oacp_cache_artifact_type ON oacp_artifact_cache_records (artifact_type);")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_oacp_cache_expires_at ON oacp_artifact_cache_records (expires_at);")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_cache_freshness_status "
+        "ON oacp_artifact_cache_records (freshness_status);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_cache_revocation_status "
+        "ON oacp_artifact_cache_records (revocation_snapshot_status);"
+    )
+    op.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_oacp_cache_artifact_scope
+            ON oacp_artifact_cache_records (
+                tenant_id,
+                COALESCE(merchant_id, ''),
+                COALESCE(seller_agent_id, ''),
+                COALESCE(buyer_agent_id, ''),
+                artifact_id,
+                artifact_type
+            );
+    """)
+    op.execute("ALTER TABLE oacp_artifact_cache_records ENABLE ROW LEVEL SECURITY;")
+    op.execute("ALTER TABLE oacp_artifact_cache_records FORCE ROW LEVEL SECURITY;")
+    op.execute("DROP POLICY IF EXISTS oacp_artifact_cache_records_tenant_isolation ON oacp_artifact_cache_records;")
+    op.execute("""
+        CREATE POLICY oacp_artifact_cache_records_tenant_isolation
+            ON oacp_artifact_cache_records
+            USING (tenant_id = current_setting('agenticorg.tenant_id', true))
+            WITH CHECK (tenant_id = current_setting('agenticorg.tenant_id', true));
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS oacp_artifact_cache_records_tenant_isolation ON oacp_artifact_cache_records;")
+    op.execute("DROP INDEX IF EXISTS uq_oacp_cache_artifact_scope;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_cache_revocation_status;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_cache_freshness_status;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_cache_expires_at;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_cache_artifact_type;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_cache_artifact_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_cache_buyer_agent_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_cache_seller_agent_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_cache_merchant_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_cache_tenant_id;")
+    op.execute("DROP TABLE IF EXISTS oacp_artifact_cache_records;")

--- a/tests/unit/test_oacp_c6x4_durable_cache_repository.py
+++ b/tests/unit/test_oacp_c6x4_durable_cache_repository.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from core.commerce.oacp_artifacts import (
+    DurableOacpArtifactCacheRepository,
+    OacpArtifactCacheRepositoryQuery,
+    OacpPersistentArtifactCacheRecord,
+)
+from core.models.oacp_artifact_cache import OacpArtifactCacheRecordRow
+
+C6X4_DOC_PATH = Path("docs/reports/commerce-agent-c6x4-durable-oacp-cache-repository.md")
+C6X4_MIGRATION_PATH = Path("migrations/versions/v6_x4_oacp_artifact_cache.py")
+
+
+def _doc() -> str:
+    return C6X4_DOC_PATH.read_text(encoding="utf-8")
+
+
+def _migration() -> str:
+    return C6X4_MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+def _record(**overrides: object) -> OacpPersistentArtifactCacheRecord:
+    base = OacpPersistentArtifactCacheRecord(
+        cache_record_id="cache_price_C6X4",
+        artifact_id="price_C6W3",
+        artifact_type="price",
+        authority="grantex_canonical_oacp_artifact_authority",
+        issuer="grantex",
+        scope_kind="buyer_agent",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+        source_refs=("source_ref_price_C6X4",),
+        evidence_refs=("evidence_price_C6X4_redacted",),
+        generated_at="2026-06-11T00:00:00.000Z",
+        cached_at="2026-06-11T00:00:10.000Z",
+        expires_at="2026-06-11T00:05:00.000Z",
+        freshness_status="fresh",
+        revocation_snapshot_status="fresh",
+        revocation_snapshot_observed_at="2026-06-11T00:00:30.000Z",
+        revocation_snapshot_age_seconds=30,
+        ttl_policy_seconds=300,
+        risk_tier="low",
+        blocked_capabilities=("checkout_payment_creation", "live_provider_call"),
+        unsupported_capabilities=("transaction_authority_from_adapter_preview",),
+        verifier_result_ref="verifier_result_price_C6X4",
+    )
+    return replace(base, **overrides)
+
+
+class _FakeScalars:
+    def __init__(self, rows: list[OacpArtifactCacheRecordRow]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[OacpArtifactCacheRecordRow]:
+        return self._rows
+
+
+class _FakeAsyncSession:
+    def __init__(self) -> None:
+        self.rows: dict[str, OacpArtifactCacheRecordRow] = {}
+
+    async def get(
+        self,
+        _model: type[OacpArtifactCacheRecordRow],
+        cache_record_id: str,
+    ) -> OacpArtifactCacheRecordRow | None:
+        return self.rows.get(cache_record_id)
+
+    def add(self, row: OacpArtifactCacheRecordRow) -> None:
+        self.rows[row.cache_record_id] = row
+
+    async def flush(self) -> None:
+        return None
+
+    async def scalars(self, _statement: object) -> _FakeScalars:
+        return _FakeScalars(list(self.rows.values()))
+
+
+@pytest.fixture()
+def repository() -> DurableOacpArtifactCacheRepository:
+    return DurableOacpArtifactCacheRepository(_FakeAsyncSession())
+
+
+@pytest.mark.asyncio
+async def test_c6x4_durable_repository_upserts_gets_and_lists_all_scopes(
+    repository: DurableOacpArtifactCacheRepository,
+) -> None:
+    records = (
+        _record(scope_kind="buyer_agent"),
+        _record(
+            cache_record_id="cache_seller_C6X4",
+            artifact_id="seller_agent_capability_C6X4",
+            artifact_type="seller_agent_capability",
+            scope_kind="seller_agent",
+            buyer_agent_id=None,
+            ttl_policy_seconds=6 * 60 * 60,
+        ),
+        _record(
+            cache_record_id="cache_tenant_C6X4",
+            artifact_id="policy_C6X4",
+            artifact_type="policy",
+            scope_kind="tenant",
+            merchant_id=None,
+            seller_agent_id=None,
+            buyer_agent_id=None,
+            ttl_policy_seconds=6 * 60 * 60,
+        ),
+        _record(
+            cache_record_id="cache_merchant_C6X4",
+            artifact_id="merchant_capability_C6X4",
+            artifact_type="merchant_capability",
+            scope_kind="merchant",
+            seller_agent_id=None,
+            buyer_agent_id=None,
+            ttl_policy_seconds=24 * 60 * 60,
+        ),
+    )
+
+    for record in records:
+        result = await repository.upsert(record)
+        assert result["stored"] is True
+        assert result["durable_repository"] is True
+        assert result["allowed_to_execute"] is False
+        assert result["non_authoritative_for_transaction"] is True
+
+    stored = await repository.get("cache_price_C6X4")
+    assert stored is not None
+    assert stored.artifact_id == "price_C6W3"
+    assert stored.evidence_refs == ("evidence_price_C6X4_redacted",)
+
+    tenant_records = await repository.list_for_scope(OacpArtifactCacheRepositoryQuery(tenant_id="cten_C6W3"))
+    assert {record.scope_kind for record in tenant_records} == {"buyer_agent", "seller_agent", "tenant", "merchant"}
+
+    buyer_records = await repository.list_for_scope(
+        OacpArtifactCacheRepositoryQuery(
+            scope_kind="buyer_agent",
+            tenant_id="cten_C6W3",
+            merchant_id="mch_C6W3",
+            seller_agent_id="seller_C6W3",
+            buyer_agent_id="buyer_C6W3",
+        )
+    )
+    assert [record.cache_record_id for record in buyer_records] == ["cache_price_C6X4"]
+
+
+@pytest.mark.asyncio
+async def test_c6x4_durable_repository_evaluates_without_grantex_toll_booth(
+    repository: DurableOacpArtifactCacheRepository,
+) -> None:
+    await repository.upsert(_record())
+
+    preview = await repository.evaluate(
+        cache_record_id="cache_price_C6X4",
+        action_intent="non_binding_preview",
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=False,
+        expected_scope={"tenant_id": "cten_C6W3", "merchant_id": "mch_C6W3"},
+    )
+    assert preview["status"] == "usable_for_non_binding_cache"
+    assert preview["allowed_to_preview"] is True
+    assert preview["allowed_to_execute"] is False
+    assert preview["grantex_runtime_required"] is False
+
+    commitment = await repository.evaluate(
+        cache_record_id="cache_price_C6X4",
+        action_intent="final_commitment",
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=False,
+        expected_scope={
+            "tenant_id": "cten_C6W3",
+            "merchant_id": "mch_C6W3",
+            "seller_agent_id": "seller_C6W3",
+            "buyer_agent_id": "buyer_C6W3",
+        },
+    )
+    assert commitment["status"] == "prepared_only_for_commitment_boundary"
+    assert commitment["allowed_to_prepare"] is True
+    assert commitment["allowed_to_execute"] is False
+    assert commitment["non_authoritative_for_transaction"] is True
+
+
+@pytest.mark.asyncio
+async def test_c6x4_durable_repository_fails_closed_before_storage(
+    repository: DurableOacpArtifactCacheRepository,
+) -> None:
+    cases = [
+        (_record(cache_record_id=""), "cache_record_identity_missing"),
+        (_record(evidence_refs=("raw_jwt_ref",)), "cache_refs_missing_or_private"),
+        (_record(allowed_to_execute=True), "non_enablement_flags_missing"),
+        (_record(cached_at="not-a-date"), "cache_timestamps_invalid"),
+        (_record(revocation_snapshot_status="unknown"), "cache_revocation_snapshot_ambiguous"),
+    ]
+
+    for record, refusal_code in cases:
+        result = await repository.upsert(record)
+        assert result["stored"] is False
+        assert result["allowed_to_execute"] is False
+        assert result["refusal_code"] == refusal_code
+
+    assert await repository.get("") is None
+
+
+def test_c6x4_migration_has_tenant_safe_indexes_and_non_execution_guards() -> None:
+    migration = _migration()
+    for expected in (
+        "CREATE TABLE IF NOT EXISTS oacp_artifact_cache_records",
+        "ix_oacp_cache_tenant_id",
+        "ix_oacp_cache_merchant_id",
+        "ix_oacp_cache_seller_agent_id",
+        "ix_oacp_cache_buyer_agent_id",
+        "ix_oacp_cache_artifact_id",
+        "ix_oacp_cache_artifact_type",
+        "ix_oacp_cache_expires_at",
+        "ix_oacp_cache_freshness_status",
+        "ix_oacp_cache_revocation_status",
+        "uq_oacp_cache_artifact_scope",
+        "allowed_to_execute IS FALSE",
+        "ENABLE ROW LEVEL SECURITY",
+        "DROP TABLE IF EXISTS oacp_artifact_cache_records",
+    ):
+        assert expected in migration
+
+
+def test_c6x4_docs_capture_durable_scope_and_guardrails() -> None:
+    doc = _doc()
+    for heading in (
+        "Scope",
+        "Correct Ownership Model",
+        "Durable Repository Contract",
+        "Stored Fields",
+        "Migration Decision",
+        "Fail-Closed Storage And Evaluation",
+        "Guardrails",
+        "What C6X4 Does Not Enable",
+        "Future Work",
+    ):
+        assert f"## {heading}" in doc
+
+    assert "AgenticOrg remains the buyer and seller AI-agent runtime" in doc
+    assert "without calling Grantex for every non-binding turn" in doc
+    assert "v6x4_oacp_cache" in doc
+    assert "allowed_to_execute = false" in doc
+    assert "no public endpoint" in doc
+    assert "checkout, payment" in doc
+    assert "no live provider rail" in doc


### PR DESCRIPTION
## Summary
- Adds a durable SQLAlchemy-backed OACP artifact cache repository and ORM model.
- Adds a narrow Alembic migration for tenant-safe durable cache records.
- Adds focused tests and docs for fail-closed storage/evaluation over buyer agent, seller agent, tenant, and merchant scopes.

## Migration decision
- A migration is included because C6X4 is the first durable-cache foundation and C6X3 only provided an in-memory adapter.
- The table is narrow, tenant-scoped, indexed by artifact/scope/freshness/revocation fields, and guarded by non-execution constraints.
- The repository validates records before upsert and does not commit, execute, call providers, call merchant private APIs, or create checkout/payment/order/hold/refund/return/shipping behavior.

## Validation
- `python -m pytest tests/unit/test_oacp_c6x2_artifact_cache.py tests/unit/test_oacp_c6x3_cache_repository.py tests/unit/test_oacp_c6x4_durable_cache_repository.py --no-cov`
- `python -m ruff check core/commerce/oacp_artifacts.py core/models/oacp_artifact_cache.py core/models/__init__.py tests/unit/test_oacp_c6x4_durable_cache_repository.py migrations/versions/v6_x4_oacp_artifact_cache.py`
- `python -m mypy core/commerce/oacp_artifacts.py core/models/oacp_artifact_cache.py tests/unit/test_oacp_c6x4_durable_cache_repository.py`
- `python -m alembic heads`
- `python scripts/check_migration_required.py`
- `git diff --cached --check`

## Guardrails
- Internal-only, non-publication, non-certifying, non-production, non-executing.
- Valid cache records may support non-binding preview/prepare flows without routing every turn through Grantex.
- Final commitment remains prepared-only or refused; `allowed_to_execute = false`.
- No public endpoints, public OpenAPI runtime contracts, workflows, production config, provider calls, merchant private API calls, checkout/payment/public discovery/live rail enablement, allowlists, or OACP publication.
