### PR TITLE
Fix production A2A task schema drift

### DIFF
--- a/docs/bug_triage_skill.md
+++ b/docs/bug_triage_skill.md
@@ -2,7 +2,7 @@
 
 **Status:** Mandatory for every bug fix, reopen analysis, and QA-driven PR.
 **Owner:** CLAUDE.md references this file directly.
-**Last updated:** 2026-04-22.
+**Last updated:** 2026-06-14.
 
 This file exists because reopens kept happening on the same bug IDs across three QA sweeps (Aishwarya 21-Apr, 22-Apr AM, 22-Apr PM). The diagnosis — documented in `~/.claude/projects/C--Users-mishr-agentic-org/memory/feedback_shallow_fix_autopsy.md` — was that I (the author) claimed "fixed" when the fix was hypothesis-grade. This skill codifies the process that must be followed so that "fixed" means the user will not see the bug again.
 
@@ -161,6 +161,7 @@ If the answer is "probably", the fix is a hypothesis. Tighten it until the answe
 - [ ] Connector discovery-to-action context is preserved: IDs returned by discovery tools are accepted by downstream tools, normalized without lossy type coercion, sent in the provider-required location, and kept out of request bodies when they are query/path context (Rule 13).
 - [ ] Connector catalog/tool-list claims are backed by executable native connector methods, endpoint-path tests, and a UI/Playwright check when the claim is operator-visible (Rule 13).
 - [ ] Capability claim backed by producer route/connector/UI/regression evidence; roadmap-scale items labeled as not shipped (Rule 15).
+- [ ] Persisted runtime flow checked against actual DB shape, not only `alembic_version`; production-shaped stamped DB drift simulated when fixing a migration-backed 500 (Rule 16).
 
 ---
 
@@ -440,6 +441,44 @@ Reference: `tests/regression/test_ramesh_12jun2026_ca_feedback.py`,
 `connectors/finance/professional_tax.py`, `api/v1/professional_tax.py`,
 `api/v1/client_portal.py`, `api/v1/ca_billing.py`,
 `api/v1/ca_operations.py`, `api/v1/companies.py`, `connectors/finance/gstn.py`.
+
+---
+
+## Rule 16 - Runtime schema drift is a product bug even when Alembic says "head"
+
+Added 2026-06-14 after production A2A commerce returned HTTP 500 from
+`POST /api/v1/a2a/tasks`: Cloud Run logs showed
+`relation "a2a_tasks" does not exist` even though the migration job had
+completed and the database was stamped beyond the original v4.4.0 creator.
+
+The shallow failure pattern was assuming `alembic_version == head` proves the
+runtime schema. It does not. Environments can be stamped past a historical
+creator during cutovers or emergency repairs, leaving a runtime-critical table
+missing while every migration job appears green.
+
+Discipline:
+
+1. **Treat missing-table 500s as schema drift until proven otherwise.** Read the
+   production stack trace and identify the exact table, route, and synchronous
+   write path before changing application code.
+2. **Repair at the current head, never by editing old migrations.** Add an
+   idempotent forward migration with `CREATE TABLE IF NOT EXISTS`, guarded
+   indexes, and the tenant RLS policy expected by the runtime.
+3. **Verify the production-shaped case locally.** Simulate a DB stamped at the
+   previous head with the runtime table absent, run `scripts/alembic_migrate.py`,
+   then query Postgres for table existence, indexes, RLS, policy, and final
+   `alembic_version`.
+4. **Migration success must assert runtime-critical tables.** The deploy wrapper
+   should fail after `upgrade head` if a table required by synchronous request
+   paths is still missing; a green migration job must not be a false positive.
+5. **Regression coverage must include both contracts.** Add a source-level
+   guard for the repair migration and a Docker/Postgres integration run for the
+   migration wrapper. Re-run the original production E2E probe after deploy.
+
+Reference: `migrations/versions/v6_y4_repair_a2a_tasks.py`,
+`scripts/alembic_migrate.py`,
+`tests/regression/test_prod_qa_e2e_20260614.py`,
+`tests/integration/test_alembic_e2e.py`.
 
 ---
 

