### PR TITLE
C6X7 OACP operator decision records

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -189,6 +189,16 @@ OacpCacheMaintenanceReportKind = Literal[
     "stale_or_revoked_artifact_summary",
     "source_refresh_request_preview",
 ]
+OacpCacheOperatorDecisionKind = Literal[
+    "approve_future_refresh_request",
+    "approve_future_eviction_request",
+    "approve_future_quarantine_request",
+    "request_more_evidence",
+    "reject_maintenance_action",
+    "defer_until_freshness_update",
+    "escalate_to_human_support",
+    "block_unsafe_action",
+]
 
 OACP_ARTIFACT_SIGNATURE_PROFILE: dict[str, Any] = {
     "payload_format": "canonical_json",
@@ -5281,6 +5291,311 @@ def build_oacp_cache_maintenance_dry_run_report(
         "dry_run_report_only": True,
         "operator_review_only": True,
         "maintenance_report_only": True,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "raw_payloads_included": False,
+        "grantex_runtime_required": False,
+    }
+
+
+_C6X7_DECISION_KINDS: frozenset[str] = frozenset(
+    {
+        "approve_future_refresh_request",
+        "approve_future_eviction_request",
+        "approve_future_quarantine_request",
+        "request_more_evidence",
+        "reject_maintenance_action",
+        "defer_until_freshness_update",
+        "escalate_to_human_support",
+        "block_unsafe_action",
+    }
+)
+_C6X7_DECISION_NEXT_STEP_LABELS: dict[str, str] = {
+    "approve_future_refresh_request": "future_refresh_request_label_only_no_api_call",
+    "approve_future_eviction_request": "future_eviction_request_label_only_no_api_call",
+    "approve_future_quarantine_request": "future_quarantine_request_label_only_no_api_call",
+    "request_more_evidence": "request_more_redacted_evidence_no_api_call",
+    "reject_maintenance_action": "reject_maintenance_action_no_execution",
+    "defer_until_freshness_update": "defer_until_freshness_update_no_execution",
+    "escalate_to_human_support": "human_support_review_label_only_no_api_call",
+    "block_unsafe_action": "block_unsafe_action_no_execution",
+}
+_C6X7_SAFE_FALLBACK_DECIDED_AT = "1970-01-01T00:00:00.000Z"
+_C6X7_OPAQUE_REVIEWER_PREFIXES = ("operator_ref_", "reviewer_ref_")
+_C6X7_REVIEWER_PRIVATE_MARKERS = (
+    "@",
+    "mailto:",
+    "tel:",
+    "phone",
+    "email",
+    "token",
+    "jwt",
+    "secret",
+    "password",
+    "credential",
+    "private",
+    "raw",
+)
+
+
+def _c6x7_string(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _c6x7_string_list(value: Any) -> list[str]:
+    return [item for item in value if isinstance(item, str)] if isinstance(value, list) else []
+
+
+def _c6x7_decision_record_id(payload: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(canonicalize_oacp_payload(dict(payload)).encode("utf-8")).hexdigest()
+    return f"oacp_c6x7_operator_decision_{digest[:20]}"
+
+
+def _c6x7_packet_flags_safe(packet: Mapping[str, Any]) -> bool:
+    return (
+        packet.get("allowed_to_execute") is False
+        and packet.get("no_execution") is True
+        and packet.get("maintenance_report_only") is True
+        and packet.get("operator_review_only") is True
+        and packet.get("non_authoritative_for_transaction") is True
+        and packet.get("no_checkout_payment_enablement") is True
+        and packet.get("no_live_provider_enablement") is True
+        and packet.get("no_public_discovery_enablement") is True
+    )
+
+
+def _c6x7_refs_safe(packet: Mapping[str, Any]) -> bool:
+    refs: list[str] = []
+    refs.extend(_c6x7_string_list(packet.get("source_refs")))
+    refs.extend(_c6x7_string_list(packet.get("evidence_refs")))
+    source_refresh_preview = packet.get("source_refresh_request_preview")
+    if isinstance(source_refresh_preview, Mapping):
+        refs.extend(_c6x7_string_list(source_refresh_preview.get("source_refs")))
+        refs.extend(_c6x7_string_list(source_refresh_preview.get("evidence_refs")))
+    return bool(refs) and _c6x2_refs_safe(tuple(refs))
+
+
+def _c6x7_reviewer_ref_safe(reviewer_identity_ref: str | None) -> bool:
+    if reviewer_identity_ref is None:
+        return False
+    normalized = reviewer_identity_ref.strip().lower()
+    if not normalized.startswith(_C6X7_OPAQUE_REVIEWER_PREFIXES):
+        return False
+    if any(marker in normalized for marker in _C6X7_REVIEWER_PRIVATE_MARKERS):
+        return False
+    return _c6x2_refs_safe((reviewer_identity_ref,))
+
+
+def _c6x7_packet_malformed(packet: Mapping[str, Any]) -> bool:
+    return (
+        _c6x7_string(packet.get("report_id")) is None
+        or _c6x7_string(packet.get("source_plan_id")) is None
+        or _c6x7_string(packet.get("generated_at")) is None
+        or not isinstance(packet.get("scope_summary"), Mapping)
+        or not isinstance(packet.get("artifact_family_counts"), Mapping)
+        or not isinstance(packet.get("per_record_reason_codes"), Mapping)
+    )
+
+
+def _c6x7_risky_state_requires_future_label(
+    packet: Mapping[str, Any],
+    decision_kind: str,
+    next_step_label: str,
+) -> bool:
+    if not decision_kind.startswith("approve_future_"):
+        return True
+    revocation_summary = packet.get("revocation_snapshot_summary")
+    risk_summary = packet.get("risk_tier_summary")
+    risky = False
+    if isinstance(revocation_summary, Mapping):
+        risky = any(key in revocation_summary for key in ("revoked", "ambiguous", "stale", "expired"))
+    if isinstance(risk_summary, Mapping):
+        risky = risky or any(key in risk_summary for key in ("high", "critical"))
+    if not risky:
+        return True
+    return "future" in next_step_label or "review" in next_step_label
+
+
+def _c6x7_blocked_decision_record(
+    *,
+    requested_decision_kind: str,
+    reason_code: str,
+    message: str,
+    review_packet: Mapping[str, Any] | None = None,
+    decided_at: str | None = None,
+) -> dict[str, Any]:
+    decision_time = (
+        decided_at
+        or (_c6x7_string(review_packet.get("generated_at")) if review_packet is not None else None)
+        or _C6X7_SAFE_FALLBACK_DECIDED_AT
+    )
+    review_packet_id = _c6x7_string(review_packet.get("report_id")) if review_packet is not None else None
+    maintenance_plan_id = _c6x7_string(review_packet.get("source_plan_id")) if review_packet is not None else None
+    payload = {
+        "decision_kind": "block_unsafe_action",
+        "requested_decision_kind": requested_decision_kind,
+        "review_packet_id": review_packet_id,
+        "maintenance_plan_id": maintenance_plan_id,
+        "decided_at": decision_time,
+        "reason_code": reason_code,
+    }
+    return {
+        "decision_record_id": _c6x7_decision_record_id(payload),
+        "decision_kind": "block_unsafe_action",
+        "requested_decision_kind": requested_decision_kind,
+        "review_packet_id": review_packet_id,
+        "maintenance_plan_id": maintenance_plan_id,
+        "generated_at": decision_time,
+        "decided_at": decision_time,
+        "status": "blocked",
+        "block_reason": reason_code,
+        "scope_summary": {"buyer_agent": {}, "seller_agent": {}, "tenant": {}, "merchant": {}},
+        "artifact_families_affected": [],
+        "artifact_family_counts": {},
+        "redacted_reason_codes": {},
+        "source_refs": [],
+        "evidence_refs": [],
+        "reviewer_identity_ref": None,
+        "next_step_labels": ["block_unsafe_action_no_execution"],
+        "buyer_safe_message": message,
+        "seller_safe_message": message,
+        "operator_safe_message": message,
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "operator_decision_only": True,
+        "audit_safe_decision_record": True,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "raw_payloads_included": False,
+        "grantex_runtime_required": False,
+    }
+
+
+def build_oacp_cache_operator_decision_record(
+    *,
+    review_packet: Mapping[str, Any] | None,
+    decision_kind: OacpCacheOperatorDecisionKind | str,
+    reviewer_identity_ref: str | None,
+    decided_at: str | None = None,
+) -> dict[str, Any]:
+    if decision_kind not in _C6X7_DECISION_KINDS:
+        return _c6x7_blocked_decision_record(
+            requested_decision_kind=str(decision_kind),
+            reason_code="unsupported_or_executable_decision_kind",
+            message="C6X7 only records known future-only operator decisions.",
+            review_packet=review_packet,
+            decided_at=decided_at,
+        )
+    if review_packet is None:
+        return _c6x7_blocked_decision_record(
+            requested_decision_kind=decision_kind,
+            reason_code="review_packet_missing",
+            message="C6X7 requires a C6X6 operator review packet before recording a decision.",
+            decided_at=decided_at,
+        )
+    try:
+        assert_no_forbidden_oacp_artifact_fields(review_packet)
+    except ValueError:
+        return _c6x7_blocked_decision_record(
+            requested_decision_kind=decision_kind,
+            reason_code="private_or_enabling_review_packet_field",
+            message="C6X7 refuses review packets with private, raw, or enabling fields.",
+            review_packet=review_packet,
+            decided_at=decided_at,
+        )
+    if review_packet.get("report_kind") != "operator_review_packet":
+        return _c6x7_blocked_decision_record(
+            requested_decision_kind=decision_kind,
+            reason_code="review_packet_kind_mismatch",
+            message="C6X7 consumes C6X6 operator review packets only.",
+            review_packet=review_packet,
+            decided_at=decided_at,
+        )
+    if _c6x7_packet_malformed(review_packet):
+        return _c6x7_blocked_decision_record(
+            requested_decision_kind=decision_kind,
+            reason_code="review_packet_malformed",
+            message="C6X7 requires report id, maintenance plan id, scope, family, and reason summaries.",
+            review_packet=review_packet,
+            decided_at=decided_at,
+        )
+    if not _c6x7_packet_flags_safe(review_packet):
+        return _c6x7_blocked_decision_record(
+            requested_decision_kind=decision_kind,
+            reason_code="review_packet_executable_or_enabling",
+            message="C6X7 refuses executable or enabling operator review packets.",
+            review_packet=review_packet,
+            decided_at=decided_at,
+        )
+    if not _c6x7_refs_safe(review_packet):
+        return _c6x7_blocked_decision_record(
+            requested_decision_kind=decision_kind,
+            reason_code="review_packet_private_or_missing_refs",
+            message="C6X7 requires redacted source and evidence refs only.",
+            review_packet=review_packet,
+            decided_at=decided_at,
+        )
+    if not _c6x7_reviewer_ref_safe(reviewer_identity_ref):
+        return _c6x7_blocked_decision_record(
+            requested_decision_kind=decision_kind,
+            reason_code="reviewer_identity_not_opaque",
+            message="C6X7 requires an opaque reviewer reference, not raw contact or credential data.",
+            review_packet=review_packet,
+            decided_at=decided_at,
+        )
+
+    next_step_label = _C6X7_DECISION_NEXT_STEP_LABELS[decision_kind]
+    if not _c6x7_risky_state_requires_future_label(review_packet, decision_kind, next_step_label):
+        return _c6x7_blocked_decision_record(
+            requested_decision_kind=decision_kind,
+            reason_code="risky_state_without_future_or_review_label",
+            message="C6X7 refuses risky decisions without future-only or review-only labels.",
+            review_packet=review_packet,
+            decided_at=decided_at,
+        )
+
+    review_packet_id = cast(str, review_packet["report_id"])
+    maintenance_plan_id = cast(str, review_packet["source_plan_id"])
+    decision_time = decided_at or cast(str, review_packet["generated_at"])
+    artifact_family_counts = dict(cast(Mapping[str, Any], review_packet["artifact_family_counts"]))
+    payload = {
+        "decision_kind": decision_kind,
+        "review_packet_id": review_packet_id,
+        "maintenance_plan_id": maintenance_plan_id,
+        "reviewer_identity_ref": reviewer_identity_ref,
+        "decided_at": decision_time,
+    }
+    return {
+        "decision_record_id": _c6x7_decision_record_id(payload),
+        "decision_kind": decision_kind,
+        "review_packet_id": review_packet_id,
+        "maintenance_plan_id": maintenance_plan_id,
+        "generated_at": decision_time,
+        "decided_at": decision_time,
+        "status": "recorded_for_future_review",
+        "scope_summary": dict(cast(Mapping[str, Any], review_packet["scope_summary"])),
+        "artifact_families_affected": sorted(str(key) for key in artifact_family_counts),
+        "artifact_family_counts": artifact_family_counts,
+        "redacted_reason_codes": dict(cast(Mapping[str, Any], review_packet["per_record_reason_codes"])),
+        "source_refs": sorted(set(_c6x7_string_list(review_packet.get("source_refs")))),
+        "evidence_refs": sorted(set(_c6x7_string_list(review_packet.get("evidence_refs")))),
+        "reviewer_identity_ref": reviewer_identity_ref,
+        "next_step_labels": [next_step_label],
+        "buyer_safe_message": (
+            "C6X7 recorded an operator cache-maintenance decision only; no cache action was executed."
+        ),
+        "seller_safe_message": (
+            "C6X7 does not refresh, evict, quarantine, schedule, call Grantex, or call merchant or provider systems."
+        ),
+        "operator_safe_message": "Decision recorded as label-only future intent. Execute nothing in C6X7.",
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "operator_decision_only": True,
+        "audit_safe_decision_record": True,
         "non_authoritative_for_transaction": True,
         "no_checkout_payment_enablement": True,
         "no_live_provider_enablement": True,

--- a/docs/reports/commerce-agent-c6x7-oacp-operator-decisions.md
+++ b/docs/reports/commerce-agent-c6x7-oacp-operator-decisions.md
@@ -1,0 +1,49 @@
+# Commerce Agent C6X7 OACP Operator Decisions
+
+## Scope
+
+C6X7 adds internal operator decision intake over C6X6 OACP cache maintenance review packets. It produces an operator decision record only. It does not refresh artifacts, evict cache records, quarantine records, schedule maintenance, and does not call Grantex live, providers, merchant systems, connector systems, or expose an API.
+
+C6X7 consumes an existing local C6X6 `operator_review_packet` and records label-only future intent. It is not a maintenance runner and it is not a durable audit log.
+
+## Correct Ownership Model
+
+AgenticOrg remains the buyer and seller AI-agent runtime and owns local and durable OACP artifact cache behavior. Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. Merchant systems remain operational sources of record. Provider and fintech rails own mandate and payment execution where separately approved.
+
+Grantex is not required in every non-binding buyer or seller agent turn. Valid cached OACP artifacts and local review packets can support non-binding and prepare-only flows without turning Grantex into a transaction toll booth.
+
+## Decision Kinds
+
+C6X7 decision kinds are `approve_future_refresh_request`, `approve_future_eviction_request`, `approve_future_quarantine_request`, `request_more_evidence`, `reject_maintenance_action`, `defer_until_freshness_update`, `escalate_to_human_support`, and `block_unsafe_action`.
+
+The `approve_future_*` decisions are future-only labels. They are not merchant approval, payment approval, checkout approval, mandate approval, production approval, or permission to execute cache maintenance in C6X7.
+
+## Decision Record Output
+
+Decision records include decision id, review packet id, maintenance plan id, generated and decided timestamps, decision kind, scope summary by buyer agent, seller agent, tenant, and merchant, artifact families and types affected, redacted reason codes, redacted source refs, redacted evidence refs, opaque reviewer reference, next-step labels, buyer-safe message, seller-safe message, and operator-safe message.
+
+Every decision record keeps `allowed_to_execute = false`, `non_authoritative_for_transaction = true`, `no_checkout_payment_enablement = true`, `no_live_provider_enablement = true`, and `no_public_discovery_enablement = true`.
+
+Reviewer identity is represented only by an opaque reviewer reference. Raw contact details, credentials, tokens, private payloads, and customer identifiers are not allowed.
+
+## Fail-Closed Rules
+
+C6X7 returns a blocked decision record when the review packet is missing, malformed, not an `operator_review_packet`, executable, unsafe, missing non-enablement flags, missing redacted refs, contains private or raw values, includes a non-opaque reviewer reference, requests an unsupported or immediate action, or attempts publication or launch claims.
+
+Stale, revoked, ambiguous, or high-risk records may only receive future-only or review-only labels. C6X7 does not convert a stale, revoked, or high-risk packet into executable maintenance behavior.
+
+## Migration Scheduler And Persistence Decision
+
+C6X7 adds no migration and no scheduler. It stores no decision records, creates no cron job, creates no queue, and adds no background worker. Durable decision persistence or maintenance execution requires a later separately approved slice.
+
+## Guardrails
+
+C6X7 carries only public-safe source and evidence refs. It excludes raw artifact payloads, raw provider payloads, raw connector payloads, raw JWTs, credentials, tokens, private keys, bank or card data, private customer data, private merchant API values, secrets, production allowlists, executable URLs, checkout/payment enablement, live provider rail enablement, public discovery enablement, external OACP publication, certification, conformance, standardization, and readiness claims.
+
+## What C6X7 Does Not Enable
+
+C6X7 adds no public endpoint, public OpenAPI runtime contract, workflow, cron, scheduler, queue, background worker, cloud resource, production config, secret, public discovery enablement, checkout, payment, order, hold, refund, return, shipping execution, live provider rail enablement, merchant private API execution, external OACP publication, approval claim, certification claim, conformance claim, standardization claim, or production-readiness claim.
+
+## Future Work
+
+Future slices may add a separately approved durable decision log, operator workflow, or maintenance runner. Those must stay separate from checkout, payment, provider rail, merchant private API, public OACP publication, and production enablement unless separately approved.

--- a/tests/unit/test_oacp_c6x7_operator_decisions.py
+++ b/tests/unit/test_oacp_c6x7_operator_decisions.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from core.commerce.oacp_artifacts import (
+    OacpArtifactCacheRepositoryQuery,
+    OacpPersistentArtifactCacheRecord,
+    build_oacp_cache_maintenance_dry_run_report,
+    build_oacp_cache_operator_decision_record,
+    plan_oacp_artifact_cache_maintenance,
+)
+
+C6X7_DOC_PATH = Path("docs/reports/commerce-agent-c6x7-oacp-operator-decisions.md")
+
+
+def _doc() -> str:
+    return C6X7_DOC_PATH.read_text(encoding="utf-8")
+
+
+def _record(**overrides: object) -> OacpPersistentArtifactCacheRecord:
+    base = OacpPersistentArtifactCacheRecord(
+        cache_record_id="cache_price_C6X7",
+        artifact_id="price_C6W3",
+        artifact_type="price",
+        authority="grantex_canonical_oacp_artifact_authority",
+        issuer="grantex",
+        scope_kind="buyer_agent",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+        source_refs=("source_ref_price_C6X7",),
+        evidence_refs=("evidence_price_C6X7_redacted",),
+        generated_at="2026-06-11T00:00:00.000Z",
+        cached_at="2026-06-11T00:00:10.000Z",
+        expires_at="2026-06-11T00:05:00.000Z",
+        freshness_status="fresh",
+        revocation_snapshot_status="fresh",
+        revocation_snapshot_observed_at="2026-06-11T00:00:30.000Z",
+        revocation_snapshot_age_seconds=30,
+        ttl_policy_seconds=300,
+        risk_tier="low",
+        blocked_capabilities=("checkout_payment_creation", "live_provider_call"),
+        unsupported_capabilities=("transaction_authority_from_adapter_preview",),
+        verifier_result_ref="verifier_result_price_C6X7",
+    )
+    return replace(base, **overrides)
+
+
+def _review_packet() -> dict[str, object]:
+    plan = plan_oacp_artifact_cache_maintenance(
+        records=(
+            _record(cache_record_id="cache_refresh_C6X7", expires_at="2026-06-11T00:01:45.000Z"),
+            _record(cache_record_id="cache_revoked_C6X7", revocation_snapshot_status="revoked"),
+            _record(cache_record_id="cache_review_C6X7", artifact_type="protocol_adapter", risk_tier="high"),
+        ),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+        action_intent="final_commitment",
+        risk_tier="medium",
+        scope_filter=OacpArtifactCacheRepositoryQuery(tenant_id="cten_C6W3"),
+    )
+    return build_oacp_cache_maintenance_dry_run_report(
+        maintenance_plan=plan,
+        report_kind="operator_review_packet",
+    )
+
+
+def test_c6x7_operator_decision_record_is_audit_safe_and_non_executing() -> None:
+    decision = build_oacp_cache_operator_decision_record(
+        review_packet=_review_packet(),
+        decision_kind="approve_future_refresh_request",
+        reviewer_identity_ref="operator_ref_c6x7_reviewer_001",
+        decided_at="2026-06-11T00:02:00.000Z",
+    )
+
+    assert decision["decision_kind"] == "approve_future_refresh_request"
+    assert decision["status"] == "recorded_for_future_review"
+    assert decision["review_packet_id"]
+    assert decision["maintenance_plan_id"]
+    assert decision["scope_summary"]["buyer_agent"] == {"buyer_C6W3": 3}
+    assert decision["artifact_families_affected"] == ["price", "protocol_adapter"]
+    assert "cache_refresh_C6X7" in decision["redacted_reason_codes"]
+    assert decision["reviewer_identity_ref"] == "operator_ref_c6x7_reviewer_001"
+    assert decision["next_step_labels"] == ["future_refresh_request_label_only_no_api_call"]
+    assert decision["allowed_to_execute"] is False
+    assert decision["no_execution"] is True
+    assert decision["operator_decision_only"] is True
+    assert decision["audit_safe_decision_record"] is True
+    assert decision["non_authoritative_for_transaction"] is True
+    assert decision["no_checkout_payment_enablement"] is True
+    assert decision["no_live_provider_enablement"] is True
+    assert decision["no_public_discovery_enablement"] is True
+    assert decision["raw_payloads_included"] is False
+    assert decision["grantex_runtime_required"] is False
+
+
+def test_c6x7_supports_known_future_or_review_decision_kinds() -> None:
+    packet = _review_packet()
+    for decision_kind in (
+        "approve_future_refresh_request",
+        "approve_future_eviction_request",
+        "approve_future_quarantine_request",
+        "request_more_evidence",
+        "reject_maintenance_action",
+        "defer_until_freshness_update",
+        "escalate_to_human_support",
+        "block_unsafe_action",
+    ):
+        decision = build_oacp_cache_operator_decision_record(
+            review_packet=packet,
+            decision_kind=decision_kind,
+            reviewer_identity_ref="reviewer_ref_c6x7_safe_opaque",
+        )
+
+        assert decision["status"] == "recorded_for_future_review"
+        assert decision["decision_kind"] == decision_kind
+        assert decision["allowed_to_execute"] is False
+        assert "http" not in " ".join(decision["next_step_labels"])
+
+
+def test_c6x7_blocks_missing_executable_private_or_non_opaque_inputs() -> None:
+    missing = build_oacp_cache_operator_decision_record(
+        review_packet=None,
+        decision_kind="approve_future_refresh_request",
+        reviewer_identity_ref="operator_ref_c6x7_reviewer_001",
+    )
+    assert missing["status"] == "blocked"
+    assert missing["block_reason"] == "review_packet_missing"
+
+    executable_packet = dict(_review_packet())
+    executable_packet["allowed_to_execute"] = True
+    executable = build_oacp_cache_operator_decision_record(
+        review_packet=executable_packet,
+        decision_kind="approve_future_eviction_request",
+        reviewer_identity_ref="operator_ref_c6x7_reviewer_001",
+    )
+    assert executable["block_reason"] == "review_packet_executable_or_enabling"
+    assert executable["no_execution"] is True
+
+    private_ref_packet = dict(_review_packet())
+    private_ref_packet["evidence_refs"] = ["raw_jwt_c6x7_marker"]
+    private_ref = build_oacp_cache_operator_decision_record(
+        review_packet=private_ref_packet,
+        decision_kind="request_more_evidence",
+        reviewer_identity_ref="operator_ref_c6x7_reviewer_001",
+    )
+    assert private_ref["block_reason"] == "review_packet_private_or_missing_refs"
+
+    non_opaque_reviewer = build_oacp_cache_operator_decision_record(
+        review_packet=_review_packet(),
+        decision_kind="request_more_evidence",
+        reviewer_identity_ref="reviewer_ref_phone_marker",
+    )
+    assert non_opaque_reviewer["block_reason"] == "reviewer_identity_not_opaque"
+
+    immediate_action = build_oacp_cache_operator_decision_record(
+        review_packet=_review_packet(),
+        decision_kind="execute_maintenance_now",
+        reviewer_identity_ref="operator_ref_c6x7_reviewer_001",
+    )
+    assert immediate_action["block_reason"] == "unsupported_or_executable_decision_kind"
+    assert immediate_action["allowed_to_execute"] is False
+
+
+def test_c6x7_docs_capture_decision_boundaries_and_no_persistence() -> None:
+    doc = _doc()
+    for heading in (
+        "Scope",
+        "Correct Ownership Model",
+        "Decision Kinds",
+        "Decision Record Output",
+        "Fail-Closed Rules",
+        "Migration Scheduler And Persistence Decision",
+        "Guardrails",
+        "What C6X7 Does Not Enable",
+        "Future Work",
+    ):
+        assert f"## {heading}" in doc
+
+    assert "operator decision record only" in doc
+    assert "allowed_to_execute = false" in doc
+    assert "opaque reviewer reference" in doc
+    assert "does not call Grantex live" in doc
+    assert "adds no migration" in doc


### PR DESCRIPTION
C6X7 internal helper/tests/docs for operator decision intake over cache maintenance review packets. Pure model behavior only: no migrations, schedulers, endpoints, workflows, provider calls, Grantex live calls, or execution behavior. Local validation: focused C6X4-C6X7 pytest, ruff, mypy, diff checks, and guardrail scans passed.