### PR TITLE
C6X8 durable OACP operator decision repository

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -966,6 +966,17 @@ class OacpArtifactCacheRepositoryQuery:
     authority: str | None = None
 
 
+@dataclass(frozen=True)
+class OacpOperatorDecisionRepositoryQuery:
+    tenant_id: str | None = None
+    merchant_id: str | None = None
+    seller_agent_id: str | None = None
+    buyer_agent_id: str | None = None
+    decision_kind: OacpCacheOperatorDecisionKind | None = None
+    review_packet_id: str | None = None
+    maintenance_plan_id: str | None = None
+
+
 class OacpArtifactCacheRepositoryPort(Protocol):
     def upsert(self, record: OacpPersistentArtifactCacheRecord) -> dict[str, Any]:
         """Store or replace a local cache record without external calls."""
@@ -989,6 +1000,24 @@ class OacpArtifactCacheRepositoryPort(Protocol):
         expected_scope: dict[str, str | None] | None = None,
     ) -> dict[str, Any]:
         """Evaluate one stored record using the C6X2 fail-closed cache policy."""
+        ...
+
+
+class OacpOperatorDecisionRepositoryPort(Protocol):
+    def upsert_decision(self, decision_record: Mapping[str, Any]) -> dict[str, Any]:
+        """Store or replace one audit-safe operator decision record without external calls."""
+        ...
+
+    def get_decision(self, decision_id: str) -> dict[str, Any] | None:
+        """Read one operator decision record by deterministic decision id."""
+        ...
+
+    def list_decisions_for_scope(self, query: OacpOperatorDecisionRepositoryQuery) -> tuple[dict[str, Any], ...]:
+        """List local operator decision records for a tenant, merchant, seller, or buyer scope."""
+        ...
+
+    def evaluate_decision_for_future_action(self, decision_id: str) -> dict[str, Any]:
+        """Evaluate a decision record for a future action without approving execution."""
         ...
 
 
@@ -5603,6 +5632,372 @@ def build_oacp_cache_operator_decision_record(
         "raw_payloads_included": False,
         "grantex_runtime_required": False,
     }
