### PR TITLE
C6X6 OACP cache maintenance dry-run reports

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
@@ -181,6 +181,13 @@ OacpCacheMaintenanceOutcome = Literal[
     "source_refresh_needed",
     "human_review_required",
     "blocked_unsafe",
+]
+OacpCacheMaintenanceReportKind = Literal[
+    "cache_maintenance_dry_run_report",
+    "operator_review_packet",
+    "blocked_cache_action_report",
+    "stale_or_revoked_artifact_summary",
+    "source_refresh_request_preview",
 ]
 
 OACP_ARTIFACT_SIGNATURE_PROFILE: dict[str, Any] = {
@@ -4937,6 +4944,349 @@ def plan_oacp_artifact_cache_maintenance(
         "seller_safe_message": (
             "C6X5 does not refresh, evict, schedule, call Grantex, or call merchant or provider systems."
         ),
+    }
+
+
+_C6X6_REPORT_KINDS: frozenset[str] = frozenset(
+    {
+        "cache_maintenance_dry_run_report",
+        "operator_review_packet",
+        "blocked_cache_action_report",
+        "stale_or_revoked_artifact_summary",
+        "source_refresh_request_preview",
+    }
+)
+_C6X6_KNOWN_OUTCOMES: frozenset[str] = frozenset(
+    {
+        "keep_usable",
+        "refresh_recommended",
+        "refresh_required_before_commitment",
+        "evict_expired",
+        "purge_revoked",
+        "quarantine_ambiguous_revocation",
+        "quarantine_scope_mismatch",
+        "quarantine_private_or_raw_ref",
+        "source_refresh_needed",
+        "human_review_required",
+        "blocked_unsafe",
+    }
+)
+_C6X6_SAFE_FALLBACK_GENERATED_AT = "1970-01-01T00:00:00.000Z"
+
+
+def _c6x6_string(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _c6x6_string_list(value: Any) -> list[str]:
+    return [item for item in value if isinstance(item, str)] if isinstance(value, list) else []
+
+
+def _c6x6_report_id(payload: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(canonicalize_oacp_payload(dict(payload)).encode("utf-8")).hexdigest()
+    return f"oacp_c6x6_cache_report_{digest[:20]}"
+
+
+def _c6x6_count_by(actions: Sequence[Mapping[str, Any]], field_name: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for action in actions:
+        value = _c6x6_string(action.get(field_name))
+        if value is not None:
+            counts[value] = counts.get(value, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _c6x6_scope_summary(actions: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, int]]:
+    scope_fields = {
+        "buyer_agent": "buyer_agent_id",
+        "seller_agent": "seller_agent_id",
+        "tenant": "tenant_id",
+        "merchant": "merchant_id",
+    }
+    return {scope_name: _c6x6_count_by(actions, field_name) for scope_name, field_name in scope_fields.items()}
+
+
+def _c6x6_safe_reason_codes(value: Any) -> list[str]:
+    codes = _c6x6_string_list(value)
+    return [code for code in codes if all(char.isalnum() or char == "_" for char in code)]
+
+
+def _c6x6_plan_flags_safe(plan: Mapping[str, Any]) -> bool:
+    return (
+        plan.get("allowed_to_execute") is False
+        and plan.get("no_execution") is True
+        and plan.get("maintenance_plan_only") is True
+        and plan.get("non_authoritative_for_transaction") is True
+        and plan.get("no_checkout_payment_enablement") is True
+        and plan.get("no_live_provider_enablement") is True
+        and plan.get("no_public_discovery_enablement") is True
+    )
+
+
+def _c6x6_action_flags_safe(action: Mapping[str, Any]) -> bool:
+    return (
+        action.get("allowed_to_execute") is False
+        and action.get("maintenance_plan_only") is True
+        and action.get("non_authoritative_for_transaction") is True
+        and action.get("no_checkout_payment_enablement") is True
+        and action.get("no_live_provider_enablement") is True
+        and action.get("no_public_discovery_enablement") is True
+    )
+
+
+def _c6x6_refs_from_plan(plan: Mapping[str, Any], actions: Sequence[Mapping[str, Any]]) -> tuple[str, ...]:
+    refs: list[str] = []
+    refs.extend(_c6x6_string_list(plan.get("source_refs")))
+    refs.extend(_c6x6_string_list(plan.get("evidence_refs")))
+    for action in actions:
+        refs.extend(_c6x6_string_list(action.get("source_refs")))
+        refs.extend(_c6x6_string_list(action.get("evidence_refs")))
+        verifier_result_ref = _c6x6_string(action.get("verifier_result_ref"))
+        if verifier_result_ref is not None:
+            refs.append(verifier_result_ref)
+    return tuple(refs)
+
+
+def _c6x6_plan_refs_safe(plan: Mapping[str, Any], actions: Sequence[Mapping[str, Any]]) -> bool:
+    refs = _c6x6_refs_from_plan(plan, actions)
+    return not refs or _c6x2_refs_safe(refs)
+
+
+def _c6x6_actions_safe(actions: Sequence[Mapping[str, Any]]) -> bool:
+    for action in actions:
+        outcome = _c6x6_string(action.get("maintenance_outcome"))
+        if outcome not in _C6X6_KNOWN_OUTCOMES:
+            return False
+        if not _c6x6_string(action.get("cache_record_id")):
+            return False
+        if not _c6x6_action_flags_safe(action):
+            return False
+        if len(_c6x6_safe_reason_codes(action.get("reason_codes"))) != len(
+            _c6x6_string_list(action.get("reason_codes"))
+        ):
+            return False
+    return True
+
+
+def _c6x6_blocked_report(
+    *,
+    report_kind: str,
+    reason_code: str,
+    message: str,
+    maintenance_plan: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    generated_at = (
+        _c6x6_string(maintenance_plan.get("generated_at")) if maintenance_plan is not None else None
+    ) or _C6X6_SAFE_FALLBACK_GENERATED_AT
+    source_plan_id = _c6x6_string(maintenance_plan.get("plan_id")) if maintenance_plan is not None else None
+    payload = {
+        "report_kind": report_kind,
+        "reason_code": reason_code,
+        "source_plan_id": source_plan_id,
+        "generated_at": generated_at,
+    }
+    return {
+        "report_id": _c6x6_report_id(payload),
+        "report_kind": "blocked_cache_action_report",
+        "requested_report_kind": report_kind,
+        "source_plan_id": source_plan_id,
+        "generated_at": generated_at,
+        "status": "blocked",
+        "block_reason": reason_code,
+        "buyer_safe_message": message,
+        "operator_safe_message": message,
+        "scope_summary": {"buyer_agent": {}, "seller_agent": {}, "tenant": {}, "merchant": {}},
+        "artifact_family_counts": {},
+        "records_seen": 0,
+        "records_kept": [],
+        "records_to_refresh": [],
+        "records_to_evict": [],
+        "records_to_quarantine": [],
+        "records_requiring_human_review": [],
+        "per_record_reason_codes": {},
+        "source_refs": [],
+        "evidence_refs": [],
+        "freshness_summary": {},
+        "ttl_summary": {"records_with_ttl": 0, "minimum_remaining_ttl_seconds": None},
+        "revocation_snapshot_summary": {},
+        "risk_tier_summary": {},
+        "unsupported_capability_summary": {},
+        "blocked_capability_summary": {reason_code: 1},
+        "next_step_labels": ["operator_review_required_no_execution"],
+        "source_refresh_request_preview": {
+            "preview_only": True,
+            "next_system_step_label": "operator_review_required_no_api_call",
+            "records": [],
+        },
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "dry_run_report_only": True,
+        "operator_review_only": True,
+        "maintenance_report_only": True,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+    }
+
+
+def build_oacp_cache_maintenance_dry_run_report(
+    *,
+    maintenance_plan: Mapping[str, Any] | None,
+    report_kind: OacpCacheMaintenanceReportKind = "cache_maintenance_dry_run_report",
+) -> dict[str, Any]:
+    if report_kind not in _C6X6_REPORT_KINDS:
+        return _c6x6_blocked_report(
+            report_kind=str(report_kind),
+            reason_code="unsupported_report_kind",
+            message="C6X6 only prepares known internal maintenance dry-run reports.",
+            maintenance_plan=maintenance_plan,
+        )
+    if maintenance_plan is None:
+        return _c6x6_blocked_report(
+            report_kind=report_kind,
+            reason_code="maintenance_plan_missing",
+            message="C6X6 requires a C6X5 maintenance plan before preparing an operator report.",
+        )
+    try:
+        assert_no_forbidden_oacp_artifact_fields(maintenance_plan)
+    except ValueError:
+        return _c6x6_blocked_report(
+            report_kind=report_kind,
+            reason_code="private_or_enabling_plan_field",
+            message="C6X6 refuses maintenance plans with private, raw, or enabling fields.",
+            maintenance_plan=maintenance_plan,
+        )
+
+    source_plan_id = _c6x6_string(maintenance_plan.get("plan_id"))
+    generated_at = _c6x6_string(maintenance_plan.get("generated_at"))
+    raw_actions = maintenance_plan.get("record_actions")
+    if source_plan_id is None or generated_at is None or not isinstance(raw_actions, list):
+        return _c6x6_blocked_report(
+            report_kind=report_kind,
+            reason_code="maintenance_plan_malformed",
+            message="C6X6 requires plan id, generated time, and record actions.",
+            maintenance_plan=maintenance_plan,
+        )
+    actions: list[Mapping[str, Any]] = []
+    for action in raw_actions:
+        if not isinstance(action, Mapping):
+            return _c6x6_blocked_report(
+                report_kind=report_kind,
+                reason_code="maintenance_plan_malformed",
+                message="C6X6 requires each record action to be a structured map.",
+                maintenance_plan=maintenance_plan,
+            )
+        actions.append(action)
+    if not _c6x6_plan_flags_safe(maintenance_plan):
+        return _c6x6_blocked_report(
+            report_kind=report_kind,
+            reason_code="maintenance_plan_executable_or_enabling",
+            message="C6X6 refuses executable or enabling maintenance plans.",
+            maintenance_plan=maintenance_plan,
+        )
+    if not _c6x6_actions_safe(actions) or not _c6x6_plan_refs_safe(maintenance_plan, actions):
+        return _c6x6_blocked_report(
+            report_kind=report_kind,
+            reason_code="maintenance_plan_private_or_unsafe",
+            message="C6X6 refuses unsafe maintenance actions or private/raw refs.",
+            maintenance_plan=maintenance_plan,
+        )
+
+    records_to_refresh = _c6x6_string_list(maintenance_plan.get("records_to_refresh"))
+    records_to_evict = _c6x6_string_list(maintenance_plan.get("records_to_evict"))
+    records_to_quarantine = _c6x6_string_list(maintenance_plan.get("records_to_quarantine"))
+    records_requiring_human_review = _c6x6_string_list(maintenance_plan.get("records_requiring_human_review"))
+    next_step_labels = ["review_report_no_execution"]
+    if records_to_refresh:
+        next_step_labels.append("prepare_source_refresh_request_preview")
+    if records_to_evict:
+        next_step_labels.append("operator_review_evict_or_purge_label")
+    if records_to_quarantine:
+        next_step_labels.append("operator_review_quarantine_label")
+    if records_requiring_human_review:
+        next_step_labels.append("human_review_required_label")
+    if len(next_step_labels) == 1:
+        next_step_labels.append("no_action_for_valid_cache_records")
+
+    ttl_values = [
+        action["remaining_ttl_seconds"]
+        for action in actions
+        if type(action.get("remaining_ttl_seconds")) is int
+    ]
+    per_record_reason_codes = {
+        str(action["cache_record_id"]): _c6x6_safe_reason_codes(action.get("reason_codes")) for action in actions
+    }
+    source_refs = sorted(set(_c6x6_string_list(maintenance_plan.get("source_refs"))))
+    evidence_refs = sorted(set(_c6x6_string_list(maintenance_plan.get("evidence_refs"))))
+    unsupported_capabilities = [
+        capability for action in actions for capability in _c6x6_string_list(action.get("unsupported_capabilities"))
+    ]
+    blocked_capabilities = [
+        capability for action in actions for capability in _c6x6_string_list(action.get("blocked_capabilities"))
+    ]
+    report_payload = {
+        "report_kind": report_kind,
+        "source_plan_id": source_plan_id,
+        "generated_at": generated_at,
+        "records": [(action["cache_record_id"], action["maintenance_outcome"]) for action in actions],
+    }
+    return {
+        "report_id": _c6x6_report_id(report_payload),
+        "report_kind": report_kind,
+        "source_plan_id": source_plan_id,
+        "generated_at": generated_at,
+        "status": "prepared_for_operator_review",
+        "scope_summary": _c6x6_scope_summary(actions),
+        "artifact_family_counts": _c6x6_count_by(actions, "artifact_type"),
+        "records_seen": maintenance_plan.get("records_seen", len(actions)),
+        "records_kept": _c6x6_string_list(maintenance_plan.get("records_kept")),
+        "records_to_refresh": records_to_refresh,
+        "records_to_evict": records_to_evict,
+        "records_to_quarantine": records_to_quarantine,
+        "records_requiring_human_review": records_requiring_human_review,
+        "per_record_reason_codes": per_record_reason_codes,
+        "source_refs": source_refs,
+        "evidence_refs": evidence_refs,
+        "freshness_summary": _c6x6_count_by(actions, "freshness_status"),
+        "ttl_summary": {
+            "records_with_ttl": len(ttl_values),
+            "minimum_remaining_ttl_seconds": min(ttl_values) if ttl_values else None,
+        },
+        "revocation_snapshot_summary": _c6x6_count_by(actions, "revocation_snapshot_status"),
+        "risk_tier_summary": _c6x6_count_by(actions, "risk_tier"),
+        "unsupported_capability_summary": dict(
+            sorted((item, unsupported_capabilities.count(item)) for item in set(unsupported_capabilities))
+        ),
+        "blocked_capability_summary": dict(
+            sorted((item, blocked_capabilities.count(item)) for item in set(blocked_capabilities))
+        ),
+        "next_step_labels": next_step_labels,
+        "source_refresh_request_preview": {
+            "preview_only": True,
+            "next_system_step_label": "source_refresh_request_label_only_no_api_call",
+            "records": records_to_refresh,
+            "source_refs": source_refs,
+            "evidence_refs": evidence_refs,
+        },
+        "buyer_safe_message": "C6X6 prepared a cache maintenance dry-run report only; no cache action was executed.",
+        "seller_safe_message": (
+            "C6X6 produced label-only review output and did not call source, provider, or merchant systems."
+        ),
+        "operator_safe_message": (
+            "Review the report labels and redacted refs before any separately approved maintenance action."
+        ),
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "dry_run_report_only": True,
+        "operator_review_only": True,
+        "maintenance_report_only": True,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "raw_payloads_included": False,
+        "grantex_runtime_required": False,
     }
 
 

--- a/docs/reports/commerce-agent-c6x6-oacp-cache-maintenance-reports.md
+++ b/docs/reports/commerce-agent-c6x6-oacp-cache-maintenance-reports.md
@@ -1,0 +1,53 @@
+# Commerce Agent C6X6 OACP Cache Maintenance Reports
+
+## Scope
+
+C6X6 adds internal dry-run report and operator-review packet generation over C6X5 OACP cache maintenance plans. It is dry-run report only: it does not refresh, evict, purge, quarantine, schedule, and does not call Grantex live, providers, merchant systems, or connector systems.
+
+C6X6 consumes an existing local C6X5 maintenance plan and returns deterministic review artifacts only.
+
+C6X6 does not call providers. It also does not call Grantex live, merchant private APIs, carriers, shipping providers, or payment rails.
+
+## Correct Ownership Model
+
+AgenticOrg remains the buyer and seller AI-agent runtime and owns local and durable OACP artifact cache behavior. Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. Merchant systems remain operational sources of record. Provider and fintech rails own mandate and payment execution where separately approved.
+
+## Report Kinds
+
+C6X6 report kinds are `cache_maintenance_dry_run_report`, `operator_review_packet`, `blocked_cache_action_report`, `stale_or_revoked_artifact_summary`, and `source_refresh_request_preview`.
+
+Each report keeps `allowed_to_execute = false`, `non_authoritative_for_transaction = true`, `no_checkout_payment_enablement = true`, `no_live_provider_enablement = true`, and `no_public_discovery_enablement = true`.
+
+## Report Output
+
+Reports include report id, generated time, source plan id, scope summary by buyer agent, seller agent, tenant, and merchant, artifact family counts, records seen, records kept, records to refresh, records to evict, records to quarantine, records requiring human review, per-record redacted reason codes, redacted source refs, redacted evidence refs, freshness summary, TTL summary, revocation snapshot summary, risk-tier summary, unsupported capability summary, blocked capability summary, and next-step labels.
+
+Reports never include raw artifact payloads, provider payloads, connector payloads, JWTs, credentials, private customer data, payment data, bank or card data, raw merchant private API values, or secrets.
+
+## Operator Review Packet
+
+The operator review packet is label-only. It can identify records and reason codes that an operator should inspect, but it does not provide an executable endpoint, executable target, API payload, scheduled job, queue message, or external system call.
+
+Final commitment and high-risk cache records remain prepared-only or review-only. The report may explain that a record needs refresh, eviction, quarantine, or human review, but it does not perform that action.
+
+## Fail-Closed Rules
+
+C6X6 returns a blocked cache action report when the C6X5 plan is missing, malformed, executable, unsafe, contains private or raw values, has false non-enablement flags, contains unknown maintenance outcomes, or attempts to publish, approve, or claim launch status.
+
+Unsafe plans remain non-authoritative for transactions and cannot become checkout, payment, provider, merchant private API, public discovery, shipping, refund, return, hold, order, or live rail behavior.
+
+## Migration And Scheduler Decision
+
+C6X6 adds no migration and no scheduler. It stores no report records, creates no cron job, creates no queue, and adds no background worker. Any future durable report log or scheduled maintenance runner requires a separate approved slice.
+
+## Guardrails
+
+C6X6 carries only public-safe source and evidence refs. It excludes raw provider payloads, raw connector payloads, raw JWTs, credentials, tokens, private keys, bank or card data, private customer data, private merchant API values, secrets, production allowlists, executable URLs, checkout/payment enablement, live provider rail enablement, public discovery enablement, external OACP publication, and approval claims.
+
+## What C6X6 Does Not Enable
+
+C6X6 adds no public endpoint, public OpenAPI runtime contract, workflow, cron, scheduler, queue, background worker, cloud resource, production config, secret, public discovery enablement, checkout, payment, order, hold, refund, return, shipping execution, live provider rail enablement, merchant private API execution, external OACP publication, or approval claim.
+
+## Future Work
+
+Future slices may add a separately approved internal report archive, operator workflow, or maintenance runner. Those must stay separate from checkout, payment, provider rail, merchant private API, and public OACP publication behavior unless separately approved.

--- a/tests/unit/test_oacp_c6x6_cache_maintenance_reports.py
+++ b/tests/unit/test_oacp_c6x6_cache_maintenance_reports.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from core.commerce.oacp_artifacts import (
+    OacpArtifactCacheRepositoryQuery,
+    OacpPersistentArtifactCacheRecord,
+    build_oacp_cache_maintenance_dry_run_report,
+    plan_oacp_artifact_cache_maintenance,
+)
+
+C6X6_DOC_PATH = Path("docs/reports/commerce-agent-c6x6-oacp-cache-maintenance-reports.md")
+
+
+def _doc() -> str:
+    return C6X6_DOC_PATH.read_text(encoding="utf-8")
+
+
+def _record(**overrides: object) -> OacpPersistentArtifactCacheRecord:
+    base = OacpPersistentArtifactCacheRecord(
+        cache_record_id="cache_price_C6X6",
+        artifact_id="price_C6W3",
+        artifact_type="price",
+        authority="grantex_canonical_oacp_artifact_authority",
+        issuer="grantex",
+        scope_kind="buyer_agent",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+        source_refs=("source_ref_price_C6X6",),
+        evidence_refs=("evidence_price_C6X6_redacted",),
+        generated_at="2026-06-11T00:00:00.000Z",
+        cached_at="2026-06-11T00:00:10.000Z",
+        expires_at="2026-06-11T00:05:00.000Z",
+        freshness_status="fresh",
+        revocation_snapshot_status="fresh",
+        revocation_snapshot_observed_at="2026-06-11T00:00:30.000Z",
+        revocation_snapshot_age_seconds=30,
+        ttl_policy_seconds=300,
+        risk_tier="low",
+        blocked_capabilities=("checkout_payment_creation", "live_provider_call"),
+        unsupported_capabilities=("transaction_authority_from_adapter_preview",),
+        verifier_result_ref="verifier_result_price_C6X6",
+    )
+    return replace(base, **overrides)
+
+
+def _plan() -> dict[str, object]:
+    return plan_oacp_artifact_cache_maintenance(
+        records=(
+            _record(cache_record_id="cache_keep_C6X6"),
+            _record(cache_record_id="cache_refresh_C6X6", expires_at="2026-06-11T00:01:45.000Z"),
+            _record(cache_record_id="cache_expired_C6X6", expires_at="2026-06-11T00:00:59.000Z"),
+            _record(cache_record_id="cache_revoked_C6X6", revocation_snapshot_status="revoked"),
+            _record(cache_record_id="cache_review_C6X6", artifact_type="protocol_adapter"),
+        ),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+        action_intent="final_commitment",
+        risk_tier="medium",
+        scope_filter=OacpArtifactCacheRepositoryQuery(tenant_id="cten_C6W3"),
+    )
+
+
+def test_c6x6_dry_run_report_summarizes_maintenance_plan_without_execution() -> None:
+    report = build_oacp_cache_maintenance_dry_run_report(maintenance_plan=_plan())
+
+    assert report["report_kind"] == "cache_maintenance_dry_run_report"
+    assert report["source_plan_id"]
+    assert report["status"] == "prepared_for_operator_review"
+    assert report["records_seen"] == 5
+    assert report["records_to_refresh"] == ["cache_keep_C6X6", "cache_refresh_C6X6"]
+    assert set(report["records_to_evict"]) == {"cache_expired_C6X6", "cache_revoked_C6X6"}
+    assert report["records_requiring_human_review"] == ["cache_review_C6X6"]
+    assert report["scope_summary"]["buyer_agent"] == {"buyer_C6W3": 5}
+    assert report["artifact_family_counts"] == {"price": 4, "protocol_adapter": 1}
+    assert report["freshness_summary"] == {"fresh": 5}
+    assert report["revocation_snapshot_summary"] == {"fresh": 4, "revoked": 1}
+    assert report["risk_tier_summary"] == {"low": 5}
+    assert report["ttl_summary"]["records_with_ttl"] == 5
+    assert report["allowed_to_execute"] is False
+    assert report["no_execution"] is True
+    assert report["dry_run_report_only"] is True
+    assert report["operator_review_only"] is True
+    assert report["non_authoritative_for_transaction"] is True
+    assert report["no_checkout_payment_enablement"] is True
+    assert report["no_live_provider_enablement"] is True
+    assert report["no_public_discovery_enablement"] is True
+    assert report["raw_payloads_included"] is False
+
+
+def test_c6x6_source_refresh_preview_is_label_only_and_redacted() -> None:
+    report = build_oacp_cache_maintenance_dry_run_report(
+        maintenance_plan=_plan(),
+        report_kind="source_refresh_request_preview",
+    )
+
+    preview = report["source_refresh_request_preview"]
+    assert report["report_kind"] == "source_refresh_request_preview"
+    assert preview["preview_only"] is True
+    assert preview["next_system_step_label"] == "source_refresh_request_label_only_no_api_call"
+    assert preview["records"] == ["cache_keep_C6X6", "cache_refresh_C6X6"]
+    assert "evidence_price_C6X6_redacted" in preview["evidence_refs"]
+    assert "http" not in preview["next_system_step_label"]
+    assert "raw_jwt" not in str(report)
+    assert "password" not in str(report)
+
+
+def test_c6x6_blocks_missing_executable_or_private_plan_inputs() -> None:
+    missing_report = build_oacp_cache_maintenance_dry_run_report(maintenance_plan=None)
+    assert missing_report["report_kind"] == "blocked_cache_action_report"
+    assert missing_report["block_reason"] == "maintenance_plan_missing"
+    assert missing_report["allowed_to_execute"] is False
+
+    executable_plan = dict(_plan())
+    executable_plan["allowed_to_execute"] = True
+    executable_report = build_oacp_cache_maintenance_dry_run_report(maintenance_plan=executable_plan)
+    assert executable_report["block_reason"] == "maintenance_plan_executable_or_enabling"
+    assert executable_report["no_execution"] is True
+
+    private_plan = dict(_plan())
+    private_plan["raw_jwt"] = "raw_jwt_value"
+    private_report = build_oacp_cache_maintenance_dry_run_report(maintenance_plan=private_plan)
+    assert private_report["block_reason"] == "private_or_enabling_plan_field"
+    assert private_report["non_authoritative_for_transaction"] is True
+
+
+def test_c6x6_docs_capture_report_boundaries_and_no_scheduler() -> None:
+    doc = _doc()
+    for heading in (
+        "Scope",
+        "Correct Ownership Model",
+        "Report Kinds",
+        "Report Output",
+        "Operator Review Packet",
+        "Fail-Closed Rules",
+        "Migration And Scheduler Decision",
+        "Guardrails",
+        "What C6X6 Does Not Enable",
+        "Future Work",
+    ):
+        assert f"## {heading}" in doc
+
+    assert "dry-run report only" in doc
+    assert "allowed_to_execute = false" in doc
+    assert "label-only" in doc
+    assert "no scheduler" in doc
+    assert "does not call Grantex live" in doc
+    assert "does not call providers" in doc


### PR DESCRIPTION
## Summary
- Adds internal C6X6 cache maintenance dry-run report and operator review packet generation over C6X5 plans.
- Produces cache_maintenance_dry_run_report, operator_review_packet, blocked_cache_action_report, stale_or_revoked_artifact_summary, and source_refresh_request_preview outputs.
- Keeps reports label-only, redacted, non-executing, non-authoritative for transactions, migration-free, and scheduler-free.

## Validation
- python -m pytest tests/unit/test_oacp_c6x3_cache_repository.py tests/unit/test_oacp_c6x4_durable_cache_repository.py tests/unit/test_oacp_c6x5_cache_maintenance.py tests/unit/test_oacp_c6x6_cache_maintenance_reports.py --no-cov
- python -m ruff check core/commerce/oacp_artifacts.py tests/unit/test_oacp_c6x6_cache_maintenance_reports.py
- python -m mypy core/commerce/oacp_artifacts.py tests/unit/test_oacp_c6x6_cache_maintenance_reports.py
- git diff --check origin/main...HEAD

## Guardrails
- No public endpoints, migrations, workflows, schedulers, cron, queues, background workers, config, secrets, external calls, provider calls, merchant private API calls, checkout/payment/order/hold/refund/return/shipping execution, public discovery enablement, live rails, or OACP publication.