### PR TITLE
[codex] fix prod QA agent workflows and CSP analytics

### DIFF
--- a/core/agents/ops/support_triage.py
+++ b/core/agents/ops/support_triage.py
@@ -55,6 +55,21 @@ KB_MATCH_THRESHOLD = 0.85
 HITL_PRIORITIES = {"P1"}
 
 
+def _ticket_from_inputs(inputs: Any) -> dict[str, Any]:
+    """Normalize workflow/API ticket payloads into the dict shape this agent uses."""
+    if isinstance(inputs, str):
+        return {"description": inputs}
+    if not isinstance(inputs, dict):
+        return {"description": str(inputs or "")}
+
+    ticket = inputs.get("ticket", inputs)
+    if isinstance(ticket, dict):
+        return ticket
+    if isinstance(ticket, str):
+        return {"description": ticket}
+    return {"description": str(ticket or "")}
+
+
 @AgentRegistry.register
 class SupportTriageAgent(BaseAgent):
     agent_type = "support_triage"
@@ -70,12 +85,12 @@ class SupportTriageAgent(BaseAgent):
         msg_id = f"msg_{uuid.uuid4().hex[:12]}"
 
         try:
-            inputs = task.task.inputs if hasattr(task.task, "inputs") else task.task.get("inputs", {})
-            ticket = inputs.get("ticket", inputs)
+            raw_inputs = task.task.inputs if hasattr(task.task, "inputs") else task.task.get("inputs", {})
+            ticket = _ticket_from_inputs(raw_inputs)
             ticket_id = ticket.get("ticket_id", ticket.get("id", ""))
             subject = str(ticket.get("subject", "")).strip()
             description = str(ticket.get("description", ticket.get("body", ""))).strip()
-            customer_tier = ticket.get("customer_tier", ticket.get("tier", "business")).lower()
+            customer_tier = str(ticket.get("customer_tier", ticket.get("tier", "business"))).lower()
             trace.append(f"Triage ticket: id={ticket_id}, subject='{subject[:60]}', tier={customer_tier}")
 
             combined_text = f"{subject} {description}".lower()

--- a/scripts/deploy_cloud_run.sh
+++ b/scripts/deploy_cloud_run.sh
@@ -688,6 +688,8 @@ echo "Previous UI traffic        : $PREVIOUS_UI_TRAFFIC_SUMMARY"
 
 API_IMAGE="${GAR_REGISTRY}/agenticorg:${DEPLOY_SHA}"
 UI_IMAGE="${GAR_REGISTRY}/agenticorg-ui-cloudrun:${DEPLOY_SHA}"
+API_UPDATE_ENV_VARS="AGENTICORG_GIT_SHA=${DEPLOY_SHA},AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED=true"
+UI_UPDATE_ENV_VARS="GIT_SHA=${DEPLOY_SHA}"
 
 # 3. Build + push images.
 if [[ $SKIP_BUILD -eq 0 ]]; then
@@ -786,12 +788,12 @@ fi
 # API public health passes so an API failure cannot leave a new UI revision live.
 API_NEW_REVISION=""
 UI_NEW_REVISION=""
-update_service_no_traffic API_NEW_REVISION "$API_SERVICE" "$API_IMAGE" "AGENTICORG_GIT_SHA=${DEPLOY_SHA}" "API" "$API_IMAGE_DIGEST" "AGENTICORG_GIT_SHA"
+update_service_no_traffic API_NEW_REVISION "$API_SERVICE" "$API_IMAGE" "$API_UPDATE_ENV_VARS" "API" "$API_IMAGE_DIGEST" "AGENTICORG_GIT_SHA"
 
 echo "Staged API revision: $API_NEW_REVISION"
 
 if [[ "$TRAFFIC_MODE" == "preserve" ]]; then
-  update_service_no_traffic UI_NEW_REVISION "$UI_SERVICE" "$UI_IMAGE" "GIT_SHA=${DEPLOY_SHA}" "UI" "$UI_IMAGE_DIGEST" "GIT_SHA"
+  update_service_no_traffic UI_NEW_REVISION "$UI_SERVICE" "$UI_IMAGE" "$UI_UPDATE_ENV_VARS" "UI" "$UI_IMAGE_DIGEST" "GIT_SHA"
   echo "Staged UI revision : $UI_NEW_REVISION"
   echo "NOT DEPLOYED: --traffic preserve staged revisions but left production traffic unchanged."
   echo "Current API traffic: $(traffic_summary "$API_SERVICE")"
