### PR TITLE
[codex] Fix C6Z artifact cache store reporting

### DIFF
--- a/api/v1/commerce_runtime.py
+++ b/api/v1/commerce_runtime.py
@@ -312,7 +312,7 @@ async def cache_grantex_artifacts(
                 status_code=422,
                 detail={
                     "status": "artifact_cache_rejected",
-                    "records_stored": len(store_results) - len(rejected),
+                    "records_stored": 0,
                     "records_rejected": len(rejected),
                     "store_results": store_results,
                     "allowed_to_execute": False,

--- a/api/v1/commerce_runtime.py
+++ b/api/v1/commerce_runtime.py
@@ -296,7 +296,7 @@ async def cache_grantex_artifacts(
     now_iso = _now_iso()
     async with get_tenant_session(_tenant_uuid(tenant_id)) as session:
         repo = DurableOacpArtifactCacheRepository(session)
-        stored: list[dict[str, Any]] = []
+        store_results: list[dict[str, Any]] = []
         for artifact in body.artifacts:
             record = build_cache_record_from_grantex_artifact(
                 artifact,
@@ -305,11 +305,25 @@ async def cache_grantex_artifacts(
             )
             if record.tenant_id != tenant_id:
                 raise HTTPException(403, "Artifact tenant scope mismatch")
-            stored.append(await repo.upsert(record))
+            store_results.append(await repo.upsert(record))
+        rejected = [result for result in store_results if result.get("stored") is not True]
+        if rejected:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "status": "artifact_cache_rejected",
+                    "records_stored": len(store_results) - len(rejected),
+                    "records_rejected": len(rejected),
+                    "store_results": store_results,
+                    "allowed_to_execute": False,
+                    "non_authoritative_for_transaction": True,
+                },
+            )
     return {
         "status": "cached",
-        "records_stored": len(stored),
-        "store_results": stored,
+        "records_stored": len(store_results),
+        "records_rejected": 0,
+        "store_results": store_results,
         "allowed_to_execute": False,
         "non_authoritative_for_transaction": True,
     }

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -2013,7 +2013,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-buyer-session",
     "scope": "commerce.runtime.buyer_sessions.ask",
-    "source_line": 327,
+    "source_line": 341,
     "tenant_required": true
   },
   {
@@ -2031,7 +2031,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "commerce.runtime.products.read",
-    "source_line": 414,
+    "source_line": 428,
     "tenant_required": true
   },
   {
@@ -2049,7 +2049,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-runtime-external",
     "scope": "commerce.runtime.providers.plural_pine.verify",
-    "source_line": 380,
+    "source_line": 394,
     "tenant_required": true
   },
   {

--- a/tests/unit/test_oacp_c6z_runtime_vertical.py
+++ b/tests/unit/test_oacp_c6z_runtime_vertical.py
@@ -302,6 +302,56 @@ async def test_cache_endpoint_rejects_failed_repository_store_results(monkeypatc
     assert detail["store_results"][0]["refusal_code"] == "cache_timestamps_invalid"
 
 
+@pytest.mark.asyncio
+async def test_cache_endpoint_reports_zero_stored_records_for_rolled_back_mixed_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    @asynccontextmanager
+    async def fake_session(_tenant_id):
+        yield object()
+
+    class FakeRepository:
+        def __init__(self, _session: object) -> None:
+            self._calls = 0
+
+        async def upsert(self, _record) -> dict:
+            self._calls += 1
+            if self._calls == 1:
+                return {
+                    "stored": True,
+                    "status": "stored",
+                    "cache_record_id": "cache_c6z_catalog_1",
+                    "artifact_id": "c6z:catalog_snapshot:tenant:merchant:seller",
+                }
+            return {
+                "stored": False,
+                "status": "stale",
+                "refusal_code": "cache_timestamps_invalid",
+                "cache_record_id": "cache_c6z_catalog_2",
+                "artifact_id": "c6z:catalog_snapshot:tenant:merchant:seller",
+            }
+
+    monkeypatch.setattr(commerce_runtime_api, "get_tenant_session", fake_session)
+    monkeypatch.setattr(commerce_runtime_api, "DurableOacpArtifactCacheRepository", FakeRepository)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await commerce_runtime_api.cache_grantex_artifacts(
+            commerce_runtime_api.CacheArtifactsRequest(
+                artifacts=[
+                    _grantex_artifact(),
+                    _grantex_artifact(),
+                ]
+            ),
+            tenant_id="11111111-1111-1111-1111-111111111111",
+        )
+
+    detail = exc_info.value.detail
+    assert detail["status"] == "artifact_cache_rejected"
+    assert detail["records_stored"] == 0
+    assert detail["records_rejected"] == 1
+    assert [result["stored"] for result in detail["store_results"]] == [True, False]
+
+
 def test_shopify_webhook_hmac_verification_and_idempotency_are_deterministic() -> None:
     raw_body = b'{"id":1,"title":"Canvas Tote"}'
     secret = "webhook-secret"

--- a/tests/unit/test_oacp_c6z_runtime_vertical.py
+++ b/tests/unit/test_oacp_c6z_runtime_vertical.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import httpx
 import pytest
+from fastapi import HTTPException
 
+from api.v1 import commerce_runtime as commerce_runtime_api
 from core.commerce.c6z_runtime_vertical import (
     C6ZRuntimeValidationError,
     answer_product_question_from_cache,
@@ -81,6 +84,30 @@ def _shopify_product() -> dict:
                     "inventoryItem": {"id": "gid://shopify/InventoryItem/1"},
                 }
             ]
+        },
+    }
+
+
+def _grantex_artifact() -> dict:
+    now = _now()
+    return {
+        "artifact_family": "catalog_snapshot",
+        "envelope": {
+            "artifact_id": "c6z:catalog_snapshot:tenant:merchant:seller",
+            "artifact_type": "catalog_snapshot",
+            "issuer": "grantex_internal_oacp_authority",
+            "issued_at": _iso(now),
+            "expires_at": _iso(now + timedelta(minutes=5)),
+        },
+        "payload": {
+            "artifact_family": "catalog_snapshot",
+            "tenant_id": "11111111-1111-1111-1111-111111111111",
+            "merchant_id": "merchant_1",
+            "seller_agent_id": "seller_agent_1",
+            "source_evidence_ref": "agenticorg:shopify:evidence:abc:redacted",
+            "allowed_to_execute": False,
+            "no_payment_execution": True,
+            "no_public_discovery_enablement": True,
         },
     }
 
