### PR TITLE
[codex] Validate SDK launch workflows end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - **Commerce boundary**: OACP cache work is internal and fail-closed. It does not enable public OACP publication, live checkout, live payments, live provider rails, merchant private APIs, or production commerce readiness.
 - **Security hardening**: production dependencies were trimmed, JWT runtime moved to `PyJWT[crypto]`, `python-jose`/`ecdsa` are blocked by regression gates, Docker runtime no longer needs `curl`, and security CI fails closed on high-risk findings.
 - **Deployment hardening**: production rollout uses the manual Cloud Run helper with split Cloud Run and Artifact Registry regions, image digest and commit metadata checks, migration-first rollout support, and explicit traffic modes.
+- **SDK launch coverage**: Python SDK, TypeScript SDK, and MCP server now cover A2A/MCP discovery, `commerce_sales_agent` launch, connector listing, knowledge search, agent generation, workflow generation, workflow creation, workflow runs, and run-status polling in regression tests.
 
 ---
 
@@ -424,6 +425,7 @@ Base URL: `https://app.agenticorg.ai/api/v1`
 | POST | /demo-request | No | Demo form → lead + sales agent |
 | GET | /agents | JWT | List agents (RBAC filtered) |
 | POST | /agents | JWT | Create agent (tools auto-populated by type/domain) |
+| POST | /agents/generate | JWT | Generate launchable agent config from plain English |
 | POST | /agents/{id}/run | JWT | Execute agent |
 | PATCH | /agents/{id} | JWT | Update (prompt lock on active) |
 | GET | /agents/org-tree | JWT | Org chart tree (department hierarchy) |
@@ -438,12 +440,18 @@ Base URL: `https://app.agenticorg.ai/api/v1`
 | POST | /sales/process-inbox | JWT | Process Gmail replies |
 | GET | /sales/metrics | JWT | Weekly digest data |
 | GET | /workflows | JWT | List workflows |
+| POST | /workflows/generate | JWT | Generate workflow definition from plain English |
+| GET | /workflows/templates | JWT | List workflow templates |
+| POST | /workflows | JWT | Create workflow |
+| POST | /workflows/{id}/run | JWT | Start workflow run |
+| GET | /workflows/runs/{id} | JWT | Get workflow run status and steps |
 | GET | /approvals | JWT | HITL approval queue |
 | GET | /audit | JWT | Audit log |
 | GET | /kpis/cfo | JWT | CFO dashboard KPIs |
 | GET | /kpis/cmo | JWT | CMO dashboard KPIs |
 | POST | /chat/query | JWT | NL Query (natural language question) |
 | GET | /chat/history | JWT | Chat history for current user |
+| POST | /knowledge/search | JWT | Search tenant knowledge base |
 | GET | /companies | JWT | List companies (multi-company) |
 | POST | /companies | JWT | Create company entity |
 | PATCH | /companies/{id} | JWT | Update company entity |
@@ -461,6 +469,7 @@ Base URL: `https://app.agenticorg.ai/api/v1`
 | GET | /org/api-keys | Admin | List API keys |
 | DELETE | /org/api-keys/{id} | Admin | Revoke API key |
 | GET | /a2a/agent-card | No | A2A agent discovery card |
+| GET | /a2a/agents | No | A2A launchable agent catalog |
 | POST | /a2a/tasks | JWT/Grantex | Execute A2A task |
 | GET | /mcp/tools | No | List MCP tools (see /api/v1/product-facts.tool_count) |
 | POST | /mcp/call | JWT/Grantex | Call MCP tool |
@@ -483,6 +492,16 @@ from agenticorg import AgenticOrg
 client = AgenticOrg(api_key="ao_sk_your_key_here")
 result = client.agents.run("ap_processor", inputs={"invoice_id": "INV-001"})
 agents = client.agents.list()
+commerce = client.agents.run(
+    "commerce_sales_agent",
+    action="buyer_discovery_preview",
+    inputs={"merchant_id": "merchant_demo", "query": "Show laptops under Rs 50000"},
+)
+draft_agent = client.agents.generate("Create a contract intelligence agent using Confluence and Jira")
+kb = client.knowledge.search("vendor renewal policy", top_k=3)
+workflow_draft = client.workflows.generate("Review vendor renewal risk using KB and Jira, then notify vendor_manager")
+workflow = client.workflows.create(name="Renewal Risk Review", definition=workflow_draft["workflow"], domain="ops")
+run = client.workflows.run(workflow["id"], payload={"vendor_id": "V-100"})
 sop = client.sop.parse_text("When invoice > 5L, require CFO approval")
 card = client.a2a.agent_card()
 ```
@@ -498,6 +517,13 @@ import { AgenticOrg } from "agenticorg-sdk";
 
 const client = new AgenticOrg({ apiKey: "ao_sk_your_key_here" });
 const result = await client.agents.run("ap_processor", { inputs: { invoice_id: "INV-001" } });
+const commerce = await client.agents.run("commerce_sales_agent", {
+  action: "buyer_discovery_preview",
+  inputs: { merchant_id: "merchant_demo", query: "Show laptops under Rs 50000" },
+});
+const draftAgent = await client.agents.generate("Create a contract intelligence agent using Confluence and Jira");
+const kb = await client.knowledge.search("vendor renewal policy", { topK: 3 });
+const workflowDraft = await client.workflows.generate("Review vendor renewal risk using KB and Jira, then notify vendor_manager");
 const agents = await client.agents.list();
 ```
 
@@ -529,6 +555,10 @@ pip install agenticorg
 
 agenticorg agents list
 agenticorg agents run ap_processor --input '{"invoice_id": "INV-001"}'
+agenticorg agents run commerce_sales_agent --action buyer_discovery_preview --input '{"merchant_id":"merchant_demo"}'
+agenticorg agents generate "Create a contract intelligence agent using Confluence and Jira"
+agenticorg knowledge search "vendor renewal policy" --top-k 3
+agenticorg workflows generate "Review vendor renewal risk using KB and Jira"
 agenticorg sop parse "When invoice > 5L, require CFO approval"
 agenticorg mcp tools
 ```

--- a/core/agent_generator.py
+++ b/core/agent_generator.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import structlog
 
+from core.commerce.sales_guardrails import GRANTEX_COMMERCE_DEFAULT_TOOLS
 from core.llm.router import LLMRouter, llm_router
 
 logger = structlog.get_logger()
@@ -20,6 +21,14 @@ logger = structlog.get_logger()
 # ── Known agent types with domains (for prompt context + validation) ──────────
 
 AGENT_TYPE_CATALOG: dict[str, dict[str, str]] = {
+    # Commerce
+    "commerce_sales_agent": {
+        "domain": "commerce",
+        "desc": (
+            "Commerce buyer/seller runtime -- Grantex-grounded discovery, "
+            "catalog, consent, checkout handoff, and payment-status guardrails"
+        ),
+    },
     # Finance
     "ap_processor": {
         "domain": "finance",
@@ -174,6 +183,7 @@ AGENT_TYPE_CATALOG: dict[str, dict[str, str]] = {
 
 # ── Default tools by agent type (mirrors _AGENT_TYPE_DEFAULT_TOOLS in agents.py)
 _AGENT_TYPE_DEFAULT_TOOLS: dict[str, list[str]] = {
+    "commerce_sales_agent": list(GRANTEX_COMMERCE_DEFAULT_TOOLS),
     "ap_processor": [
         "fetch_bank_statement", "check_account_balance", "post_voucher",
         "get_ledger_balance", "get_trial_balance", "create_order",
@@ -326,7 +336,7 @@ _AGENT_TYPE_DEFAULT_TOOLS: dict[str, list[str]] = {
     "chat_agent": ["slack_send_message", "send_email", "read_inbox"],
 }
 
-VALID_DOMAINS = {"finance", "hr", "marketing", "ops", "backoffice", "comms"}
+VALID_DOMAINS = {"commerce", "finance", "hr", "marketing", "ops", "backoffice", "comms"}
 VALID_AGENT_TYPES = set(AGENT_TYPE_CATALOG.keys())
 
 # ── Prompt injection patterns ─────────────────────────────────────────────────

--- a/core/workflow_generator.py
+++ b/core/workflow_generator.py
@@ -12,50 +12,18 @@ from typing import Any
 
 import structlog
 
+from core.agent_generator import _AGENT_TYPE_DEFAULT_TOOLS as CANONICAL_AGENT_DEFAULT_TOOLS
 from workflows.parser import WorkflowParser
 
 logger = structlog.get_logger()
 
 # ---------------------------------------------------------------------------
-# Available agent types (from the 35 built-in agents)
+# Available agent types (canonical runtime launch catalog)
 # ---------------------------------------------------------------------------
-KNOWN_AGENT_TYPES: list[str] = [
-    "ap_processor",
-    "ar_collector",
-    "bank_reconciler",
-    "budget_analyst",
-    "expense_auditor",
-    "financial_reporter",
-    "gst_filer",
-    "invoice_processor",
-    "payroll_processor",
-    "tax_analyst",
-    "treasury_manager",
-    "leave_manager",
-    "onboarding_specialist",
-    "recruiter",
-    "timesheet_processor",
-    "campaign_manager",
-    "content_creator",
-    "lead_scorer",
-    "seo_optimizer",
-    "social_media_manager",
-    "compliance_monitor",
-    "data_migrator",
-    "fleet_ops_manager",
-    "incident_responder",
-    "it_helpdesk",
-    "procurement_manager",
-    "quality_inspector",
-    "scheduler",
-    "vendor_manager",
-    "customer_success",
-    "sales_forecaster",
-    "support_deflection",
-    "collections_agent",
-    "fraud_detector",
-    "report_generator",
-]
+# Keep NL workflow generation aligned with the agents that A2A/MCP/API can
+# actually execute. A stale independent list creates workflows that validate
+# locally but fail at runtime because the referenced agent type is not launchable.
+KNOWN_AGENT_TYPES: list[str] = sorted(CANONICAL_AGENT_DEFAULT_TOOLS)
 
 # ---------------------------------------------------------------------------
 # Available workflow step types

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -203,6 +203,40 @@ Creates a new agent in `shadow` status. Requires `agenticorg:agents:write` scope
 }
 ```
 
