### PR TITLE
chore: prepare SDK and MCP releases

### DIFF
--- a/docs/release-sdks.md
+++ b/docs/release-sdks.md
@@ -4,6 +4,14 @@ Version is bumped in-repo by the PR that ships the API change; the
 actual PyPI / npm publish is a separate manual step (needs
 credentials, should not live in CI without a release-gating flow).
 
+## Current release targets
+
+- Python SDK + CLI: `agenticorg==0.3.0` on PyPI.
+- TypeScript SDK: `agenticorg-sdk@0.3.0` on npm. The scoped package
+  `@agenticorg/sdk` is not currently published.
+- MCP server npm package: `agenticorg-mcp-server@4.0.5`.
+- MCP registry server: `io.github.mishrasanjeev/agenticorg@4.0.5`.
+
 ## Python SDK (PyPI)
 
 **Prereqs:** `pip install build twine`. PyPI token in `~/.pypirc`.
@@ -97,7 +105,7 @@ sweep fails if any drifts.
 - Patch bump for bugfix-only changes.
 
 SDK versions track the server's wire contract, not the app version.
-A main app at `4.8.0` is fine with SDKs at `0.2.0` — what matters is
+A main app at `4.8.0` is fine with SDKs at `0.3.0` — what matters is
 that the SDK can parse what the server emits.
 
 ## Drift guard

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -1,5 +1,20 @@
 # agenticorg-mcp-server changelog
 
+## 4.0.5 - 2026-06-14
+
+MCP registry metadata alignment.
+
+### Fixed
+- `server.json` now advertises the same tools the MCP server actually exposes:
+  `list_agents`, `run_agent`, `get_agent_details`, `create_agent_from_sop`,
+  `deploy_agent`, `list_connectors`, `list_mcp_tools`,
+  `discover_agents_a2a`, and `get_agent_card`.
+- Removed stale registry/README claims for direct connector invocation and
+  nonexistent workflow/knowledge tools. Connector workflows are reached through
+  agents, not `call_connector_tool`.
+- `package.json`, `package-lock.json`, `server.json.version`, and
+  `server.json.packages[0].version` moved together to `4.0.5`.
+
 ## 4.0.4 — 2026-05-12
 
 Security republish — same runtime as 4.0.3, with patched transitive

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,6 +1,6 @@
 # agenticorg-mcp-server
 