@@ -800,7 +802,7 @@ if [[ "$TRAFFIC_MODE" == "preserve" ]]; then
 fi
 
 if [[ "$TRAFFIC_MODE" == "manual" ]]; then
-  update_service_no_traffic UI_NEW_REVISION "$UI_SERVICE" "$UI_IMAGE" "GIT_SHA=${DEPLOY_SHA}" "UI" "$UI_IMAGE_DIGEST" "GIT_SHA"
+  update_service_no_traffic UI_NEW_REVISION "$UI_SERVICE" "$UI_IMAGE" "$UI_UPDATE_ENV_VARS" "UI" "$UI_IMAGE_DIGEST" "GIT_SHA"
   echo "Staged UI revision : $UI_NEW_REVISION"
   echo "NOT DEPLOYED: --traffic manual staged revisions but left production traffic unchanged."
   print_manual_traffic_commands "$API_NEW_REVISION" "$UI_NEW_REVISION"
@@ -843,7 +845,7 @@ if ! poll_health_url "$HEALTH_URL" "public API" 30; then
   exit 1
 fi
 
-if ! update_service_no_traffic UI_NEW_REVISION "$UI_SERVICE" "$UI_IMAGE" "GIT_SHA=${DEPLOY_SHA}" "UI" "$UI_IMAGE_DIGEST" "GIT_SHA"; then
+if ! update_service_no_traffic UI_NEW_REVISION "$UI_SERVICE" "$UI_IMAGE" "$UI_UPDATE_ENV_VARS" "UI" "$UI_IMAGE_DIGEST" "GIT_SHA"; then
   remove_probe_tag "$API_SERVICE" "$API_PROBE_TAG"
   echo "::error::Failed to stage UI revision after API verification; rolling back API/UI traffic." >&2
   rollback_service_traffic "$API_SERVICE" "$PREVIOUS_API_TRAFFIC_SPEC" "API"