--- a/migrations/versions/v6_y4_repair_a2a_tasks.py
+++ b/migrations/versions/v6_y4_repair_a2a_tasks.py
@@ -1,0 +1,60 @@
+"""Repair missing persisted A2A task table.
+
+Revision ID: v6y4_repair_a2a_tasks
+Revises: v6y3_industry_pack_uuid_default
+Create Date: 2026-06-14
+
+Production E2E on 2026-06-14 found that ``/api/v1/a2a/tasks`` could
+return 500 even after the database was stamped at the current Alembic
+head: the original v4.4.0 migration was marked as applied, but the
+``a2a_tasks`` table was absent. This mirrors the older
+``report_schedules`` drift class and must be repaired at the current
+head so already-stamped environments pick it up on the next deploy.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v6y4_repair_a2a_tasks"
+down_revision = "v6y3_industry_pack_uuid_default"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS a2a_tasks (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id UUID NOT NULL REFERENCES tenants(id),
+            task_id VARCHAR(100) NOT NULL UNIQUE,
+            agent_type VARCHAR(100),
+            status VARCHAR(20) DEFAULT 'pending',
+            input_data JSONB DEFAULT '{}'::jsonb,
+            output_data JSONB,
+            error TEXT,
+            created_at TIMESTAMPTZ DEFAULT now(),
+            updated_at TIMESTAMPTZ
+        );
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_a2a_tasks_tenant
+            ON a2a_tasks(tenant_id);
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_a2a_tasks_task_id
+            ON a2a_tasks(task_id);
+    """)
+    op.execute("ALTER TABLE a2a_tasks ENABLE ROW LEVEL SECURITY;")
+    op.execute("ALTER TABLE a2a_tasks FORCE ROW LEVEL SECURITY;")
+    op.execute("DROP POLICY IF EXISTS a2a_tasks_tenant_isolation ON a2a_tasks;")
+    op.execute("""
+        CREATE POLICY a2a_tasks_tenant_isolation ON a2a_tasks
+        USING (tenant_id::text = current_setting('agenticorg.tenant_id', true));
+    """)
+
+
+def downgrade() -> None:
+    # No-op by design. v4.4.0 remains the canonical owner of this table;
+    # this revision only repairs environments that were stamped past it.
+    pass

--- a/scripts/alembic_migrate.py
+++ b/scripts/alembic_migrate.py
@@ -44,6 +44,14 @@ BASELINE_REVISION = "v480_baseline"
 # A table that exists after the full init_db() / v480 chain.
 BASELINE_PROBE_TABLE = "connector_configs"
 ALEMBIC_VERSION_TABLE = "alembic_version"
+REQUIRED_RUNTIME_TABLES = frozenset(
+    {
+        # A2A task execution writes here synchronously before dispatch. A
+        # stamped-but-missing table caused prod A2A commerce to return 500
+        # on 2026-06-14; migration success must verify more than version_num.
+        "a2a_tasks",
+    }
+)
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger("alembic_migrate")
@@ -75,6 +83,24 @@ def _create_orm_baseline(engine) -> None:
     BaseModel.metadata.create_all(engine)
 
 
+def _assert_required_runtime_tables(engine) -> None:
+    with engine.connect() as conn:
+        tables = set(inspect(conn).get_table_names())
+    missing = sorted(REQUIRED_RUNTIME_TABLES - tables)
+    if missing:
+        joined = ", ".join(missing)
+        raise RuntimeError(
+            "Alembic reported success but required runtime tables are missing: "
+            f"{joined}. Add or repair the forward migration before deploying."
+        )
+
+
+def _upgrade_head_and_verify(cfg: Config, engine, complete_message: str) -> None:
+    command.upgrade(cfg, "head")
+    _assert_required_runtime_tables(engine)
+    logger.info(complete_message)
+
+
 def main() -> int:
     url = _sync_url()
     logger.info("connecting to database for pre-rollout migration check")
@@ -87,8 +113,7 @@ def main() -> int:
 
     if ALEMBIC_VERSION_TABLE in tables:
         logger.info("alembic_version present — running upgrade head")
-        command.upgrade(cfg, "head")
-        logger.info("alembic upgrade head complete")
+        _upgrade_head_and_verify(cfg, engine, "alembic upgrade head complete")
         return 0
 
     if BASELINE_PROBE_TABLE in tables:
@@ -99,8 +124,7 @@ def main() -> int:
             BASELINE_REVISION,
         )
         command.stamp(cfg, BASELINE_REVISION)
-        command.upgrade(cfg, "head")
-        logger.info("stamp + upgrade complete")
+        _upgrade_head_and_verify(cfg, engine, "stamp + upgrade complete")
         return 0
 
     if not tables:
@@ -110,8 +134,7 @@ def main() -> int:
         )
         _create_orm_baseline(engine)
         command.stamp(cfg, BASELINE_REVISION)
-        command.upgrade(cfg, "head")
-        logger.info("empty database bootstrap + upgrade complete")
+        _upgrade_head_and_verify(cfg, engine, "empty database bootstrap + upgrade complete")
         return 0
 
     table_sample = ", ".join(sorted(tables)[:10])

--- a/tests/regression/test_prod_qa_e2e_20260614.py
+++ b/tests/regression/test_prod_qa_e2e_20260614.py
@@ -111,3 +111,28 @@ def test_cloud_run_deploy_enables_commerce_public_discovery() -> None:
     assert "API_UPDATE_ENV_VARS=" in src
     assert "AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED=true" in src
     assert 'update_service_no_traffic API_NEW_REVISION "$API_SERVICE" "$API_IMAGE" "$API_UPDATE_ENV_VARS"' in src
+
+
+def test_a2a_tasks_repair_migration_is_idempotent_and_tenant_scoped() -> None:
+    migration = (ROOT / "migrations" / "versions" / "v6_y4_repair_a2a_tasks.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'revision = "v6y4_repair_a2a_tasks"' in migration
+    assert 'down_revision = "v6y3_industry_pack_uuid_default"' in migration
+    assert "CREATE TABLE IF NOT EXISTS a2a_tasks" in migration
+    assert "tenant_id UUID NOT NULL REFERENCES tenants(id)" in migration
+    assert "input_data JSONB DEFAULT '{}'::jsonb" in migration
+    assert "CREATE INDEX IF NOT EXISTS ix_a2a_tasks_tenant" in migration
+    assert "CREATE INDEX IF NOT EXISTS ix_a2a_tasks_task_id" in migration
+    assert "ALTER TABLE a2a_tasks FORCE ROW LEVEL SECURITY" in migration
+    assert "CREATE POLICY a2a_tasks_tenant_isolation" in migration
+
+
+def test_migration_wrapper_checks_required_runtime_tables_after_upgrade() -> None:
+    src = (ROOT / "scripts" / "alembic_migrate.py").read_text(encoding="utf-8")
+
+    assert '"a2a_tasks"' in src
+    assert "REQUIRED_RUNTIME_TABLES" in src
+    assert "_assert_required_runtime_tables(engine)" in src
+    assert "Alembic reported success but required runtime tables are missing" in src


### PR DESCRIPTION
## Summary
- add an idempotent current-head repair migration for missing a2a_tasks
- enforce tenant RLS on the repaired A2A task table
- make scripts/alembic_migrate.py fail if required runtime tables are still missing after upgrade
- record the schema-drift learning in docs/bug_triage_skill.md and add regression pins

## Root cause
Production A2A commerce returned HTTP 500 because POST /api/v1/a2a/tasks writes to a2a_tasks synchronously, but production was stamped beyond the historical v4.4.0 creator while the table was absent. A green alembic_version row was not sufficient evidence of runtime DB shape.

## Tests
- python -m ruff check migrations\\versions\\v6_y4_repair_a2a_tasks.py scripts\\alembic_migrate.py tests\\regression\\test_prod_qa_e2e_20260614.py
- python -m pytest tests\\regression\\test_prod_qa_e2e_20260614.py -q
- python -m pytest tests\\integration\\test_alembic_e2e.py -q with Docker Postgres
- simulated production drift locally: dropped a2a_tasks, set alembic_version to v6y3_industry_pack_uuid_default, ran scripts/alembic_migrate.py, verified a2a_tasks, forced RLS, policy, and v6y4 head
- python -m pytest tests\\unit\\test_a2a_mcp.py tests\\unit\\test_runtime_schema_verification.py tests\\regression\\test_prod_qa_e2e_20260614.py -q
- python -m pytest tests\\integration\\test_db_api_endpoints.py::TestA2ATaskIntegration -q with Docker Postgres