### PR TITLE
[codex] Add C6Y5 retention disposition decision repository

### DIFF
--- a/core/commerce/oacp_artifacts.py
+++ b/core/commerce/oacp_artifacts.py
@@ -204,6 +204,15 @@ OacpAuditExportReviewRetentionClass = Literal[
     "standard_internal_review",
     "legal_hold_candidate",
 ]
+OacpRetentionDispositionDecisionKind = Literal[
+    "approve_future_retention_review",
+    "approve_future_redaction_review",
+    "approve_future_legal_hold_review",
+    "request_more_evidence",
+    "reject_disposition",
+    "defer_until_recheck",
+    "block_unsafe_disposition",
+]
 
 OACP_ARTIFACT_SIGNATURE_PROFILE: dict[str, Any] = {
     "payload_format": "canonical_json",
@@ -999,6 +1008,23 @@ class OacpAuditReviewManifestRepositoryQuery:
     unsupported_capability: str | None = None
 
 
+@dataclass(frozen=True)
+class OacpRetentionDispositionDecisionRepositoryQuery:
+    tenant_id: str | None = None
+    merchant_id: str | None = None
+    seller_agent_id: str | None = None
+    buyer_agent_id: str | None = None
+    decision_kind: OacpRetentionDispositionDecisionKind | None = None
+    source_summary_id: str | None = None
+    source_dry_run_id: str | None = None
+    source_operator_packet_id: str | None = None
+    retention_class: OacpAuditExportReviewRetentionClass | None = None
+    retain_until_before: str | None = None
+    retain_until_after: str | None = None
+    decided_at_before: str | None = None
+    decided_at_after: str | None = None
+
+
 class OacpArtifactCacheRepositoryPort(Protocol):
     def upsert(self, record: OacpPersistentArtifactCacheRecord) -> dict[str, Any]:
         """Store or replace a local cache record without external calls."""
@@ -1067,6 +1093,27 @@ class OacpAuditReviewManifestRepositoryPort(Protocol):
         generated_at: str,
     ) -> dict[str, Any]:
         """Build a redacted internal summary over stored manifests without writing export files."""
+        ...
+
+
+class OacpRetentionDispositionDecisionRepositoryPort(Protocol):
+    def upsert_disposition_decision(self, decision_record: Mapping[str, Any]) -> dict[str, Any]:
+        """Store or replace one audit-safe retention disposition decision without executing retention."""
+        ...
+
+    def get_disposition_decision(self, disposition_decision_id: str) -> dict[str, Any] | None:
+        """Read one retention disposition decision by deterministic local id."""
+        ...
+
+    def list_disposition_decisions_for_scope(
+        self,
+        query: OacpRetentionDispositionDecisionRepositoryQuery,
+    ) -> tuple[dict[str, Any], ...]:
+        """List local disposition decisions for a tenant, merchant, seller, buyer, or source scope."""
+        ...
+
+    def evaluate_disposition_decision_for_future_review(self, disposition_decision_id: str) -> dict[str, Any]:
+        """Evaluate a stored disposition decision without approving or executing retention."""
         ...
 
 
@@ -8203,6 +8250,808 @@ def build_oacp_c6y4_retention_operator_review_packet(
             "C6Y4 prepared an operator review packet only; it is not approval to delete, retain, or export."
         ),
     }