-MCP (Model Context Protocol) server for [AgenticOrg](https://agenticorg.ai) — expose every AgenticOrg AI agent and native tool to any MCP-compatible client (live counts: `/api/v1/product-facts`).
+MCP (Model Context Protocol) server for [AgenticOrg](https://agenticorg.ai). It exposes AgenticOrg AI agents, A2A discovery, SOP parsing/deploy, connector discovery, and platform MCP tool discovery to any MCP-compatible client.
 
 ## Quick Start
 
@@ -38,7 +38,7 @@ Add to your MCP client configuration:
 | Client | macOS | Windows |
 |--------|-------|---------|
 | **Claude Desktop** | `~/Library/Application Support/Claude/claude_desktop_config.json` | `%APPDATA%\Claude\claude_desktop_config.json` |
-| **ChatGPT Desktop** | Currently in beta — config path may change. Check OpenAI docs for the latest. | Currently in beta — config path may change. |
+| **ChatGPT Desktop** | Currently in beta; config path may change. Check OpenAI docs for the latest. | Currently in beta; config path may change. |
 | **Cursor** | `.cursor/mcp.json` in your project root | `.cursor/mcp.json` in your project root |
 
 ## Available Tools
@@ -46,52 +46,59 @@ Add to your MCP client configuration:
 | Tool | Description |
 |------|-------------|
 | `list_agents` | List all AI agents, filter by domain |
-| `run_agent` | Run any agent (AP Processor, Recon, Payroll, etc.) |
+| `run_agent` | Run any agent, including `commerce_sales_agent` |
 | `get_agent_details` | Get full agent config and capabilities |
-| `create_agent_from_sop` | Parse SOP text → create new agent |
+| `create_agent_from_sop` | Parse SOP text and create a draft agent |
 | `deploy_agent` | Deploy an agent configuration |
-| `list_connectors` | List all native connectors and status |
-| `call_connector_tool` | Call any connector tool |
-| `list_mcp_tools` | Discover all available tools |
+| `list_connectors` | List native connectors and status for discovery |
+| `list_mcp_tools` | Discover AgenticOrg agent tools exposed by the platform MCP API |
 | `discover_agents_a2a` | A2A protocol agent discovery |
 | `get_agent_card` | Get the public A2A Agent Card |
+
+Connector tools are not exposed as direct MCP tools. Use `run_agent` for the agent that owns the connector workflow, or run `list_mcp_tools` to see platform agent tools such as `agenticorg_commerce_sales_agent`.
 
 ## Authentication
 
 Set one of these environment variables:
 
-- `AGENTICORG_API_KEY` — API key from your AgenticOrg dashboard (Settings → API Keys)
-- `AGENTICORG_GRANTEX_TOKEN` — Grantex grant token for delegated agent access
+- `AGENTICORG_API_KEY`: API key from your AgenticOrg dashboard (Settings > API Keys)
+- `AGENTICORG_GRANTEX_TOKEN`: Grantex grant token for delegated agent access
 
 Optional:
 
-- `AGENTICORG_BASE_URL` — Custom base URL (default: `https://app.agenticorg.ai`)
+- `AGENTICORG_BASE_URL`: custom API base URL (default: `https://app.agenticorg.ai`)
 
-## Example: Run an Invoice Agent from ChatGPT
+## Example: Run a Commerce Agent from ChatGPT
 
 Once configured, you can say in ChatGPT:
 
-> "Use AgenticOrg to process invoice INV-2024-001 from Tata Consultancy"
+> "Use AgenticOrg to show a read-only buyer discovery preview for merchant_demo."
 
 ChatGPT will call the `run_agent` tool with:
+
 ```json
 {
-  "agent_type": "ap_processor",
-  "inputs": { "invoice_id": "INV-2024-001", "vendor": "Tata Consultancy" }
+  "agent_type": "commerce_sales_agent",
+  "action": "buyer_discovery_preview",
+  "inputs": {
+    "merchant_id": "merchant_demo",
+    "request_text": "show a read-only buyer discovery preview"
+  }
 }
 ```
 
 ## Example: Create an Agent from SOP via ChatGPT
 
-You can create a new agent directly from a standard operating procedure:
+You can create a new agent draft directly from a standard operating procedure:
 
-> "Use AgenticOrg to create an agent from this SOP: Step 1 — Receive vendor invoice. Step 2 — Validate GSTIN. Step 3 — 3-way match with PO and GRN. Step 4 — If amount > 5L, escalate to CFO."
+> "Use AgenticOrg to create an agent from this SOP: Step 1 - Receive vendor invoice. Step 2 - Validate GSTIN. Step 3 - 3-way match with PO and GRN. Step 4 - If amount > 5L, escalate to CFO."
 
 ChatGPT will call the `create_agent_from_sop` tool with:
+
 ```json
 {
   "sop_text": "Step 1: Receive vendor invoice\nStep 2: Validate GSTIN on GST portal\nStep 3: 3-way match with PO and GRN\nStep 4: If amount > 5L, escalate to CFO",
-  "domain": "finance"
+  "domain_hint": "finance"
 }
 ```
 
@@ -100,24 +107,30 @@ The server parses the SOP, generates an agent configuration, and returns the dra
 ## Troubleshooting
 
 **"AGENTICORG_API_KEY not set" error**
+
 Make sure the `env` block in your MCP config includes the key, or export it in your shell before running:
+
 ```bash
 export AGENTICORG_API_KEY=your-api-key
 ```
 
 **"Connection refused" or server not starting**
+
 - Verify Node.js >= 18 is installed: `node --version`
 - Try running manually first: `AGENTICORG_API_KEY=your-key npx agenticorg-mcp-server`
 - Check that no firewall or proxy is blocking local stdio communication
 
 **"Tool not found" when calling a connector tool**
-- Run `list_mcp_tools` first to see all available tool names
-- Tool names follow the format `connector_name:action` (e.g., `oracle_fusion:read:purchase_order`)
+
+- Direct connector tools are not exposed by this MCP server.
+- Use `run_agent` for the agent that owns the connector workflow.
+- Run `list_mcp_tools` to see agent tools exposed by the platform.
 
 **Claude Desktop / Cursor not detecting the server**
-- Ensure the config JSON is valid (no trailing commas)
-- Restart the client after editing the config file
-- Check the client's MCP log for error messages
+
+- Ensure the config JSON is valid.
+- Restart the client after editing the config file.
+- Check the client's MCP log for error messages.
 
 ## License
 

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenticorg-mcp-server",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenticorg-mcp-server",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticorg-mcp-server",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "mcpName": "io.github.mishrasanjeev/agenticorg",
   "description": "MCP server for AgenticOrg — expose every AgenticOrg AI agent and native tool to ChatGPT, Claude, and any MCP client",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,45 +1,69 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.mishrasanjeev/agenticorg",
-  "description": "AgenticOrg AI agents + native connectors + 1000+ via Composio. Finance/HR/Marketing/Ops.",
+  "description": "AgenticOrg MCP server for AI agents, A2A discovery, SOP deploy, and MCP tool listing.",
   "repository": {
     "url": "https://github.com/mishrasanjeev/agentic-org",
     "source": "github"
   },
-  "version": "4.0.4",
+  "version": "4.0.5",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "agenticorg-mcp-server",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "transport": {
         "type": "stdio"
       }
     }
   ],
   "tools": [
-    { "name": "list_agents", "description": "List every AgenticOrg AI agent across Finance, HR, Marketing, Ops — filter by domain, status, type" },
-    { "name": "run_agent", "description": "Execute any AI agent (ap_processor, payroll_engine, campaign_pilot, support_triage, etc.) with real tool calls" },
-    { "name": "get_agent_details", "description": "Get agent config, scopes, tools, confidence floor, HITL conditions, shadow status" },
-    { "name": "create_agent", "description": "Create a new AI agent from natural language description or manual config" },
-    { "name": "create_agent_from_sop", "description": "Parse an SOP/policy document (PDF/Word) and auto-generate an AI agent" },
-    { "name": "list_connectors", "description": "List native connectors + 1000+ via Composio (SAP, Oracle, Jira, HubSpot, Salesforce, GSTN, Tally, Stripe, Gmail, Slack, Teams)" },
-    { "name": "call_connector_tool", "description": "Call any connector tool — create Jira tickets, send emails, query CRM, file GST returns, process payments" },
-    { "name": "list_workflows", "description": "List 20+ workflow templates — invoice_to_pay, month_end_close, campaign_launch, incident_response" },
-    { "name": "run_workflow", "description": "Trigger a multi-step workflow with parallel agents, HITL approval gates, and adaptive replanning" },
-    { "name": "search_knowledge_base", "description": "Search company documents (PDF, Word, Excel) via RAG — agents answer from your uploaded policies and SOPs" },
-    { "name": "list_mcp_tools", "description": "Discover all available MCP tools across native connectors and 1000+ Composio integrations" },
-    { "name": "get_agent_card", "description": "Get the A2A protocol Agent Card for cross-platform agent discovery" }
+    {
+      "name": "list_agents",
+      "description": "List AgenticOrg AI agents; optionally filter by domain."
+    },
+    {
+      "name": "run_agent",
+      "description": "Run an AI agent by type using the AgenticOrg A2A task endpoint."
+    },
+    {
+      "name": "get_agent_details",
+      "description": "Get agent config, scopes, tools, confidence floor, HITL conditions, and status."
+    },
+    {
+      "name": "create_agent_from_sop",
+      "description": "Parse SOP text and generate a draft AI agent configuration."
+    },
+    {
+      "name": "deploy_agent",
+      "description": "Deploy a reviewed agent configuration from SOP parsing or manual config."
+    },
+    {
+      "name": "list_connectors",
+      "description": "List AgenticOrg native connectors and their status for discovery."
+    },
+    {
+      "name": "list_mcp_tools",
+      "description": "List AgenticOrg agent tools exposed by the platform MCP API."
+    },
+    {
+      "name": "discover_agents_a2a",
+      "description": "Discover available agent skills through the A2A protocol."
+    },
+    {
+      "name": "get_agent_card",
+      "description": "Get the public A2A Agent Card for this AgenticOrg instance."
+    }
   ],
   "environmentVariables": [
     {
       "name": "AGENTICORG_API_KEY",
-      "description": "API key from your AgenticOrg dashboard (Settings > API Keys). Start free at agenticorg.ai",
+      "description": "API key from your AgenticOrg dashboard (Settings > API Keys).",
       "required": true
     },
     {
       "name": "AGENTICORG_BASE_URL",
-      "description": "Custom API base URL (default: https://app.agenticorg.ai). Set for self-hosted deployments.",
+      "description": "Custom API base URL (default: https://app.agenticorg.ai).",
       "required": false
     }
   ]

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -1,5 +1,21 @@
 # agenticorg-sdk changelog
 
