### PR TITLE
C6Y4 OACP retention disposition dry-runs

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -7719,6 +7719,492 @@ def build_oacp_c6y3_audit_review_manifest_summary(
     }
 
 
+def _c6y4_retention_refusal(
+    *,
+    packet_kind: str,
+    status: str,
+    refusal_code: str,
+    message: str,
+    generated_at: str | None = None,
+    summary_id: str | None = None,
+    tenant_id: str | None = None,
+    merchant_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "packet_built": False,
+        "packet_id": None,
+        "packet_kind": packet_kind,
+        "status": status,
+        "refusal_code": refusal_code,
+        "message": message,
+        "generated_at": generated_at,
+        "summary_id": summary_id,
+        "tenant_id": tenant_id,
+        "merchant_id": merchant_id,
+        "disposition_previews": [
+            {
+                "disposition": "blocked_unsafe",
+                "reason_code": refusal_code,
+                "next_step_label": "operator_review_required_label_only",
+            }
+        ],
+        "future_retention_action_allowed": False,
+        "records_deleted": False,
+        "retention_executed": False,
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "retention_disposition_dry_run_only": True,
+        "operator_review_packet_only": packet_kind == "oacp_retention_disposition_operator_review_packet",
+        "no_export_file_written": True,
+        "export_file_written": False,
+        "export_writer_added": False,
+        "scheduler_added": False,
+        "cli_added": False,
+        "migration_added": False,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "grantex_runtime_required": False,
+    }
+
+
+def _c6y4_summary_flags_safe(summary: Mapping[str, Any]) -> bool:
+    return (
+        summary.get("summary_built") is True
+        and summary.get("summary_kind") == "oacp_audit_review_manifest_redacted_summary"
+        and summary.get("status") == "ready_for_internal_review"
+        and summary.get("allowed_to_execute") is False
+        and summary.get("no_execution") is True
+        and summary.get("review_manifest_summary_only") is True
+        and summary.get("no_export_file_written") is True
+        and summary.get("export_file_written") is False
+        and summary.get("export_writer_added") is False
+        and summary.get("scheduler_added") is False
+        and summary.get("non_authoritative_for_transaction") is True
+        and summary.get("no_checkout_payment_enablement") is True
+        and summary.get("no_live_provider_enablement") is True
+        and summary.get("no_public_discovery_enablement") is True
+        and summary.get("grantex_runtime_required") is False
+    )
+
+
+def _c6y4_dry_run_flags_safe(dry_run: Mapping[str, Any]) -> bool:
+    return (
+        dry_run.get("packet_built") is True
+        and dry_run.get("packet_kind") == "oacp_retention_disposition_dry_run"
+        and dry_run.get("status") == "ready_for_operator_review"
+        and dry_run.get("allowed_to_execute") is False
+        and dry_run.get("no_execution") is True
+        and dry_run.get("retention_disposition_dry_run_only") is True
+        and dry_run.get("future_retention_action_allowed") is False
+        and dry_run.get("records_deleted") is False
+        and dry_run.get("retention_executed") is False
+        and dry_run.get("no_export_file_written") is True
+        and dry_run.get("export_file_written") is False
+        and dry_run.get("export_writer_added") is False
+        and dry_run.get("scheduler_added") is False
+        and dry_run.get("cli_added") is False
+        and dry_run.get("migration_added") is False
+        and dry_run.get("non_authoritative_for_transaction") is True
+        and dry_run.get("no_checkout_payment_enablement") is True
+        and dry_run.get("no_live_provider_enablement") is True
+        and dry_run.get("no_public_discovery_enablement") is True
+        and dry_run.get("grantex_runtime_required") is False
+    )
+
+
+def _c6y4_label_values(value: Any) -> list[str]:
+    if isinstance(value, Mapping):
+        return [str(key) for key in value]
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str)]
+    return []
+
+
+def _c6y4_summary_strings(summary: Mapping[str, Any]) -> list[str]:
+    values = [
+        _c6x7_string(summary.get("summary_id")),
+        _c6x7_string(summary.get("tenant_id")),
+        _c6x7_string(summary.get("merchant_id")),
+        _c6x7_string(summary.get("operator_safe_message")),
+    ]
+    values.extend(_c6x8_list(summary.get("next_step_labels")))
+    values.extend(_c6y4_label_values(summary.get("retention_class_counts")))
+    values.extend(_c6y4_label_values(summary.get("artifact_family_counts")))
+    values.extend(_c6y4_label_values(summary.get("risk_tier_counts")))
+    return [value for value in values if value is not None]
+
+
+def _c6y4_summary_safe(summary: Mapping[str, Any]) -> dict[str, Any]:
+    summary_id = _c6x7_string(summary.get("summary_id"))
+    tenant_id = _c6x7_string(summary.get("tenant_id"))
+    merchant_id = _c6x7_string(summary.get("merchant_id"))
+    generated_at = _c6x7_string(summary.get("generated_at"))
+    if not all((summary_id, tenant_id, merchant_id)):
+        return _c6y4_retention_refusal(
+            packet_kind="oacp_retention_disposition_dry_run",
+            status="blocked",
+            refusal_code="summary_identity_or_scope_missing",
+            message="C6Y4 requires summary, tenant, and merchant identifiers.",
+            generated_at=generated_at,
+            summary_id=summary_id,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+        )
+    if not _c6y4_summary_flags_safe(summary):
+        return _c6y4_retention_refusal(
+            packet_kind="oacp_retention_disposition_dry_run",
+            status="unsafe",
+            refusal_code="summary_non_enablement_flags_invalid",
+            message="C6Y4 refuses executable summaries or summaries with writer, scheduler, or enablement flags.",
+            generated_at=generated_at,
+            summary_id=summary_id,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+        )
+    if _parse_iso(generated_at) is None:
+        return _c6y4_retention_refusal(
+            packet_kind="oacp_retention_disposition_dry_run",
+            status="blocked",
+            refusal_code="summary_generated_at_invalid",
+            message="C6Y4 requires a valid C6Y3 summary generated_at timestamp.",
+            generated_at=generated_at,
+            summary_id=summary_id,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+        )
+    if not _c6x9_mapping_scope_matches(
+        summary,
+        tenant_id=tenant_id,
+        merchant_id=merchant_id,
+        seller_agent_id=_c6x7_string(summary.get("seller_agent_id")),
+        buyer_agent_id=_c6x7_string(summary.get("buyer_agent_id")),
+    ):
+        return _c6y4_retention_refusal(
+            packet_kind="oacp_retention_disposition_dry_run",
+            status="blocked",
+            refusal_code="summary_scope_mismatch",
+            message="C6Y4 refuses summaries whose direct and summarized scopes do not match.",
+            generated_at=generated_at,
+            summary_id=summary_id,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+        )
+    if summary.get("redacted_evidence_refs") not in (None, [], ()):
+        return _c6y4_retention_refusal(
+            packet_kind="oacp_retention_disposition_dry_run",
+            status="unsafe",
+            refusal_code="summary_contains_evidence_ref_values",
+            message="C6Y4 consumes evidence ref counts only, not evidence ref values.",
+            generated_at=generated_at,
+            summary_id=summary_id,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+        )
+    labels = tuple(_c6x8_list(summary.get("next_step_labels")))
+    if not labels or not _c6x8_labels_safe(labels):
+        return _c6y4_retention_refusal(
+            packet_kind="oacp_retention_disposition_dry_run",
+            status="unsafe",
+            refusal_code="summary_labels_executable_or_private",
+            message="C6Y4 accepts label-only next steps, not executable targets.",
+            generated_at=generated_at,
+            summary_id=summary_id,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+        )
+    if _c6y1_values_private_or_overclaim(_c6y4_summary_strings(summary)):
+        return _c6y4_retention_refusal(
+            packet_kind="oacp_retention_disposition_dry_run",
+            status="unsafe",
+            refusal_code="summary_private_or_overclaiming_values",
+            message="C6Y4 refuses private values, publication wording, or approval/readiness claims.",
+            generated_at=generated_at,
+            summary_id=summary_id,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+        )
+    return {
+        "packet_built": True,
+        "summary_id": summary_id,
+        "tenant_id": tenant_id,
+        "merchant_id": merchant_id,
+        "generated_at": generated_at,
+    }
+
+
+def _c6y4_positive_int(value: Any) -> int:
+    return value if isinstance(value, int) and value > 0 else 0
+
+
+def _c6y4_disposition_previews(summary: Mapping[str, Any]) -> list[dict[str, Any]]:
+    manifest_count = _c6y4_positive_int(summary.get("manifest_count"))
+    retention_due_count = _c6y4_positive_int(summary.get("retention_due_count"))
+    legal_hold_candidate_count = _c6y4_positive_int(summary.get("legal_hold_candidate_count"))
+    evidence_ref_count = _c6y4_positive_int(summary.get("redacted_evidence_ref_count"))
+    previews: list[dict[str, Any]] = []
+    if manifest_count == 0:
+        previews.append(
+            {
+                "disposition": "review_later",
+                "reason_code": "no_manifests_matched_scope",
+                "record_count": 0,
+                "next_step_label": "operator_review_later_label_only",
+            }
+        )
+    if manifest_count > 0 and evidence_ref_count == 0:
+        previews.append(
+            {
+                "disposition": "redaction_review_required",
+                "reason_code": "redacted_evidence_ref_counts_missing",
+                "record_count": manifest_count,
+                "next_step_label": "operator_redaction_review_label_only",
+            }
+        )
+    if legal_hold_candidate_count > 0:
+        previews.append(
+            {
+                "disposition": "legal_hold_review",
+                "reason_code": "legal_hold_candidate_present",
+                "record_count": legal_hold_candidate_count,
+                "next_step_label": "operator_legal_hold_review_label_only",
+            }
+        )
+    if retention_due_count > 0:
+        previews.append(
+            {
+                "disposition": "retention_due_review",
+                "reason_code": "retention_boundary_due",
+                "record_count": retention_due_count,
+                "next_step_label": "operator_retention_due_review_label_only",
+            }
+        )
+    if not previews:
+        previews.append(
+            {
+                "disposition": "retain",
+                "reason_code": "retention_boundary_not_due",
+                "record_count": manifest_count,
+                "next_step_label": "operator_retain_review_label_only",
+            }
+        )
+    return previews
+
+
+def _c6y4_packet_id(
+    *,
+    packet_kind: str,
+    generated_at: str,
+    source_id: str,
+    dispositions: Sequence[Mapping[str, Any]],
+) -> str:
+    digest = hash_oacp_payload(
+        {
+            "packet_kind": packet_kind,
+            "generated_at": generated_at,
+            "source_id": source_id,
+            "dispositions": [
+                {
+                    "disposition": item.get("disposition"),
+                    "reason_code": item.get("reason_code"),
+                    "record_count": item.get("record_count"),
+                }
+                for item in dispositions
+            ],
+        }
+    )
+    return f"oacp_c6y4_{packet_kind}_{digest[:20]}"
+
+
+def build_oacp_c6y4_retention_disposition_dry_run(
+    *,
+    manifest_summary: Mapping[str, Any],
+    generated_at: str,
+) -> dict[str, Any]:
+    """Build a C6Y4 retention disposition preview without executing retention or writing exports."""
+
+    summary_check = _c6y4_summary_safe(manifest_summary)
+    summary_id = _c6x7_string(manifest_summary.get("summary_id"))
+    tenant_id = _c6x7_string(manifest_summary.get("tenant_id"))
+    merchant_id = _c6x7_string(manifest_summary.get("merchant_id"))
+    if summary_check.get("packet_built") is not True:
+        return summary_check
+    if _parse_iso(generated_at) is None:
+        return _c6y4_retention_refusal(
+            packet_kind="oacp_retention_disposition_dry_run",
+            status="blocked",
+            refusal_code="disposition_generated_at_invalid",
+            message="C6Y4 requires a valid disposition generated_at timestamp.",
+            generated_at=generated_at,
+            summary_id=summary_id,
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+        )
+    dispositions = _c6y4_disposition_previews(manifest_summary)
+    labels = _c6x9_unique(
+        [
+            *(_c6x8_list(manifest_summary.get("next_step_labels"))),
+            *(str(item["next_step_label"]) for item in dispositions),
+            "operator_retention_disposition_review_label_only",
+        ]
+    )
+    return {
+        "packet_built": True,
+        "packet_id": _c6y4_packet_id(
+            packet_kind="retention_disposition_dry_run",
+            generated_at=generated_at,
+            source_id=cast(str, summary_id),
+            dispositions=dispositions,
+        ),
+        "packet_kind": "oacp_retention_disposition_dry_run",
+        "status": "ready_for_operator_review",
+        "generated_at": generated_at,
+        "summary_id": summary_id,
+        "summary_generated_at": manifest_summary["generated_at"],
+        "tenant_id": tenant_id,
+        "merchant_id": merchant_id,
+        "scope_summary": dict(_c6x8_mapping(manifest_summary.get("scope_summary"))),
+        "manifest_count": _c6y4_positive_int(manifest_summary.get("manifest_count")),
+        "retention_class_counts": dict(_c6x8_mapping(manifest_summary.get("retention_class_counts"))),
+        "retention_due_count": _c6y4_positive_int(manifest_summary.get("retention_due_count")),
+        "legal_hold_candidate_count": _c6y4_positive_int(manifest_summary.get("legal_hold_candidate_count")),
+        "artifact_family_counts": dict(_c6x8_mapping(manifest_summary.get("artifact_family_counts"))),
+        "risk_tier_counts": dict(_c6x8_mapping(manifest_summary.get("risk_tier_counts"))),
+        "blocked_capability_summary": dict(_c6x8_mapping(manifest_summary.get("blocked_capability_summary"))),
+        "unsupported_capability_summary": dict(
+            _c6x8_mapping(manifest_summary.get("unsupported_capability_summary"))
+        ),
+        "freshness_ttl_summary": dict(_c6x8_mapping(manifest_summary.get("freshness_ttl_summary"))),
+        "revocation_snapshot_summary": dict(_c6x8_mapping(manifest_summary.get("revocation_snapshot_summary"))),
+        "redacted_evidence_ref_count": _c6y4_positive_int(manifest_summary.get("redacted_evidence_ref_count")),
+        "disposition_previews": dispositions,
+        "next_step_labels": labels,
+        "future_retention_action_allowed": False,
+        "records_deleted": False,
+        "retention_executed": False,
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "retention_disposition_dry_run_only": True,
+        "operator_review_packet_only": False,
+        "no_export_file_written": True,
+        "export_file_written": False,
+        "export_writer_added": False,
+        "scheduler_added": False,
+        "cli_added": False,
+        "migration_added": False,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "grantex_runtime_required": False,
+        "operator_safe_message": (
+            "C6Y4 produced a retention disposition dry-run only; it does not delete records or write exports."
+        ),
+    }
+
+
+def build_oacp_c6y4_retention_operator_review_packet(
+    *,
+    retention_disposition_dry_run: Mapping[str, Any],
+    generated_at: str,
+) -> dict[str, Any]:
+    """Build a C6Y4 operator packet over a retention dry-run without approving future action."""
+
+    dry_run_id = _c6x7_string(retention_disposition_dry_run.get("packet_id"))
+    tenant_id = _c6x7_string(retention_disposition_dry_run.get("tenant_id"))
+    merchant_id = _c6x7_string(retention_disposition_dry_run.get("merchant_id"))
+    if not dry_run_id or not _c6y4_dry_run_flags_safe(retention_disposition_dry_run):
+        return _c6y4_retention_refusal(
+            packet_kind="oacp_retention_disposition_operator_review_packet",
+            status="unsafe",
+            refusal_code="dry_run_missing_or_unsafe",
+            message="C6Y4 operator packets require a safe retention disposition dry-run.",
+            generated_at=generated_at,
+            summary_id=_c6x7_string(retention_disposition_dry_run.get("summary_id")),
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+        )
+    if _parse_iso(generated_at) is None:
+        return _c6y4_retention_refusal(
+            packet_kind="oacp_retention_disposition_operator_review_packet",
+            status="blocked",
+            refusal_code="operator_packet_generated_at_invalid",
+            message="C6Y4 operator packets require a valid generated_at timestamp.",
+            generated_at=generated_at,
+            summary_id=_c6x7_string(retention_disposition_dry_run.get("summary_id")),
+            tenant_id=tenant_id,
+            merchant_id=merchant_id,
+        )
+    dispositions = [
+        dict(item)
+        for item in retention_disposition_dry_run.get("disposition_previews", [])
+        if isinstance(item, Mapping)
+    ]
+    labels = _c6x9_unique(
+        [
+            *(_c6x8_list(retention_disposition_dry_run.get("next_step_labels"))),
+            "operator_review_packet_label_only",
+        ]
+    )
+    return {
+        "packet_built": True,
+        "packet_id": _c6y4_packet_id(
+            packet_kind="retention_disposition_operator_review_packet",
+            generated_at=generated_at,
+            source_id=dry_run_id,
+            dispositions=dispositions,
+        ),
+        "packet_kind": "oacp_retention_disposition_operator_review_packet",
+        "status": "ready_for_operator_review",
+        "generated_at": generated_at,
+        "retention_disposition_dry_run_id": dry_run_id,
+        "summary_id": retention_disposition_dry_run.get("summary_id"),
+        "tenant_id": tenant_id,
+        "merchant_id": merchant_id,
+        "scope_summary": dict(_c6x8_mapping(retention_disposition_dry_run.get("scope_summary"))),
+        "manifest_count": _c6y4_positive_int(retention_disposition_dry_run.get("manifest_count")),
+        "retention_due_count": _c6y4_positive_int(retention_disposition_dry_run.get("retention_due_count")),
+        "legal_hold_candidate_count": _c6y4_positive_int(
+            retention_disposition_dry_run.get("legal_hold_candidate_count")
+        ),
+        "artifact_family_counts": dict(_c6x8_mapping(retention_disposition_dry_run.get("artifact_family_counts"))),
+        "risk_tier_counts": dict(_c6x8_mapping(retention_disposition_dry_run.get("risk_tier_counts"))),
+        "blocked_capability_summary": dict(
+            _c6x8_mapping(retention_disposition_dry_run.get("blocked_capability_summary"))
+        ),
+        "unsupported_capability_summary": dict(
+            _c6x8_mapping(retention_disposition_dry_run.get("unsupported_capability_summary"))
+        ),
+        "redacted_evidence_ref_count": _c6y4_positive_int(
+            retention_disposition_dry_run.get("redacted_evidence_ref_count")
+        ),
+        "disposition_previews": dispositions,
+        "next_step_labels": labels,
+        "future_retention_action_allowed": False,
+        "records_deleted": False,
+        "retention_executed": False,
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "retention_disposition_dry_run_only": True,
+        "operator_review_packet_only": True,
+        "no_export_file_written": True,
+        "export_file_written": False,
+        "export_writer_added": False,
+        "scheduler_added": False,
+        "cli_added": False,
+        "migration_added": False,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "grantex_runtime_required": False,
+        "operator_safe_message": (
+            "C6Y4 prepared an operator review packet only; it is not approval to delete, retain, or export."
+        ),
+    }
+
+
 class DurableOacpAuditReviewManifestRepository:
     """Async SQLAlchemy-backed review manifest repository; it writes no export files and executes nothing."""
 

