### PR TITLE
Fix production smoke fallback blockers

### DIFF
--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -3026,6 +3026,18 @@ async def promote_agent(agent_id: UUID, tenant_id: str = Depends(get_current_ten
         if not agent:
             raise HTTPException(404, "Agent not found")
 
+        if agent.status == "active":
+            version = agent.version or "1.0.0"
+            return {
+                "id": str(agent_id),
+                "promoted": False,
+                "already_active": True,
+                "from": "active",
+                "to": "active",
+                "from_version": version,
+                "to_version": version,
+            }
+
         new_status = _PROMOTE_MAP.get(agent.status)
         if new_status is None:
             raise HTTPException(

--- a/core/embeddings.py
+++ b/core/embeddings.py
@@ -60,6 +60,9 @@ logger = structlog.get_logger()
 
 DEFAULT_EMBEDDING_MODEL = "BAAI/bge-small-en-v1.5"
 BGE_M3_MODEL = "BAAI/bge-m3"
+DEFAULT_TEI_READ_TIMEOUT_SECONDS = 5.0
+DEFAULT_TEI_CONNECT_TIMEOUT_SECONDS = 2.0
+MAX_TEI_READ_TIMEOUT_SECONDS = 25.0
 
 
 def rag_use_bge_m3() -> bool:
@@ -105,6 +108,42 @@ def _configured_model_name() -> str:
 
 EMBEDDING_MODEL_NAME = _configured_model_name()
 EMBEDDING_DIM = _MODEL_DIMS.get(EMBEDDING_MODEL_NAME, 384)
+
+
+def _bounded_float_env(
+    name: str,
+    *,
+    default: float,
+    minimum: float,
+    maximum: float,
+) -> float:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return max(minimum, min(maximum, value))
+
+
+def _tei_read_timeout_seconds() -> float:
+    return _bounded_float_env(
+        "AGENTICORG_TEI_TIMEOUT_SECONDS",
+        default=DEFAULT_TEI_READ_TIMEOUT_SECONDS,
+        minimum=1.0,
+        maximum=MAX_TEI_READ_TIMEOUT_SECONDS,
+    )
+
+
+def _tei_connect_timeout_seconds(read_timeout: float) -> float:
+    configured = _bounded_float_env(
+        "AGENTICORG_TEI_CONNECT_TIMEOUT_SECONDS",
+        default=DEFAULT_TEI_CONNECT_TIMEOUT_SECONDS,
+        minimum=0.5,
+        maximum=read_timeout,
+    )
+    return min(configured, read_timeout)
 
 
 def model_dim(model_name: str) -> int:
@@ -279,17 +318,22 @@ def _embed_via_tei(texts: list[str]) -> list[list[float]]:
     # timeout is ~30s. The api was waiting indefinitely on the TEI
     # POST, GFE killed the upstream request, and the user saw 504.
     #
-    # Cap the per-request wait at 25s so:
+    # Cap the per-request wait well under the product smoke/client budget so:
     #   - on a WARM TEI (~50ms response), the call returns immediately
-    #   - on a COLD TEI (>25s), httpx raises TimeoutException, the
-    #     caller (api/v1/knowledge.py:884) falls through to keyword
-    #     search, and the user gets results (lower quality, never 504)
+    #   - on a COLD or unhealthy TEI, httpx raises TimeoutException, the
+    #     caller (api/v1/knowledge.py) falls through to keyword search,
+    #     and the user gets results quickly (lower quality, never 504)
     #   - the next call after the cold-start window will succeed
     #     because TEI is now warm
     #
-    # The previous default (60s) blew past the 30s GFE budget and
-    # surfaced as a 504 to the browser.
-    timeout = httpx.Timeout(25.0, connect=5.0)
+    # Operators can raise AGENTICORG_TEI_TIMEOUT_SECONDS up to 25s, but
+    # the default must stay short enough for production smoke and browser
+    # callers to observe the fallback before their own client timeout.
+    read_timeout = _tei_read_timeout_seconds()
+    timeout = httpx.Timeout(
+        read_timeout,
+        connect=_tei_connect_timeout_seconds(read_timeout),
+    )
     with httpx.Client(timeout=timeout) as client:
         response = client.post(f"{base}/embed", json=payload, headers=headers)
         response.raise_for_status()

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -518,7 +518,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 3856,
+    "source_line": 3868,
     "tenant_required": true
   },
   {
@@ -590,7 +590,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.amendments.read",
-    "source_line": 3815,
+    "source_line": 3827,
     "tenant_required": true
   },
   {
@@ -608,7 +608,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.budget.read",
-    "source_line": 3529,
+    "source_line": 3541,
     "tenant_required": true
   },
   {
@@ -626,7 +626,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 3374,
+    "source_line": 3386,
     "tenant_required": true
   },
   {
@@ -662,7 +662,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.explanation.read",
-    "source_line": 3675,
+    "source_line": 3687,
     "tenant_required": true
   },
   {
@@ -680,7 +680,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.feedback.list",
-    "source_line": 3647,
+    "source_line": 3659,
     "tenant_required": true
   },
   {
@@ -698,7 +698,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-feedback",
     "scope": "agents.feedback.write",
-    "source_line": 3601,
+    "source_line": 3613,
     "tenant_required": true
   },
   {
@@ -716,7 +716,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.feedback.analyze",
-    "source_line": 3791,
+    "source_line": 3803,
     "tenant_required": true
   },
   {
@@ -770,7 +770,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.prompt_history",
-    "source_line": 3487,
+    "source_line": 3499,
     "tenant_required": true
   },
   {
@@ -806,7 +806,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3189,
+    "source_line": 3201,
     "tenant_required": true
   },
   {
@@ -824,7 +824,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3138,
+    "source_line": 3150,
     "tenant_required": true
   },
   {
@@ -842,7 +842,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3250,
+    "source_line": 3262,
     "tenant_required": true
   },
   {

--- a/tests/regression/test_qa_27apr_sweep.py
+++ b/tests/regression/test_qa_27apr_sweep.py
@@ -184,18 +184,21 @@ def test_ramesh_agents_loads_connector_configs_for_shadow_runs() -> None:
 
 
 # ──────────────────────────────────────────────────────────────────
-# TC_002 — TEI httpx client caps wait at 25s
+# TC_002 — TEI httpx client caps wait below caller timeout
 # ──────────────────────────────────────────────────────────────────
 
 
 def test_tc_002_tei_client_caps_wait_under_gfe_timeout() -> None:
-    """Pin the 25s read timeout so the Google Frontend 30s gateway
-    timeout never fires on a TEI cold-start. The keyword fallback
-    in api/v1/knowledge.py:884 only fires if the embed call raises
-    BEFORE the GFE kills the upstream request."""
+    """Pin a short default read timeout so the Google Frontend 30s
+    gateway timeout and the production smoke/client timeout never fire
+    on a TEI cold-start. The keyword fallback only fires if the embed
+    call raises before the upstream client gives up."""
     src = (REPO / "core" / "embeddings.py").read_text(encoding="utf-8")
-    assert "httpx.Timeout(25.0, connect=5.0)" in src
+    assert "DEFAULT_TEI_READ_TIMEOUT_SECONDS = 5.0" in src
+    assert "MAX_TEI_READ_TIMEOUT_SECONDS = 25.0" in src
+    assert "AGENTICORG_TEI_TIMEOUT_SECONDS" in src
     # The comment must explain the budget so a future contributor
     # doesn't bump it past the GFE limit thinking it's just a
     # "client wait".
     assert "Google Frontend" in src or "GFE" in src
+    assert "production smoke" in src

--- a/tests/regression/test_tei_embeddings_client.py
+++ b/tests/regression/test_tei_embeddings_client.py
@@ -38,6 +38,8 @@ def test_empty_input_short_circuits(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_routes_via_tei_when_env_set(monkeypatch: pytest.MonkeyPatch) -> None:
     """Setting ``AGENTICORG_TEI_URL`` switches to the HTTP path."""
     monkeypatch.setenv("AGENTICORG_TEI_URL", "http://example/tei")
+    monkeypatch.delenv("AGENTICORG_TEI_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("AGENTICORG_TEI_CONNECT_TIMEOUT_SECONDS", raising=False)
     from core import embeddings as emb
 
     expected = [[0.5] * 1024, [0.25] * 1024]
@@ -50,7 +52,7 @@ def test_routes_via_tei_when_env_set(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_client.__enter__.return_value.post.return_value = mock_response
 
     with (
-        patch("httpx.Client", return_value=mock_client),
+        patch("httpx.Client", return_value=mock_client) as client,
         # Mocking out auth so the test runs without GCP creds.
         patch("google.oauth2.id_token.fetch_id_token", return_value="fake-id-token"),
     ):
@@ -63,6 +65,32 @@ def test_routes_via_tei_when_env_set(monkeypatch: pytest.MonkeyPatch) -> None:
     assert kwargs["json"]["inputs"] == ["hello", "world"]
     assert kwargs["json"]["normalize"] is True
     assert kwargs["headers"]["Authorization"].startswith("Bearer ")
+    timeout = client.call_args.kwargs["timeout"]
+    assert timeout.read == 5.0
+    assert timeout.connect == 2.0
+
+
+def test_tei_timeout_is_configurable_but_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTICORG_TEI_URL", "http://example/tei")
+    monkeypatch.setenv("AGENTICORG_TEI_TIMEOUT_SECONDS", "99")
+    monkeypatch.setenv("AGENTICORG_TEI_CONNECT_TIMEOUT_SECONDS", "40")
+    from core import embeddings as emb
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = [[0.0] * 1024]
+    mock_response.raise_for_status.return_value = None
+    mock_client = MagicMock()
+    mock_client.__enter__.return_value.post.return_value = mock_response
+
+    with (
+        patch("httpx.Client", return_value=mock_client) as client,
+        patch("google.oauth2.id_token.fetch_id_token", return_value="fake-id-token"),
+    ):
+        emb.embed_bge_m3(["hello"])
+
+    timeout = client.call_args.kwargs["timeout"]
+    assert timeout.read == 25.0
+    assert timeout.connect == 25.0
 
 
 def test_falls_back_to_flagembedding_without_env(

--- a/tests/unit/test_agents_and_sales.py
+++ b/tests/unit/test_agents_and_sales.py
@@ -810,11 +810,32 @@ class TestPromoteAgent:
         assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
-    async def test_promote_active_agent_rejected(self, mock_session, tenant_id):
+    async def test_promote_active_agent_is_idempotent(self, mock_session, tenant_id):
         from api.v1.agents import promote_agent
 
         aid = uuid.uuid4()
-        agent = make_mock_agent(id=aid, status="active")
+        agent = make_mock_agent(id=aid, status="active", version="2.1.0")
+        exec_result = MagicMock()
+        exec_result.scalar_one_or_none.return_value = agent
+        mock_session.execute = AsyncMock(return_value=exec_result)
+
+        with patch("api.v1.agents.get_tenant_session") as mock_gts:
+            mock_gts.return_value = _make_tenant_session_ctx(mock_session)
+            result = await promote_agent(agent_id=aid, tenant_id=tenant_id)
+
+        assert result["promoted"] is False
+        assert result["already_active"] is True
+        assert result["from"] == "active"
+        assert result["to"] == "active"
+        assert result["from_version"] == "2.1.0"
+        assert result["to_version"] == "2.1.0"
+
+    @pytest.mark.asyncio
+    async def test_promote_paused_agent_rejected(self, mock_session, tenant_id):
+        from api.v1.agents import promote_agent
+
+        aid = uuid.uuid4()
+        agent = make_mock_agent(id=aid, status="paused")
         exec_result = MagicMock()
         exec_result.scalar_one_or_none.return_value = agent
         mock_session.execute = AsyncMock(return_value=exec_result)


### PR DESCRIPTION
## Summary
- shorten TEI embedding default timeout so knowledge search falls back before smoke/browser callers time out
- make already-active agent promotion idempotent for repeatable lifecycle smoke checks
- add regression coverage for TEI timeout bounds and idempotent active promotion
- update route inventory after promotion handler line shifts

## Local validation
- python -m ruff check core\\embeddings.py api\\v1\\agents.py tests\\regression\\test_tei_embeddings_client.py tests\\regression\\test_qa_27apr_sweep.py tests\\unit\\test_agents_and_sales.py tests\\unit\\test_false_success_exception_paths.py
- python scripts/check_enterprise_stability_gates.py
- python -m pytest tests\\regression\\test_tei_embeddings_client.py tests\\regression\\test_qa_27apr_sweep.py tests\\unit\\test_agents_and_sales.py::TestPromoteAgent tests\\unit\\test_false_success_exception_paths.py::test_knowledge_search_embedding_timeout_uses_keyword_fallback tests\\unit\\test_prod_smoke_check.py -q