### PR TITLE
C6Y3 OACP audit review manifest summaries

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -990,6 +990,13 @@ class OacpAuditReviewManifestRepositoryQuery:
     buyer_agent_id: str | None = None
     bundle_id: str | None = None
     retention_class: OacpAuditExportReviewRetentionClass | None = None
+    retain_until_before: str | None = None
+    retain_until_after: str | None = None
+    generated_at_before: str | None = None
+    generated_at_after: str | None = None
+    artifact_family: str | None = None
+    blocked_capability: str | None = None
+    unsupported_capability: str | None = None
 
 
 class OacpArtifactCacheRepositoryPort(Protocol):
@@ -1051,6 +1058,15 @@ class OacpAuditReviewManifestRepositoryPort(Protocol):
 
     def evaluate_manifest_for_internal_review(self, manifest_id: str) -> dict[str, Any]:
         """Evaluate a review manifest without writing export files or approving execution."""
+        ...
+
+    def build_redacted_manifest_summary(
+        self,
+        query: OacpAuditReviewManifestRepositoryQuery,
+        *,
+        generated_at: str,
+    ) -> dict[str, Any]:
+        """Build a redacted internal summary over stored manifests without writing export files."""
         ...
 
 
@@ -7316,7 +7332,23 @@ def _c6y2_row_to_manifest(row: Any) -> dict[str, Any]:
     }
 
 
+def _c6y3_summary_contains(value: Any, label: str | None) -> bool:
+    if label is None:
+        return True
+    if isinstance(value, Mapping):
+        return label in value
+    if isinstance(value, list):
+        return label in value
+    return False
+
+
 def _c6y2_query_matches(manifest: Mapping[str, Any], query: OacpAuditReviewManifestRepositoryQuery) -> bool:
+    retain_until = _parse_iso(_c6x7_string(_c6y2_retention_boundary(manifest).get("retain_until")))
+    generated_at = _parse_iso(_c6x7_string(manifest.get("generated_at")))
+    retain_until_before = _parse_iso(query.retain_until_before)
+    retain_until_after = _parse_iso(query.retain_until_after)
+    generated_at_before = _parse_iso(query.generated_at_before)
+    generated_at_after = _parse_iso(query.generated_at_after)
     return (
         (query.tenant_id is None or manifest.get("tenant_id") == query.tenant_id)
         and (query.merchant_id is None or manifest.get("merchant_id") == query.merchant_id)
@@ -7327,7 +7359,364 @@ def _c6y2_query_matches(manifest: Mapping[str, Any], query: OacpAuditReviewManif
             query.retention_class is None
             or _c6y2_retention_boundary(manifest).get("retention_class") == query.retention_class
         )
+        and (
+            query.retain_until_before is None
+            or (retain_until is not None and retain_until_before is not None and retain_until <= retain_until_before)
+        )
+        and (
+            query.retain_until_after is None
+            or (retain_until is not None and retain_until_after is not None and retain_until >= retain_until_after)
+        )
+        and (
+            query.generated_at_before is None
+            or (generated_at is not None and generated_at_before is not None and generated_at <= generated_at_before)
+        )
+        and (
+            query.generated_at_after is None
+            or (generated_at is not None and generated_at_after is not None and generated_at >= generated_at_after)
+        )
+        and _c6y3_summary_contains(manifest.get("artifact_family_counts"), query.artifact_family)
+        and _c6y3_summary_contains(manifest.get("blocked_capability_summary"), query.blocked_capability)
+        and _c6y3_summary_contains(manifest.get("unsupported_capability_summary"), query.unsupported_capability)
     )
