### PR TITLE
C6Y2 audit review manifest repository

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -982,6 +982,16 @@ class OacpOperatorDecisionRepositoryQuery:
     maintenance_plan_id: str | None = None
 
 
+@dataclass(frozen=True)
+class OacpAuditReviewManifestRepositoryQuery:
+    tenant_id: str | None = None
+    merchant_id: str | None = None
+    seller_agent_id: str | None = None
+    buyer_agent_id: str | None = None
+    bundle_id: str | None = None
+    retention_class: OacpAuditExportReviewRetentionClass | None = None
+
+
 class OacpArtifactCacheRepositoryPort(Protocol):
     def upsert(self, record: OacpPersistentArtifactCacheRecord) -> dict[str, Any]:
         """Store or replace a local cache record without external calls."""
@@ -1023,6 +1033,24 @@ class OacpOperatorDecisionRepositoryPort(Protocol):
 
     def evaluate_decision_for_future_action(self, decision_id: str) -> dict[str, Any]:
         """Evaluate a decision record for a future action without approving execution."""
+        ...
+
+
+class OacpAuditReviewManifestRepositoryPort(Protocol):
+    def upsert_manifest(self, manifest: Mapping[str, Any]) -> dict[str, Any]:
+        """Store or replace one audit-safe review manifest without external calls."""
+        ...
+
+    def get_manifest(self, manifest_id: str) -> dict[str, Any] | None:
+        """Read one review manifest by deterministic manifest id."""
+        ...
+
+    def list_manifests_for_scope(self, query: OacpAuditReviewManifestRepositoryQuery) -> tuple[dict[str, Any], ...]:
+        """List local review manifests for a tenant, merchant, seller, buyer, bundle, or retention scope."""
+        ...
+
+    def evaluate_manifest_for_internal_review(self, manifest_id: str) -> dict[str, Any]:
+        """Evaluate a review manifest without writing export files or approving execution."""
         ...
 
 
@@ -6952,6 +6980,443 @@ def build_oacp_c6y1_audit_export_review_manifest(
             "Review this manifest and retention boundary as label-only evidence; it is not an export writer."
         ),
     }