+
+
+_C6Y5_DECISION_KINDS = frozenset(
+    {
+        "approve_future_retention_review",
+        "approve_future_redaction_review",
+        "approve_future_legal_hold_review",
+        "request_more_evidence",
+        "reject_disposition",
+        "defer_until_recheck",
+        "block_unsafe_disposition",
+    }
+)
+_C6Y5_DECISION_NEXT_STEP_LABELS = {
+    "approve_future_retention_review": "operator_future_retention_review_label_only",
+    "approve_future_redaction_review": "operator_future_redaction_review_label_only",
+    "approve_future_legal_hold_review": "operator_future_legal_hold_review_label_only",
+    "request_more_evidence": "operator_request_more_evidence_label_only",
+    "reject_disposition": "operator_reject_disposition_label_only",
+    "defer_until_recheck": "operator_defer_until_recheck_label_only",
+    "block_unsafe_disposition": "operator_block_unsafe_disposition_label_only",
+}
+_C6Y5_SAFE_FALLBACK_DECIDED_AT = "1970-01-01T00:00:00.000Z"
+_C6Y5_FORBIDDEN_LABEL_MARKERS = (
+    "delete",
+    "purge",
+    "redact_persisted",
+    "retention_execute",
+    "execute_retention",
+    "retention_executed",
+    "export_file",
+    "write_export",
+    "scheduler",
+    "queue",
+    "worker",
+    "cli",
+    "endpoint",
+    "url",
+)
+
+
+def _c6y5_decision_id(payload: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(canonicalize_oacp_payload(dict(payload)).encode("utf-8")).hexdigest()
+    return f"oacp_c6y5_retention_disposition_{digest[:20]}"
+
+
+def _c6y5_disposition_refusal(
+    *,
+    status: str,
+    refusal_code: str,
+    message: str,
+    disposition_decision_id: str | None = None,
+    decision_record: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "stored": False,
+        "decision_record_built": False,
+        "status": status,
+        "refusal_code": refusal_code,
+        "message": message,
+        "disposition_decision_id": disposition_decision_id
+        or _c6x7_string(decision_record.get("disposition_decision_id") if decision_record is not None else None),
+        "future_retention_action_allowed": False,
+        "records_deleted": False,
+        "retention_executed": False,
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "retention_disposition_decision_only": True,
+        "durable_disposition_decision_only": True,
+        "export_file_written": False,
+        "export_writer_added": False,
+        "scheduler_added": False,
+        "cli_added": False,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "grantex_runtime_required": False,
+    }
+
+
+def _c6y5_operator_packet_flags_safe(packet: Mapping[str, Any]) -> bool:
+    return (
+        packet.get("packet_built") is True
+        and packet.get("packet_kind") == "oacp_retention_disposition_operator_review_packet"
+        and packet.get("status") == "ready_for_operator_review"
+        and packet.get("allowed_to_execute") is False
+        and packet.get("no_execution") is True
+        and packet.get("retention_disposition_dry_run_only") is True
+        and packet.get("operator_review_packet_only") is True
+        and packet.get("future_retention_action_allowed") is False
+        and packet.get("records_deleted") is False
+        and packet.get("retention_executed") is False
+        and packet.get("no_export_file_written") is True
+        and packet.get("export_file_written") is False
+        and packet.get("export_writer_added") is False
+        and packet.get("scheduler_added") is False
+        and packet.get("cli_added") is False
+        and packet.get("migration_added") is False
+        and packet.get("non_authoritative_for_transaction") is True
+        and packet.get("no_checkout_payment_enablement") is True
+        and packet.get("no_live_provider_enablement") is True
+        and packet.get("no_public_discovery_enablement") is True
+        and packet.get("grantex_runtime_required") is False
+    )
+
+
+def _c6y5_scope_value(source: Mapping[str, Any], scope_kind: str, field_name: str) -> str | None:
+    direct = _c6x7_string(source.get(field_name))
+    if direct is not None:
+        return direct
+    values = _c6x8_mapping(source.get("scope_summary")).get(scope_kind)
+    if isinstance(values, Mapping):
+        keys = sorted(str(key) for key in values if isinstance(key, str) and key)
+        return keys[0] if len(keys) == 1 else None
+    return None
+
+
+def _c6y5_retention_class(source: Mapping[str, Any]) -> OacpAuditExportReviewRetentionClass | None:
+    direct = _c6x7_string(source.get("retention_class"))
+    if direct in _C6Y1_RETENTION_DAYS_BY_CLASS:
+        return cast(OacpAuditExportReviewRetentionClass, direct)
+    counts = _c6x8_mapping(source.get("retention_class_counts"))
+    candidates = sorted(
+        key
+        for key, count in counts.items()
+        if isinstance(key, str)
+        and key in _C6Y1_RETENTION_DAYS_BY_CLASS
+        and isinstance(count, int)
+        and count > 0
+    )
+    return cast(OacpAuditExportReviewRetentionClass, candidates[0]) if len(candidates) == 1 else None
+
+
+def _c6y5_retain_until(source: Mapping[str, Any], retention_class: OacpAuditExportReviewRetentionClass) -> str | None:
+    direct = _c6x7_string(source.get("retain_until"))
+    if _parse_iso(direct) is not None:
+        return direct
+    boundary = source.get("retention_boundary")
+    if isinstance(boundary, Mapping):
+        boundary_retain_until = _c6x7_string(boundary.get("retain_until"))
+        if _parse_iso(boundary_retain_until) is not None:
+            return boundary_retain_until
+    base_time = _parse_iso(_c6x7_string(source.get("summary_generated_at")) or _c6x7_string(source.get("generated_at")))
+    if base_time is None:
+        return None
+    return _c6y2_row_time(base_time + timedelta(days=_C6Y1_RETENTION_DAYS_BY_CLASS[retention_class]))
+
+
+def _c6y5_reason_codes_from_previews(packet: Mapping[str, Any]) -> dict[str, int]:
+    return _c6x9_count(
+        [
+            str(item["reason_code"])
+            for item in packet.get("disposition_previews", [])
+            if isinstance(item, Mapping) and isinstance(item.get("reason_code"), str)
+        ]
+    )
+
+
+def _c6y5_labels_safe(labels: tuple[str, ...]) -> bool:
+    return _c6x8_labels_safe(labels) and not any(
+        any(marker in label.strip().lower() for marker in _C6Y5_FORBIDDEN_LABEL_MARKERS)
+        for label in labels
+    )
+
+
+def _c6y5_decision_scope_matches(decision_record: Mapping[str, Any]) -> bool:
+    tenant_id = _c6x7_string(decision_record.get("tenant_id"))
+    merchant_id = _c6x7_string(decision_record.get("merchant_id"))
+    if tenant_id is None or merchant_id is None:
+        return False
+    return _c6x9_mapping_scope_matches(
+        decision_record,
+        tenant_id=tenant_id,
+        merchant_id=merchant_id,
+        seller_agent_id=_c6x7_string(decision_record.get("seller_agent_id")),
+        buyer_agent_id=_c6x7_string(decision_record.get("buyer_agent_id")),
+    )
+
+
+def _c6y5_decision_flags_safe(decision_record: Mapping[str, Any]) -> bool:
+    return (
+        decision_record.get("decision_record_built") is True
+        and decision_record.get("status") == "recorded_for_future_review"
+        and decision_record.get("allowed_to_execute") is False
+        and decision_record.get("no_execution") is True
+        and decision_record.get("future_retention_action_allowed") is False
+        and decision_record.get("records_deleted") is False
+        and decision_record.get("retention_executed") is False
+        and decision_record.get("retention_disposition_decision_only") is True
+        and decision_record.get("durable_disposition_decision_only") is True
+        and decision_record.get("export_file_written") is False
+        and decision_record.get("export_writer_added") is False
+        and decision_record.get("scheduler_added") is False
+        and decision_record.get("cli_added") is False
+        and decision_record.get("non_authoritative_for_transaction") is True
+        and decision_record.get("no_checkout_payment_enablement") is True
+        and decision_record.get("no_live_provider_enablement") is True
+        and decision_record.get("no_public_discovery_enablement") is True
+        and decision_record.get("grantex_runtime_required") is False
+    )
+
+
+def _c6y5_decision_strings(decision_record: Mapping[str, Any]) -> list[str]:
+    values = [
+        _c6x7_string(decision_record.get("disposition_decision_id")),
+        _c6x7_string(decision_record.get("source_summary_id")),
+        _c6x7_string(decision_record.get("source_dry_run_id")),
+        _c6x7_string(decision_record.get("source_operator_packet_id")),
+        _c6x7_string(decision_record.get("tenant_id")),
+        _c6x7_string(decision_record.get("merchant_id")),
+        _c6x7_string(decision_record.get("reviewer_ref")),
+        _c6x7_string(decision_record.get("operator_safe_message")),
+    ]
+    values.extend(_c6x8_list(decision_record.get("next_step_labels")))
+    values.extend(_c6x9_reason_code_values(decision_record.get("redacted_reason_codes")))
+    values.extend(_c6x9_reason_code_values(decision_record.get("blocked_capability_summary")))
+    values.extend(_c6x9_reason_code_values(decision_record.get("unsupported_capability_summary")))
+    return [value for value in values if value is not None]
+
+
+def build_oacp_c6y5_retention_disposition_decision_record(
+    *,
+    retention_disposition_dry_run: Mapping[str, Any] | None,
+    operator_review_packet: Mapping[str, Any] | None,
+    decision_kind: OacpRetentionDispositionDecisionKind | str,
+    reviewer_identity_ref: str | None,
+    decided_at: str,
+) -> dict[str, Any]:
+    """Build a durable C6Y5 decision record without executing retention or writing exports."""
+
+    if decision_kind not in _C6Y5_DECISION_KINDS:
+        return _c6y5_disposition_refusal(
+            status="blocked",
+            refusal_code="unsupported_or_executable_decision_kind",
+            message="C6Y5 records known future-review disposition decisions only.",
+        )
+    if retention_disposition_dry_run is None or operator_review_packet is None:
+        return _c6y5_disposition_refusal(
+            status="blocked",
+            refusal_code="source_packets_missing",
+            message="C6Y5 requires C6Y4 dry-run and operator review packets before recording a decision.",
+        )
+    try:
+        assert_no_forbidden_oacp_artifact_fields(dict(retention_disposition_dry_run))
+        assert_no_forbidden_oacp_artifact_fields(dict(operator_review_packet))
+    except ValueError:
+        return _c6y5_disposition_refusal(
+            status="unsafe",
+            refusal_code="private_or_enabling_source_packet_field",
+            message="C6Y5 refuses source packets with private, raw, or enabling fields.",
+        )
+
+    dry_run_id = _c6x7_string(retention_disposition_dry_run.get("packet_id"))
+    packet_id = _c6x7_string(operator_review_packet.get("packet_id"))
+    summary_id = _c6x7_string(retention_disposition_dry_run.get("summary_id"))
+    tenant_id = _c6x7_string(retention_disposition_dry_run.get("tenant_id"))
+    merchant_id = _c6x7_string(retention_disposition_dry_run.get("merchant_id"))
+    generated_at = _c6x7_string(operator_review_packet.get("generated_at"))
+    if not all((dry_run_id, packet_id, summary_id, tenant_id, merchant_id, generated_at)):
+        return _c6y5_disposition_refusal(
+            status="blocked",
+            refusal_code="decision_source_identity_or_scope_missing",
+            message="C6Y5 requires source summary, dry-run, operator packet, tenant, and merchant identifiers.",
+        )
+    if (
+        operator_review_packet.get("retention_disposition_dry_run_id") != dry_run_id
+        or operator_review_packet.get("summary_id") != summary_id
+        or operator_review_packet.get("tenant_id") != tenant_id
+        or operator_review_packet.get("merchant_id") != merchant_id
+    ):
+        return _c6y5_disposition_refusal(
+            status="blocked",
+            refusal_code="source_packet_scope_mismatch",
+            message="C6Y5 refuses decisions whose dry-run and operator packet source scopes do not match.",
+        )
+    if not _c6y4_dry_run_flags_safe(retention_disposition_dry_run) or not _c6y5_operator_packet_flags_safe(
+        operator_review_packet
+    ):
+        return _c6y5_disposition_refusal(
+            status="unsafe",
+            refusal_code="source_packet_executable_or_enabling",
+            message="C6Y5 refuses executable or enabling source packets.",
+        )
+    if not _c6x7_reviewer_ref_safe(reviewer_identity_ref):
+        return _c6y5_disposition_refusal(
+            status="unsafe",
+            refusal_code="reviewer_identity_not_opaque",
+            message="C6Y5 requires an opaque reviewer reference, not raw contact or credential data.",
+        )
+    generated = _parse_iso(generated_at)
+    decided = _parse_iso(decided_at)
+    retention_class = _c6y5_retention_class(retention_disposition_dry_run)
+    if retention_class is None:
+        return _c6y5_disposition_refusal(
+            status="blocked",
+            refusal_code="retention_class_invalid",
+            message="C6Y5 stores only supported internal retention disposition classes.",
+        )
+    retain_until = _c6y5_retain_until(retention_disposition_dry_run, retention_class)
+    retained_until = _parse_iso(retain_until)
+    if (
+        generated is None
+        or decided is None
+        or retained_until is None
+        or generated > decided
+        or generated >= retained_until
+    ):
+        return _c6y5_disposition_refusal(
+            status="blocked",
+            refusal_code="decision_timestamps_invalid",
+            message="C6Y5 requires ordered generated, decided, and retention timestamps.",
+        )
+    if retention_disposition_dry_run.get("redacted_evidence_refs") not in (None, [], ()):
+        return _c6y5_disposition_refusal(
+            status="unsafe",
+            refusal_code="source_contains_evidence_ref_values",
+            message="C6Y5 stores redacted evidence reference counts only, not evidence ref values.",
+        )
+
+    labels = _c6x9_unique(
+        [
+            *(_c6x8_list(operator_review_packet.get("next_step_labels"))),
+            _C6Y5_DECISION_NEXT_STEP_LABELS[str(decision_kind)],
+            "operator_retention_disposition_decision_label_only",
+        ]
+    )
+    if not labels or not _c6y5_labels_safe(tuple(labels)):
+        return _c6y5_disposition_refusal(
+            status="unsafe",
+            refusal_code="decision_labels_executable_or_private",
+            message="C6Y5 stores label-only next steps, not execution targets.",
+        )
+
+    payload = {
+        "decision_kind": decision_kind,
+        "source_summary_id": summary_id,
+        "source_dry_run_id": dry_run_id,
+        "source_operator_packet_id": packet_id,
+        "reviewer_identity_ref": reviewer_identity_ref,
+        "decided_at": decided_at,
+    }
+    seller_agent_id = _c6y5_scope_value(retention_disposition_dry_run, "seller_agent", "seller_agent_id")
+    buyer_agent_id = _c6y5_scope_value(retention_disposition_dry_run, "buyer_agent", "buyer_agent_id")
+    return {
+        "decision_record_built": True,
+        "disposition_decision_id": _c6y5_decision_id(payload),
+        "source_summary_id": summary_id,
+        "source_dry_run_id": dry_run_id,
+        "source_operator_packet_id": packet_id,
+        "tenant_id": tenant_id,
+        "merchant_id": merchant_id,
+        "seller_agent_id": seller_agent_id,
+        "buyer_agent_id": buyer_agent_id,
+        "generated_at": generated_at,
+        "decided_at": decided_at,
+        "decision_kind": decision_kind,
+        "retention_class": retention_class,
+        "retain_until": retain_until,
+        "manifest_count": _c6y4_positive_int(retention_disposition_dry_run.get("manifest_count")),
+        "retention_due_count": _c6y4_positive_int(retention_disposition_dry_run.get("retention_due_count")),
+        "legal_hold_candidate_count": _c6y4_positive_int(
+            retention_disposition_dry_run.get("legal_hold_candidate_count")
+        ),
+        "artifact_family_counts": dict(_c6x8_mapping(retention_disposition_dry_run.get("artifact_family_counts"))),
+        "risk_tier_counts": dict(_c6x8_mapping(retention_disposition_dry_run.get("risk_tier_counts"))),
+        "blocked_capability_summary": dict(
+            _c6x8_mapping(retention_disposition_dry_run.get("blocked_capability_summary"))
+        ),
+        "unsupported_capability_summary": dict(
+            _c6x8_mapping(retention_disposition_dry_run.get("unsupported_capability_summary"))
+        ),
+        "redacted_evidence_ref_count": _c6y4_positive_int(
+            retention_disposition_dry_run.get("redacted_evidence_ref_count")
+        ),
+        "redacted_reason_codes": _c6y5_reason_codes_from_previews(retention_disposition_dry_run),
+        "reviewer_ref": reviewer_identity_ref,
+        "scope_summary": dict(_c6x8_mapping(retention_disposition_dry_run.get("scope_summary"))),
+        "next_step_labels": labels,
+        "status": "recorded_for_future_review",
+        "future_retention_action_allowed": False,
+        "records_deleted": False,
+        "retention_executed": False,
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "retention_disposition_decision_only": True,
+        "durable_disposition_decision_only": True,
+        "export_file_written": False,
+        "export_writer_added": False,
+        "scheduler_added": False,
+        "cli_added": False,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "grantex_runtime_required": False,
+        "operator_safe_message": (
+            "C6Y5 stores a redacted retention disposition decision only; it does not delete records."
+        ),
+    }
+
+
+def _c6y5_disposition_decision_safe_for_storage(decision_record: Mapping[str, Any]) -> dict[str, Any]:
+    disposition_decision_id = _c6x7_string(decision_record.get("disposition_decision_id"))
+    source_summary_id = _c6x7_string(decision_record.get("source_summary_id"))
+    source_dry_run_id = _c6x7_string(decision_record.get("source_dry_run_id"))
+    source_operator_packet_id = _c6x7_string(decision_record.get("source_operator_packet_id"))
+    tenant_id = _c6x7_string(decision_record.get("tenant_id"))
+    merchant_id = _c6x7_string(decision_record.get("merchant_id"))
+    decision_kind = _c6x7_string(decision_record.get("decision_kind"))
+    retention_class = _c6x7_string(decision_record.get("retention_class"))
+    generated_at = _c6x7_string(decision_record.get("generated_at"))
+    decided_at = _c6x7_string(decision_record.get("decided_at"))
+    retain_until = _c6x7_string(decision_record.get("retain_until"))
+
+    if not all(
+        (
+            disposition_decision_id,
+            source_summary_id,
+            source_dry_run_id,
+            source_operator_packet_id,
+            tenant_id,
+            merchant_id,
+        )
+    ):
+        return _c6y5_disposition_refusal(
+            status="blocked",
+            refusal_code="disposition_decision_identity_or_scope_missing",
+            message="C6Y5 durable decisions require decision, source, tenant, and merchant identifiers.",
+            decision_record=decision_record,
+        )
+    if decision_kind not in _C6Y5_DECISION_KINDS:
+        return _c6y5_disposition_refusal(
+            status="blocked",
+            refusal_code="decision_kind_invalid",
+            message="C6Y5 stores known future-review disposition decision kinds only.",
+            decision_record=decision_record,
+        )
+    if retention_class not in _C6Y1_RETENTION_DAYS_BY_CLASS:
+        return _c6y5_disposition_refusal(
+            status="blocked",
+            refusal_code="retention_class_invalid",
+            message="C6Y5 stores only supported internal retention classes.",
+            decision_record=decision_record,
+        )
+    parsed_generated_at = _parse_iso(generated_at)
+    parsed_decided_at = _parse_iso(decided_at)
+    parsed_retain_until = _parse_iso(retain_until)
+    if (
+        parsed_generated_at is None
+        or parsed_decided_at is None
+        or parsed_retain_until is None
+        or parsed_generated_at > parsed_decided_at
+        or parsed_generated_at >= parsed_retain_until
+    ):
+        return _c6y5_disposition_refusal(
+            status="blocked",
+            refusal_code="decision_timestamps_invalid",
+            message="C6Y5 durable decisions require ordered generated, decided, and retention timestamps.",
+            decision_record=decision_record,
+        )
+    try:
+        assert_no_forbidden_oacp_artifact_fields(dict(decision_record))
+    except ValueError:
+        return _c6y5_disposition_refusal(
+            status="unsafe",
+            refusal_code="private_or_enabling_decision_field",
+            message="C6Y5 refuses disposition decisions with private, raw, credential, or enabling fields.",
+            decision_record=decision_record,
+        )
+    if not _c6y5_decision_scope_matches(decision_record):
+        return _c6y5_disposition_refusal(
+            status="blocked",
+            refusal_code="decision_scope_mismatch",
+            message="C6Y5 refuses disposition decisions whose direct and summary scopes do not match.",
+            decision_record=decision_record,
+        )
+    if not _c6y5_decision_flags_safe(decision_record):
+        return _c6y5_disposition_refusal(
+            status="unsafe",
+            refusal_code="non_enablement_flags_missing",
+            message="C6Y5 refuses executable, deletion, scheduler, export-writer, or enabling flags.",
+            decision_record=decision_record,
+        )
+    if not _c6x7_reviewer_ref_safe(_c6x7_string(decision_record.get("reviewer_ref"))):
+        return _c6y5_disposition_refusal(
+            status="unsafe",
+            refusal_code="reviewer_identity_not_opaque",
+            message="C6Y5 stores opaque reviewer references only.",
+            decision_record=decision_record,
+        )
+    if not isinstance(decision_record.get("redacted_evidence_ref_count"), int):
+        return _c6y5_disposition_refusal(
+            status="unsafe",
+            refusal_code="redacted_evidence_count_invalid",
+            message="C6Y5 stores redacted evidence reference counts only.",
+            decision_record=decision_record,
+        )
+    labels = tuple(_c6x8_list(decision_record.get("next_step_labels")))
+    if not labels or not _c6y5_labels_safe(labels):
+        return _c6y5_disposition_refusal(
+            status="unsafe",
+            refusal_code="decision_labels_executable_or_private",
+            message="C6Y5 stores label-only next steps, not execution targets.",
+            decision_record=decision_record,
+        )
+    if _c6y1_values_private_or_overclaim(_c6y5_decision_strings(decision_record)):
+        return _c6y5_disposition_refusal(
+            status="unsafe",
+            refusal_code="decision_private_or_overclaiming_values",
+            message="C6Y5 refuses private values, publication wording, or approval/readiness claims.",
+            decision_record=decision_record,
+        )
+    return {
+        "stored": True,
+        "status": "stored",
+        "disposition_decision_id": disposition_decision_id,
+        "source_summary_id": source_summary_id,
+        "source_dry_run_id": source_dry_run_id,
+        "source_operator_packet_id": source_operator_packet_id,
+        "tenant_id": tenant_id,
+        "merchant_id": merchant_id,
+        "decision_kind": decision_kind,
+        "retention_class": retention_class,
+        "retain_until": retain_until,
+        "durable_repository": True,
+        "future_retention_action_allowed": False,
+        "records_deleted": False,
+        "retention_executed": False,
+        "allowed_to_execute": False,
+        "no_execution": True,
+        "retention_disposition_decision_only": True,
+        "durable_disposition_decision_only": True,
+        "export_file_written": False,
+        "export_writer_added": False,
+        "scheduler_added": False,
+        "cli_added": False,
+        "non_authoritative_for_transaction": True,
+        "no_checkout_payment_enablement": True,
+        "no_live_provider_enablement": True,
+        "no_public_discovery_enablement": True,
+        "grantex_runtime_required": False,
+    }
+
+
+def _c6y5_apply_decision_to_row(row: Any, decision_record: Mapping[str, Any]) -> None:
+    row.source_summary_id = cast(str, decision_record["source_summary_id"])
+    row.source_dry_run_id = cast(str, decision_record["source_dry_run_id"])
+    row.source_operator_packet_id = cast(str, decision_record["source_operator_packet_id"])
+    row.tenant_id = cast(str, decision_record["tenant_id"])
+    row.merchant_id = cast(str, decision_record["merchant_id"])
+    row.seller_agent_id = _c6x7_string(decision_record.get("seller_agent_id"))
+    row.buyer_agent_id = _c6x7_string(decision_record.get("buyer_agent_id"))
+    row.generated_at = _parse_iso(cast(str, decision_record["generated_at"]))
+    row.decided_at = _parse_iso(cast(str, decision_record["decided_at"]))
+    row.decision_kind = cast(str, decision_record["decision_kind"])
+    row.retention_class = cast(str, decision_record["retention_class"])
+    row.retain_until = _parse_iso(cast(str, decision_record["retain_until"]))
+    row.manifest_count = int(cast(int, decision_record["manifest_count"]))
+    row.retention_due_count = int(cast(int, decision_record["retention_due_count"]))
+    row.legal_hold_candidate_count = int(cast(int, decision_record["legal_hold_candidate_count"]))
+    row.artifact_family_counts = dict(_c6x8_mapping(decision_record.get("artifact_family_counts")))
+    row.risk_tier_counts = dict(_c6x8_mapping(decision_record.get("risk_tier_counts")))
+    row.blocked_capability_summary = dict(_c6x8_mapping(decision_record.get("blocked_capability_summary")))
+    row.unsupported_capability_summary = dict(_c6x8_mapping(decision_record.get("unsupported_capability_summary")))
+    row.redacted_evidence_ref_count = int(cast(int, decision_record["redacted_evidence_ref_count"]))
+    row.redacted_reason_codes = dict(_c6x8_mapping(decision_record.get("redacted_reason_codes")))
+    row.reviewer_ref = cast(str, decision_record["reviewer_ref"])
+    row.scope_summary = dict(_c6x8_mapping(decision_record.get("scope_summary")))
+    row.next_step_labels = _c6x8_list(decision_record.get("next_step_labels"))
+    row.future_retention_action_allowed = False
+    row.records_deleted = False
+    row.retention_executed = False
+    row.allowed_to_execute = False
+    row.no_execution = True
+    row.retention_disposition_decision_only = True
+    row.durable_disposition_decision_only = True
+    row.export_file_written = False
+    row.export_writer_added = False
+    row.scheduler_added = False
+    row.cli_added = False
+    row.non_authoritative_for_transaction = True
+    row.no_checkout_payment_enablement = True
+    row.no_live_provider_enablement = True
+    row.no_public_discovery_enablement = True
+
+
+def _c6y5_row_to_decision(row: Any) -> dict[str, Any]:
+    return {
+        "decision_record_built": True,
+        "disposition_decision_id": str(row.disposition_decision_id),
+        "source_summary_id": str(row.source_summary_id),
+        "source_dry_run_id": str(row.source_dry_run_id),
+        "source_operator_packet_id": str(row.source_operator_packet_id),
+        "tenant_id": str(row.tenant_id),
+        "merchant_id": str(row.merchant_id),
+        "seller_agent_id": None if row.seller_agent_id is None else str(row.seller_agent_id),
+        "buyer_agent_id": None if row.buyer_agent_id is None else str(row.buyer_agent_id),
+        "generated_at": _c6y2_row_time(row.generated_at),
+        "decided_at": _c6y2_row_time(row.decided_at),
+        "decision_kind": str(row.decision_kind),
+        "retention_class": str(row.retention_class),
+        "retain_until": _c6y2_row_time(row.retain_until),
+        "manifest_count": int(row.manifest_count),
+        "retention_due_count": int(row.retention_due_count),
+        "legal_hold_candidate_count": int(row.legal_hold_candidate_count),
+        "artifact_family_counts": dict(row.artifact_family_counts or {}),
+        "risk_tier_counts": dict(row.risk_tier_counts or {}),
+        "blocked_capability_summary": dict(row.blocked_capability_summary or {}),
+        "unsupported_capability_summary": dict(row.unsupported_capability_summary or {}),
+        "redacted_evidence_ref_count": int(row.redacted_evidence_ref_count),
+        "redacted_reason_codes": dict(row.redacted_reason_codes or {}),
+        "reviewer_ref": str(row.reviewer_ref),
+        "scope_summary": dict(row.scope_summary or {}),
+        "next_step_labels": list(row.next_step_labels or []),
+        "status": "recorded_for_future_review",
+        "future_retention_action_allowed": bool(row.future_retention_action_allowed),
+        "records_deleted": bool(row.records_deleted),
+        "retention_executed": bool(row.retention_executed),
+        "allowed_to_execute": bool(row.allowed_to_execute),
+        "no_execution": bool(row.no_execution),
+        "retention_disposition_decision_only": bool(row.retention_disposition_decision_only),
+        "durable_disposition_decision_only": bool(row.durable_disposition_decision_only),
+        "export_file_written": bool(row.export_file_written),
+        "export_writer_added": bool(row.export_writer_added),
+        "scheduler_added": bool(row.scheduler_added),
+        "cli_added": bool(row.cli_added),
+        "non_authoritative_for_transaction": bool(row.non_authoritative_for_transaction),
+        "no_checkout_payment_enablement": bool(row.no_checkout_payment_enablement),
+        "no_live_provider_enablement": bool(row.no_live_provider_enablement),
+        "no_public_discovery_enablement": bool(row.no_public_discovery_enablement),
+        "grantex_runtime_required": False,
+        "operator_safe_message": (
+            "C6Y5 stores a redacted retention disposition decision only; it does not delete records."
+        ),
+    }
+
+
+def _c6y5_query_matches(
+    decision_record: Mapping[str, Any],
+    query: OacpRetentionDispositionDecisionRepositoryQuery,
+) -> bool:
+    retain_until = _parse_iso(_c6x7_string(decision_record.get("retain_until")))
+    decided_at = _parse_iso(_c6x7_string(decision_record.get("decided_at")))
+    retain_until_before = _parse_iso(query.retain_until_before)
+    retain_until_after = _parse_iso(query.retain_until_after)
+    decided_at_before = _parse_iso(query.decided_at_before)
+    decided_at_after = _parse_iso(query.decided_at_after)
+    return (
+        (query.tenant_id is None or decision_record.get("tenant_id") == query.tenant_id)
+        and (query.merchant_id is None or decision_record.get("merchant_id") == query.merchant_id)
+        and (query.seller_agent_id is None or decision_record.get("seller_agent_id") == query.seller_agent_id)
+        and (query.buyer_agent_id is None or decision_record.get("buyer_agent_id") == query.buyer_agent_id)
+        and (query.decision_kind is None or decision_record.get("decision_kind") == query.decision_kind)
+        and (query.source_summary_id is None or decision_record.get("source_summary_id") == query.source_summary_id)
+        and (query.source_dry_run_id is None or decision_record.get("source_dry_run_id") == query.source_dry_run_id)
+        and (
+            query.source_operator_packet_id is None
+            or decision_record.get("source_operator_packet_id") == query.source_operator_packet_id
+        )
+        and (query.retention_class is None or decision_record.get("retention_class") == query.retention_class)
+        and (
+            query.retain_until_before is None
+            or (retain_until is not None and retain_until_before is not None and retain_until <= retain_until_before)
+        )
+        and (
+            query.retain_until_after is None
+            or (retain_until is not None and retain_until_after is not None and retain_until >= retain_until_after)
+        )
+        and (
+            query.decided_at_before is None
+            or (decided_at is not None and decided_at_before is not None and decided_at <= decided_at_before)
+        )
+        and (
+            query.decided_at_after is None
+            or (decided_at is not None and decided_at_after is not None and decided_at >= decided_at_after)
+        )
+    )
+
+
+class DurableOacpRetentionDispositionDecisionRepository:
+    """Async SQLAlchemy-backed retention disposition decision repository; it executes nothing."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def upsert_disposition_decision(self, decision_record: Mapping[str, Any]) -> dict[str, Any]:
+        from core.models.oacp_retention_disposition_decision import OacpRetentionDispositionDecisionRecordRow
+
+        store_result = _c6y5_disposition_decision_safe_for_storage(decision_record)
+        if store_result["stored"] is not True:
+            return store_result
+
+        disposition_decision_id = cast(str, store_result["disposition_decision_id"])
+        row = await self._session.get(OacpRetentionDispositionDecisionRecordRow, disposition_decision_id)
+        if row is None:
+            row = OacpRetentionDispositionDecisionRecordRow(disposition_decision_id=disposition_decision_id)
+            self._session.add(row)
+        _c6y5_apply_decision_to_row(row, decision_record)
+        await self._session.flush()
+        return store_result
+
+    async def get_disposition_decision(self, disposition_decision_id: str) -> dict[str, Any] | None:
+        from core.models.oacp_retention_disposition_decision import OacpRetentionDispositionDecisionRecordRow
+
+        row = await self._session.get(OacpRetentionDispositionDecisionRecordRow, disposition_decision_id)
+        return None if row is None else _c6y5_row_to_decision(row)
+
+    async def list_disposition_decisions_for_scope(
+        self,
+        query: OacpRetentionDispositionDecisionRepositoryQuery,
+    ) -> tuple[dict[str, Any], ...]:
+        from sqlalchemy import select
+
+        from core.models.oacp_retention_disposition_decision import OacpRetentionDispositionDecisionRecordRow
+
+        statement = select(OacpRetentionDispositionDecisionRecordRow)
+        if query.tenant_id is not None:
+            statement = statement.where(OacpRetentionDispositionDecisionRecordRow.tenant_id == query.tenant_id)
+        if query.merchant_id is not None:
+            statement = statement.where(OacpRetentionDispositionDecisionRecordRow.merchant_id == query.merchant_id)
+        if query.seller_agent_id is not None:
+            statement = statement.where(
+                OacpRetentionDispositionDecisionRecordRow.seller_agent_id == query.seller_agent_id
+            )
+        if query.buyer_agent_id is not None:
+            statement = statement.where(
+                OacpRetentionDispositionDecisionRecordRow.buyer_agent_id == query.buyer_agent_id
+            )
+        if query.decision_kind is not None:
+            statement = statement.where(OacpRetentionDispositionDecisionRecordRow.decision_kind == query.decision_kind)
+        if query.source_summary_id is not None:
+            statement = statement.where(
+                OacpRetentionDispositionDecisionRecordRow.source_summary_id == query.source_summary_id
+            )
+        if query.source_dry_run_id is not None:
+            statement = statement.where(
+                OacpRetentionDispositionDecisionRecordRow.source_dry_run_id == query.source_dry_run_id
+            )
+        if query.source_operator_packet_id is not None:
+            statement = statement.where(
+                OacpRetentionDispositionDecisionRecordRow.source_operator_packet_id == query.source_operator_packet_id
+            )
+        if query.retention_class is not None:
+            statement = statement.where(
+                OacpRetentionDispositionDecisionRecordRow.retention_class == query.retention_class
+            )
+        if query.retain_until_before is not None and (parsed := _parse_iso(query.retain_until_before)) is not None:
+            statement = statement.where(OacpRetentionDispositionDecisionRecordRow.retain_until <= parsed)
+        if query.retain_until_after is not None and (parsed := _parse_iso(query.retain_until_after)) is not None:
+            statement = statement.where(OacpRetentionDispositionDecisionRecordRow.retain_until >= parsed)
+        if query.decided_at_before is not None and (parsed := _parse_iso(query.decided_at_before)) is not None:
+            statement = statement.where(OacpRetentionDispositionDecisionRecordRow.decided_at <= parsed)
+        if query.decided_at_after is not None and (parsed := _parse_iso(query.decided_at_after)) is not None:
+            statement = statement.where(OacpRetentionDispositionDecisionRecordRow.decided_at >= parsed)
+
+        rows = (
+            await self._session.scalars(
+                statement.order_by(OacpRetentionDispositionDecisionRecordRow.disposition_decision_id)
+            )
+        ).all()
+        decisions = tuple(_c6y5_row_to_decision(row) for row in rows)
+        return tuple(decision for decision in decisions if _c6y5_query_matches(decision, query))
+
+    async def evaluate_disposition_decision_for_future_review(self, disposition_decision_id: str) -> dict[str, Any]:
+        decision_record = await self.get_disposition_decision(disposition_decision_id)
+        if decision_record is None:
+            return _c6y5_disposition_refusal(
+                status="blocked",
+                refusal_code="disposition_decision_missing",
+                message="C6Y5 requires a stored disposition decision before future review evaluation.",
+            )
+        store_result = _c6y5_disposition_decision_safe_for_storage(decision_record)
+        if store_result["stored"] is not True:
+            return store_result
+        return {
+            "evaluated": True,
+            "status": "future_retention_review_requires_separate_action",
+            "disposition_decision_id": disposition_decision_id,
+            "source_summary_id": decision_record["source_summary_id"],
+            "source_dry_run_id": decision_record["source_dry_run_id"],
+            "source_operator_packet_id": decision_record["source_operator_packet_id"],
+            "decision_kind": decision_record["decision_kind"],
+            "retention_class": decision_record["retention_class"],
+            "future_retention_action_allowed": False,
+            "records_deleted": False,
+            "retention_executed": False,
+            "allowed_to_execute": False,
+            "no_execution": True,
+            "retention_disposition_decision_only": True,
+            "durable_disposition_decision_only": True,
+            "export_file_written": False,
+            "export_writer_added": False,
+            "scheduler_added": False,
+            "cli_added": False,
+            "non_authoritative_for_transaction": True,
+            "no_checkout_payment_enablement": True,
+            "no_live_provider_enablement": True,
+            "no_public_discovery_enablement": True,
+            "grantex_runtime_required": False,
+            "message": "C6Y5 stores a disposition decision only; it does not execute retention or delete records.",
+        }
 
 
 class DurableOacpAuditReviewManifestRepository:

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -61,6 +61,9 @@ from core.models.oacp_audit_review_manifest import (
     OacpAuditReviewManifestRecordRow as OacpAuditReviewManifestRecordRow,
 )
 from core.models.oacp_operator_decision import OacpOperatorDecisionRecordRow as OacpOperatorDecisionRecordRow
+from core.models.oacp_retention_disposition_decision import (
+    OacpRetentionDispositionDecisionRecordRow as OacpRetentionDispositionDecisionRecordRow,
+)
 from core.models.organization import CostCenter as CostCenter
 from core.models.organization import Department as Department
 from core.models.professional_tax import ProfessionalTaxRegistration as ProfessionalTaxRegistration

--- a/core/models/oacp_retention_disposition_decision.py
+++ b/core/models/oacp_retention_disposition_decision.py
@@ -1,0 +1,110 @@
+"""Durable OACP retention disposition decision model.
+
+The table stores only redacted, audit-safe retention disposition decision
+metadata for AgenticOrg internal review. It does not execute retention, delete
+records, write export files, schedule work, or provide transaction authority.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import JSON, TIMESTAMP, Boolean, Index, Integer, String, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.models.base import BaseModel
+
+OACP_RETENTION_DISPOSITION_DECISION_JSON = JSONB().with_variant(JSON(), "sqlite")
+
+
+class OacpRetentionDispositionDecisionRecordRow(BaseModel):
+    __tablename__ = "oacp_retention_disposition_decision_records"
+    __table_args__ = (
+        Index("ix_oacp_retention_disposition_decision_tenant_id", "tenant_id"),
+        Index("ix_oacp_retention_disposition_decision_merchant_id", "merchant_id"),
+        Index("ix_oacp_retention_disposition_decision_seller_agent_id", "seller_agent_id"),
+        Index("ix_oacp_retention_disposition_decision_buyer_agent_id", "buyer_agent_id"),
+        Index("ix_oacp_retention_disposition_decision_kind", "decision_kind"),
+        Index("ix_oacp_retention_disposition_decision_summary_id", "source_summary_id"),
+        Index("ix_oacp_retention_disposition_decision_dry_run_id", "source_dry_run_id"),
+        Index("ix_oacp_retention_disposition_decision_packet_id", "source_operator_packet_id"),
+        Index("ix_oacp_retention_disposition_decision_retention_class", "retention_class"),
+        Index("ix_oacp_retention_disposition_decision_retain_until", "retain_until"),
+        Index("ix_oacp_retention_disposition_decision_decided_at", "decided_at"),
+    )
+
+    disposition_decision_id: Mapped[str] = mapped_column(String(180), primary_key=True)
+    source_summary_id: Mapped[str] = mapped_column(String(180), nullable=False)
+    source_dry_run_id: Mapped[str] = mapped_column(String(180), nullable=False)
+    source_operator_packet_id: Mapped[str] = mapped_column(String(180), nullable=False)
+    tenant_id: Mapped[str] = mapped_column(String(160), nullable=False)
+    merchant_id: Mapped[str] = mapped_column(String(160), nullable=False)
+    seller_agent_id: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    buyer_agent_id: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    generated_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    decided_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    decision_kind: Mapped[str] = mapped_column(String(64), nullable=False)
+    retention_class: Mapped[str] = mapped_column(String(64), nullable=False)
+    retain_until: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    manifest_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    retention_due_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    legal_hold_candidate_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    artifact_family_counts: Mapped[dict[str, object]] = mapped_column(
+        OACP_RETENTION_DISPOSITION_DECISION_JSON,
+        nullable=False,
+        default=dict,
+    )
+    risk_tier_counts: Mapped[dict[str, object]] = mapped_column(
+        OACP_RETENTION_DISPOSITION_DECISION_JSON,
+        nullable=False,
+        default=dict,
+    )
+    blocked_capability_summary: Mapped[dict[str, object]] = mapped_column(
+        OACP_RETENTION_DISPOSITION_DECISION_JSON,
+        nullable=False,
+        default=dict,
+    )
+    unsupported_capability_summary: Mapped[dict[str, object]] = mapped_column(
+        OACP_RETENTION_DISPOSITION_DECISION_JSON,
+        nullable=False,
+        default=dict,
+    )
+    redacted_evidence_ref_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    redacted_reason_codes: Mapped[dict[str, object]] = mapped_column(
+        OACP_RETENTION_DISPOSITION_DECISION_JSON,
+        nullable=False,
+        default=dict,
+    )
+    reviewer_ref: Mapped[str] = mapped_column(String(160), nullable=False)
+    scope_summary: Mapped[dict[str, object]] = mapped_column(
+        OACP_RETENTION_DISPOSITION_DECISION_JSON,
+        nullable=False,
+        default=dict,
+    )
+    next_step_labels: Mapped[list[str]] = mapped_column(
+        OACP_RETENTION_DISPOSITION_DECISION_JSON,
+        nullable=False,
+        default=list,
+    )
+    future_retention_action_allowed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    records_deleted: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    retention_executed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    allowed_to_execute: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    no_execution: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    retention_disposition_decision_only: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    durable_disposition_decision_only: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    export_file_written: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    export_writer_added: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    scheduler_added: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    cli_added: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    non_authoritative_for_transaction: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    no_checkout_payment_enablement: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    no_live_provider_enablement: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    no_public_discovery_enablement: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
+    updated_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=True,
+        onupdate=func.now(),
+    )