+
+
+def _c6x8_decision_repository_refusal(
+    *,
+    status: str,
+    refusal_code: str,
+    message: str,
+    decision_record: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "stored": False,
+        "status": status,
+        "refusal_code": refusal_code,
+        "message": message,
+        "decision_id": None if decision_record is None else _c6x7_string(decision_record.get("decision_record_id")),
+        "review_packet_id": None if decision_record is None else _c6x7_string(decision_record.get("review_packet_id")),
+        "maintenance_plan_id": (
+            None if decision_record is None else _c6x7_string(decision_record.get("maintenance_plan_id"))
+        ),
+        "durable_repository": True,
+        "future_action_allowed": False,
+        "allowed_to_execute": False,
+        "prepared_only": True,
+        "operator_decision_only": True,
+        "audit_safe_decision_record": True,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "grantex_runtime_required": False,
+    }
+
+
+def _c6x8_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _c6x8_scope_id(scope_summary: Mapping[str, Any], scope_kind: str) -> str | None:
+    values = scope_summary.get(scope_kind)
+    if not isinstance(values, Mapping) or not values:
+        return None
+    for key in sorted(str(candidate) for candidate in values if isinstance(candidate, str) and candidate):
+        return key
+    return None
+
+
+def _c6x8_list(value: Any) -> list[str]:
+    return [item for item in value if isinstance(item, str)] if isinstance(value, list) else []
+
+
+def _c6x8_flags_safe(decision_record: Mapping[str, Any]) -> bool:
+    return (
+        decision_record.get("allowed_to_execute") is False
+        and decision_record.get("no_execution") is True
+        and decision_record.get("operator_decision_only") is True
+        and decision_record.get("audit_safe_decision_record") is True
+        and decision_record.get("non_authoritative_for_transaction") is True
+        and decision_record.get("no_checkout_payment_enablement") is True
+        and decision_record.get("no_live_provider_enablement") is True
+        and decision_record.get("no_public_discovery_enablement") is True
+    )
+
+
+def _c6x8_labels_safe(values: tuple[str, ...]) -> bool:
+    if not values:
+        return False
+    unsafe_markers = (
+        "execute",
+        "payment",
+        "provider",
+        "public_discovery",
+        "live_rail",
+        "merchant_private_api",
+        "checkout",
+        "order",
+        "hold",
+        "refund",
+        "return",
+        "shipping",
+        "publish",
+        "certif",
+        "compliance",
+        "conformance",
+        "standard",
+        "readiness",
+    )
+    safe_markers = ("no_", "future_", "request_", "reject_", "defer_", "block_", "label_only", "review")
+    for value in values:
+        normalized = value.strip().lower()
+        if not normalized:
+            return False
+        if any(marker in normalized for marker in unsafe_markers) and not any(
+            marker in normalized for marker in safe_markers
+        ):
+            return False
+    return _c6x2_refs_safe(values)
+
+
+def _c6x8_decision_safe_for_storage(decision_record: Mapping[str, Any]) -> dict[str, Any]:
+    decision_id = _c6x7_string(decision_record.get("decision_record_id"))
+    review_packet_id = _c6x7_string(decision_record.get("review_packet_id"))
+    maintenance_plan_id = _c6x7_string(decision_record.get("maintenance_plan_id"))
+    generated_at = _c6x7_string(decision_record.get("generated_at"))
+    decided_at = _c6x7_string(decision_record.get("decided_at"))
+    decision_kind = _c6x7_string(decision_record.get("decision_kind"))
+    reviewer_ref = _c6x7_string(decision_record.get("reviewer_identity_ref"))
+    scope_summary = _c6x8_mapping(decision_record.get("scope_summary"))
+    tenant_id = _c6x8_scope_id(scope_summary, "tenant")
+    if not all((decision_id, review_packet_id, maintenance_plan_id, generated_at, decided_at, decision_kind)):
+        return _c6x8_decision_repository_refusal(
+            status="blocked",
+            refusal_code="decision_identity_missing",
+            message="C6X8 durable decisions require decision, packet, plan, timestamp, and kind identifiers.",
+            decision_record=decision_record,
+        )
+    if decision_kind not in _C6X7_DECISION_KINDS:
+        return _c6x8_decision_repository_refusal(
+            status="blocked",
+            refusal_code="decision_kind_unsupported",
+            message="C6X8 stores known C6X7 operator decision kinds only.",
+            decision_record=decision_record,
+        )
+    if not tenant_id:
+        return _c6x8_decision_repository_refusal(
+            status="blocked",
+            refusal_code="tenant_scope_missing",
+            message="C6X8 durable decisions require tenant-scoped audit storage.",
+            decision_record=decision_record,
+        )
+    try:
+        assert_no_forbidden_oacp_artifact_fields(dict(decision_record))
+    except ValueError:
+        return _c6x8_decision_repository_refusal(
+            status="unsafe",
+            refusal_code="private_or_enabling_decision_field",
+            message="C6X8 refuses decision records with private, raw, or enabling fields.",
+            decision_record=decision_record,
+        )
+    if not _c6x8_flags_safe(decision_record):
+        return _c6x8_decision_repository_refusal(
+            status="unsafe",
+            refusal_code="non_enablement_flags_missing",
+            message="C6X8 refuses executable or enabling operator decision records.",
+            decision_record=decision_record,
+        )
+    refs = (*_c6x8_list(decision_record.get("source_refs")), *_c6x8_list(decision_record.get("evidence_refs")))
+    labels = tuple(_c6x8_list(decision_record.get("next_step_labels")))
+    if not refs or not _c6x2_refs_safe(refs):
+        return _c6x8_decision_repository_refusal(
+            status="unsafe",
+            refusal_code="decision_refs_missing_or_private",
+            message="C6X8 stores redacted source and evidence refs only.",
+            decision_record=decision_record,
+        )
+    if not _c6x8_labels_safe(labels):
+        return _c6x8_decision_repository_refusal(
+            status="unsafe",
+            refusal_code="decision_labels_executable_or_private",
+            message="C6X8 stores next-step labels only, not execution targets.",
+            decision_record=decision_record,
+        )
+    if not _c6x7_reviewer_ref_safe(reviewer_ref):
+        return _c6x8_decision_repository_refusal(
+            status="unsafe",
+            refusal_code="reviewer_identity_not_opaque",
+            message="C6X8 stores opaque reviewer references only.",
+            decision_record=decision_record,
+        )
+    parsed_generated_at = _parse_iso(generated_at)
+    parsed_decided_at = _parse_iso(decided_at)
+    if parsed_generated_at is None or parsed_decided_at is None or parsed_generated_at > parsed_decided_at:
+        return _c6x8_decision_repository_refusal(
+            status="stale",
+            refusal_code="decision_timestamps_invalid",
+            message="C6X8 durable decisions require ordered generated and decided timestamps.",
+            decision_record=decision_record,
+        )
+    return {
+        "stored": True,
+        "status": "stored",
+        "decision_id": decision_id,
+        "review_packet_id": review_packet_id,
+        "maintenance_plan_id": maintenance_plan_id,
+        "tenant_id": tenant_id,
+        "decision_kind": decision_kind,
+        "durable_repository": True,
+        "future_action_allowed": False,
+        "allowed_to_execute": False,
+        "prepared_only": True,
+        "operator_decision_only": True,
+        "audit_safe_decision_record": True,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "grantex_runtime_required": False,
+    }
+
+
+def _c6x8_apply_decision_to_row(row: Any, decision_record: Mapping[str, Any]) -> None:
+    scope_summary = _c6x8_mapping(decision_record.get("scope_summary"))
+    row.review_packet_id = cast(str, decision_record["review_packet_id"])
+    row.maintenance_plan_id = cast(str, decision_record["maintenance_plan_id"])
+    row.generated_at = _parse_iso(cast(str, decision_record["generated_at"]))
+    row.decided_at = _parse_iso(cast(str, decision_record["decided_at"]))
+    row.decision_kind = cast(str, decision_record["decision_kind"])
+    row.tenant_id = _c6x8_scope_id(scope_summary, "tenant")
+    row.merchant_id = _c6x8_scope_id(scope_summary, "merchant")
+    row.seller_agent_id = _c6x8_scope_id(scope_summary, "seller_agent")
+    row.buyer_agent_id = _c6x8_scope_id(scope_summary, "buyer_agent")
+    row.scope_summary = dict(scope_summary)
+    row.artifact_family_summary = dict(_c6x8_mapping(decision_record.get("artifact_family_counts")))
+    row.artifact_families_affected = _c6x8_list(decision_record.get("artifact_families_affected"))
+    row.redacted_reason_codes = dict(_c6x8_mapping(decision_record.get("redacted_reason_codes")))
+    row.source_refs = _c6x8_list(decision_record.get("source_refs"))
+    row.evidence_refs = _c6x8_list(decision_record.get("evidence_refs"))
+    row.reviewer_ref = cast(str, decision_record["reviewer_identity_ref"])
+    row.next_step_labels = _c6x8_list(decision_record.get("next_step_labels"))
+    row.allowed_to_execute = False
+    row.future_action_allowed = False
+    row.prepared_only = True
+    row.operator_decision_only = True
+    row.audit_safe_decision_record = True
+    row.non_authoritative_for_transaction = True
+    row.no_checkout_payment_enablement = True
+    row.no_live_provider_enablement = True
+    row.no_public_discovery_enablement = True
+
+
+def _c6x8_row_time(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    return str(value)
+
+
+def _c6x8_row_to_decision(row: Any) -> dict[str, Any]:
+    return {
+        "decision_record_id": str(row.decision_id),
+        "review_packet_id": str(row.review_packet_id),
+        "maintenance_plan_id": str(row.maintenance_plan_id),
+        "generated_at": _c6x8_row_time(row.generated_at),
+        "decided_at": _c6x8_row_time(row.decided_at),
+        "decision_kind": str(row.decision_kind),
+        "scope_summary": dict(row.scope_summary or {}),
+        "artifact_family_counts": dict(row.artifact_family_summary or {}),
+        "artifact_families_affected": list(row.artifact_families_affected or []),
+        "redacted_reason_codes": dict(row.redacted_reason_codes or {}),
+        "source_refs": list(row.source_refs or []),
+        "evidence_refs": list(row.evidence_refs or []),
+        "reviewer_identity_ref": str(row.reviewer_ref),
+        "next_step_labels": list(row.next_step_labels or []),
+        "allowed_to_execute": bool(row.allowed_to_execute),
+        "future_action_allowed": bool(row.future_action_allowed),
+        "prepared_only": bool(row.prepared_only),
+        "no_execution": True,
+        "operator_decision_only": bool(row.operator_decision_only),
+        "audit_safe_decision_record": bool(row.audit_safe_decision_record),
+        "non_authoritative_for_transaction": bool(row.non_authoritative_for_transaction),
+        "no_checkout_payment_enablement": bool(row.no_checkout_payment_enablement),
+        "no_live_provider_enablement": bool(row.no_live_provider_enablement),
+        "no_public_discovery_enablement": bool(row.no_public_discovery_enablement),
+        "raw_payloads_included": False,
+        "grantex_runtime_required": False,
+    }
+
+
+def _c6x8_query_matches(decision_record: Mapping[str, Any], query: OacpOperatorDecisionRepositoryQuery) -> bool:
+    scope_summary = _c6x8_mapping(decision_record.get("scope_summary"))
+    return (
+        (query.tenant_id is None or _c6x8_scope_id(scope_summary, "tenant") == query.tenant_id)
+        and (query.merchant_id is None or _c6x8_scope_id(scope_summary, "merchant") == query.merchant_id)
+        and (query.seller_agent_id is None or _c6x8_scope_id(scope_summary, "seller_agent") == query.seller_agent_id)
+        and (query.buyer_agent_id is None or _c6x8_scope_id(scope_summary, "buyer_agent") == query.buyer_agent_id)
+        and (query.decision_kind is None or decision_record.get("decision_kind") == query.decision_kind)
+        and (query.review_packet_id is None or decision_record.get("review_packet_id") == query.review_packet_id)
+        and (
+            query.maintenance_plan_id is None
+            or decision_record.get("maintenance_plan_id") == query.maintenance_plan_id
+        )
+    )
+
+
+class DurableOacpOperatorDecisionRepository:
+    """Async SQLAlchemy-backed operator decision repository; it performs no maintenance actions."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def upsert_decision(self, decision_record: Mapping[str, Any]) -> dict[str, Any]:
+        from core.models.oacp_operator_decision import OacpOperatorDecisionRecordRow
+
+        store_result = _c6x8_decision_safe_for_storage(decision_record)
+        if store_result["stored"] is not True:
+            return store_result
+
+        decision_id = cast(str, store_result["decision_id"])
+        row = await self._session.get(OacpOperatorDecisionRecordRow, decision_id)
+        if row is None:
+            row = OacpOperatorDecisionRecordRow(decision_id=decision_id)
+            self._session.add(row)
+        _c6x8_apply_decision_to_row(row, decision_record)
+        await self._session.flush()
+        return store_result
+
+    async def get_decision(self, decision_id: str) -> dict[str, Any] | None:
+        from core.models.oacp_operator_decision import OacpOperatorDecisionRecordRow
+
+        row = await self._session.get(OacpOperatorDecisionRecordRow, decision_id)
+        return None if row is None else _c6x8_row_to_decision(row)
+
+    async def list_decisions_for_scope(
+        self,
+        query: OacpOperatorDecisionRepositoryQuery,
+    ) -> tuple[dict[str, Any], ...]:
+        from sqlalchemy import select
+
+        from core.models.oacp_operator_decision import OacpOperatorDecisionRecordRow
+
+        statement = select(OacpOperatorDecisionRecordRow)
+        if query.tenant_id is not None:
+            statement = statement.where(OacpOperatorDecisionRecordRow.tenant_id == query.tenant_id)
+        if query.merchant_id is not None:
+            statement = statement.where(OacpOperatorDecisionRecordRow.merchant_id == query.merchant_id)
+        if query.seller_agent_id is not None:
+            statement = statement.where(OacpOperatorDecisionRecordRow.seller_agent_id == query.seller_agent_id)
+        if query.buyer_agent_id is not None:
+            statement = statement.where(OacpOperatorDecisionRecordRow.buyer_agent_id == query.buyer_agent_id)
+        if query.decision_kind is not None:
+            statement = statement.where(OacpOperatorDecisionRecordRow.decision_kind == query.decision_kind)
+        if query.review_packet_id is not None:
+            statement = statement.where(OacpOperatorDecisionRecordRow.review_packet_id == query.review_packet_id)
+        if query.maintenance_plan_id is not None:
+            statement = statement.where(OacpOperatorDecisionRecordRow.maintenance_plan_id == query.maintenance_plan_id)
+
+        rows = (await self._session.scalars(statement.order_by(OacpOperatorDecisionRecordRow.decision_id))).all()
+        decisions = tuple(_c6x8_row_to_decision(row) for row in rows)
+        return tuple(decision for decision in decisions if _c6x8_query_matches(decision, query))
+
+    async def evaluate_decision_for_future_action(self, decision_id: str) -> dict[str, Any]:
+        decision_record = await self.get_decision(decision_id)
+        if decision_record is None:
+            return _c6x8_decision_repository_refusal(
+                status="blocked",
+                refusal_code="decision_missing",
+                message="C6X8 requires a stored operator decision before future action review.",
+            )
+        store_result = _c6x8_decision_safe_for_storage(decision_record)
+        if store_result["stored"] is not True:
+            return store_result
+        return {
+            "evaluated": True,
+            "status": "future_action_requires_separate_approval",
+            "decision_id": decision_id,
+            "decision_kind": decision_record["decision_kind"],
+            "future_action_allowed": False,
+            "allowed_to_execute": False,
+            "prepared_only": True,
+            "operator_decision_only": True,
+            "audit_safe_decision_record": True,
+            "non_authoritative_for_transaction": True,
+            "no_checkout_payment_enablement": True,
+            "no_live_provider_enablement": True,
+            "no_public_discovery_enablement": True,
+            "grantex_runtime_required": False,
+            "message": "C6X8 stores an audit-safe decision only; it does not execute maintenance.",
+        }
 
 
 class OacpArtifactCache:

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -57,6 +57,7 @@ from core.models.kpi_cache import KPICache as KPICache
 from core.models.lead_pipeline import EmailSequence as EmailSequence
 from core.models.lead_pipeline import LeadPipeline as LeadPipeline
 from core.models.oacp_artifact_cache import OacpArtifactCacheRecordRow as OacpArtifactCacheRecordRow
+from core.models.oacp_operator_decision import OacpOperatorDecisionRecordRow as OacpOperatorDecisionRecordRow
 from core.models.organization import CostCenter as CostCenter
 from core.models.organization import Department as Department
 from core.models.professional_tax import ProfessionalTaxRegistration as ProfessionalTaxRegistration

--- a/core/models/oacp_operator_decision.py
+++ b/core/models/oacp_operator_decision.py
@@ -1,0 +1,81 @@
+"""Durable OACP operator decision record model.
+
+The table stores only audit-safe, redacted operator decision metadata for
+AgenticOrg local cache maintenance review. It is not transaction authority.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import JSON, TIMESTAMP, Boolean, Index, String, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.models.base import BaseModel
+
+OACP_OPERATOR_DECISION_JSON = JSONB().with_variant(JSON(), "sqlite")
+
+
+class OacpOperatorDecisionRecordRow(BaseModel):
+    __tablename__ = "oacp_operator_decision_records"
+    __table_args__ = (
+        Index("ix_oacp_operator_decision_tenant_id", "tenant_id"),
+        Index("ix_oacp_operator_decision_merchant_id", "merchant_id"),
+        Index("ix_oacp_operator_decision_seller_agent_id", "seller_agent_id"),
+        Index("ix_oacp_operator_decision_buyer_agent_id", "buyer_agent_id"),
+        Index("ix_oacp_operator_decision_review_packet_id", "review_packet_id"),
+        Index("ix_oacp_operator_decision_maintenance_plan_id", "maintenance_plan_id"),
+        Index("ix_oacp_operator_decision_decision_kind", "decision_kind"),
+        Index("ix_oacp_operator_decision_decided_at", "decided_at"),
+    )
+
+    decision_id: Mapped[str] = mapped_column(String(180), primary_key=True)
+    review_packet_id: Mapped[str] = mapped_column(String(180), nullable=False)
+    maintenance_plan_id: Mapped[str] = mapped_column(String(180), nullable=False)
+    generated_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    decided_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    decision_kind: Mapped[str] = mapped_column(String(64), nullable=False)
+    tenant_id: Mapped[str] = mapped_column(String(160), nullable=False)
+    merchant_id: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    seller_agent_id: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    buyer_agent_id: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    scope_summary: Mapped[dict[str, object]] = mapped_column(
+        OACP_OPERATOR_DECISION_JSON,
+        nullable=False,
+        default=dict,
+    )
+    artifact_family_summary: Mapped[dict[str, object]] = mapped_column(
+        OACP_OPERATOR_DECISION_JSON,
+        nullable=False,
+        default=dict,
+    )
+    artifact_families_affected: Mapped[list[str]] = mapped_column(
+        OACP_OPERATOR_DECISION_JSON,
+        nullable=False,
+        default=list,
+    )
+    redacted_reason_codes: Mapped[dict[str, object]] = mapped_column(
+        OACP_OPERATOR_DECISION_JSON,
+        nullable=False,
+        default=dict,
+    )
+    source_refs: Mapped[list[str]] = mapped_column(OACP_OPERATOR_DECISION_JSON, nullable=False, default=list)
+    evidence_refs: Mapped[list[str]] = mapped_column(OACP_OPERATOR_DECISION_JSON, nullable=False, default=list)
+    reviewer_ref: Mapped[str] = mapped_column(String(160), nullable=False)
+    next_step_labels: Mapped[list[str]] = mapped_column(OACP_OPERATOR_DECISION_JSON, nullable=False, default=list)
+    allowed_to_execute: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    future_action_allowed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    prepared_only: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    operator_decision_only: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    audit_safe_decision_record: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    non_authoritative_for_transaction: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    no_checkout_payment_enablement: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    no_live_provider_enablement: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    no_public_discovery_enablement: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
+    updated_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=True,
+        onupdate=func.now(),
+    )