--- a/tests/regression/test_prod_qa_e2e_20260614.py
+++ b/tests/regression/test_prod_qa_e2e_20260614.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_support_triage_accepts_raw_ticket_text() -> None:
+    from core.agents.ops.support_triage import _ticket_from_inputs
+
+    assert _ticket_from_inputs("Dashboard is blank after login") == {
+        "description": "Dashboard is blank after login"
+    }
+    assert _ticket_from_inputs({"ticket": "Cannot access dashboard after login"}) == {
+        "description": "Cannot access dashboard after login"
+    }
+    assert _ticket_from_inputs({"ticket": {"subject": "Login fails"}}) == {
+        "subject": "Login fails"
+    }
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_step_uses_stored_agent_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    from core.agents.registry import AgentRegistry
+    from core.schemas.messages import TaskResult
+    from workflows import step_types
+
+    captured: dict[str, object] = {}
+
+    async def fake_load_agent_config(agent_id: str, tenant_id: str) -> dict:
+        captured["loaded"] = {"agent_id": agent_id, "tenant_id": tenant_id}
+        return {
+            "id": agent_id,
+            "tenant_id": tenant_id,
+            "agent_type": "support_triage",
+            "authorized_tools": ["freshdesk:update_ticket"],
+            "prompt_variables": {"tone": "concise"},
+            "hitl_condition": "confidence < 0.5",
+            "output_schema": "support_triage_result",
+            "llm_model": "gemini-2.5-flash",
+            "cost_controls": {"daily_token_budget": 1000},
+            "system_prompt_text": "Use the stored QA support prompt.",
+        }
+
+    class CapturingAgent:
+        async def execute(self, task):
+            captured["task"] = task
+            return TaskResult(
+                message_id="msg_test",
+                correlation_id=task.correlation_id,
+                workflow_run_id=task.workflow_run_id,
+                step_id=task.step_id,
+                agent_id=task.target_agent.agent_id,
+                status="completed",
+                output={"ok": True},
+                confidence=0.91,
+            )
+
+    def fake_create_from_config(config: dict):
+        captured["config"] = dict(config)
+        return CapturingAgent()
+
+    monkeypatch.setattr(step_types, "_llm_available_for_workflow", lambda: True)
+    monkeypatch.setattr(step_types, "_fake_llm_allowed", lambda: False)
+    monkeypatch.setattr(step_types, "_load_workflow_agent_config", fake_load_agent_config)
+    monkeypatch.setattr(
+        AgentRegistry,
+        "create_from_config",
+        staticmethod(fake_create_from_config),
+    )
+
+    result = await step_types.execute_step(
+        {
+            "id": "triage_ticket",
+            "type": "agent",
+            "agent_id": "11111111-1111-1111-1111-111111111111",
+            "action": "triage",
+            "inputs": {"ticket": "QA smoke ticket: dashboard is blank after login"},
+        },
+        {
+            "id": "wfr_test",
+            "tenant_id": "22222222-2222-2222-2222-222222222222",
+            "context": {},
+        },
+    )
+
+    assert result["status"] == "completed"
+    assert captured["loaded"] == {
+        "agent_id": "11111111-1111-1111-1111-111111111111",
+        "tenant_id": "22222222-2222-2222-2222-222222222222",
+    }
+    assert captured["config"] == {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "tenant_id": "22222222-2222-2222-2222-222222222222",
+        "agent_type": "support_triage",
+        "authorized_tools": ["freshdesk:update_ticket"],
+        "prompt_variables": {"tone": "concise"},
+        "hitl_condition": "confidence < 0.5",
+        "output_schema": "support_triage_result",
+        "system_prompt_text": "Use the stored QA support prompt.",
+        "llm_model": "gemini-2.5-flash",
+        "cost_controls": {"daily_token_budget": 1000},
+    }
+
+
+def test_cloud_run_deploy_enables_commerce_public_discovery() -> None:
+    src = (ROOT / "scripts" / "deploy_cloud_run.sh").read_text(encoding="utf-8")
+
+    assert "API_UPDATE_ENV_VARS=" in src
+    assert "AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED=true" in src
+    assert 'update_service_no_traffic API_NEW_REVISION "$API_SERVICE" "$API_IMAGE" "$API_UPDATE_ENV_VARS"' in src

--- a/tests/regression/test_security_pr_g2_csp_hash_pinning.py
+++ b/tests/regression/test_security_pr_g2_csp_hash_pinning.py
@@ -29,6 +29,7 @@ NGINX_CONFIGS = (
     REPO_ROOT / "ui" / "nginx.conf",
     REPO_ROOT / "ui" / "nginx.cloudrun.conf.template",
 )