--- a/docs/reports/commerce-agent-c6y5-oacp-retention-disposition-decisions.md
+++ b/docs/reports/commerce-agent-c6y5-oacp-retention-disposition-decisions.md
@@ -24,7 +24,7 @@ C6Y5 implements persistence because AgenticOrg already has the same safe pattern
 - C6X8 durable operator decision records
 - C6Y2 durable audit review manifest records
 
-The new Alembic migration is `v6y5_retention_decisions` and depends on `v6y3_industry_pack_uuid_default`, the current migration head in this branch. It adds one narrow table, tenant-safe indexes, a uniqueness guard for packet/kind/reviewer scope, rollback, and RLS.
+The new Alembic migration is `v6y5_retention_decisions` and depends on `v6y4_repair_a2a_tasks`, the current migration head in this branch. It adds one narrow table, tenant-safe indexes, a uniqueness guard for packet/kind/reviewer scope, rollback, and RLS.
 
 ## Durable Repository Contract
 

--- a/docs/reports/commerce-agent-c6y5-oacp-retention-disposition-decisions.md
+++ b/docs/reports/commerce-agent-c6y5-oacp-retention-disposition-decisions.md
@@ -24,7 +24,7 @@ C6Y5 implements persistence because AgenticOrg already has the same safe pattern
 - C6X8 durable operator decision records
 - C6Y2 durable audit review manifest records
 