+
+
+def _c6y2_manifest_repository_refusal(
+    *,
+    status: str,
+    refusal_code: str,
+    message: str,
+    manifest: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "stored": False,
+        "status": status,
+        "refusal_code": refusal_code,
+        "message": message,
+        "manifest_id": None if manifest is None else _c6x7_string(manifest.get("manifest_id")),
+        "bundle_id": None if manifest is None else _c6x7_string(manifest.get("bundle_id")),
+        "tenant_id": None if manifest is None else _c6x7_string(manifest.get("tenant_id")),
+        "merchant_id": None if manifest is None else _c6x7_string(manifest.get("merchant_id")),
+        "durable_repository": True,
+        "future_export_allowed": False,
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "review_manifest_only": True,
+        "retention_boundary_only": True,
+        "audit_export_bundle_review_only": True,
+        "export_file_written": False,
+        "export_writer_added": False,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "grantex_runtime_required": False,
+    }
+
+
+def _c6y2_retention_boundary(manifest: Mapping[str, Any]) -> Mapping[str, Any]:
+    return _c6x8_mapping(manifest.get("retention_boundary"))
+
+
+def _c6y2_retention_class(manifest: Mapping[str, Any]) -> str | None:
+    retention_class = _c6x7_string(_c6y2_retention_boundary(manifest).get("retention_class"))
+    return retention_class if retention_class in _C6Y1_RETENTION_DAYS_BY_CLASS else None
+
+
+def _c6y2_manifest_scope_matches(manifest: Mapping[str, Any]) -> bool:
+    tenant_id = _c6x7_string(manifest.get("tenant_id"))
+    merchant_id = _c6x7_string(manifest.get("merchant_id"))
+    seller_agent_id = _c6x7_string(manifest.get("seller_agent_id"))
+    buyer_agent_id = _c6x7_string(manifest.get("buyer_agent_id"))
+    scope_summary = _c6x8_mapping(manifest.get("scope_summary"))
+    return _c6x9_mapping_scope_matches(
+        {
+            "tenant_id": tenant_id,
+            "merchant_id": merchant_id,
+            "seller_agent_id": seller_agent_id,
+            "buyer_agent_id": buyer_agent_id,
+            "scope_summary": scope_summary,
+        },
+        tenant_id=tenant_id or "",
+        merchant_id=merchant_id or "",
+        seller_agent_id=seller_agent_id,
+        buyer_agent_id=buyer_agent_id,
+    )
+
+
+def _c6y2_manifest_flags_safe(manifest: Mapping[str, Any]) -> bool:
+    return (
+        manifest.get("allowed_to_execute") is False
+        and manifest.get("no_execution") is True
+        and manifest.get("review_manifest_only") is True
+        and manifest.get("retention_boundary_only") is True
+        and manifest.get("audit_export_bundle_review_only") is True
+        and manifest.get("export_file_written") is False
+        and manifest.get("export_writer_added") is False
+        and manifest.get("generated_artifact_written") is False
+        and manifest.get("scheduler_added") is False
+        and manifest.get("non_authoritative_for_transaction") is True
+        and manifest.get("no_checkout_payment_enablement") is True
+        and manifest.get("no_live_provider_enablement") is True
+        and manifest.get("no_public_discovery_enablement") is True
+        and manifest.get("raw_payloads_included") is False
+        and manifest.get("grantex_runtime_required") is False
+    )
+
+
+def _c6y2_manifest_strings(manifest: Mapping[str, Any]) -> list[str]:
+    values = _c6y1_bundle_strings(manifest)
+    values.extend(_c6x9_reason_code_values(manifest.get("artifact_family_counts")))
+    values.extend(_c6x9_reason_code_values(manifest.get("freshness_ttl_summary")))
+    values.extend(_c6x9_reason_code_values(manifest.get("revocation_snapshot_summary")))
+    values.extend(_c6x9_reason_code_values(manifest.get("risk_tier_summary")))
+    for field_name in ("buyer_safe_message", "seller_safe_message", "operator_safe_message", "message"):
+        value = _c6x7_string(manifest.get(field_name))
+        if value is not None:
+            values.append(value)
+    return values
+
+
+def _c6y2_manifest_refs_safe(manifest: Mapping[str, Any]) -> bool:
+    refs = tuple(
+        ref
+        for field_name in _C6Y1_BUNDLE_REF_FIELDS
+        for ref in _c6x8_list(manifest.get(field_name))
+    )
+    return bool(_c6x8_list(manifest.get("redacted_evidence_refs"))) and _c6x2_refs_safe(refs)
+
+
+def _c6y2_manifest_safe_for_storage(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    manifest_id = _c6x7_string(manifest.get("manifest_id"))
+    bundle_id = _c6x7_string(manifest.get("bundle_id"))
+    tenant_id = _c6x7_string(manifest.get("tenant_id"))
+    merchant_id = _c6x7_string(manifest.get("merchant_id"))
+    generated_at = _c6x7_string(manifest.get("generated_at"))
+    bundle_generated_at = _c6x7_string(manifest.get("bundle_generated_at"))
+    retention = _c6y2_retention_boundary(manifest)
+    retention_class = _c6y2_retention_class(manifest)
+    retention_days = retention.get("retention_days")
+    retain_until = _c6x7_string(retention.get("retain_until"))
+    retention_clock_source = _c6x7_string(retention.get("retention_clock_source"))
+
+    if not all((manifest_id, bundle_id, tenant_id, merchant_id)):
+        return _c6y2_manifest_repository_refusal(
+            status="blocked",
+            refusal_code="manifest_identity_or_scope_missing",
+            message="C6Y2 durable review manifests require manifest, bundle, tenant, and merchant identifiers.",
+            manifest=manifest,
+        )
+    if (
+        manifest.get("manifest_kind") != "oacp_audit_export_review_manifest"
+        or manifest.get("status") != "ready_for_internal_review"
+    ):
+        return _c6y2_manifest_repository_refusal(
+            status="blocked",
+            refusal_code="manifest_not_ready_for_storage",
+            message="C6Y2 stores C6Y1 ready internal review manifests only.",
+            manifest=manifest,
+        )
+    if retention_class is None or not isinstance(retention_days, int) or retention_days <= 0:
+        return _c6y2_manifest_repository_refusal(
+            status="blocked",
+            refusal_code="retention_class_invalid",
+            message="C6Y2 stores only supported internal retention review classes.",
+            manifest=manifest,
+        )
+    parsed_generated_at = _parse_iso(generated_at)
+    parsed_bundle_generated_at = _parse_iso(bundle_generated_at)
+    parsed_retain_until = _parse_iso(retain_until)
+    if (
+        parsed_generated_at is None
+        or parsed_bundle_generated_at is None
+        or parsed_retain_until is None
+        or parsed_bundle_generated_at > parsed_generated_at
+        or parsed_generated_at >= parsed_retain_until
+        or not retention_clock_source
+    ):
+        return _c6y2_manifest_repository_refusal(
+            status="blocked",
+            refusal_code="retention_timestamps_invalid",
+            message="C6Y2 requires ordered bundle, manifest, and retention timestamps.",
+            manifest=manifest,
+        )
+    if not _c6y2_manifest_scope_matches(manifest):
+        return _c6y2_manifest_repository_refusal(
+            status="blocked",
+            refusal_code="manifest_scope_mismatch",
+            message="C6Y2 refuses manifests whose direct and summary scopes do not match.",
+            manifest=manifest,
+        )
+    try:
+        assert_no_forbidden_oacp_artifact_fields(dict(manifest))
+    except ValueError:
+        return _c6y2_manifest_repository_refusal(
+            status="unsafe",
+            refusal_code="private_or_enabling_manifest_field",
+            message="C6Y2 refuses manifests with private, raw, credential, or enabling fields.",
+            manifest=manifest,
+        )
+    if not _c6y2_manifest_flags_safe(manifest):
+        return _c6y2_manifest_repository_refusal(
+            status="unsafe",
+            refusal_code="non_enablement_flags_missing",
+            message="C6Y2 refuses review manifests with executable posture or writer/scheduler flags.",
+            manifest=manifest,
+        )
+    labels = tuple(_c6x8_list(manifest.get("next_step_labels")))
+    if not labels or not _c6x8_labels_safe(labels):
+        return _c6y2_manifest_repository_refusal(
+            status="unsafe",
+            refusal_code="manifest_labels_executable_or_private",
+            message="C6Y2 stores label-only next steps, not execution targets.",
+            manifest=manifest,
+        )
+    if not _c6y2_manifest_refs_safe(manifest) or _c6y1_values_private_or_overclaim(_c6y2_manifest_strings(manifest)):
+        return _c6y2_manifest_repository_refusal(
+            status="unsafe",
+            refusal_code="manifest_refs_private_or_overclaim",
+            message="C6Y2 stores redacted refs only and blocks publication or approval/readiness claims.",
+            manifest=manifest,
+        )
+    return {
+        "stored": True,
+        "status": "stored",
+        "manifest_id": manifest_id,
+        "bundle_id": bundle_id,
+        "tenant_id": tenant_id,
+        "merchant_id": merchant_id,
+        "retention_class": retention_class,
+        "retention_days": retention_days,
+        "retain_until": retain_until,
+        "durable_repository": True,
+        "future_export_allowed": False,
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "review_manifest_only": True,
+        "retention_boundary_only": True,
+        "audit_export_bundle_review_only": True,
+        "export_file_written": False,
+        "export_writer_added": False,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "grantex_runtime_required": False,
+    }
+
+
+def _c6y2_apply_manifest_to_row(row: Any, manifest: Mapping[str, Any]) -> None:
+    retention = _c6y2_retention_boundary(manifest)
+    row.bundle_id = cast(str, manifest["bundle_id"])
+    row.generated_at = _parse_iso(cast(str, manifest["generated_at"]))
+    row.bundle_generated_at = _parse_iso(cast(str, manifest["bundle_generated_at"]))
+    row.tenant_id = cast(str, manifest["tenant_id"])
+    row.merchant_id = cast(str, manifest["merchant_id"])
+    row.seller_agent_id = _c6x7_string(manifest.get("seller_agent_id"))
+    row.buyer_agent_id = _c6x7_string(manifest.get("buyer_agent_id"))
+    row.scope_summary = dict(_c6x8_mapping(manifest.get("scope_summary")))
+    row.retention_class = cast(str, retention["retention_class"])
+    row.retention_days = int(cast(int, retention["retention_days"]))
+    row.retain_until = _parse_iso(cast(str, retention["retain_until"]))
+    row.retention_clock_source = cast(str, retention["retention_clock_source"])
+    row.artifact_family_counts = dict(_c6x8_mapping(manifest.get("artifact_family_counts")))
+    row.cache_record_references = _c6x8_list(manifest.get("cache_record_references"))
+    row.maintenance_plan_references = _c6x8_list(manifest.get("maintenance_plan_references"))
+    row.review_packet_references = _c6x8_list(manifest.get("review_packet_references"))
+    row.decision_record_references = _c6x8_list(manifest.get("decision_record_references"))
+    row.redacted_reason_codes = dict(_c6x8_mapping(manifest.get("redacted_reason_codes")))
+    row.redacted_source_refs = _c6x8_list(manifest.get("redacted_source_refs"))
+    row.redacted_evidence_refs = _c6x8_list(manifest.get("redacted_evidence_refs"))
+    row.freshness_ttl_summary = dict(_c6x8_mapping(manifest.get("freshness_ttl_summary")))
+    row.revocation_snapshot_summary = dict(_c6x8_mapping(manifest.get("revocation_snapshot_summary")))
+    row.risk_tier_summary = dict(_c6x8_mapping(manifest.get("risk_tier_summary")))
+    row.unsupported_capability_summary = dict(_c6x8_mapping(manifest.get("unsupported_capability_summary")))
+    row.blocked_capability_summary = dict(_c6x8_mapping(manifest.get("blocked_capability_summary")))
+    row.next_step_labels = _c6x8_list(manifest.get("next_step_labels"))
+    row.allowed_to_execute = False
+    row.no_execution = True
+    row.review_manifest_only = True
+    row.retention_boundary_only = True
+    row.audit_export_bundle_review_only = True
+    row.export_file_written = False
+    row.export_writer_added = False
+    row.generated_artifact_written = False
+    row.non_authoritative_for_transaction = True
+    row.no_checkout_payment_enablement = True
+    row.no_live_provider_enablement = True
+    row.no_public_discovery_enablement = True
+
+
+def _c6y2_row_time(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    return str(value)
+
+
+def _c6y2_row_to_manifest(row: Any) -> dict[str, Any]:
+    return {
+        "manifest_id": str(row.manifest_id),
+        "manifest_kind": "oacp_audit_export_review_manifest",
+        "status": "ready_for_internal_review",
+        "generated_at": _c6y2_row_time(row.generated_at),
+        "bundle_id": str(row.bundle_id),
+        "bundle_generated_at": _c6y2_row_time(row.bundle_generated_at),
+        "tenant_id": str(row.tenant_id),
+        "merchant_id": str(row.merchant_id),
+        "seller_agent_id": None if row.seller_agent_id is None else str(row.seller_agent_id),
+        "buyer_agent_id": None if row.buyer_agent_id is None else str(row.buyer_agent_id),
+        "scope_summary": dict(row.scope_summary or {}),
+        "artifact_family_counts": dict(row.artifact_family_counts or {}),
+        "cache_record_references": list(row.cache_record_references or []),
+        "maintenance_plan_references": list(row.maintenance_plan_references or []),
+        "review_packet_references": list(row.review_packet_references or []),
+        "decision_record_references": list(row.decision_record_references or []),
+        "redacted_reason_codes": dict(row.redacted_reason_codes or {}),
+        "redacted_source_refs": list(row.redacted_source_refs or []),
+        "redacted_evidence_refs": list(row.redacted_evidence_refs or []),
+        "freshness_ttl_summary": dict(row.freshness_ttl_summary or {}),
+        "revocation_snapshot_summary": dict(row.revocation_snapshot_summary or {}),
+        "risk_tier_summary": dict(row.risk_tier_summary or {}),
+        "unsupported_capability_summary": dict(row.unsupported_capability_summary or {}),
+        "blocked_capability_summary": dict(row.blocked_capability_summary or {}),
+        "retention_boundary": {
+            "retention_class": str(row.retention_class),
+            "retention_days": int(row.retention_days),
+            "retain_until": _c6y2_row_time(row.retain_until),
+            "retention_clock_source": str(row.retention_clock_source),
+            "persistence_required": False,
+            "requires_separate_persistence_approval": False,
+            "export_file_writer_added": bool(row.export_writer_added),
+            "generated_artifact_written": bool(row.generated_artifact_written),
+        },
+        "redaction_boundary": {
+            "redacted_refs_only": True,
+            "raw_payloads_included": False,
+            "private_values_blocked": True,
+            "raw_reviewer_identity_included": False,
+            "non_sensitive_evidence_refs_only": True,
+        },
+        "next_step_labels": list(row.next_step_labels or []),
+        "allowed_to_execute": bool(row.allowed_to_execute),
+        "no_execution": bool(row.no_execution),
+        "review_manifest_only": bool(row.review_manifest_only),
+        "retention_boundary_only": bool(row.retention_boundary_only),
+        "audit_export_bundle_review_only": bool(row.audit_export_bundle_review_only),
+        "export_file_written": bool(row.export_file_written),
+        "export_writer_added": bool(row.export_writer_added),
+        "generated_artifact_written": bool(row.generated_artifact_written),
+        "scheduler_added": False,
+        "raw_payloads_included": False,
+        "non_authoritative_for_transaction": bool(row.non_authoritative_for_transaction),
+        "no_checkout_payment_enablement": bool(row.no_checkout_payment_enablement),
+        "no_live_provider_enablement": bool(row.no_live_provider_enablement),
+        "no_public_discovery_enablement": bool(row.no_public_discovery_enablement),
+        "grantex_runtime_required": False,
+    }
+
+
+def _c6y2_query_matches(manifest: Mapping[str, Any], query: OacpAuditReviewManifestRepositoryQuery) -> bool:
+    return (
+        (query.tenant_id is None or manifest.get("tenant_id") == query.tenant_id)
+        and (query.merchant_id is None or manifest.get("merchant_id") == query.merchant_id)
+        and (query.seller_agent_id is None or manifest.get("seller_agent_id") == query.seller_agent_id)
+        and (query.buyer_agent_id is None or manifest.get("buyer_agent_id") == query.buyer_agent_id)
+        and (query.bundle_id is None or manifest.get("bundle_id") == query.bundle_id)
+        and (
+            query.retention_class is None
+            or _c6y2_retention_boundary(manifest).get("retention_class") == query.retention_class
+        )
+    )
+
+
+class DurableOacpAuditReviewManifestRepository:
+    """Async SQLAlchemy-backed review manifest repository; it writes no export files and executes nothing."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def upsert_manifest(self, manifest: Mapping[str, Any]) -> dict[str, Any]:
+        from core.models.oacp_audit_review_manifest import OacpAuditReviewManifestRecordRow
+
+        store_result = _c6y2_manifest_safe_for_storage(manifest)
+        if store_result["stored"] is not True:
+            return store_result
+
+        manifest_id = cast(str, store_result["manifest_id"])
+        row = await self._session.get(OacpAuditReviewManifestRecordRow, manifest_id)
+        if row is None:
+            row = OacpAuditReviewManifestRecordRow(manifest_id=manifest_id)
+            self._session.add(row)
+        _c6y2_apply_manifest_to_row(row, manifest)
+        await self._session.flush()
+        return store_result
+
+    async def get_manifest(self, manifest_id: str) -> dict[str, Any] | None:
+        from core.models.oacp_audit_review_manifest import OacpAuditReviewManifestRecordRow
+
+        row = await self._session.get(OacpAuditReviewManifestRecordRow, manifest_id)
+        return None if row is None else _c6y2_row_to_manifest(row)
+
+    async def list_manifests_for_scope(
+        self,
+        query: OacpAuditReviewManifestRepositoryQuery,
+    ) -> tuple[dict[str, Any], ...]:
+        from sqlalchemy import select
+
+        from core.models.oacp_audit_review_manifest import OacpAuditReviewManifestRecordRow
+
+        statement = select(OacpAuditReviewManifestRecordRow)
+        if query.tenant_id is not None:
+            statement = statement.where(OacpAuditReviewManifestRecordRow.tenant_id == query.tenant_id)
+        if query.merchant_id is not None:
+            statement = statement.where(OacpAuditReviewManifestRecordRow.merchant_id == query.merchant_id)
+        if query.seller_agent_id is not None:
+            statement = statement.where(OacpAuditReviewManifestRecordRow.seller_agent_id == query.seller_agent_id)
+        if query.buyer_agent_id is not None:
+            statement = statement.where(OacpAuditReviewManifestRecordRow.buyer_agent_id == query.buyer_agent_id)
+        if query.bundle_id is not None:
+            statement = statement.where(OacpAuditReviewManifestRecordRow.bundle_id == query.bundle_id)
+        if query.retention_class is not None:
+            statement = statement.where(OacpAuditReviewManifestRecordRow.retention_class == query.retention_class)
+
+        rows = (await self._session.scalars(statement.order_by(OacpAuditReviewManifestRecordRow.manifest_id))).all()
+        manifests = tuple(_c6y2_row_to_manifest(row) for row in rows)
+        return tuple(manifest for manifest in manifests if _c6y2_query_matches(manifest, query))
+
+    async def evaluate_manifest_for_internal_review(self, manifest_id: str) -> dict[str, Any]:
+        manifest = await self.get_manifest(manifest_id)
+        if manifest is None:
+            return _c6y2_manifest_repository_refusal(
+                status="blocked",
+                refusal_code="manifest_missing",
+                message="C6Y2 requires a stored review manifest before internal review evaluation.",
+            )
+        store_result = _c6y2_manifest_safe_for_storage(manifest)
+        if store_result["stored"] is not True:
+            return store_result
+        return {
+            "evaluated": True,
+            "status": "internal_review_requires_separate_export_approval",
+            "manifest_id": manifest_id,
+            "bundle_id": manifest["bundle_id"],
+            "retention_class": _c6y2_retention_boundary(manifest)["retention_class"],
+            "retain_until": _c6y2_retention_boundary(manifest)["retain_until"],
+            "future_export_allowed": False,
+            "allowed_to_execute": False,
+            "no_execution": True,
+            "review_manifest_only": True,
+            "retention_boundary_only": True,
+            "audit_export_bundle_review_only": True,
+            "export_file_written": False,
+            "export_writer_added": False,
+            "non_authoritative_for_transaction": True,
+            "no_checkout_payment_enablement": True,
+            "no_live_provider_enablement": True,
+            "no_public_discovery_enablement": True,
+            "grantex_runtime_required": False,
+            "message": "C6Y2 stores an audit review manifest only; it does not write export files.",
+        }
 
 
 class OacpArtifactCache:

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -57,6 +57,9 @@ from core.models.kpi_cache import KPICache as KPICache
 from core.models.lead_pipeline import EmailSequence as EmailSequence
 from core.models.lead_pipeline import LeadPipeline as LeadPipeline
 from core.models.oacp_artifact_cache import OacpArtifactCacheRecordRow as OacpArtifactCacheRecordRow
+from core.models.oacp_audit_review_manifest import (
+    OacpAuditReviewManifestRecordRow as OacpAuditReviewManifestRecordRow,
+)
 from core.models.oacp_operator_decision import OacpOperatorDecisionRecordRow as OacpOperatorDecisionRecordRow
 from core.models.organization import CostCenter as CostCenter
 from core.models.organization import Department as Department

--- a/core/models/oacp_audit_review_manifest.py
+++ b/core/models/oacp_audit_review_manifest.py
@@ -1,0 +1,138 @@
+"""Durable OACP audit review manifest model.
+
+The table stores only redacted, audit-safe review manifest metadata for
+AgenticOrg internal review and retention boundaries. It does not write export
+files and is not transaction authority.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import JSON, TIMESTAMP, Boolean, Index, Integer, String, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.models.base import BaseModel
+
+OACP_AUDIT_REVIEW_MANIFEST_JSON = JSONB().with_variant(JSON(), "sqlite")
+
+
+class OacpAuditReviewManifestRecordRow(BaseModel):
+    __tablename__ = "oacp_audit_review_manifest_records"
+    __table_args__ = (
+        Index("ix_oacp_audit_review_manifest_tenant_id", "tenant_id"),
+        Index("ix_oacp_audit_review_manifest_merchant_id", "merchant_id"),
+        Index("ix_oacp_audit_review_manifest_seller_agent_id", "seller_agent_id"),
+        Index("ix_oacp_audit_review_manifest_buyer_agent_id", "buyer_agent_id"),
+        Index("ix_oacp_audit_review_manifest_bundle_id", "bundle_id"),
+        Index("ix_oacp_audit_review_manifest_retention_class", "retention_class"),
+        Index("ix_oacp_audit_review_manifest_retain_until", "retain_until"),
+        Index("ix_oacp_audit_review_manifest_generated_at", "generated_at"),
+    )
+
+    manifest_id: Mapped[str] = mapped_column(String(180), primary_key=True)
+    bundle_id: Mapped[str] = mapped_column(String(180), nullable=False)
+    generated_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    bundle_generated_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    tenant_id: Mapped[str] = mapped_column(String(160), nullable=False)
+    merchant_id: Mapped[str] = mapped_column(String(160), nullable=False)
+    seller_agent_id: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    buyer_agent_id: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    scope_summary: Mapped[dict[str, object]] = mapped_column(
+        OACP_AUDIT_REVIEW_MANIFEST_JSON,
+        nullable=False,
+        default=dict,
+    )
+    retention_class: Mapped[str] = mapped_column(String(64), nullable=False)
+    retention_days: Mapped[int] = mapped_column(Integer, nullable=False)
+    retain_until: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    retention_clock_source: Mapped[str] = mapped_column(String(64), nullable=False)
+    artifact_family_counts: Mapped[dict[str, object]] = mapped_column(
+        OACP_AUDIT_REVIEW_MANIFEST_JSON,
+        nullable=False,
+        default=dict,
+    )
+    cache_record_references: Mapped[list[str]] = mapped_column(
+        OACP_AUDIT_REVIEW_MANIFEST_JSON,
+        nullable=False,
+        default=list,
+    )
+    maintenance_plan_references: Mapped[list[str]] = mapped_column(
+        OACP_AUDIT_REVIEW_MANIFEST_JSON,
+        nullable=False,
+        default=list,
+    )
+    review_packet_references: Mapped[list[str]] = mapped_column(
+        OACP_AUDIT_REVIEW_MANIFEST_JSON,
+        nullable=False,
+        default=list,
+    )
+    decision_record_references: Mapped[list[str]] = mapped_column(
+        OACP_AUDIT_REVIEW_MANIFEST_JSON,
+        nullable=False,
+        default=list,
+    )
+    redacted_reason_codes: Mapped[dict[str, object]] = mapped_column(
+        OACP_AUDIT_REVIEW_MANIFEST_JSON,
+        nullable=False,
+        default=dict,
+    )
+    redacted_source_refs: Mapped[list[str]] = mapped_column(
+        OACP_AUDIT_REVIEW_MANIFEST_JSON,
+        nullable=False,
+        default=list,
+    )
+    redacted_evidence_refs: Mapped[list[str]] = mapped_column(
+        OACP_AUDIT_REVIEW_MANIFEST_JSON,
+        nullable=False,
+        default=list,
+    )
+    freshness_ttl_summary: Mapped[dict[str, object]] = mapped_column(
+        OACP_AUDIT_REVIEW_MANIFEST_JSON,
+        nullable=False,
+        default=dict,
+    )
+    revocation_snapshot_summary: Mapped[dict[str, object]] = mapped_column(
+        OACP_AUDIT_REVIEW_MANIFEST_JSON,
+        nullable=False,
+        default=dict,
+    )
+    risk_tier_summary: Mapped[dict[str, object]] = mapped_column(
+        OACP_AUDIT_REVIEW_MANIFEST_JSON,
+        nullable=False,
+        default=dict,
+    )
+    unsupported_capability_summary: Mapped[dict[str, object]] = mapped_column(
+        OACP_AUDIT_REVIEW_MANIFEST_JSON,
+        nullable=False,
+        default=dict,
+    )
+    blocked_capability_summary: Mapped[dict[str, object]] = mapped_column(
+        OACP_AUDIT_REVIEW_MANIFEST_JSON,
+        nullable=False,
+        default=dict,
+    )
+    next_step_labels: Mapped[list[str]] = mapped_column(
+        OACP_AUDIT_REVIEW_MANIFEST_JSON,
+        nullable=False,
+        default=list,
+    )
+    allowed_to_execute: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    no_execution: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    review_manifest_only: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    retention_boundary_only: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    audit_export_bundle_review_only: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    export_file_written: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    export_writer_added: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    generated_artifact_written: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    non_authoritative_for_transaction: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    no_checkout_payment_enablement: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    no_live_provider_enablement: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    no_public_discovery_enablement: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
+    updated_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=True,
+        onupdate=func.now(),
+    )

--- a/docs/reports/commerce-agent-c6y2-oacp-audit-review-manifest-repository.md
+++ b/docs/reports/commerce-agent-c6y2-oacp-audit-review-manifest-repository.md
@@ -1,0 +1,60 @@
+# Commerce Agent C6Y2 OACP Audit Review Manifest Repository
+
+## Scope
+
+C6Y2 adds an internal AgenticOrg durable repository for C6Y1 OACP audit export review manifests and retention boundary metadata. The repository stores redacted, audit-safe manifest metadata only. It does not write export files, expose an API, run jobs, schedule maintenance, call Grantex live, call providers, call merchant systems, refresh artifacts, execute cache maintenance, or execute commerce actions.
+
+## Correct Ownership Model
+
+AgenticOrg is the buyer and seller AI-agent runtime. AgenticOrg owns durable and local OACP artifact cache behavior, local operator decision handling, internal audit export bundle generation, and audit review manifest handling. AgenticOrg owns audit review manifest handling inside the local runtime boundary. Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. Grantex is not a transaction toll booth for every non-binding buyer or seller agent turn. Merchant systems remain operational sources of record, and provider or fintech rails own mandate and payment execution where separately approved.
+
+## Persistence Decision
+
+C6Y2 implements persistence because the existing C6X4 and C6X8 AgenticOrg migrations establish a narrow Alembic-managed pattern for OACP-owned durable internal records with tenant indexes, non-enablement constraints, rollback, and RLS. The migration is `v6y2_oacp_review_manifests` and depends on `v6x9_audit_log_action_text`, the current migration head.
+
+The repository is internal only. It stores review metadata after C6Y1 manifest generation and does not create a command, CLI, scheduler, worker, queue, route, public endpoint, or public OpenAPI runtime contract.
+
+## Durable Repository Contract
+
+The repository methods are:
+
+- `upsert_manifest`
+- `get_manifest`
+- `list_manifests_for_scope`
+- `evaluate_manifest_for_internal_review`
+
+Evaluation is review-only. It returns `future_export_allowed = false`, `allowed_to_execute = false`, `export_file_written = false`, `export_writer_added = false`, and `non_authoritative_for_transaction = true`.
+
+## Stored Fields
+
+The table preserves manifest id, bundle id, tenant id, merchant id, seller-agent id, buyer-agent id, generated timestamps, bundle generated timestamp, retention class, retention days, retain-until timestamp, retention clock source, artifact family counts, cache record references, maintenance plan references, review packet references, decision record references, redacted reason codes, redacted source refs, redacted evidence refs, freshness and TTL summary, revocation snapshot summary, risk-tier summary, unsupported capability summary, blocked capability summary, next-step labels, non-enablement flags, and created or updated timestamps.
+
+The repository stores only redacted refs and summary metadata. It does not store raw artifact payloads, provider payloads, connector payloads, raw JWTs or passports, credentials, tokens, private keys, private customer data, payment data, bank or card data, raw merchant private API values, raw reviewer identity values, secrets, production allowlists, executable URLs, or action targets.
+
+## Retention Boundary
+
+C6Y2 persists C6Y1 internal retention classes only: `short_lived_internal_review`, `standard_internal_review`, and `legal_hold_candidate`. The retention window is metadata for review and retention boundary handling. It is not public publication, public launch readiness, checkout approval, payment approval, mandate approval, live-provider approval, merchant approval, certification, compliance, conformance, or standardization.
+
+## Fail-Closed Persistence And Evaluation
+
+The repository refuses storage when manifest id, bundle id, tenant id, or merchant id is missing; the manifest is not a C6Y1 ready review manifest; retention class is invalid; generated, bundle generated, or retain-until timestamps are malformed or unordered; direct scope and summary scope mismatch; private or raw refs are present; executable or export-writer flags are present; non-enablement flags are false; next-step labels imply execution; or publication, approval, or readiness wording appears.
+
+Blocked records are not stored. Missing records evaluate to blocked. Stored records evaluate as internal review records only and do not authorize future export, cache maintenance, checkout, payment, provider, merchant private API, public discovery, or Grantex live behavior.
+
+## Migration Safety
+
+The migration adds one narrow table, tenant and scope indexes, a uniqueness guard for bundle and retention scope, timestamp ordering checks, non-execution constraints, and tenant RLS using `agenticorg.tenant_id`. Rollback drops the policy, indexes, unique scope guard, and table. There is no runtime startup schema mutation and no production config change.
+
+## Guardrails
+
+C6Y2 remains internal-only, non-publication, non-certifying, non-production, non-executing, fail-closed, scheduler-free, export-writer-free, and non-authoritative for transactions. It keeps `allowed_to_execute = false`, `future_export_allowed = false`, `non_authoritative_for_transaction = true`, `no_checkout_payment_enablement = true`, `no_live_provider_enablement = true`, and `no_public_discovery_enablement = true`.
+
+## What C6Y2 Does Not Enable
+
+C6Y2 adds no public endpoint, route, public OpenAPI runtime contract, workflow, scheduler, cron job, queue, background worker, CLI, export-file writer, production config, secret, public discovery enablement, checkout, payment, order, hold, refund, return, shipping execution, live provider rail, live Plural behavior, provider call, merchant private API call, allowlist, external OACP publication, or approval/readiness claim.
+
+Grantex does not receive every review manifest, audit bundle, cache report, operator decision, or non-binding buyer or seller interaction.
+
+## Future Work
+
+Future slices may define a controlled internal review surface, explicit retention operations, or an export writer. Those slices must remain separate from checkout, payment, provider rails, merchant private APIs, public OACP publication, production config, workflow scheduling, public endpoint behavior, and readiness or approval claims unless separately approved.

--- a/migrations/versions/v6_y2_oacp_audit_review_manifests.py
+++ b/migrations/versions/v6_y2_oacp_audit_review_manifests.py
@@ -1,0 +1,170 @@
+"""C6Y2 durable OACP audit review manifests.
+
+Revision ID: v6y2_oacp_review_manifests
+Revises: v6x9_audit_log_action_text
+Create Date: 2026-06-13
+
+This table is an AgenticOrg-owned internal review manifest repository. It
+stores only redacted, audit-safe metadata and retention boundary fields for
+C6Y1 audit review manifests. It is not transaction authority and does not
+enable export-file writing, scheduling, checkout, payment, provider calls,
+merchant private API calls, public discovery, or Grantex live calls.
+
+Rollback: drop the review manifest table, indexes, unique scope guard, and RLS
+policy. No merchant source-of-record, provider, payment, checkout, export file,
+or canonical Grantex artifact state is stored here.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v6y2_oacp_review_manifests"
+down_revision = "v6x9_audit_log_action_text"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS oacp_audit_review_manifest_records (
+            manifest_id VARCHAR(180) PRIMARY KEY,
+            bundle_id VARCHAR(180) NOT NULL,
+            generated_at TIMESTAMPTZ NOT NULL,
+            bundle_generated_at TIMESTAMPTZ NOT NULL,
+            tenant_id VARCHAR(160) NOT NULL,
+            merchant_id VARCHAR(160) NOT NULL,
+            seller_agent_id VARCHAR(160),
+            buyer_agent_id VARCHAR(160),
+            scope_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+            retention_class VARCHAR(64) NOT NULL,
+            retention_days INTEGER NOT NULL,
+            retain_until TIMESTAMPTZ NOT NULL,
+            retention_clock_source VARCHAR(64) NOT NULL,
+            artifact_family_counts JSONB NOT NULL DEFAULT '{}'::jsonb,
+            cache_record_references JSONB NOT NULL DEFAULT '[]'::jsonb,
+            maintenance_plan_references JSONB NOT NULL DEFAULT '[]'::jsonb,
+            review_packet_references JSONB NOT NULL DEFAULT '[]'::jsonb,
+            decision_record_references JSONB NOT NULL DEFAULT '[]'::jsonb,
+            redacted_reason_codes JSONB NOT NULL DEFAULT '{}'::jsonb,
+            redacted_source_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+            redacted_evidence_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+            freshness_ttl_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+            revocation_snapshot_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+            risk_tier_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+            unsupported_capability_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+            blocked_capability_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+            next_step_labels JSONB NOT NULL DEFAULT '[]'::jsonb,
+            allowed_to_execute BOOLEAN NOT NULL DEFAULT FALSE,
+            no_execution BOOLEAN NOT NULL DEFAULT TRUE,
+            review_manifest_only BOOLEAN NOT NULL DEFAULT TRUE,
+            retention_boundary_only BOOLEAN NOT NULL DEFAULT TRUE,
+            audit_export_bundle_review_only BOOLEAN NOT NULL DEFAULT TRUE,
+            export_file_written BOOLEAN NOT NULL DEFAULT FALSE,
+            export_writer_added BOOLEAN NOT NULL DEFAULT FALSE,
+            generated_artifact_written BOOLEAN NOT NULL DEFAULT FALSE,
+            non_authoritative_for_transaction BOOLEAN NOT NULL DEFAULT TRUE,
+            no_checkout_payment_enablement BOOLEAN NOT NULL DEFAULT TRUE,
+            no_live_provider_enablement BOOLEAN NOT NULL DEFAULT TRUE,
+            no_public_discovery_enablement BOOLEAN NOT NULL DEFAULT TRUE,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ,
+            CONSTRAINT ck_oacp_review_manifest_retention_class
+                CHECK (
+                    retention_class IN (
+                        'short_lived_internal_review',
+                        'standard_internal_review',
+                        'legal_hold_candidate'
+                    )
+                ),
+            CONSTRAINT ck_oacp_review_manifest_retention_days CHECK (retention_days > 0),
+            CONSTRAINT ck_oacp_review_manifest_ordered_timestamps
+                CHECK (bundle_generated_at <= generated_at AND generated_at < retain_until),
+            CONSTRAINT ck_oacp_review_manifest_non_execution_flags CHECK (
+                allowed_to_execute IS FALSE
+                AND no_execution IS TRUE
+                AND review_manifest_only IS TRUE
+                AND retention_boundary_only IS TRUE
+                AND audit_export_bundle_review_only IS TRUE
+                AND export_file_written IS FALSE
+                AND export_writer_added IS FALSE
+                AND generated_artifact_written IS FALSE
+                AND non_authoritative_for_transaction IS TRUE
+                AND no_checkout_payment_enablement IS TRUE
+                AND no_live_provider_enablement IS TRUE
+                AND no_public_discovery_enablement IS TRUE
+            )
+        );
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_audit_review_manifest_tenant_id "
+        "ON oacp_audit_review_manifest_records (tenant_id);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_audit_review_manifest_merchant_id "
+        "ON oacp_audit_review_manifest_records (merchant_id);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_audit_review_manifest_seller_agent_id "
+        "ON oacp_audit_review_manifest_records (seller_agent_id);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_audit_review_manifest_buyer_agent_id "
+        "ON oacp_audit_review_manifest_records (buyer_agent_id);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_audit_review_manifest_bundle_id "
+        "ON oacp_audit_review_manifest_records (bundle_id);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_audit_review_manifest_retention_class "
+        "ON oacp_audit_review_manifest_records (retention_class);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_audit_review_manifest_retain_until "
+        "ON oacp_audit_review_manifest_records (retain_until);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_audit_review_manifest_generated_at "
+        "ON oacp_audit_review_manifest_records (generated_at);"
+    )
+    op.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_oacp_review_manifest_bundle_retention_scope
+            ON oacp_audit_review_manifest_records (
+                tenant_id,
+                merchant_id,
+                COALESCE(seller_agent_id, ''),
+                COALESCE(buyer_agent_id, ''),
+                bundle_id,
+                retention_class
+            );
+    """)
+    op.execute("ALTER TABLE oacp_audit_review_manifest_records ENABLE ROW LEVEL SECURITY;")
+    op.execute("ALTER TABLE oacp_audit_review_manifest_records FORCE ROW LEVEL SECURITY;")
+    op.execute(
+        "DROP POLICY IF EXISTS oacp_audit_review_manifest_records_tenant_isolation "
+        "ON oacp_audit_review_manifest_records;"
+    )
+    op.execute("""
+        CREATE POLICY oacp_audit_review_manifest_records_tenant_isolation
+            ON oacp_audit_review_manifest_records
+            USING (tenant_id = current_setting('agenticorg.tenant_id', true))
+            WITH CHECK (tenant_id = current_setting('agenticorg.tenant_id', true));
+    """)
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP POLICY IF EXISTS oacp_audit_review_manifest_records_tenant_isolation "
+        "ON oacp_audit_review_manifest_records;"
+    )
+    op.execute("DROP INDEX IF EXISTS uq_oacp_review_manifest_bundle_retention_scope;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_audit_review_manifest_generated_at;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_audit_review_manifest_retain_until;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_audit_review_manifest_retention_class;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_audit_review_manifest_bundle_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_audit_review_manifest_buyer_agent_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_audit_review_manifest_seller_agent_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_audit_review_manifest_merchant_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_audit_review_manifest_tenant_id;")
+    op.execute("DROP TABLE IF EXISTS oacp_audit_review_manifest_records;")