+ANALYTICS_COMPONENT = REPO_ROOT / "ui" / "src" / "components" / "Analytics.tsx"
 
 _INLINE_JSON_LD = re.compile(
     r'<script type="application/ld\+json">\n(.*?)\n  </script>',
@@ -141,3 +142,24 @@ def test_sec_009_csp_does_not_have_wildcard_in_script_src() -> None:
         assert " * " not in (" " + m.group(1) + " "), (
             f"{config.name}: script-src must not include a wildcard."
         )
+
+
+def test_sec_009_analytics_bootstrap_does_not_inject_inline_script() -> None:
+    """GA can run under strict CSP without runtime inline script tags.
+
+    The production CSP hashes only static JSON-LD blocks from index.html.
+    Adding a runtime ``script.textContent`` bootstrap creates unpinned inline
+    script and reopens the browser console CSP violation caught by Playwright.
+    """
+    text = ANALYTICS_COMPONENT.read_text(encoding="utf-8")
+    forbidden = (
+        ".textContent",
+        "innerHTML",
+        "appendChild(inline",
+    )
+    missing = [pattern for pattern in forbidden if pattern in text]
+    assert not missing, (
+        "Analytics bootstrap must not create runtime inline scripts under "
+        f"strict CSP; found {', '.join(missing)}"
+    )
+    assert "window.gtag" in text and "window.dataLayer" in text

--- a/tests/unit/test_deploy_cloud_run_script.py
+++ b/tests/unit/test_deploy_cloud_run_script.py
@@ -12,8 +12,11 @@ def _deploy_script() -> str:
 def test_cloud_run_deploy_stamps_api_and_ui_commit_metadata() -> None:
     script = _deploy_script()
 
-    assert '"AGENTICORG_GIT_SHA=${DEPLOY_SHA}"' in script
-    assert '"GIT_SHA=${DEPLOY_SHA}"' in script
+    assert (
+        'API_UPDATE_ENV_VARS="AGENTICORG_GIT_SHA=${DEPLOY_SHA},'
+        'AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED=true"'
+    ) in script
+    assert 'UI_UPDATE_ENV_VARS="GIT_SHA=${DEPLOY_SHA}"' in script
     assert '--update-env-vars="$env_vars"' in script
     assert '"$UI_IMAGE"' in script
 
@@ -30,7 +33,7 @@ def test_ui_metadata_is_set_on_ui_service_update() -> None:
     assert len(ui_update_calls) >= 3
     for ui_update_call in ui_update_calls:
         assert '"$UI_IMAGE"' in ui_update_call
-        assert '"GIT_SHA=${DEPLOY_SHA}"' in ui_update_call
+        assert '"$UI_UPDATE_ENV_VARS"' in ui_update_call
         assert '"$UI_IMAGE_DIGEST"' in ui_update_call
         assert '"GIT_SHA"' in ui_update_call
 

--- a/ui/src/components/Analytics.tsx
+++ b/ui/src/components/Analytics.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
 const GA_ID = import.meta.env.VITE_GA4_ID || "";
+let analyticsInitialized = false;
 
 /** Fire a GA4 custom event. Safe to call even if GA is not loaded. */
 export function trackEvent(
@@ -34,24 +35,26 @@ export default function Analytics() {
   const location = useLocation();
 
   useEffect(() => {
-    if (!GA_ID) return;
-    // Load gtag.js once
+    if (!GA_ID || analyticsInitialized) return;
+    analyticsInitialized = true;
+
+    window.dataLayer = window.dataLayer || [];
+    window.gtag =
+      window.gtag ||
+      function gtag(...args: Parameters<typeof window.gtag>) {
+        window.dataLayer.push(args);
+      };
+
     if (!document.getElementById("ga-script")) {
       const script = document.createElement("script");
       script.id = "ga-script";
       script.async = true;
       script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
       document.head.appendChild(script);
-
-      const inline = document.createElement("script");
-      inline.textContent = `
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', '${GA_ID}', { send_page_view: false });
-      `;
-      document.head.appendChild(inline);
     }
+
+    window.gtag("js", new Date());
+    window.gtag("config", GA_ID, { send_page_view: false });
   }, []);
 
   // Track page views on route change

--- a/workflows/step_types.py
+++ b/workflows/step_types.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -125,6 +126,43 @@ def _missing_llm_result(step: dict, agent_type: str, action: str) -> dict[str, A
         step_type="agent",
         failure=MissingLLMProviderConfigError(agent=agent_type, step_id=step_id),
     )
+
+
+async def _load_workflow_agent_config(agent_id: str, tenant_id: str) -> dict[str, Any]:
+    """Load stored agent defaults for workflow steps that reference a DB agent."""
+    if not agent_id or not tenant_id:
+        return {}
+    try:
+        agent_uuid = uuid.UUID(str(agent_id))
+        tenant_uuid = uuid.UUID(str(tenant_id))
+    except (TypeError, ValueError):
+        return {}
+
+    from sqlalchemy import select
+
+    from core.database import get_tenant_session
+    from core.models.agent import Agent
+
+    async with get_tenant_session(tenant_uuid) as session:
+        result = await session.execute(
+            select(Agent).where(Agent.id == agent_uuid, Agent.tenant_id == tenant_uuid)
+        )
+        agent = result.scalar_one_or_none()
+    if agent is None or agent.status in {"deleted", "retired"}:
+        return {}
+
+    return {
+        "id": str(agent.id),
+        "tenant_id": str(agent.tenant_id),
+        "agent_type": agent.agent_type,
+        "authorized_tools": agent.authorized_tools or [],
+        "prompt_variables": agent.prompt_variables or {},
+        "hitl_condition": agent.hitl_condition or "",
+        "output_schema": agent.output_schema,
+        "llm_model": agent.llm_model,
+        "cost_controls": agent.cost_controls or {},
+        "system_prompt_text": agent.system_prompt_text or "",
+    }
 
 
 def _normalize_key(value: Any) -> str:
@@ -300,8 +338,10 @@ async def _execute_collaboration(step: dict, state: dict) -> dict[str, Any]:
 
 async def _execute_agent(step: dict, state: dict) -> dict[str, Any]:
     """Execute an agent step by instantiating and running the configured agent."""
-    agent_type = step.get("agent", step.get("agent_type", ""))
     agent_id = step.get("agent_id", "")
+    tenant_id = state.get("tenant_id", "")
+    stored_config = await _load_workflow_agent_config(agent_id, tenant_id)
+    agent_type = step.get("agent", step.get("agent_type", "")) or stored_config.get("agent_type", "")
     action = step.get("action", "process")
     inputs = step.get("inputs", state.get("trigger_payload", {}))
 
@@ -312,8 +352,6 @@ async def _execute_agent(step: dict, state: dict) -> dict[str, Any]:
         return _missing_llm_result(step, agent_type, action)
 
     try:
-        import uuid
-
         import core.agents  # noqa: F401 - triggers registration
         from core.agents.registry import AgentRegistry
         from core.schemas.messages import (
@@ -324,14 +362,41 @@ async def _execute_agent(step: dict, state: dict) -> dict[str, Any]:
             TaskMetadata,
         )
 
-        tenant_id = state.get("tenant_id", "")
         config = {
-            "id": agent_id or f"wf_agent_{step['id']}",
-            "tenant_id": tenant_id,
+            "id": stored_config.get("id") or agent_id or f"wf_agent_{step['id']}",
+            "tenant_id": stored_config.get("tenant_id") or tenant_id,
             "agent_type": agent_type,
-            "authorized_tools": step.get("authorized_tools", []),
-            "system_prompt_text": step.get("system_prompt_text", ""),
-            "llm_model": step.get("llm_model"),
+            "authorized_tools": (
+                step["authorized_tools"]
+                if "authorized_tools" in step
+                else stored_config.get("authorized_tools", [])
+            ),
+            "prompt_variables": (
+                step["prompt_variables"]
+                if "prompt_variables" in step
+                else stored_config.get("prompt_variables", {})
+            ),
+            "hitl_condition": (
+                step["hitl_condition"]
+                if "hitl_condition" in step
+                else stored_config.get("hitl_condition", "")
+            ),
+            "output_schema": (
+                step["output_schema"]
+                if "output_schema" in step
+                else stored_config.get("output_schema")
+            ),
+            "system_prompt_text": (
+                step["system_prompt_text"]
+                if "system_prompt_text" in step
+                else stored_config.get("system_prompt_text", "")
+            ),
+            "llm_model": step.get("llm_model") or stored_config.get("llm_model"),
+            "cost_controls": (
+                step["cost_controls"]
+                if "cost_controls" in step
+                else stored_config.get("cost_controls")
+            ),
         }
 
         if _fake_llm_allowed() and not _real_llm_provider_configured():


### PR DESCRIPTION
## Summary
- remove the runtime inline GA bootstrap so production CSP no longer blocks public pages
- make workflow agent steps hydrate the stored DB agent config when a step references agent_id
- normalize raw/string support tickets in support_triage and keep commerce discovery enabled during Cloud Run deploys

## Root cause
Production QA found two real product defects: the analytics component created an unpinned inline script under strict CSP, and workflow agent steps referenced saved agents without loading their stored type/tools/prompt/model. Commerce A2A/MCP discovery was also hidden unless the production deploy set AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED=true.

## Validation
- python -m pytest tests/regression/test_prod_qa_e2e_20260614.py tests/regression/test_security_pr_g2_csp_hash_pinning.py tests/unit/test_workflow_no_false_success.py -q
- python -m ruff check .
- npm --prefix ui run typecheck
- npm --prefix ui run lint
- npm --prefix ui run build
- npm test in sdk-ts
- npm test in mcp-server