-The new Alembic migration is `v6y5_oacp_retention_disposition_decisions` and depends on `v6y3_industry_pack_uuid_default`, the current migration head in this branch. It adds one narrow table, tenant-safe indexes, a uniqueness guard for packet/kind/reviewer scope, rollback, and RLS.
+The new Alembic migration is `v6y5_retention_decisions` and depends on `v6y3_industry_pack_uuid_default`, the current migration head in this branch. It adds one narrow table, tenant-safe indexes, a uniqueness guard for packet/kind/reviewer scope, rollback, and RLS.
 
 ## Durable Repository Contract
 

--- a/docs/reports/commerce-agent-c6y5-oacp-retention-disposition-decisions.md
+++ b/docs/reports/commerce-agent-c6y5-oacp-retention-disposition-decisions.md
@@ -1,0 +1,146 @@
+# C6Y5 OACP Retention Disposition Decisions
+
+## Scope
+
+C6Y5 adds durable AgenticOrg retention disposition decision records over C6Y4 retention disposition dry-runs and operator review packets. The slice stores redacted, audit-safe decision metadata only.
+
+This does not execute retention, delete records, purge records, redact persisted records, write export files, schedule jobs, call Grantex live, call providers, call merchant systems, expose APIs, or publish OACP.
+
+## Correct Ownership Model
+
+AgenticOrg is the buyer and seller AI-agent runtime. AgenticOrg owns durable/local OACP artifact cache behavior, local operator decision handling, audit export bundle generation, audit review manifest handling, manifest query/summary behavior, and retention disposition review.
+
+AgenticOrg owns retention disposition review and stores these disposition decisions locally for internal operator review.
+
+Grantex remains the trust, protocol, policy, and canonical OACP artifact authority. Grantex does not become a transaction toll booth for non-binding buyer/seller agent interactions, audit review summaries, retention disposition dry-runs, operator packets, or disposition decisions.
+
+Merchant systems remain operational sources of record. Provider and fintech rails own mandate and payment execution where separately approved.
+
+## Persistence Decision
+
+C6Y5 implements persistence because AgenticOrg already has the same safe pattern for internal OACP records:
+
+- C6X4 durable artifact cache records
+- C6X8 durable operator decision records
+- C6Y2 durable audit review manifest records
+
+The new Alembic migration is `v6y5_oacp_retention_disposition_decisions` and depends on `v6y3_industry_pack_uuid_default`, the current migration head in this branch. It adds one narrow table, tenant-safe indexes, a uniqueness guard for packet/kind/reviewer scope, rollback, and RLS.
+
+## Durable Repository Contract
+
+The C6Y5 repository methods are:
+
+- `upsert_disposition_decision`
+- `get_disposition_decision`
+- `list_disposition_decisions_for_scope`
+- `evaluate_disposition_decision_for_future_review`
+
+Evaluation is non-executing. It can say that future retention review needs a separate action, but it cannot delete, purge, redact, export, schedule, call Grantex, call providers, or call merchant private APIs.
+
+## Stored Fields
+
+C6Y5 stores redacted decision metadata:
+
+- disposition_decision_id
+- source_summary_id
+- source_dry_run_id
+- source_operator_packet_id
+- tenant_id and merchant_id
+- seller_agent_id and buyer_agent_id when applicable
+- generated_at, decided_at, retention_class, and retain_until
+- decision_kind
+- manifest_count, retention_due_count, and legal_hold_candidate_count
+- artifact_family_counts and risk_tier_counts
+- blocked and unsupported capability summaries
+- redacted_evidence_ref_count only
+- redacted reason codes
+- opaque reviewer_ref only
+- next_step_labels
+- non-enablement flags
+- allowed_to_execute = false
+- future_retention_action_allowed = false
+- records_deleted = false
+- retention_executed = false
+- non_authoritative_for_transaction = true
+
+Decision kinds are limited to:
+
+- approve_future_retention_review
+- approve_future_redaction_review
+- approve_future_legal_hold_review
+- request_more_evidence
+- reject_disposition
+- defer_until_recheck
+- block_unsafe_disposition
+
+The `approve_future_*` labels are review labels only. They are not merchant, Grantex, checkout, payment, mandate, live-provider, production, certification, compliance, conformance, standardization, or public launch decisions.
+
+## Fail-Closed Persistence And Evaluation
+
+C6Y5 refuses storage when:
+
+- disposition_decision_id, source_summary_id, source_dry_run_id, source_operator_packet_id, tenant_id, or merchant_id is missing
+- decision_kind or retention_class is not supported
+- generated_at, decided_at, or retain_until is malformed or impossible
+- dry-run and operator-packet scope does not match
+- raw or private refs appear
+- reviewer_ref is a raw email, phone, token, credential, or non-opaque value
+- executable or action-target fields appear
+- export writer, scheduler, worker, queue, CLI, deletion, purge, or retention execution flags appear
+- non-enablement flags are false
+- public discovery, payment, live rail, provider, private API, publication, approval, or readiness wording appears outside negative guardrail wording
+
+Failed evaluations return blocked, non-executing records with `allowed_to_execute = false`, `future_retention_action_allowed = false`, `records_deleted = false`, and `retention_executed = false`.
+
+## Migration Safety
+
+The migration is narrow and tenant safe:
+
+- one new internal table
+- no runtime schema mutation
+- no production config
+- no public endpoint
+- tenant_id and merchant_id are required
+- seller_agent_id and buyer_agent_id are indexed when present
+- source_summary_id, source_dry_run_id, source_operator_packet_id, decision_kind, retention_class, retain_until, and decided_at are indexed
+- unique guard prevents duplicate active decision records for the same tenant/merchant/seller/buyer/operator packet/decision kind/reviewer
+- RLS is enabled and forced with `agenticorg.tenant_id`
+- rollback drops the RLS policy, indexes, and table
+
+The table stores no source-of-record merchant data, provider data, payment data, card data, bank data, raw customer data, raw artifact payloads, raw connector payloads, or credentials.
+
+## Guardrails
+
+C6Y5 remains:
+
+- internal-only
+- non-publication
+- non-certifying
+- non-production
+- non-executing
+- fail-closed
+- export-writer-free
+- scheduler-free
+- CLI-free
+- endpoint-free
+- non-authoritative for transactions
+
+It keeps:
+
+- allowed_to_execute = false
+- future_retention_action_allowed = false
+- records_deleted = false
+- retention_executed = false
+- no_checkout_payment_enablement = true
+- no_live_provider_enablement = true
+- no_public_discovery_enablement = true
+
+## What C6Y5 Does Not Enable
+
+C6Y5 does not execute retention, delete records, purge records, redact persisted records, write export files, create jobs, schedule jobs, expose endpoints, add public OpenAPI runtime contracts, create orders, create holds, capture payments, create mandates, issue refunds, process returns, create shipments, call providers, call carriers, call shipping providers, call merchant private APIs, call Grantex live endpoints, publish OACP, submit protocols externally, or enable public discovery.
+
+C6Y5 does not claim certification, compliance, conformance, standardization, production readiness, public launch readiness, merchant approval, checkout approval, payment approval, mandate approval, live-provider readiness, or OACP approval.
+
+## Future Work
+
+A future approved slice may add an internal operator UI or a separate retention execution controller. That future work must remain separately reviewed and must not infer execution authority from C6Y5 decision records.

