### PR TITLE
[codex] Add C6X9 OACP audit export bundle

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -6000,6 +6000,610 @@ class DurableOacpOperatorDecisionRepository:
         }
 
 
+_C6X9_SAFE_FALLBACK_GENERATED_AT = "2026-06-11T00:00:00.000Z"
+_C6X9_RISKY_REVOCATION_STATES = frozenset({"revoked", "ambiguous", "stale", "expired"})
+_C6X9_HIGH_RISK_TIERS = frozenset({"high", "critical"})
+_C6X9_OVERCLAIM_MARKERS = (
+    "certification",
+    "certified",
+    "compliance",
+    "compliant",
+    "conformance",
+    "standardization",
+    "standardized",
+    "production_ready",
+    "public_launch",
+    "execution_ready",
+    "merchant_approval",
+    "checkout_approval",
+    "payment_approval",
+    "mandate_approval",
+    "live_provider_readiness",
+    "oacp_approval",
+)
+
+
+def _c6x9_bundle_id(payload: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(canonicalize_oacp_payload(dict(payload)).encode("utf-8")).hexdigest()
+    return f"oacp_c6x9_audit_export_{digest[:20]}"
+
+
+def _c6x9_blocked_bundle(
+    *,
+    reason_code: str,
+    message: str,
+    generated_at: str | None = None,
+    tenant_id: str | None = None,
+    merchant_id: str | None = None,
+    seller_agent_id: str | None = None,
+    buyer_agent_id: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at or _C6X9_SAFE_FALLBACK_GENERATED_AT
+    return {
+        "bundle_id": _c6x9_bundle_id(
+            {
+                "status": "blocked",
+                "reason_code": reason_code,
+                "tenant_id": tenant_id,
+                "merchant_id": merchant_id,
+                "generated_at": generated,
+            }
+        ),
+        "bundle_kind": "blocked_oacp_cache_operator_audit_export_bundle",
+        "status": "blocked",
+        "block_reason": reason_code,
+        "message": message,
+        "generated_at": generated,
+        "tenant_id": tenant_id,
+        "merchant_id": merchant_id,
+        "seller_agent_id": seller_agent_id,
+        "buyer_agent_id": buyer_agent_id,
+        "scope_summary": {"buyer_agent": {}, "seller_agent": {}, "tenant": {}, "merchant": {}},
+        "artifact_family_counts": {},
+        "cache_record_references": [],
+        "maintenance_plan_references": [],
+        "review_packet_references": [],
+        "decision_record_references": [],
+        "redacted_reason_codes": {},
+        "redacted_source_refs": [],
+        "redacted_evidence_refs": [],
+        "freshness_ttl_summary": {"freshness": {}, "records_with_ttl": 0, "minimum_ttl_policy_seconds": None},
+        "revocation_snapshot_summary": {},
+        "risk_tier_summary": {},
+        "unsupported_capability_summary": {},
+        "blocked_capability_summary": {reason_code: 1},
+        "next_step_labels": ["operator_review_required_no_export_execution"],
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "audit_export_bundle_only": True,
+        "export_ready": False,
+        "generated_artifact_written": False,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "raw_payloads_included": False,
+        "grantex_runtime_required": False,
+    }
+
+
+def _c6x9_unique(values: Sequence[str]) -> list[str]:
+    return sorted({value for value in values if value})
+
+
+def _c6x9_count(values: Sequence[str]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for value in values:
+        if value:
+            counts[value] = counts.get(value, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _c6x9_scope_count(
+    records: Sequence[OacpPersistentArtifactCacheRecord],
+    field_name: str,
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for record in records:
+        value = getattr(record, field_name)
+        if isinstance(value, str) and value:
+            counts[value] = counts.get(value, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _c6x9_scope_summary(records: Sequence[OacpPersistentArtifactCacheRecord]) -> dict[str, dict[str, int]]:
+    return {
+        "buyer_agent": _c6x9_scope_count(records, "buyer_agent_id"),
+        "seller_agent": _c6x9_scope_count(records, "seller_agent_id"),
+        "tenant": _c6x9_scope_count(records, "tenant_id"),
+        "merchant": _c6x9_scope_count(records, "merchant_id"),
+    }
+
+
+def _c6x9_record_scope_matches(
+    record: OacpPersistentArtifactCacheRecord,
+    *,
+    tenant_id: str,
+    merchant_id: str,
+    seller_agent_id: str | None,
+    buyer_agent_id: str | None,
+) -> bool:
+    if record.tenant_id != tenant_id or record.merchant_id != merchant_id:
+        return False
+    if seller_agent_id is not None and record.seller_agent_id not in (None, seller_agent_id):
+        return False
+    if buyer_agent_id is not None and record.buyer_agent_id not in (None, buyer_agent_id):
+        return False
+    return True
+
+
+def _c6x9_mapping_scope_matches(
+    item: Mapping[str, Any],
+    *,
+    tenant_id: str,
+    merchant_id: str,
+    seller_agent_id: str | None,
+    buyer_agent_id: str | None,
+) -> bool:
+    direct_fields = {
+        "tenant_id": tenant_id,
+        "merchant_id": merchant_id,
+        "seller_agent_id": seller_agent_id,
+        "buyer_agent_id": buyer_agent_id,
+    }
+    direct_scope_present = False
+    for field_name, expected in direct_fields.items():
+        value = item.get(field_name)
+        direct_scope_present = direct_scope_present or (field_name in item and isinstance(value, str) and bool(value))
+        if expected is not None and isinstance(value, str) and value and value != expected:
+            return False
+
+    scope_summary = _c6x8_mapping(item.get("scope_summary"))
+    if not scope_summary and direct_scope_present:
+        return True
+    scope_expectations = {
+        "tenant": (tenant_id, True),
+        "merchant": (merchant_id, True),
+        "seller_agent": (seller_agent_id, False),
+        "buyer_agent": (buyer_agent_id, False),
+    }
+    for scope_kind, (expected, required) in scope_expectations.items():
+        values = scope_summary.get(scope_kind)
+        if not isinstance(values, Mapping) or not values:
+            if required:
+                return False
+            continue
+        keys = {str(key) for key in values if isinstance(key, str) and key}
+        if expected is not None and expected not in keys:
+            return False
+    return True
+
+
+def _c6x9_components_scope_match(
+    *,
+    tenant_id: str,
+    merchant_id: str,
+    seller_agent_id: str | None,
+    buyer_agent_id: str | None,
+    cache_records: Sequence[OacpPersistentArtifactCacheRecord],
+    maintenance_plans: Sequence[Mapping[str, Any]],
+    review_packets: Sequence[Mapping[str, Any]],
+    decision_records: Sequence[Mapping[str, Any]],
+) -> bool:
+    for record in cache_records:
+        if not _c6x9_record_scope_matches(
+            record,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        ):
+            return False
+    mapped_components: list[Mapping[str, Any]] = list(review_packets) + list(decision_records)
+    for plan in maintenance_plans:
+        for action in plan.get("record_actions", []):
+            if isinstance(action, Mapping):
+                mapped_components.append(action)
+    return all(
+        _c6x9_mapping_scope_matches(
+            component,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+        for component in mapped_components
+    )
+
+
+def _c6x9_private_or_overclaim_values(values: Sequence[str]) -> bool:
+    for value in values:
+        normalized = value.strip().lower()
+        if not normalized:
+            return True
+        if any(marker in normalized for marker in C6X2_PRIVATE_REF_MARKERS):
+            return True
+        if any(marker in normalized for marker in _C6X9_OVERCLAIM_MARKERS):
+            return True
+    return False
+
+
+def _c6x9_reason_code_values(value: Any) -> list[str]:
+    values: list[str] = []
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if isinstance(key, str):
+                values.append(key)
+            values.extend(_c6x9_reason_code_values(child))
+    elif isinstance(value, list):
+        for child in value:
+            values.extend(_c6x9_reason_code_values(child))
+    elif isinstance(value, str):
+        values.append(value)
+    return values
+
+
+def _c6x9_inputs_private_or_overclaim(
+    *,
+    maintenance_plans: Sequence[Mapping[str, Any]],
+    review_packets: Sequence[Mapping[str, Any]],
+    decision_records: Sequence[Mapping[str, Any]],
+) -> bool:
+    strings: list[str] = []
+    for plan in maintenance_plans:
+        strings.extend(_c6x6_string_list(plan.get("source_refs")))
+        strings.extend(_c6x6_string_list(plan.get("evidence_refs")))
+        strings.extend(_c6x9_reason_code_values(plan.get("per_record_reason_codes")))
+    for packet in review_packets:
+        strings.extend(_c6x7_string_list(packet.get("source_refs")))
+        strings.extend(_c6x7_string_list(packet.get("evidence_refs")))
+        strings.extend(_c6x7_string_list(packet.get("next_step_labels")))
+        strings.extend(_c6x9_reason_code_values(packet.get("per_record_reason_codes")))
+    for decision in decision_records:
+        strings.extend(_c6x8_list(decision.get("source_refs")))
+        strings.extend(_c6x8_list(decision.get("evidence_refs")))
+        strings.extend(_c6x8_list(decision.get("next_step_labels")))
+        strings.extend(_c6x9_reason_code_values(decision.get("redacted_reason_codes")))
+        reviewer_ref = _c6x7_string(decision.get("reviewer_identity_ref"))
+        if reviewer_ref is not None:
+            strings.append(reviewer_ref)
+    return _c6x9_private_or_overclaim_values(strings)
+
+
+def _c6x9_timestamps_valid(
+    *,
+    generated_at: str,
+    cache_records: Sequence[OacpPersistentArtifactCacheRecord],
+    maintenance_plans: Sequence[Mapping[str, Any]],
+    review_packets: Sequence[Mapping[str, Any]],
+    decision_records: Sequence[Mapping[str, Any]],
+) -> bool:
+    values: list[str | None] = [generated_at]
+    for record in cache_records:
+        values.extend(
+            [
+                record.generated_at,
+                record.cached_at,
+                record.expires_at,
+                record.revocation_snapshot_observed_at,
+            ]
+        )
+    for plan in maintenance_plans:
+        values.append(_c6x6_string(plan.get("generated_at")))
+    for packet in review_packets:
+        values.append(_c6x7_string(packet.get("generated_at")))
+    for decision in decision_records:
+        values.extend([_c6x7_string(decision.get("generated_at")), _c6x7_string(decision.get("decided_at"))])
+    return all(_parse_iso(value) is not None for value in values)
+
+
+def _c6x9_components_non_executing(
+    *,
+    maintenance_plans: Sequence[Mapping[str, Any]],
+    review_packets: Sequence[Mapping[str, Any]],
+    decision_records: Sequence[Mapping[str, Any]],
+) -> bool:
+    for plan in maintenance_plans:
+        if not _c6x6_plan_flags_safe(plan):
+            return False
+        actions = plan.get("record_actions")
+        if not isinstance(actions, list):
+            return False
+        mapped_actions = [action for action in actions if isinstance(action, Mapping)]
+        if len(mapped_actions) != len(actions) or not _c6x6_actions_safe(mapped_actions):
+            return False
+    for packet in review_packets:
+        if not _c6x7_packet_flags_safe(packet) or not _c6x7_refs_safe(packet):
+            return False
+    for decision in decision_records:
+        if _c6x8_decision_safe_for_storage(decision).get("stored") is not True:
+            return False
+    return True
+
+
+def _c6x9_approved_risky_state(
+    *,
+    cache_records: Sequence[OacpPersistentArtifactCacheRecord],
+    review_packets: Sequence[Mapping[str, Any]],
+    decision_records: Sequence[Mapping[str, Any]],
+) -> bool:
+    risky_cache = any(
+        record.risk_tier in _C6X9_HIGH_RISK_TIERS
+        or record.revocation_snapshot_status in _C6X9_RISKY_REVOCATION_STATES
+        or record.freshness_status in {"stale", "expired"}
+        for record in cache_records
+    )
+    risky_packet = False
+    for packet in review_packets:
+        revocation_summary = _c6x8_mapping(packet.get("revocation_snapshot_summary"))
+        risk_summary = _c6x8_mapping(packet.get("risk_tier_summary"))
+        freshness_summary = _c6x8_mapping(packet.get("freshness_summary"))
+        risky_packet = risky_packet or any(key in revocation_summary for key in _C6X9_RISKY_REVOCATION_STATES)
+        risky_packet = risky_packet or any(key in risk_summary for key in _C6X9_HIGH_RISK_TIERS)
+        risky_packet = risky_packet or any(key in freshness_summary for key in ("stale", "expired"))
+    approved = any(
+        str(decision.get("decision_kind", "")).startswith("approve_future_")
+        for decision in decision_records
+    )
+    return approved and (risky_cache or risky_packet)
+
+
+def _c6x9_merge_reason_codes(*items: Mapping[str, Any]) -> dict[str, list[str]]:
+    merged: dict[str, list[str]] = {}
+    for item in items:
+        for key, value in _c6x8_mapping(item).items():
+            codes = [str(code) for code in value] if isinstance(value, list) else [str(value)]
+            merged[str(key)] = _c6x9_unique([*merged.get(str(key), []), *codes])
+    return dict(sorted(merged.items()))
+
+
+def _c6x9_capability_summary(records: Sequence[OacpPersistentArtifactCacheRecord], field_name: str) -> dict[str, int]:
+    values: list[str] = []
+    for record in records:
+        field_value = getattr(record, field_name)
+        if isinstance(field_value, tuple):
+            values.extend(str(value) for value in field_value)
+    return _c6x9_count(values)
+
+
+def build_oacp_c6x9_audit_export_bundle(
+    *,
+    cache_records: Sequence[OacpPersistentArtifactCacheRecord],
+    maintenance_plans: Sequence[Mapping[str, Any]],
+    review_packets: Sequence[Mapping[str, Any]],
+    operator_decision_records: Sequence[Mapping[str, Any]],
+    durable_decision_records: Sequence[Mapping[str, Any]] = (),
+    generated_at: str,
+    tenant_id: str,
+    merchant_id: str,
+    seller_agent_id: str | None = None,
+    buyer_agent_id: str | None = None,
+) -> dict[str, Any]:
+    """Build a redacted C6X9 audit export bundle without writing, publishing, or executing it."""
+
+    all_decision_records = tuple(operator_decision_records) + tuple(durable_decision_records)
+    if not tenant_id or not merchant_id:
+        return _c6x9_blocked_bundle(
+            reason_code="tenant_or_merchant_scope_missing",
+            message="C6X9 audit export bundles require tenant and merchant scope.",
+            generated_at=generated_at,
+            tenant_id=tenant_id or None,
+            merchant_id=merchant_id or None,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+    if not cache_records or not all_decision_records:
+        return _c6x9_blocked_bundle(
+            reason_code="audit_export_lineage_missing",
+            message="C6X9 requires local cache records and operator decision records before preparing an audit bundle.",
+            generated_at=generated_at,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+    if not _c6x9_timestamps_valid(
+        generated_at=generated_at,
+        cache_records=cache_records,
+        maintenance_plans=maintenance_plans,
+        review_packets=review_packets,
+        decision_records=all_decision_records,
+    ):
+        return _c6x9_blocked_bundle(
+            reason_code="malformed_timestamp",
+            message="C6X9 refuses audit bundles with malformed cache, plan, report, or decision timestamps.",
+            generated_at=generated_at,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+    if not all(_c6x3_record_safe_for_repository(record).get("stored") is True for record in cache_records):
+        return _c6x9_blocked_bundle(
+            reason_code="cache_record_private_or_unsafe",
+            message="C6X9 refuses cache records with missing scope, private refs, or executable posture.",
+            generated_at=generated_at,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+    if not _c6x9_components_scope_match(
+        tenant_id=tenant_id,
+        merchant_id=merchant_id,
+        seller_agent_id=seller_agent_id,
+        buyer_agent_id=buyer_agent_id,
+        cache_records=cache_records,
+        maintenance_plans=maintenance_plans,
+        review_packets=review_packets,
+        decision_records=all_decision_records,
+    ):
+        return _c6x9_blocked_bundle(
+            reason_code="audit_export_scope_mismatch",
+            message="C6X9 refuses bundles whose cache, plan, report, or decision scopes do not match.",
+            generated_at=generated_at,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+    try:
+        for component in [*maintenance_plans, *review_packets, *all_decision_records]:
+            assert_no_forbidden_oacp_artifact_fields(dict(component))
+    except ValueError:
+        return _c6x9_blocked_bundle(
+            reason_code="private_or_enabling_export_field",
+            message="C6X9 refuses private, raw, credential, or enabling export input fields.",
+            generated_at=generated_at,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+    if not _c6x9_components_non_executing(
+        maintenance_plans=maintenance_plans,
+        review_packets=review_packets,
+        decision_records=all_decision_records,
+    ):
+        return _c6x9_blocked_bundle(
+            reason_code="export_component_executable_or_enabling",
+            message="C6X9 refuses executable or enabling maintenance, review, or decision records.",
+            generated_at=generated_at,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+    if _c6x9_inputs_private_or_overclaim(
+        maintenance_plans=maintenance_plans,
+        review_packets=review_packets,
+        decision_records=all_decision_records,
+    ):
+        return _c6x9_blocked_bundle(
+            reason_code="private_ref_or_overclaim_detected",
+            message="C6X9 refuses private refs, raw reviewer identity, or publication/readiness claims.",
+            generated_at=generated_at,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+    if _c6x9_approved_risky_state(
+        cache_records=cache_records,
+        review_packets=review_packets,
+        decision_records=all_decision_records,
+    ):
+        return _c6x9_blocked_bundle(
+            reason_code="risky_state_represented_as_approved",
+            message="C6X9 refuses to export stale, revoked, or high-risk states as approved.",
+            generated_at=generated_at,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+
+    sorted_records = tuple(sorted(cache_records, key=lambda record: record.cache_record_id))
+    sorted_plans = tuple(sorted(maintenance_plans, key=lambda plan: str(plan.get("plan_id", ""))))
+    sorted_packets = tuple(sorted(review_packets, key=lambda packet: str(packet.get("report_id", ""))))
+    sorted_decisions = tuple(
+        sorted(all_decision_records, key=lambda decision: str(decision.get("decision_record_id", "")))
+    )
+    source_refs = _c6x9_unique(
+        [
+            *(ref for record in sorted_records for ref in record.source_refs),
+            *(ref for plan in sorted_plans for ref in _c6x6_string_list(plan.get("source_refs"))),
+            *(ref for packet in sorted_packets for ref in _c6x7_string_list(packet.get("source_refs"))),
+            *(ref for decision in sorted_decisions for ref in _c6x8_list(decision.get("source_refs"))),
+        ]
+    )
+    evidence_refs = _c6x9_unique(
+        [
+            *(ref for record in sorted_records for ref in record.evidence_refs),
+            *(ref for plan in sorted_plans for ref in _c6x6_string_list(plan.get("evidence_refs"))),
+            *(ref for packet in sorted_packets for ref in _c6x7_string_list(packet.get("evidence_refs"))),
+            *(ref for decision in sorted_decisions for ref in _c6x8_list(decision.get("evidence_refs"))),
+        ]
+    )
+    if not evidence_refs or not _c6x2_refs_safe((*source_refs, *evidence_refs)):
+        return _c6x9_blocked_bundle(
+            reason_code="redacted_evidence_refs_missing_or_private",
+            message="C6X9 requires redacted source and evidence refs only.",
+            generated_at=generated_at,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+
+    plan_reason_maps = [_c6x8_mapping(plan.get("per_record_reason_codes")) for plan in sorted_plans]
+    packet_reason_maps = [_c6x8_mapping(packet.get("per_record_reason_codes")) for packet in sorted_packets]
+    decision_reason_maps = [_c6x8_mapping(decision.get("redacted_reason_codes")) for decision in sorted_decisions]
+    bundle_payload = {
+        "tenant_id": tenant_id,
+        "merchant_id": merchant_id,
+        "seller_agent_id": seller_agent_id,
+        "buyer_agent_id": buyer_agent_id,
+        "generated_at": generated_at,
+        "cache_records": [record.cache_record_id for record in sorted_records],
+        "maintenance_plans": [str(plan.get("plan_id", "")) for plan in sorted_plans],
+        "review_packets": [str(packet.get("report_id", "")) for packet in sorted_packets],
+        "decision_records": [str(decision.get("decision_record_id", "")) for decision in sorted_decisions],
+    }
+    return {
+        "bundle_id": _c6x9_bundle_id(bundle_payload),
+        "bundle_kind": "oacp_cache_operator_decision_audit_export_bundle",
+        "status": "export_ready",
+        "generated_at": generated_at,
+        "tenant_id": tenant_id,
+        "merchant_id": merchant_id,
+        "seller_agent_id": seller_agent_id,
+        "buyer_agent_id": buyer_agent_id,
+        "scope_summary": _c6x9_scope_summary(sorted_records),
+        "artifact_family_counts": _c6x9_count([record.artifact_type for record in sorted_records]),
+        "cache_record_references": [record.cache_record_id for record in sorted_records],
+        "maintenance_plan_references": [str(plan.get("plan_id")) for plan in sorted_plans],
+        "review_packet_references": [str(packet.get("report_id")) for packet in sorted_packets],
+        "decision_record_references": [str(decision.get("decision_record_id")) for decision in sorted_decisions],
+        "redacted_reason_codes": _c6x9_merge_reason_codes(
+            *plan_reason_maps,
+            *packet_reason_maps,
+            *decision_reason_maps,
+        ),
+        "redacted_source_refs": source_refs,
+        "redacted_evidence_refs": evidence_refs,
+        "freshness_ttl_summary": {
+            "freshness": _c6x9_count([record.freshness_status for record in sorted_records]),
+            "records_with_ttl": len([record for record in sorted_records if record.ttl_policy_seconds > 0]),
+            "minimum_ttl_policy_seconds": min(record.ttl_policy_seconds for record in sorted_records),
+            "earliest_expires_at": min(record.expires_at for record in sorted_records),
+        },
+        "revocation_snapshot_summary": _c6x9_count([record.revocation_snapshot_status for record in sorted_records]),
+        "risk_tier_summary": _c6x9_count([record.risk_tier for record in sorted_records]),
+        "unsupported_capability_summary": _c6x9_capability_summary(sorted_records, "unsupported_capabilities"),
+        "blocked_capability_summary": _c6x9_capability_summary(sorted_records, "blocked_capabilities"),
+        "next_step_labels": _c6x9_unique(
+            [label for decision in sorted_decisions for label in _c6x8_list(decision.get("next_step_labels"))]
+        ),
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "audit_export_bundle_only": True,
+        "export_ready": True,
+        "generated_artifact_written": False,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "raw_payloads_included": False,
+        "grantex_runtime_required": False,
+        "buyer_safe_message": "C6X9 prepared an internal redacted audit export bundle only; no commerce action ran.",
+        "seller_safe_message": "C6X9 does not call Grantex live, merchant systems, providers, or schedulers.",
+        "operator_safe_message": (
+            "Review this export-ready bundle as evidence only. It is not an execution instruction."
+        ),
+    }
+
+
 class OacpArtifactCache:
     def __init__(self) -> None:
         self._items: dict[str, OacpCachedArtifact] = {}

--- a/docs/reports/commerce-agent-c6x9-oacp-audit-export-bundle.md
+++ b/docs/reports/commerce-agent-c6x9-oacp-audit-export-bundle.md
@@ -1,0 +1,72 @@
+# Commerce Agent C6X9 OACP Audit Export Bundle
+
+## Scope
+
+C6X9 adds an internal AgenticOrg audit export bundle builder over local OACP cache and operator-decision artifacts. The builder prepares an export-ready in-memory structure for operator review only. It does not write generated export files, expose an API, run jobs, call Grantex live, call providers, call merchant systems, refresh artifacts, evict records, quarantine records, or execute commerce actions.
+
+## Correct Ownership Model
+
+AgenticOrg is the buyer and seller AI-agent runtime. AgenticOrg owns durable and local OACP artifact cache behavior, seller-agent initiated connector sync intent, runtime artifact consumption, and local operator decision handling. Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. Grantex is not a transaction toll booth for every non-binding buyer or seller agent turn. Merchant systems remain operational sources of record, and provider or fintech rails own mandate and payment execution where separately approved.
+
+## Bundle Inputs
+
+The C6X9 builder consumes local and cached structures only:
+
+- C6X4 durable OACP cache records
+- C6X5 maintenance plan summaries
+- C6X6 dry-run reports and operator review packets
+- C6X7 operator decision records
+- C6X8 durable operator decision repository records
+
+Inputs must carry tenant and merchant scope. Seller-agent and buyer-agent scope are preserved where present. Input refs must be redacted source refs, evidence refs, verifier result refs, review packet refs, maintenance plan refs, and decision record refs only.
+
+## Bundle Output
+
+The audit export bundle includes:
+
+- deterministic bundle id
+- generated timestamp
+- tenant, merchant, seller-agent, and buyer-agent scope
+- artifact family counts
+- cache record references
+- maintenance plan references
+- review packet references
+- decision record references
+- redacted reason codes
+- redacted source and evidence refs
+- freshness and TTL summary
+- revocation snapshot summary
+- risk-tier summary
+- unsupported and blocked capability summaries
+- label-only next steps
+- non-enablement flags
+
+The bundle fixes `allowed_to_execute = false`, `non_authoritative_for_transaction = true`, `no_checkout_payment_enablement = true`, `no_live_provider_enablement = true`, and `no_public_discovery_enablement = true`.
+
+## Fail-Closed Rules
+
+C6X9 refuses bundle creation when tenant or merchant scope is missing, lineage records are missing, scopes mismatch across cache/plan/report/decision inputs, timestamps are malformed, cache records are private or unsafe, maintenance plans are executable, review packets are executable, decision records are executable, refs are private or raw, reviewer identity is raw, publication or readiness claims appear, or stale, revoked, or high-risk states are represented as approved.
+
+The builder preserves blocked and unsupported capability summaries as evidence, but those summaries do not become authority to run checkout, payment, order, hold, refund, return, shipping, provider, merchant private API, public discovery, or publication behavior.
+
+## Persistence Migration Scheduler And Export Decision
+
+C6X9 adds no migration, repository table, scheduler, cron job, queue, background worker, command, public endpoint, public OpenAPI runtime contract, or export-file writer. The builder returns an in-memory/export-ready structure only. A later slice may define a controlled operator export surface or persistence strategy, but that is outside C6X9.
+
+C6X9 does not call Grantex live, providers, merchant systems, carriers, shipping systems, schedulers, workers, queues, or external APIs.
+
+## Guardrails
+
+C6X9 remains internal-only, non-publication, non-certifying, non-production, non-executing, fail-closed, and non-authoritative for transactions. It is an audit export bundle only. It stores no new data and writes no generated artifact by itself.
+
+The bundle must never include raw artifact payloads, provider payloads, connector payloads, raw JWTs or passports, credentials, tokens, private keys, private customer data, payment data, bank or card data, raw merchant private API values, raw reviewer email or phone values, secrets, production allowlists, executable URLs, or action targets.
+
+## What C6X9 Does Not Enable
+
+C6X9 adds no public endpoint, route, public OpenAPI runtime contract, workflow, scheduler, cron job, queue, background worker, migration, production config, secret, public discovery enablement, checkout, payment, order, hold, refund, return, shipping execution, live provider rail, live Plural behavior, provider call, merchant private API call, allowlist, external OACP publication, or approval/readiness claim.
+
+C6X9 audit bundles are not merchant approvals, checkout approvals, payment approvals, mandate approvals, live-provider approvals, production approvals, certification, compliance, conformance, standardization, or public launch readiness.
+
+## Future Work
+
+Future slices may define an internal operator export review surface, a controlled export writer, retention rules, or a separately approved audit-chain handoff. Those slices must stay separate from checkout, payment, provider rails, merchant private APIs, public OACP publication, production config, workflow scheduling, and public endpoint behavior unless explicitly approved.

--- a/tests/unit/test_oacp_c6x9_audit_export_bundle.py
+++ b/tests/unit/test_oacp_c6x9_audit_export_bundle.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from core.commerce.oacp_artifacts import (
+    OacpArtifactCacheRepositoryQuery,
+    OacpPersistentArtifactCacheRecord,
+    build_oacp_c6x9_audit_export_bundle,
+    build_oacp_cache_maintenance_dry_run_report,
+    build_oacp_cache_operator_decision_record,
+    plan_oacp_artifact_cache_maintenance,
+)
+
+C6X9_DOC_PATH = Path("docs/reports/commerce-agent-c6x9-oacp-audit-export-bundle.md")
+
+
+def _doc() -> str:
+    return C6X9_DOC_PATH.read_text(encoding="utf-8")
+
+
+def _record(**overrides: object) -> OacpPersistentArtifactCacheRecord:
+    base = OacpPersistentArtifactCacheRecord(
+        cache_record_id="cache_price_C6X9",
+        artifact_id="price_C6W3",
+        artifact_type="price",
+        authority="grantex_canonical_oacp_artifact_authority",
+        issuer="grantex",
+        scope_kind="buyer_agent",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+        source_refs=("source_ref_price_C6X9",),
+        evidence_refs=("evidence_price_C6X9_redacted",),
+        generated_at="2026-06-11T00:00:00.000Z",
+        cached_at="2026-06-11T00:00:10.000Z",
+        expires_at="2026-06-11T00:05:00.000Z",
+        freshness_status="fresh",
+        revocation_snapshot_status="fresh",
+        revocation_snapshot_observed_at="2026-06-11T00:00:30.000Z",
+        revocation_snapshot_age_seconds=30,
+        ttl_policy_seconds=300,
+        risk_tier="low",
+        blocked_capabilities=("checkout_payment_creation", "live_provider_call"),
+        unsupported_capabilities=("transaction_authority_from_adapter_preview",),
+        verifier_result_ref="verifier_result_price_C6X9",
+    )
+    return replace(base, **overrides)
+
+
+def _plan(records: tuple[OacpPersistentArtifactCacheRecord, ...]) -> dict[str, object]:
+    return plan_oacp_artifact_cache_maintenance(
+        records=records,
+        now_iso="2026-06-11T00:01:00.000Z",
+        grantex_available=True,
+        action_intent="prepare_only",
+        risk_tier="low",
+        scope_filter=OacpArtifactCacheRepositoryQuery(tenant_id="cten_C6W3", merchant_id="mch_C6W3"),
+    )
+
+
+def _review_packet(plan: dict[str, object]) -> dict[str, object]:
+    return build_oacp_cache_maintenance_dry_run_report(
+        maintenance_plan=plan,
+        report_kind="operator_review_packet",
+    )
+
+
+def _decision(packet: dict[str, object], **overrides: object) -> dict[str, object]:
+    decision = build_oacp_cache_operator_decision_record(
+        review_packet=packet,
+        decision_kind="request_more_evidence",
+        reviewer_identity_ref="operator_ref_c6x9_reviewer_001",
+        decided_at="2026-06-11T00:02:00.000Z",
+    )
+    decision.update(overrides)
+    return decision
+
+
+def _bundle(
+    *,
+    records: tuple[OacpPersistentArtifactCacheRecord, ...] | None = None,
+    decision_overrides: dict[str, object] | None = None,
+) -> dict[str, object]:
+    cache_records = records or (_record(),)
+    plan = _plan(cache_records)
+    packet = _review_packet(plan)
+    decision = _decision(packet, **(decision_overrides or {}))
+    return build_oacp_c6x9_audit_export_bundle(
+        cache_records=cache_records,
+        maintenance_plans=(plan,),
+        review_packets=(packet,),
+        operator_decision_records=(decision,),
+        durable_decision_records=(dict(decision),),
+        generated_at="2026-06-11T00:03:00.000Z",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+    )
+
+
+def test_c6x9_audit_export_bundle_is_deterministic_redacted_and_non_executing() -> None:
+    bundle = _bundle()
+    second_bundle = _bundle()
+
+    assert bundle["bundle_id"] == second_bundle["bundle_id"]
+    assert bundle["bundle_kind"] == "oacp_cache_operator_decision_audit_export_bundle"
+    assert bundle["status"] == "export_ready"
+    assert bundle["tenant_id"] == "cten_C6W3"
+    assert bundle["merchant_id"] == "mch_C6W3"
+    assert bundle["seller_agent_id"] == "seller_C6W3"
+    assert bundle["buyer_agent_id"] == "buyer_C6W3"
+    assert bundle["scope_summary"]["buyer_agent"] == {"buyer_C6W3": 1}
+    assert bundle["artifact_family_counts"] == {"price": 1}
+    assert bundle["cache_record_references"] == ["cache_price_C6X9"]
+    assert len(bundle["maintenance_plan_references"]) == 1
+    assert len(bundle["review_packet_references"]) == 1
+    assert len(bundle["decision_record_references"]) == 2
+    assert bundle["redacted_evidence_refs"] == ["evidence_price_C6X9_redacted"]
+    assert bundle["freshness_ttl_summary"]["freshness"] == {"fresh": 1}
+    assert bundle["revocation_snapshot_summary"] == {"fresh": 1}
+    assert bundle["risk_tier_summary"] == {"low": 1}
+    assert bundle["blocked_capability_summary"] == {
+        "checkout_payment_creation": 1,
+        "live_provider_call": 1,
+    }
+    assert bundle["allowed_to_execute"] is False
+    assert bundle["no_execution"] is True
+    assert bundle["audit_export_bundle_only"] is True
+    assert bundle["generated_artifact_written"] is False
+    assert bundle["non_authoritative_for_transaction"] is True
+    assert bundle["no_checkout_payment_enablement"] is True
+    assert bundle["no_live_provider_enablement"] is True
+    assert bundle["no_public_discovery_enablement"] is True
+    assert bundle["raw_payloads_included"] is False
+    assert bundle["grantex_runtime_required"] is False
+    assert "raw_jwt" not in str(bundle)
+    assert "password" not in str(bundle)
+
+
+def test_c6x9_audit_export_bundle_fails_closed_for_unsafe_inputs() -> None:
+    missing_scope = build_oacp_c6x9_audit_export_bundle(
+        cache_records=(_record(),),
+        maintenance_plans=(),
+        review_packets=(),
+        operator_decision_records=(),
+        generated_at="2026-06-11T00:03:00.000Z",
+        tenant_id="",
+        merchant_id="mch_C6W3",
+    )
+    assert missing_scope["status"] == "blocked"
+    assert missing_scope["block_reason"] == "tenant_or_merchant_scope_missing"
+
+    private_ref = _bundle(records=(_record(evidence_refs=("raw_jwt_marker",)),))
+    assert private_ref["status"] == "blocked"
+    assert private_ref["block_reason"] == "cache_record_private_or_unsafe"
+
+    scope_mismatch = build_oacp_c6x9_audit_export_bundle(
+        cache_records=(_record(),),
+        maintenance_plans=(_plan((_record(),)),),
+        review_packets=(_review_packet(_plan((_record(),))),),
+        operator_decision_records=(_decision(_review_packet(_plan((_record(),))),),),
+        generated_at="2026-06-11T00:03:00.000Z",
+        tenant_id="cten_other",
+        merchant_id="mch_C6W3",
+    )
+    assert scope_mismatch["status"] == "blocked"
+    assert scope_mismatch["block_reason"] == "audit_export_scope_mismatch"
+
+    executable_decision = _bundle(decision_overrides={"allowed_to_execute": True})
+    assert executable_decision["status"] == "blocked"
+    assert executable_decision["block_reason"] == "export_component_executable_or_enabling"
+
+
+def test_c6x9_blocks_risky_states_represented_as_approved() -> None:
+    risky_record = _record(risk_tier="high")
+    plan = _plan((risky_record,))
+    packet = _review_packet(plan)
+    approved_decision = build_oacp_cache_operator_decision_record(
+        review_packet=packet,
+        decision_kind="approve_future_refresh_request",
+        reviewer_identity_ref="operator_ref_c6x9_reviewer_001",
+        decided_at="2026-06-11T00:02:00.000Z",
+    )
+
+    bundle = build_oacp_c6x9_audit_export_bundle(
+        cache_records=(risky_record,),
+        maintenance_plans=(plan,),
+        review_packets=(packet,),
+        operator_decision_records=(approved_decision,),
+        generated_at="2026-06-11T00:03:00.000Z",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+    )
+
+    assert bundle["status"] == "blocked"
+    assert bundle["block_reason"] == "risky_state_represented_as_approved"
+    assert bundle["allowed_to_execute"] is False
+
+
+def test_c6x9_docs_capture_internal_audit_export_boundaries() -> None:
+    doc = _doc()
+    for heading in (
+        "Scope",
+        "Correct Ownership Model",
+        "Bundle Inputs",
+        "Bundle Output",
+        "Fail-Closed Rules",
+        "Persistence Migration Scheduler And Export Decision",
+        "Guardrails",
+        "What C6X9 Does Not Enable",
+        "Future Work",
+    ):
+        assert f"## {heading}" in doc
+
+    assert "audit export bundle only" in doc
+    assert "allowed_to_execute = false" in doc
+    assert "does not write generated export files" in doc
+    assert "does not call Grantex live" in doc
+    assert "not a transaction toll booth" in doc


### PR DESCRIPTION
## Summary
- add internal C6X9 audit export bundle builder over local OACP cache, maintenance, report, and operator decision records
- keep output in-memory/export-ready only with no migration, scheduler, API, generated artifact writer, or external calls
- preserve fail-closed, redacted, non-executing OACP posture

## Validation
- python -m pytest tests/unit/test_oacp_c6x6_cache_maintenance_reports.py tests/unit/test_oacp_c6x7_operator_decisions.py tests/unit/test_oacp_c6x8_operator_decision_repository.py tests/unit/test_oacp_c6x9_audit_export_bundle.py --no-cov
- python -m ruff check core/commerce/oacp_artifacts.py tests/unit/test_oacp_c6x9_audit_export_bundle.py
- python -m mypy core/commerce/oacp_artifacts.py tests/unit/test_oacp_c6x9_audit_export_bundle.py
- git diff --check origin/main...HEAD
- ASCII/hidden Unicode and guardrail scans on touched files