### PR TITLE
C6X5 OACP cache maintenance planner

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
@@ -168,6 +168,19 @@ PersistentCacheEvaluationStatus = Literal[
     "mismatched",
     "unsafe",
     "unsupported",
+]
+OacpCacheMaintenanceOutcome = Literal[
+    "keep_usable",
+    "refresh_recommended",
+    "refresh_required_before_commitment",
+    "evict_expired",
+    "purge_revoked",
+    "quarantine_ambiguous_revocation",
+    "quarantine_scope_mismatch",
+    "quarantine_private_or_raw_ref",
+    "source_refresh_needed",
+    "human_review_required",
+    "blocked_unsafe",
 ]
 
 OACP_ARTIFACT_SIGNATURE_PROFILE: dict[str, Any] = {
@@ -4565,6 +4578,366 @@ class DurableOacpArtifactCacheRepository:
             grantex_available=grantex_available,
             expected_scope=expected_scope,
         )
+
+
+_C6X5_RISK_RANK: dict[RiskTier, int] = {
+    "informational": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "critical": 4,
+}
+_C6X5_COMMITMENT_REVOCATION_MAX_AGE_SECONDS = 2 * 60
+
+
+def _c6x5_safe_public_refs(values: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(value for value in values if _c6x2_refs_safe((value,)))
+
+
+def _c6x5_remaining_ttl_seconds(record: OacpPersistentArtifactCacheRecord, now: datetime | None) -> int | None:
+    expires_at = _parse_iso(record.expires_at)
+    if now is None or expires_at is None:
+        return None
+    return max(0, int((expires_at - now).total_seconds()))
+
+
+def _c6x5_refresh_recommended(record: OacpPersistentArtifactCacheRecord, now: datetime | None) -> bool:
+    remaining = _c6x5_remaining_ttl_seconds(record, now)
+    max_revocation_age = OACP_REVOCATION_SNAPSHOT_MAX_AGE_SECONDS[record.risk_tier]
+    ttl_refresh_window = max(60, int(record.ttl_policy_seconds * 0.2))
+    revocation_refresh_window = None if max_revocation_age is None else int(max_revocation_age * 0.8)
+    return (
+        record.freshness_status == "provisional"
+        or remaining is None
+        or remaining <= ttl_refresh_window
+        or (
+            revocation_refresh_window is not None
+            and record.revocation_snapshot_age_seconds is not None
+            and record.revocation_snapshot_age_seconds >= revocation_refresh_window
+        )
+    )
+
+
+def _c6x5_record_action(
+    *,
+    record: OacpPersistentArtifactCacheRecord,
+    outcome: OacpCacheMaintenanceOutcome,
+    reason_codes: tuple[str, ...],
+    action_intent: PersistentCacheActionIntent,
+    grantex_available: bool,
+    now: datetime | None,
+) -> dict[str, Any]:
+    return {
+        "cache_record_id": record.cache_record_id,
+        "artifact_id": record.artifact_id,
+        "artifact_type": record.artifact_type,
+        "scope_kind": record.scope_kind,
+        "tenant_id": record.tenant_id,
+        "merchant_id": record.merchant_id,
+        "seller_agent_id": record.seller_agent_id,
+        "buyer_agent_id": record.buyer_agent_id,
+        "maintenance_outcome": outcome,
+        "reason_codes": list(reason_codes),
+        "action_intent": action_intent,
+        "risk_tier": record.risk_tier,
+        "source_refs": list(_c6x5_safe_public_refs(record.source_refs)),
+        "evidence_refs": list(_c6x5_safe_public_refs(record.evidence_refs)),
+        "verifier_result_ref": (
+            None
+            if record.verifier_result_ref is None or not _c6x2_refs_safe((record.verifier_result_ref,))
+            else record.verifier_result_ref
+        ),
+        "expires_at": record.expires_at,
+        "remaining_ttl_seconds": _c6x5_remaining_ttl_seconds(record, now),
+        "freshness_status": record.freshness_status,
+        "revocation_snapshot_status": record.revocation_snapshot_status,
+        "revocation_snapshot_age_seconds": record.revocation_snapshot_age_seconds,
+        "blocked_capabilities": list(record.blocked_capabilities),
+        "unsupported_capabilities": list(record.unsupported_capabilities),
+        "grantex_available": grantex_available,
+        "allowed_to_execute": False,
+        "maintenance_plan_only": True,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+    }
+
+
+def _c6x5_classify_record(
+    *,
+    record: OacpPersistentArtifactCacheRecord,
+    now: datetime | None,
+    grantex_available: bool,
+    action_intent: PersistentCacheActionIntent,
+    risk_tier: RiskTier,
+    scope_filter: OacpArtifactCacheRepositoryQuery | None,
+) -> dict[str, Any]:
+    if not record.cache_record_id or not record.artifact_id or not record.authority or not record.issuer:
+        return _c6x5_record_action(
+            record=record,
+            outcome="blocked_unsafe",
+            reason_codes=("cache_record_identity_missing",),
+            action_intent=action_intent,
+            grantex_available=grantex_available,
+            now=now,
+        )
+    if not _c6x2_scope_present(record):
+        return _c6x5_record_action(
+            record=record,
+            outcome="blocked_unsafe",
+            reason_codes=("cache_scope_missing",),
+            action_intent=action_intent,
+            grantex_available=grantex_available,
+            now=now,
+        )
+    if scope_filter is not None and not _c6x3_query_matches(record, scope_filter):
+        return _c6x5_record_action(
+            record=record,
+            outcome="quarantine_scope_mismatch",
+            reason_codes=("cache_scope_mismatch",),
+            action_intent=action_intent,
+            grantex_available=grantex_available,
+            now=now,
+        )
+    if not _c6x2_non_enablement_flags_intact(record):
+        return _c6x5_record_action(
+            record=record,
+            outcome="blocked_unsafe",
+            reason_codes=("non_enablement_flags_missing",),
+            action_intent=action_intent,
+            grantex_available=grantex_available,
+            now=now,
+        )
+
+    refs_to_check = (
+        *record.source_refs,
+        *record.evidence_refs,
+        *(() if record.verifier_result_ref is None else (record.verifier_result_ref,)),
+    )
+    if not record.source_refs or not record.evidence_refs or not _c6x2_refs_safe(refs_to_check):
+        return _c6x5_record_action(
+            record=record,
+            outcome="quarantine_private_or_raw_ref",
+            reason_codes=("cache_refs_missing_or_private",),
+            action_intent=action_intent,
+            grantex_available=grantex_available,
+            now=now,
+        )
+
+    generated_at = _parse_iso(record.generated_at)
+    cached_at = _parse_iso(record.cached_at)
+    expires_at = _parse_iso(record.expires_at)
+    if now is None or generated_at is None or cached_at is None or expires_at is None or generated_at > cached_at:
+        return _c6x5_record_action(
+            record=record,
+            outcome="source_refresh_needed",
+            reason_codes=("cache_freshness_missing",),
+            action_intent=action_intent,
+            grantex_available=grantex_available,
+            now=now,
+        )
+    if now >= expires_at:
+        return _c6x5_record_action(
+            record=record,
+            outcome="evict_expired",
+            reason_codes=("cache_record_expired",),
+            action_intent=action_intent,
+            grantex_available=grantex_available,
+            now=now,
+        )
+    if record.ttl_policy_seconds <= 0 or record.ttl_policy_seconds > OACP_ARTIFACT_TTLS_SECONDS[record.artifact_type]:
+        return _c6x5_record_action(
+            record=record,
+            outcome="source_refresh_needed",
+            reason_codes=("cache_ttl_policy_invalid",),
+            action_intent=action_intent,
+            grantex_available=grantex_available,
+            now=now,
+        )
+    if record.freshness_status not in {"fresh", "provisional"}:
+        return _c6x5_record_action(
+            record=record,
+            outcome="source_refresh_needed",
+            reason_codes=("cache_freshness_stale",),
+            action_intent=action_intent,
+            grantex_available=grantex_available,
+            now=now,
+        )
+
+    if record.revocation_snapshot_status == "revoked":
+        return _c6x5_record_action(
+            record=record,
+            outcome="purge_revoked",
+            reason_codes=("cache_record_revoked",),
+            action_intent=action_intent,
+            grantex_available=grantex_available,
+            now=now,
+        )
+    max_revocation_age = OACP_REVOCATION_SNAPSHOT_MAX_AGE_SECONDS[record.risk_tier]
+    if (
+        max_revocation_age is None
+        or record.revocation_snapshot_status != "fresh"
+        or record.revocation_snapshot_observed_at is None
+        or _parse_iso(record.revocation_snapshot_observed_at) is None
+        or record.revocation_snapshot_age_seconds is None
+        or record.revocation_snapshot_age_seconds > max_revocation_age
+    ):
+        return _c6x5_record_action(
+            record=record,
+            outcome="quarantine_ambiguous_revocation",
+            reason_codes=("cache_revocation_snapshot_ambiguous",),
+            action_intent=action_intent,
+            grantex_available=grantex_available,
+            now=now,
+        )
+
+    if _C6X5_RISK_RANK[risk_tier] >= _C6X5_RISK_RANK["critical"] or record.risk_tier == "critical":
+        return _c6x5_record_action(
+            record=record,
+            outcome="blocked_unsafe",
+            reason_codes=("critical_risk_cache_use_blocked",),
+            action_intent=action_intent,
+            grantex_available=grantex_available,
+            now=now,
+        )
+
+    if action_intent == "final_commitment":
+        if record.artifact_type in C6X2_ARTIFACTS_NOT_TRANSACTION_AUTHORITY:
+            return _c6x5_record_action(
+                record=record,
+                outcome="human_review_required",
+                reason_codes=("artifact_not_transaction_authority",),
+                action_intent=action_intent,
+                grantex_available=grantex_available,
+                now=now,
+            )
+        if (
+            record.freshness_status != "fresh"
+            or record.revocation_snapshot_age_seconds > _C6X5_COMMITMENT_REVOCATION_MAX_AGE_SECONDS
+            or _C6X5_RISK_RANK[record.risk_tier] < _C6X5_RISK_RANK[risk_tier]
+            or not grantex_available
+            or _c6x5_refresh_recommended(record, now)
+        ):
+            return _c6x5_record_action(
+                record=record,
+                outcome="refresh_required_before_commitment",
+                reason_codes=("final_commitment_requires_fresh_source_posture",),
+                action_intent=action_intent,
+                grantex_available=grantex_available,
+                now=now,
+            )
+
+    if action_intent == "prepare_only" and not grantex_available and record.freshness_status == "provisional":
+        return _c6x5_record_action(
+            record=record,
+            outcome="source_refresh_needed",
+            reason_codes=("prepared_flow_needs_source_refresh",),
+            action_intent=action_intent,
+            grantex_available=grantex_available,
+            now=now,
+        )
+    if _c6x5_refresh_recommended(record, now):
+        return _c6x5_record_action(
+            record=record,
+            outcome="refresh_recommended",
+            reason_codes=("ttl_or_revocation_refresh_window_reached",),
+            action_intent=action_intent,
+            grantex_available=grantex_available,
+            now=now,
+        )
+
+    return _c6x5_record_action(
+        record=record,
+        outcome="keep_usable",
+        reason_codes=("cache_record_usable_for_requested_intent",),
+        action_intent=action_intent,
+        grantex_available=grantex_available,
+        now=now,
+    )
+
+
+def _c6x5_ids_for_outcomes(actions: Sequence[dict[str, Any]], outcomes: set[str]) -> list[str]:
+    return [str(action["cache_record_id"]) for action in actions if action["maintenance_outcome"] in outcomes]
+
+
+def plan_oacp_artifact_cache_maintenance(
+    *,
+    records: Sequence[OacpPersistentArtifactCacheRecord],
+    now_iso: str,
+    grantex_available: bool,
+    action_intent: PersistentCacheActionIntent,
+    risk_tier: RiskTier,
+    max_batch_size: int | None = None,
+    scope_filter: OacpArtifactCacheRepositoryQuery | None = None,
+) -> dict[str, Any]:
+    selected_records = tuple(records[: max(0, max_batch_size)] if max_batch_size is not None else records)
+    now = _parse_iso(now_iso)
+    actions = tuple(
+        _c6x5_classify_record(
+            record=record,
+            now=now,
+            grantex_available=grantex_available,
+            action_intent=action_intent,
+            risk_tier=risk_tier,
+            scope_filter=scope_filter,
+        )
+        for record in selected_records
+    )
+    evidence_refs = sorted({ref for action in actions for ref in action["evidence_refs"]})
+    source_refs = sorted({ref for action in actions for ref in action["source_refs"]})
+    plan_payload = {
+        "generated_at": now_iso,
+        "action_intent": action_intent,
+        "risk_tier": risk_tier,
+        "grantex_available": grantex_available,
+        "records": [(action["cache_record_id"], action["maintenance_outcome"]) for action in actions],
+    }
+    digest = hashlib.sha256(canonicalize_oacp_payload(plan_payload).encode("utf-8")).hexdigest()
+    return {
+        "plan_id": f"oacp_c6x5_maintenance_plan_{digest[:20]}",
+        "generated_at": now_iso,
+        "action_intent": action_intent,
+        "risk_tier": risk_tier,
+        "grantex_available": grantex_available,
+        "records_seen": len(selected_records),
+        "records_kept": _c6x5_ids_for_outcomes(actions, {"keep_usable"}),
+        "records_to_refresh": _c6x5_ids_for_outcomes(
+            actions,
+            {"refresh_recommended", "refresh_required_before_commitment", "source_refresh_needed"},
+        ),
+        "records_to_evict": _c6x5_ids_for_outcomes(actions, {"evict_expired", "purge_revoked"}),
+        "records_to_quarantine": _c6x5_ids_for_outcomes(
+            actions,
+            {
+                "quarantine_ambiguous_revocation",
+                "quarantine_scope_mismatch",
+                "quarantine_private_or_raw_ref",
+                "blocked_unsafe",
+            },
+        ),
+        "records_requiring_human_review": _c6x5_ids_for_outcomes(actions, {"human_review_required"}),
+        "per_record_reason_codes": {
+            str(action["cache_record_id"]): list(action["reason_codes"]) for action in actions
+        },
+        "record_actions": list(actions),
+        "source_refs": source_refs,
+        "evidence_refs": evidence_refs,
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "maintenance_plan_only": True,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "grantex_runtime_required": False,
+        "buyer_safe_message": (
+            "C6X5 planned cache maintenance only. Non-binding cache use may continue only for valid local records."
+        ),
+        "seller_safe_message": (
+            "C6X5 does not refresh, evict, schedule, call Grantex, or call merchant or provider systems."
+        ),
+    }
 
 
 class OacpArtifactCache:

--- a/docs/reports/commerce-agent-c6x5-oacp-cache-maintenance.md
+++ b/docs/reports/commerce-agent-c6x5-oacp-cache-maintenance.md
@@ -1,0 +1,45 @@
+# Commerce Agent C6X5 OACP Cache Maintenance Planner
+
+## Scope
+
+C6X5 adds an internal AgenticOrg planner over durable OACP cache records. The planner classifies local cache records into refresh, eviction, quarantine, review, or keep outcomes. It is planner only: it does not refresh, evict, purge, schedule, call Grantex live, call providers, or call merchant systems.
+
+C6X5 does not call Grantex live. It consumes existing local durable cache records and returns maintenance recommendations only.
+
+C6X5 does not call providers. It also does not call merchant private APIs, carriers, shipping providers, or payment rails.
+
+## Correct Ownership Model
+
+AgenticOrg remains the buyer and seller AI-agent runtime and owns local and durable OACP artifact cache behavior. Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. Merchant systems remain operational sources of record. Provider and fintech rails own mandate and payment execution where separately approved.
+
+## Maintenance Planner Inputs
+
+Inputs are current time, Grantex availability, action intent, risk tier, optional max batch size, optional buyer-agent, seller-agent, tenant, merchant, or artifact filters, and C6X4 cache records. The planner preserves cache scopes for buyer agent, seller agent, tenant, and merchant records.
+
+## Maintenance Outcomes
+
+Planner outcomes are `keep_usable`, `refresh_recommended`, `refresh_required_before_commitment`, `evict_expired`, `purge_revoked`, `quarantine_ambiguous_revocation`, `quarantine_scope_mismatch`, `quarantine_private_or_raw_ref`, `source_refresh_needed`, `human_review_required`, and `blocked_unsafe`.
+
+## Plan Output
+
+The plan includes a deterministic local plan id, generated time, record counts, record ids grouped by maintenance action, per-record reason codes, public-safe source refs, public-safe evidence refs, `allowed_to_execute = false`, `non_authoritative_for_transaction = true`, and no checkout, live provider, or public discovery enablement flags.
+
+## Fail-Closed Rules
+
+The planner fails closed for missing identity, missing scope, mismatched scope, invalid timestamps, expired records, revoked records, ambiguous revocation snapshots, stale freshness, private or raw refs, executable flags, false non-enablement flags, critical risk, unsupported transaction authority, and stricter final-commitment freshness needs.
+
+## Migration And Scheduler Decision
+
+C6X5 adds no migration and no scheduler. It reuses C6X4 durable cache records and produces maintenance plans only. Any future durable maintenance log, cron job, queue, or background worker requires a separate approved slice.
+
+## Guardrails
+
+C6X5 stores nothing new and performs no side effects. It carries only public-safe source and evidence refs and excludes raw provider payloads, raw connector payloads, raw JWTs, credentials, tokens, private keys, bank or card data, private customer data, private merchant API values, secrets, production allowlists, or executable targets.
+
+## What C6X5 Does Not Enable
+
+C6X5 adds no public endpoint, public OpenAPI runtime contract, workflow, cron, scheduler, queue, background worker, cloud resource, production config, secret, public discovery enablement, checkout, payment, order, hold, refund, return, shipping execution, live provider rail enablement, merchant private API execution, external OACP publication, or approval claim.
+
+## Future Work
+
+Future slices may implement a separately approved internal maintenance runner, refresh intent queue, or eviction audit trail. Those must stay separate from checkout, payment, provider rail, merchant private API, and public OACP publication behavior unless separately approved.

--- a/tests/unit/test_oacp_c6x5_cache_maintenance.py
+++ b/tests/unit/test_oacp_c6x5_cache_maintenance.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from core.commerce.oacp_artifacts import (
+    OacpArtifactCacheRepositoryQuery,
+    OacpPersistentArtifactCacheRecord,
+    plan_oacp_artifact_cache_maintenance,
+)
+
+C6X5_DOC_PATH = Path("docs/reports/commerce-agent-c6x5-oacp-cache-maintenance.md")
+
+
+def _doc() -> str:
+    return C6X5_DOC_PATH.read_text(encoding="utf-8")
+
+
+def _record(**overrides: object) -> OacpPersistentArtifactCacheRecord:
+    base = OacpPersistentArtifactCacheRecord(
+        cache_record_id="cache_price_C6X5",
+        artifact_id="price_C6W3",
+        artifact_type="price",
+        authority="grantex_canonical_oacp_artifact_authority",
+        issuer="grantex",
+        scope_kind="buyer_agent",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+        source_refs=("source_ref_price_C6X5",),
+        evidence_refs=("evidence_price_C6X5_redacted",),
+        generated_at="2026-06-11T00:00:00.000Z",
+        cached_at="2026-06-11T00:00:10.000Z",
+        expires_at="2026-06-11T00:05:00.000Z",
+        freshness_status="fresh",
+        revocation_snapshot_status="fresh",
+        revocation_snapshot_observed_at="2026-06-11T00:00:30.000Z",
+        revocation_snapshot_age_seconds=30,
+        ttl_policy_seconds=300,
+        risk_tier="low",
+        blocked_capabilities=("checkout_payment_creation", "live_provider_call"),
+        unsupported_capabilities=("transaction_authority_from_adapter_preview",),
+        verifier_result_ref="verifier_result_price_C6X5",
+    )
+    return replace(base, **overrides)
+
+
+def test_c6x5_maintenance_plan_classifies_cache_records_without_execution() -> None:
+    records = (
+        _record(cache_record_id="cache_keep_C6X5"),
+        _record(cache_record_id="cache_refresh_C6X5", expires_at="2026-06-11T00:01:45.000Z"),
+        _record(cache_record_id="cache_expired_C6X5", expires_at="2026-06-11T00:00:59.000Z"),
+        _record(cache_record_id="cache_revoked_C6X5", revocation_snapshot_status="revoked"),
+        _record(cache_record_id="cache_ambiguous_C6X5", revocation_snapshot_status="unknown"),
+        _record(cache_record_id="cache_mismatch_C6X5", tenant_id="cten_other"),
+        _record(cache_record_id="cache_private_C6X5", evidence_refs=("raw_jwt_ref",)),
+        _record(cache_record_id="cache_source_C6X5", freshness_status="stale"),
+        _record(cache_record_id="cache_unsafe_C6X5", allowed_to_execute=True),
+    )
+
+    plan = plan_oacp_artifact_cache_maintenance(
+        records=records,
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=False,
+        action_intent="non_binding_preview",
+        risk_tier="low",
+        scope_filter=OacpArtifactCacheRepositoryQuery(tenant_id="cten_C6W3"),
+    )
+
+    assert plan["records_seen"] == len(records)
+    assert plan["records_kept"] == ["cache_keep_C6X5"]
+    assert set(plan["records_to_refresh"]) == {"cache_refresh_C6X5", "cache_source_C6X5"}
+    assert set(plan["records_to_evict"]) == {"cache_expired_C6X5", "cache_revoked_C6X5"}
+    assert set(plan["records_to_quarantine"]) == {
+        "cache_ambiguous_C6X5",
+        "cache_mismatch_C6X5",
+        "cache_private_C6X5",
+        "cache_unsafe_C6X5",
+    }
+    assert plan["records_requiring_human_review"] == []
+    assert plan["allowed_to_execute"] is False
+    assert plan["no_execution"] is True
+    assert plan["non_authoritative_for_transaction"] is True
+    assert plan["no_checkout_payment_enablement"] is True
+    assert plan["no_live_provider_enablement"] is True
+    assert plan["no_public_discovery_enablement"] is True
+
+    outcomes = {action["cache_record_id"]: action["maintenance_outcome"] for action in plan["record_actions"]}
+    assert outcomes["cache_keep_C6X5"] == "keep_usable"
+    assert outcomes["cache_refresh_C6X5"] == "refresh_recommended"
+    assert outcomes["cache_expired_C6X5"] == "evict_expired"
+    assert outcomes["cache_revoked_C6X5"] == "purge_revoked"
+    assert outcomes["cache_ambiguous_C6X5"] == "quarantine_ambiguous_revocation"
+    assert outcomes["cache_mismatch_C6X5"] == "quarantine_scope_mismatch"
+    assert outcomes["cache_private_C6X5"] == "quarantine_private_or_raw_ref"
+    assert outcomes["cache_source_C6X5"] == "source_refresh_needed"
+    assert outcomes["cache_unsafe_C6X5"] == "blocked_unsafe"
+    assert "raw_jwt_ref" not in plan["evidence_refs"]
+
+
+def test_c6x5_final_commitment_is_prepared_only_and_stricter() -> None:
+    records = (
+        _record(cache_record_id="cache_commitment_refresh_C6X5", risk_tier="low"),
+        _record(
+            cache_record_id="cache_human_review_C6X5",
+            artifact_id="protocol_adapter_C6X5",
+            artifact_type="protocol_adapter",
+            expires_at="2026-06-11T12:00:00.000Z",
+            ttl_policy_seconds=24 * 60 * 60,
+        ),
+    )
+
+    plan = plan_oacp_artifact_cache_maintenance(
+        records=records,
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+        action_intent="final_commitment",
+        risk_tier="medium",
+    )
+
+    assert plan["records_to_refresh"] == ["cache_commitment_refresh_C6X5"]
+    assert plan["records_requiring_human_review"] == ["cache_human_review_C6X5"]
+    assert plan["allowed_to_execute"] is False
+    assert plan["no_execution"] is True
+
+    reasons = plan["per_record_reason_codes"]
+    assert reasons["cache_commitment_refresh_C6X5"] == ["final_commitment_requires_fresh_source_posture"]
+    assert reasons["cache_human_review_C6X5"] == ["artifact_not_transaction_authority"]
+
+
+def test_c6x5_maintenance_plan_supports_batch_limits_and_source_safe_refs() -> None:
+    plan = plan_oacp_artifact_cache_maintenance(
+        records=(
+            _record(cache_record_id="cache_one_C6X5"),
+            _record(cache_record_id="cache_two_C6X5", evidence_refs=("evidence_two_C6X5_redacted",)),
+        ),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+        action_intent="prepare_only",
+        risk_tier="low",
+        max_batch_size=1,
+    )
+
+    assert plan["records_seen"] == 1
+    assert plan["records_kept"] == ["cache_one_C6X5"]
+    assert plan["evidence_refs"] == ["evidence_price_C6X5_redacted"]
+    assert plan["grantex_runtime_required"] is False
+
+
+def test_c6x5_docs_capture_planner_boundaries_and_no_scheduler() -> None:
+    doc = _doc()
+    for heading in (
+        "Scope",
+        "Correct Ownership Model",
+        "Maintenance Planner Inputs",
+        "Maintenance Outcomes",
+        "Plan Output",
+        "Fail-Closed Rules",
+        "Migration And Scheduler Decision",
+        "Guardrails",
+        "What C6X5 Does Not Enable",
+        "Future Work",
+    ):
+        assert f"## {heading}" in doc
+
+    assert "planner only" in doc
+    assert "no migration" in doc
+    assert "no scheduler" in doc
+    assert "allowed_to_execute = false" in doc
+    assert "does not call Grantex live" in doc
+    assert "does not call providers" in doc


### PR DESCRIPTION
## Summary
- Adds a pure internal C6X5 OACP cache maintenance planner over C6X4 durable cache records.
- Classifies cache records into keep, refresh, eviction, purge, quarantine, source refresh, human review, and unsafe outcomes.
- Adds focused tests and internal docs for fail-closed cache maintenance planning.

## Migration and scheduler decision
- No migration is added; C6X5 reuses C6X4 durable cache records.
- No scheduler, cron, queue, or background worker is added; this slice produces plans only.
- The planner does not refresh, evict, purge, call Grantex live, call providers, call merchant private APIs, or expose APIs.

## Validation
- `python -m pytest tests/unit/test_oacp_c6x2_artifact_cache.py tests/unit/test_oacp_c6x3_cache_repository.py tests/unit/test_oacp_c6x4_durable_cache_repository.py tests/unit/test_oacp_c6x5_cache_maintenance.py --no-cov`
- `python -m ruff check core/commerce/oacp_artifacts.py tests/unit/test_oacp_c6x5_cache_maintenance.py`
- `python -m mypy core/commerce/oacp_artifacts.py tests/unit/test_oacp_c6x5_cache_maintenance.py`
- `git diff --cached --check`

## Guardrails
- Internal-only, non-publication, non-certifying, non-production, non-executing.
- Non-binding cache continuation remains local when TTL and revocation posture are valid.
- Final commitment remains prepared-only or refused; `allowed_to_execute = false`.
- No public endpoints, OpenAPI runtime contracts, workflows, production config, scheduler, provider calls, merchant private API calls, checkout/payment/public discovery/live rail enablement, allowlists, or OACP publication.