--- a/docs/reports/commerce-agent-c6y4-oacp-retention-disposition.md
+++ b/docs/reports/commerce-agent-c6y4-oacp-retention-disposition.md
@@ -1,0 +1,88 @@
+# C6Y4 OACP Retention Disposition Dry-Run
+
+## Scope
+
+C6Y4 adds internal helper behavior that consumes C6Y3 redacted audit review manifest summaries and produces retention disposition dry-runs plus operator review packets. AgenticOrg owns audit review manifest handling and retention review previews for its local durable OACP metadata.
+
+The slice is planning and model/helper behavior only. It does not expose an endpoint, command, CLI, workflow, scheduler, cron job, queue, background worker, migration, export-file writer, or generated report artifact.
+
+## Correct Ownership Model
+
+AgenticOrg remains the buyer and seller AI-agent runtime. It owns durable/local OACP artifact cache behavior, local operator decision handling, audit export bundle generation, audit review manifest handling, internal manifest query/summary behavior, and C6Y4 retention disposition dry-runs.
+
+Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. Grantex is not a transaction toll booth and does not receive every manifest summary, retention disposition dry-run, operator packet, or non-binding buyer/seller interaction.
+
+Merchant systems remain operational sources of record. Provider and fintech rails own mandate and payment execution. OACP remains internal, non-publication, non-certifying, non-production, and non-executing.
+
+## Disposition Dry-Run Outcomes
+
+C6Y4 produces deterministic disposition previews only:
+
+- retain
+- review_later
+- legal_hold_review
+- redaction_review_required
+- retention_due_review
+- blocked_unsafe
+
+The preview can indicate that an operator should review a due retention boundary, legal hold candidate, missing redacted-evidence count, empty scope result, or unsafe input. It cannot delete, purge, retain, export, approve, or execute anything.
+
+## Operator Review Packet
+
+The operator review packet carries label-only disposition previews from the dry-run. It retains tenant, merchant, seller-agent, buyer-agent, retention, risk, freshness, revocation, blocked, unsupported, and evidence-count summaries.
+
+The packet includes:
+
+- packet id and generated_at
+- source C6Y3 summary id
+- source C6Y4 dry-run id
+- scope summary
+- manifest_count
+- retention_due_count
+- legal_hold_candidate_count
+- artifact and risk counts
+- blocked and unsupported capability summaries
+- redacted evidence ref count only
+- next-step labels only
+- allowed_to_execute = false
+- future_retention_action_allowed = false
+- records_deleted = false
+- non_authoritative_for_transaction = true
+
+## Fail-Closed Rules
+
+C6Y4 fails closed when the C6Y3 summary is missing, malformed, executable, missing tenant or merchant scope, has mismatched scope, includes evidence ref values instead of counts, contains malformed timestamps, has export-writer/scheduler/CLI/migration flags, has false non-enablement flags, includes private/raw values, or contains publication, approval, certification, compliance, conformance, standardization, or readiness wording.
+
+Operator packets fail closed unless the dry-run is safe, ready for operator review, label-only, non-executing, and explicitly blocks future retention action.
+
+## Migration Scheduler CLI And Export Writer Decision
+
+C6Y4 adds no DB migration. It reuses C6Y3 redacted summary structures and C6Y2 durable manifest metadata.
+
+C6Y4 adds no scheduler, cron job, queue, background worker, CLI, export-file writer, generated report artifact, endpoint, public API, or runtime OpenAPI contract. It does not write export files and does not call Grantex live, providers, merchant systems, carriers, shipping providers, or payment rails.
+
+## Guardrails
+
+The dry-run and operator packet keep the non-enablement posture intact:
+
+- allowed_to_execute = false
+- future_retention_action_allowed = false
+- records_deleted = false
+- retention_executed = false
+- non_authoritative_for_transaction = true
+- no_checkout_payment_enablement = true
+- no_live_provider_enablement = true
+- no_public_discovery_enablement = true
+- no_export_file_written = true
+
+Outputs must never include raw artifact payloads, provider payloads, connector payloads, raw JWTs or passports, credentials, tokens, private keys, private customer data, payment data, bank/card data, raw merchant private API values, raw reviewer identity, or secrets.
+
+## What C6Y4 Does Not Enable
+
+C6Y4 does not execute retention, delete records, purge records, write export files, schedule retention, expose APIs, create orders, create holds, capture payments, create mandates, issue refunds, process returns, create shipments, call providers, call carriers, call shipping providers, call Grantex live, call merchant private APIs, publish OACP, submit protocols externally, or enable public discovery.
+
+C6Y4 dry-runs and operator packets are not Grantex approvals, merchant approvals, checkout approvals, payment approvals, mandate approvals, live-provider approvals, production approvals, public launch approvals, certifications, compliance statements, conformance statements, standardization claims, or OACP approvals.
+
+## Future Work
+
+A future approved slice may add durable disposition-decision records or an internal operator surface. That work must remain tenant-scoped, redacted, non-executing, and separately reviewed before any endpoint, scheduler, CLI, export writer, migration, or production retention action is introduced.

