### PR TITLE
docs: reconcile OACP launch evidence and blockers

### DIFF
--- a/api/v1/commerce_runtime.py
+++ b/api/v1/commerce_runtime.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import os
+import re
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Any, cast
@@ -22,6 +24,7 @@ from core.commerce.c6z_runtime_vertical import (
     SHOPIFY_WEBHOOK_ENV_VARS,
     C6ZRuntimeValidationError,
     ShopifyAdminGraphQLClient,
+    ShopifyCredentials,
     answer_product_question_from_cache,
     build_cache_record_from_grantex_artifact,
     build_grantex_authority_request_payload,
@@ -38,12 +41,15 @@ from core.commerce.oacp_artifacts import (
     DurableOacpArtifactCacheRepository,
     OacpArtifactCacheRepositoryQuery,
 )
+from core.crypto import encrypt_for_tenant
+from core.crypto.tenant_secrets import decrypt_for_tenant
 from core.database import get_tenant_session
 from core.models.commerce_c6z_runtime import (
     C6ZConnectorEvidenceRow,
     C6ZProviderCapabilityEvidenceRow,
     C6ZSellerOnboardingPacketRow,
 )
+from core.models.connector_config import ConnectorConfig
 
 router = APIRouter(
     prefix="/commerce/runtime",
@@ -69,6 +75,18 @@ class ShopifySyncRequest(BaseModel):
     page_size: int = Field(default=50, ge=1, le=100)
     max_pages: int = Field(default=10, ge=1, le=20)
     currency: str | None = None
+
+
+class ShopifyConnectorCredentialRequest(BaseModel):
+    merchant_id: str = Field(min_length=1)
+    shop_domain: str = Field(min_length=1)
+    api_version: str = "2026-04"
+    admin_access_token: str | None = None
+    oauth_code: str | None = None
+    client_id: str | None = None
+    client_secret: str | None = None
+    redirect_uri: str | None = None
+    validate_read: bool = True
 
 
 class GrantexAuthorityRequest(BaseModel):
@@ -140,6 +158,137 @@ async def get_seller_onboarding_packet(
         return {"packet": _row_to_packet(row)}
 
 
+@router.post("/seller-agents/connectors/shopify/credentials")
+@route_meta(
+    auth_required=True,
+    tenant_required=True,
+    scope="commerce.runtime.shopify.credentials.write",
+    rate_limit="commerce-runtime-write",
+    idempotency="merchant-shopify-credential-upsert",
+    audit_event="commerce.runtime.shopify.credentials.upsert",
+)
+async def upsert_shopify_connector_credentials(
+    body: ShopifyConnectorCredentialRequest,
+    tenant_id: str = Depends(get_current_tenant),
+) -> dict[str, Any]:
+    tid = _tenant_uuid(tenant_id)
+    credentials, credential_source, granted_scopes = await _resolve_submitted_shopify_credentials(body)
+    if body.validate_read:
+        await _validate_shopify_read_credentials(credentials)
+
+    secret_fields = {
+        "admin_access_token": credentials.admin_access_token,
+        "shop_domain": credentials.shop_domain,
+        "api_version": credentials.api_version,
+        "credential_source": credential_source,
+    }
+    encrypted = await encrypt_for_tenant(json.dumps(secret_fields), tid)
+    config = {
+        "merchant_id": body.merchant_id,
+        "shop_domain": credentials.shop_domain,
+        "api_version": credentials.api_version,
+        "connector_type": "shopify",
+        "connector_mode": "read_only",
+        "credential_source": credential_source,
+        "granted_scopes": granted_scopes,
+        "raw_payload_stored": False,
+        "allowed_to_execute": False,
+        "no_payment_execution": True,
+        "no_public_discovery_enablement": True,
+        "non_authoritative_for_transaction": True,
+        "configured_by": "commerce_runtime",
+        "configured_at": _now_iso(),
+    }
+    connector_name = _shopify_connector_config_name(body.merchant_id)
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(ConnectorConfig).where(
+                ConnectorConfig.tenant_id == tid,
+                ConnectorConfig.connector_name == connector_name,
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            row = ConnectorConfig(
+                tenant_id=tid,
+                connector_name=connector_name,
+                display_name=f"Shopify read-only - {body.merchant_id}",
+                auth_type="shopify_admin_api",
+                credentials_encrypted={"_encrypted": encrypted},
+                config=config,
+                status="configured",
+                health_status="healthy" if body.validate_read else "unknown",
+                last_health_check=datetime.now(tz=UTC) if body.validate_read else None,
+            )
+            session.add(row)
+        else:
+            row.display_name = f"Shopify read-only - {body.merchant_id}"
+            row.auth_type = "shopify_admin_api"
+            row.credentials_encrypted = {"_encrypted": encrypted}
+            row.config = config
+            row.status = "configured"
+            row.health_status = "healthy" if body.validate_read else "unknown"
+            row.last_health_check = datetime.now(tz=UTC) if body.validate_read else row.last_health_check
+            row.sync_error = None
+    return {
+        "status": "shopify_connector_configured",
+        "merchant_id": body.merchant_id,
+        "connector_name": connector_name,
+        "shop_domain": credentials.shop_domain,
+        "api_version": credentials.api_version,
+        "credential_source": credential_source,
+        "validated": body.validate_read,
+        "credential_values_redacted": True,
+        "raw_payload_stored": False,
+        "allowed_to_execute": False,
+        "no_payment_execution": True,
+        "no_public_discovery_enablement": True,
+        "non_authoritative_for_transaction": True,
+    }
+
+
+@router.get("/seller-agents/connectors/shopify/status")
+@route_meta(
+    auth_required=True,
+    tenant_required=True,
+    scope="commerce.runtime.shopify.credentials.read",
+    rate_limit="standard",
+    idempotency="read-only",
+    audit_event="commerce.runtime.shopify.credentials.read",
+)
+async def get_shopify_connector_status(
+    merchant_id: str,
+    tenant_id: str = Depends(get_current_tenant),
+) -> dict[str, Any]:
+    tid = _tenant_uuid(tenant_id)
+    async with get_tenant_session(tid) as session:
+        row = await _load_shopify_connector_config_row(session, tid, merchant_id)
+    if row is None:
+        return {
+            "status": "not_configured",
+            "merchant_id": merchant_id,
+            "credential_values_redacted": True,
+            "allowed_to_execute": False,
+            "non_authoritative_for_transaction": True,
+        }
+    config = row.config or {}
+    return {
+        "status": row.status,
+        "health_status": row.health_status or "unknown",
+        "merchant_id": merchant_id,
+        "connector_name": row.connector_name,
+        "shop_domain": config.get("shop_domain"),
+        "api_version": config.get("api_version"),
+        "connector_mode": config.get("connector_mode", "read_only"),
+        "credential_values_redacted": True,
+        "raw_payload_stored": False,
+        "allowed_to_execute": False,
+        "no_payment_execution": True,
+        "no_public_discovery_enablement": True,
+        "non_authoritative_for_transaction": True,
+    }
+
+
 @router.post("/seller-agents/shopify/sync")
 @route_meta(
     auth_required=True,
@@ -153,22 +302,16 @@ async def sync_shopify_read_only(
     body: ShopifySyncRequest,
     tenant_id: str = Depends(get_current_tenant),
 ) -> dict[str, Any]:
-    env_resolution = resolve_env(SHOPIFY_ENV_VARS)
-    if not env_resolution.ready:
-        raise HTTPException(
-            status_code=424,
-            detail={
-                "status": "blocked_missing_shopify_env",
-                "missing_env_vars": list(env_resolution.missing),
-                "external_validation_performed": False,
-            },
-        )
     async with get_tenant_session(_tenant_uuid(tenant_id)) as session:
         packet_row = await session.get(C6ZSellerOnboardingPacketRow, body.packet_id)
         if packet_row is None or packet_row.tenant_id != tenant_id:
             raise HTTPException(404, "Seller Commerce Agent onboarding packet not found")
         packet = _row_to_packet(packet_row)
-        credentials = resolve_shopify_credentials()
+        credentials, credential_source = await _resolve_shopify_credentials_for_packet(
+            session=session,
+            tenant_id=_tenant_uuid(tenant_id),
+            packet=packet,
+        )
         client = ShopifyAdminGraphQLClient(credentials)
         try:
             products = await client.fetch_products(page_size=body.page_size, max_pages=body.max_pages)
@@ -190,6 +333,7 @@ async def sync_shopify_read_only(
         packet_row.status = "artifact_issuance_ready"
     return {
         "status": "shopify_sync_stored",
+        "credential_source": credential_source,
         "evidence_id": evidence["evidence_id"],
         "product_count": evidence["product_count"],
         "variant_count": evidence["variant_count"],
@@ -477,6 +621,248 @@ def _build_packet_from_body(body: SellerOnboardingPacketCreate, tenant_id: str) 
         source_freshness_policy=body.source_freshness_policy or {"max_age_seconds": 900},
         connector_metadata=body.connector_metadata,
     )
+
+
+async def _resolve_submitted_shopify_credentials(
+    body: ShopifyConnectorCredentialRequest,
+) -> tuple[ShopifyCredentials, str, list[str]]:
+    token = (body.admin_access_token or "").strip()
+    granted_scopes: list[str] = []
+    credential_source = "admin_access_token"
+    if token and any((body.oauth_code, body.client_id, body.client_secret)):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "shopify_credential_mode_ambiguous",
+                "message": "Send either admin_access_token or OAuth code material, not both.",
+            },
+        )
+    if not token:
+        token_data = await _exchange_shopify_oauth_code(body)
+        token = str(token_data.get("access_token") or "").strip()
+        granted_scopes = _scope_list(token_data.get("scope"))
+        credential_source = "oauth_code_exchange"
+    if not token:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "shopify_token_required",
+                "message": "Shopify setup requires an Admin API token or OAuth code exchange material.",
+            },
+        )
+    return (
+        ShopifyCredentials(
+            shop_domain=_normalize_shopify_domain_for_api(body.shop_domain),
+            admin_access_token=token,
+            api_version=_validate_shopify_api_version(body.api_version),
+        ),
+        credential_source,
+        granted_scopes,
+    )
+
+
+async def _exchange_shopify_oauth_code(body: ShopifyConnectorCredentialRequest) -> dict[str, Any]:
+    missing = [
+        label
+        for value, label in (
+            (body.oauth_code, "oauth_code"),
+            (body.client_id, "client_id"),
+            (body.client_secret, "client_secret"),
+        )
+        if not str(value or "").strip()
+    ]
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "shopify_oauth_material_required",
+                "missing": missing,
+                "message": "OAuth setup requires oauth_code, client_id, and client_secret.",
+            },
+        )
+    form = {
+        "client_id": str(body.client_id).strip(),
+        "client_secret": str(body.client_secret).strip(),
+        "code": str(body.oauth_code).strip(),
+    }
+    if body.redirect_uri:
+        form["redirect_uri"] = body.redirect_uri.strip()
+    shop_domain = _normalize_shopify_domain_for_api(body.shop_domain)
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        response = await client.post(
+            f"https://{shop_domain}/admin/oauth/access_token",
+            data=form,
+            headers={"Accept": "application/json"},
+        )
+    body_json: dict[str, Any]
+    try:
+        body_json = cast(dict[str, Any], response.json())
+    except ValueError:
+        body_json = {"message": response.text[:200]}
+    if response.status_code >= 400:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "shopify_oauth_code_rejected",
+                "status_code": response.status_code,
+                "message": _safe_external_error(body_json),
+            },
+        )
+    if "access_token" not in body_json:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "shopify_oauth_token_missing",
+                "message": "Shopify accepted the OAuth request but did not return an access token.",
+            },
+        )
+    return body_json
+
+
+async def _validate_shopify_read_credentials(credentials: ShopifyCredentials) -> None:
+    client = ShopifyAdminGraphQLClient(credentials)
+    try:
+        await client.fetch_products(page_size=1, max_pages=1)
+    except (httpx.HTTPError, C6ZRuntimeValidationError) as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "shopify_read_validation_failed",
+                "message": "Shopify rejected the read-only product sync validation.",
+                "external_validation_performed": True,
+                "credential_values_redacted": True,
+            },
+        ) from exc
+
+
+async def _resolve_shopify_credentials_for_packet(
+    *,
+    session: Any,
+    tenant_id: UUID,
+    packet: Mapping[str, Any],
+) -> tuple[ShopifyCredentials, str]:
+    row = await _load_shopify_connector_config_row(session, tenant_id, str(packet["merchant_id"]))
+    if row is not None and row.credentials_encrypted:
+        enc = row.credentials_encrypted.get("_encrypted") if isinstance(row.credentials_encrypted, dict) else None
+        if not isinstance(enc, str) or not enc:
+            raise HTTPException(status_code=424, detail="Shopify connector credential vault is empty")
+        try:
+            credential_data = json.loads(decrypt_for_tenant(enc))
+        except Exception as exc:
+            raise HTTPException(
+                status_code=424,
+                detail={
+                    "status": "blocked_shopify_credential_decrypt_failed",
+                    "credential_values_redacted": True,
+                    "allowed_to_execute": False,
+                },
+            ) from exc
+        token = str(
+            credential_data.get("admin_access_token")
+            or credential_data.get("access_token")
+            or "",
+        ).strip()
+        if not token:
+            raise HTTPException(status_code=424, detail="Shopify connector token is missing")
+        return (
+            ShopifyCredentials(
+                shop_domain=_normalize_shopify_domain_for_api(
+                    credential_data.get("shop_domain")
+                    or (row.config or {}).get("shop_domain")
+                    or ((packet.get("connector_metadata_redacted") or {}).get("shop_domain"))
+                    or "",
+                ),
+                admin_access_token=token,
+                api_version=_validate_shopify_api_version(
+                    str(credential_data.get("api_version") or (row.config or {}).get("api_version") or "2026-04")
+                ),
+            ),
+            "tenant_connector_config",
+        )
+
+    env_resolution = resolve_env(SHOPIFY_ENV_VARS)
+    if not env_resolution.ready:
+        raise HTTPException(
+            status_code=424,
+            detail={
+                "status": "blocked_missing_shopify_credentials",
+                "missing_env_vars": list(env_resolution.missing),
+                "expected_connector_config": _shopify_connector_config_name(str(packet["merchant_id"])),
+                "external_validation_performed": False,
+            },
+        )
+    return resolve_shopify_credentials(), "environment"
+
+
+async def _load_shopify_connector_config_row(
+    session: Any,
+    tenant_id: UUID,
+    merchant_id: str,
+) -> ConnectorConfig | None:
+    names = (_shopify_connector_config_name(merchant_id), "shopify")
+    result = await session.execute(
+        select(ConnectorConfig).where(
+            ConnectorConfig.tenant_id == tenant_id,
+            ConnectorConfig.connector_name.in_(names),
+        )
+    )
+    rows = list(result.scalars().all())
+    if not rows:
+        return None
+    merchant_specific = _shopify_connector_config_name(merchant_id)
+    for row in rows:
+        if row.connector_name == merchant_specific:
+            return row
+    for row in rows:
+        config = row.config or {}
+        if not config.get("merchant_id") or config.get("merchant_id") == merchant_id:
+            return row
+    return None
+
+
+def _shopify_connector_config_name(merchant_id: str) -> str:
+    suffix = re.sub(r"[^a-zA-Z0-9_]+", "_", merchant_id.strip()).strip("_").lower()
+    if not suffix:
+        suffix = "merchant"
+    return f"commerce_shopify_{suffix[:72]}"
+
+
+def _normalize_shopify_domain_for_api(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    text = text.removeprefix("https://").removeprefix("http://").strip("/")
+    if not text or "/" in text or "." not in text:
+        raise HTTPException(status_code=400, detail="Shopify shop_domain must be a host name")
+    return text
+
+
+def _validate_shopify_api_version(value: str) -> str:
+    text = str(value or "").strip()
+    if not re.fullmatch(r"\d{4}-\d{2}", text):
+        raise HTTPException(status_code=400, detail="Shopify api_version must look like YYYY-MM")
+    return text
+
+
+def _scope_list(value: Any) -> list[str]:
+    if not value:
+        return []
+    return [part.strip() for part in str(value).split(",") if part.strip()]
+
+
+def _safe_external_error(value: Any) -> str:
+    text = json.dumps(value, sort_keys=True) if not isinstance(value, str) else value
+    lowered = text.lower()
+    sensitive_markers = (
+        "access_token",
+        "authorization",
+        "bearer ",
+        "client_secret",
+        "password",
+        "secret",
+        "shpat_",
+    )
+    if any(marker in lowered for marker in sensitive_markers):
+        return "<redacted external error body contained sensitive marker>"
+    return text[:500]
 
 
 def _apply_packet(row: C6ZSellerOnboardingPacketRow, packet: Mapping[str, Any]) -> None:

--- a/api/v1/commerce_runtime.py
+++ b/api/v1/commerce_runtime.py
@@ -748,6 +748,7 @@ async def _resolve_shopify_credentials_for_packet(
             raise HTTPException(status_code=424, detail="Shopify connector credential vault is empty")
         try:
             credential_data = json.loads(decrypt_for_tenant(enc))
+        # enterprise-gate: broad-except-ok reason=shopify-credential-decrypt-failure-raises-424-no-success
         except Exception as exc:
             raise HTTPException(
                 status_code=424,

--- a/docs/commerce-agent-agentic-commerce-implementation-prd.md
+++ b/docs/commerce-agent-agentic-commerce-implementation-prd.md
@@ -134,7 +134,7 @@ Regular transaction:
 | OACP consumer foundation | C6W3-C6Z helper/tests/docs and runtime paths consume artifact schemas, adapter previews, commitment boundaries, prepared envelopes, response reconciliations, eligibility packets, dry-run verifier results, C6Z authority responses, cached seller facts, buyer answer sources, MCP bridge facts, and Plural/Pine capability metadata. | Internal only; the 2026-06-18 production vertical is blocked by Shopify token and Grantex tenant-token provisioning issues; no execution, public protocol publication, certification, or production readiness. |
 | OACP cache foundation | C6X1-C6X5 add cache verifier/runtime planning, fail-closed cache evaluation, repository boundary, durable SQL-backed cache records, and local maintenance planning. | Internal only; planner/cache do not call Grantex live, providers, merchant private APIs, checkout, payments, schedulers, or queues. |
 
-### 2.1 Current OACP Status Through C6Z
+### 2.1 Current OACP Status Through C6X5 And C6Z Runtime Extension
 
 AgenticOrg currently has local consumer and runtime behavior for:
 

--- a/docs/commerce-agent-agentic-commerce-implementation-prd.md
+++ b/docs/commerce-agent-agentic-commerce-implementation-prd.md
@@ -131,12 +131,12 @@ Regular transaction:
 | Public discovery gate | Commerce metadata is fail-closed behind `AGENTICORG_COMMERCE_PUBLIC_DISCOVERY_ENABLED`. | Safe posture. |
 | Docs-only CI guard | `.github/workflows/deploy.yml` classifies docs-only changes and skips cloud auth/build/push/deploy-adjacent jobs. | Correct for future planning docs merges. |
 | Merchant education docs | C5O-C5X docs cover self-onboarding, architecture, API/data model proposals, UI wireframes, validator, review workflow, rollout automation, demo merchant, and launch rehearsal. | Good planning foundation; runtime implementation still pending. |
-| OACP consumer foundation | C6W3-C6W9 helper/tests/docs consume artifact schemas, adapter previews, commitment boundaries, prepared envelopes, response reconciliations, eligibility packets, and dry-run verifier results. | Internal only; no execution, public protocol publication, certification, or production readiness. |
+| OACP consumer foundation | C6W3-C6Z helper/tests/docs and runtime paths consume artifact schemas, adapter previews, commitment boundaries, prepared envelopes, response reconciliations, eligibility packets, dry-run verifier results, C6Z authority responses, cached seller facts, buyer answer sources, MCP bridge facts, and Plural/Pine capability metadata. | Internal only; the 2026-06-18 production vertical is blocked by Shopify token and Grantex tenant-token provisioning issues; no execution, public protocol publication, certification, or production readiness. |
 | OACP cache foundation | C6X1-C6X5 add cache verifier/runtime planning, fail-closed cache evaluation, repository boundary, durable SQL-backed cache records, and local maintenance planning. | Internal only; planner/cache do not call Grantex live, providers, merchant private APIs, checkout, payments, schedulers, or queues. |
 
-### 2.1 Current OACP Status Through C6X5
+### 2.1 Current OACP Status Through C6Z
 
-AgenticOrg currently has local consumer behavior for:
+AgenticOrg currently has local consumer and runtime behavior for:
 
 - public-safe OACP artifact family validation;
 - adapter preview consumption for schema.org, UCP-style, ACP-style,
@@ -150,15 +150,29 @@ AgenticOrg currently has local consumer behavior for:
 - repository port plus in-memory adapter;
 - durable cache records scoped by buyer agent, seller agent, tenant, and
   merchant;
-- local maintenance planning over durable records.
+- local maintenance planning over durable records;
+- Seller Commerce Agent packet creation for the C6Z vertical;
+- Shopify read-only sync initiation and normalized connector evidence handling;
+- Grantex internal authority request handoff;
+- artifact cache records consumed by buyer answer generation;
+- MCP seller fact bridge over cached artifacts;
+- Plural/Pine capability verifier metadata checks that do not execute mandates
+  or payments.
+
+The 2026-06-18 production closure run is blocked: the mounted Shopify Admin
+token returns `401 Unauthorized`, and the AgenticOrg-configured Grantex token
+returns `422 tenant_not_provisioned`. Local C6Z unit tests and MCP smoke pass,
+but the real production vertical is not complete.
 
 Still missing:
 
-- seller-agent onboarding UI/runtime for OACP;
-- real Shopify/WooCommerce/ERP connector sync initiation;
+- successful production Shopify sync with a valid merchant-approved token;
+- Grantex commerce tenant/developer mapping for the AgenticOrg production
+  internal token;
+- self-serve seller-agent onboarding UX beyond the current runtime/API path;
 - cache refresh/eviction scheduler, durable maintenance log, and refresh intent
   queue;
-- provider-owned mandate capability verifier runtime;
+- provider-owned mandate capability verification for live provider approval;
 - channel bridges for ChatGPT-style, Claude/MCP-style, Gemini-style,
   Perplexity/search-style, web, and messaging surfaces;
 - public seller cards and third-party agent cards with risk controls;
@@ -411,8 +425,8 @@ AgenticOrg landing page planning blocks:
   logistics, support, CSV/API.
 - Section 5: Provider Mandate Boundary - provider-owned setup and execution,
   approved capability verification, non-sensitive evidence refs only.
-- Section 6: OACP Status - internal C6W9 foundation, no public standard or live
-  execution claim.
+- Section 6: OACP Status - internal C6Z foundation with blocked production
+  vertical, no public standard or live execution claim.
 
 Blog series plan:
 
@@ -424,7 +438,7 @@ Blog series plan:
 | Shopify And WooCommerce In Agentic Commerce | Integrators | Connector custody and sync evidence flow. |
 | Provider-Owned Mandates Without Payment Execution In The Agent | Fintech and risk teams | Provider mandate setup -> capability verification -> evidence ref. |
 | ChatGPT, Claude, Gemini, And Search-Style Channels | GTM and engineering | Channel bridge matrix and supported action labels. |
-| What Is Still Missing Before Autonomous Commerce | Leadership | C6W9 complete vs runtime gaps. |
+| What Is Still Missing Before Autonomous Commerce | Leadership | C6Z blocked production vertical vs pilot gaps. |
 
 Avoid claims that imply:
 

--- a/docs/commerce-agent-overview.md
+++ b/docs/commerce-agent-overview.md
@@ -39,6 +39,7 @@ commerce transaction should work end to end.
 | C6X1-C6X3 OACP cache foundation | Verifier/runtime planning, fail-closed cache evaluator, repository port, and in-memory adapter for non-binding preview/prepare behavior. |
 | C6X4 durable OACP cache | SQL-backed durable cache records scoped by buyer agent, seller agent, tenant, and merchant with TTL, freshness, revocation snapshot, risk tier, non-enablement flags, RLS, and tenant-safe indexes. |
 | C6X5 cache maintenance planner | Deterministic local planner that classifies durable cache records into keep, refresh, evict, purge, quarantine, source refresh, or human-review outcomes. No scheduler and no side effects. |
+| C6Z runtime vertical | Implemented, but production closure is blocked by Shopify token `401 Unauthorized` and Grantex `tenant_not_provisioned` for the configured AgenticOrg token. |
 | Payment execution | Blocked. AgenticOrg may verify provider-owned mandate capability only through separately approved verifier flows. |
 | Live checkout/payments/Plural | Blocked. |
 | C6H buyer discovery consumer | Read-only sandbox consumer foundation; not public discovery or checkout/payment. |
@@ -115,8 +116,10 @@ For merchants, the intended product experience should be simple:
 3. Grantex validates public-safe facts, source/freshness, policy, and evidence
    references into OACP artifacts.
 4. The merchant previews exactly what an AI agent can see.
-5. The merchant chooses which actions agents may request, such as browse,
-   cart draft, checkout request, order status, or support handoff.
+5. The merchant chooses which non-executing actions agents may request, such as
+   browse, compare, product explanation, or support handoff. Checkout, order,
+   payment, mandate, refund, return, shipment, and inventory hold execution
+   require a separate future rollout and are not enabled by C6Z.
 6. Grantex runs validation scans and review gates.
 7. AgenticOrg agents use valid OACP artifacts, approved authority refresh, and
    approved provider/connector verifier flows.
@@ -134,12 +137,12 @@ The operational flow is:
 
 1. Seller completes one-time setup in AgenticOrg Seller Commerce Agent and
    Grantex authority review: onboarding packet, connected systems, catalog,
-   inventory, policy, payment/mandate path, approvals, smoke evidence, and
+   inventory, policy, capability metadata, approvals, smoke evidence, and
    rollback ownership.
 2. Buyer completes one-time setup in their preferred channel: account/session
-   linking, safe preferences, and understanding that checkout requires Grantex
-   consent.
-3. Buyer asks the agent to find, compare, or buy.
+   linking, safe preferences, and understanding that current C6Z behavior is
+   non-executing. Any future checkout path requires separate approval.
+3. Buyer asks the agent to find, compare, or request a non-executing handoff.
 4. AgenticOrg reads valid durable OACP cache records when TTL, freshness,
    revocation, scope, source, and risk rules allow; otherwise it blocks or
    asks Grantex for authority refresh in a separately approved path.
@@ -214,21 +217,30 @@ payment status.
 
 ## Tool Aliases
 
+The aliases below describe historical or adjacent Grantex commerce connector
+surfaces. They are not proof that the C6Z OACP runtime artifact vertical has
+completed, and they are not enabled by OACP C6Z launch evidence.
+
 | Alias | Purpose |
 | --- | --- |
 | `grantex_commerce:merchant_get_profile` | Read merchant and policy status. |
 | `grantex_commerce:catalog_search` | Search grounded product data. |
 | `grantex_commerce:catalog_get_item` | Fetch exact product or variant details. |
 | `grantex_commerce:inventory_check` | Check availability, using a browse passport when required. |
-| `grantex_commerce:cart_create` | Create a cart draft from grounded items. |
-| `grantex_commerce:consent_request` | Request user consent with supported checkout scopes. |
-| `grantex_commerce:consent_exchange` | Exchange granted consent only when granted consent fixture material exists. |
+| `grantex_commerce:cart_create` | Historical payment-control pilot alias; not enabled by OACP C6Z runtime artifact proof. |
+| `grantex_commerce:consent_request` | Historical payment-control pilot alias; not enabled by OACP C6Z runtime artifact proof. |
+| `grantex_commerce:consent_exchange` | Historical fixture-backed alias; not enabled by OACP C6Z runtime artifact proof. |
 | `grantex_commerce:buyer_discovery_preview` | Read Grantex C6G sandbox buyer discovery handoff preview data. |
-| `grantex_commerce:payment_create_intent` | Create Grantex provider-neutral payment intent with supported fields only. |
-| `grantex_commerce:checkout_create` | Create Grantex checkout handoff. |
-| `grantex_commerce:payment_get_status` | Poll Grantex payment status. |
+| `grantex_commerce:payment_create_intent` | Historical Grantex payment-control pilot alias; not enabled by OACP C6Z runtime artifact proof. |
+| `grantex_commerce:checkout_create` | Historical Grantex checkout handoff alias; not enabled by OACP C6Z runtime artifact proof. |
+| `grantex_commerce:payment_get_status` | Historical Grantex payment-status alias; not enabled by OACP C6Z runtime artifact proof. |
 
-## Consent And Fixture Behavior
+## Historical Consent And Fixture Behavior
+
+This section describes earlier fixture-backed Grantex payment-control pilot
+behavior. It is not proof that the AgenticOrg C6Z OACP runtime artifact vertical
+has completed, and it does not enable checkout, payment, mandate, order, refund,
+return, shipment, public discovery, or live-provider execution.
 
 ```mermaid
 sequenceDiagram

--- a/docs/reports/commerce-agent-c6z-runtime-vertical-demo.md
+++ b/docs/reports/commerce-agent-c6z-runtime-vertical-demo.md
@@ -14,7 +14,21 @@ C6Z adds a real internal runtime path for a Seller Commerce Agent:
 8. MCP tools expose the same cached product facts to local agent clients.
 9. Plural/Pine mandate capability can be checked only when sandbox env vars are present.
 
-The vertical is internal, non-publication, non-certifying, non-production, and non-executing. It does not create checkout sessions, payments, mandates, orders, holds, refunds, returns, shipments, public discovery entries, or live-provider actions.
+The vertical is internal, non-publication, non-certifying, and non-executing. It does not create checkout sessions, payments, mandates, orders, holds, refunds, returns, shipments, public discovery entries, or live-provider actions.
+
+## Production Closure Status
+
+The June 18, 2026 production closure run did not complete the real vertical:
+
+- AgenticOrg production health was healthy at commit `2fdccc7ca1337b3b2caa20a2e9ac1d03c7bfbc9c`.
+- Grantex production health was healthy at commit `7fd4dd3c865fbd8187d92aec792cff249c9c01c3`.
+- Authenticated Seller Commerce Agent onboarding packet creation succeeded.
+- Shopify Admin GraphQL read-only sync failed with `401 Unauthorized`.
+- A direct status-only Shopify GraphQL probe using the mounted AgenticOrg C6Z Shopify token also returned `401`.
+- Grantex C6Z authority called with AgenticOrg's configured internal token returned `422 tenant_not_provisioned`.
+- Grantex C6Z authority called by a platform-admin operator issued 8 verifier-valid, non-executing artifacts. That proves the Grantex route, not the configured AgenticOrg-to-Grantex path.
+
+Do not use this document to claim internal runtime demo completion, closed merchant pilot readiness, public OACP preview readiness, certification, conformance, standardization, payment approval, mandate approval, or live-provider readiness.
 
 ## Runtime Boundaries
 
@@ -70,6 +84,8 @@ Missing external credentials cause blocked or skipped results with exact env var
 10. Run the Plural/Pine capability check only with sandbox env vars present.
 
 The sequence proves non-binding product answers from cached internal artifacts. It does not create a payment, order, checkout session, mandate, inventory hold, refund, return, shipment, public discovery publication, or live-provider action.
+
+In production, this sequence must not be marked complete until the Shopify token and Grantex tenant-mapping blockers above are fixed and the complete path is re-run.
 
 ## Local Commands
 

--- a/docs/reports/commerce-agent-oacp-documentation-inventory.md
+++ b/docs/reports/commerce-agent-oacp-documentation-inventory.md
@@ -1,0 +1,31 @@
+# Commerce Agent OACP Documentation Inventory
+
+Status: current OACP closure inventory.
+
+Last updated: 2026-06-18.
+
+## Canonical Current Docs
+
+| Document | Purpose | Current status |
+| --- | --- | --- |
+| `commerce-agent-oacp-runtime-launch-runbook.md` | Safe production runbook for C6Z. | Current. |
+| `commerce-agent-oacp-public-narrative-boundary.md` | Allowed and disallowed public claims. | Current. |
+| `commerce-agent-oacp-final-launch-evidence.md` | Final launch evidence packet. | Current. |
+| `commerce-agent-oacp-landing-blog-plan.md` | Landing/blog plan. | Updated for C6Z blocker and payment-control separation. |
+| `commerce-agent-c6z-runtime-vertical-demo.md` | C6Z implementation/demo notes. | Updated with production blocker. |
+| `docs/commerce-agent-overview.md` | Product overview and architecture. | Updated with current C6Z launch status. |
+| `mcp-server/README.md` | MCP bridge usage. | Updated to clarify cached-artifact, non-executing seller tools. |
+
+## Historical Or Adjacent Docs
+
+Older C6W/C6X/C6Y implementation reports remain trace history. They must not be used to claim public discovery, certification, conformance, standardization, payment readiness, live-provider readiness, or production launch readiness.
+
+## Required Scan Terms
+
+Scan new or changed OACP docs for:
+
+- `certified`, `certification`, `conformant`, `conformance`, `standardized`, `standardization`
+- `public discovery enabled`
+- `production ready`, `public launch ready`, `live-provider ready`
+- `checkout`, `payment`, `order`, `mandate`, `refund`, `return`, `shipment`, `inventory hold`
+- `all through Grantex`, `thin client`, `Grantex owns every interaction`

--- a/docs/reports/commerce-agent-oacp-final-launch-evidence.md
+++ b/docs/reports/commerce-agent-oacp-final-launch-evidence.md
@@ -1,0 +1,97 @@
+# Commerce Agent OACP Final Launch Evidence
+
+Status: blocked for production C6Z launch.
+
+Evidence date: 2026-06-18.
+
+## Repository And Deployment State
+
+| Item | Evidence |
+| --- | --- |
+| AgenticOrg `origin/main` | `2fdccc7ca1337b3b2caa20a2e9ac1d03c7bfbc9c` |
+| AgenticOrg API revision | `agenticorg-api-00103-jbk`, 100 percent traffic |
+| AgenticOrg UI revision | `agenticorg-ui-00064-kcp`, 100 percent traffic |
+| Grantex `origin/main` | `7fd4dd3c865fbd8187d92aec792cff249c9c01c3` |
+| Grantex revision | `grantex-auth-00204-zhz`, 100 percent traffic |
+
+## Production Health
+
+- `https://app.agenticorg.ai/api/v1/health`: healthy; commit `2fdccc7ca1337b3b2caa20a2e9ac1d03c7bfbc9c`; DB healthy; Redis healthy.
+- `https://app.agenticorg.ai/`: HTTP 200.
+- `https://api.grantex.dev/health`: healthy; database ok; Redis ok.
+
+## Production Vertical Result
+
+The required production vertical did not complete.
+
+Completed before blocker:
+
+- Authenticated smoke login succeeded.
+- Seller Commerce Agent onboarding packet was created for merchant id `mch_shopify_mgx0n6_22` and seller agent id `seller_oacp_launch_evidence_20260618`.
+- Identity fields used:
+  - tenant id: redacted; production smoke tenant is managed through Secret Manager and is not printed in this packet.
+  - merchant id: `mch_shopify_mgx0n6_22`
+  - seller agent id: `seller_oacp_launch_evidence_20260618`
+  - buyer agent id requested for the vertical: `buyer_oacp_launch_evidence_20260618`
+  - packet id: created by the API, but not captured because the smoke aborted before emitting the final summary; a later safe recapture attempt was blocked by current Secret Manager access.
+  - evidence id: not created because Shopify sync failed before connector evidence was produced.
+
+Blocking evidence:
+
+- AgenticOrg Shopify Admin GraphQL read-only sync reached `mgx0n6-22.myshopify.com` and failed with `401 Unauthorized`.
+- Direct status-only Shopify GraphQL probe with the mounted AgenticOrg C6Z Shopify token also returned `401`.
+- Grantex C6Z authority called with AgenticOrg's configured internal token returned `422 tenant_not_provisioned`.
+
+Because Shopify sync did not produce connector evidence and the configured Grantex token is not mapped, the run did not complete:
+
+- Shopify product count and variant count from a real sync: blocked.
+- Grantex authority request through the configured AgenticOrg path: blocked.
+- AgenticOrg artifact cache record count: blocked.
+- Buyer answer sample from real cached artifacts: blocked.
+- MCP production seller facts from real cached artifacts: blocked.
+- Plural/Pine capability metadata verification in the same vertical: blocked.
+
+## Grantex Issuer Isolation Proof
+
+Grantex C6Z authority was also tested with a platform-admin operator token to isolate the route:
+
+- status `artifact_issuance_ready`
+- route kind `grantex_internal_c6z_authority_request`
+- artifact count `8`
+- artifact families: `merchant_profile`, `seller_agent_card`, `connector_evidence`, `catalog_snapshot`, `offer_price_snapshot`, `inventory_snapshot`, `policy_scope`, `authority_request_status`
+- verifier summary: 8 valid, 0 invalid
+- `allowed_to_execute=false`
+- `no_payment_execution=true`
+- `no_public_discovery_enablement=true`
+- `non_authoritative_for_transaction=true`
+
+This proves the Grantex issuer route works, but not the configured AgenticOrg-to-Grantex production path.
+
+## MCP And Local Validation
+
+- `npm --prefix mcp-server test`: passed; MCP build plus smoke, 4 backend calls.
+- `python -m pytest tests/unit/test_oacp_c6z_runtime_vertical.py --no-cov`: passed, 16 tests.
+- `python -m pytest tests/integration/test_c6z_external_integrations.py --no-cov`: skipped 2 tests because local Shopify and Plural/Pine env vars are absent.
+- `python -m ruff check core/commerce/c6z_runtime_vertical.py api/v1/commerce_runtime.py tests/unit/test_oacp_c6z_runtime_vertical.py tests/integration/test_c6z_external_integrations.py`: passed.
+- `python -m mypy core/commerce/c6z_runtime_vertical.py api/v1/commerce_runtime.py`: passed.
+
+## Safety
+
+- AgenticOrg public discovery flag: `false`.
+- Grantex public discovery flag: `false`.
+- `allowed_to_execute=false`.
+- `raw_payload_stored=false` for C6Z code paths; no raw Shopify payload was persisted by the failed sync.
+- No checkout, payment, order, mandate, refund, return, shipment, inventory hold, provider execution, public discovery publication, or OACP external publication was performed.
+- No secrets, bearer tokens, raw Shopify payloads, raw provider payloads, raw Grantex artifacts, JWTs, passports, DB URLs, Redis URLs, or Secret Manager values are included in this evidence packet.
+
+## Exact Launch Status
+
+- Internal runtime demo: blocked in production.
+- Closed merchant pilot: blocked.
+- Public OACP preview: blocked.
+
+## Required Next Actions
+
+1. AgenticOrg owner: rotate or replace `agenticorg-c6z-shopify-admin-access-token`, then verify a status-only Shopify GraphQL query returns 200.
+2. Grantex owner: provision the commerce tenant/developer mapping for the AgenticOrg internal token or replace it with an approved mapped credential.
+3. Re-run the production vertical and update this evidence packet only after Shopify sync, Grantex issuance, AgenticOrg cache, buyer answer, MCP seller facts, and Plural/Pine capability metadata all complete without execution.

--- a/docs/reports/commerce-agent-oacp-final-launch-evidence.md
+++ b/docs/reports/commerce-agent-oacp-final-launch-evidence.md
@@ -42,6 +42,15 @@ Blocking evidence:
 - Direct status-only Shopify GraphQL probe with the mounted AgenticOrg C6Z Shopify token also returned `401`.
 - Grantex C6Z authority called with AgenticOrg's configured internal token returned `422 tenant_not_provisioned`.
 
+Follow-up implementation in this PR adds the AgenticOrg-owned merchant connector path that was missing from the original closure run:
+
+- `POST /commerce/runtime/seller-agents/connectors/shopify/credentials` stores a merchant-scoped Shopify credential in tenant-aware encrypted `ConnectorConfig` storage.
+- The endpoint accepts either a direct Admin API token or Shopify OAuth code exchange material, validates read-only product access, and returns only redacted status.
+- Shopify sync now prefers the encrypted merchant connector config before falling back to legacy process environment variables.
+- The Commerce Runtime UI exposes the connector setup and status path without rendering credential values.
+
+This removes the single global Shopify token dependency after merge/deploy, but does not by itself make the production vertical complete. The merchant credential still has to be valid in Shopify, and Grantex tenant-token provisioning must still be fixed.
+
 Because Shopify sync did not produce connector evidence and the configured Grantex token is not mapped, the run did not complete:
 
 - Shopify product count and variant count from a real sync: blocked.

--- a/docs/reports/commerce-agent-oacp-landing-blog-plan.md
+++ b/docs/reports/commerce-agent-oacp-landing-blog-plan.md
@@ -23,7 +23,12 @@ rails own mandate and payment execution.
 
 ## Current Implementation Summary
 
-AgenticOrg has internal C6W3-C6W9 consumer behavior:
+AgenticOrg has internal C6W3-C6Z consumer behavior, but the production C6Z
+vertical is currently blocked. The June 18, 2026 production run found
+Shopify `401 Unauthorized` for the mounted C6Z Shopify token and Grantex
+`422 tenant_not_provisioned` for the AgenticOrg-configured internal token.
+
+Implementation status:
 
 | Slice | AgenticOrg behavior | Public posture |
 | --- | --- | --- |
@@ -34,6 +39,7 @@ AgenticOrg has internal C6W3-C6W9 consumer behavior:
 | C6W7 | Reconciles local/cached response evidence. | Reconciled only. |
 | C6W8 | Consumes eligibility/audit packets. | Eligibility only. |
 | C6W9 | Consumes dry-run verifier results. | Dry-run only. |
+| C6Z | Seller onboarding, Shopify sync path, Grantex authority handoff, artifact cache, buyer answer, MCP seller tools, and Plural/Pine capability verifier. | Implemented locally; full production vertical blocked. |
 
 ## Landing Page Plan
 
@@ -173,3 +179,5 @@ sequenceDiagram
 - No claim implies production readiness, public discovery, live checkout/payment,
   live provider rails, certification, compliance, conformance, or merchant
   approval.
+- Grantex Commerce payment-control pilot wording remains separate from OACP
+  runtime artifact protocol wording.

--- a/docs/reports/commerce-agent-oacp-public-narrative-boundary.md
+++ b/docs/reports/commerce-agent-oacp-public-narrative-boundary.md
@@ -1,0 +1,28 @@
+# Commerce Agent OACP Public Narrative Boundary
+
+Status: canonical public-claims boundary.
+
+Last updated: 2026-06-18.
+
+## Allowed Wording
+
+- "AgenticOrg is the buyer and seller AI-agent runtime."
+- "Grantex is the trust, protocol, policy, and canonical OACP artifact authority."
+- "Shopify remains the operational source of record for catalog facts."
+- "Plural/Pine owns mandate and payment execution; AgenticOrg only verifies capability metadata where approved."
+- "Cached OACP artifacts support non-binding answers only when freshness, scope, revocation, and safety checks pass."
+- "The production C6Z vertical is currently blocked by Shopify credential and Grantex tenant-mapping issues."
+
+## Disallowed Wording
+
+Do not say or imply:
+
+- OACP is externally standardized, certified, conformant, or compliance-approved.
+- AgenticOrg public OACP discovery is enabled.
+- OACP launch proof enables checkout, payment, order, mandate, refund, return, shipment, inventory hold, provider execution, or merchant-private API mutation.
+- AgenticOrg is a thin client that routes every interaction through Grantex.
+- The Grantex payment-control pilot proves the AgenticOrg C6Z OACP runtime artifact vertical.
+
+## Separation Rule
+
+Keep "Grantex Commerce payment-control pilot" separate from "OACP runtime artifact protocol." The former may discuss consent, Commerce Passport, payment-control, webhook intake, reconciliation, and audit. The latter may discuss seller onboarding, Shopify read-only evidence, Grantex artifact issuance, AgenticOrg cache, buyer source/freshness answers, MCP seller facts, and capability metadata verification.

--- a/docs/reports/commerce-agent-oacp-runtime-launch-runbook.md
+++ b/docs/reports/commerce-agent-oacp-runtime-launch-runbook.md
@@ -1,0 +1,43 @@
+# Commerce Agent OACP Runtime Launch Runbook
+
+Status: internal C6Z production runbook.
+
+Last updated: 2026-06-18.
+
+## Canonical Architecture
+
+- AgenticOrg is the buyer and seller AI-agent runtime.
+- Grantex is the trust, protocol, policy, and canonical OACP artifact authority.
+- Shopify and other merchant systems remain operational systems of record.
+- Plural/Pine and other provider or fintech rails own mandate and payment execution.
+- Grantex is not a toll booth for every non-binding buyer/seller interaction.
+
+## Safe Run Steps
+
+1. Confirm AgenticOrg health and deployed SHA.
+2. Confirm Grantex health and deployed SHA.
+3. Confirm public discovery remains disabled.
+4. Create or reuse a Seller Commerce Agent onboarding packet for the approved Shopify pilot merchant.
+5. Run Shopify Admin GraphQL read-only sync.
+6. Send the AgenticOrg authority request to Grantex.
+7. Cache Grantex artifacts in AgenticOrg.
+8. Ask a buyer product question from cached artifacts and record source/freshness labels.
+9. Smoke MCP seller facts against the cached products.
+10. Run Plural/Pine capability metadata verification only.
+
+## Hard Stops
+
+Stop immediately if any check attempts or requires:
+
+- checkout, payment, order, mandate, refund, return, shipment, inventory hold, live-provider execution, merchant-private API mutation, production allowlist changes, public discovery publication, OACP external publication, or certification/conformance/standardization claims;
+- printing secrets, tokens, raw Shopify payloads, raw provider payloads, raw Grantex artifacts, JWTs, passports, DB URLs, Redis URLs, or Secret Manager values.
+
+## Current Production Result
+
+The 2026-06-18 production run is blocked:
+
+- Shopify Admin GraphQL read-only sync returns `401 Unauthorized` using the mounted AgenticOrg C6Z Shopify token.
+- Direct status-only Shopify GraphQL probe with the same token returns `401`.
+- Grantex C6Z authority called with AgenticOrg's configured internal token returns `422 tenant_not_provisioned`.
+
+Do not report internal runtime demo, closed merchant pilot, or public OACP preview as complete until both blockers are fixed and the full vertical is re-run.

--- a/docs/reports/commerce-agent-oacp-runtime-launch-runbook.md
+++ b/docs/reports/commerce-agent-oacp-runtime-launch-runbook.md
@@ -18,12 +18,15 @@ Last updated: 2026-06-18.
 2. Confirm Grantex health and deployed SHA.
 3. Confirm public discovery remains disabled.
 4. Create or reuse a Seller Commerce Agent onboarding packet for the approved Shopify pilot merchant.
-5. Run Shopify Admin GraphQL read-only sync.
-6. Send the AgenticOrg authority request to Grantex.
-7. Cache Grantex artifacts in AgenticOrg.
-8. Ask a buyer product question from cached artifacts and record source/freshness labels.
-9. Smoke MCP seller facts against the cached products.
-10. Run Plural/Pine capability metadata verification only.
+5. Configure or verify the merchant Shopify connector through AgenticOrg:
+   preferred route `POST /commerce/runtime/seller-agents/connectors/shopify/credentials`;
+   storage target tenant-aware encrypted `ConnectorConfig`; response values redacted.
+6. Run Shopify Admin GraphQL read-only sync. It must prefer the merchant connector config and only fall back to legacy environment credentials when no merchant config exists.
+7. Send the AgenticOrg authority request to Grantex.
+8. Cache Grantex artifacts in AgenticOrg.
+9. Ask a buyer product question from cached artifacts and record source/freshness labels.
+10. Smoke MCP seller facts against the cached products.
+11. Run Plural/Pine capability metadata verification only.
 
 ## Hard Stops
 
@@ -41,3 +44,5 @@ The 2026-06-18 production run is blocked:
 - Grantex C6Z authority called with AgenticOrg's configured internal token returns `422 tenant_not_provisioned`.
 
 Do not report internal runtime demo, closed merchant pilot, or public OACP preview as complete until both blockers are fixed and the full vertical is re-run.
+
+Follow-up implementation in this PR adds the encrypted merchant Shopify connector setup route and Commerce Runtime UI controls. After merge/deploy, the Shopify blocker should be handled through that AgenticOrg path instead of a single global Shopify token. Grantex tenant-token provisioning remains separate.

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -1977,7 +1977,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-runtime-write",
     "scope": "commerce.runtime.artifacts.cache",
-    "source_line": 292,
+    "source_line": 436,
     "tenant_required": true
   },
   {
@@ -1995,7 +1995,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-runtime-external",
     "scope": "commerce.runtime.grantex.authority_request",
-    "source_line": 255,
+    "source_line": 399,
     "tenant_required": true
   },
   {
@@ -2013,7 +2013,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-buyer-session",
     "scope": "commerce.runtime.buyer_sessions.ask",
-    "source_line": 341,
+    "source_line": 485,
     "tenant_required": true
   },
   {
@@ -2031,7 +2031,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "commerce.runtime.products.read",
-    "source_line": 428,
+    "source_line": 572,
     "tenant_required": true
   },
   {
@@ -2049,7 +2049,43 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-runtime-external",
     "scope": "commerce.runtime.providers.plural_pine.verify",
-    "source_line": 394,
+    "source_line": 538,
+    "tenant_required": true
+  },
+  {
+    "audit_event": "commerce.runtime.shopify.credentials.upsert",
+    "auth_required": true,
+    "function": "upsert_shopify_connector_credentials",
+    "idempotency": "merchant-shopify-credential-upsert",
+    "key": "POST /api/v1/commerce/runtime/seller-agents/connectors/shopify/credentials api/v1/commerce_runtime.py:upsert_shopify_connector_credentials",
+    "metadata_present": true,
+    "methods": [
+      "POST"
+    ],
+    "module": "api/v1/commerce_runtime.py",
+    "path": "/api/v1/commerce/runtime/seller-agents/connectors/shopify/credentials",
+    "public_exempt_reason": null,
+    "rate_limit": "commerce-runtime-write",
+    "scope": "commerce.runtime.shopify.credentials.write",
+    "source_line": 170,
+    "tenant_required": true
+  },
+  {
+    "audit_event": "commerce.runtime.shopify.credentials.read",
+    "auth_required": true,
+    "function": "get_shopify_connector_status",
+    "idempotency": "read-only",
+    "key": "GET /api/v1/commerce/runtime/seller-agents/connectors/shopify/status api/v1/commerce_runtime.py:get_shopify_connector_status",
+    "metadata_present": true,
+    "methods": [
+      "GET"
+    ],
+    "module": "api/v1/commerce_runtime.py",
+    "path": "/api/v1/commerce/runtime/seller-agents/connectors/shopify/status",
+    "public_exempt_reason": null,
+    "rate_limit": "standard",
+    "scope": "commerce.runtime.shopify.credentials.read",
+    "source_line": 259,
     "tenant_required": true
   },
   {
@@ -2067,7 +2103,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-runtime-write",
     "scope": "commerce.runtime.seller_agents.write",
-    "source_line": 109,
+    "source_line": 127,
     "tenant_required": true
   },
   {
@@ -2085,7 +2121,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "commerce.runtime.seller_agents.read",
-    "source_line": 132,
+    "source_line": 150,
     "tenant_required": true
   },
   {
@@ -2103,7 +2139,7 @@
     "public_exempt_reason": null,
     "rate_limit": "connector-bulk",
     "scope": "commerce.runtime.shopify.sync",
-    "source_line": 152,
+    "source_line": 301,
     "tenant_required": true
   },
   {
@@ -2121,7 +2157,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-webhook",
     "scope": "commerce.runtime.shopify.webhook",
-    "source_line": 210,
+    "source_line": 354,
     "tenant_required": true
   },
   {

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -63,6 +63,14 @@ Add to your MCP client configuration:
 
 Connector tools are not exposed as direct MCP tools. The `seller.*` tools read AgenticOrg cached OACP artifact evidence only and do not create checkout, payment, order, hold, refund, return, shipping, mandate, or live-provider actions. Use `run_agent` for agent workflows, or run `list_mcp_tools` to see platform agent tools such as `agenticorg_commerce_sales_agent`.
 
+Current production C6Z note, June 18, 2026: the MCP seller tools are implemented
+and the local MCP build/smoke passes, but production seller facts for the
+approved Shopify pilot are blocked until AgenticOrg's Shopify token returns
+read-only GraphQL data and the AgenticOrg-to-Grantex internal token is mapped in
+Grantex. Do not treat MCP tool presence as public discovery, checkout/payment
+approval, mandate execution, certification, conformance, or production launch
+readiness.
+
 ## Authentication
 
 Set one of these environment variables:

--- a/tests/unit/test_oacp_c6z_runtime_vertical.py
+++ b/tests/unit/test_oacp_c6z_runtime_vertical.py
@@ -178,6 +178,80 @@ def test_onboarding_packet_is_read_only_and_rejects_secret_metadata() -> None:
         )
 
 
+def test_shopify_connector_config_name_is_deterministic_and_bounded() -> None:
+    name = commerce_runtime_api._shopify_connector_config_name("Merchant / Demo Store #1")
+
+    assert name == "commerce_shopify_merchant_demo_store_1"
+    assert len(name) <= 100
+
+
+@pytest.mark.asyncio
+async def test_shopify_credential_submission_requires_one_mode() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await commerce_runtime_api._resolve_submitted_shopify_credentials(
+            commerce_runtime_api.ShopifyConnectorCredentialRequest(
+                merchant_id="merchant_1",
+                shop_domain="demo.myshopify.com",
+                admin_access_token="token",
+                oauth_code="code",
+                client_id="client-id",
+                client_secret="client-secret",
+            )
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["error"] == "shopify_credential_mode_ambiguous"
+
+
+@pytest.mark.asyncio
+async def test_shopify_sync_prefers_encrypted_tenant_connector_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResult:
+        def __init__(self, row):
+            self._row = row
+
+        def scalars(self):
+            return self
+
+        def all(self):
+            return [self._row]
+
+    class FakeSession:
+        async def execute(self, _statement):
+            return FakeResult(
+                SimpleNamespace(
+                    connector_name="commerce_shopify_merchant_1",
+                    config={
+                        "merchant_id": "merchant_1",
+                        "shop_domain": "demo.myshopify.com",
+                        "api_version": "2026-04",
+                    },
+                    credentials_encrypted={"_encrypted": "encrypted-fixture"},
+                )
+            )
+
+    monkeypatch.setattr(
+        commerce_runtime_api,
+        "decrypt_for_tenant",
+        lambda _value: json.dumps(
+            {
+                "admin_access_token": "fixture-admin-token",
+                "shop_domain": "demo.myshopify.com",
+                "api_version": "2026-04",
+            }
+        ),
+    )
+
+    credentials, source = await commerce_runtime_api._resolve_shopify_credentials_for_packet(
+        session=FakeSession(),
+        tenant_id=commerce_runtime_api._tenant_uuid("11111111-1111-1111-1111-111111111111"),
+        packet=_packet(),
+    )
+
+    assert source == "tenant_connector_config"
+    assert credentials.shop_domain == "demo.myshopify.com"
+    assert credentials.admin_access_token == "fixture-admin-token"
+
+
 def test_shopify_evidence_normalizes_products_without_raw_payloads() -> None:
     evidence = build_shopify_connector_evidence(
         packet=_packet(),

--- a/ui/src/__tests__/CommerceRuntimeDemo.test.tsx
+++ b/ui/src/__tests__/CommerceRuntimeDemo.test.tsx
@@ -4,6 +4,8 @@ import CommerceRuntimeDemo from "../pages/CommerceRuntimeDemo";
 
 const apiMock = vi.hoisted(() => ({
   createOnboardingPacket: vi.fn(),
+  upsertShopifyCredentials: vi.fn(),
+  getShopifyStatus: vi.fn(),
   syncShopify: vi.fn(),
   requestGrantexAuthority: vi.fn(),
   cacheArtifacts: vi.fn(),
@@ -18,6 +20,30 @@ vi.mock("../lib/api", () => ({
 }));
 
 describe("CommerceRuntimeDemo", () => {
+  it("stores Shopify connector credentials through the runtime API without rendering secrets", async () => {
+    apiMock.upsertShopifyCredentials.mockResolvedValueOnce({
+      data: {
+        status: "shopify_connector_configured",
+        shop_domain: "mgx0n6-22.myshopify.com",
+        credential_values_redacted: true,
+      },
+    });
+
+    render(<CommerceRuntimeDemo />);
+    fireEvent.change(screen.getByLabelText("Shopify Admin API token"), {
+      target: { value: "fixture-admin-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => expect(apiMock.upsertShopifyCredentials).toHaveBeenCalledWith(expect.objectContaining({
+      admin_access_token: "fixture-admin-token",
+      merchant_id: "merchant_demo",
+      shop_domain: "mgx0n6-22.myshopify.com",
+    })));
+    await waitFor(() => expect(screen.getAllByText("shopify_connector_configured").length).toBeGreaterThan(0));
+    expect(screen.queryByText("fixture-admin-token")).not.toBeInTheDocument();
+  });
+
   it("creates an onboarding packet and answers from cached artifact labels", async () => {
     apiMock.createOnboardingPacket.mockResolvedValueOnce({
       data: { packet: { packet_id: "packet_1" } },

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -202,6 +202,10 @@ export const commerceRuntimeApi = {
     api.post("/commerce/runtime/seller-agents/onboarding-packets", data),
   getOnboardingPacket: (packetId: string) =>
     api.get(`/commerce/runtime/seller-agents/onboarding-packets/${packetId}`),
+  upsertShopifyCredentials: (data: any) =>
+    api.post("/commerce/runtime/seller-agents/connectors/shopify/credentials", data),
+  getShopifyStatus: (params: any) =>
+    api.get("/commerce/runtime/seller-agents/connectors/shopify/status", { params }),
   syncShopify: (data: any) => api.post("/commerce/runtime/seller-agents/shopify/sync", data),
   requestGrantexAuthority: (data: any) => api.post("/commerce/runtime/authority/grantex/request", data),
   cacheArtifacts: (data: any) => api.post("/commerce/runtime/artifacts/cache", data),

--- a/ui/src/pages/CommerceRuntimeDemo.tsx
+++ b/ui/src/pages/CommerceRuntimeDemo.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Bot, Box, RefreshCw, Send, ShieldCheck } from "lucide-react";
+import { Bot, Box, KeyRound, RefreshCw, Send, ShieldCheck } from "lucide-react";
 import { commerceRuntimeApi, extractApiError } from "../lib/api";
 
 type RuntimeLog = {
@@ -14,6 +14,13 @@ export default function CommerceRuntimeDemo() {
   const [buyerAgentId, setBuyerAgentId] = useState("buyer_agent_demo");
   const [displayName, setDisplayName] = useState("Demo Shopify Store");
   const [categories, setCategories] = useState("apparel, accessories");
+  const [shopDomain, setShopDomain] = useState("mgx0n6-22.myshopify.com");
+  const [shopifyToken, setShopifyToken] = useState("");
+  const [shopifyOauthCode, setShopifyOauthCode] = useState("");
+  const [shopifyClientId, setShopifyClientId] = useState("");
+  const [shopifyClientSecret, setShopifyClientSecret] = useState("");
+  const [shopifyRedirectUri, setShopifyRedirectUri] = useState("https://app.agenticorg.ai/callback");
+  const [shopifyStatus, setShopifyStatus] = useState<any>(null);
   const [packetId, setPacketId] = useState("");
   const [evidenceId, setEvidenceId] = useState("");
   const [buyerQuestion, setBuyerQuestion] = useState("Show me available products with prices");
@@ -54,12 +61,57 @@ export default function CommerceRuntimeDemo() {
         },
         artifact_cache_scope: { merchant_id: merchantId, seller_agent_id: sellerAgentId },
         source_freshness_policy: { max_age_seconds: 900 },
-        connector_metadata: { credential_ref: "env", mode: "read_only" },
+        connector_metadata: { credential_ref: "tenant_connector_config", mode: "read_only", shop_domain: shopDomain },
       });
       setPacketId(data.packet.packet_id);
       pushLog("Onboarding packet", data.packet.packet_id, "ok");
     } catch (error) {
       pushLog("Onboarding blocked", extractApiError(error), "warn");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function saveShopifyConnector() {
+    setBusy("credentials");
+    try {
+      const payload: any = {
+        merchant_id: merchantId,
+        shop_domain: shopDomain,
+        api_version: "2026-04",
+        validate_read: true,
+      };
+      if (shopifyToken.trim()) {
+        payload.admin_access_token = shopifyToken.trim();
+      } else {
+        payload.oauth_code = shopifyOauthCode.trim();
+        payload.client_id = shopifyClientId.trim();
+        payload.client_secret = shopifyClientSecret.trim();
+        payload.redirect_uri = shopifyRedirectUri.trim();
+      }
+      const { data } = await commerceRuntimeApi.upsertShopifyCredentials(payload);
+      setShopifyToken("");
+      setShopifyOauthCode("");
+      setShopifyClientSecret("");
+      setShopifyStatus(data);
+      pushLog("Shopify connector", data.status, "ok");
+    } catch (error) {
+      setShopifyToken("");
+      setShopifyClientSecret("");
+      pushLog("Shopify connector blocked", extractApiError(error), "warn");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function loadShopifyStatus() {
+    setBusy("credential-status");
+    try {
+      const { data } = await commerceRuntimeApi.getShopifyStatus({ merchant_id: merchantId });
+      setShopifyStatus(data);
+      pushLog("Shopify connector status", data.health_status || data.status, data.status === "not_configured" ? "warn" : "ok");
+    } catch (error) {
+      pushLog("Shopify status blocked", extractApiError(error), "warn");
     } finally {
       setBusy(null);
     }
@@ -170,6 +222,37 @@ export default function CommerceRuntimeDemo() {
               <input className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm" value={buyerAgentId} onChange={(event) => setBuyerAgentId(event.target.value)} aria-label="Buyer agent ID" />
               <input className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm" value={displayName} onChange={(event) => setDisplayName(event.target.value)} aria-label="Merchant display name" />
               <input className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm" value={categories} onChange={(event) => setCategories(event.target.value)} aria-label="Commerce categories" />
+            </div>
+            <div className="mt-4 grid gap-3 border-t border-slate-800 pt-4">
+              <div className="flex items-center gap-2 text-sm font-semibold text-slate-200">
+                <KeyRound className="h-4 w-4" />
+                Shopify Connector
+              </div>
+              <input className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm" value={shopDomain} onChange={(event) => setShopDomain(event.target.value)} aria-label="Shopify shop domain" />
+              <input className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm" type="password" value={shopifyToken} onChange={(event) => setShopifyToken(event.target.value)} aria-label="Shopify Admin API token" autoComplete="off" />
+              <div className="grid gap-2 md:grid-cols-2">
+                <input className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm" value={shopifyOauthCode} onChange={(event) => setShopifyOauthCode(event.target.value)} aria-label="Shopify OAuth code" autoComplete="off" />
+                <input className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm" value={shopifyClientId} onChange={(event) => setShopifyClientId(event.target.value)} aria-label="Shopify client ID" autoComplete="off" />
+                <input className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm" type="password" value={shopifyClientSecret} onChange={(event) => setShopifyClientSecret(event.target.value)} aria-label="Shopify client secret" autoComplete="off" />
+                <input className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm" value={shopifyRedirectUri} onChange={(event) => setShopifyRedirectUri(event.target.value)} aria-label="Shopify redirect URI" autoComplete="off" />
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <button className="inline-flex items-center justify-center gap-2 rounded-md bg-emerald-400 px-3 py-2 text-sm font-semibold text-slate-950 disabled:opacity-50" onClick={saveShopifyConnector} disabled={busy !== null}>
+                  <KeyRound className="h-4 w-4" />
+                  Save
+                </button>
+                <button className="inline-flex items-center justify-center gap-2 rounded-md border border-slate-700 px-3 py-2 text-sm font-semibold disabled:opacity-50" onClick={loadShopifyStatus} disabled={busy !== null}>
+                  <ShieldCheck className="h-4 w-4" />
+                  Status
+                </button>
+              </div>
+              {shopifyStatus && (
+                <div className="rounded-md border border-slate-800 bg-slate-950 p-3 text-xs text-slate-300">
+                  <div>{shopifyStatus.status}</div>
+                  <div>{shopifyStatus.shop_domain}</div>
+                  <div>{shopifyStatus.credential_values_redacted ? "credentials redacted" : ""}</div>
+                </div>
+              )}
             </div>
             <div className="mt-4 grid grid-cols-2 gap-2">
               <button className="inline-flex items-center justify-center gap-2 rounded-md bg-cyan-500 px-3 py-2 text-sm font-semibold text-slate-950 disabled:opacity-50" onClick={createPacket} disabled={busy !== null}>


### PR DESCRIPTION
OACP C6Z closure packet plus merchant Shopify connector implementation.

Updates:
- Adds final launch evidence and stale-doc reconciliation.
- Adds AgenticOrg merchant-scoped Shopify credential setup route: POST /commerce/runtime/seller-agents/connectors/shopify/credentials.
- Supports direct Admin API token or Shopify OAuth code exchange material.
- Stores credentials in tenant-aware encrypted ConnectorConfig and returns redacted status only.
- Makes C6Z Shopify sync prefer encrypted merchant connector config before legacy env fallback.
- Adds Commerce Runtime UI controls for connector setup/status without rendering secret values.

Validation:
- python -m pytest tests/unit/test_oacp_c6z_runtime_vertical.py --no-cov
- python -m pytest tests/integration/test_c6z_external_integrations.py --no-cov (2 skipped: local env absent)
- python -m ruff check api/v1/commerce_runtime.py core/commerce/c6z_runtime_vertical.py tests/unit/test_oacp_c6z_runtime_vertical.py
- python -m mypy api/v1/commerce_runtime.py core/commerce/c6z_runtime_vertical.py
- npm --prefix ui test -- CommerceRuntimeDemo.test.tsx
- npm --prefix ui run typecheck

Remaining production dependency after merge/deploy: a valid merchant-authorized Shopify credential must be configured through the new AgenticOrg path, and Grantex tenant-token provisioning still must be fixed.