### PR TITLE
[codex] Fix production auth and audit regressions

### DIFF
--- a/auth/grantex_middleware.py
+++ b/auth/grantex_middleware.py
@@ -102,9 +102,23 @@ class GrantexAuthMiddleware(BaseHTTPMiddleware):
         else:
             auth_header = request.headers.get("Authorization", "")
             if auth_header.startswith("Bearer "):
-                token = auth_header[7:]
+                token = auth_header[7:].strip()
+                if not token:
+                    await record_auth_failure(client_ip)
+                    return JSONResponse(
+                        status_code=401,
+                        content={"detail": "Invalid or expired token"},
+                    )
+            elif auth_header:
+                await record_auth_failure(client_ip)
+                return JSONResponse(
+                    status_code=401,
+                    content={"detail": "Unsupported Authorization scheme"},
+                )
         if not token:
-            await record_auth_failure(client_ip)
+            # Missing credentials are expected for session-discovery probes
+            # such as /auth/me on public pages. Only supplied-but-invalid
+            # credentials should poison the brute-force counter.
             return JSONResponse(
                 status_code=401,
                 content={"detail": "Missing session cookie or Authorization header"},

--- a/auth/middleware.py
+++ b/auth/middleware.py
@@ -64,9 +64,23 @@ class AuthMiddleware(BaseHTTPMiddleware):
         else:
             auth_header = request.headers.get("Authorization", "")
             if auth_header.startswith("Bearer "):
-                token = auth_header[7:]
+                token = auth_header[7:].strip()
+                if not token:
+                    await record_auth_failure(client_ip)
+                    return JSONResponse(
+                        status_code=401,
+                        content={"detail": "Invalid or expired token"},
+                    )
+            elif auth_header:
+                await record_auth_failure(client_ip)
+                return JSONResponse(
+                    status_code=401,
+                    content={"detail": "Unsupported Authorization scheme"},
+                )
         if not token:
-            await record_auth_failure(client_ip)
+            # Anonymous session probes are not credential failures. Public
+            # pages call /auth/me to discover session state; counting missing
+            # credentials here lets normal browsing block an IP.
             return JSONResponse(
                 status_code=401,
                 content={"detail": "Missing session cookie or Authorization header"},

--- a/core/models/audit.py
+++ b/core/models/audit.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import TIMESTAMP, String, func
+from sqlalchemy import TIMESTAMP, String, Text, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -25,7 +25,7 @@ class AuditLog(BaseModel):
     workflow_run_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     resource_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
     resource_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    action: Mapped[str] = mapped_column(String(100), nullable=False)
+    action: Mapped[str] = mapped_column(Text, nullable=False)
     outcome: Mapped[str] = mapped_column(String(50), nullable=False)
     details: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     signature: Mapped[str | None] = mapped_column(String(512), nullable=True)

--- a/migrations/versions/v6_x9_audit_log_action_text.py
+++ b/migrations/versions/v6_x9_audit_log_action_text.py
@@ -1,0 +1,31 @@
+"""Widen audit log action to text.
+
+Revision ID: v6x9_audit_log_action_text
+Revises: v6x8_oacp_operator_decisions
+Create Date: 2026-06-13
+
+Production incident: creating an agent with API-allowed name and type lengths
+could build an audit action longer than VARCHAR(100), causing the whole
+request transaction to fail. The audit action is descriptive event text, not a
+bounded enum, so the database contract must match the API contract.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v6x9_audit_log_action_text"
+down_revision = "v6x8_oacp_operator_decisions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE audit_log ALTER COLUMN action TYPE TEXT;")
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE audit_log ALTER COLUMN action TYPE VARCHAR(100) "
+        "USING left(action, 100);"
+    )

--- a/tests/regression/test_pr_fixes_april2026.py
+++ b/tests/regression/test_pr_fixes_april2026.py
@@ -300,8 +300,8 @@ class TestGrantexMiddlewareFailureClearing:
         assert client_ip not in _failed_attempts
 
     @pytest.mark.asyncio
-    async def test_missing_auth_header_records_failure(self):
-        """Missing Authorization header records a failure."""
+    async def test_missing_auth_header_does_not_record_failure(self):
+        """Missing credentials return 401 without poisoning the IP."""
         from auth.grantex_middleware import GrantexAuthMiddleware
         from core.auth_state import _mem_blocked as _blocked_ips
         from core.auth_state import _mem_failures as _failed_attempts
@@ -317,7 +317,7 @@ class TestGrantexMiddlewareFailureClearing:
         resp = await middleware.dispatch(request, call_next)
 
         assert resp.status_code == 401
-        assert client_ip in _failed_attempts
+        assert client_ip not in _failed_attempts
 
     @pytest.mark.asyncio
     async def test_clear_auth_failures_removes_ip(self):

--- a/tests/regression/test_prod_incidents_20260613.py
+++ b/tests/regression/test_prod_incidents_20260613.py
@@ -1,0 +1,181 @@
+"""Regression coverage for production incidents found on 2026-06-13."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import Text
+
+TENANT_ID = "00000000-0000-0000-0000-000000000001"
+
+
+class _Headers:
+    def __init__(self, values: dict[str, str] | None = None) -> None:
+        self._values = values or {}
+
+    def get(self, key: str, default: str = "") -> str:
+        return self._values.get(key, default)
+
+
+def _request(auth_header: str | None = None, client_ip: str = "203.0.113.10"):
+    request = MagicMock()
+    request.url.path = "/api/v1/auth/me"
+    request.client.host = client_ip
+    request.cookies.get.return_value = ""
+    request.headers = _Headers(
+        {"Authorization": auth_header} if auth_header is not None else {}
+    )
+    request.path_params = {}
+    request.state = SimpleNamespace()
+    return request
+
+
+def test_audit_action_accepts_full_agent_create_contract() -> None:
+    """Allowed agent names/types must not overflow audit_log.action."""
+    from core.models.audit import AuditLog
+    from core.schemas.api import AgentCreate
+
+    body = AgentCreate(
+        name="n" * 255,
+        agent_type="t" * 100,
+        domain="sales",
+    )
+    action = f"Created agent '{body.name}' ({body.agent_type})"
+
+    assert len(action) > 100
+    assert isinstance(AuditLog.__table__.c.action.type, Text)
+
+
+@pytest.mark.asyncio
+async def test_legacy_auth_missing_credentials_do_not_increment_lockout() -> None:
+    from auth.middleware import AuthMiddleware
+    from core.auth_state import _mem_blocked, _mem_failures
+
+    _mem_failures.clear()
+    _mem_blocked.clear()
+    middleware = AuthMiddleware(app=MagicMock())
+    call_next = AsyncMock()
+    client_ip = "203.0.113.11"
+
+    with patch("core.auth_state._get_redis", new_callable=AsyncMock, return_value=None):
+        response = await middleware.dispatch(
+            _request(auth_header=None, client_ip=client_ip),
+            call_next,
+        )
+
+    assert response.status_code == 401
+    assert client_ip not in _mem_failures
+    call_next.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_legacy_auth_invalid_credentials_still_increment_lockout() -> None:
+    from auth.middleware import AuthMiddleware
+    from core.auth_state import _mem_blocked, _mem_failures
+
+    _mem_failures.clear()
+    _mem_blocked.clear()
+    middleware = AuthMiddleware(app=MagicMock())
+    client_ip = "203.0.113.12"
+
+    with patch("core.auth_state._get_redis", new_callable=AsyncMock, return_value=None), \
+         patch(
+             "auth.middleware.validate_token",
+             new_callable=AsyncMock,
+             side_effect=ValueError("bad token"),
+         ):
+        response = await middleware.dispatch(
+            _request(auth_header="Bearer bad-token", client_ip=client_ip),
+            AsyncMock(),
+        )
+
+    assert response.status_code == 401
+    assert len(_mem_failures[client_ip]) == 1
+
+
+@pytest.mark.asyncio
+async def test_legacy_auth_malformed_authorization_increments_lockout() -> None:
+    from auth.middleware import AuthMiddleware
+    from core.auth_state import _mem_blocked, _mem_failures
+
+    _mem_failures.clear()
+    _mem_blocked.clear()
+    middleware = AuthMiddleware(app=MagicMock())
+    client_ip = "203.0.113.15"
+
+    with patch("core.auth_state._get_redis", new_callable=AsyncMock, return_value=None):
+        response = await middleware.dispatch(
+            _request(auth_header="Basic bad-token", client_ip=client_ip),
+            AsyncMock(),
+        )
+
+    assert response.status_code == 401
+    assert len(_mem_failures[client_ip]) == 1
+
+
+@pytest.mark.asyncio
+async def test_grantex_auth_missing_credentials_do_not_increment_lockout() -> None:
+    from auth.grantex_middleware import GrantexAuthMiddleware
+    from core.auth_state import _mem_blocked, _mem_failures
+
+    _mem_failures.clear()
+    _mem_blocked.clear()
+    middleware = GrantexAuthMiddleware(app=MagicMock())
+    client_ip = "203.0.113.13"
+
+    with patch("core.auth_state._get_redis", new_callable=AsyncMock, return_value=None):
+        response = await middleware.dispatch(
+            _request(auth_header=None, client_ip=client_ip),
+            AsyncMock(),
+        )
+
+    assert response.status_code == 401
+    assert client_ip not in _mem_failures
+
+
+@pytest.mark.asyncio
+async def test_grantex_auth_invalid_credentials_still_increment_lockout() -> None:
+    from auth.grantex_middleware import GrantexAuthMiddleware
+    from core.auth_state import _mem_blocked, _mem_failures
+
+    _mem_failures.clear()
+    _mem_blocked.clear()
+    middleware = GrantexAuthMiddleware(app=MagicMock())
+    client_ip = "203.0.113.14"
+
+    with patch("core.auth_state._get_redis", new_callable=AsyncMock, return_value=None), \
+         patch("auth.grantex_middleware._is_grantex_token", return_value=False), \
+         patch(
+             "auth.grantex_middleware.validate_token",
+             new_callable=AsyncMock,
+             side_effect=ValueError("bad token"),
+         ):
+        response = await middleware.dispatch(
+            _request(auth_header="Bearer bad-token", client_ip=client_ip),
+            AsyncMock(),
+        )
+
+    assert response.status_code == 401
+    assert len(_mem_failures[client_ip]) == 1
+
+
+@pytest.mark.asyncio
+async def test_grantex_auth_empty_bearer_increments_lockout() -> None:
+    from auth.grantex_middleware import GrantexAuthMiddleware
+    from core.auth_state import _mem_blocked, _mem_failures
+
+    _mem_failures.clear()
+    _mem_blocked.clear()
+    middleware = GrantexAuthMiddleware(app=MagicMock())
+    client_ip = "203.0.113.16"
+
+    with patch("core.auth_state._get_redis", new_callable=AsyncMock, return_value=None):
+        response = await middleware.dispatch(
+            _request(auth_header="Bearer ", client_ip=client_ip),
+            AsyncMock(),
+        )
+
+    assert response.status_code == 401
+    assert len(_mem_failures[client_ip]) == 1

--- a/tests/unit/test_auth_and_core.py
+++ b/tests/unit/test_auth_and_core.py
@@ -674,6 +674,7 @@ class TestAuthMiddleware:
             request.headers = _FakeHeaders({"Authorization": auth_header})
         else:
             request.headers = _FakeHeaders({})
+        request.cookies.get.return_value = ""
         return request
 
     @pytest.mark.asyncio
@@ -714,6 +715,7 @@ class TestAuthMiddleware:
         call_next = AsyncMock()
         response = await middleware.dispatch(request, call_next)
         assert response.status_code == 401
+        assert "10.0.0.1" not in _mem_failures
         call_next.assert_not_called()
 
     @pytest.mark.asyncio
@@ -783,10 +785,18 @@ class TestAuthMiddleware:
         client_ip = "10.0.0.99"
 
         # Force in-memory path so the test does not depend on a live Redis.
-        with patch("core.auth_state._get_redis", new_callable=AsyncMock, return_value=None):
-            # Simulate AUTH_MAX_FAILURES failures
+        with patch("core.auth_state._get_redis", new_callable=AsyncMock, return_value=None), \
+             patch(
+                 "auth.middleware.validate_token",
+                 new_callable=AsyncMock,
+                 side_effect=ValueError("bad"),
+             ):
+            # Simulate AUTH_MAX_FAILURES supplied-but-invalid credentials.
             for _ in range(AUTH_MAX_FAILURES):
-                request = self._make_request(auth_header=None, client_ip=client_ip)
+                request = self._make_request(
+                    auth_header="Bearer bad-token",
+                    client_ip=client_ip,
+                )
                 await middleware.dispatch(request, AsyncMock())
 
             # Next request from same IP should be 429

--- a/ui/e2e/auth-public-hydration.spec.ts
+++ b/ui/e2e/auth-public-hydration.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "@playwright/test";
+
+const PUBLIC_BRANDING = {
+  product_name: "AgenticOrg",
+  logo_url: null,
+  favicon_url: null,
+  primary_color: "#7c3aed",
+  accent_color: "#1e293b",
+  support_email: "support@example.com",
+  footer_text: null,
+};
+
+const PUBLIC_PRODUCT_FACTS = {
+  version: "test",
+  connector_count: 55,
+  agent_count: 26,
+  tool_count: 250,
+};
+
+async function installApiRoutes(page: import("@playwright/test").Page) {
+  const authMeRequests: string[] = [];
+
+  await page.route("**/api/v1/**", async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname;
+
+    if (path.endsWith("/api/v1/auth/me")) {
+      authMeRequests.push(route.request().url());
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "Missing session cookie or Authorization header" }),
+      });
+      return;
+    }
+
+    if (path.endsWith("/api/v1/branding")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(PUBLIC_BRANDING),
+      });
+      return;
+    }
+
+    if (path.endsWith("/api/v1/product-facts")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(PUBLIC_PRODUCT_FACTS),
+      });
+      return;
+    }
+
+    if (path.endsWith("/api/v1/auth/config")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ google_client_id: null }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 404,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "Not found in auth hydration regression stub" }),
+    });
+  });
+
+  return authMeRequests;
+}
+
+test.describe("route-aware auth hydration", () => {
+  test("public pages do not probe protected /auth/me on mount", async ({ page, baseURL }) => {
+    const authMeRequests = await installApiRoutes(page);
+    const publicPaths = ["/", "/pricing", "/blog", "/dashboard-public"];
+
+    for (const path of publicPaths) {
+      await page.goto(`${baseURL}${path}`, { waitUntil: "domcontentloaded" });
+      await expect(page.locator("body")).toBeVisible();
+      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForTimeout(250);
+      expect(authMeRequests, `${path} must not call /api/v1/auth/me`).toEqual([]);
+    }
+  });
+
+  test("protected dashboard pages still hydrate through /auth/me", async ({
+    page,
+    baseURL,
+  }) => {
+    const authMeRequests = await installApiRoutes(page);
+
+    await page.goto(`${baseURL}/dashboard`, { waitUntil: "domcontentloaded" });
+
+    await expect.poll(() => authMeRequests.length).toBeGreaterThan(0);
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/ui/src/__tests__/AuthContext.test.tsx
+++ b/ui/src/__tests__/AuthContext.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  AuthProvider,
+  shouldHydrateSessionForPath,
+  useAuth,
+} from "../contexts/AuthContext";
+
+function Probe() {
+  const auth = useAuth();
+  return (
+    <div>
+      <span data-testid="hydrating">{String(auth.isHydrating)}</span>
+      <span data-testid="authenticated">{String(auth.isAuthenticated)}</span>
+      <span data-testid="email">{auth.user?.email ?? ""}</span>
+    </div>
+  );
+}
+
+function renderAt(pathname: string) {
+  render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("AuthProvider route-aware session hydration", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not call /auth/me on public routes", async () => {
+    renderAt("/");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hydrating")).toHaveTextContent("false");
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(screen.getByTestId("authenticated")).toHaveTextContent("false");
+  });
+
+  it("hydrates from /auth/me on protected dashboard routes", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        email: "admin@example.com",
+        name: "Admin",
+        role: "admin",
+        domain: "ops",
+        tenant_id: "tenant-1",
+        onboarding_complete: true,
+      }),
+    } as Response);
+
+    renderAt("/dashboard/agents");
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/v1/auth/me",
+        expect.objectContaining({ credentials: "include" }),
+      );
+      expect(screen.getByTestId("hydrating")).toHaveTextContent("false");
+      expect(screen.getByTestId("authenticated")).toHaveTextContent("true");
+    });
+    expect(screen.getByTestId("email")).toHaveTextContent("admin@example.com");
+  });
+
+  it("keeps the protected route list explicit", () => {
+    expect(shouldHydrateSessionForPath("/")).toBe(false);
+    expect(shouldHydrateSessionForPath("/pricing")).toBe(false);
+    expect(shouldHydrateSessionForPath("/blog/some-post")).toBe(false);
+    expect(shouldHydrateSessionForPath("/dashboard-public")).toBe(false);
+    expect(shouldHydrateSessionForPath("/dashboard")).toBe(true);
+    expect(shouldHydrateSessionForPath("/dashboard/billing/callback")).toBe(true);
+    expect(shouldHydrateSessionForPath("/onboarding")).toBe(true);
+  });
+});

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useCallback, useEffect, ReactNode } from "react";
+import { useLocation } from "react-router-dom";
 
 const API_BASE = import.meta.env.VITE_API_URL
   ? `${import.meta.env.VITE_API_URL}/api/v1`