+### Generate Agent
+```
+POST /api/v1/agents/generate
+```
+Generates one or more launchable agent configurations from a plain-English
+description. If `deploy` is true, the top suggestion is created as a shadow
+agent. Generated `agent_type`, `domain`, and tool selections are validated
+against the same runtime catalog used by A2A, MCP, and workflow generation.
+
+**Request Body:**
+```json
+{
+  "description": "Create a contract intelligence agent that uses Confluence knowledge and Jira issues to review renewal risk.",
+  "deploy": false,
+  "company_id": "optional-company-uuid"
+}
+```
+
+**Response:** `200 OK`
+```json
+{
+  "suggestions": [
+    {
+      "employee_name": "Contract Intelligence Analyst",
+      "agent_type": "contract_intelligence",
+      "domain": "ops",
+      "suggested_tools": ["search_content_fulltext", "create_page", "search_issues"]
+    }
+  ],
+  "deployed": false,
+  "agent_id": null
+}
+```
+
 ### Agent CRUD Flow
 
 ```mermaid
@@ -2146,6 +2180,65 @@ hardcoded list. Add a template by editing `core/workflows/template_catalog.py`
 — no UI change required.
 
 Source: PR #207 (PR-C3 / Phase 7.2).
+
+### Generate workflow
+
+```
+POST /api/v1/workflows/generate
+```
+
+Generates a workflow definition from a plain-English process description.
+Generated workflow agent references are validated against the launchable
+agent-type catalog shared by A2A/MCP discovery and agent generation.
+
+**Request:**
+
+```json
+{
+  "description": "When a contract renewal is 30 days away, search knowledge, check Jira, ask contract_intelligence to summarize risk, then notify vendor_manager.",
+  "deploy": false
+}
+```
+
+**Response:**
+
+```json
+{
+  "workflow": {
+    "name": "Renewal Risk Review",
+    "domain": "ops",
+    "trigger_type": "manual",
+    "steps": [
+      {"id": "search_policy", "type": "agent_task", "agent_type": "contract_intelligence"},
+      {"id": "notify_vendor", "type": "agent_task", "agent_type": "vendor_manager"}
+    ]
+  },
+  "deployed": false,
+  "workflow_id": null
+}
+```
+
+### Run workflow
+
+```
+POST /api/v1/workflows/{id}/run
+GET  /api/v1/workflows/runs/{run_id}
+```
+
+Starts a workflow run and then polls the run record, including step status,
+inputs, outputs, confidence, and errors.
+
+### SDK launch contract
+
+The Python SDK, TypeScript SDK, and MCP server are expected to cover this
+end-to-end path:
+
+1. Discover launchable agents through `GET /api/v1/a2a/agent-card`,
+   `GET /api/v1/a2a/agents`, and `GET /api/v1/mcp/tools`.
+2. Launch `commerce_sales_agent` through `POST /api/v1/a2a/tasks` or MCP for
+   buyer/seller discovery.
+3. List connectors, search knowledge, generate an agent, generate a workflow,
+   create the workflow, run it, and poll the run status.
 
 ### Knowledge search — native pgvector fallback
 

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -29,6 +29,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "npm run build && node test/mcp-server-smoke.mjs",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/mcp-server/test/mcp-server-smoke.mjs
+++ b/mcp-server/test/mcp-server-smoke.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const calls = [];
+
+const api = http.createServer((req, res) => {
+  let raw = "";
+  req.setEncoding("utf8");
+  req.on("data", (chunk) => {
+    raw += chunk;
+  });
+  req.on("end", () => {
+    const body = raw ? JSON.parse(raw) : {};
+    calls.push({
+      method: req.method,
+      path: req.url?.split("?")[0],
+      body,
+      authorization: req.headers.authorization,
+    });
+
+    const json = (payload, status = 200) => {
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end(JSON.stringify(payload));
+    };
+
+    if (req.method === "GET" && req.url?.startsWith("/api/v1/agents")) {
+      return json({
+        items: [
+          {
+            name: "Commerce Sales Agent",
+            agent_type: "commerce_sales_agent",
+            domain: "commerce",
+            status: "shadow",
+            description: "Grantex-grounded buyer/seller commerce runtime",
+          },
+        ],
+      });
+    }
+    if (req.method === "POST" && req.url === "/api/v1/a2a/tasks") {
+      return json({
+        run_id: "mcp_a2a_1",
+        status: "completed",
+        agent_type: body.agent_type,
+        output: { commerce_response: { status: "preview_only" } },
+        confidence: 0.93,
+        runtime: "a2a",
+        tool_calls: [{ tool: "grantex_commerce:buyer_discovery_preview" }],
+      });
+    }
+    if (req.method === "POST" && req.url === "/api/v1/sop/parse-text") {
+      return json({
+        status: "draft",
+        config: {
+          agent_type: "contract_intelligence",
+          domain: "ops",
+          required_tools: ["search_content_fulltext", "create_page"],
+        },
+      });
+    }
+    if (req.method === "GET" && req.url === "/api/v1/connectors") {
+      return json({ items: [{ id: "registry-confluence", category: "ops" }] });
+    }
+    if (req.method === "GET" && req.url === "/api/v1/mcp/tools") {
+      return json({ tools: [{ name: "agenticorg_commerce_sales_agent", inputSchema: { type: "object" } }] });
+    }
+    if (req.method === "GET" && req.url === "/api/v1/a2a/agents") {
+      return json({ agents: [{ id: "commerce_sales_agent", tools: ["grantex_commerce:buyer_discovery_preview"] }] });
+    }
+    if (req.method === "GET" && req.url === "/api/v1/a2a/agent-card") {
+      return json({ name: "AgenticOrg Agent Platform", skills: [{ id: "commerce_sales_agent" }] });
+    }
+    return json({ error: `unhandled ${req.method} ${req.url}` }, 404);
+  });
+});
+
+await new Promise((resolve) => api.listen(0, "127.0.0.1", resolve));
+const address = api.address();
+const baseUrl = `http://127.0.0.1:${address.port}`;
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: ["dist/index.js"],
+  env: {
+    ...process.env,
+    AGENTICORG_API_KEY: "mcp-test-key",
+    AGENTICORG_BASE_URL: baseUrl,
+  },
+});
+const client = new Client({ name: "agenticorg-mcp-smoke", version: "1.0.0" });
+
+try {
+  await client.connect(transport);
+  const tools = await client.listTools();
+  const names = new Set(tools.tools.map((tool) => tool.name));
+  for (const expected of [
+    "list_agents",
+    "run_agent",
+    "create_agent_from_sop",
+    "list_connectors",
+    "list_mcp_tools",
+    "discover_agents_a2a",
+    "get_agent_card",
+  ]) {
+    assert.ok(names.has(expected), `missing MCP tool ${expected}`);
+  }
+
+  const run = await client.callTool({
+    name: "run_agent",
+    arguments: {
+      agent_type: "commerce_sales_agent",
+      action: "discover",
+      inputs: { merchant_id: "mch_C6W3" },
+    },
+  });
+  assert.match(run.content[0].text, /commerce_sales_agent|Commerce Sales Agent|completed/);
+
+  const listed = await client.callTool({ name: "list_mcp_tools", arguments: {} });
+  assert.match(listed.content[0].text, /agenticorg_commerce_sales_agent/);
+} finally {
+  await client.close();
+  await new Promise((resolve) => api.close(resolve));
+}
+
+assert.ok(calls.some((call) => call.path === "/api/v1/a2a/tasks"));
+assert.ok(calls.some((call) => call.path === "/api/v1/mcp/tools"));
+assert.equal(new Set(calls.map((call) => call.authorization)).size, 1);
+assert.equal(calls[0].authorization, "Bearer mcp-test-key");
+
+console.log(`mcp server smoke passed (${calls.length} backend calls)`);

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -1,6 +1,8 @@
 # agenticorg-sdk
 
-TypeScript SDK for AgenticOrg — run AI agents, create from SOP, A2A/MCP access.
+TypeScript SDK for AgenticOrg - run AI agents, generate agents from plain
+English or SOPs, discover A2A/MCP tools, search knowledge, and create/run
+workflows.
 
 ## Install
 
@@ -23,21 +25,52 @@ console.log(result.status);     // "completed"
 console.log(result.confidence); // 0.95
 console.log(result.output);     // {...structured result...}
 
+// Buyer/seller commerce discovery via the seller commerce agent
+const commerce = await client.agents.run("commerce_sales_agent", {
+  action: "buyer_discovery_preview",
+  inputs: {
+    merchant_id: "merchant_demo",
+    query: "Show available laptop stands under Rs 3000",
+  },
+});
+
+// Generate any launchable AI-template agent from skills/tools/connectors context
+const draftAgent = await client.agents.generate(
+  "Create a contract intelligence agent that uses Confluence knowledge, " +
+    "Jira issues, and vendor policy documents to review renewal risk.",
+);
+
 // Create agent from SOP
