### PR TITLE
chore: normalize npm repository metadata

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mishrasanjeev/agentic-org"
+    "url": "git+https://github.com/mishrasanjeev/agentic-org.git"
   },
   "keywords": [
     "mcp",

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mishrasanjeev/agentic-org"
+    "url": "git+https://github.com/mishrasanjeev/agentic-org.git"
   },
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary
- normalize sdk-ts and mcp-server repository URLs to npm's expected git+https form
- removes npm publish auto-correction warnings before SDK/MCP release

## Local validation
- clean temp export of committed source
- npm ci && npm run build && npm publish --dry-run --access public (sdk-ts)
- npm ci && npm run build && npm publish --dry-run --access public (mcp-server)