@@ -197,26 +224,7 @@ def test_grantex_authority_payload_matches_issuer_contract() -> None:
 
 def test_cache_record_accepts_grantex_artifact_with_sibling_payload() -> None:
     now = _iso(_now())
-    artifact = {
-        "artifact_family": "catalog_snapshot",
-        "envelope": {
-            "artifact_id": "c6z:catalog_snapshot:tenant:merchant:seller",
-            "artifact_type": "catalog_snapshot",
-            "issuer": "grantex_internal_oacp_authority",
-            "issued_at": now,
-            "expires_at": _iso(_now() + timedelta(minutes=5)),
-        },
-        "payload": {
-            "artifact_family": "catalog_snapshot",
-            "tenant_id": "11111111-1111-1111-1111-111111111111",
-            "merchant_id": "merchant_1",
-            "seller_agent_id": "seller_agent_1",
-            "source_evidence_ref": "agenticorg:shopify:evidence:abc:redacted",
-            "allowed_to_execute": False,
-            "no_payment_execution": True,
-            "no_public_discovery_enablement": True,
-        },
-    }
+    artifact = _grantex_artifact()
 
     record = build_cache_record_from_grantex_artifact(artifact, cached_at=now)
 
@@ -224,6 +232,74 @@ def test_cache_record_accepts_grantex_artifact_with_sibling_payload() -> None:
     assert record.tenant_id == "11111111-1111-1111-1111-111111111111"
     assert record.allowed_to_execute is False
     assert record.non_authoritative_for_transaction is True
+
+
+@pytest.mark.asyncio
+async def test_cache_endpoint_reports_only_successfully_stored_records(monkeypatch: pytest.MonkeyPatch) -> None:
+    @asynccontextmanager
+    async def fake_session(_tenant_id):
+        yield object()
+
+    class FakeRepository:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        async def upsert(self, _record) -> dict:
+            return {
+                "stored": True,
+                "status": "stored",
+                "cache_record_id": "cache_c6z_catalog",
+                "artifact_id": "c6z:catalog_snapshot:tenant:merchant:seller",
+            }
+
+    monkeypatch.setattr(commerce_runtime_api, "get_tenant_session", fake_session)
+    monkeypatch.setattr(commerce_runtime_api, "DurableOacpArtifactCacheRepository", FakeRepository)
+
+    result = await commerce_runtime_api.cache_grantex_artifacts(
+        commerce_runtime_api.CacheArtifactsRequest(artifacts=[_grantex_artifact()]),
+        tenant_id="11111111-1111-1111-1111-111111111111",
+    )
+
+    assert result["status"] == "cached"
+    assert result["records_stored"] == 1
+    assert result["records_rejected"] == 0
+    assert result["store_results"][0]["stored"] is True
+
+
+@pytest.mark.asyncio
+async def test_cache_endpoint_rejects_failed_repository_store_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    @asynccontextmanager
+    async def fake_session(_tenant_id):
+        yield object()
+
+    class FakeRepository:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        async def upsert(self, _record) -> dict:
+            return {
+                "stored": False,
+                "status": "stale",
+                "refusal_code": "cache_timestamps_invalid",
+                "cache_record_id": "cache_c6z_catalog",
+                "artifact_id": "c6z:catalog_snapshot:tenant:merchant:seller",
+            }
+
+    monkeypatch.setattr(commerce_runtime_api, "get_tenant_session", fake_session)
+    monkeypatch.setattr(commerce_runtime_api, "DurableOacpArtifactCacheRepository", FakeRepository)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await commerce_runtime_api.cache_grantex_artifacts(
+            commerce_runtime_api.CacheArtifactsRequest(artifacts=[_grantex_artifact()]),
+            tenant_id="11111111-1111-1111-1111-111111111111",
+        )
+
+    assert exc_info.value.status_code == 422
+    detail = exc_info.value.detail
+    assert detail["status"] == "artifact_cache_rejected"
+    assert detail["records_stored"] == 0
+    assert detail["records_rejected"] == 1
+    assert detail["store_results"][0]["refusal_code"] == "cache_timestamps_invalid"
 
 
 def test_shopify_webhook_hmac_verification_and_idempotency_are_deterministic() -> None:


### PR DESCRIPTION
Production C6Z smoke found that POST /api/v1/commerce/runtime/artifacts/cache returned records_stored=1 even when the durable repository refused the record with stored=false/cache_timestamps_invalid. That made buyer-session ask return cache_not_usable with no reason because no record had actually been persisted.\n\nFixes:\n- Treat repository stored=false results as HTTP 422 artifact_cache_rejected.\n- Roll back the request if any artifact is rejected.\n- Count only successfully stored records and return records_rejected=0 on success.\n- Add regression coverage for both accepted and rejected repository results.\n\nLocal verification:\n- python -m ruff check api/v1/commerce_runtime.py tests/unit/test_oacp_c6z_runtime_vertical.py\n- python -m pytest tests/unit/test_oacp_c6z_runtime_vertical.py\n- python scripts/check_migration_required.py\n- git diff --check