--- a/migrations/versions/v6_y5_oacp_retention_disposition_decisions.py
+++ b/migrations/versions/v6_y5_oacp_retention_disposition_decisions.py
@@ -1,0 +1,209 @@
+"""C6Y5 durable OACP retention disposition decision records.
+
+Revision ID: v6y5_oacp_retention_disposition_decisions
+Revises: v6y3_industry_pack_uuid_default
+Create Date: 2026-06-14
+
+This table is an AgenticOrg-owned internal retention disposition decision
+repository. It stores only redacted, audit-safe decision metadata over C6Y4
+dry-runs and operator review packets. It does not execute retention, delete or
+purge records, write export files, schedule work, call Grantex live, call
+providers, call merchant private APIs, or provide transaction authority.
+
+Rollback: drop the disposition decision table, indexes, unique scope guard, and
+RLS policy. No merchant source-of-record, provider, payment, checkout, export
+file, retention execution, or canonical Grantex artifact state is stored here.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v6y5_oacp_retention_disposition_decisions"
+down_revision = "v6y3_industry_pack_uuid_default"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS oacp_retention_disposition_decision_records (
+            disposition_decision_id VARCHAR(180) PRIMARY KEY,
+            source_summary_id VARCHAR(180) NOT NULL,
+            source_dry_run_id VARCHAR(180) NOT NULL,
+            source_operator_packet_id VARCHAR(180) NOT NULL,
+            tenant_id VARCHAR(160) NOT NULL,
+            merchant_id VARCHAR(160) NOT NULL,
+            seller_agent_id VARCHAR(160),
+            buyer_agent_id VARCHAR(160),
+            generated_at TIMESTAMPTZ NOT NULL,
+            decided_at TIMESTAMPTZ NOT NULL,
+            decision_kind VARCHAR(64) NOT NULL,
+            retention_class VARCHAR(64) NOT NULL,
+            retain_until TIMESTAMPTZ NOT NULL,
+            manifest_count INTEGER NOT NULL DEFAULT 0,
+            retention_due_count INTEGER NOT NULL DEFAULT 0,
+            legal_hold_candidate_count INTEGER NOT NULL DEFAULT 0,
+            artifact_family_counts JSONB NOT NULL DEFAULT '{}'::jsonb,
+            risk_tier_counts JSONB NOT NULL DEFAULT '{}'::jsonb,
+            blocked_capability_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+            unsupported_capability_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+            redacted_evidence_ref_count INTEGER NOT NULL DEFAULT 0,
+            redacted_reason_codes JSONB NOT NULL DEFAULT '{}'::jsonb,
+            reviewer_ref VARCHAR(160) NOT NULL,
+            scope_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+            next_step_labels JSONB NOT NULL DEFAULT '[]'::jsonb,
+            future_retention_action_allowed BOOLEAN NOT NULL DEFAULT FALSE,
+            records_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+            retention_executed BOOLEAN NOT NULL DEFAULT FALSE,
+            allowed_to_execute BOOLEAN NOT NULL DEFAULT FALSE,
+            no_execution BOOLEAN NOT NULL DEFAULT TRUE,
+            retention_disposition_decision_only BOOLEAN NOT NULL DEFAULT TRUE,
+            durable_disposition_decision_only BOOLEAN NOT NULL DEFAULT TRUE,
+            export_file_written BOOLEAN NOT NULL DEFAULT FALSE,
+            export_writer_added BOOLEAN NOT NULL DEFAULT FALSE,
+            scheduler_added BOOLEAN NOT NULL DEFAULT FALSE,
+            cli_added BOOLEAN NOT NULL DEFAULT FALSE,
+            non_authoritative_for_transaction BOOLEAN NOT NULL DEFAULT TRUE,
+            no_checkout_payment_enablement BOOLEAN NOT NULL DEFAULT TRUE,
+            no_live_provider_enablement BOOLEAN NOT NULL DEFAULT TRUE,
+            no_public_discovery_enablement BOOLEAN NOT NULL DEFAULT TRUE,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ,
+            CONSTRAINT ck_oacp_retention_disposition_decision_kind
+                CHECK (
+                    decision_kind IN (
+                        'approve_future_retention_review',
+                        'approve_future_redaction_review',
+                        'approve_future_legal_hold_review',
+                        'request_more_evidence',
+                        'reject_disposition',
+                        'defer_until_recheck',
+                        'block_unsafe_disposition'
+                    )
+                ),
+            CONSTRAINT ck_oacp_retention_disposition_decision_retention_class
+                CHECK (
+                    retention_class IN (
+                        'short_lived_internal_review',
+                        'standard_internal_review',
+                        'legal_hold_candidate'
+                    )
+                ),
+            CONSTRAINT ck_oacp_retention_disposition_decision_counts CHECK (
+                manifest_count >= 0
+                AND retention_due_count >= 0
+                AND legal_hold_candidate_count >= 0
+                AND redacted_evidence_ref_count >= 0
+            ),
+            CONSTRAINT ck_oacp_retention_disposition_decision_reviewer_ref
+                CHECK (reviewer_ref LIKE 'operator_ref_%' OR reviewer_ref LIKE 'reviewer_ref_%'),
+            CONSTRAINT ck_oacp_retention_disposition_decision_ordered_timestamps
+                CHECK (generated_at <= decided_at AND generated_at < retain_until),
+            CONSTRAINT ck_oacp_retention_disposition_decision_non_execution_flags CHECK (
+                future_retention_action_allowed IS FALSE
+                AND records_deleted IS FALSE
+                AND retention_executed IS FALSE
+                AND allowed_to_execute IS FALSE
+                AND no_execution IS TRUE
+                AND retention_disposition_decision_only IS TRUE
+                AND durable_disposition_decision_only IS TRUE
+                AND export_file_written IS FALSE
+                AND export_writer_added IS FALSE
+                AND scheduler_added IS FALSE
+                AND cli_added IS FALSE
+                AND non_authoritative_for_transaction IS TRUE
+                AND no_checkout_payment_enablement IS TRUE
+                AND no_live_provider_enablement IS TRUE
+                AND no_public_discovery_enablement IS TRUE
+            )
+        );
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_retention_disposition_decision_tenant_id "
+        "ON oacp_retention_disposition_decision_records (tenant_id);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_retention_disposition_decision_merchant_id "
+        "ON oacp_retention_disposition_decision_records (merchant_id);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_retention_disposition_decision_seller_agent_id "
+        "ON oacp_retention_disposition_decision_records (seller_agent_id);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_retention_disposition_decision_buyer_agent_id "
+        "ON oacp_retention_disposition_decision_records (buyer_agent_id);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_retention_disposition_decision_kind "
+        "ON oacp_retention_disposition_decision_records (decision_kind);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_retention_disposition_decision_summary_id "
+        "ON oacp_retention_disposition_decision_records (source_summary_id);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_retention_disposition_decision_dry_run_id "
+        "ON oacp_retention_disposition_decision_records (source_dry_run_id);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_retention_disposition_decision_packet_id "
+        "ON oacp_retention_disposition_decision_records (source_operator_packet_id);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_retention_disposition_decision_retention_class "
+        "ON oacp_retention_disposition_decision_records (retention_class);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_retention_disposition_decision_retain_until "
+        "ON oacp_retention_disposition_decision_records (retain_until);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oacp_retention_disposition_decision_decided_at "
+        "ON oacp_retention_disposition_decision_records (decided_at);"
+    )
+    op.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_oacp_retention_disposition_decision_packet_kind_reviewer
+            ON oacp_retention_disposition_decision_records (
+                tenant_id,
+                merchant_id,
+                COALESCE(seller_agent_id, ''),
+                COALESCE(buyer_agent_id, ''),
+                source_operator_packet_id,
+                decision_kind,
+                reviewer_ref
+            );
+    """)
+    op.execute("ALTER TABLE oacp_retention_disposition_decision_records ENABLE ROW LEVEL SECURITY;")
+    op.execute("ALTER TABLE oacp_retention_disposition_decision_records FORCE ROW LEVEL SECURITY;")
+    op.execute(
+        "DROP POLICY IF EXISTS oacp_retention_disposition_decision_records_tenant_isolation "
+        "ON oacp_retention_disposition_decision_records;"
+    )
+    op.execute("""
+        CREATE POLICY oacp_retention_disposition_decision_records_tenant_isolation
+            ON oacp_retention_disposition_decision_records
+            USING (tenant_id = current_setting('agenticorg.tenant_id', true))
+            WITH CHECK (tenant_id = current_setting('agenticorg.tenant_id', true));
+    """)
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP POLICY IF EXISTS oacp_retention_disposition_decision_records_tenant_isolation "
+        "ON oacp_retention_disposition_decision_records;"
+    )
+    op.execute("DROP INDEX IF EXISTS uq_oacp_retention_disposition_decision_packet_kind_reviewer;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_retention_disposition_decision_decided_at;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_retention_disposition_decision_retain_until;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_retention_disposition_decision_retention_class;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_retention_disposition_decision_packet_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_retention_disposition_decision_dry_run_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_retention_disposition_decision_summary_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_retention_disposition_decision_kind;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_retention_disposition_decision_buyer_agent_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_retention_disposition_decision_seller_agent_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_retention_disposition_decision_merchant_id;")
+    op.execute("DROP INDEX IF EXISTS ix_oacp_retention_disposition_decision_tenant_id;")
+    op.execute("DROP TABLE IF EXISTS oacp_retention_disposition_decision_records;")