@@ -54,6 +55,14 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | null>(null);
 
+export function shouldHydrateSessionForPath(pathname: string) {
+  return (
+    pathname === "/onboarding" ||
+    pathname === "/dashboard" ||
+    pathname.startsWith("/dashboard/")
+  );
+}
+
 const SESSION_FETCH_OPTS: RequestInit = {
   // Browser must send the agenticorg_session HttpOnly cookie on every
   // call. Without this, /auth/me returns 401 even when the cookie is
@@ -75,6 +84,7 @@ function _purgeLegacyTokenStorage() {
 }
 
 export function AuthProvider({ children }: { children: ReactNode }) {
+  const location = useLocation();
   const [user, setUser] = useState<AuthUser | null>(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isHydrating, setIsHydrating] = useState(true);
@@ -101,8 +111,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     _purgeLegacyTokenStorage();
+    if (!shouldHydrateSessionForPath(location.pathname)) {
+      setIsHydrating(false);
+      return;
+    }
+    setIsHydrating(true);
     void _hydrateFromCookie().finally(() => setIsHydrating(false));
-  }, [_hydrateFromCookie]);
+  }, [_hydrateFromCookie, location.pathname]);
 
   const login = useCallback(async (email: string, password: string) => {
     const res = await fetch(`${API_BASE}/auth/login`, {


### PR DESCRIPTION
## Summary
- stop public routes from probing protected /api/v1/auth/me on mount while preserving protected dashboard/onboarding hydration
- keep anonymous missing credentials from incrementing auth-failure lockout counters while malformed/invalid auth still records failures
- widen audit_log.action to TEXT with migration so long agent-create audit events cannot truncate/fail
- add backend, React, and Playwright regressions for these production incidents

## Root cause
Public SPA routes mounted the global auth provider and hit /auth/me even when no session was expected. Separately, middleware counted missing anonymous credentials as auth failures, and audit_log.action was narrower than the API contract allowed.

## Validation
- npm test -- AuthContext.test.tsx
- npm run typecheck
- local Vite + Chromium: npm run test:e2e -- auth-public-hydration.spec.ts --project=chromium
- python -m pytest tests\\regression\\test_prod_incidents_20260613.py -q
- python -m pytest tests\\unit\\test_auth_and_core.py::TestAuthMiddleware tests\\regression\\test_pr_fixes_april2026.py::TestGrantexMiddlewareFailureClearing -q
- git diff --check