+## 0.3.0 - 2026-06-14
+
+Commerce, A2A/MCP, workflow, and knowledge release.
+
+### Added
+- `client.agents.run("commerce_sales_agent", { action: "buyer_discovery_preview", ... })`
+  coverage through the A2A task endpoint.
+- Agent generation, workflow generation/create/run, workflow template listing,
+  knowledge search, A2A discovery, and MCP tool calls in the public SDK surface.
+
+### Fixed
+- Source examples now import the published npm package name `agenticorg-sdk`
+  instead of the unpublished scoped name `@agenticorg/sdk`.
+- Release metadata now matches the package contents so npm can publish the
+  previously-unpublished SDK capabilities without reusing version `0.2.0`.
+
 ## 0.2.0 — 2026-04-19
 
 Canonical `AgentRunResult` contract.

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenticorg-sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenticorg-sdk",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticorg-sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "TypeScript SDK for AgenticOrg - run agents, generate agents/workflows, use KB, A2A, and MCP",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -3,7 +3,7 @@
  *
  * @example
  * ```typescript
- * import { AgenticOrg } from "@agenticorg/sdk";
+ * import { AgenticOrg } from "agenticorg-sdk";
  *
  * const client = new AgenticOrg({ apiKey: "your-key" });
  * const result = await client.agents.run("ap_processor", { inputs: { invoice_id: "INV-001" } });

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,21 @@
 # AgenticOrg Python SDK changelog
 
+## 0.3.0 - 2026-06-14
+
+Commerce, A2A/MCP, workflow, knowledge, and CLI release.
+
+### Added
+- `client.agents.run("commerce_sales_agent", action="buyer_discovery_preview", ...)`
+  coverage through the A2A task endpoint.
+- Agent generation, workflow generation/create/run, workflow template listing,
+  knowledge search, A2A discovery, and MCP tool calls in the public SDK surface.
+- CLI commands for agents, connectors, SOP parsing, workflows, knowledge, A2A,
+  and MCP discovery.
+
+### Fixed
+- Release metadata now matches the package contents so PyPI can publish the
+  previously-unpublished SDK/CLI capabilities without reusing version `0.2.0`.
+
 ## 0.2.0 — 2026-04-19
 
 Canonical `AgentRunResult` contract.

--- a/sdk/agenticorg/__init__.py
+++ b/sdk/agenticorg/__init__.py
@@ -12,4 +12,4 @@ Quickstart:
 from agenticorg.client import AgenticOrg, AgentRunResult
 
 __all__ = ["AgenticOrg", "AgentRunResult"]
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agenticorg"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python SDK for AgenticOrg - run agents, generate agents/workflows, use KB, A2A, and MCP"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/regression/test_sdk_release_metadata_20260614.py
+++ b/tests/regression/test_sdk_release_metadata_20260614.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_json(path: str) -> dict:
+    return json.loads((ROOT / path).read_text(encoding="utf-8"))
+
+
+def test_python_sdk_release_version_matches_cli_package_metadata() -> None:
+    pyproject = tomllib.loads((ROOT / "sdk" / "pyproject.toml").read_text(encoding="utf-8"))
+    init_text = (ROOT / "sdk" / "agenticorg" / "__init__.py").read_text(encoding="utf-8")
+    match = re.search(r'__version__\s*=\s*"([^"]+)"', init_text)
+
+    assert match
+    assert pyproject["project"]["name"] == "agenticorg"
+    assert pyproject["project"]["version"] == "0.3.0"
+    assert match.group(1) == pyproject["project"]["version"]
+    assert pyproject["project"]["scripts"]["agenticorg"] == "agenticorg.cli:main"
+
+
+def test_typescript_sdk_release_metadata_uses_published_package_name() -> None:
+    package_json = _read_json("sdk-ts/package.json")
+    package_lock = _read_json("sdk-ts/package-lock.json")
+    source = (ROOT / "sdk-ts" / "src" / "index.ts").read_text(encoding="utf-8")
+
+    assert package_json["name"] == "agenticorg-sdk"
+    assert package_json["version"] == "0.3.0"
+    assert package_lock["version"] == package_json["version"]
+    assert package_lock["packages"][""]["version"] == package_json["version"]
+    assert 'from "agenticorg-sdk"' in source
+    assert "@agenticorg/sdk" not in source
+
+
+def test_mcp_server_release_metadata_is_lockstep_and_runtime_truthful() -> None:
+    package_json = _read_json("mcp-server/package.json")
+    package_lock = _read_json("mcp-server/package-lock.json")
+    server_json = _read_json("mcp-server/server.json")
+    readme = (ROOT / "mcp-server" / "README.md").read_text(encoding="utf-8")
+
+    assert package_json["version"] == "4.0.5"
+    assert package_lock["version"] == package_json["version"]
+    assert package_lock["packages"][""]["version"] == package_json["version"]
+    assert server_json["version"] == package_json["version"]
+    assert server_json["packages"][0]["version"] == package_json["version"]
+    assert len(server_json["description"]) <= 100
+
+    expected_tools = {
+        "list_agents",
+        "run_agent",
+        "get_agent_details",
+        "create_agent_from_sop",
+        "deploy_agent",
+        "list_connectors",
+        "list_mcp_tools",
+        "discover_agents_a2a",
+        "get_agent_card",
+    }
+    assert {tool["name"] for tool in server_json["tools"]} == expected_tools
+
+    removed_or_unimplemented_tools = {
+        "call_connector_tool",
+        "create_agent",
+        "list_workflows",
+        "run_workflow",
+        "search_knowledge_base",
+    }
+    assert removed_or_unimplemented_tools.isdisjoint({tool["name"] for tool in server_json["tools"]})
+    assert "call_connector_tool" not in readme


### PR DESCRIPTION
## Summary
- bump Python SDK/CLI to agenticorg 0.3.0 for commerce, A2A/MCP, workflows, and knowledge surface
- bump TypeScript SDK to agenticorg-sdk 0.3.0 and fix source import example to the published npm package name
- bump MCP server metadata to 4.0.5 and align server.json with the actual runtime MCP tools
- document current PyPI/npm/MCP registry release targets
- add regression coverage for SDK/MCP release metadata and MCP tool manifest parity

## Local validation
- python -m pytest tests/regression/test_sdk_release_metadata_20260614.py tests/regression/test_agent_run_contract.py tests/regression/test_sdk_e2e_launch_and_workflows_20260613.py -q
- python -m build (sdk)
- python -m twine check sdk/dist/*
- pip install --no-deps --target temp sdk/dist/agenticorg-0.3.0-py3-none-any.whl + import smoke
- npm ci && npm test (sdk-ts)
- npm ci && npm test (mcp-server)
- npm pack (sdk-ts, mcp-server)
- npm audit --omit=dev (sdk-ts, mcp-server)
- python scripts/consistency_sweep.py
- mcp-publisher validate

## Publish note
This machine is not authenticated for npm and has no PyPI token configured, so registry publish should happen after merge from an authenticated release shell.