--- a/tests/unit/test_oacp_c6y2_audit_review_manifest_repository.py
+++ b/tests/unit/test_oacp_c6y2_audit_review_manifest_repository.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from core.commerce.oacp_artifacts import (
+    DurableOacpAuditReviewManifestRepository,
+    OacpArtifactCacheRepositoryQuery,
+    OacpAuditReviewManifestRepositoryQuery,
+    OacpPersistentArtifactCacheRecord,
+    build_oacp_c6x9_audit_export_bundle,
+    build_oacp_c6y1_audit_export_review_manifest,
+    build_oacp_cache_maintenance_dry_run_report,
+    build_oacp_cache_operator_decision_record,
+    plan_oacp_artifact_cache_maintenance,
+)
+from core.models.oacp_audit_review_manifest import OacpAuditReviewManifestRecordRow
+
+C6Y2_DOC_PATH = Path("docs/reports/commerce-agent-c6y2-oacp-audit-review-manifest-repository.md")
+C6Y2_MIGRATION_PATH = Path("migrations/versions/v6_y2_oacp_audit_review_manifests.py")
+
+
+def _doc() -> str:
+    return C6Y2_DOC_PATH.read_text(encoding="utf-8")
+
+
+def _migration() -> str:
+    return C6Y2_MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+def _record(**overrides: object) -> OacpPersistentArtifactCacheRecord:
+    base = OacpPersistentArtifactCacheRecord(
+        cache_record_id="cache_price_C6Y2",
+        artifact_id="price_C6W3",
+        artifact_type="price",
+        authority="grantex_canonical_oacp_artifact_authority",
+        issuer="grantex",
+        scope_kind="buyer_agent",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+        source_refs=("source_ref_price_C6Y2",),
+        evidence_refs=("evidence_price_C6Y2_redacted",),
+        generated_at="2026-06-12T00:00:00.000Z",
+        cached_at="2026-06-12T00:00:10.000Z",
+        expires_at="2026-06-12T00:05:00.000Z",
+        freshness_status="fresh",
+        revocation_snapshot_status="fresh",
+        revocation_snapshot_observed_at="2026-06-12T00:00:30.000Z",
+        revocation_snapshot_age_seconds=30,
+        ttl_policy_seconds=300,
+        risk_tier="low",
+        blocked_capabilities=("checkout_payment_creation", "live_provider_call"),
+        unsupported_capabilities=("transaction_authority_from_adapter_preview",),
+        verifier_result_ref="verifier_result_price_C6Y2",
+    )
+    return replace(base, **overrides)
+
+
+def _plan(records: tuple[OacpPersistentArtifactCacheRecord, ...]) -> dict[str, object]:
+    return plan_oacp_artifact_cache_maintenance(
+        records=records,
+        now_iso="2026-06-12T00:01:00.000Z",
+        grantex_available=True,
+        action_intent="prepare_only",
+        risk_tier="low",
+        scope_filter=OacpArtifactCacheRepositoryQuery(tenant_id="cten_C6W3", merchant_id="mch_C6W3"),
+    )
+
+
+def _review_packet(plan: dict[str, object]) -> dict[str, object]:
+    return build_oacp_cache_maintenance_dry_run_report(
+        maintenance_plan=plan,
+        report_kind="operator_review_packet",
+    )
+
+
+def _decision(packet: dict[str, object], **overrides: object) -> dict[str, object]:
+    decision = build_oacp_cache_operator_decision_record(
+        review_packet=packet,
+        decision_kind="request_more_evidence",
+        reviewer_identity_ref="operator_ref_c6y2_reviewer_001",
+        decided_at="2026-06-12T00:02:00.000Z",
+    )
+    decision.update(overrides)
+    return decision
+
+
+def _bundle() -> dict[str, object]:
+    cache_records = (_record(),)
+    plan = _plan(cache_records)
+    packet = _review_packet(plan)
+    decision = _decision(packet)
+    return build_oacp_c6x9_audit_export_bundle(
+        cache_records=cache_records,
+        maintenance_plans=(plan,),
+        review_packets=(packet,),
+        operator_decision_records=(decision,),
+        durable_decision_records=(dict(decision),),
+        generated_at="2026-06-12T00:03:00.000Z",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+    )
+
+
+def _manifest(**overrides: object) -> dict[str, object]:
+    manifest = build_oacp_c6y1_audit_export_review_manifest(
+        audit_export_bundle=_bundle(),
+        generated_at="2026-06-12T00:04:00.000Z",
+        retention_class="standard_internal_review",
+    )
+    manifest.update(overrides)
+    return manifest
+
+
+class _FakeScalars:
+    def __init__(self, rows: list[OacpAuditReviewManifestRecordRow]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[OacpAuditReviewManifestRecordRow]:
+        return self._rows
+
+
+class _FakeAsyncSession:
+    def __init__(self) -> None:
+        self.rows: dict[str, OacpAuditReviewManifestRecordRow] = {}
+
+    async def get(
+        self,
+        _model: type[OacpAuditReviewManifestRecordRow],
+        manifest_id: str,
+    ) -> OacpAuditReviewManifestRecordRow | None:
+        return self.rows.get(manifest_id)
+
+    def add(self, row: OacpAuditReviewManifestRecordRow) -> None:
+        self.rows[row.manifest_id] = row
+
+    async def flush(self) -> None:
+        return None
+
+    async def scalars(self, _statement: object) -> _FakeScalars:
+        return _FakeScalars(list(self.rows.values()))
+
+
+@pytest.fixture()
+def repository() -> DurableOacpAuditReviewManifestRepository:
+    return DurableOacpAuditReviewManifestRepository(_FakeAsyncSession())
+
+
+@pytest.mark.asyncio
+async def test_c6y2_repository_upserts_gets_lists_and_evaluates_without_export_or_execution(
+    repository: DurableOacpAuditReviewManifestRepository,
+) -> None:
+    manifest = _manifest()
+    result = await repository.upsert_manifest(manifest)
+
+    assert result["stored"] is True
+    assert result["durable_repository"] is True
+    assert result["future_export_allowed"] is False
+    assert result["allowed_to_execute"] is False
+    assert result["non_authoritative_for_transaction"] is True
+
+    stored = await repository.get_manifest(str(manifest["manifest_id"]))
+    assert stored is not None
+    assert stored["bundle_id"] == manifest["bundle_id"]
+    assert stored["redacted_evidence_refs"] == ["evidence_price_C6Y2_redacted"]
+    assert stored["retention_boundary"]["retention_class"] == "standard_internal_review"
+    assert stored["export_file_written"] is False
+    assert stored["grantex_runtime_required"] is False
+
+    scoped = await repository.list_manifests_for_scope(
+        OacpAuditReviewManifestRepositoryQuery(
+            tenant_id="cten_C6W3",
+            merchant_id="mch_C6W3",
+            buyer_agent_id="buyer_C6W3",
+            retention_class="standard_internal_review",
+        ),
+    )
+    assert [item["manifest_id"] for item in scoped] == [manifest["manifest_id"]]
+
+    evaluation = await repository.evaluate_manifest_for_internal_review(str(manifest["manifest_id"]))
+    assert evaluation["status"] == "internal_review_requires_separate_export_approval"
+    assert evaluation["future_export_allowed"] is False
+    assert evaluation["allowed_to_execute"] is False
+    assert evaluation["export_file_written"] is False
+
+
+@pytest.mark.asyncio
+async def test_c6y2_repository_fails_closed_before_storage(
+    repository: DurableOacpAuditReviewManifestRepository,
+) -> None:
+    bad_retention = _manifest()
+    bad_retention["retention_boundary"] = {
+        **dict(bad_retention["retention_boundary"]),
+        "retention_class": "public_export_ready",
+    }
+    bad_order = _manifest()
+    bad_order["retention_boundary"] = {
+        **dict(bad_order["retention_boundary"]),
+        "retain_until": "2026-06-12T00:03:59.000Z",
+    }
+
+    cases = [
+        (_manifest(manifest_id=""), "manifest_identity_or_scope_missing"),
+        (bad_retention, "retention_class_invalid"),
+        (bad_order, "retention_timestamps_invalid"),
+        (_manifest(redacted_evidence_refs=["raw_jwt_marker"]), "manifest_refs_private_or_overclaim"),
+        (_manifest(allowed_to_execute=True), "non_enablement_flags_missing"),
+        (_manifest(export_file_written=True), "non_enablement_flags_missing"),
+        (_manifest(next_step_labels=["execute_export_file_now"]), "manifest_labels_executable_or_private"),
+        (_manifest(operator_safe_message="production readiness approved"), "manifest_refs_private_or_overclaim"),
+    ]
+
+    for manifest, refusal_code in cases:
+        result = await repository.upsert_manifest(manifest)
+        assert result["stored"] is False
+        assert result["allowed_to_execute"] is False
+        assert result["future_export_allowed"] is False
+        assert result["refusal_code"] == refusal_code
+
+    missing = await repository.evaluate_manifest_for_internal_review("missing_manifest_C6Y2")
+    assert missing["status"] == "blocked"
+    assert missing["refusal_code"] == "manifest_missing"
+
+
+def test_c6y2_migration_has_tenant_safe_indexes_rls_and_non_execution_guards() -> None:
+    migration = _migration()
+    for expected in (
+        "CREATE TABLE IF NOT EXISTS oacp_audit_review_manifest_records",
+        "down_revision = \"v6x9_audit_log_action_text\"",
+        "ix_oacp_audit_review_manifest_tenant_id",
+        "ix_oacp_audit_review_manifest_merchant_id",
+        "ix_oacp_audit_review_manifest_seller_agent_id",
+        "ix_oacp_audit_review_manifest_buyer_agent_id",
+        "ix_oacp_audit_review_manifest_bundle_id",
+        "ix_oacp_audit_review_manifest_retention_class",
+        "uq_oacp_review_manifest_bundle_retention_scope",
+        "allowed_to_execute IS FALSE",
+        "export_file_written IS FALSE",
+        "export_writer_added IS FALSE",
+        "ENABLE ROW LEVEL SECURITY",
+        "FORCE ROW LEVEL SECURITY",
+        "DROP TABLE IF EXISTS oacp_audit_review_manifest_records",
+    ):
+        assert expected in migration
+
+
+def test_c6y2_docs_capture_durable_repository_scope_and_non_goals() -> None:
+    doc = _doc()
+    for heading in (
+        "Scope",
+        "Correct Ownership Model",
+        "Persistence Decision",
+        "Durable Repository Contract",
+        "Stored Fields",
+        "Retention Boundary",
+        "Fail-Closed Persistence And Evaluation",
+        "Migration Safety",
+        "Guardrails",
+        "What C6Y2 Does Not Enable",
+        "Future Work",
+    ):
+        assert f"## {heading}" in doc
+
+    assert "AgenticOrg owns audit review manifest handling" in doc
+    assert "v6y2_oacp_review_manifests" in doc
+    assert "RLS" in doc
+    assert "allowed_to_execute = false" in doc
+    assert "future_export_allowed = false" in doc
+    assert "does not write export files" in doc


### PR DESCRIPTION
## Summary
- Add AgenticOrg durable OACP audit review manifest repository with tenant-safe/RLS-protected migration.
- Persist redacted C6Y1 review manifest metadata and retention boundaries only.
- Keep evaluation non-executing, export-writer-free, scheduler-free, and non-authoritative for transactions.

## Validation
- python -m pytest tests/unit/test_oacp_c6x9_audit_export_bundle.py tests/unit/test_oacp_c6y1_audit_review_manifest.py tests/unit/test_oacp_c6y2_audit_review_manifest_repository.py --no-cov
- python -m ruff check core/commerce/oacp_artifacts.py core/models/oacp_audit_review_manifest.py migrations/versions/v6_y2_oacp_audit_review_manifests.py tests/unit/test_oacp_c6y2_audit_review_manifest_repository.py
- python -m mypy core/commerce/oacp_artifacts.py core/models/oacp_audit_review_manifest.py migrations/versions/v6_y2_oacp_audit_review_manifests.py tests/unit/test_oacp_c6y2_audit_review_manifest_repository.py
- python -m pytest tests/unit/test_migration_guard.py --no-cov
- python -m alembic heads
- BASE_REF=origin/main python scripts/check_migration_required.py
- python scripts/check_encrypted_migration_uses_helpers.py
- git diff --check origin/main...HEAD

## Guardrails
Internal repository only. No endpoints, workflows, schedulers, queues, CLIs, export writers, provider calls, merchant private APIs, checkout/payment enablement, public discovery, live rails, Grantex live calls, or OACP publication.