-const draft = await client.sop.parseText(`
+const sopDraft = await client.sop.parseText(`
   Step 1: Receive invoice from vendor
   Step 2: Validate GSTIN on GST portal
   Step 3: 3-way match with PO and GRN
   Step 4: If amount > 5L, escalate to CFO
 `, "finance");
 
-const agent = await client.sop.deploy(draft.config);
+const agent = await client.sop.deploy(sopDraft.config);
 
 // MCP tools (for ChatGPT/Claude integration)
 const tools = await client.mcp.tools();
 
 // A2A discovery
 const card = await client.a2a.agentCard();
+const a2aAgents = await client.a2a.agents();
+
+// Knowledge + workflow generation
+const kb = await client.knowledge.search("vendor renewal policy", { topK: 3 });
+const workflowDraft = await client.workflows.generate(
+  "When a contract renewal is 30 days away, search knowledge, check Jira, " +
+    "ask contract_intelligence to summarize risk, then notify vendor_manager.",
+);
+const workflow = await client.workflows.create({
+  name: "Renewal Risk Review",
+  definition: workflowDraft.workflow as Record<string, unknown>,
+  domain: "ops",
+});
+const run = await client.workflows.run(workflow.id as string, {
+  payload: { vendor_id: "V-100" },
+});
 ```
 
 ## Authentication
@@ -58,10 +91,13 @@ new AgenticOrg();
 
 | Resource | Methods |
 |----------|---------|
-| `client.agents` | `list()`, `get(id)`, `run(type, opts)`, `create(data)` |
+| `client.agents` | `list()`, `get(id)`, `run(type, opts)`, `create(data)`, `generate(description, opts?)` |
+| `client.connectors` | `list(category?)`, `get(id)` |
 | `client.sop` | `parseText(text, domain?)`, `deploy(config)` |
 | `client.a2a` | `agentCard()`, `agents()` |
 | `client.mcp` | `tools()`, `call(name, args?)` |
+| `client.workflows` | `templates()`, `list()`, `generate(description)`, `create(opts)`, `get(id)`, `run(id, opts?)`, `getRun(id)` |
+| `client.knowledge` | `search(query, { topK })` |
 
 ## License
 

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agenticorg-sdk",
   "version": "0.2.0",
-  "description": "TypeScript SDK for AgenticOrg — run AI agents, create from SOP, A2A/MCP access",
+  "description": "TypeScript SDK for AgenticOrg - run agents, generate agents/workflows, use KB, A2A, and MCP",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
@@ -24,6 +24,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "npm run build && node test/sdk-contract-smoke.mjs",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -23,6 +23,11 @@ export interface RunOptions {
   context?: Record<string, unknown>;
 }
 
+export interface GenerateAgentOptions {
+  deploy?: boolean;
+  companyId?: string;
+}
+
 /**
  * Canonical response shape for every agent-execution endpoint.
  * Mirrors `docs/api/agent-run-contract.md`. Both `/agents/{id}/run`
@@ -126,6 +131,28 @@ export interface SOPParseResult {
   document_length?: number;
 }
 
+export interface WorkflowCreateOptions {
+  name: string;
+  definition: Record<string, unknown>;
+  version?: string;
+  description?: string;
+  domain?: string;
+  triggerType?: string;
+  triggerConfig?: Record<string, unknown>;
+  replanOnFailure?: boolean;
+  companyId?: string;
+}
+
+export interface WorkflowRunOptions {
+  payload?: Record<string, unknown>;
+}
+
+export interface KnowledgeSearchResult {
+  chunk_text: string;
+  score: number;
+  document_name: string;
+}
+
 class HttpClient {
   private baseUrl: string;
   private headers: Record<string, string>;
@@ -200,6 +227,32 @@ class AgentsResource {
   async create(data: Record<string, unknown>): Promise<Record<string, unknown>> {
     return (await this.http.post("/api/v1/agents", data)) as Record<string, unknown>;
   }
+
+  async generate(
+    description: string,
+    options: GenerateAgentOptions = {},
+  ): Promise<Record<string, unknown>> {
+    const payload: Record<string, unknown> = {
+      description,
+      deploy: options.deploy ?? false,
+    };
+    if (options.companyId) payload.company_id = options.companyId;
+    return (await this.http.post("/api/v1/agents/generate", payload)) as Record<string, unknown>;
+  }
+}
+
+class ConnectorsResource {
+  constructor(private http: HttpClient) {}
+
+  async list(category?: string): Promise<Record<string, unknown>[]> {
+    const params = category ? { category } : undefined;
+    const data = (await this.http.get("/api/v1/connectors", params)) as any;
+    return data.items ?? data;
+  }
+
+  async get(connectorId: string): Promise<Record<string, unknown>> {
+    return (await this.http.get(`/api/v1/connectors/${connectorId}`)) as Record<string, unknown>;
+  }
 }
 
 class SOPResource {
@@ -246,11 +299,81 @@ class MCPResource {
   }
 }
 
+class WorkflowsResource {
+  constructor(private http: HttpClient) {}
+
+  async templates(domain?: string): Promise<Record<string, unknown>[]> {
+    const params = domain ? { domain } : undefined;
+    const data = (await this.http.get("/api/v1/workflows/templates", params)) as any;
+    return data.items ?? data;
+  }
+
+  async list(options: { page?: number; perPage?: number; companyId?: string } = {}): Promise<Record<string, unknown>> {
+    const params: Record<string, string> = {
+      page: String(options.page ?? 1),
+      per_page: String(options.perPage ?? 20),
+    };
+    if (options.companyId) params.company_id = options.companyId;
+    return (await this.http.get("/api/v1/workflows", params)) as Record<string, unknown>;
+  }
+
+  async generate(description: string, options: { deploy?: boolean } = {}): Promise<Record<string, unknown>> {
+    return (await this.http.post("/api/v1/workflows/generate", {
+      description,
+      deploy: options.deploy ?? false,
+    })) as Record<string, unknown>;
+  }
+
+  async create(options: WorkflowCreateOptions): Promise<Record<string, unknown>> {
+    const payload: Record<string, unknown> = {
+      name: options.name,
+      version: options.version ?? "1.0",
+      definition: options.definition,
+      replan_on_failure: options.replanOnFailure ?? false,
+    };
+    if (options.description !== undefined) payload.description = options.description;
+    if (options.domain !== undefined) payload.domain = options.domain;
+    if (options.triggerType !== undefined) payload.trigger_type = options.triggerType;
+    if (options.triggerConfig !== undefined) payload.trigger_config = options.triggerConfig;
+    if (options.companyId !== undefined) payload.company_id = options.companyId;
+    return (await this.http.post("/api/v1/workflows", payload)) as Record<string, unknown>;
+  }
+
+  async get(workflowId: string): Promise<Record<string, unknown>> {
+    return (await this.http.get(`/api/v1/workflows/${workflowId}`)) as Record<string, unknown>;
+  }
+
+  async run(workflowId: string, options: WorkflowRunOptions = {}): Promise<Record<string, unknown>> {
+    return (await this.http.post(`/api/v1/workflows/${workflowId}/run`, {
+      payload: options.payload ?? {},
+    })) as Record<string, unknown>;
+  }
+
+  async getRun(runId: string): Promise<Record<string, unknown>> {
+    return (await this.http.get(`/api/v1/workflows/runs/${runId}`)) as Record<string, unknown>;
+  }
+}
+
+class KnowledgeResource {
+  constructor(private http: HttpClient) {}
+
+  async search(query: string, options: { topK?: number } = {}): Promise<KnowledgeSearchResult[]> {
+    const data = (await this.http.post("/api/v1/knowledge/search", {
+      query,
+      top_k: options.topK ?? 5,
+    })) as any;
+    return data.results ?? data;
+  }
+}
+
 export class AgenticOrg {
   public agents: AgentsResource;
+  public connectors: ConnectorsResource;
   public sop: SOPResource;
   public a2a: A2AResource;
   public mcp: MCPResource;
+  public workflows: WorkflowsResource;
+  public knowledge: KnowledgeResource;
 
   constructor(config: AgenticOrgConfig = {}) {
     const apiKey = config.apiKey ?? process.env.AGENTICORG_API_KEY ?? "";
@@ -273,8 +396,11 @@ export class AgenticOrg {
     const http = new HttpClient(baseUrl, headers, timeout);
 
     this.agents = new AgentsResource(http);
+    this.connectors = new ConnectorsResource(http);
     this.sop = new SOPResource(http);
     this.a2a = new A2AResource(http);
     this.mcp = new MCPResource(http);
+    this.workflows = new WorkflowsResource(http);
+    this.knowledge = new KnowledgeResource(http);
   }
 }

--- a/sdk-ts/test/sdk-contract-smoke.mjs
+++ b/sdk-ts/test/sdk-contract-smoke.mjs
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { AgenticOrg, toAgentRunResult } = require("../dist/index.js");
+
+const calls = [];
+
+globalThis.fetch = async (url, init = {}) => {
+  const parsed = new URL(url);
+  const body = init.body ? JSON.parse(String(init.body)) : undefined;
+  calls.push({
+    method: init.method || "GET",
+    path: parsed.pathname,
+    params: Object.fromEntries(parsed.searchParams.entries()),
+    body,
+    authorization: init.headers?.Authorization || init.headers?.authorization,
+  });
+
+  const json = (payload, status = 200) =>
+    new Response(JSON.stringify(payload), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+
+  if (parsed.pathname === "/api/v1/connectors") {
+    return json({ items: [{ id: "registry-confluence", category: "ops" }] });
+  }
+  if (parsed.pathname === "/api/v1/agents/generate") {
+    return json({
+      suggestions: [
+        {
+          agent_type: "contract_intelligence",
+          domain: "ops",
+          suggested_tools: ["search_content_fulltext", "create_page"],
+        },
+      ],
+      deployed: { agent_id: "agent_shadow_ts", status: "shadow" },
+    });
+  }
+  if (parsed.pathname === "/api/v1/a2a/tasks") {
+    return json({
+      run_id: "a2a_ts_1",
+      status: "completed",
+      agent_type: body.agent_type,
+      output: { commerce_response: { status: "preview_only" } },
+      confidence: 0.92,
+      runtime: "a2a",
+      tool_calls: [{ tool: "grantex_commerce:buyer_discovery_preview" }],
+    });
+  }
+  if (parsed.pathname === "/api/v1/a2a/agent-card") {
+    return json({ name: "AgenticOrg Agent Platform", skills: [{ id: "commerce_sales_agent" }] });
+  }
+  if (parsed.pathname === "/api/v1/a2a/agents") {
+    return json({ agents: [{ id: "commerce_sales_agent" }] });
+  }
+  if (parsed.pathname === "/api/v1/mcp/tools") {
+    return json({ tools: [{ name: "agenticorg_commerce_sales_agent", inputSchema: { type: "object" } }] });
+  }
+  if (parsed.pathname === "/api/v1/mcp/call") {
+    return json({ content: [{ type: "text", text: "Status: completed" }], isError: false });
+  }
+  if (parsed.pathname === "/api/v1/knowledge/search") {
+    return json({
+      results: [{ chunk_text: "KB result", score: 0.91, document_name: "contract-kb.md" }],
+    });
+  }
+  if (parsed.pathname === "/api/v1/workflows/templates") {
+    return json({ items: [{ id: "tpl-contract-renewal", domain: "ops" }] });
+  }
+  if (parsed.pathname === "/api/v1/workflows/generate") {
+    return json({
+      workflow: {
+        name: "Contract Workflow",
+        steps: [{ id: "search_kb", type: "agent", agent_type: "contract_intelligence" }],
+      },
+      deployed: false,
+      workflow_id: null,
+    });
+  }
+  if (parsed.pathname === "/api/v1/workflows") {
+    return json({ workflow_id: "wf_ts_1", name: body.name, version: body.version });
+  }
+  if (parsed.pathname === "/api/v1/workflows/wf_ts_1/run") {
+    return json({ run_id: "run_ts_1", status: "running" });
+  }
+  if (parsed.pathname === "/api/v1/workflows/runs/run_ts_1") {
+    return json({ run_id: "run_ts_1", status: "completed", steps: [{ step_id: "search_kb" }] });
+  }
+  return json({ error: `unhandled ${parsed.pathname}` }, 404);
+};
+
+const legacy = toAgentRunResult({
+  id: "legacy_a2a",
+  status: "completed",
+  result: { output: { ok: true }, confidence: 0.8 },
+});
+assert.equal(legacy.run_id, "legacy_a2a");
+assert.deepEqual(legacy.output, { ok: true });
+assert.equal(legacy.confidence, 0.8);
+
+const client = new AgenticOrg({ apiKey: "sdk-ts-test-key", baseUrl: "https://agenticorg.test" });
+
+assert.equal((await client.connectors.list("ops"))[0].id, "registry-confluence");
+assert.equal((await client.a2a.agentCard()).skills[0].id, "commerce_sales_agent");
+assert.equal((await client.a2a.agents())[0].id, "commerce_sales_agent");
+assert.equal((await client.mcp.tools())[0].name, "agenticorg_commerce_sales_agent");
+
+const generatedAgent = await client.agents.generate("Create a contract intelligence agent.", { deploy: true });
+assert.equal(generatedAgent.deployed.status, "shadow");
+
+const commerceRun = await client.agents.run("commerce_sales_agent", {
+  action: "discover",
+  inputs: { merchant_id: "mch_C6W3" },
+});
+assert.equal(commerceRun.status, "completed");
+assert.equal(commerceRun.agent_type, "commerce_sales_agent");
+assert.equal(commerceRun.output.commerce_response.status, "preview_only");
+assert.equal(commerceRun.tool_calls[0].tool, "grantex_commerce:buyer_discovery_preview");
+
+assert.equal((await client.mcp.call("agenticorg_commerce_sales_agent", { inputs: {} })).isError, false);
+assert.equal((await client.knowledge.search("renewal policy", { topK: 1 }))[0].document_name, "contract-kb.md");
+assert.equal((await client.workflows.templates("ops"))[0].id, "tpl-contract-renewal");
+assert.equal(
+  (await client.workflows.generate("Search the KB and open a Jira issue.")).workflow.steps[0].agent_type,
+  "contract_intelligence",
+);
+
+const workflow = await client.workflows.create({
+  name: "Contract Workflow",
+  domain: "ops",
+  triggerType: "manual",
+  definition: {
+    steps: [
+      {
+        id: "search_kb",
+        type: "agent",
+        agent_type: "contract_intelligence",
+        authorized_tools: ["search_content_fulltext"],
+        knowledge_sources: ["kb_contracts"],
+      },
+    ],
+  },
+});
+const run = await client.workflows.run(workflow.workflow_id, { payload: { contract_id: "CTR-1" } });
+assert.equal((await client.workflows.getRun(run.run_id)).status, "completed");
+
+assert.equal(new Set(calls.map((call) => call.authorization)).size, 1);
+assert.equal(calls[0].authorization, "Bearer sdk-ts-test-key");
+for (const expected of [
+  "/api/v1/connectors",
+  "/api/v1/agents/generate",
+  "/api/v1/a2a/tasks",
+  "/api/v1/mcp/call",
+  "/api/v1/knowledge/search",
+  "/api/v1/workflows/templates",
+  "/api/v1/workflows/generate",
+  "/api/v1/workflows",
+]) {
+  assert.ok(calls.some((call) => call.path === expected), `missing call to ${expected}`);
+}
+
+console.log(`sdk contract smoke passed (${calls.length} calls)`);

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,6 +1,7 @@
 # AgenticOrg Python SDK
 
-Run AI agents, create agents from SOPs, and manage connectors — all from Python or the terminal.
+Run AI agents, generate agents from plain English or SOPs, discover A2A/MCP
+tools, search knowledge, and create/run workflows from Python or the terminal.
 
 ## Install
 
@@ -11,7 +12,7 @@ pip install agenticorg
 ## Quickstart (Python)
 
 ```python
-from agenticorg import AgenticOrg
+from agenticorg import AgenticOrg, AgentRunResult
 
 client = AgenticOrg(api_key="your-key")
 
@@ -19,17 +20,35 @@ client = AgenticOrg(api_key="your-key")
 agents = client.agents.list(domain="finance")
 
 # Run an agent
-result = client.agents.run("ap_processor", inputs={
+result: AgentRunResult = client.agents.run("ap_processor", inputs={
     "invoice_id": "INV-001",
     "vendor_id": "V-100",
 })
-print(result["status"])      # "completed"
-print(result["confidence"])  # 0.95
-print(result["output"])      # {...structured result...}
+print(result.status)      # "completed"
+print(result.confidence)  # 0.95
+print(result.output)      # {...structured result...}
+
+# Buyer/seller commerce discovery via the seller commerce agent
+commerce: AgentRunResult = client.agents.run(
+    "commerce_sales_agent",
+    action="buyer_discovery_preview",
+    inputs={
+        "merchant_id": "merchant_demo",
+        "query": "Show available laptop stands under Rs 3000",
+    },
+)
+print(commerce.status, commerce.output)
+
+# Generate any launchable AI-template agent from skills/tools/connectors context
+draft_agent = client.agents.generate(
+    "Create a contract intelligence agent that uses Confluence knowledge, "
+    "Jira issues, and vendor policy documents to review renewal risk.",
+)
+print(draft_agent["suggestions"][0]["agent_type"])
 
 # Create an agent directly
 agent = client.agents.create(
-    name="Invoice Validator — GST Specialist",
+    name="Invoice Validator - GST Specialist",
     agent_type="invoice_validator_gst",
     domain="finance",
     llm_model="claude-3-5-sonnet-20241022",
@@ -45,7 +64,7 @@ print(agent["agent_id"])     # new agent UUID
 print(agent["status"])       # "shadow"
 
 # Create agent from SOP
-draft = client.sop.parse_text("""
+sop_draft = client.sop.parse_text("""
 Step 1: Receive invoice from vendor
 Step 2: Validate GSTIN on GST portal
 Step 3: 3-way match with PO and GRN
@@ -54,8 +73,22 @@ Step 5: Post journal entry
 """, domain_hint="finance")
 
 # Review and deploy
-agent = client.sop.deploy(draft["config"])
+agent = client.sop.deploy(sop_draft["config"])
 print(agent["agent_id"])  # deployed as shadow agent
+
+# Search tenant knowledge and generate/run workflows
+matches = client.knowledge.search("vendor renewal policy", top_k=3)
+workflow_draft = client.workflows.generate(
+    "When a contract renewal is 30 days away, search knowledge, check Jira, "
+    "ask contract_intelligence to summarize risk, then notify vendor_manager.",
+)
+workflow = client.workflows.create(
+    name="Renewal Risk Review",
+    definition=workflow_draft["workflow"],
+    domain="ops",
+)
+run = client.workflows.run(workflow["id"], payload={"vendor_id": "V-100"})
+print(matches[0]["document_name"], run["run_id"])
 ```
 
 ## Quickstart (CLI)
@@ -70,6 +103,13 @@ agenticorg agents list --domain finance
 
 # Run an agent
 agenticorg agents run ap_processor --input '{"invoice_id": "INV-001"}'
+agenticorg agents run commerce_sales_agent --action buyer_discovery_preview --input '{"merchant_id":"merchant_demo"}'
+
+# Generate agents, query knowledge, and run workflows
+agenticorg agents generate "Create a contract intelligence agent using Confluence and Jira"
+agenticorg knowledge search "vendor renewal policy" --top-k 3
+agenticorg workflows generate "Review vendor renewal risk using KB and Jira"
+agenticorg workflows run wf-123 --input '{"vendor_id":"V-100"}'
 
 # Parse SOP and create agent
 agenticorg sop parse --file invoice_sop.pdf --domain finance
@@ -93,11 +133,13 @@ Three options:
 
 | Resource | Methods |
 |----------|---------|
-| `client.agents` | `list()`, `get(id)`, `run(type, inputs=...)`, `create(...)` |
+| `client.agents` | `list()`, `get(id)`, `run(type, inputs=...)`, `create(...)`, `generate(description, deploy=False)` |
 | `client.connectors` | `list()`, `get(id)` |
 | `client.sop` | `parse_text(text)`, `upload(file)`, `deploy(config)` |
 | `client.a2a` | `agent_card()`, `agents()` |
 | `client.mcp` | `tools()`, `call(name, args)` |
+| `client.workflows` | `templates()`, `list()`, `generate(description)`, `create(...)`, `get(id)`, `run(id, payload=...)`, `get_run(id)` |
+| `client.knowledge` | `search(query, top_k=5)` |
 
 ## License
 

--- a/sdk/agenticorg/__init__.py
+++ b/sdk/agenticorg/__init__.py
@@ -1,4 +1,4 @@
-"""AgenticOrg Python SDK — run AI agents, create from SOP, manage connectors.
+"""AgenticOrg Python SDK - run agents, generate agents/workflows, use KB and MCP.
 
 Quickstart:
     from agenticorg import AgenticOrg
@@ -6,9 +6,10 @@ Quickstart:
     client = AgenticOrg(api_key="your-key")
     agents = client.agents.list()
     result = client.agents.run("ap_processor", inputs={"invoice_id": "INV-001"})
+    workflow = client.workflows.generate("Review vendor renewal risk")
 """
 
-from agenticorg.client import AgenticOrg, AgentRunResult
+from agenticorg.client import AgentRunResult, AgenticOrg
 
 __all__ = ["AgenticOrg", "AgentRunResult"]
 __version__ = "0.2.0"

--- a/sdk/agenticorg/__init__.py
+++ b/sdk/agenticorg/__init__.py
@@ -9,7 +9,7 @@ Quickstart:
     workflow = client.workflows.generate("Review vendor renewal risk")
 """
 
-from agenticorg.client import AgentRunResult, AgenticOrg
+from agenticorg.client import AgenticOrg, AgentRunResult
 
 __all__ = ["AgenticOrg", "AgentRunResult"]
 __version__ = "0.2.0"

--- a/sdk/agenticorg/cli.py
+++ b/sdk/agenticorg/cli.py
@@ -1,12 +1,12 @@
-"""AgenticOrg CLI — manage AI agents from the terminal.
+"""AgenticOrg CLI - launch agents, discover A2A/MCP, use KB, and run workflows.
 
 Usage:
     agenticorg agents list
-    agenticorg agents list --domain finance
-    agenticorg agents run ap_processor --input '{"invoice_id": "INV-001"}'
-    agenticorg agents get <agent-id>
-    agenticorg sop parse --file invoice_sop.pdf --domain finance
-    agenticorg sop parse --text "Step 1: Receive invoice..."
+    agenticorg agents run commerce_sales_agent --action buyer_discovery_preview --input '{"merchant_id": "merchant_demo"}'
+    agenticorg agents generate "Create a contract intelligence agent using Confluence and Jira"
+    agenticorg workflows generate "Review vendor renewal risk"
+    agenticorg workflows run <workflow-id> --input '{"vendor_id": "V-100"}'
+    agenticorg knowledge search "vendor renewal policy"
     agenticorg a2a card
     agenticorg mcp tools
 """
@@ -17,12 +17,15 @@ import argparse
 import json
 import os
 import sys
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         prog="agenticorg",
-        description="AgenticOrg CLI — manage AI agents from the terminal",
+        description="AgenticOrg CLI - launch agents, discover tools, and run workflows",
     )
     parser.add_argument("--api-key", help="API key (or set AGENTICORG_API_KEY env var)")
     parser.add_argument("--base-url", help="Base URL (default: https://app.agenticorg.ai)")
@@ -31,7 +34,7 @@ def main():
 
     # agents
     agents_parser = subparsers.add_parser("agents", help="Manage agents")
-    agents_sub = agents_parser.add_subparsers(dest="action")
+    agents_sub = agents_parser.add_subparsers(dest="agents_action")
 
     list_p = agents_sub.add_parser("list", help="List agents")
     list_p.add_argument("--domain", help="Filter by domain")
@@ -42,26 +45,78 @@ def main():
     run_p = agents_sub.add_parser("run", help="Run an agent")
     run_p.add_argument("agent_type", help="Agent type or UUID")
     run_p.add_argument("--input", dest="input_json", help="JSON input data")
-    run_p.add_argument("--action", default="process", help="Action (default: process)")
+    run_p.add_argument("--action", dest="run_action", default="process", help="Action (default: process)")
+
+    gen_p = agents_sub.add_parser("generate", help="Generate an agent from a description")
+    gen_p.add_argument("description", help="Plain-English agent description")
+    gen_p.add_argument("--deploy", action="store_true", help="Deploy top suggestion as a shadow agent")
+    gen_p.add_argument("--company-id", help="Company UUID for deployment")
+
+    # connectors
+    connectors_parser = subparsers.add_parser("connectors", help="Manage connectors")
+    connectors_sub = connectors_parser.add_subparsers(dest="connectors_action")
+    connectors_list = connectors_sub.add_parser("list", help="List connectors")
+    connectors_list.add_argument("--category", help="Filter by category")
+    connectors_get = connectors_sub.add_parser("get", help="Get connector details")
+    connectors_get.add_argument("connector_id", help="Connector ID")
 
     # sop
     sop_parser = subparsers.add_parser("sop", help="Create agent from SOP")
-    sop_sub = sop_parser.add_subparsers(dest="action")
+    sop_sub = sop_parser.add_subparsers(dest="sop_action")
 
     parse_p = sop_sub.add_parser("parse", help="Parse SOP document")
     parse_p.add_argument("--file", help="Path to PDF/markdown file")
     parse_p.add_argument("--text", help="SOP text (inline)")
     parse_p.add_argument("--domain", help="Domain hint")
 
+    # workflows
+    workflows_parser = subparsers.add_parser("workflows", help="Generate and run workflows")
+    workflows_sub = workflows_parser.add_subparsers(dest="workflows_action")
+
+    templates_p = workflows_sub.add_parser("templates", help="List workflow templates")
+    templates_p.add_argument("--domain", help="Filter by domain")
+
+    workflows_sub.add_parser("list", help="List workflows")
+
+    wf_get_p = workflows_sub.add_parser("get", help="Get workflow details")
+    wf_get_p.add_argument("workflow_id", help="Workflow ID")
+
+    wf_gen_p = workflows_sub.add_parser("generate", help="Generate workflow from description")
+    wf_gen_p.add_argument("description", help="Plain-English workflow description")
+    wf_gen_p.add_argument("--deploy", action="store_true", help="Create active workflow from generated definition")
+
+    wf_create_p = workflows_sub.add_parser("create", help="Create workflow from JSON definition")
+    wf_create_p.add_argument("--name", required=True, help="Workflow name")
+    wf_create_p.add_argument("--definition", help="Workflow definition JSON")
+    wf_create_p.add_argument("--definition-file", help="Path to workflow definition JSON")
+    wf_create_p.add_argument("--domain", help="Workflow domain")
+    wf_create_p.add_argument("--description", help="Workflow description")
+    wf_create_p.add_argument("--trigger-type", help="Trigger type")
+    wf_create_p.add_argument("--company-id", help="Company UUID")
+
+    wf_run_p = workflows_sub.add_parser("run", help="Run a workflow")
+    wf_run_p.add_argument("workflow_id", help="Workflow ID")
+    wf_run_p.add_argument("--input", dest="input_json", help="JSON trigger payload")
+
+    wf_run_get_p = workflows_sub.add_parser("get-run", help="Get workflow run status")
+    wf_run_get_p.add_argument("run_id", help="Workflow run ID")
+
+    # knowledge
+    knowledge_parser = subparsers.add_parser("knowledge", help="Search tenant knowledge base")
+    knowledge_sub = knowledge_parser.add_subparsers(dest="knowledge_action")
+    knowledge_search = knowledge_sub.add_parser("search", help="Search tenant knowledge base")
+    knowledge_search.add_argument("query", help="Search query")
+    knowledge_search.add_argument("--top-k", type=int, default=5, help="Number of results")
+
     # a2a
     a2a_parser = subparsers.add_parser("a2a", help="A2A protocol")
-    a2a_sub = a2a_parser.add_subparsers(dest="action")
+    a2a_sub = a2a_parser.add_subparsers(dest="a2a_action")
     a2a_sub.add_parser("card", help="Get agent discovery card")
     a2a_sub.add_parser("agents", help="List A2A agents")
 
     # mcp
     mcp_parser = subparsers.add_parser("mcp", help="MCP protocol")
-    mcp_sub = mcp_parser.add_subparsers(dest="action")
+    mcp_sub = mcp_parser.add_subparsers(dest="mcp_action")
     mcp_sub.add_parser("tools", help="List MCP tools")
 
     args = parser.parse_args()
@@ -70,7 +125,6 @@ def main():
         parser.print_help()
         return
 
-    # Build client
     from agenticorg import AgenticOrg
 
     try:
@@ -78,50 +132,71 @@ def main():
             api_key=args.api_key or os.getenv("AGENTICORG_API_KEY"),
             base_url=args.base_url,
         )
-    except ValueError as e:
-        print(f"Error: {e}", file=sys.stderr)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 
     try:
         if args.command == "agents":
             _handle_agents(client, args)
+        elif args.command == "connectors":
+            _handle_connectors(client, args)
         elif args.command == "sop":
             _handle_sop(client, args)
+        elif args.command == "workflows":
+            _handle_workflows(client, args)
+        elif args.command == "knowledge":
+            _handle_knowledge(client, args)
         elif args.command == "a2a":
             _handle_a2a(client, args)
         elif args.command == "mcp":
             _handle_mcp(client, args)
-    except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
     finally:
         client.close()
 
 
-def _handle_agents(client, args):
-    if args.action == "list":
+def _handle_agents(client: Any, args: argparse.Namespace) -> None:
+    if args.agents_action == "list":
         agents = client.agents.list(domain=args.domain)
-        for a in agents:
-            name = a.get("employee_name") or a.get("name", "")
-            agent_type = a.get("agent_type", "")
-            status = a.get("status", "")
-            # Agent IDs truncated — no sensitive data exposed
-            agent_id_short = str(a.get("id", ""))[:8]
+        for agent in agents:
+            name = agent.get("employee_name") or agent.get("name", "")
+            agent_type = agent.get("agent_type", "")
+            status = agent.get("status", "")
+            agent_id_short = str(agent.get("id", ""))[:8]
             print(f"  {agent_id_short + '...':<12} {name:<25} {agent_type:<20} {status}")
         print(f"\n{len(agents)} agents")
+    elif args.agents_action == "get":
+        _print_json(client.agents.get(args.agent_id))
+    elif args.agents_action == "run":
+        inputs = _load_json(args.input_json, default={})
+        result = client.agents.run(args.agent_type, action=args.run_action, inputs=inputs)
+        _print_json(result)
+    elif args.agents_action == "generate":
+        _print_json(
+            client.agents.generate(
+                args.description,
+                deploy=args.deploy,
+                company_id=args.company_id,
+            )
+        )
+    else:
+        raise ValueError("Unknown agents action")
 
-    elif args.action == "get":
-        agent = client.agents.get(args.agent_id)
-        print(json.dumps(agent, indent=2, default=str))
 
-    elif args.action == "run":
-        inputs = json.loads(args.input_json) if args.input_json else {}
-        result = client.agents.run(args.agent_type, action=args.action, inputs=inputs)
-        print(json.dumps(result, indent=2, default=str))
+def _handle_connectors(client: Any, args: argparse.Namespace) -> None:
+    if args.connectors_action == "list":
+        _print_json(client.connectors.list(category=args.category))
+    elif args.connectors_action == "get":
+        _print_json(client.connectors.get(args.connector_id))
+    else:
+        raise ValueError("Unknown connectors action")
 
 
-def _handle_sop(client, args):
-    if args.action == "parse":
+def _handle_sop(client: Any, args: argparse.Namespace) -> None:
+    if args.sop_action == "parse":
         if args.file:
             result = client.sop.upload(args.file, domain_hint=args.domain or "")
         elif args.text:
@@ -129,25 +204,96 @@ def _handle_sop(client, args):
         else:
             print("Error: --file or --text required", file=sys.stderr)
             sys.exit(1)
-        print(json.dumps(result, indent=2, default=str))
+        _print_json(result)
+    else:
+        raise ValueError("Unknown SOP action")
 
 
-def _handle_a2a(client, args):
-    if args.action == "card":
-        card = client.a2a.agent_card()
-        print(json.dumps(card, indent=2, default=str))
-    elif args.action == "agents":
+def _handle_workflows(client: Any, args: argparse.Namespace) -> None:
+    if args.workflows_action == "templates":
+        _print_json(client.workflows.templates(domain=args.domain))
+    elif args.workflows_action == "list":
+        _print_json(client.workflows.list())
+    elif args.workflows_action == "get":
+        _print_json(client.workflows.get(args.workflow_id))
+    elif args.workflows_action == "generate":
+        _print_json(client.workflows.generate(args.description, deploy=args.deploy))
+    elif args.workflows_action == "create":
+        definition = _load_workflow_definition(args.definition, args.definition_file)
+        _print_json(
+            client.workflows.create(
+                name=args.name,
+                definition=definition,
+                domain=args.domain,
+                description=args.description,
+                trigger_type=args.trigger_type,
+                company_id=args.company_id,
+            )
+        )
+    elif args.workflows_action == "run":
+        _print_json(
+            client.workflows.run(
+                args.workflow_id,
+                payload=_load_json(args.input_json, default={}),
+            )
+        )
+    elif args.workflows_action == "get-run":
+        _print_json(client.workflows.get_run(args.run_id))
+    else:
+        raise ValueError("Unknown workflows action")
+
+
+def _handle_knowledge(client: Any, args: argparse.Namespace) -> None:
+    if args.knowledge_action == "search":
+        _print_json(client.knowledge.search(args.query, top_k=args.top_k))
+    else:
+        raise ValueError("Unknown knowledge action")
+
+
+def _handle_a2a(client: Any, args: argparse.Namespace) -> None:
+    if args.a2a_action == "card":
+        _print_json(client.a2a.agent_card())
+    elif args.a2a_action == "agents":
         agents = client.a2a.agents()
-        for a in agents:
-            print(f"  {a['id']:<25} {a['name']:<25} {a['domain']}")
+        for agent in agents:
+            print(f"  {agent['id']:<25} {agent['name']:<25} {agent['domain']}")
+    else:
+        raise ValueError("Unknown A2A action")
 
 
-def _handle_mcp(client, args):
-    if args.action == "tools":
+def _handle_mcp(client: Any, args: argparse.Namespace) -> None:
+    if args.mcp_action == "tools":
         tools = client.mcp.tools()
-        for t in tools:
-            print(f"  {t['name']:<35} {t['description'][:60]}")
+        for tool in tools:
+            print(f"  {tool['name']:<35} {tool['description'][:60]}")
         print(f"\n{len(tools)} tools")
+    else:
+        raise ValueError("Unknown MCP action")
+
+
+def _load_json(raw: str | None, *, default: dict[str, Any]) -> dict[str, Any]:
+    if not raw:
+        return default
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("JSON input must be an object")
+    return data
+
+
+def _load_workflow_definition(raw: str | None, file_path: str | None) -> dict[str, Any]:
+    if raw and file_path:
+        raise ValueError("Use only one of --definition or --definition-file")
+    if file_path:
+        raw = Path(file_path).read_text(encoding="utf-8")
+    if not raw:
+        raise ValueError("--definition or --definition-file is required")
+    return _load_json(raw, default={})
+
+
+def _print_json(value: Any) -> None:
+    if is_dataclass(value):
+        value = asdict(value)
+    print(json.dumps(value, indent=2, default=str))
 
 
 if __name__ == "__main__":

--- a/sdk/agenticorg/cli.py
+++ b/sdk/agenticorg/cli.py
@@ -2,7 +2,8 @@
 
 Usage:
     agenticorg agents list
-    agenticorg agents run commerce_sales_agent --action buyer_discovery_preview --input '{"merchant_id": "merchant_demo"}'
+    agenticorg agents run commerce_sales_agent --action buyer_discovery_preview \
+        --input '{"merchant_id": "merchant_demo"}'
     agenticorg agents generate "Create a contract intelligence agent using Confluence and Jira"
     agenticorg workflows generate "Review vendor renewal risk"
     agenticorg workflows run <workflow-id> --input '{"vendor_id": "V-100"}'

--- a/sdk/agenticorg/client.py
+++ b/sdk/agenticorg/client.py
@@ -119,6 +119,8 @@ class AgenticOrg:
         self.sop = _SOPResource(self._http)
         self.a2a = _A2AResource(self._http)
         self.mcp = _MCPResource(self._http)
+        self.workflows = _WorkflowsResource(self._http)
+        self.knowledge = _KnowledgeResource(self._http)
 
     def _build_headers(self) -> dict[str, str]:
         headers = {"Content-Type": "application/json"}
@@ -205,6 +207,25 @@ class _AgentsResource:
     def create(self, **kwargs: Any) -> dict[str, Any]:
         """Create a new agent."""
         resp = self._http.post("/api/v1/agents", json=kwargs)
+        resp.raise_for_status()
+        return resp.json()
+
+    def generate(
+        self,
+        description: str,
+        *,
+        deploy: bool = False,
+        company_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Generate an agent config from a plain-English description.
+
+        If ``deploy`` is true, the API creates the top suggestion as a shadow
+        agent. This mirrors ``POST /api/v1/agents/generate``.
+        """
+        payload: dict[str, Any] = {"description": description, "deploy": deploy}
+        if company_id:
+            payload["company_id"] = company_id
+        resp = self._http.post("/api/v1/agents/generate", json=payload)
         resp.raise_for_status()
         return resp.json()
 
@@ -305,3 +326,113 @@ class _MCPResource:
         })
         resp.raise_for_status()
         return resp.json()
+
+
+class _WorkflowsResource:
+    def __init__(self, http: httpx.Client):
+        self._http = http
+
+    def templates(self, domain: str | None = None) -> list[dict[str, Any]]:
+        """List workflow templates, optionally filtered by domain."""
+        params = {"domain": domain} if domain else {}
+        resp = self._http.get("/api/v1/workflows/templates", params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("items", data) if isinstance(data, dict) else data
+
+    def list(
+        self,
+        *,
+        page: int = 1,
+        per_page: int = 20,
+        company_id: str | None = None,
+    ) -> dict[str, Any]:
+        """List deployed workflows."""
+        params: dict[str, Any] = {"page": page, "per_page": per_page}
+        if company_id:
+            params["company_id"] = company_id
+        resp = self._http.get("/api/v1/workflows", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    def generate(self, description: str, *, deploy: bool = False) -> dict[str, Any]:
+        """Generate a workflow definition from a natural-language description."""
+        resp = self._http.post(
+            "/api/v1/workflows/generate",
+            json={"description": description, "deploy": deploy},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def create(
+        self,
+        *,
+        name: str,
+        definition: dict[str, Any],
+        version: str = "1.0",
+        description: str | None = None,
+        domain: str | None = None,
+        trigger_type: str | None = None,
+        trigger_config: dict[str, Any] | None = None,
+        replan_on_failure: bool = False,
+        company_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a workflow definition."""
+        payload: dict[str, Any] = {
+            "name": name,
+            "version": version,
+            "definition": definition,
+            "replan_on_failure": replan_on_failure,
+        }
+        optional = {
+            "description": description,
+            "domain": domain,
+            "trigger_type": trigger_type,
+            "trigger_config": trigger_config,
+            "company_id": company_id,
+        }
+        payload.update({key: value for key, value in optional.items() if value is not None})
+        resp = self._http.post("/api/v1/workflows", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get(self, workflow_id: str) -> dict[str, Any]:
+        """Get a workflow definition."""
+        resp = self._http.get(f"/api/v1/workflows/{workflow_id}")
+        resp.raise_for_status()
+        return resp.json()
+
+    def run(
+        self,
+        workflow_id: str,
+        *,
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Start a workflow run."""
+        resp = self._http.post(
+            f"/api/v1/workflows/{workflow_id}/run",
+            json={"payload": payload or {}},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_run(self, run_id: str) -> dict[str, Any]:
+        """Get workflow run status and step outputs."""
+        resp = self._http.get(f"/api/v1/workflows/runs/{run_id}")
+        resp.raise_for_status()
+        return resp.json()
+
+
+class _KnowledgeResource:
+    def __init__(self, http: httpx.Client):
+        self._http = http
+
+    def search(self, query: str, *, top_k: int = 5) -> list[dict[str, Any]]:
+        """Search the tenant knowledge base."""
+        resp = self._http.post(
+            "/api/v1/knowledge/search",
+            json={"query": query, "top_k": top_k},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("results", data) if isinstance(data, dict) else data

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "agenticorg"
 version = "0.2.0"
-description = "Python SDK for AgenticOrg — run AI agents, create from SOP, manage connectors"
+description = "Python SDK for AgenticOrg - run agents, generate agents/workflows, use KB, A2A, and MCP"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"

--- a/tests/regression/test_sdk_e2e_launch_and_workflows_20260613.py
+++ b/tests/regression/test_sdk_e2e_launch_and_workflows_20260613.py
@@ -1,0 +1,658 @@
+"""End-to-end SDK launch and workflow composition regressions.
+
+This suite pins the user-facing contract across the SDKs, A2A/MCP discovery,
+commerce buyer/seller guardrails, and template-to-workflow generation. It uses
+deterministic local doubles for external HTTP/LLM systems, but calls the real
+SDK/client/generator/commerce code in this checkout.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+
+TENANT_ID = "00000000-0000-0000-0000-000000000001"
+
+
+def _load_repo_sdk_client_module() -> Any:
+    root = pathlib.Path(__file__).resolve().parents[2]
+    client_path = root / "sdk" / "agenticorg" / "client.py"
+    spec = importlib.util.spec_from_file_location("_repo_sdk_e2e_client", client_path)
+    assert spec and spec.loader, f"cannot load {client_path}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_repo_sdk_e2e_client"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_python_sdk_can_launch_agents_discover_mcp_use_kb_and_workflows(monkeypatch: pytest.MonkeyPatch) -> None:
+    sdk_mod = _load_repo_sdk_client_module()
+    calls: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8")) if request.content else {}
+        calls.append(
+            {
+                "method": request.method,
+                "path": request.url.path,
+                "params": dict(request.url.params),
+                "json": body,
+                "authorization": request.headers.get("authorization"),
+            }
+        )
+        path = request.url.path
+        method = request.method
+
+        if method == "GET" and path == "/api/v1/a2a/agent-card":
+            return httpx.Response(
+                200,
+                json={
+                    "name": "AgenticOrg Agent Platform",
+                    "skills": [
+                        {"id": "commerce_sales_agent", "tools": ["grantex_commerce:buyer_discovery_preview"]},
+                        {"id": "contract_intelligence", "tools": ["search_content_fulltext"]},
+                    ],
+                },
+            )
+        if method == "GET" and path == "/api/v1/a2a/agents":
+            return httpx.Response(200, json={"agents": [{"id": "commerce_sales_agent"}]})
+        if method == "GET" and path == "/api/v1/mcp/tools":
+            return httpx.Response(
+                200,
+                json={"tools": [{"name": "agenticorg_commerce_sales_agent", "inputSchema": {"type": "object"}}]},
+            )
+        if method == "POST" and path == "/api/v1/mcp/call":
+            return httpx.Response(
+                200,
+                json={
+                    "content": [{"type": "text", "text": "Agent: Commerce Sales Agent\nStatus: completed"}],
+                    "isError": False,
+                },
+            )
+        if method == "GET" and path == "/api/v1/connectors":
+            return httpx.Response(200, json={"items": [{"id": "registry-confluence", "category": "ops"}]})
+        if method == "POST" and path == "/api/v1/agents/generate":
+            return httpx.Response(
+                200,
+                json={
+                    "suggestions": [
+                        {
+                            "agent_type": "contract_intelligence",
+                            "domain": "ops",
+                            "suggested_tools": ["search_content_fulltext", "create_page", "search_issues"],
+                        }
+                    ],
+                    "deployed": {"agent_id": "agent_shadow_1", "status": "shadow"},
+                },
+            )
+        if method == "POST" and path == "/api/v1/a2a/tasks":
+            return httpx.Response(
+                200,
+                json={
+                    "run_id": "a2a_commerce_1",
+                    "agent_type": body["agent_type"],
+                    "status": "completed",
+                    "output": {
+                        "commerce_response": {
+                            "status": "preview_only",
+                            "merchant_preview": {"display_name": "Grounded Store"},
+                        }
+                    },
+                    "confidence": 0.91,
+                    "runtime": "a2a",
+                    "reasoning_trace": ["read Grantex buyer preview"],
+                    "tool_calls": [{"tool": "grantex_commerce:buyer_discovery_preview"}],
+                },
+            )
+        if method == "POST" and path == "/api/v1/knowledge/search":
+            return httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {
+                            "chunk_text": "Refunds require seller-source confirmation.",
+                            "score": 0.94,
+                            "document_name": "commerce-policy.md",
+                        }
+                    ]
+                },
+            )
+        if method == "GET" and path == "/api/v1/workflows/templates":
+            return httpx.Response(200, json={"items": [{"id": "tpl-contract-renewal", "domain": "ops"}]})
+        if method == "POST" and path == "/api/v1/workflows/generate":
+            return httpx.Response(
+                200,
+                json={
+                    "workflow": {
+                        "name": "Contract Intelligence Workflow",
+                        "steps": [{"id": "search_kb", "type": "agent", "agent_type": "contract_intelligence"}],
+                    },
+                    "deployed": False,
+                    "workflow_id": None,
+                },
+            )
+        if method == "POST" and path == "/api/v1/workflows":
+            return httpx.Response(201, json={"workflow_id": "wf_contract_1", "name": body["name"], "version": "1.0"})
+        if method == "POST" and path == "/api/v1/workflows/wf_contract_1/run":
+            return httpx.Response(200, json={"run_id": "run_contract_1", "status": "running"})
+        if method == "GET" and path == "/api/v1/workflows/runs/run_contract_1":
+            return httpx.Response(
+                200,
+                json={"run_id": "run_contract_1", "status": "completed", "steps": [{"step_id": "search_kb"}]},
+            )
+        return httpx.Response(404, json={"error": f"unhandled {method} {path}"})
+
+    transport = httpx.MockTransport(handler)
+    original_client = sdk_mod.httpx.Client
+
+    def client_factory(*args: Any, **kwargs: Any) -> httpx.Client:
+        kwargs["transport"] = transport
+        return original_client(*args, **kwargs)
+
+    monkeypatch.setattr(sdk_mod.httpx, "Client", client_factory)
+
+    client = sdk_mod.AgenticOrg(api_key="sdk-test-key", base_url="https://agenticorg.test")
+    try:
+        assert client.a2a.agent_card()["skills"][0]["id"] == "commerce_sales_agent"
+        assert client.a2a.agents()[0]["id"] == "commerce_sales_agent"
+        assert client.mcp.tools()[0]["name"] == "agenticorg_commerce_sales_agent"
+        assert client.connectors.list(category="ops")[0]["id"] == "registry-confluence"
+
+        generated_agent = client.agents.generate(
+            "Create a contract intelligence agent that uses knowledge search and Jira.",
+            deploy=True,
+        )
+        assert generated_agent["deployed"]["status"] == "shadow"
+
+        commerce_run = client.agents.run(
+            "commerce_sales_agent",
+            action="discover",
+            inputs={"merchant_id": "mch_C6W3", "buyer_agent_id": "buyer_C6W3"},
+        )
+        assert commerce_run.status == "completed"
+        assert commerce_run.agent_type == "commerce_sales_agent"
+        assert commerce_run.output["commerce_response"]["status"] == "preview_only"
+        assert commerce_run.tool_calls[0]["tool"] == "grantex_commerce:buyer_discovery_preview"
+
+        mcp_call = client.mcp.call("agenticorg_commerce_sales_agent", {"inputs": {"merchant_id": "mch_C6W3"}})
+        assert mcp_call["isError"] is False
+
+        kb = client.knowledge.search("refund confirmation policy", top_k=1)
+        assert kb[0]["document_name"] == "commerce-policy.md"
+
+        assert client.workflows.templates(domain="ops")[0]["id"] == "tpl-contract-renewal"
+        generated_workflow = client.workflows.generate("Search KB then open a Jira-backed renewal workflow.")
+        assert generated_workflow["workflow"]["steps"][0]["agent_type"] == "contract_intelligence"
+
+        workflow = client.workflows.create(
+            name="Contract Intelligence Workflow",
+            domain="ops",
+            trigger_type="manual",
+            definition={
+                "steps": [
+                    {
+                        "id": "search_kb",
+                        "type": "agent",
+                        "agent_type": "contract_intelligence",
+                        "authorized_tools": ["search_content_fulltext"],
+                        "knowledge_sources": ["kb_contracts"],
+                    }
+                ]
+            },
+        )
+        run = client.workflows.run(workflow["workflow_id"], payload={"contract_id": "CTR-1"})
+        assert client.workflows.get_run(run["run_id"])["status"] == "completed"
+    finally:
+        client.close()
+
+    paths = [call["path"] for call in calls]
+    for expected in (
+        "/api/v1/a2a/agent-card",
+        "/api/v1/a2a/tasks",
+        "/api/v1/mcp/tools",
+        "/api/v1/mcp/call",
+        "/api/v1/agents/generate",
+        "/api/v1/knowledge/search",
+        "/api/v1/workflows/templates",
+        "/api/v1/workflows/generate",
+        "/api/v1/workflows",
+    ):
+        assert expected in paths
+    assert {call["authorization"] for call in calls} == {"Bearer sdk-test-key"}
+
+
+def test_python_cli_launch_generation_knowledge_and_workflow_commands(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = pathlib.Path(__file__).resolve().parents[2]
+    monkeypatch.syspath_prepend(str(root / "sdk"))
+    for module_name in ("agenticorg.cli", "agenticorg"):
+        sys.modules.pop(module_name, None)
+
+    import agenticorg
+    from agenticorg import cli
+
+    class FakeClient:
+        instances: list["FakeClient"] = []
+
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+            self.calls: list[tuple[str, dict[str, Any]]] = []
+            self.agents = SimpleNamespace(
+                run=self._agents_run,
+                generate=self._agents_generate,
+                list=lambda domain=None: [],
+                get=lambda agent_id: {"id": agent_id},
+            )
+            self.connectors = SimpleNamespace(
+                list=lambda category=None: [{"id": "registry-jira", "category": category}],
+                get=lambda connector_id: {"id": connector_id},
+            )
+            self.workflows = SimpleNamespace(
+                generate=self._workflows_generate,
+                run=self._workflows_run,
+                get_run=lambda run_id: {"run_id": run_id, "status": "completed"},
+                templates=lambda domain=None: [{"id": "tpl-renewal", "domain": domain}],
+                list=lambda: {"items": []},
+                get=lambda workflow_id: {"id": workflow_id},
+                create=lambda **kwargs: {"id": "wf-created", **kwargs},
+            )
+            self.knowledge = SimpleNamespace(
+                search=lambda query, top_k=5: [{"document_name": "policy.md", "query": query, "top_k": top_k}],
+            )
+            self.sop = SimpleNamespace(parse_text=lambda text, domain_hint="": {"text": text, "domain_hint": domain_hint})
+            self.a2a = SimpleNamespace(agent_card=lambda: {"skills": []}, agents=lambda: [])
+            self.mcp = SimpleNamespace(tools=lambda: [])
+            FakeClient.instances.append(self)
+
+        def close(self) -> None:
+            self.calls.append(("close", {}))
+
+        def _agents_run(self, agent_type: str, *, action: str, inputs: dict[str, Any]) -> dict[str, Any]:
+            call = {"agent_type": agent_type, "action": action, "inputs": inputs}
+            self.calls.append(("agents.run", call))
+            return call
+
+        def _agents_generate(self, description: str, *, deploy: bool = False, company_id: str | None = None) -> dict[str, Any]:
+            call = {"description": description, "deploy": deploy, "company_id": company_id}
+            self.calls.append(("agents.generate", call))
+            return call
+
+        def _workflows_generate(self, description: str, *, deploy: bool = False) -> dict[str, Any]:
+            call = {"description": description, "deploy": deploy}
+            self.calls.append(("workflows.generate", call))
+            return call
+
+        def _workflows_run(self, workflow_id: str, *, payload: dict[str, Any]) -> dict[str, Any]:
+            call = {"workflow_id": workflow_id, "payload": payload}
+            self.calls.append(("workflows.run", call))
+            return call
+
+    monkeypatch.setattr(agenticorg, "AgenticOrg", FakeClient)
+
+    def run_cli(argv: list[str]) -> tuple[dict[str, Any] | list[Any], FakeClient]:
+        monkeypatch.setattr(sys, "argv", ["agenticorg", "--api-key", "cli-key", *argv])
+        cli.main()
+        stdout = capsys.readouterr().out
+        return json.loads(stdout), FakeClient.instances[-1]
+
+    output, client = run_cli(
+        [
+            "agents",
+            "run",
+            "commerce_sales_agent",
+            "--action",
+            "buyer_discovery_preview",
+            "--input",
+            '{"merchant_id":"merchant_demo"}',
+        ]
+    )
+    assert output["agent_type"] == "commerce_sales_agent"
+    assert output["action"] == "buyer_discovery_preview"
+    assert output["inputs"] == {"merchant_id": "merchant_demo"}
+    assert ("agents.run", output) in client.calls
+
+    output, _ = run_cli(["agents", "generate", "Create contract intelligence agent", "--deploy"])
+    assert output["deploy"] is True
+
+    output, _ = run_cli(["knowledge", "search", "vendor renewal policy", "--top-k", "2"])
+    assert output[0]["document_name"] == "policy.md"
+    assert output[0]["top_k"] == 2
+
+    output, _ = run_cli(["workflows", "generate", "Review vendor renewal risk"])
+    assert output["description"] == "Review vendor renewal risk"
+
+    output, _ = run_cli(["workflows", "run", "wf-1", "--input", '{"vendor_id":"V-100"}'])
+    assert output["workflow_id"] == "wf-1"
+    assert output["payload"] == {"vendor_id": "V-100"}
+
+
+@pytest.mark.asyncio
+async def test_runtime_catalogs_do_not_drift_between_generators_a2a_and_mcp(monkeypatch: pytest.MonkeyPatch) -> None:
+    from api.v1.a2a import list_available_agents
+    from api.v1.agents import _AGENT_TYPE_DEFAULT_TOOLS as API_AGENT_TOOLS
+    from api.v1.mcp import list_tools
+    from core.agent_generator import VALID_AGENT_TYPES
+    from core.commerce.discovery_gate import COMMERCE_PUBLIC_DISCOVERY_ENV
+    from core.workflow_generator import KNOWN_AGENT_TYPES
+
+    monkeypatch.setenv(COMMERCE_PUBLIC_DISCOVERY_ENV, "true")
+
+    api_agent_types = set(API_AGENT_TOOLS)
+    assert "commerce_sales_agent" in api_agent_types
+    assert set(KNOWN_AGENT_TYPES) == api_agent_types
+    assert VALID_AGENT_TYPES == api_agent_types
+
+    a2a_agent_ids = {agent["id"] for agent in (await list_available_agents())["agents"]}
+    mcp_agent_ids = {tool["name"].removeprefix("agenticorg_") for tool in (await list_tools())["tools"]}
+    assert a2a_agent_ids == api_agent_types
+    assert mcp_agent_ids == api_agent_types
+
+
+@pytest.mark.asyncio
+async def test_buyer_seller_commerce_discovery_and_prepared_handoff_are_non_executing() -> None:
+    from core.commerce.buyer_session import start_buyer_discovery_session
+    from core.commerce.oacp_artifacts import (
+        InMemoryOacpArtifactCacheRepository,
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES,
+        OacpArtifactCacheRepositoryQuery,
+        OacpPersistentArtifactCacheRecord,
+        evaluate_agenticorg_c6w5_commitment_boundary,
+        prepare_agenticorg_c6w6_commitment_envelope,
+    )
+    from core.commerce.sales_guardrails import validate_payment_action
+
+    class FakeConnector:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, str]] = []
+
+        async def buyer_discovery_preview(self, **params: str) -> dict[str, Any]:
+            self.calls.append(dict(params))
+            return {
+                "data": {
+                    "merchant_reference": "safe-merchant-ref",
+                    "display_name": "Grounded Preview Store",
+                    "integration_status": "sandbox_handoff_requested",
+                    "generated_at": "2026-06-13T10:00:00Z",
+                    "audit_event_id": "audit_sdk_e2e",
+                    "merchant": {
+                        "display_name": "Grounded Preview Store",
+                        "category_preset": "electronics_appliances",
+                        "country_code": "IN",
+                        "default_currency": "INR",
+                        "public_discovery_description_draft": "Preview-only catalog evidence.",
+                    },
+                    "readiness_summary": {"overall_status": "ready"},
+                    "agent_facing_preview_summary": {"preview_status": "ready", "sample_product_count": 1},
+                    "rollout_proposal_summary": {"proposal_status": "dry_run_passed"},
+                    "evidence_checklist": [{"key": "preview", "label": "Preview ready", "status": "pass"}],
+                    "sample_products": [
+                        {
+                            "title": "Grounded Mixer",
+                            "brand": "SafeBrand",
+                            "category_preset": "electronics_appliances",
+                            "price": "999",
+                            "currency": "INR",
+                            "source_label": "grantex_preview",
+                        }
+                    ],
+                    "allowed_buyer_agent_capabilities": ["read_only_catalog_discovery_preview"],
+                    "blocked_buyer_agent_capabilities": [
+                        "checkout_payment_creation",
+                        "live_payment",
+                        "order_fulfillment",
+                    ],
+                    "blockers": [],
+                    "sandbox_only": True,
+                    "buyer_agent_discovery_is_public": False,
+                    "agenticorg_public_discovery_enabled": False,
+                    "public_discovery_enabled": False,
+                    "checkout_payment_enabled": False,
+                    "live_provider_enabled": False,
+                    "live_mode_status": "not_live",
+                    "production_approval_status": "not_approved",
+                }
+            }
+
+    connector = FakeConnector()
+    buyer_response = await start_buyer_discovery_session(
+        connector,
+        merchant_id="mch_C6W3",
+        request_text="Show me this seller catalog preview.",
+        channel="chatgpt",
+    )
+    assert connector.calls == [{"merchant_id": "mch_C6W3"}]
+    assert buyer_response["status"] == "preview_only"
+    assert buyer_response["merchant_preview"]["display_name"] == "Grounded Preview Store"
+    assert buyer_response["evidence_summary"]["grantex_grounded"] is True
+    assert "checkout_payment_creation" in buyer_response["blocked_capabilities"]
+
+    checkout = validate_payment_action("checkout_create", {"merchant_id": "mch_C6W3", "provider_key": "mock"})
+    assert checkout["allowed"] is False
+    assert checkout["error"] == "consent_required"
+
+    repository = InMemoryOacpArtifactCacheRepository()
+    base_cache_record = OacpPersistentArtifactCacheRecord(
+        cache_record_id="cache_price_sdk_e2e",
+        artifact_id="price_C6W3",
+        artifact_type="price",
+        authority="grantex_canonical_oacp_artifact_authority",
+        issuer="grantex",
+        scope_kind="buyer_agent",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+        source_refs=("source_ref_price_sdk_e2e",),
+        evidence_refs=("evidence_price_sdk_e2e_redacted",),
+        generated_at="2026-06-11T00:00:00.000Z",
+        cached_at="2026-06-11T00:00:10.000Z",
+        expires_at="2026-06-11T00:05:00.000Z",
+        freshness_status="fresh",
+        revocation_snapshot_status="fresh",
+        revocation_snapshot_observed_at="2026-06-11T00:00:30.000Z",
+        revocation_snapshot_age_seconds=30,
+        ttl_policy_seconds=300,
+        risk_tier="low",
+        blocked_capabilities=("checkout_payment_creation", "live_provider_call"),
+        unsupported_capabilities=("transaction_authority_from_adapter_preview",),
+        verifier_result_ref="verifier_result_price_sdk_e2e",
+    )
+    assert repository.upsert(base_cache_record)["stored"] is True
+    assert repository.upsert(
+        replace(
+            base_cache_record,
+            cache_record_id="cache_seller_sdk_e2e",
+            artifact_id="seller_agent_capability_C6W3",
+            artifact_type="seller_agent_capability",
+            scope_kind="seller_agent",
+            buyer_agent_id=None,
+            ttl_policy_seconds=6 * 60 * 60,
+        )
+    )["stored"] is True
+    assert repository.list_for_scope(
+        OacpArtifactCacheRepositoryQuery(
+            tenant_id="cten_C6W3",
+            merchant_id="mch_C6W3",
+            seller_agent_id="seller_C6W3",
+        )
+    )
+
+    commitment = repository.evaluate(
+        cache_record_id="cache_price_sdk_e2e",
+        action_intent="final_commitment",
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=False,
+        expected_scope={
+            "tenant_id": "cten_C6W3",
+            "merchant_id": "mch_C6W3",
+            "seller_agent_id": "seller_C6W3",
+            "buyer_agent_id": "buyer_C6W3",
+        },
+    )
+    assert commitment["allowed_to_prepare"] is True
+    assert commitment["allowed_to_execute"] is False
+    assert commitment["non_authoritative_for_transaction"] is True
+
+    artifacts = [
+        OACP_C6W3_VALID_ARTIFACT_FIXTURES[name]
+        for name in (
+            "merchant_capability",
+            "seller_agent_capability",
+            "catalog_snapshot",
+            "offer",
+            "price",
+            "inventory",
+            "policy",
+            "mandate_capability",
+            "commitment_evidence",
+            "protocol_adapter",
+        )
+    ]
+    preview = {
+        "generated": True,
+        "status": "preview_only",
+        "surface": "mcp_tool_resource_capability",
+        "source_artifact_ids": [artifact["envelope"]["artifact_id"] for artifact in artifacts],
+        "source_artifact_families": [artifact["envelope"]["artifact_type"] for artifact in artifacts],
+        "source_authority": "grantex_canonical_oacp_artifact_authority",
+        "generated_at": "2026-06-11T00:00:30.000Z",
+        "expires_at": "2026-06-11T00:02:00.000Z",
+        "max_ttl_seconds": 90,
+        "freshness_tier": "fresh",
+        "unsupported_capabilities": ["checkout_create", "payment_authorize", "live_provider_call"],
+        "blocked_capabilities": ["checkout_create", "payment_authorize"],
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+    }
+    decision = evaluate_agenticorg_c6w5_commitment_boundary(
+        action="price_lock",
+        cached_artifacts=artifacts,
+        adapter_preview=preview,
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=False,
+        revocation_snapshot_age_seconds=30,
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+        max_quantity_per_sku=1,
+    )
+    envelope = prepare_agenticorg_c6w6_commitment_envelope(
+        envelope_kind="buyer_confirmation_request",
+        resolver_decision=decision,
+        created_at="2026-06-11T00:01:15.000Z",
+        evidence_refs=["price-evidence-ref", "https://private.example/internal"],
+        currency="INR",
+        amount_minor_units=200000,
+        total_quantity=1,
+    )
+    assert envelope["generated"] is True
+    assert envelope["envelope"]["prepared_only"] is True
+    assert envelope["envelope"]["allowed_to_execute"] is False
+    assert envelope["envelope"]["commerce_facts_invented"] is False
+    assert "redacted_private_evidence_ref" in envelope["envelope"]["redacted_evidence_refs"]
+
+
+@pytest.mark.asyncio
+async def test_template_skills_connectors_tools_and_kb_generate_launchable_workflows() -> None:
+    from api.v1.agents import _AGENT_TYPE_DEFAULT_TOOLS as API_AGENT_TOOLS
+    from core.agent_generator import generate_agent_config
+    from core.workflow_generator import generate_workflow
+
+    suggestion = {
+        "confidence": 0.94,
+        "agent_type": "contract_intelligence",
+        "domain": "ops",
+        "employee_name": "Ananya Rao",
+        "designation": "Contract Intelligence Lead",
+        "suggested_tools": ["search_content_fulltext", "create_page", "search_issues"],
+        "system_prompt": (
+            "You inspect contract renewal requests, search approved knowledge bases, "
+            "prepare source-grounded summaries, and open follow-up issues for human review."
+        ),
+        "confidence_floor": 0.9,
+        "hitl_condition": "confidence < 0.9 OR renewal_value > 500000",
+        "specialization": "Contract renewal workflows with KB and Jira evidence",
+    }
+
+    class MockLLM:
+        async def complete(self, **_kwargs: Any) -> SimpleNamespace:
+            return SimpleNamespace(
+                content=json.dumps({"suggestions": [suggestion]}),
+                model="mock-agent-generator",
+                tokens_used=123,
+            )
+
+    generated_agent = await generate_agent_config(
+        "Launch a contract intelligence agent using Confluence KB, Jira issues, and source-grounded tools.",
+        llm=MockLLM(),
+    )
+    top = generated_agent["suggestions"][0]
+    assert top["agent_type"] == "contract_intelligence"
+    assert set(top["suggested_tools"]) <= set(API_AGENT_TOOLS[top["agent_type"]])
+    assert "validation_errors" not in top
+
+    workflow_definition = {
+        "name": "Contract Renewal Intelligence",
+        "description": "Search KB, inspect vendor issues, and route renewal decisions.",
+        "domain": "ops",
+        "trigger_type": "manual",
+        "trigger_config": {},
+        "version": "1.0",
+        "steps": [
+            {
+                "id": "search_contract_kb",
+                "type": "agent",
+                "title": "Search approved contract KB",
+                "agent_type": "contract_intelligence",
+                "authorized_tools": ["search_content_fulltext", "create_page"],
+                "connectors": ["confluence"],
+                "knowledge_sources": ["kb_contracts"],
+            },
+            {
+                "id": "inspect_vendor_issue",
+                "type": "agent",
+                "title": "Inspect vendor issue history",
+                "agent_type": "vendor_manager",
+                "authorized_tools": ["search_issues", "create_issue"],
+                "connectors": ["jira"],
+                "depends_on": ["search_contract_kb"],
+            },
+            {
+                "id": "human_review",
+                "type": "human_in_loop",
+                "title": "Human renewal approval",
+                "assignee_role": "legal_ops",
+                "timeout_hours": 4,
+                "depends_on": ["inspect_vendor_issue"],
+            },
+        ],
+    }
+
+    async def mock_workflow_llm(_messages: list[dict[str, str]]) -> str:
+        return json.dumps(workflow_definition)
+
+    generated_workflow = await generate_workflow(
+        "Create a workflow from the contract intelligence AI template using KB search, Confluence, and Jira.",
+        TENANT_ID,
+        _llm_override=mock_workflow_llm,
+    )
+    assert generated_workflow["name"] == "Contract Renewal Intelligence"
+    for step in generated_workflow["steps"]:
+        if step.get("type") == "agent":
+            agent_type = step["agent_type"]
+            assert agent_type in API_AGENT_TOOLS
+            assert set(step.get("authorized_tools", [])) <= set(API_AGENT_TOOLS[agent_type])
+    assert generated_workflow["steps"][0]["knowledge_sources"] == ["kb_contracts"]
+    assert generated_workflow["steps"][0]["connectors"] == ["confluence"]

--- a/tests/regression/test_sdk_e2e_launch_and_workflows_20260613.py
+++ b/tests/regression/test_sdk_e2e_launch_and_workflows_20260613.py
@@ -242,7 +242,7 @@ def test_python_cli_launch_generation_knowledge_and_workflow_commands(
     from agenticorg import cli
 
     class FakeClient:
-        instances: list["FakeClient"] = []
+        instances: list[FakeClient] = []
 
         def __init__(self, **kwargs: Any) -> None:
             self.kwargs = kwargs
@@ -269,7 +269,9 @@ def test_python_cli_launch_generation_knowledge_and_workflow_commands(
             self.knowledge = SimpleNamespace(
                 search=lambda query, top_k=5: [{"document_name": "policy.md", "query": query, "top_k": top_k}],
             )
-            self.sop = SimpleNamespace(parse_text=lambda text, domain_hint="": {"text": text, "domain_hint": domain_hint})
+            self.sop = SimpleNamespace(
+                parse_text=lambda text, domain_hint="": {"text": text, "domain_hint": domain_hint}
+            )
             self.a2a = SimpleNamespace(agent_card=lambda: {"skills": []}, agents=lambda: [])
             self.mcp = SimpleNamespace(tools=lambda: [])
             FakeClient.instances.append(self)
@@ -282,7 +284,13 @@ def test_python_cli_launch_generation_knowledge_and_workflow_commands(
             self.calls.append(("agents.run", call))
             return call
 
-        def _agents_generate(self, description: str, *, deploy: bool = False, company_id: str | None = None) -> dict[str, Any]:
+        def _agents_generate(
+            self,
+            description: str,
+            *,
+            deploy: bool = False,
+            company_id: str | None = None,
+        ) -> dict[str, Any]:
             call = {"description": description, "deploy": deploy, "company_id": company_id}
             self.calls.append(("agents.generate", call))
             return call
@@ -362,8 +370,8 @@ async def test_runtime_catalogs_do_not_drift_between_generators_a2a_and_mcp(monk
 async def test_buyer_seller_commerce_discovery_and_prepared_handoff_are_non_executing() -> None:
     from core.commerce.buyer_session import start_buyer_discovery_session
     from core.commerce.oacp_artifacts import (
-        InMemoryOacpArtifactCacheRepository,
         OACP_C6W3_VALID_ARTIFACT_FIXTURES,
+        InMemoryOacpArtifactCacheRepository,
         OacpArtifactCacheRepositoryQuery,
         OacpPersistentArtifactCacheRecord,
         evaluate_agenticorg_c6w5_commitment_boundary,

--- a/tests/unit/test_workflow_generator.py
+++ b/tests/unit/test_workflow_generator.py
@@ -41,7 +41,7 @@ def _make_valid_workflow_json(
                 "id": "extract_invoice",
                 "type": "agent",
                 "title": "Extract invoice data",
-                "agent_type": "invoice_processor",
+                "agent_type": "ap_processor",
             },
             {
                 "id": "check_amount",
@@ -97,7 +97,7 @@ def _make_parallel_workflow_json() -> str:
                 "id": "validate_employee",
                 "type": "agent",
                 "title": "Validate employee data",
-                "agent_type": "onboarding_specialist",
+                "agent_type": "onboarding_agent",
             },
             {
                 "id": "create_accounts_parallel",
@@ -114,21 +114,21 @@ def _make_parallel_workflow_json() -> str:
                 "id": "create_slack",
                 "type": "agent",
                 "title": "Create Slack account",
-                "agent_type": "it_helpdesk",
+                "agent_type": "it_operations",
                 "depends_on": ["validate_employee"],
             },
             {
                 "id": "create_gmail",
                 "type": "agent",
                 "title": "Create Gmail account",
-                "agent_type": "it_helpdesk",
+                "agent_type": "it_operations",
                 "depends_on": ["validate_employee"],
             },
             {
                 "id": "create_jira",
                 "type": "agent",
                 "title": "Create Jira account",
-                "agent_type": "it_helpdesk",
+                "agent_type": "it_operations",
                 "depends_on": ["validate_employee"],
             },
             {
@@ -586,7 +586,7 @@ class TestValidation:
     def test_defaults_filled_in(self) -> None:
         """Minimal valid workflow gets defaults filled in."""
         defn = {
-            "steps": [{"id": "s1", "type": "agent", "agent_type": "invoice_processor"}],
+            "steps": [{"id": "s1", "type": "agent", "agent_type": "ap_processor"}],
         }
         result = _validate_generated_workflow(defn)
         assert result["name"] == "Generated Workflow"

--- a/ui/e2e/sdk-launch-discovery-workflows.spec.ts
+++ b/ui/e2e/sdk-launch-discovery-workflows.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * SDK launch/discovery/workflow regression coverage.
+ *
+ * Hermetic local test: API responses are route-mocked so the UI contract can be
+ * verified without production credentials.
+ */
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+const APP = process.env.BASE_URL || "http://127.0.0.1:5176";
+
+function json(route: Route, body: unknown, status = 200) {
+  return route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function setSessionCookies(page: Page) {
+  const url = new URL(APP);
+  const isHttps = url.protocol === "https:";
+  await page.context().addCookies([
+    {
+      name: "agenticorg_session",
+      value: "e2e-session",
+      domain: url.hostname,
+      path: "/",
+      httpOnly: true,
+      secure: isHttps,
+      sameSite: "Lax",
+    },
+    {
+      name: "agenticorg_csrf",
+      value: "e2e-csrf",
+      domain: url.hostname,
+      path: "/",
+      httpOnly: false,
+      secure: isHttps,
+      sameSite: "Lax",
+    },
+  ]);
+}
+
+async function mockApi(page: Page) {
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+
+    if (path.endsWith("/auth/me")) {
+      return json(route, {
+        email: "qa@agenticorg.ai",
+        name: "QA Admin",
+        role: "admin",
+        domain: "all",
+        tenant_id: "tenant-e2e",
+        onboarding_complete: true,
+      });
+    }
+
+    if (path.endsWith("/companies")) {
+      return json(route, {
+        items: [{ id: "company-e2e", name: "E2E Company" }],
+        total: 1,
+      });
+    }
+
+    if (path.endsWith("/a2a/agent-card")) {
+      return json(route, {
+        name: "AgenticOrg",
+        skills: [
+          {
+            id: "commerce_sales_agent",
+            name: "Commerce Sales Agent",
+            description: "Grantex-grounded buyer/seller discovery",
+            domain: "commerce",
+            tools: ["grantex_commerce:buyer_discovery_preview"],
+          },
+          {
+            id: "contract_intelligence",
+            name: "Contract Intelligence",
+            description: "Contract and policy review",
+            domain: "ops",
+            tools: ["search_content_fulltext", "search_issues"],
+          },
+        ],
+      });
+    }
+
+    if (path.endsWith("/a2a/agents")) {
+      return json(route, {
+        agents: [
+          { id: "commerce_sales_agent", name: "Commerce Sales Agent", domain: "commerce" },
+          { id: "contract_intelligence", name: "Contract Intelligence", domain: "ops" },
+        ],
+      });
+    }
+
+    if (path.endsWith("/mcp/tools")) {
+      return json(route, {
+        tools: [
+          {
+            name: "agenticorg_commerce_sales_agent",
+            description: "Run the commerce seller agent",
+            inputSchema: { type: "object" },
+          },
+          {
+            name: "agenticorg_contract_intelligence",
+            description: "Run contract intelligence",
+            inputSchema: { type: "object" },
+          },
+        ],
+      });
+    }
+
+    return json(route, { items: [], total: 0 });
+  });
+
+  await setSessionCookies(page);
+}
+
+test.describe("SDK launch, discovery, KB, and workflow examples", () => {
+  test("Integrations page exposes current Python and TypeScript SDK contract", async ({ page }) => {
+    await mockApi(page);
+
+    await page.goto(`${APP}/dashboard/integrations`, { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "External Integrations" })).toBeVisible();
+
+    const python = page.getByTestId("sdk-snippet-python");
+    await expect(python).toContainText("AgentRunResult");
+    await expect(python).toContainText('client.agents.run(');
+    await expect(python).toContainText('"commerce_sales_agent"');
+    await expect(python).toContainText(".status");
+    await expect(python).toContainText(".confidence");
+    await expect(python).toContainText(".output");
+    await expect(python).toContainText("client.agents.generate(");
+    await expect(python).toContainText("client.knowledge.search(");
+    await expect(python).toContainText("client.workflows.generate(");
+    await expect(python).toContainText("client.workflows.run(");
+
+    const ts = page.getByTestId("sdk-snippet-typescript");
+    await expect(ts).toContainText('new AgenticOrg({ apiKey: "your-key" })');
+    await expect(ts).toContainText('client.agents.run("commerce_sales_agent"');
+    await expect(ts).toContainText("client.agents.generate(");
+    await expect(ts).toContainText("client.knowledge.search(");
+    await expect(ts).toContainText("client.workflows.generate(");
+    await expect(ts).toContainText("client.workflows.run(");
+
+    await expect(page.locator("main")).toContainText("Commerce Sales Agent");
+    await expect(page.locator("main")).toContainText("agenticorg_commerce_sales_agent");
+  });
+});

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -164,9 +164,13 @@ export const promptTemplatesApi = {
   delete: (id: string) => api.delete(`/prompt-templates/${id}`),
 };
 export const workflowsApi = {
-  list: () => api.get("/workflows"),
+  templates: (params?: Record<string, string>) => api.get("/workflows/templates", { params }),
+  list: (params?: Record<string, string>) => api.get("/workflows", { params }),
+  get: (id: string) => api.get(`/workflows/${id}`),
+  generate: (description: string, deploy = false) => api.post("/workflows/generate", { description, deploy }),
   create: (data: any) => api.post("/workflows", data),
-  run: (id: string, payload?: any) => api.post(`/workflows/${id}/run`, payload),
+  run: (id: string, payload?: any) => api.post(`/workflows/${id}/run`, { payload: payload || {} }),
+  getRun: (id: string) => api.get(`/workflows/runs/${id}`),
 };
 export const approvalsApi = {
   list: () => api.get("/approvals"),

--- a/ui/src/pages/Integrations.tsx
+++ b/ui/src/pages/Integrations.tsx
@@ -23,7 +23,7 @@ export default function Integrations() {
       <div>
         <h2 className="text-2xl font-bold">External Integrations</h2>
         <p className="text-sm text-muted-foreground mt-1">
-          Connect external AI systems to your agents via SDK, CLI, A2A, or MCP
+          Connect SDKs, external agents, MCP clients, connectors, workflows, and knowledge.
         </p>
       </div>
 
@@ -31,97 +31,128 @@ export default function Integrations() {
         <p className="text-muted-foreground">Loading...</p>
       ) : (
         <>
-          {/* SDK Quickstart */}
           <Card>
             <CardHeader>
-              <div className="flex justify-between items-center">
+              <div className="flex justify-between items-center gap-3">
                 <CardTitle>Python SDK</CardTitle>
                 <Badge>pip install agenticorg</Badge>
               </div>
             </CardHeader>
             <CardContent className="space-y-4">
-              <p className="text-sm text-muted-foreground">
-                The fastest way to run agents, create from SOP, and manage connectors programmatically.
-              </p>
-
               <div>
-                <label className="text-xs text-muted-foreground uppercase tracking-wide">Install</label>
-                <pre className="bg-muted rounded p-3 text-sm font-mono mt-1">pip install agenticorg</pre>
-              </div>
-
-              <div>
-                <label className="text-xs text-muted-foreground uppercase tracking-wide">Run an Agent (3 lines)</label>
+                <label className="text-xs text-muted-foreground uppercase tracking-wide">Launch agents, commerce, KB, and workflows</label>
                 <pre className="bg-muted rounded p-3 text-sm font-mono mt-1 whitespace-pre-wrap" data-testid="sdk-snippet-python">{`from agenticorg import AgenticOrg, AgentRunResult
 
 client = AgenticOrg(api_key="your-key")
+
 result: AgentRunResult = client.agents.run(
     "ap_processor",
     inputs={"invoice_id": "INV-001"},
 )
-print(result.status, result.confidence, result.output)`}</pre>
-              </div>
+print(result.status, result.confidence, result.output)
 
-              <div>
-                <label className="text-xs text-muted-foreground uppercase tracking-wide">Create Agent from SOP (5 lines)</label>
-                <pre className="bg-muted rounded p-3 text-sm font-mono mt-1 whitespace-pre-wrap">{`draft = client.sop.parse_text("""
-Step 1: Receive invoice from vendor
-Step 2: Validate GSTIN
-Step 3: 3-way match with PO
-Step 4: If amount > 5L, escalate to CFO
-""", domain_hint="finance")
+commerce: AgentRunResult = client.agents.run(
+    "commerce_sales_agent",
+    action="buyer_discovery_preview",
+    inputs={
+        "merchant_id": "merchant_demo",
+        "query": "Show available laptop stands under Rs 3000",
+    },
+)
 
-agent = client.sop.deploy(draft["config"])
-print(agent["agent_id"])  # deployed as shadow agent`}</pre>
+draft_agent = client.agents.generate(
+    "Create a contract intelligence agent that uses Confluence knowledge, "
+    "Jira issues, and vendor policy documents to review renewal risk.",
+)
+
+matches = client.knowledge.search("vendor renewal policy", top_k=3)
+workflow_draft = client.workflows.generate(
+    "Review vendor renewal risk using KB and Jira, then notify vendor_manager."
+)
+workflow = client.workflows.create(
+    name="Renewal Risk Review",
+    definition=workflow_draft["workflow"],
+    domain="ops",
+)
+run = client.workflows.run(workflow["id"], payload={"vendor_id": "V-100"})`}</pre>
               </div>
             </CardContent>
           </Card>
 
-          {/* CLI */}
           <Card>
             <CardHeader>
-              <div className="flex justify-between items-center">
+              <div className="flex justify-between items-center gap-3">
+                <CardTitle>TypeScript SDK</CardTitle>
+                <Badge variant="secondary">npm i agenticorg-sdk</Badge>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <pre className="bg-muted rounded p-3 text-sm font-mono whitespace-pre-wrap" data-testid="sdk-snippet-typescript">{`import { AgenticOrg } from "agenticorg-sdk";
+
+const client = new AgenticOrg({ apiKey: "your-key" });
+
+const result = await client.agents.run("ap_processor", {
+  inputs: { invoice_id: "INV-001" },
+});
+
+const commerce = await client.agents.run("commerce_sales_agent", {
+  action: "buyer_discovery_preview",
+  inputs: {
+    merchant_id: "merchant_demo",
+    query: "Show available laptop stands under Rs 3000",
+  },
+});
+
+const draftAgent = await client.agents.generate(
+  "Create a contract intelligence agent using Confluence, Jira, and vendor policy KB.",
+);
+
+const kb = await client.knowledge.search("vendor renewal policy", { topK: 3 });
+const workflowDraft = await client.workflows.generate(
+  "Review vendor renewal risk using KB and Jira, then notify vendor_manager.",
+);
+const workflow = await client.workflows.create({
+  name: "Renewal Risk Review",
+  definition: workflowDraft.workflow,
+  domain: "ops",
+});
+const run = await client.workflows.run(workflow.id, {
+  payload: { vendor_id: "V-100" },
+});`}</pre>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <div className="flex justify-between items-center gap-3">
                 <CardTitle>CLI Tool</CardTitle>
                 <Badge variant="secondary">Terminal</Badge>
               </div>
             </CardHeader>
             <CardContent className="space-y-3">
-              <pre className="bg-muted rounded p-3 text-sm font-mono whitespace-pre-wrap">{`# Set API key
-export AGENTICORG_API_KEY=your-key
+              <pre className="bg-muted rounded p-3 text-sm font-mono whitespace-pre-wrap">{`export AGENTICORG_API_KEY=your-key
 
-# List agents
 agenticorg agents list --domain finance
-
-# Run an agent
 agenticorg agents run ap_processor --input '{"invoice_id": "INV-001"}'
-
-# Parse SOP document
 agenticorg sop parse --file invoice_sop.pdf --domain finance
-
-# View A2A agent card
 agenticorg a2a card
-
-# List MCP tools (for ChatGPT/Claude)
 agenticorg mcp tools`}</pre>
             </CardContent>
           </Card>
 
-          {/* A2A Protocol */}
           <Card>
             <CardHeader>
-              <div className="flex justify-between items-center">
+              <div className="flex justify-between items-center gap-3">
                 <CardTitle>Agent-to-Agent (A2A) Protocol</CardTitle>
                 <Badge>Grantex Auth</Badge>
               </div>
             </CardHeader>
             <CardContent className="space-y-3">
               <p className="text-sm text-muted-foreground">
-                Other AI agents discover and call your agents via A2A. Auth uses Grantex grant tokens.
+                External buyer agents discover launchable AgenticOrg seller agents through A2A.
               </p>
 
-              <pre className="bg-muted rounded p-3 text-sm font-mono whitespace-pre-wrap">{`# Discover agents (SDK)
-agents = client.a2a.agents()
-
-# Or via A2A protocol directly
+              <pre className="bg-muted rounded p-3 text-sm font-mono whitespace-pre-wrap">{`agents = client.a2a.agents()
 card = client.a2a.agent_card()  # ${agentCard?.skills?.length || 25} skills available`}</pre>
 
               {agentCard && (
@@ -137,25 +168,25 @@ card = client.a2a.agent_card()  # ${agentCard?.skills?.length || 25} skills avai
             </CardContent>
           </Card>
 
-          {/* MCP */}
           <Card>
             <CardHeader>
-              <div className="flex justify-between items-center">
+              <div className="flex justify-between items-center gap-3">
                 <CardTitle>Model Context Protocol (MCP)</CardTitle>
                 <Badge variant="secondary">ChatGPT / Claude</Badge>
               </div>
             </CardHeader>
             <CardContent className="space-y-3">
               <p className="text-sm text-muted-foreground">
-                ChatGPT, Claude, and MCP-compatible interfaces use your agents as tools.
+                MCP-compatible clients can discover AgenticOrg agents and call them as tools.
               </p>
 
-              <pre className="bg-muted rounded p-3 text-sm font-mono whitespace-pre-wrap">{`# List tools (SDK)
-tools = client.mcp.tools()  # ${mcpTools.length} tools
+              <pre className="bg-muted rounded p-3 text-sm font-mono whitespace-pre-wrap">{`tools = client.mcp.tools()  # ${mcpTools.length} tools
 
-# Call a tool
-result = client.mcp.call("agenticorg_ap_processor", {
-    "inputs": {"invoice_id": "INV-001"}
+result = client.mcp.call("agenticorg_commerce_sales_agent", {
+    "inputs": {
+        "merchant_id": "merchant_demo",
+        "query": "Show available laptop stands under Rs 3000",
+    }
 })`}</pre>
 
               <div>
@@ -176,24 +207,23 @@ result = client.mcp.call("agenticorg_ap_processor", {
             </CardContent>
           </Card>
 
-          {/* Auth */}
           <Card>
             <CardHeader><CardTitle>Authentication</CardTitle></CardHeader>
             <CardContent className="space-y-3 text-sm">
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 <div className="border rounded p-3">
                   <p className="font-medium">API Key</p>
-                  <p className="text-xs text-muted-foreground mt-1">For dashboard users. Get from Settings page.</p>
+                  <p className="text-xs text-muted-foreground mt-1">For dashboard users.</p>
                   <code className="text-xs bg-muted px-1 rounded mt-1 block">AgenticOrg(api_key="...")</code>
                 </div>
                 <div className="border rounded p-3">
                   <p className="font-medium">Grantex Token</p>
-                  <p className="text-xs text-muted-foreground mt-1">For external agents. RS256 JWT with scoped grants.</p>
+                  <p className="text-xs text-muted-foreground mt-1">For scoped external agents.</p>
                   <code className="text-xs bg-muted px-1 rounded mt-1 block">AgenticOrg(grantex_token="...")</code>
                 </div>
                 <div className="border rounded p-3">
                   <p className="font-medium">Environment</p>
-                  <p className="text-xs text-muted-foreground mt-1">Auto-detected from env vars.</p>
+                  <p className="text-xs text-muted-foreground mt-1">Detected by SDKs and MCP server.</p>
                   <code className="text-xs bg-muted px-1 rounded mt-1 block">AGENTICORG_API_KEY=...</code>
                 </div>
               </div>

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -1382,7 +1382,7 @@ export default function Landing() {
               </div>
               <h2 className="text-3xl sm:text-4xl font-bold text-white">Build With AgenticOrg</h2>
               <p className="mt-4 text-lg text-slate-400 max-w-2xl mx-auto">
-                Python SDK, TypeScript SDK, CLI, and MCP Server. Run AI agents from your code, ChatGPT, Claude, or any MCP-compatible client.
+                Python SDK, TypeScript SDK, CLI, and MCP Server. Launch agents, discover commerce tools, query knowledge, and run workflows from your code or any MCP-compatible client.
               </p>
             </div>
           </FadeIn>
@@ -1398,10 +1398,13 @@ export default function Landing() {
 
 client = AgenticOrg(api_key="ao_sk_...")
 result = client.agents.run(
-  "ap_processor",
-  inputs={"invoice_id": "INV-001"}
+  "commerce_sales_agent",
+  action="buyer_discovery_preview",
+  inputs={"merchant_id": "merchant_demo"}
 )
-print(result.output)`,
+workflow = client.workflows.generate(
+  "Review vendor renewal risk"
+)`,
                 link: "https://pypi.org/project/agenticorg/",
                 color: "from-yellow-500 to-yellow-600",
               },
@@ -1415,8 +1418,11 @@ const client = new AgenticOrg({
   apiKey: "ao_sk_..."
 })
 const result = await client.agents.run(
-  "recon_agent",
-  { inputs: { bank_id: "SBI-001" } }
+  "commerce_sales_agent",
+  { action: "buyer_discovery_preview" }
+)
+const kb = await client.knowledge.search(
+  "vendor renewal policy"
 )`,
                 link: "https://www.npmjs.com/package/agenticorg-sdk",
                 color: "from-blue-500 to-blue-600",


### PR DESCRIPTION
## Summary
- Align runtime/generator agent catalogs so workflow generation cannot emit locally-valid but unlaunchable agent types.
- Expand Python SDK, Python CLI, TypeScript SDK, and MCP smoke coverage for agent launch, commerce discovery, connectors, knowledge search, and workflows.
- Update landing/integrations docs and README/API docs so the public SDK surface reflects the latest launch/workflow capabilities.

## Root Cause
SDK/documentation coverage had drifted from the backend runtime surface. The workflow generator also kept its own stale agent catalog, which let generated workflows reference agent types the A2A/MCP/runtime launch path did not expose.

## Validation
- `python -m pytest tests\unit\test_a2a_mcp.py tests\regression\test_agent_run_contract.py tests\unit\test_commerce_buyer_discovery.py tests\unit\test_commerce_buyer_session.py tests\evals\test_commerce_sales_agent_demo.py tests\regression\test_sdk_e2e_launch_and_workflows_20260613.py tests\unit\test_workflow_generator.py tests\unit\test_agent_generator.py -q` -> 124 passed
- `npm test` in `sdk-ts` -> build + SDK contract smoke passed, 13 calls
- `npm test` in `mcp-server` -> build + MCP server smoke passed, 2 backend calls
- `npm ci` in `ui` -> 0 vulnerabilities
- `npm run typecheck` in `ui` -> passed
- `npm run build` in `ui` -> passed
- `BASE_URL=http://127.0.0.1:5176 npx playwright test e2e/sdk-launch-discovery-workflows.spec.ts --reporter=line` in `ui` -> 1 passed