+
+
+def _c6y3_manifest_summary_refusal(
+    *,
+    status: str,
+    refusal_code: str,
+    message: str,
+    generated_at: str | None = None,
+    tenant_id: str | None = None,
+    merchant_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "summary_built": False,
+        "summary_id": None,
+        "summary_kind": "oacp_audit_review_manifest_redacted_summary",
+        "status": status,
+        "refusal_code": refusal_code,
+        "message": message,
+        "generated_at": generated_at,
+        "tenant_id": tenant_id,
+        "merchant_id": merchant_id,
+        "manifest_count": 0,
+        "retention_due_count": 0,
+        "legal_hold_candidate_count": 0,
+        "redacted_evidence_ref_count": 0,
+        "future_export_allowed": False,
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "review_manifest_summary_only": True,
+        "no_export_file_written": True,
+        "export_file_written": False,
+        "export_writer_added": False,
+        "scheduler_added": False,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "grantex_runtime_required": False,
+    }
+
+
+def _c6y3_filter_value_safe(value: str | None, *, allow_blocked_or_unsupported_label: bool = False) -> bool:
+    if value is None:
+        return True
+    normalized = value.strip().lower()
+    if not normalized:
+        return False
+    unsafe_markers = (
+        *C6X2_PRIVATE_REF_MARKERS,
+        "://",
+        "@",
+        "raw_email",
+        "raw_phone",
+        "action_target",
+        "endpoint_target",
+        "execute",
+        "execute_now",
+        "write_export",
+        "export_file_writer",
+        "publish",
+        "submission",
+        "certif",
+        "compliance",
+        "conformance",
+        "standardization",
+        "readiness",
+        "approval",
+        "approved",
+    )
+    if any(marker in normalized for marker in unsafe_markers):
+        return False
+    if allow_blocked_or_unsupported_label:
+        return True
+    return not any(marker in normalized for marker in C6X2_ENABLEMENT_REF_MARKERS)
+
+
+def _c6y3_query_safe(query: OacpAuditReviewManifestRepositoryQuery) -> bool:
+    if not query.tenant_id:
+        return False
+    for value in (
+        query.tenant_id,
+        query.merchant_id,
+        query.seller_agent_id,
+        query.buyer_agent_id,
+        query.bundle_id,
+        query.artifact_family,
+    ):
+        if not _c6y3_filter_value_safe(value):
+            return False
+    for value in (query.blocked_capability, query.unsupported_capability):
+        if not _c6y3_filter_value_safe(value, allow_blocked_or_unsupported_label=True):
+            return False
+    for value in (
+        query.retain_until_before,
+        query.retain_until_after,
+        query.generated_at_before,
+        query.generated_at_after,
+    ):
+        if value is not None and _parse_iso(value) is None:
+            return False
+    return True
+
+
+def _c6y3_count_mapping_values(values: Mapping[str, Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for key, value in values.items():
+        if isinstance(value, int):
+            counts[str(key)] = counts.get(str(key), 0) + value
+        elif isinstance(value, str) and value:
+            counts[value] = counts.get(value, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _c6y3_merge_counts(manifests: Sequence[Mapping[str, Any]], field_name: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for manifest in manifests:
+        for key, value in _c6y3_count_mapping_values(_c6x8_mapping(manifest.get(field_name))).items():
+            counts[key] = counts.get(key, 0) + value
+    return dict(sorted(counts.items()))
+
+
+def _c6y3_merge_nested_summary(manifests: Sequence[Mapping[str, Any]], field_name: str) -> dict[str, Any]:
+    merged_counts: dict[str, dict[str, int]] = {}
+    scalar_values: dict[str, set[str]] = {}
+    for manifest in manifests:
+        for key, value in _c6x8_mapping(manifest.get(field_name)).items():
+            key_text = str(key)
+            if isinstance(value, Mapping):
+                bucket = merged_counts.setdefault(key_text, {})
+                for child_key, child_value in _c6y3_count_mapping_values(value).items():
+                    bucket[child_key] = bucket.get(child_key, 0) + child_value
+            elif isinstance(value, int):
+                bucket = merged_counts.setdefault(key_text, {})
+                bucket[key_text] = bucket.get(key_text, 0) + value
+            elif isinstance(value, str) and value:
+                scalar_values.setdefault(key_text, set()).add(value)
+    result: dict[str, Any] = {
+        key: dict(sorted(value.items())) for key, value in sorted(merged_counts.items())
+    }
+    for key, values in sorted(scalar_values.items()):
+        result[key] = sorted(values)
+    return result
+
+
+def _c6y3_scope_summary(manifests: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, int]]:
+    return {
+        "buyer_agent": _c6x9_count(
+            [
+                buyer_agent_id
+                for manifest in manifests
+                if (buyer_agent_id := _c6x7_string(manifest.get("buyer_agent_id"))) is not None
+            ]
+        ),
+        "seller_agent": _c6x9_count(
+            [
+                seller_agent_id
+                for manifest in manifests
+                if (seller_agent_id := _c6x7_string(manifest.get("seller_agent_id"))) is not None
+            ]
+        ),
+        "tenant": _c6x9_count(
+            [
+                tenant_id
+                for manifest in manifests
+                if (tenant_id := _c6x7_string(manifest.get("tenant_id"))) is not None
+            ]
+        ),
+        "merchant": _c6x9_count(
+            [
+                merchant_id
+                for manifest in manifests
+                if (merchant_id := _c6x7_string(manifest.get("merchant_id"))) is not None
+            ]
+        ),
+    }
+
+
+def _c6y3_manifest_count_due(manifests: Sequence[Mapping[str, Any]], generated_at: datetime) -> int:
+    count = 0
+    for manifest in manifests:
+        retain_until = _parse_iso(_c6x7_string(_c6y2_retention_boundary(manifest).get("retain_until")))
+        if retain_until is not None and retain_until <= generated_at:
+            count += 1
+    return count
+
+
+def _c6y3_manifest_summary_id(
+    *,
+    generated_at: str,
+    query: OacpAuditReviewManifestRepositoryQuery,
+    manifest_ids: Sequence[str],
+) -> str:
+    payload = {
+        "generated_at": generated_at,
+        "query": {
+            "tenant_id": query.tenant_id,
+            "merchant_id": query.merchant_id,
+            "seller_agent_id": query.seller_agent_id,
+            "buyer_agent_id": query.buyer_agent_id,
+            "bundle_id": query.bundle_id,
+            "retention_class": query.retention_class,
+            "retain_until_before": query.retain_until_before,
+            "retain_until_after": query.retain_until_after,
+            "generated_at_before": query.generated_at_before,
+            "generated_at_after": query.generated_at_after,
+            "artifact_family": query.artifact_family,
+            "blocked_capability": query.blocked_capability,
+            "unsupported_capability": query.unsupported_capability,
+        },
+        "manifest_ids": list(manifest_ids),
+    }
+    return f"oacp_c6y3_review_manifest_summary_{hash_oacp_payload(payload)[:20]}"
+
+
+def build_oacp_c6y3_audit_review_manifest_summary(
+    manifests: Sequence[Mapping[str, Any]],
+    *,
+    query: OacpAuditReviewManifestRepositoryQuery,
+    generated_at: str,
+) -> dict[str, Any]:
+    """Build an internal redacted review-manifest summary without exporting or executing anything."""
+
+    if not _c6y3_query_safe(query):
+        return _c6y3_manifest_summary_refusal(
+            status="blocked",
+            refusal_code="query_scope_or_filter_unsafe",
+            message="C6Y3 summaries require a tenant-scoped, non-executable, non-private query.",
+            generated_at=generated_at,
+            tenant_id=query.tenant_id,
+            merchant_id=query.merchant_id,
+        )
+
+    parsed_generated_at = _parse_iso(generated_at)
+    if parsed_generated_at is None:
+        return _c6y3_manifest_summary_refusal(
+            status="blocked",
+            refusal_code="summary_generated_at_invalid",
+            message="C6Y3 summaries require a valid generated_at timestamp.",
+            generated_at=generated_at,
+            tenant_id=query.tenant_id,
+            merchant_id=query.merchant_id,
+        )
+
+    matched_manifests = tuple(
+        manifest for manifest in manifests if _c6y2_query_matches(manifest, query)
+    )
+    for manifest in matched_manifests:
+        safe_result = _c6y2_manifest_safe_for_storage(manifest)
+        if safe_result.get("stored") is not True:
+            return _c6y3_manifest_summary_refusal(
+                status="unsafe",
+                refusal_code="manifest_not_safe_for_summary",
+                message="C6Y3 refuses to summarize manifests that fail C6Y2 storage guardrails.",
+                generated_at=generated_at,
+                tenant_id=query.tenant_id,
+                merchant_id=query.merchant_id,
+            )
+        if manifest.get("tenant_id") != query.tenant_id:
+            return _c6y3_manifest_summary_refusal(
+                status="blocked",
+                refusal_code="cross_tenant_query_refused",
+                message="C6Y3 refuses cross-tenant audit review manifest summaries.",
+                generated_at=generated_at,
+                tenant_id=query.tenant_id,
+                merchant_id=query.merchant_id,
+            )
+
+    manifest_ids = sorted(_c6x7_string(manifest.get("manifest_id")) or "" for manifest in matched_manifests)
+    evidence_ref_counts = {
+        manifest_id: len(_c6x8_list(manifest.get("redacted_evidence_refs")))
+        for manifest_id, manifest in sorted(
+            (
+                (_c6x7_string(manifest.get("manifest_id")) or "", manifest)
+                for manifest in matched_manifests
+            ),
+            key=lambda item: item[0],
+        )
+        if manifest_id
+    }
+    next_step_labels = _c6x9_unique(
+        [
+            label
+            for manifest in matched_manifests
+            for label in _c6x8_list(manifest.get("next_step_labels"))
+        ]
+        + ["internal_review_summary_label_only"]
+    )
+    return {
+        "summary_built": True,
+        "summary_id": _c6y3_manifest_summary_id(
+            generated_at=generated_at,
+            query=query,
+            manifest_ids=manifest_ids,
+        ),
+        "summary_kind": "oacp_audit_review_manifest_redacted_summary",
+        "status": "ready_for_internal_review",
+        "generated_at": generated_at,
+        "tenant_id": query.tenant_id,
+        "merchant_id": query.merchant_id,
+        "scope_summary": _c6y3_scope_summary(matched_manifests),
+        "manifest_count": len(matched_manifests),
+        "retention_class_counts": _c6x9_count(
+            [
+                retention_class
+                for manifest in matched_manifests
+                if (retention_class := _c6y2_retention_class(manifest)) is not None
+            ]
+        ),
+        "retention_due_count": _c6y3_manifest_count_due(matched_manifests, parsed_generated_at),
+        "legal_hold_candidate_count": sum(
+            1 for manifest in matched_manifests if _c6y2_retention_class(manifest) == "legal_hold_candidate"
+        ),
+        "artifact_family_counts": _c6y3_merge_counts(matched_manifests, "artifact_family_counts"),
+        "risk_tier_counts": _c6y3_merge_counts(matched_manifests, "risk_tier_summary"),
+        "blocked_capability_summary": _c6y3_merge_counts(matched_manifests, "blocked_capability_summary"),
+        "unsupported_capability_summary": _c6y3_merge_counts(matched_manifests, "unsupported_capability_summary"),
+        "freshness_ttl_summary": _c6y3_merge_nested_summary(matched_manifests, "freshness_ttl_summary"),
+        "revocation_snapshot_summary": _c6y3_merge_counts(matched_manifests, "revocation_snapshot_summary"),
+        "redacted_evidence_ref_count": sum(evidence_ref_counts.values()),
+        "redacted_evidence_ref_counts": evidence_ref_counts,
+        "next_step_labels": next_step_labels,
+        "future_export_allowed": False,
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "review_manifest_summary_only": True,
+        "no_export_file_written": True,
+        "export_file_written": False,
+        "export_writer_added": False,
+        "scheduler_added": False,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "grantex_runtime_required": False,
+        "operator_safe_message": (
+            "C6Y3 summarizes stored audit review manifests with counts only; it does not write export files."
+        ),
+    }
 
 
 class DurableOacpAuditReviewManifestRepository:
@@ -7379,6 +7768,14 @@ class DurableOacpAuditReviewManifestRepository:
             statement = statement.where(OacpAuditReviewManifestRecordRow.bundle_id == query.bundle_id)
         if query.retention_class is not None:
             statement = statement.where(OacpAuditReviewManifestRecordRow.retention_class == query.retention_class)
+        if query.retain_until_before is not None and (parsed := _parse_iso(query.retain_until_before)) is not None:
+            statement = statement.where(OacpAuditReviewManifestRecordRow.retain_until <= parsed)
+        if query.retain_until_after is not None and (parsed := _parse_iso(query.retain_until_after)) is not None:
+            statement = statement.where(OacpAuditReviewManifestRecordRow.retain_until >= parsed)
+        if query.generated_at_before is not None and (parsed := _parse_iso(query.generated_at_before)) is not None:
+            statement = statement.where(OacpAuditReviewManifestRecordRow.generated_at <= parsed)
+        if query.generated_at_after is not None and (parsed := _parse_iso(query.generated_at_after)) is not None:
+            statement = statement.where(OacpAuditReviewManifestRecordRow.generated_at >= parsed)
 
         rows = (await self._session.scalars(statement.order_by(OacpAuditReviewManifestRecordRow.manifest_id))).all()
         manifests = tuple(_c6y2_row_to_manifest(row) for row in rows)
@@ -7417,6 +7814,19 @@ class DurableOacpAuditReviewManifestRepository:
             "grantex_runtime_required": False,
             "message": "C6Y2 stores an audit review manifest only; it does not write export files.",
         }
+
+    async def build_redacted_manifest_summary(
+        self,
+        query: OacpAuditReviewManifestRepositoryQuery,
+        *,
+        generated_at: str,
+    ) -> dict[str, Any]:
+        manifests = await self.list_manifests_for_scope(query)
+        return build_oacp_c6y3_audit_review_manifest_summary(
+            manifests,
+            query=query,
+            generated_at=generated_at,
+        )
 
 
 class OacpArtifactCache:

--- a/docs/reports/commerce-agent-c6y3-oacp-audit-review-manifest-summary.md
+++ b/docs/reports/commerce-agent-c6y3-oacp-audit-review-manifest-summary.md
@@ -1,0 +1,80 @@
+# C6Y3 OACP Audit Review Manifest Query And Summary
+
+## Scope
+
+C6Y3 adds an internal query/filter and redacted summary helper over C6Y2 durable OACP audit review manifests. AgenticOrg owns audit review manifest handling and can summarize local manifest metadata for operator review without routing every non-binding buyer or seller agent turn through Grantex.
+
+The helper is model/repository behavior only. It does not expose an endpoint, command, CLI, workflow, scheduler, queue, background worker, or export-file writer.
+
+## Correct Ownership Model
+
+AgenticOrg remains the buyer and seller AI-agent runtime. It owns durable/local OACP artifact cache behavior, local operator decision handling, audit export bundle generation, and internal audit review manifest generation and querying.
+
+Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. Grantex issues and verifies canonical artifact boundaries, but it is not a transaction toll booth and does not receive every manifest summary or every non-binding buyer/seller interaction.
+
+Merchant systems remain operational sources of record. Provider and fintech rails own mandate and payment execution. OACP remains internal, non-publication, non-certifying, non-production, and non-executing.
+
+## Query Filters
+
+The internal repository query can filter durable review manifests by tenant, merchant, seller agent, buyer agent, bundle id, retention class, retain-until range, generated-at range, artifact family, blocked capability label, and unsupported capability label.
+
+Tenant scope is required for summary generation. Cross-tenant summary attempts fail closed. JSON summary fields are filtered in process from C6Y2 stored metadata, so C6Y3 does not require a DB migration.
+
+## Redacted Summary Output
+
+The redacted summary includes deterministic internal fields only:
+
+- summary id and generated_at
+- scope summary by buyer agent, seller agent, tenant, and merchant
+- manifest_count
+- retention_class_counts
+- retention_due_count
+- legal_hold_candidate_count
+- artifact_family_counts
+- risk_tier_counts
+- blocked_capability_summary
+- unsupported_capability_summary
+- freshness_ttl_summary
+- revocation_snapshot_summary
+- redacted evidence ref counts only
+- next_step_labels
+- allowed_to_execute = false
+- non_authoritative_for_transaction = true
+- no_export_file_written = true
+
+The summary deliberately counts redacted evidence references instead of returning evidence reference values unless a future internal slice explicitly needs a narrower reviewed subset.
+
+## Fail-Closed Rules
+
+C6Y3 fails closed when the query has no tenant scope, crosses tenant boundaries, contains malformed timestamps, requests executable/action targets, includes private/raw labels, includes export-writer flags, has false non-enablement flags, or contains publication, certification, approval, or readiness wording.
+
+Each summarized manifest must still pass the C6Y2 durable manifest storage guardrails. A manifest that is executable, unsafe, private, stale in its retention ordering, or overclaiming is refused before it can appear in a summary.
+
+## Persistence Migration Scheduler And Export Writer Decision
+
+C6Y3 adds no DB migration. The C6Y2 durable audit review manifest table already stores the scope, retention, artifact summary, freshness, revocation, risk, blocked, unsupported, evidence count source, and non-enablement fields needed for internal summaries.
+
+C6Y3 adds no scheduler, cron job, queue, background worker, CLI, export-file writer, generated report artifact, public API, or runtime OpenAPI contract. It does not write export files and does not call Grantex live, providers, merchant systems, carriers, shipping providers, or payment rails.
+
+## Guardrails
+
+The helper keeps all non-enablement posture intact:
+
+- allowed_to_execute = false
+- non_authoritative_for_transaction = true
+- no_checkout_payment_enablement = true
+- no_live_provider_enablement = true
+- no_public_discovery_enablement = true
+- no_export_file_written = true
+
+The summary must never include raw artifact payloads, provider payloads, connector payloads, raw JWTs or passports, credentials, tokens, private keys, private customer data, payment data, bank/card data, raw merchant private API values, raw reviewer identity, or secrets.
+
+## What C6Y3 Does Not Enable
+
+C6Y3 does not create orders, holds, payments, mandates, refunds, returns, shipments, checkout sessions, public discovery changes, live provider calls, live rail calls, live Plural behavior, Grantex live calls, merchant private API calls, protocol publication, certification, conformance, compliance, standardization, production readiness, or public-launch readiness.
+
+C6Y3 summaries are not Grantex approvals, merchant approvals, checkout approvals, payment approvals, mandate approvals, live-provider approvals, production approvals, or OACP approvals.
+
+## Future Work
+
+A future approved slice may add a guarded internal operator view or retention workflow. That future work must remain tenant-scoped, redacted, non-executing, and separately reviewed before any endpoint, scheduler, CLI, export writer, or production retention action is introduced.

--- a/tests/unit/test_oacp_c6y3_audit_review_manifest_summary.py
+++ b/tests/unit/test_oacp_c6y3_audit_review_manifest_summary.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from core.commerce.oacp_artifacts import (
+    DurableOacpAuditReviewManifestRepository,
+    OacpArtifactCacheRepositoryQuery,
+    OacpAuditExportReviewRetentionClass,
+    OacpAuditReviewManifestRepositoryQuery,
+    OacpPersistentArtifactCacheRecord,
+    build_oacp_c6x9_audit_export_bundle,
+    build_oacp_c6y1_audit_export_review_manifest,
+    build_oacp_c6y3_audit_review_manifest_summary,
+    build_oacp_cache_maintenance_dry_run_report,
+    build_oacp_cache_operator_decision_record,
+    plan_oacp_artifact_cache_maintenance,
+)
+from core.models.oacp_audit_review_manifest import OacpAuditReviewManifestRecordRow
+
+C6Y3_DOC_PATH = Path("docs/reports/commerce-agent-c6y3-oacp-audit-review-manifest-summary.md")
+
+
+def _doc() -> str:
+    return C6Y3_DOC_PATH.read_text(encoding="utf-8")
+
+
+def _record(**overrides: object) -> OacpPersistentArtifactCacheRecord:
+    base = OacpPersistentArtifactCacheRecord(
+        cache_record_id="cache_price_C6Y3",
+        artifact_id="price_C6W3",
+        artifact_type="price",
+        authority="grantex_canonical_oacp_artifact_authority",
+        issuer="grantex",
+        scope_kind="buyer_agent",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+        source_refs=("source_ref_price_C6Y3",),
+        evidence_refs=("evidence_price_C6Y3_redacted",),
+        generated_at="2026-06-12T00:00:00.000Z",
+        cached_at="2026-06-12T00:00:10.000Z",
+        expires_at="2026-06-12T00:05:00.000Z",
+        freshness_status="fresh",
+        revocation_snapshot_status="fresh",
+        revocation_snapshot_observed_at="2026-06-12T00:00:30.000Z",
+        revocation_snapshot_age_seconds=30,
+        ttl_policy_seconds=300,
+        risk_tier="low",
+        blocked_capabilities=("checkout_payment_creation", "live_provider_call"),
+        unsupported_capabilities=("transaction_authority_from_adapter_preview",),
+        verifier_result_ref="verifier_result_price_C6Y3",
+    )
+    return replace(base, **overrides)
+
+
+def _plan(records: tuple[OacpPersistentArtifactCacheRecord, ...]) -> dict[str, object]:
+    return plan_oacp_artifact_cache_maintenance(
+        records=records,
+        now_iso="2026-06-12T00:01:00.000Z",
+        grantex_available=True,
+        action_intent="prepare_only",
+        risk_tier="low",
+        scope_filter=OacpArtifactCacheRepositoryQuery(tenant_id="cten_C6W3", merchant_id="mch_C6W3"),
+    )
+
+
+def _review_packet(plan: dict[str, object]) -> dict[str, object]:
+    return build_oacp_cache_maintenance_dry_run_report(
+        maintenance_plan=plan,
+        report_kind="operator_review_packet",
+    )
+
+
+def _decision(packet: dict[str, object]) -> dict[str, object]:
+    return build_oacp_cache_operator_decision_record(
+        review_packet=packet,
+        decision_kind="request_more_evidence",
+        reviewer_identity_ref="operator_ref_c6y3_reviewer_001",
+        decided_at="2026-06-12T00:02:00.000Z",
+    )
+
+
+def _bundle(
+    records: tuple[OacpPersistentArtifactCacheRecord, ...],
+    *,
+    generated_at: str = "2026-06-12T00:03:00.000Z",
+) -> dict[str, object]:
+    plan = _plan(records)
+    packet = _review_packet(plan)
+    decision = _decision(packet)
+    return build_oacp_c6x9_audit_export_bundle(
+        cache_records=records,
+        maintenance_plans=(plan,),
+        review_packets=(packet,),
+        operator_decision_records=(decision,),
+        durable_decision_records=(dict(decision),),
+        generated_at=generated_at,
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+    )
+
+
+def _manifest(
+    records: tuple[OacpPersistentArtifactCacheRecord, ...] | None = None,
+    *,
+    generated_at: str = "2026-06-12T00:04:00.000Z",
+    retention_class: OacpAuditExportReviewRetentionClass = "standard_internal_review",
+    **overrides: object,
+) -> dict[str, object]:
+    manifest = build_oacp_c6y1_audit_export_review_manifest(
+        audit_export_bundle=_bundle(records or (_record(),)),
+        generated_at=generated_at,
+        retention_class=retention_class,
+    )
+    manifest.update(overrides)
+    return manifest
+
+
+class _FakeScalars:
+    def __init__(self, rows: list[OacpAuditReviewManifestRecordRow]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[OacpAuditReviewManifestRecordRow]:
+        return self._rows
+
+
+class _FakeAsyncSession:
+    def __init__(self) -> None:
+        self.rows: dict[str, OacpAuditReviewManifestRecordRow] = {}
+
+    async def get(
+        self,
+        _model: type[OacpAuditReviewManifestRecordRow],
+        manifest_id: str,
+    ) -> OacpAuditReviewManifestRecordRow | None:
+        return self.rows.get(manifest_id)
+
+    def add(self, row: OacpAuditReviewManifestRecordRow) -> None:
+        self.rows[row.manifest_id] = row
+
+    async def flush(self) -> None:
+        return None
+
+    async def scalars(self, _statement: object) -> _FakeScalars:
+        return _FakeScalars(list(self.rows.values()))
+
+
+@pytest.fixture()
+def repository() -> DurableOacpAuditReviewManifestRepository:
+    return DurableOacpAuditReviewManifestRepository(_FakeAsyncSession())
+
+
+@pytest.mark.asyncio
+async def test_c6y3_repository_filters_and_builds_redacted_summary_without_export_or_execution(
+    repository: DurableOacpAuditReviewManifestRepository,
+) -> None:
+    price_manifest = _manifest()
+    inventory_manifest = _manifest(
+        (
+            _record(
+                cache_record_id="cache_inventory_C6Y3",
+                artifact_id="inventory_C6W3",
+                artifact_type="inventory",
+                evidence_refs=("evidence_inventory_C6Y3_redacted",),
+                risk_tier="medium",
+                verifier_result_ref="verifier_result_inventory_C6Y3",
+            ),
+        ),
+        generated_at="2026-06-12T00:04:30.000Z",
+    )
+    await repository.upsert_manifest(price_manifest)
+    await repository.upsert_manifest(inventory_manifest)
+
+    query = OacpAuditReviewManifestRepositoryQuery(
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        artifact_family="price",
+        generated_at_after="2026-06-12T00:03:59.000Z",
+        generated_at_before="2026-06-12T00:04:01.000Z",
+        blocked_capability="checkout_payment_creation",
+    )
+
+    scoped = await repository.list_manifests_for_scope(query)
+    assert [item["manifest_id"] for item in scoped] == [price_manifest["manifest_id"]]
+
+    summary = await repository.build_redacted_manifest_summary(
+        query,
+        generated_at="2026-06-12T00:05:00.000Z",
+    )
+    assert summary["summary_built"] is True
+    assert summary["manifest_count"] == 1
+    assert summary["artifact_family_counts"] == {"price": 1}
+    assert summary["retention_due_count"] == 0
+    assert summary["redacted_evidence_ref_count"] == 1
+    assert summary["redacted_evidence_ref_counts"] == {price_manifest["manifest_id"]: 1}
+    assert summary["allowed_to_execute"] is False
+    assert summary["non_authoritative_for_transaction"] is True
+    assert summary["no_export_file_written"] is True
+    assert summary["grantex_runtime_required"] is False
+    assert "evidence_price_C6Y3_redacted" not in str(summary)
+
+
+def test_c6y3_summary_counts_due_and_legal_hold_without_evidence_values() -> None:
+    manifest = _manifest(
+        retention_class="legal_hold_candidate",
+        generated_at="2026-06-12T00:04:00.000Z",
+    )
+    summary = build_oacp_c6y3_audit_review_manifest_summary(
+        (manifest,),
+        query=OacpAuditReviewManifestRepositoryQuery(
+            tenant_id="cten_C6W3",
+            merchant_id="mch_C6W3",
+            retention_class="legal_hold_candidate",
+            retain_until_before="2036-06-11T00:00:00.000Z",
+        ),
+        generated_at="2036-06-11T00:00:00.000Z",
+    )
+
+    assert summary["summary_built"] is True
+    assert summary["retention_class_counts"] == {"legal_hold_candidate": 1}
+    assert summary["retention_due_count"] == 1
+    assert summary["legal_hold_candidate_count"] == 1
+    assert summary["risk_tier_counts"] == {"low": 1}
+    assert summary["redacted_evidence_ref_count"] == 1
+    assert "evidence_price_C6Y3_redacted" not in str(summary)
+
+
+def test_c6y3_summary_fails_closed_for_unsafe_queries_and_manifests() -> None:
+    manifest = _manifest()
+    missing_tenant = build_oacp_c6y3_audit_review_manifest_summary(
+        (manifest,),
+        query=OacpAuditReviewManifestRepositoryQuery(merchant_id="mch_C6W3"),
+        generated_at="2026-06-12T00:05:00.000Z",
+    )
+    unsafe_filter = build_oacp_c6y3_audit_review_manifest_summary(
+        (manifest,),
+        query=OacpAuditReviewManifestRepositoryQuery(
+            tenant_id="cten_C6W3",
+            blocked_capability="execute_checkout_payment_now",
+        ),
+        generated_at="2026-06-12T00:05:00.000Z",
+    )
+    bad_time = build_oacp_c6y3_audit_review_manifest_summary(
+        (manifest,),
+        query=OacpAuditReviewManifestRepositoryQuery(tenant_id="cten_C6W3"),
+        generated_at="not-a-time",
+    )
+    executable_manifest = build_oacp_c6y3_audit_review_manifest_summary(
+        (_manifest(allowed_to_execute=True),),
+        query=OacpAuditReviewManifestRepositoryQuery(tenant_id="cten_C6W3"),
+        generated_at="2026-06-12T00:05:00.000Z",
+    )
+
+    assert missing_tenant["summary_built"] is False
+    assert missing_tenant["refusal_code"] == "query_scope_or_filter_unsafe"
+    assert unsafe_filter["summary_built"] is False
+    assert unsafe_filter["refusal_code"] == "query_scope_or_filter_unsafe"
+    assert bad_time["summary_built"] is False
+    assert bad_time["refusal_code"] == "summary_generated_at_invalid"
+    assert executable_manifest["summary_built"] is False
+    assert executable_manifest["refusal_code"] == "manifest_not_safe_for_summary"
+    for result in (missing_tenant, unsafe_filter, bad_time, executable_manifest):
+        assert result["allowed_to_execute"] is False
+        assert result["future_export_allowed"] is False
+        assert result["no_export_file_written"] is True
+
+
+def test_c6y3_docs_capture_query_summary_boundary_and_non_goals() -> None:
+    doc = _doc()
+    for heading in (
+        "Scope",
+        "Correct Ownership Model",
+        "Query Filters",
+        "Redacted Summary Output",
+        "Fail-Closed Rules",
+        "Persistence Migration Scheduler And Export Writer Decision",
+        "Guardrails",
+        "What C6Y3 Does Not Enable",
+        "Future Work",
+    ):
+        assert f"## {heading}" in doc
+
+    assert "AgenticOrg owns audit review manifest handling" in doc
+    assert "not a transaction toll booth" in doc
+    assert "allowed_to_execute = false" in doc
+    assert "no_export_file_written = true" in doc
+    assert "does not write export files" in doc
+    assert "does not call Grantex live" in doc


### PR DESCRIPTION
C6Y3 internal AgenticOrg query/filter and redacted summary helper over C6Y2 durable audit review manifests. No migration, endpoint, workflow, scheduler, CLI, export writer, provider call, payment/checkout enablement, public discovery, live rail, Grantex live call, or publication behavior. Local validation: C6Y1-C6Y3 focused tests, ruff, mypy, git diff --check.