--- a/docs/reports/commerce-agent-c6x8-oacp-operator-decision-repository.md
+++ b/docs/reports/commerce-agent-c6x8-oacp-operator-decision-repository.md
@@ -1,0 +1,85 @@
+# Commerce Agent C6X8 OACP Operator Decision Repository
+
+## Scope
+
+C6X8 adds a durable AgenticOrg repository for audit-safe C6X7 operator decision records over local OACP cache maintenance review packets. The repository stores redacted decision metadata only. It does not call Grantex live, refresh artifacts, evict records, quarantine records, schedule maintenance, call merchant systems, call providers, or expose an API.
+
+## Correct Ownership Model
+
+AgenticOrg is the buyer and seller AI-agent runtime. AgenticOrg owns local operator decision handling for its durable OACP artifact cache. Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. Grantex is not a transaction toll booth for every non-binding buyer or seller agent turn. Merchant systems remain operational sources of record, and provider or fintech rails own mandate and payment execution where separately approved.
+
+## Persistence Decision
+
+C6X8 implements persistence because C6X4 established a safe Alembic and SQLAlchemy pattern for internal OACP cache storage. The new repository mirrors that pattern with a narrow table, tenant-safe indexes, row-level security, static migration tests, rollback notes, and non-execution constraints.
+
+The migration is `v6x8_oacp_operator_decisions`. It creates only `oacp_operator_decision_records` and does not mutate runtime startup schema, production config, workflows, endpoints, or public OpenAPI contracts.
+
+## Durable Repository Contract
+
+The internal repository exposes:
+
+- `upsert_decision`
+- `get_decision`
+- `list_decisions_for_scope`
+- `evaluate_decision_for_future_action`
+
+Evaluation is intentionally conservative. A stored decision can be retrieved for future review, but `future_action_allowed = false`, `allowed_to_execute = false`, and `prepared_only = true` remain fixed until a later separately approved controller slice exists.
+
+## Stored Fields
+
+The repository stores:
+
+- decision id
+- review packet id
+- maintenance plan id
+- generated and decided timestamps
+- decision kind
+- tenant, merchant, seller-agent, and buyer-agent scope ids where present
+- scope summary
+- artifact family summary
+- redacted reason codes
+- redacted source refs
+- redacted evidence refs
+- opaque reviewer reference
+- next-step labels only
+- non-enablement flags
+- created and updated timestamps
+
+It stores no raw artifact payloads, provider payloads, connector payloads, JWTs, credentials, private customer data, payment data, bank or card data, raw merchant private API values, secrets, production allowlists, executable URLs, or action targets.
+
+## Fail-Closed Persistence And Evaluation
+
+Persistence fails closed when a decision record has missing ids, unsupported decision kind, missing tenant scope, invalid timestamps, private or enabling fields, raw source or evidence refs, raw reviewer identity, unsafe next-step labels, executable posture, or false non-enablement flags.
+
+Evaluation fails closed when the stored decision is missing or no longer satisfies the same audit-safe validation. Evaluation never approves refresh, eviction, quarantine, checkout, payment, order, hold, refund, return, shipping, provider, merchant private API, public discovery, or publication behavior.
+
+## Migration Safety
+
+The migration adds only one tenant-scoped table and indexes:
+
+- tenant id
+- merchant id
+- seller agent id
+- buyer agent id
+- review packet id
+- maintenance plan id
+- decision kind
+- decided timestamp
+
+It includes a uniqueness guard for the same tenant/scope, review packet, decision kind, and reviewer reference. It enables and forces tenant row-level security using `agenticorg.tenant_id`, matching the C6X4 cache posture. Rollback drops only the operator decision table, indexes, and policy.
+
+## Guardrails
+
+C6X8 remains internal-only, non-publication, non-certifying, non-production, non-executing, fail-closed, and non-authoritative for transactions. Valid records preserve `allowed_to_execute = false`, `future_action_allowed = false`, `non_authoritative_for_transaction = true`, `no_checkout_payment_enablement = true`, `no_live_provider_enablement = true`, and `no_public_discovery_enablement = true`.
+
+The repository can support non-binding audit review without routing every local cache interaction through Grantex. It does not make AgenticOrg a merchant system of record, and it does not make Grantex a transaction control plane.
+
+## What C6X8 Does Not Enable
+
+C6X8 adds no public endpoint, route, public OpenAPI runtime contract, workflow, scheduler, cron job, queue, background worker, production config, secret, public discovery enablement, checkout, payment, order, hold, refund, return, shipping execution, live provider rail, live Plural behavior, provider call, merchant private API call, allowlist, external OACP publication, or approval/readiness claim.
+
+Operator decisions are not merchant approvals, checkout approvals, payment approvals, mandate approvals, live-provider approvals, production approvals, certification, compliance, conformance, standardization, or public launch readiness.
+
+## Future Work
+
+Future slices may add a separately approved internal operator workflow or maintenance runner. Those slices must remain separate from checkout, payment, provider rail, merchant private API, public OACP publication, production config, workflow scheduling, and public endpoint behavior unless explicitly approved.