--- a/migrations/versions/v6_y5_oacp_retention_disposition_decisions.py
+++ b/migrations/versions/v6_y5_oacp_retention_disposition_decisions.py
@@ -1,6 +1,6 @@
 """C6Y5 durable OACP retention disposition decision records.
 
-Revision ID: v6y5_oacp_retention_disposition_decisions
+Revision ID: v6y5_retention_decisions
 Revises: v6y3_industry_pack_uuid_default
 Create Date: 2026-06-14
 
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from alembic import op
 
-revision = "v6y5_oacp_retention_disposition_decisions"
+revision = "v6y5_retention_decisions"
 down_revision = "v6y3_industry_pack_uuid_default"
 branch_labels = None
 depends_on = None

--- a/migrations/versions/v6_y5_oacp_retention_disposition_decisions.py
+++ b/migrations/versions/v6_y5_oacp_retention_disposition_decisions.py
@@ -1,7 +1,7 @@
 """C6Y5 durable OACP retention disposition decision records.
 
 Revision ID: v6y5_retention_decisions
-Revises: v6y3_industry_pack_uuid_default
+Revises: v6y4_repair_a2a_tasks
 Create Date: 2026-06-14
 
 This table is an AgenticOrg-owned internal retention disposition decision
@@ -20,7 +20,7 @@ from __future__ import annotations
 from alembic import op
 
 revision = "v6y5_retention_decisions"