--- a/tests/unit/test_oacp_c6y4_retention_disposition.py
+++ b/tests/unit/test_oacp_c6y4_retention_disposition.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from core.commerce.oacp_artifacts import (
+    OacpArtifactCacheRepositoryQuery,
+    OacpAuditExportReviewRetentionClass,
+    OacpAuditReviewManifestRepositoryQuery,
+    OacpPersistentArtifactCacheRecord,
+    build_oacp_c6x9_audit_export_bundle,
+    build_oacp_c6y1_audit_export_review_manifest,
+    build_oacp_c6y3_audit_review_manifest_summary,
+    build_oacp_c6y4_retention_disposition_dry_run,
+    build_oacp_c6y4_retention_operator_review_packet,
+    build_oacp_cache_maintenance_dry_run_report,
+    build_oacp_cache_operator_decision_record,
+    plan_oacp_artifact_cache_maintenance,
+)
+
+C6Y4_DOC_PATH = Path("docs/reports/commerce-agent-c6y4-oacp-retention-disposition.md")
+
+
+def _doc() -> str:
+    return C6Y4_DOC_PATH.read_text(encoding="utf-8")
+
+
+def _record(**overrides: object) -> OacpPersistentArtifactCacheRecord:
+    base = OacpPersistentArtifactCacheRecord(
+        cache_record_id="cache_price_C6Y4",
+        artifact_id="price_C6W3",
+        artifact_type="price",
+        authority="grantex_canonical_oacp_artifact_authority",
+        issuer="grantex",
+        scope_kind="buyer_agent",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+        source_refs=("source_ref_price_C6Y4",),
+        evidence_refs=("evidence_price_C6Y4_redacted",),
+        generated_at="2026-06-12T00:00:00.000Z",
+        cached_at="2026-06-12T00:00:10.000Z",
+        expires_at="2026-06-12T00:05:00.000Z",
+        freshness_status="fresh",
+        revocation_snapshot_status="fresh",
+        revocation_snapshot_observed_at="2026-06-12T00:00:30.000Z",
+        revocation_snapshot_age_seconds=30,
+        ttl_policy_seconds=300,
+        risk_tier="low",
+        blocked_capabilities=("checkout_payment_creation", "live_provider_call"),
+        unsupported_capabilities=("transaction_authority_from_adapter_preview",),
+        verifier_result_ref="verifier_result_price_C6Y4",
+    )
+    return replace(base, **overrides)
+
+
+def _plan(records: tuple[OacpPersistentArtifactCacheRecord, ...]) -> dict[str, object]:
+    return plan_oacp_artifact_cache_maintenance(
+        records=records,
+        now_iso="2026-06-12T00:01:00.000Z",
+        grantex_available=True,
+        action_intent="prepare_only",
+        risk_tier="low",
+        scope_filter=OacpArtifactCacheRepositoryQuery(tenant_id="cten_C6W3", merchant_id="mch_C6W3"),
+    )
+
+
+def _review_packet(plan: dict[str, object]) -> dict[str, object]:
+    return build_oacp_cache_maintenance_dry_run_report(
+        maintenance_plan=plan,
+        report_kind="operator_review_packet",
+    )
+
+
+def _decision(packet: dict[str, object]) -> dict[str, object]:
+    return build_oacp_cache_operator_decision_record(
+        review_packet=packet,
+        decision_kind="request_more_evidence",
+        reviewer_identity_ref="operator_ref_c6y4_reviewer_001",
+        decided_at="2026-06-12T00:02:00.000Z",
+    )
+
+
+def _bundle(records: tuple[OacpPersistentArtifactCacheRecord, ...]) -> dict[str, object]:
+    plan = _plan(records)
+    packet = _review_packet(plan)
+    decision = _decision(packet)
+    return build_oacp_c6x9_audit_export_bundle(
+        cache_records=records,
+        maintenance_plans=(plan,),
+        review_packets=(packet,),
+        operator_decision_records=(decision,),
+        durable_decision_records=(dict(decision),),
+        generated_at="2026-06-12T00:03:00.000Z",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+    )
+
+
+def _manifest(
+    *,
+    retention_class: OacpAuditExportReviewRetentionClass = "standard_internal_review",
+    generated_at: str = "2026-06-12T00:04:00.000Z",
+) -> dict[str, object]:
+    return build_oacp_c6y1_audit_export_review_manifest(
+        audit_export_bundle=_bundle((_record(),)),
+        generated_at=generated_at,
+        retention_class=retention_class,
+    )
+
+
+def _summary(
+    *,
+    retention_class: OacpAuditExportReviewRetentionClass = "standard_internal_review",
+    generated_at: str = "2026-06-12T00:05:00.000Z",
+) -> dict[str, object]:
+    return build_oacp_c6y3_audit_review_manifest_summary(
+        (_manifest(retention_class=retention_class),),
+        query=OacpAuditReviewManifestRepositoryQuery(
+            tenant_id="cten_C6W3",
+            merchant_id="mch_C6W3",
+            retention_class=retention_class,
+        ),
+        generated_at=generated_at,
+    )
+
+
+def _disposition_values(packet: dict[str, object]) -> set[str]:
+    return {
+        str(item["disposition"])
+        for item in packet["disposition_previews"]
+        if isinstance(item, dict)
+    }
+
+
+def test_c6y4_retention_disposition_dry_run_and_operator_packet_retain_without_execution() -> None:
+    summary = _summary()
+    dry_run = build_oacp_c6y4_retention_disposition_dry_run(
+        manifest_summary=summary,
+        generated_at="2026-06-12T00:06:00.000Z",
+    )
+    packet = build_oacp_c6y4_retention_operator_review_packet(
+        retention_disposition_dry_run=dry_run,
+        generated_at="2026-06-12T00:07:00.000Z",
+    )
+
+    assert dry_run["packet_built"] is True
+    assert dry_run["packet_kind"] == "oacp_retention_disposition_dry_run"
+    assert _disposition_values(dry_run) == {"retain"}
+    assert dry_run["future_retention_action_allowed"] is False
+    assert dry_run["records_deleted"] is False
+    assert dry_run["allowed_to_execute"] is False
+    assert dry_run["no_export_file_written"] is True
+    assert packet["packet_built"] is True
+    assert packet["packet_kind"] == "oacp_retention_disposition_operator_review_packet"
+    assert packet["operator_review_packet_only"] is True
+    assert packet["allowed_to_execute"] is False
+    assert packet["non_authoritative_for_transaction"] is True
+    assert "evidence_price_C6Y4_redacted" not in str(dry_run)
+    assert "evidence_price_C6Y4_redacted" not in str(packet)
+
+
+def test_c6y4_retention_disposition_flags_due_and_legal_hold_for_review_only() -> None:
+    summary = _summary(
+        retention_class="legal_hold_candidate",
+        generated_at="2028-06-12T00:05:00.000Z",
+    )
+    dry_run = build_oacp_c6y4_retention_disposition_dry_run(
+        manifest_summary=summary,
+        generated_at="2028-06-12T00:06:00.000Z",
+    )
+
+    assert dry_run["packet_built"] is True
+    assert _disposition_values(dry_run) == {"legal_hold_review", "retention_due_review"}
+    assert dry_run["retention_due_count"] == 1
+    assert dry_run["legal_hold_candidate_count"] == 1
+    assert dry_run["retention_executed"] is False
+    assert dry_run["records_deleted"] is False
+    assert dry_run["allowed_to_execute"] is False
+
+
+def test_c6y4_retention_disposition_requests_redaction_review_without_evidence_values() -> None:
+    summary = dict(_summary())
+    summary["redacted_evidence_ref_count"] = 0
+    summary["redacted_evidence_ref_counts"] = {}
+    dry_run = build_oacp_c6y4_retention_disposition_dry_run(
+        manifest_summary=summary,
+        generated_at="2026-06-12T00:06:00.000Z",
+    )
+
+    assert dry_run["packet_built"] is True
+    assert _disposition_values(dry_run) == {"redaction_review_required"}
+    assert dry_run["redacted_evidence_ref_count"] == 0
+    assert dry_run["allowed_to_execute"] is False
+    assert "evidence_price_C6Y4_redacted" not in str(dry_run)
+
+
+def test_c6y4_retention_disposition_fails_closed_for_unsafe_inputs() -> None:
+    summary = _summary()
+    missing_scope = build_oacp_c6y4_retention_disposition_dry_run(
+        manifest_summary={**summary, "tenant_id": ""},
+        generated_at="2026-06-12T00:06:00.000Z",
+    )
+    executable = build_oacp_c6y4_retention_disposition_dry_run(
+        manifest_summary={**summary, "allowed_to_execute": True},
+        generated_at="2026-06-12T00:06:00.000Z",
+    )
+    evidence_values = build_oacp_c6y4_retention_disposition_dry_run(
+        manifest_summary={**summary, "redacted_evidence_refs": ["evidence_price_C6Y4_redacted"]},
+        generated_at="2026-06-12T00:06:00.000Z",
+    )
+    bad_generated_at = build_oacp_c6y4_retention_disposition_dry_run(
+        manifest_summary=summary,
+        generated_at="not-a-time",
+    )
+    unsafe_packet = build_oacp_c6y4_retention_operator_review_packet(
+        retention_disposition_dry_run={"packet_id": "dry_run_C6Y4", "allowed_to_execute": True},
+        generated_at="2026-06-12T00:07:00.000Z",
+    )
+
+    assert missing_scope["refusal_code"] == "summary_identity_or_scope_missing"
+    assert executable["refusal_code"] == "summary_non_enablement_flags_invalid"
+    assert evidence_values["refusal_code"] == "summary_contains_evidence_ref_values"
+    assert bad_generated_at["refusal_code"] == "disposition_generated_at_invalid"
+    assert unsafe_packet["refusal_code"] == "dry_run_missing_or_unsafe"
+    for result in (missing_scope, executable, evidence_values, bad_generated_at, unsafe_packet):
+        assert result["packet_built"] is False
+        assert result["allowed_to_execute"] is False
+        assert result["future_retention_action_allowed"] is False
+        assert result["records_deleted"] is False
+
+
+def test_c6y4_docs_capture_retention_disposition_boundary_and_non_goals() -> None:
+    doc = _doc()
+    for heading in (
+        "Scope",
+        "Correct Ownership Model",
+        "Disposition Dry-Run Outcomes",
+        "Operator Review Packet",
+        "Fail-Closed Rules",
+        "Migration Scheduler CLI And Export Writer Decision",
+        "Guardrails",
+        "What C6Y4 Does Not Enable",
+        "Future Work",
+    ):
+        assert f"## {heading}" in doc
+
+    assert "AgenticOrg owns audit review manifest handling" in doc
+    assert "not a transaction toll booth" in doc
+    assert "allowed_to_execute = false" in doc
+    assert "future_retention_action_allowed = false" in doc
+    assert "records_deleted = false" in doc
+    assert "does not write export files" in doc
+    assert "does not call Grantex live" in doc


### PR DESCRIPTION
C6Y4 internal AgenticOrg retention disposition dry-run and operator review packet helpers over C6Y3 redacted manifest summaries. No migration, endpoint, workflow, scheduler, CLI, export writer, provider call, payment/checkout enablement, public discovery, live rail, Grantex live call, or publication behavior. Local validation: C6Y1-C6Y4 focused tests, ruff, mypy, git diff --check.