--- a/migrations/versions/v6_x8_oacp_operator_decisions.py
+++ b/migrations/versions/v6_x8_oacp_operator_decisions.py
@@ -1,0 +1,131 @@
+"""C6X8 durable OACP operator decision records.
+
+Revision ID: v6x8_oacp_operator_decisions
+Revises: v6x4_oacp_cache
+Create Date: 2026-06-13
+
+This table is an AgenticOrg-owned local decision log for C6X7 operator
+decision records. It stores only redacted, audit-safe metadata and opaque
+reviewer references. It is not transaction authority and does not enable
+checkout, payment, provider, merchant private API, public discovery, refresh,
+eviction, quarantine, scheduler, or maintenance execution.
+
+Rollback: drop the operator decision table and its indexes. No source-of-record
+merchant, provider, payment, or canonical Grantex artifact state is stored here.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v6x8_oacp_operator_decisions"
+down_revision = "v6x4_oacp_cache"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS oacp_operator_decision_records (
+            decision_id VARCHAR(180) PRIMARY KEY,
+            review_packet_id VARCHAR(180) NOT NULL,
+            maintenance_plan_id VARCHAR(180) NOT NULL,
+            generated_at TIMESTAMPTZ NOT NULL,
+            decided_at TIMESTAMPTZ NOT NULL,
+            decision_kind VARCHAR(64) NOT NULL,
+            tenant_id VARCHAR(160) NOT NULL,
+            merchant_id VARCHAR(160),
+            seller_agent_id VARCHAR(160),
+            buyer_agent_id VARCHAR(160),
+            scope_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+            artifact_family_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+            artifact_families_affected JSONB NOT NULL DEFAULT '[]'::jsonb,
+            redacted_reason_codes JSONB NOT NULL DEFAULT '{}'::jsonb,
+            source_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+            evidence_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+            reviewer_ref VARCHAR(160) NOT NULL,
+            next_step_labels JSONB NOT NULL DEFAULT '[]'::jsonb,
+            allowed_to_execute BOOLEAN NOT NULL DEFAULT FALSE,
+            future_action_allowed BOOLEAN NOT NULL DEFAULT FALSE,
+            prepared_only BOOLEAN NOT NULL DEFAULT TRUE,
+            operator_decision_only BOOLEAN NOT NULL DEFAULT TRUE,
+            audit_safe_decision_record BOOLEAN NOT NULL DEFAULT TRUE,
+            non_authoritative_for_transaction BOOLEAN NOT NULL DEFAULT TRUE,
+            no_checkout_payment_enablement BOOLEAN NOT NULL DEFAULT TRUE,
+            no_live_provider_enablement BOOLEAN NOT NULL DEFAULT TRUE,
+            no_public_discovery_enablement BOOLEAN NOT NULL DEFAULT TRUE,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ,
+            CONSTRAINT ck_oacp_operator_decision_kind
+                CHECK (
+                    decision_kind IN (
+                        'approve_future_refresh_request',
+                        'approve_future_eviction_request',
+                        'approve_future_quarantine_request',
+                        'request_more_evidence',
+                        'reject_maintenance_action',
+                        'defer_until_freshness_update',
+                        'escalate_to_human_support',
+                        'block_unsafe_action'
+                    )
+                ),
+            CONSTRAINT ck_oacp_operator_decision_reviewer_ref
+                CHECK (reviewer_ref LIKE 'operator_ref_%' OR reviewer_ref LIKE 'reviewer_ref_%'),
+            CONSTRAINT ck_oacp_operator_decision_ordered_timestamps
+                CHECK (generated_at <= decided_at),
+            CONSTRAINT ck_oacp_operator_decision_non_execution_flags CHECK (
+                allowed_to_execute IS FALSE
+                AND future_action_allowed IS FALSE
+                AND prepared_only IS TRUE
+                AND operator_decision_only IS TRUE
+                AND audit_safe_decision_record IS TRUE
+                AND non_authoritative_for_transaction IS TRUE
+                AND no_checkout_payment_enablement IS TRUE
+                AND no_live_provider_enablement IS TRUE
+                AND no_public_discovery_enablement IS TRUE
+            )
+        );
+    """)
+    op.execute("CREATE INDEX IF NOT EXISTS ix_oacp_operator_decision_tenant_id ON oacp_operator_decision_records (tenant_id);")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_oacp_operator_decision_merchant_id ON oacp_operator_decision_records (merchant_id);")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_oacp_operator_decision_seller_agent_id ON oacp_operator_decision_records (seller_agent_id);")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_oacp_operator_decision_buyer_agent_id ON oacp_operator_decision_records (buyer_agent_id);")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_oacp_operator_decision_review_packet_id ON oacp_operator_decision_records (review_packet_id);")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_oacp_operator_decision_maintenance_plan_id ON oacp_operator_decision_records (maintenance_plan_id);")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_oacp_operator_decision_decision_kind ON oacp_operator_decision_records (decision_kind);")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_oacp_operator_decision_decided_at ON oacp_operator_decision_records (decided_at);")
+    op.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_oacp_operator_decision_packet_kind_reviewer
+            ON oacp_operator_decision_records (
+                tenant_id,
+                COALESCE(merchant_id, ''),
+                COALESCE(seller_agent_id, ''),
+                COALESCE(buyer_agent_id, ''),
+                review_packet_id,
+                decision_kind,
+                reviewer_ref
+            );
+    """)
+    op.execute("ALTER TABLE oacp_operator_decision_records ENABLE ROW LEVEL SECURITY;")
+    op.execute("ALTER TABLE oacp_operator_decision_records FORCE ROW LEVEL SECURITY;")
+    op.execute("DROP POLICY IF EXISTS oacp_operator_decision_records_tenant_isolation ON oacp_operator_decision_records;")
+    op.execute("""
+        CREATE POLICY oacp_operator_decision_records_tenant_isolation
+            ON oacp_operator_decision_records
+            USING (tenant_id = current_setting('agenticorg.tenant_id', true))
+            WITH CHECK (tenant_id = current_setting('agenticorg.tenant_id', true));
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS oacp_operator_decision_records_tenant_isolation ON oacp_operator_decision_records;")
+    op.execute("DROP INDEX IF EXISTS uq_oacp_operator_decision_packet_kind_reviewer;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_operator_decision_decided_at;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_operator_decision_decision_kind;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_operator_decision_maintenance_plan_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_operator_decision_review_packet_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_operator_decision_buyer_agent_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_operator_decision_seller_agent_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_operator_decision_merchant_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_operator_decision_tenant_id;")
+    op.execute("DROP TABLE IF EXISTS oacp_operator_decision_records;")