-down_revision = "v6y3_industry_pack_uuid_default"
+down_revision = "v6y4_repair_a2a_tasks"
 branch_labels = None
 depends_on = None
 

--- a/tests/unit/test_oacp_c6y5_retention_disposition_decisions.py
+++ b/tests/unit/test_oacp_c6y5_retention_disposition_decisions.py
@@ -301,7 +301,7 @@ def test_c6y5_migration_has_tenant_safe_rls_and_non_execution_guards() -> None:
     for expected in (
         "revision = \"v6y5_retention_decisions\"",
         "CREATE TABLE IF NOT EXISTS oacp_retention_disposition_decision_records",
-        "down_revision = \"v6y3_industry_pack_uuid_default\"",
+        "down_revision = \"v6y4_repair_a2a_tasks\"",
         "ix_oacp_retention_disposition_decision_tenant_id",
         "ix_oacp_retention_disposition_decision_merchant_id",
         "ix_oacp_retention_disposition_decision_seller_agent_id",

--- a/tests/unit/test_oacp_c6y5_retention_disposition_decisions.py
+++ b/tests/unit/test_oacp_c6y5_retention_disposition_decisions.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from core.commerce.oacp_artifacts import (
+    DurableOacpRetentionDispositionDecisionRepository,
+    OacpArtifactCacheRepositoryQuery,
+    OacpAuditReviewManifestRepositoryQuery,
+    OacpPersistentArtifactCacheRecord,
+    OacpRetentionDispositionDecisionRepositoryQuery,
+    build_oacp_c6x9_audit_export_bundle,
+    build_oacp_c6y1_audit_export_review_manifest,
+    build_oacp_c6y3_audit_review_manifest_summary,
+    build_oacp_c6y4_retention_disposition_dry_run,
+    build_oacp_c6y4_retention_operator_review_packet,
+    build_oacp_c6y5_retention_disposition_decision_record,
+    build_oacp_cache_maintenance_dry_run_report,
+    build_oacp_cache_operator_decision_record,
+    plan_oacp_artifact_cache_maintenance,
+)
+from core.models.oacp_retention_disposition_decision import OacpRetentionDispositionDecisionRecordRow
+
+C6Y5_DOC_PATH = Path("docs/reports/commerce-agent-c6y5-oacp-retention-disposition-decisions.md")
+C6Y5_MIGRATION_PATH = Path("migrations/versions/v6_y5_oacp_retention_disposition_decisions.py")
+
+
+def _doc() -> str:
+    return C6Y5_DOC_PATH.read_text(encoding="utf-8")
+
+
+def _migration() -> str:
+    return C6Y5_MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+def _record(**overrides: object) -> OacpPersistentArtifactCacheRecord:
+    base = OacpPersistentArtifactCacheRecord(
+        cache_record_id="cache_price_C6Y5",
+        artifact_id="price_C6W3",
+        artifact_type="price",
+        authority="grantex_canonical_oacp_artifact_authority",
+        issuer="grantex",
+        scope_kind="buyer_agent",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+        source_refs=("source_ref_price_C6Y5",),
+        evidence_refs=("evidence_price_C6Y5_redacted",),
+        generated_at="2026-06-12T00:00:00.000Z",
+        cached_at="2026-06-12T00:00:10.000Z",
+        expires_at="2026-06-12T00:05:00.000Z",
+        freshness_status="fresh",
+        revocation_snapshot_status="fresh",
+        revocation_snapshot_observed_at="2026-06-12T00:00:30.000Z",
+        revocation_snapshot_age_seconds=30,
+        ttl_policy_seconds=300,
+        risk_tier="low",
+        blocked_capabilities=("checkout_payment_creation", "live_provider_call"),
+        unsupported_capabilities=("transaction_authority_from_adapter_preview",),
+        verifier_result_ref="verifier_result_price_C6Y5",
+    )
+    return replace(base, **overrides)
+
+
+def _plan(records: tuple[OacpPersistentArtifactCacheRecord, ...]) -> dict[str, object]:
+    return plan_oacp_artifact_cache_maintenance(
+        records=records,
+        now_iso="2026-06-12T00:01:00.000Z",
+        grantex_available=True,
+        action_intent="prepare_only",
+        risk_tier="low",
+        scope_filter=OacpArtifactCacheRepositoryQuery(tenant_id="cten_C6W3", merchant_id="mch_C6W3"),
+    )
+
+
+def _review_packet(plan: dict[str, object]) -> dict[str, object]:
+    return build_oacp_cache_maintenance_dry_run_report(
+        maintenance_plan=plan,
+        report_kind="operator_review_packet",
+    )
+
+
+def _operator_decision(packet: dict[str, object]) -> dict[str, object]:
+    return build_oacp_cache_operator_decision_record(
+        review_packet=packet,
+        decision_kind="request_more_evidence",
+        reviewer_identity_ref="operator_ref_c6y5_reviewer_001",
+        decided_at="2026-06-12T00:02:00.000Z",
+    )
+
+
+def _bundle(records: tuple[OacpPersistentArtifactCacheRecord, ...]) -> dict[str, object]:
+    plan = _plan(records)
+    packet = _review_packet(plan)
+    decision = _operator_decision(packet)
+    return build_oacp_c6x9_audit_export_bundle(
+        cache_records=records,
+        maintenance_plans=(plan,),
+        review_packets=(packet,),
+        operator_decision_records=(decision,),
+        durable_decision_records=(dict(decision),),
+        generated_at="2026-06-12T00:03:00.000Z",
+        tenant_id="cten_C6W3",
+        merchant_id="mch_C6W3",
+        seller_agent_id="seller_C6W3",
+        buyer_agent_id="buyer_C6W3",
+    )
+
+
+def _summary() -> dict[str, object]:
+    manifest = build_oacp_c6y1_audit_export_review_manifest(
+        audit_export_bundle=_bundle((_record(),)),
+        generated_at="2026-06-12T00:04:00.000Z",
+        retention_class="standard_internal_review",
+    )
+    return build_oacp_c6y3_audit_review_manifest_summary(
+        (manifest,),
+        query=OacpAuditReviewManifestRepositoryQuery(
+            tenant_id="cten_C6W3",
+            merchant_id="mch_C6W3",
+            retention_class="standard_internal_review",
+        ),
+        generated_at="2026-06-12T00:05:00.000Z",
+    )
+
+
+def _dry_run() -> dict[str, object]:
+    return build_oacp_c6y4_retention_disposition_dry_run(
+        manifest_summary=_summary(),
+        generated_at="2026-06-12T00:06:00.000Z",
+    )
+
+
+def _operator_packet(dry_run: dict[str, object]) -> dict[str, object]:
+    return build_oacp_c6y4_retention_operator_review_packet(
+        retention_disposition_dry_run=dry_run,
+        generated_at="2026-06-12T00:07:00.000Z",
+    )
+
+
+def _disposition_decision(**overrides: object) -> dict[str, object]:
+    dry_run = _dry_run()
+    decision = build_oacp_c6y5_retention_disposition_decision_record(
+        retention_disposition_dry_run=dry_run,
+        operator_review_packet=_operator_packet(dry_run),
+        decision_kind="approve_future_retention_review",
+        reviewer_identity_ref="operator_ref_c6y5_reviewer_001",
+        decided_at="2026-06-12T00:08:00.000Z",
+    )
+    decision.update(overrides)
+    return decision
+
+
+class _FakeScalars:
+    def __init__(self, rows: list[OacpRetentionDispositionDecisionRecordRow]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[OacpRetentionDispositionDecisionRecordRow]:
+        return self._rows
+
+
+class _FakeAsyncSession:
+    def __init__(self) -> None:
+        self.rows: dict[str, OacpRetentionDispositionDecisionRecordRow] = {}
+
+    async def get(
+        self,
+        _model: type[OacpRetentionDispositionDecisionRecordRow],
+        disposition_decision_id: str,
+    ) -> OacpRetentionDispositionDecisionRecordRow | None:
+        return self.rows.get(disposition_decision_id)
+
+    def add(self, row: OacpRetentionDispositionDecisionRecordRow) -> None:
+        self.rows[row.disposition_decision_id] = row
+
+    async def flush(self) -> None:
+        return None
+
+    async def scalars(self, _statement: object) -> _FakeScalars:
+        return _FakeScalars(list(self.rows.values()))
+
+
+@pytest.fixture()
+def repository() -> DurableOacpRetentionDispositionDecisionRepository:
+    return DurableOacpRetentionDispositionDecisionRepository(_FakeAsyncSession())
+
+
+@pytest.mark.asyncio
+async def test_c6y5_repository_upserts_gets_lists_and_evaluates_without_retention_execution(
+    repository: DurableOacpRetentionDispositionDecisionRepository,
+) -> None:
+    decision = _disposition_decision()
+    result = await repository.upsert_disposition_decision(decision)
+
+    assert result["stored"] is True
+    assert result["durable_repository"] is True
+    assert result["future_retention_action_allowed"] is False
+    assert result["records_deleted"] is False
+    assert result["retention_executed"] is False
+    assert result["allowed_to_execute"] is False
+    assert result["non_authoritative_for_transaction"] is True
+
+    stored = await repository.get_disposition_decision(str(decision["disposition_decision_id"]))
+    assert stored is not None
+    assert stored["source_summary_id"] == decision["source_summary_id"]
+    assert stored["source_dry_run_id"] == decision["source_dry_run_id"]
+    assert stored["source_operator_packet_id"] == decision["source_operator_packet_id"]
+    assert stored["redacted_evidence_ref_count"] == 1
+    assert stored["reviewer_ref"] == "operator_ref_c6y5_reviewer_001"
+    assert stored["export_file_written"] is False
+    assert stored["scheduler_added"] is False
+
+    scoped = await repository.list_disposition_decisions_for_scope(
+        OacpRetentionDispositionDecisionRepositoryQuery(
+            tenant_id="cten_C6W3",
+            merchant_id="mch_C6W3",
+            decision_kind="approve_future_retention_review",
+            retention_class="standard_internal_review",
+        ),
+    )
+    assert [item["disposition_decision_id"] for item in scoped] == [decision["disposition_decision_id"]]
+
+    evaluation = await repository.evaluate_disposition_decision_for_future_review(
+        str(decision["disposition_decision_id"])
+    )
+    assert evaluation["status"] == "future_retention_review_requires_separate_action"
+    assert evaluation["future_retention_action_allowed"] is False
+    assert evaluation["records_deleted"] is False
+    assert evaluation["retention_executed"] is False
+    assert evaluation["allowed_to_execute"] is False
+
+
+@pytest.mark.asyncio
+async def test_c6y5_repository_fails_closed_before_storage(
+    repository: DurableOacpRetentionDispositionDecisionRepository,
+) -> None:
+    cases = [
+        (_disposition_decision(disposition_decision_id=""), "disposition_decision_identity_or_scope_missing"),
+        (_disposition_decision(decision_kind="execute_retention_now"), "decision_kind_invalid"),
+        (_disposition_decision(retention_class="public_export_ready"), "retention_class_invalid"),
+        (_disposition_decision(retain_until="2026-06-12T00:06:59.000Z"), "decision_timestamps_invalid"),
+        (_disposition_decision(allowed_to_execute=True), "non_enablement_flags_missing"),
+        (_disposition_decision(records_deleted=True), "non_enablement_flags_missing"),
+        (_disposition_decision(retention_executed=True), "non_enablement_flags_missing"),
+        (_disposition_decision(export_file_written=True), "non_enablement_flags_missing"),
+        (_disposition_decision(scheduler_added=True), "non_enablement_flags_missing"),
+        (_disposition_decision(reviewer_ref="reviewer@example.com"), "reviewer_identity_not_opaque"),
+        (_disposition_decision(next_step_labels=["delete_records_now"]), "decision_labels_executable_or_private"),
+        (
+            _disposition_decision(operator_safe_message="production readiness approved"),
+            "decision_private_or_overclaiming_values",
+        ),
+    ]
+
+    for decision, refusal_code in cases:
+        result = await repository.upsert_disposition_decision(decision)
+        assert result["stored"] is False
+        assert result["allowed_to_execute"] is False
+        assert result["future_retention_action_allowed"] is False
+        assert result["records_deleted"] is False
+        assert result["retention_executed"] is False
+        assert result["refusal_code"] == refusal_code
+
+    missing = await repository.evaluate_disposition_decision_for_future_review("missing_decision_C6Y5")
+    assert missing["status"] == "blocked"
+    assert missing["refusal_code"] == "disposition_decision_missing"
+
+
+def test_c6y5_builder_fails_closed_for_bad_source_packets_and_raw_reviewer_identity() -> None:
+    dry_run = _dry_run()
+    packet = _operator_packet(dry_run)
+    unsafe_source = build_oacp_c6y5_retention_disposition_decision_record(
+        retention_disposition_dry_run={**dry_run, "records_deleted": True},
+        operator_review_packet=packet,
+        decision_kind="approve_future_retention_review",
+        reviewer_identity_ref="operator_ref_c6y5_reviewer_001",
+        decided_at="2026-06-12T00:08:00.000Z",
+    )
+    raw_reviewer = build_oacp_c6y5_retention_disposition_decision_record(
+        retention_disposition_dry_run=dry_run,
+        operator_review_packet=packet,
+        decision_kind="approve_future_retention_review",
+        reviewer_identity_ref="operator@example.com",
+        decided_at="2026-06-12T00:08:00.000Z",
+    )
+
+    assert unsafe_source["refusal_code"] == "source_packet_executable_or_enabling"
+    assert raw_reviewer["refusal_code"] == "reviewer_identity_not_opaque"
+    for result in (unsafe_source, raw_reviewer):
+        assert result["decision_record_built"] is False
+        assert result["records_deleted"] is False
+        assert result["retention_executed"] is False
+        assert result["allowed_to_execute"] is False
+
+
+def test_c6y5_migration_has_tenant_safe_rls_and_non_execution_guards() -> None:
+    migration = _migration()
+    for expected in (
+        "CREATE TABLE IF NOT EXISTS oacp_retention_disposition_decision_records",
+        "down_revision = \"v6y3_industry_pack_uuid_default\"",
+        "ix_oacp_retention_disposition_decision_tenant_id",
+        "ix_oacp_retention_disposition_decision_merchant_id",
+        "ix_oacp_retention_disposition_decision_seller_agent_id",
+        "ix_oacp_retention_disposition_decision_buyer_agent_id",
+        "ix_oacp_retention_disposition_decision_summary_id",
+        "ix_oacp_retention_disposition_decision_dry_run_id",
+        "ix_oacp_retention_disposition_decision_packet_id",
+        "uq_oacp_retention_disposition_decision_packet_kind_reviewer",
+        "future_retention_action_allowed IS FALSE",
+        "records_deleted IS FALSE",
+        "retention_executed IS FALSE",
+        "allowed_to_execute IS FALSE",
+        "ENABLE ROW LEVEL SECURITY",
+        "FORCE ROW LEVEL SECURITY",
+        "DROP TABLE IF EXISTS oacp_retention_disposition_decision_records",
+    ):
+        assert expected in migration
+
+
+def test_c6y5_docs_capture_durable_repository_scope_and_non_goals() -> None:
+    doc = _doc()
+    for heading in (
+        "Scope",
+        "Correct Ownership Model",
+        "Persistence Decision",
+        "Durable Repository Contract",
+        "Stored Fields",
+        "Fail-Closed Persistence And Evaluation",
+        "Migration Safety",
+        "Guardrails",
+        "What C6Y5 Does Not Enable",
+        "Future Work",
+    ):
+        assert f"## {heading}" in doc
+
+    assert "AgenticOrg owns retention disposition review" in doc
+    assert "v6y5_oacp_retention_disposition_decisions" in doc
+    assert "RLS" in doc
+    assert "allowed_to_execute = false" in doc
+    assert "future_retention_action_allowed = false" in doc
+    assert "records_deleted = false" in doc
+    assert "does not execute retention" in doc

--- a/tests/unit/test_oacp_c6y5_retention_disposition_decisions.py
+++ b/tests/unit/test_oacp_c6y5_retention_disposition_decisions.py
@@ -299,6 +299,7 @@ def test_c6y5_builder_fails_closed_for_bad_source_packets_and_raw_reviewer_ident
 def test_c6y5_migration_has_tenant_safe_rls_and_non_execution_guards() -> None:
     migration = _migration()
     for expected in (
+        "revision = \"v6y5_retention_decisions\"",
         "CREATE TABLE IF NOT EXISTS oacp_retention_disposition_decision_records",
         "down_revision = \"v6y3_industry_pack_uuid_default\"",
         "ix_oacp_retention_disposition_decision_tenant_id",
@@ -319,6 +320,8 @@ def test_c6y5_migration_has_tenant_safe_rls_and_non_execution_guards() -> None:
     ):
         assert expected in migration
 
+    assert len("v6y5_retention_decisions") <= 32
+
 
 def test_c6y5_docs_capture_durable_repository_scope_and_non_goals() -> None:
     doc = _doc()
@@ -337,7 +340,7 @@ def test_c6y5_docs_capture_durable_repository_scope_and_non_goals() -> None:
         assert f"## {heading}" in doc
 
     assert "AgenticOrg owns retention disposition review" in doc
-    assert "v6y5_oacp_retention_disposition_decisions" in doc
+    assert "v6y5_retention_decisions" in doc
     assert "RLS" in doc
     assert "allowed_to_execute = false" in doc
     assert "future_retention_action_allowed = false" in doc


### PR DESCRIPTION
Summary:
- Add durable AgenticOrg retention disposition decision repository/model/migration for redacted audit-safe decision records.
- Preserve tenant scope, RLS protection, opaque reviewer refs, non-enablement flags, and fail-closed validation.
- Keep C6Y5 internal-only, non-executing, export-writer-free, scheduler-free, and non-authoritative for transactions.

Validation:
- python -m pytest tests/unit/test_oacp_c6y3_audit_review_manifest_summary.py tests/unit/test_oacp_c6y4_retention_disposition.py tests/unit/test_oacp_c6y5_retention_disposition_decisions.py --no-cov
- python -m ruff check core/commerce/oacp_artifacts.py core/models/__init__.py core/models/oacp_retention_disposition_decision.py tests/unit/test_oacp_c6y5_retention_disposition_decisions.py migrations/versions/v6_y5_oacp_retention_disposition_decisions.py
- python -m mypy core/commerce/oacp_artifacts.py core/models/oacp_retention_disposition_decision.py tests/unit/test_oacp_c6y5_retention_disposition_decisions.py
- git diff --check origin/main...HEAD
- ASCII/hidden Unicode and guardrail scans clean; hits are expected migration, fail-closed tests, negative guardrail wording, or non-enablement flags only.