### PR TITLE
[codex] Add C6Y1 audit review manifest helper

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -12,7 +12,7 @@ import hashlib
 import json
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
 
 if TYPE_CHECKING:
@@ -198,6 +198,11 @@ OacpCacheOperatorDecisionKind = Literal[
     "defer_until_freshness_update",
     "escalate_to_human_support",
     "block_unsafe_action",
+]
+OacpAuditExportReviewRetentionClass = Literal[
+    "short_lived_internal_review",
+    "standard_internal_review",
+    "legal_hold_candidate",
 ]
 
 OACP_ARTIFACT_SIGNATURE_PROFILE: dict[str, Any] = {
@@ -6600,6 +6605,351 @@ def build_oacp_c6x9_audit_export_bundle(
         "seller_safe_message": "C6X9 does not call Grantex live, merchant systems, providers, or schedulers.",
         "operator_safe_message": (
             "Review this export-ready bundle as evidence only. It is not an execution instruction."
+        ),
+    }
+
+
+_C6Y1_SAFE_FALLBACK_GENERATED_AT = "2026-06-12T00:00:00.000Z"
+_C6Y1_RETENTION_DAYS_BY_CLASS: dict[OacpAuditExportReviewRetentionClass, int] = {
+    "short_lived_internal_review": 30,
+    "standard_internal_review": 90,
+    "legal_hold_candidate": 365,
+}
+_C6Y1_BUNDLE_REF_FIELDS = (
+    "cache_record_references",
+    "maintenance_plan_references",
+    "review_packet_references",
+    "decision_record_references",
+    "redacted_source_refs",
+    "redacted_evidence_refs",
+    "next_step_labels",
+)
+
+
+def _c6y1_manifest_id(payload: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(canonicalize_oacp_payload(dict(payload)).encode("utf-8")).hexdigest()
+    return f"oacp_c6y1_review_manifest_{digest[:20]}"
+
+
+def _c6y1_iso(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _c6y1_blocked_manifest(
+    *,
+    reason_code: str,
+    message: str,
+    generated_at: str | None = None,
+    bundle_id: str | None = None,
+    tenant_id: str | None = None,
+    merchant_id: str | None = None,
+    seller_agent_id: str | None = None,
+    buyer_agent_id: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at or _C6Y1_SAFE_FALLBACK_GENERATED_AT
+    return {
+        "manifest_id": _c6y1_manifest_id(
+            {
+                "status": "blocked",
+                "reason_code": reason_code,
+                "bundle_id": bundle_id,
+                "tenant_id": tenant_id,
+                "merchant_id": merchant_id,
+                "generated_at": generated,
+            }
+        ),
+        "manifest_kind": "blocked_oacp_audit_export_review_manifest",
+        "status": "blocked",
+        "block_reason": reason_code,
+        "message": message,
+        "generated_at": generated,
+        "bundle_id": bundle_id,
+        "tenant_id": tenant_id,
+        "merchant_id": merchant_id,
+        "seller_agent_id": seller_agent_id,
+        "buyer_agent_id": buyer_agent_id,
+        "scope_summary": {"buyer_agent": {}, "seller_agent": {}, "tenant": {}, "merchant": {}},
+        "artifact_family_counts": {},
+        "cache_record_references": [],
+        "maintenance_plan_references": [],
+        "review_packet_references": [],
+        "decision_record_references": [],
+        "redacted_reason_codes": {},
+        "redacted_source_refs": [],
+        "redacted_evidence_refs": [],
+        "freshness_ttl_summary": {},
+        "revocation_snapshot_summary": {},
+        "risk_tier_summary": {},
+        "unsupported_capability_summary": {},
+        "blocked_capability_summary": {reason_code: 1},
+        "retention_boundary": {
+            "retention_class": "blocked_no_retention_action",
+            "retention_days": 0,
+            "retain_until": None,
+            "persistence_required": False,
+            "requires_separate_persistence_approval": True,
+            "export_file_writer_added": False,
+        },
+        "redaction_boundary": {
+            "redacted_refs_only": True,
+            "raw_payloads_included": False,
+            "private_values_blocked": True,
+            "non_sensitive_evidence_refs_only": True,
+        },
+        "next_step_labels": ["operator_review_required_no_export_execution"],
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "review_manifest_only": True,
+        "retention_boundary_only": True,
+        "audit_export_bundle_review_only": True,
+        "export_file_written": False,
+        "export_writer_added": False,
+        "generated_artifact_written": False,
+        "migration_added": False,
+        "scheduler_added": False,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "raw_payloads_included": False,
+        "grantex_runtime_required": False,
+    }
+
+
+def _c6y1_bundle_flags_safe(bundle: Mapping[str, Any]) -> bool:
+    return (
+        bundle.get("allowed_to_execute") is False
+        and bundle.get("no_execution") is True
+        and bundle.get("audit_export_bundle_only") is True
+        and bundle.get("export_ready") is True
+        and bundle.get("generated_artifact_written") is False
+        and bundle.get("export_file_written") is not True
+        and bundle.get("non_authoritative_for_transaction") is True
+        and bundle.get("no_checkout_payment_enablement") is True
+        and bundle.get("no_live_provider_enablement") is True
+        and bundle.get("no_public_discovery_enablement") is True
+        and bundle.get("raw_payloads_included") is False
+        and bundle.get("grantex_runtime_required") is False
+    )
+
+
+def _c6y1_bundle_strings(bundle: Mapping[str, Any]) -> list[str]:
+    values: list[str] = []
+    for field_name in _C6Y1_BUNDLE_REF_FIELDS:
+        values.extend(_c6x8_list(bundle.get(field_name)))
+    for field_name in ("buyer_safe_message", "seller_safe_message", "operator_safe_message", "message"):
+        value = _c6x7_string(bundle.get(field_name))
+        if value is not None:
+            values.append(value)
+    values.extend(_c6x9_reason_code_values(bundle.get("redacted_reason_codes")))
+    values.extend(_c6x9_reason_code_values(bundle.get("blocked_capability_summary")))
+    values.extend(_c6x9_reason_code_values(bundle.get("unsupported_capability_summary")))
+    return values
+
+
+def _c6y1_bundle_refs_safe(bundle: Mapping[str, Any]) -> bool:
+    refs = tuple(
+        ref
+        for field_name in _C6Y1_BUNDLE_REF_FIELDS
+        for ref in _c6x8_list(bundle.get(field_name))
+    )
+    return bool(_c6x8_list(bundle.get("redacted_evidence_refs"))) and _c6x2_refs_safe(refs)
+
+
+def _c6y1_values_private_or_overclaim(values: Sequence[str]) -> bool:
+    c6y1_overclaim_markers = ("readiness", "public launch", "approved")
+    return _c6x9_private_or_overclaim_values(values) or any(
+        any(marker in value.strip().lower() for marker in c6y1_overclaim_markers)
+        for value in values
+    )
+
+
+def build_oacp_c6y1_audit_export_review_manifest(
+    *,
+    audit_export_bundle: Mapping[str, Any],
+    generated_at: str,
+    retention_class: OacpAuditExportReviewRetentionClass = "standard_internal_review",
+) -> dict[str, Any]:
+    """Build an internal C6Y1 review manifest over a C6X9 bundle without writing or executing it."""
+
+    bundle_id = _c6x7_string(audit_export_bundle.get("bundle_id"))
+    tenant_id = _c6x7_string(audit_export_bundle.get("tenant_id"))
+    merchant_id = _c6x7_string(audit_export_bundle.get("merchant_id"))
+    seller_agent_id = _c6x7_string(audit_export_bundle.get("seller_agent_id"))
+    buyer_agent_id = _c6x7_string(audit_export_bundle.get("buyer_agent_id"))
+    generated = _parse_iso(generated_at)
+    bundle_generated = _parse_iso(_c6x7_string(audit_export_bundle.get("generated_at")))
+
+    if generated is None or bundle_generated is None:
+        return _c6y1_blocked_manifest(
+            reason_code="manifest_timestamp_malformed",
+            message="C6Y1 review manifests require ordered ISO timestamps.",
+            generated_at=generated_at,
+            bundle_id=bundle_id,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+    if retention_class not in _C6Y1_RETENTION_DAYS_BY_CLASS:
+        return _c6y1_blocked_manifest(
+            reason_code="retention_class_unsupported",
+            message="C6Y1 accepts only internal retention review classes.",
+            generated_at=generated_at,
+            bundle_id=bundle_id,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+    if (
+        audit_export_bundle.get("bundle_kind") != "oacp_cache_operator_decision_audit_export_bundle"
+        or audit_export_bundle.get("status") != "export_ready"
+        or not bundle_id
+    ):
+        return _c6y1_blocked_manifest(
+            reason_code="audit_export_bundle_not_ready",
+            message="C6Y1 review manifests consume C6X9 export-ready audit bundles only.",
+            generated_at=generated_at,
+            bundle_id=bundle_id,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+    if not tenant_id or not merchant_id:
+        return _c6y1_blocked_manifest(
+            reason_code="tenant_or_merchant_scope_missing",
+            message="C6Y1 review manifests require tenant and merchant scope.",
+            generated_at=generated_at,
+            bundle_id=bundle_id,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+    try:
+        assert_no_forbidden_oacp_artifact_fields(dict(audit_export_bundle))
+    except ValueError:
+        return _c6y1_blocked_manifest(
+            reason_code="private_or_enabling_manifest_input",
+            message="C6Y1 refuses audit bundle fields that contain private, raw, credential, or enabling data.",
+            generated_at=generated_at,
+            bundle_id=bundle_id,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+    if not _c6y1_bundle_flags_safe(audit_export_bundle):
+        return _c6y1_blocked_manifest(
+            reason_code="bundle_non_enablement_flags_invalid",
+            message="C6Y1 refuses executable audit bundles or bundles that imply export-file writing.",
+            generated_at=generated_at,
+            bundle_id=bundle_id,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+    if not _c6y1_bundle_refs_safe(audit_export_bundle) or _c6y1_values_private_or_overclaim(
+        _c6y1_bundle_strings(audit_export_bundle)
+    ):
+        return _c6y1_blocked_manifest(
+            reason_code="private_ref_or_overclaim_detected",
+            message="C6Y1 refuses private refs, raw labels, publication wording, or approval/readiness claims.",
+            generated_at=generated_at,
+            bundle_id=bundle_id,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+            seller_agent_id=seller_agent_id,
+            buyer_agent_id=buyer_agent_id,
+        )
+
+    retention_days = _C6Y1_RETENTION_DAYS_BY_CLASS[retention_class]
+    retain_until = _c6y1_iso(generated + timedelta(days=retention_days))
+    manifest_payload = {
+        "bundle_id": bundle_id,
+        "tenant_id": tenant_id,
+        "merchant_id": merchant_id,
+        "seller_agent_id": seller_agent_id,
+        "buyer_agent_id": buyer_agent_id,
+        "generated_at": generated_at,
+        "retention_class": retention_class,
+    }
+    return {
+        "manifest_id": _c6y1_manifest_id(manifest_payload),
+        "manifest_kind": "oacp_audit_export_review_manifest",
+        "status": "ready_for_internal_review",
+        "generated_at": generated_at,
+        "bundle_id": bundle_id,
+        "bundle_kind": audit_export_bundle["bundle_kind"],
+        "bundle_status": audit_export_bundle["status"],
+        "bundle_generated_at": audit_export_bundle["generated_at"],
+        "tenant_id": tenant_id,
+        "merchant_id": merchant_id,
+        "seller_agent_id": seller_agent_id,
+        "buyer_agent_id": buyer_agent_id,
+        "scope_summary": dict(_c6x8_mapping(audit_export_bundle.get("scope_summary"))),
+        "artifact_family_counts": dict(_c6x8_mapping(audit_export_bundle.get("artifact_family_counts"))),
+        "cache_record_references": _c6x8_list(audit_export_bundle.get("cache_record_references")),
+        "maintenance_plan_references": _c6x8_list(audit_export_bundle.get("maintenance_plan_references")),
+        "review_packet_references": _c6x8_list(audit_export_bundle.get("review_packet_references")),
+        "decision_record_references": _c6x8_list(audit_export_bundle.get("decision_record_references")),
+        "redacted_reason_codes": dict(_c6x8_mapping(audit_export_bundle.get("redacted_reason_codes"))),
+        "redacted_source_refs": _c6x8_list(audit_export_bundle.get("redacted_source_refs")),
+        "redacted_evidence_refs": _c6x8_list(audit_export_bundle.get("redacted_evidence_refs")),
+        "freshness_ttl_summary": dict(_c6x8_mapping(audit_export_bundle.get("freshness_ttl_summary"))),
+        "revocation_snapshot_summary": dict(_c6x8_mapping(audit_export_bundle.get("revocation_snapshot_summary"))),
+        "risk_tier_summary": dict(_c6x8_mapping(audit_export_bundle.get("risk_tier_summary"))),
+        "unsupported_capability_summary": dict(
+            _c6x8_mapping(audit_export_bundle.get("unsupported_capability_summary"))
+        ),
+        "blocked_capability_summary": dict(_c6x8_mapping(audit_export_bundle.get("blocked_capability_summary"))),
+        "retention_boundary": {
+            "retention_class": retention_class,
+            "retention_days": retention_days,
+            "retain_until": retain_until,
+            "retention_clock_source": "manifest_generated_at",
+            "persistence_required": False,
+            "requires_separate_persistence_approval": True,
+            "export_file_writer_added": False,
+            "generated_artifact_written": False,
+        },
+        "redaction_boundary": {
+            "redacted_refs_only": True,
+            "raw_payloads_included": False,
+            "private_values_blocked": True,
+            "raw_reviewer_identity_included": False,
+            "non_sensitive_evidence_refs_only": True,
+        },
+        "next_step_labels": _c6x9_unique(
+            [
+                *_c6x8_list(audit_export_bundle.get("next_step_labels")),
+                "operator_review_manifest_label_only",
+                "retention_boundary_review_label_only",
+            ]
+        ),
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "review_manifest_only": True,
+        "retention_boundary_only": True,
+        "audit_export_bundle_review_only": True,
+        "export_file_written": False,
+        "export_writer_added": False,
+        "generated_artifact_written": False,
+        "migration_added": False,
+        "scheduler_added": False,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "raw_payloads_included": False,
+        "grantex_runtime_required": False,
+        "buyer_safe_message": "C6Y1 prepared an internal audit review manifest only; no commerce action ran.",
+        "seller_safe_message": "C6Y1 does not call Grantex live, merchant systems, providers, or schedulers.",
+        "operator_safe_message": (
+            "Review this manifest and retention boundary as label-only evidence; it is not an export writer."
         ),
     }
 

--- a/docs/reports/commerce-agent-c6y1-oacp-audit-review-manifest.md
+++ b/docs/reports/commerce-agent-c6y1-oacp-audit-review-manifest.md
@@ -1,0 +1,75 @@
+# Commerce Agent C6Y1 OACP Audit Review Manifest
+
+## Scope
+
+C6Y1 adds an internal AgenticOrg audit export review manifest over C6X9 audit export bundles. The manifest is a deterministic in-memory review structure for operator inspection, retention labeling, and redaction boundary checks only. It does not write export files, expose an API, run jobs, schedule maintenance, call Grantex live, call providers, call merchant systems, refresh artifacts, evict records, quarantine records, or execute commerce actions.
+
+## Correct Ownership Model
+
+AgenticOrg is the buyer and seller AI-agent runtime. AgenticOrg owns durable and local OACP artifact cache behavior, seller-agent initiated connector sync intent, runtime artifact consumption, local operator decision handling, internal audit export bundle generation, and internal review manifest preparation. Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. Grantex is not a transaction toll booth for every non-binding buyer or seller agent turn. Merchant systems remain operational sources of record, and provider or fintech rails own mandate and payment execution where separately approved.
+
+## Review Manifest Inputs
+
+The C6Y1 helper consumes a C6X9 `oacp_cache_operator_decision_audit_export_bundle` with `status = export_ready`. The bundle must already carry tenant and merchant scope, cache record refs, maintenance plan refs, review packet refs, decision record refs, redacted source refs, redacted evidence refs, freshness and TTL summary, revocation summary, risk-tier summary, unsupported capability summary, blocked capability summary, and non-enablement flags.
+
+The helper refuses blocked, malformed, executable, enabling, private, or publication-oriented bundles. It does not call Grantex to revalidate every bundle, and it does not require Grantex to receive every local audit review manifest.
+
+## Review Manifest Output
+
+The review manifest includes:
+
+- deterministic manifest id
+- generated timestamp
+- source bundle id and bundle generated timestamp
+- tenant, merchant, seller-agent, and buyer-agent scope
+- artifact family counts
+- cache record references
+- maintenance plan references
+- review packet references
+- decision record references
+- redacted reason codes
+- redacted source and evidence refs
+- freshness and TTL summary
+- revocation snapshot summary
+- risk-tier summary
+- unsupported and blocked capability summaries
+- label-only next steps
+- retention boundary
+- redaction boundary
+- non-enablement flags
+
+The manifest fixes `allowed_to_execute = false`, `non_authoritative_for_transaction = true`, `no_checkout_payment_enablement = true`, `no_live_provider_enablement = true`, and `no_public_discovery_enablement = true`.
+
+## Retention And Redaction Boundary
+
+C6Y1 uses internal retention review classes only: `short_lived_internal_review`, `standard_internal_review`, and `legal_hold_candidate`. These labels produce review-time retention windows for planning and inspection, not production persistence. The manifest records `persistence_required = false`, `requires_separate_persistence_approval = true`, `export_file_writer_added = false`, and `generated_artifact_written = false`.
+
+The redaction boundary requires redacted refs only. The manifest never includes raw artifact payloads, provider payloads, connector payloads, raw JWTs or passports, credentials, tokens, private keys, private customer data, payment data, bank or card data, raw merchant private API values, raw reviewer email or phone values, secrets, production allowlists, executable URLs, or action targets.
+
+## Fail-Closed Rules
+
+C6Y1 blocks manifest generation when the C6X9 bundle is missing, not `export_ready`, malformed, missing tenant or merchant scope, has invalid timestamps, includes private refs, includes raw labels, includes publication or approval/readiness wording, has executable or enabling flags, claims export-file writing, or lacks redacted evidence refs.
+
+Blocked manifests remain review manifest only and retention boundary only. They do not run an export, persist a record, schedule a job, or execute cache maintenance.
+
+## Persistence Migration Scheduler And Export Writer Decision
+
+C6Y1 adds no migration, repository table, scheduler, cron job, queue, background worker, command, public endpoint, public OpenAPI runtime contract, CLI, or export-file writer. The helper returns an in-memory review manifest only. A later separately approved slice may define controlled persistence, a UI review surface, or an export writer, but C6Y1 does not implement those.
+
+C6Y1 does not call Grantex live, providers, merchant systems, carriers, shipping systems, schedulers, workers, queues, or external APIs.
+
+## Guardrails
+
+C6Y1 remains internal-only, non-publication, non-certifying, non-production, non-executing, fail-closed, migration-free, scheduler-free, export-writer-free, and non-authoritative for transactions. It is a review manifest only and a retention boundary only.
+
+The manifest is not a Grantex approval, merchant approval, checkout approval, payment approval, mandate approval, live-provider approval, production approval, certification, compliance, conformance, standardization, or public launch readiness.
+
+## What C6Y1 Does Not Enable
+
+C6Y1 adds no public endpoint, route, public OpenAPI runtime contract, workflow, scheduler, cron job, queue, background worker, migration, production config, secret, public discovery enablement, checkout, payment, order, hold, refund, return, shipping execution, live provider rail, live Plural behavior, provider call, merchant private API call, allowlist, external OACP publication, or approval/readiness claim.
+
+C6Y1 does not write export files, generated reports, generated artifacts, or public docs pages.
+
+## Future Work
+
+Future slices may define a controlled internal review surface, retention persistence, export writer, or audit-chain handoff. Those slices must stay separate from checkout, payment, provider rails, merchant private APIs, public OACP publication, production config, workflow scheduling, and public endpoint behavior unless explicitly approved.

--- a/tests/unit/test_oacp_c6y1_audit_review_manifest.py
+++ b/tests/unit/test_oacp_c6y1_audit_review_manifest.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from core.commerce.oacp_artifacts import (
+    OacpArtifactCacheRepositoryQuery,
+    OacpPersistentArtifactCacheRecord,
+    build_oacp_c6x9_audit_export_bundle,
+    build_oacp_c6y1_audit_export_review_manifest,
+    build_oacp_cache_maintenance_dry_run_report,
+    build_oacp_cache_operator_decision_record,
+    plan_oacp_artifact_cache_maintenance,
+)
+
+C6Y1_DOC_PATH = Path("docs/reports/commerce-agent-c6y1-oacp-audit-review-manifest.md")
+
+
+def _doc() -> str:
+    return C6Y1_DOC_PATH.read_text(encoding="utf-8")
+
+
+def _record(**overrides: object) -> OacpPersistentArtifactCacheRecord:
+    base = OacpPersistentArtifactCacheRecord(
+        cache_record_id="cache_price_C6Y1",
+        artifact_id="price_C6W3",
+        artifact_type="price",
+        authority="grantex_canonical_oacp_artifact_authority",
+        issuer="grantex",
+        scope_kind="buyer_agent",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+        source_refs=("source_ref_price_C6Y1",),
+        evidence_refs=("evidence_price_C6Y1_redacted",),
+        generated_at="2026-06-12T00:00:00.000Z",
+        cached_at="2026-06-12T00:00:10.000Z",
+        expires_at="2026-06-12T00:05:00.000Z",
+        freshness_status="fresh",
+        revocation_snapshot_status="fresh",
+        revocation_snapshot_observed_at="2026-06-12T00:00:30.000Z",
+        revocation_snapshot_age_seconds=30,
+        ttl_policy_seconds=300,
+        risk_tier="low",
+        blocked_capabilities=("checkout_payment_creation", "live_provider_call"),
+        unsupported_capabilities=("transaction_authority_from_adapter_preview",),
+        verifier_result_ref="verifier_result_price_C6Y1",
+    )
+    return replace(base, **overrides)
+
+
+def _plan(records: tuple[OacpPersistentArtifactCacheRecord, ...]) -> dict[str, object]:
+    return plan_oacp_artifact_cache_maintenance(
+        records=records,
+        now_iso="2026-06-12T00:01:00.000Z",
+        grantex_available=True,
+        action_intent="prepare_only",
+        risk_tier="low",
+        scope_filter=OacpArtifactCacheRepositoryQuery(tenant_id="cten_C6W3", merchant_id="mch_C6W3"),
+    )
+
+
+def _review_packet(plan: dict[str, object]) -> dict[str, object]:
+    return build_oacp_cache_maintenance_dry_run_report(
+        maintenance_plan=plan,
+        report_kind="operator_review_packet",
+    )
+
+
+def _decision(packet: dict[str, object], **overrides: object) -> dict[str, object]:
+    decision = build_oacp_cache_operator_decision_record(
+        review_packet=packet,
+        decision_kind="request_more_evidence",
+        reviewer_identity_ref="operator_ref_c6y1_reviewer_001",
+        decided_at="2026-06-12T00:02:00.000Z",
+    )
+    decision.update(overrides)
+    return decision
+
+
+def _bundle(
+    *,
+    records: tuple[OacpPersistentArtifactCacheRecord, ...] | None = None,
+    decision_overrides: dict[str, object] | None = None,
+) -> dict[str, object]:
+    cache_records = records or (_record(),)
+    plan = _plan(cache_records)
+    packet = _review_packet(plan)
+    decision = _decision(packet, **(decision_overrides or {}))
+    return build_oacp_c6x9_audit_export_bundle(
+        cache_records=cache_records,
+        maintenance_plans=(plan,),
+        review_packets=(packet,),
+        operator_decision_records=(decision,),
+        durable_decision_records=(dict(decision),),
+        generated_at="2026-06-12T00:03:00.000Z",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+    )
+
+
+def _manifest(**bundle_overrides: object) -> dict[str, object]:
+    bundle = _bundle()
+    bundle.update(bundle_overrides)
+    return build_oacp_c6y1_audit_export_review_manifest(
+        audit_export_bundle=bundle,
+        generated_at="2026-06-12T00:04:00.000Z",
+        retention_class="standard_internal_review",
+    )
+
+
+def test_c6y1_review_manifest_is_deterministic_redacted_and_non_executing() -> None:
+    manifest = _manifest()
+    second_manifest = _manifest()
+
+    assert manifest["manifest_id"] == second_manifest["manifest_id"]
+    assert manifest["manifest_kind"] == "oacp_audit_export_review_manifest"
+    assert manifest["status"] == "ready_for_internal_review"
+    assert manifest["tenant_id"] == "cten_C6W3"
+    assert manifest["merchant_id"] == "mch_C6W3"
+    assert manifest["seller_agent_id"] == "seller_C6W3"
+    assert manifest["buyer_agent_id"] == "buyer_C6W3"
+    assert manifest["artifact_family_counts"] == {"price": 1}
+    assert manifest["cache_record_references"] == ["cache_price_C6Y1"]
+    assert len(manifest["decision_record_references"]) == 2
+    assert manifest["redacted_evidence_refs"] == ["evidence_price_C6Y1_redacted"]
+    assert manifest["freshness_ttl_summary"]["freshness"] == {"fresh": 1}
+    assert manifest["retention_boundary"] == {
+        "retention_class": "standard_internal_review",
+        "retention_days": 90,
+        "retain_until": "2026-09-10T00:04:00.000Z",
+        "retention_clock_source": "manifest_generated_at",
+        "persistence_required": False,
+        "requires_separate_persistence_approval": True,
+        "export_file_writer_added": False,
+        "generated_artifact_written": False,
+    }
+    assert manifest["redaction_boundary"]["redacted_refs_only"] is True
+    assert manifest["allowed_to_execute"] is False
+    assert manifest["no_execution"] is True
+    assert manifest["review_manifest_only"] is True
+    assert manifest["retention_boundary_only"] is True
+    assert manifest["export_file_written"] is False
+    assert manifest["export_writer_added"] is False
+    assert manifest["migration_added"] is False
+    assert manifest["scheduler_added"] is False
+    assert manifest["non_authoritative_for_transaction"] is True
+    assert manifest["no_checkout_payment_enablement"] is True
+    assert manifest["no_live_provider_enablement"] is True
+    assert manifest["no_public_discovery_enablement"] is True
+    assert manifest["raw_payloads_included"] is False
+    assert manifest["grantex_runtime_required"] is False
+    assert "raw_jwt" not in str(manifest)
+    assert "password" not in str(manifest)
+
+
+def test_c6y1_review_manifest_fails_closed_for_unsafe_or_unready_bundles() -> None:
+    not_ready = build_oacp_c6y1_audit_export_review_manifest(
+        audit_export_bundle={"bundle_id": "bundle_missing_status", "generated_at": "2026-06-12T00:03:00.000Z"},
+        generated_at="2026-06-12T00:04:00.000Z",
+    )
+    assert not_ready["status"] == "blocked"
+    assert not_ready["block_reason"] == "audit_export_bundle_not_ready"
+
+    export_writer_claim = _manifest(export_file_written=True)
+    assert export_writer_claim["status"] == "blocked"
+    assert export_writer_claim["block_reason"] == "bundle_non_enablement_flags_invalid"
+
+    private_ref = _manifest(redacted_evidence_refs=["raw_jwt_marker"])
+    assert private_ref["status"] == "blocked"
+    assert private_ref["block_reason"] == "private_ref_or_overclaim_detected"
+
+    overclaim = _manifest(operator_safe_message="production readiness approved")
+    assert overclaim["status"] == "blocked"
+    assert overclaim["block_reason"] == "private_ref_or_overclaim_detected"
+
+
+def test_c6y1_review_manifest_supports_internal_retention_classes_only() -> None:
+    bundle = _bundle()
+    manifest = build_oacp_c6y1_audit_export_review_manifest(
+        audit_export_bundle=bundle,
+        generated_at="2026-06-12T00:04:00.000Z",
+        retention_class="short_lived_internal_review",
+    )
+    assert manifest["status"] == "ready_for_internal_review"
+    assert manifest["retention_boundary"]["retention_days"] == 30
+    assert manifest["retention_boundary"]["persistence_required"] is False
+
+    unsupported = build_oacp_c6y1_audit_export_review_manifest(
+        audit_export_bundle=bundle,
+        generated_at="2026-06-12T00:04:00.000Z",
+        retention_class="public_export_ready",  # type: ignore[arg-type]
+    )
+    assert unsupported["status"] == "blocked"
+    assert unsupported["block_reason"] == "retention_class_unsupported"
+
+
+def test_c6y1_docs_capture_internal_review_manifest_boundary() -> None:
+    doc = _doc()
+    for heading in (
+        "Scope",
+        "Correct Ownership Model",
+        "Review Manifest Inputs",
+        "Review Manifest Output",
+        "Retention And Redaction Boundary",
+        "Fail-Closed Rules",
+        "Persistence Migration Scheduler And Export Writer Decision",
+        "Guardrails",
+        "What C6Y1 Does Not Enable",
+        "Future Work",
+    ):
+        assert f"## {heading}" in doc
+
+    assert "review manifest only" in doc
+    assert "retention boundary only" in doc
+    assert "allowed_to_execute = false" in doc
+    assert "does not write export files" in doc
+    assert "does not call Grantex live" in doc
+    assert "not a transaction toll booth" in doc


### PR DESCRIPTION
Adds C6Y1 internal OACP audit export review manifest helper, tests, and docs over C6X9 audit export bundles. The helper is pure/in-memory, retention-boundary-only, export-writer-free, migration-free, scheduler-free, non-executing, and non-authoritative for transactions. Validation: focused C6X7-C6Y1 pytest, ruff, mypy, diff checks, ASCII/hidden Unicode and guardrail scans.