--- a/tests/unit/test_oacp_c6x8_operator_decision_repository.py
+++ b/tests/unit/test_oacp_c6x8_operator_decision_repository.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from core.commerce.oacp_artifacts import (
+    DurableOacpOperatorDecisionRepository,
+    OacpArtifactCacheRepositoryQuery,
+    OacpOperatorDecisionRepositoryQuery,
+    OacpPersistentArtifactCacheRecord,
+    build_oacp_cache_maintenance_dry_run_report,
+    build_oacp_cache_operator_decision_record,
+    plan_oacp_artifact_cache_maintenance,
+)
+from core.models.oacp_operator_decision import OacpOperatorDecisionRecordRow
+
+C6X8_DOC_PATH = Path("docs/reports/commerce-agent-c6x8-oacp-operator-decision-repository.md")
+C6X8_MIGRATION_PATH = Path("migrations/versions/v6_x8_oacp_operator_decisions.py")
+
+
+def _doc() -> str:
+    return C6X8_DOC_PATH.read_text(encoding="utf-8")
+
+
+def _migration() -> str:
+    return C6X8_MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+def _record(**overrides: object) -> OacpPersistentArtifactCacheRecord:
+    base = OacpPersistentArtifactCacheRecord(
+        cache_record_id="cache_price_C6X8",
+        artifact_id="price_C6W3",
+        artifact_type="price",
+        authority="grantex_canonical_oacp_artifact_authority",
+        issuer="grantex",
+        scope_kind="buyer_agent",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+        source_refs=("source_ref_price_C6X8",),
+        evidence_refs=("evidence_price_C6X8_redacted",),
+        generated_at="2026-06-11T00:00:00.000Z",
+        cached_at="2026-06-11T00:00:10.000Z",
+        expires_at="2026-06-11T00:05:00.000Z",
+        freshness_status="fresh",
+        revocation_snapshot_status="fresh",
+        revocation_snapshot_observed_at="2026-06-11T00:00:30.000Z",
+        revocation_snapshot_age_seconds=30,
+        ttl_policy_seconds=300,
+        risk_tier="low",
+        blocked_capabilities=("checkout_payment_creation", "live_provider_call"),
+        unsupported_capabilities=("transaction_authority_from_adapter_preview",),
+        verifier_result_ref="verifier_result_price_C6X8",
+    )
+    return replace(base, **overrides)
+
+
+def _review_packet() -> dict[str, object]:
+    plan = plan_oacp_artifact_cache_maintenance(
+        records=(
+            _record(cache_record_id="cache_refresh_C6X8", expires_at="2026-06-11T00:01:45.000Z"),
+            _record(cache_record_id="cache_review_C6X8", artifact_type="protocol_adapter", risk_tier="high"),
+        ),
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+        action_intent="final_commitment",
+        risk_tier="medium",
+        scope_filter=OacpArtifactCacheRepositoryQuery(tenant_id="cten_C6W3"),
+    )
+    return build_oacp_cache_maintenance_dry_run_report(
+        maintenance_plan=plan,
+        report_kind="operator_review_packet",
+    )
+
+
+def _decision(**overrides: object) -> dict[str, object]:
+    decision = build_oacp_cache_operator_decision_record(
+        review_packet=_review_packet(),
+        decision_kind="approve_future_refresh_request",
+        reviewer_identity_ref="operator_ref_c6x8_reviewer_001",
+        decided_at="2026-06-11T00:02:00.000Z",
+    )
+    decision.update(overrides)
+    return decision
+
+
+class _FakeScalars:
+    def __init__(self, rows: list[OacpOperatorDecisionRecordRow]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[OacpOperatorDecisionRecordRow]:
+        return self._rows
+
+
+class _FakeAsyncSession:
+    def __init__(self) -> None:
+        self.rows: dict[str, OacpOperatorDecisionRecordRow] = {}
+
+    async def get(
+        self,
+        _model: type[OacpOperatorDecisionRecordRow],
+        decision_id: str,
+    ) -> OacpOperatorDecisionRecordRow | None:
+        return self.rows.get(decision_id)
+
+    def add(self, row: OacpOperatorDecisionRecordRow) -> None:
+        self.rows[row.decision_id] = row
+
+    async def flush(self) -> None:
+        return None
+
+    async def scalars(self, _statement: object) -> _FakeScalars:
+        return _FakeScalars(list(self.rows.values()))
+
+
+@pytest.fixture()
+def repository() -> DurableOacpOperatorDecisionRepository:
+    return DurableOacpOperatorDecisionRepository(_FakeAsyncSession())
+
+
+@pytest.mark.asyncio
+async def test_c6x8_durable_repository_upserts_gets_lists_and_evaluates_without_execution(
+    repository: DurableOacpOperatorDecisionRepository,
+) -> None:
+    decision = _decision()
+    result = await repository.upsert_decision(decision)
+
+    assert result["stored"] is True
+    assert result["durable_repository"] is True
+    assert result["future_action_allowed"] is False
+    assert result["allowed_to_execute"] is False
+    assert result["non_authoritative_for_transaction"] is True
+
+    stored = await repository.get_decision(str(decision["decision_record_id"]))
+    assert stored is not None
+    assert stored["review_packet_id"] == decision["review_packet_id"]
+    assert stored["evidence_refs"] == ["evidence_price_C6X8_redacted"]
+    assert stored["reviewer_identity_ref"] == "operator_ref_c6x8_reviewer_001"
+
+    scoped = await repository.list_decisions_for_scope(
+        OacpOperatorDecisionRepositoryQuery(tenant_id="cten_C6W3", buyer_agent_id="buyer_C6W3"),
+    )
+    assert [item["decision_record_id"] for item in scoped] == [decision["decision_record_id"]]
+
+    evaluation = await repository.evaluate_decision_for_future_action(str(decision["decision_record_id"]))
+    assert evaluation["status"] == "future_action_requires_separate_approval"
+    assert evaluation["future_action_allowed"] is False
+    assert evaluation["allowed_to_execute"] is False
+    assert evaluation["prepared_only"] is True
+
+
+@pytest.mark.asyncio
+async def test_c6x8_durable_repository_fails_closed_before_storage(
+    repository: DurableOacpOperatorDecisionRepository,
+) -> None:
+    cases = [
+        (_decision(decision_record_id=""), "decision_identity_missing"),
+        (_decision(evidence_refs=["raw_jwt_marker"]), "decision_refs_missing_or_private"),
+        (_decision(allowed_to_execute=True), "non_enablement_flags_missing"),
+        (_decision(reviewer_identity_ref="reviewer_ref_phone_marker"), "reviewer_identity_not_opaque"),
+        (_decision(next_step_labels=["execute_cache_eviction_now"]), "decision_labels_executable_or_private"),
+    ]
+
+    for decision, refusal_code in cases:
+        result = await repository.upsert_decision(decision)
+        assert result["stored"] is False
+        assert result["allowed_to_execute"] is False
+        assert result["future_action_allowed"] is False
+        assert result["refusal_code"] == refusal_code
+
+    missing = await repository.evaluate_decision_for_future_action("missing_decision_C6X8")
+    assert missing["status"] == "blocked"
+    assert missing["refusal_code"] == "decision_missing"
+
+
+def test_c6x8_migration_has_tenant_safe_indexes_rls_and_non_execution_guards() -> None:
+    migration = _migration()
+    for expected in (
+        "CREATE TABLE IF NOT EXISTS oacp_operator_decision_records",
+        "ix_oacp_operator_decision_tenant_id",
+        "ix_oacp_operator_decision_merchant_id",
+        "ix_oacp_operator_decision_seller_agent_id",
+        "ix_oacp_operator_decision_buyer_agent_id",
+        "ix_oacp_operator_decision_review_packet_id",
+        "ix_oacp_operator_decision_maintenance_plan_id",
+        "uq_oacp_operator_decision_packet_kind_reviewer",
+        "allowed_to_execute IS FALSE",
+        "future_action_allowed IS FALSE",
+        "ENABLE ROW LEVEL SECURITY",
+        "DROP TABLE IF EXISTS oacp_operator_decision_records",
+    ):
+        assert expected in migration
+
+
+def test_c6x8_docs_capture_durable_repository_scope_and_non_goals() -> None:
+    doc = _doc()
+    for heading in (
+        "Scope",
+        "Correct Ownership Model",
+        "Persistence Decision",
+        "Durable Repository Contract",
+        "Stored Fields",
+        "Fail-Closed Persistence And Evaluation",
+        "Migration Safety",
+        "Guardrails",
+        "What C6X8 Does Not Enable",
+        "Future Work",
+    ):
+        assert f"## {heading}" in doc
+
+    assert "AgenticOrg owns local operator decision handling" in doc
+    assert "v6x8_oacp_operator_decisions" in doc
+    assert "opaque reviewer reference" in doc
+    assert "allowed_to_execute = false" in doc
+    assert "future_action_allowed = false" in doc
+    assert "does not call Grantex live" in doc


### PR DESCRIPTION
## Summary
- Adds AgenticOrg durable OACP operator decision repository for audit-safe C6X7 decision records.
- Adds narrow Alembic migration and SQLAlchemy row model following the C6X4 durable cache pattern with tenant indexes and RLS.
- Keeps evaluation future-action-denied, prepared-only, allowed_to_execute=false, and non-authoritative for transactions.

## Validation
- python -m pytest tests/unit/test_oacp_c6x5_cache_maintenance.py tests/unit/test_oacp_c6x6_cache_maintenance_reports.py tests/unit/test_oacp_c6x7_operator_decisions.py tests/unit/test_oacp_c6x8_operator_decision_repository.py --no-cov
- python -m ruff check core/commerce/oacp_artifacts.py core/models/oacp_operator_decision.py core/models/__init__.py migrations/versions/v6_x8_oacp_operator_decisions.py tests/unit/test_oacp_c6x8_operator_decision_repository.py
- python -m mypy core/commerce/oacp_artifacts.py core/models/oacp_operator_decision.py tests/unit/test_oacp_c6x8_operator_decision_repository.py
- python -m pytest tests/integration/test_alembic_e2e.py --no-cov (skipped locally because Postgres is not reachable)
- git diff --check origin/main...HEAD
- ASCII/hidden Unicode and guardrail scans on touched files

## Guardrails
Internal-only, non-publication, non-certifying, non-production, non-executing, fail-closed, and non-authoritative for transactions. No public endpoint, OpenAPI runtime contract, workflow, scheduler, queue, provider/private API call, checkout/payment, live rail, allowlist, or OACP publication behavior is added.