### PR TITLE
[codex] Fix knowledge search embedding timeout fallback

### DIFF
--- a/api/v1/knowledge.py
+++ b/api/v1/knowledge.py
@@ -39,6 +39,15 @@ _RAGFLOW_ERRORS = ((_httpx.HTTPError,) if _httpx else ()) + (
     TypeError,
     ValueError,
 )
+_NATIVE_VECTOR_ERRORS = (
+    ImportError,
+    RuntimeError,
+    SQLAlchemyError,
+    ConnectionError,
+    TimeoutError,
+    TypeError,
+    ValueError,
+) + ((_httpx.HTTPError,) if _httpx else ())
 _DB_READ_ERRORS = (SQLAlchemyError, RuntimeError, TypeError, ValueError)
 _DB_WRITE_ERRORS = (SQLAlchemyError, RuntimeError, TypeError, ValueError)
 
@@ -1015,7 +1024,7 @@ async def _native_semantic_search(
                 )
                 for r in rows
             ]
-    except (ImportError, RuntimeError, SQLAlchemyError, TypeError, ValueError) as exc:
+    except _NATIVE_VECTOR_ERRORS as exc:
         logger.debug("native_semantic_search_skipped", error=str(exc))
 
     # Keyword fallback — surfaces something useful when embeddings are

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -3453,7 +3453,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "knowledge.sensitive.documents.list",
-    "source_line": 825,
+    "source_line": 834,
     "tenant_required": true
   },
   {
@@ -3471,7 +3471,7 @@
     "public_exempt_reason": null,
     "rate_limit": "knowledge-write",
     "scope": "knowledge.documents.delete",
-    "source_line": 919,
+    "source_line": 928,
     "tenant_required": true
   },
   {
@@ -3489,7 +3489,7 @@
     "public_exempt_reason": "deployment-smoke-test-no-tenant-data",
     "rate_limit": "healthcheck",
     "scope": "knowledge.health.public",
-    "source_line": 1182,
+    "source_line": 1191,
     "tenant_required": false
   },
   {
@@ -3507,7 +3507,7 @@
     "public_exempt_reason": null,
     "rate_limit": "knowledge-search",
     "scope": "knowledge.sensitive.search",
-    "source_line": 1124,
+    "source_line": 1133,
     "tenant_required": true
   },
   {
@@ -3525,7 +3525,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "knowledge.sensitive.stats",
-    "source_line": 1299,
+    "source_line": 1308,
     "tenant_required": true
   },
   {
@@ -3543,7 +3543,7 @@
     "public_exempt_reason": null,
     "rate_limit": "file-upload",
     "scope": "knowledge.upload",
-    "source_line": 479,
+    "source_line": 488,
     "tenant_required": true
   },
   {

--- a/tests/unit/test_false_success_exception_paths.py
+++ b/tests/unit/test_false_success_exception_paths.py
@@ -95,6 +95,47 @@ async def test_knowledge_search_exhausted_backends_raise_not_empty(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_knowledge_search_embedding_timeout_uses_keyword_fallback(monkeypatch):
+    import httpx
+
+    import core.database
+    import core.embeddings
+    from api.v1 import knowledge
+
+    class _Rows:
+        def fetchall(self):
+            return [("Smoke Doc", "AgenticOrg production smoke knowledge text")]
+
+    class _Session:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, _stmt, _params):
+            return _Rows()
+
+    monkeypatch.setattr(
+        core.embeddings,
+        "embed_one",
+        lambda _query: (_ for _ in ()).throw(httpx.ReadTimeout("TEI read timed out")),
+    )
+    monkeypatch.setattr(core.database, "get_tenant_session", lambda _tenant_id: _Session())
+
+    results = await knowledge._native_semantic_search(
+        str(uuid.uuid4()),
+        "AgenticOrg production smoke",
+        3,
+    )
+
+    assert len(results) == 1
+    assert results[0].document_name == "Smoke Doc"
+    assert results[0].chunk_text == "AgenticOrg production smoke knowledge text"
+    assert results[0].score == 0.0
+
+
+@pytest.mark.asyncio
 async def test_agent_connector_config_failure_does_not_return_partial_success(monkeypatch):
     import core.crypto
     import core.database


### PR DESCRIPTION
## Summary
- catch native embedding provider/network timeout errors in knowledge search so TEI cold starts fall through to keyword/document fallback
- add a regression for httpx.ReadTimeout from embed_one using keyword fallback results

## Root cause
Production /knowledge/search timed out in TEI after about 25 seconds and bubbled up as an ASGI 500 because the native vector fallback boundary did not include httpx.HTTPError.

## Validation
- python -m pytest tests\\unit\\test_false_success_exception_paths.py::test_knowledge_search_embedding_timeout_uses_keyword_fallback -q
- python -m pytest tests\\unit\\test_false_success_exception_paths.py -q
- python -m pytest tests\\regression\\test_tei_embeddings_client.py tests\\regression\\test_qa_27apr_sweep.py tests\\unit\\test_prod_smoke_check.py -q
- python -m pytest tests\\regression\\test_prod_incidents_20260613.py -q