### PR TITLE
[codex] fix security alerts

### DIFF
--- a/api/v1/ca_operations.py
+++ b/api/v1/ca_operations.py
@@ -33,6 +33,46 @@ class EwayBillBulkRequest(BaseModel):
     submit_to_gstn: bool = False
 
 
+def _safe_ca_row_error_message(value: Any) -> str:
+    if not isinstance(value, str):
+        return "Row failed validation."
+
+    allowed_prefixes = (
+        "Missing required e-way bill fields:",
+        "Row is missing or has invalid required fields:",
+    )
+    allowed_messages = {
+        "E-way bill row failed validation.",
+        "One or more numeric e-way bill fields are invalid.",
+        "Row failed validation.",
+        "Row has an invalid numeric amount.",
+        "rows must be a list of objects",
+    }
+    if value in allowed_messages or value.startswith(allowed_prefixes):
+        return value
+    return "Row failed validation."
+
+
+def _sanitize_ca_error_item(item: Any) -> Any:
+    if not isinstance(item, dict):
+        return {"error": "Row failed validation.", "error_code": "row_validation_failed"}
+
+    sanitized = dict(item)
+    if "error" in sanitized:
+        sanitized["error"] = _safe_ca_row_error_message(sanitized["error"])
+        sanitized.setdefault("error_code", "row_validation_failed")
+    return sanitized
+
+
+def _sanitize_ca_operation_result(result: dict[str, Any]) -> dict[str, Any]:
+    sanitized = dict(result)
+    for bucket in ("errors", "failed", "row_errors"):
+        entries = sanitized.get(bucket)
+        if isinstance(entries, list):
+            sanitized[bucket] = [_sanitize_ca_error_item(item) for item in entries]
+    return sanitized
+
+
 @router.post(
     "/connectors/traces/reconcile",
     dependencies=[require_tenant_admin],
@@ -56,11 +96,12 @@ async def reconcile_traces(
         raise HTTPException(422, "traces_statement must contain at least one row")
 
     connector = TracesConnector({})
-    return await connector.reconcile_tds_with_traces(
+    result = await connector.reconcile_tds_with_traces(
         expected_deductions=body.expected_deductions,
         traces_statement=body.traces_statement,
         tolerance_rupees=body.tolerance_rupees,
     )
+    return _sanitize_ca_operation_result(result)
 
 
 @router.post(
@@ -101,11 +142,12 @@ async def bulk_generate_eway_bills(
         )
 
     connector = GstnConnector({})
-    return await connector.bulk_generate_eway_bills(
+    result = await connector.bulk_generate_eway_bills(
         invoices=body.invoices,
         source="bulk_upload",
         submit=False,
     )
+    return _sanitize_ca_operation_result(result)
 
 
 @router.get("/ca-capabilities/status")

--- a/connectors/finance/gstn.py
+++ b/connectors/finance/gstn.py
@@ -62,6 +62,12 @@ EWAY_NUMERIC_FIELDS = {
 }
 
 
+class EwayBillValidationError(ValueError):
+    def __init__(self, public_message: str):
+        super().__init__(public_message)
+        self.public_message = public_message
+
+
 def _provider_base_url(connector_cls: type[GstnConnector]) -> str:
     base_url = getattr(connector_cls, "base_url", GSTN_API_BASE_URL)
     if base_url not in GSTN_ALLOWED_BASE_URLS:
@@ -81,6 +87,12 @@ def _to_number(value: Any) -> int | float:
     if dec == dec.to_integral_value():
         return int(dec)
     return float(dec)
+
+
+def _public_eway_bill_validation_error(exc: Exception) -> str:
+    if isinstance(exc, EwayBillValidationError):
+        return exc.public_message
+    return "E-way bill row failed validation."
 
 
 def _collect_part(params: dict[str, Any], section: str, fields: tuple[str, ...]) -> dict[str, Any]:
@@ -268,7 +280,8 @@ class GstnConnector(BaseConnector):
         if not _present(part_b.get("vehicle_number")) and not _present(part_b.get("transporter_id")):
             missing.append("vehicle_number_or_transporter_id")
         if missing:
-            raise ValueError("Missing required e-way bill fields: " + ", ".join(sorted(set(missing))))
+            fields = ", ".join(sorted(set(missing)))
+            raise EwayBillValidationError(f"Missing required e-way bill fields: {fields}")
 
         payload = {
             "part_a": dict(part_a),
@@ -282,7 +295,12 @@ class GstnConnector(BaseConnector):
         for container in (payload["part_a"], payload["part_b"]):
             for key, value in list(container.items()):
                 if key in EWAY_NUMERIC_FIELDS and _present(value):
-                    container[key] = _to_number(value)
+                    try:
+                        container[key] = _to_number(value)
+                    except ValueError as exc:
+                        raise EwayBillValidationError(
+                            "One or more numeric e-way bill fields are invalid."
+                        ) from exc
                 elif isinstance(value, str):
                     container[key] = value.strip()
 
@@ -328,7 +346,7 @@ class GstnConnector(BaseConnector):
                 failed.append({
                     "row_number": index,
                     "client_reference": invoice.get("client_reference") or invoice.get("document_number"),
-                    "error": str(exc),
+                    "error": _public_eway_bill_validation_error(exc),
                 })
 
         return {

--- a/connectors/finance/traces.py
+++ b/connectors/finance/traces.py
@@ -16,6 +16,12 @@ from typing import Any
 from connectors.framework.base_connector import BaseConnector
 
 
+class RowValidationError(ValueError):
+    def __init__(self, public_message: str):
+        super().__init__(public_message)
+        self.public_message = public_message
+
+
 def _clean(value: Any) -> str:
     return str(value or "").strip()
 
@@ -47,7 +53,10 @@ def _first(row: dict[str, Any], *keys: str) -> Any:
 def _normalize_entry(row: dict[str, Any], index: int, source: str) -> dict[str, Any]:
     pan = _upper(_first(row, "deductee_pan", "pan", "vendor_pan", "party_pan"))
     section = _upper(_first(row, "section", "tds_section", "section_code")).replace("SECTION", "").strip()
-    amount = _decimal(_first(row, "tds_amount", "tds", "tax_deducted", "amount"))
+    try:
+        amount = _decimal(_first(row, "tds_amount", "tds", "tax_deducted", "amount"))
+    except ValueError as exc:
+        raise RowValidationError("Row has an invalid numeric amount.") from exc
     date_value = _clean(_first(row, "transaction_date", "payment_date", "deduction_date", "date"))
     challan = _upper(_first(row, "challan_serial", "challan_no", "challan_number", "csi_number"))
     bsr = _upper(_first(row, "bsr_code", "bank_bsr_code", "bsr"))
@@ -61,7 +70,8 @@ def _normalize_entry(row: dict[str, Any], index: int, source: str) -> dict[str, 
     if amount <= 0:
         missing.append("tds_amount")
     if missing:
-        raise ValueError(f"{source} row {index} missing/invalid: {', '.join(missing)}")
+        fields = ", ".join(missing)
+        raise RowValidationError(f"Row is missing or has invalid required fields: {fields}")
 
     return {
         "id": _clean(_first(row, "id", "reference", "invoice_number")) or f"{source}-{index}",
@@ -76,6 +86,12 @@ def _normalize_entry(row: dict[str, Any], index: int, source: str) -> dict[str, 
         "vendor_name": _clean(_first(row, "vendor_name", "deductee_name", "party_name")),
         "raw": row,
     }
+
+
+def _public_validation_error(exc: Exception) -> str:
+    if isinstance(exc, RowValidationError):
+        return exc.public_message
+    return "Row failed validation."
 
 
 def _entry_key(entry: dict[str, Any]) -> tuple[str, str, str, str, str]:
@@ -151,7 +167,11 @@ class TracesConnector(BaseConnector):
             try:
                 normalized.append(_normalize_entry(dict(row), idx, source))
             except (TypeError, ValueError) as exc:
-                row_errors.append({"source": source, "row_number": idx, "error": str(exc)})
+                row_errors.append({
+                    "source": source,
+                    "row_number": idx,
+                    "error": _public_validation_error(exc),
+                })
 
         return {
             "status": "valid" if not row_errors else "invalid",
@@ -176,13 +196,21 @@ class TracesConnector(BaseConnector):
         for idx, row in enumerate(expected_rows, start=1):
             try:
                 expected.append(_normalize_entry(dict(row), idx, "books"))
-            except ValueError as exc:
-                row_errors.append({"source": "books", "row_number": idx, "error": str(exc)})
+            except (TypeError, ValueError) as exc:
+                row_errors.append({
+                    "source": "books",
+                    "row_number": idx,
+                    "error": _public_validation_error(exc),
+                })
         for idx, row in enumerate(traces_rows, start=1):
             try:
                 traces.append(_normalize_entry(dict(row), idx, "traces"))
-            except ValueError as exc:
-                row_errors.append({"source": "traces", "row_number": idx, "error": str(exc)})
+            except (TypeError, ValueError) as exc:
+                row_errors.append({
+                    "source": "traces",
+                    "row_number": idx,
+                    "error": _public_validation_error(exc),
+                })
 
         unmatched_traces = set(range(len(traces)))
         matched: list[dict[str, Any]] = []

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -1725,7 +1725,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "ca_capabilities.read",
-    "source_line": 120,
+    "source_line": 162,
     "tenant_required": true
   },
   {
@@ -2877,7 +2877,7 @@
     "public_exempt_reason": null,
     "rate_limit": "connector-bulk",
     "scope": "connectors.gstn.eway.bulk_generate",
-    "source_line": 78,
+    "source_line": 119,
     "tenant_required": true
   },
   {
@@ -2967,7 +2967,7 @@
     "public_exempt_reason": null,
     "rate_limit": "connector-bulk",
     "scope": "connectors.traces.reconcile",
-    "source_line": 48,
+    "source_line": 88,
     "tenant_required": true
   },
   {

--- a/tests/regression/test_security_20260618_alerts.py
+++ b/tests/regression/test_security_20260618_alerts.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def test_ui_lockfile_uses_patched_security_alert_versions() -> None:
+    lockfile = json.loads(Path("ui/package-lock.json").read_text(encoding="utf-8"))
+    packages = lockfile["packages"]
+
+    assert packages["node_modules/form-data"]["version"] == "4.0.6"
+    assert packages["node_modules/@babel/core"]["version"] == "7.29.6"
+    assert packages["node_modules/dompurify"]["version"] == "3.4.9"
+
+
+@pytest.mark.asyncio
+async def test_traces_reconciliation_does_not_echo_raw_validation_exception() -> None:
+    from connectors.finance.traces import TracesConnector
+
+    connector = TracesConnector({})
+    result = await connector.reconcile_tds_with_traces(
+        expected_deductions=[
+            {
+                "deductee_pan": "ABCDE1234F",
+                "section": "194C",
+                "tds_amount": "Traceback File C:/secret.py token=abc",
+            }
+        ],
+        traces_statement=[
+            {
+                "deductee_pan": "ABCDE1234F",
+                "section": "194C",
+                "tds_amount": "100",
+            }
+        ],
+    )
+
+    error_text = result["row_errors"][0]["error"]
+    assert error_text == "Row has an invalid numeric amount."
+    assert "Traceback" not in error_text
+    assert "File " not in error_text
+    assert "secret.py" not in error_text
+    assert "token=abc" not in error_text
+
+
+@pytest.mark.asyncio
+async def test_gstn_bulk_eway_bill_does_not_echo_raw_validation_exception() -> None:
+    from connectors.finance.gstn import GstnConnector
+
+    connector = GstnConnector({})
+    result = await connector.bulk_generate_eway_bills(
+        invoices=[
+            {
+                "supply_type": "outward",
+                "sub_supply_type": "supply",
+                "document_type": "tax invoice",
+                "document_number": "INV-1",
+                "document_date": "2026-06-18",
+                "from_gstin": "29ABCDE1234F1Z5",
+                "from_pin_code": "560001",
+                "from_state_code": "29",
+                "to_gstin": "27ABCDE1234F1Z5",
+                "to_pin_code": "400001",
+                "to_state_code": "27",
+                "product_name": "Services",
+                "hsn_code": "9983",
+                "quantity": "1",
+                "unit": "NOS",
+                "taxable_amount": "Traceback File C:/secret.py token=abc",
+                "total_invoice_value": "118",
+                "transport_mode": "road",
+                "distance_km": "10",
+                "vehicle_number": "KA01AB1234",
+            }
+        ],
+        submit=False,
+    )
+
+    error_text = result["failed"][0]["error"]
+    assert error_text == "One or more numeric e-way bill fields are invalid."
+    assert "Traceback" not in error_text
+    assert "File " not in error_text
+    assert "secret.py" not in error_text
+    assert "token=abc" not in error_text
+
+
+@pytest.mark.asyncio
+async def test_ca_operations_route_boundary_redacts_raw_connector_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    from api.v1.ca_operations import TracesReconcileRequest, reconcile_traces
+    from connectors.finance.traces import TracesConnector
+
+    async def raw_connector_result(self: TracesConnector, **params: Any) -> dict[str, Any]:
+        return {
+            "status": "needs_review",
+            "summary": {"row_errors": 1},
+            "row_errors": [
+                {
+                    "source": "books",
+                    "row_number": 1,
+                    "error": "Traceback (most recent call last): File C:/secret.py token=abc",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(TracesConnector, "reconcile_tds_with_traces", raw_connector_result)
+
+    result = await reconcile_traces(
+        TracesReconcileRequest(
+            expected_deductions=[{"deductee_pan": "ABCDE1234F"}],
+            traces_statement=[{"deductee_pan": "ABCDE1234F"}],
+        ),
+        tenant_id="tenant-1",
+    )
+
+    error_text = result["row_errors"][0]["error"]
+    assert error_text == "Row failed validation."
+    assert result["row_errors"][0]["error_code"] == "row_validation_failed"
+    assert "Traceback" not in error_text
+    assert "File " not in error_text
+    assert "secret.py" not in error_text
+    assert "token=abc" not in error_text
+
+
+@pytest.mark.asyncio
+async def test_ca_operations_gstn_boundary_redacts_raw_connector_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    from api.v1.ca_operations import EwayBillBulkRequest, bulk_generate_eway_bills
+    from connectors.finance.gstn import GstnConnector
+
+    async def raw_connector_result(self: GstnConnector, **params: Any) -> dict[str, Any]:
+        return {
+            "status": "completed_with_errors",
+            "summary": {"failed": 1},
+            "failed": [
+                {
+                    "row_number": 1,
+                    "client_reference": "INV-1",
+                    "error": "Traceback (most recent call last): File C:/secret.py token=abc",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(GstnConnector, "bulk_generate_eway_bills", raw_connector_result)
+
+    result = await bulk_generate_eway_bills(
+        EwayBillBulkRequest(invoices=[{"document_number": "INV-1"}]),
+        tenant_id="tenant-1",
+    )
+
+    error_text = result["failed"][0]["error"]
+    assert error_text == "Row failed validation."
+    assert result["failed"][0]["error_code"] == "row_validation_failed"
+    assert "Traceback" not in error_text
+    assert "File " not in error_text
+    assert "secret.py" not in error_text
+    assert "token=abc" not in error_text

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -153,18 +153,18 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.6.tgz",
+      "integrity": "sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
+        "@babel/generator": "^7.29.6",
         "@babel/helper-compilation-targets": "^7.28.6",
         "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
+        "@babel/helpers": "^7.29.2",
+        "@babel/parser": "^7.29.3",
         "@babel/template": "^7.28.6",
         "@babel/traverse": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -184,14 +184,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -270,9 +270,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -314,13 +314,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -371,14 +371,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -4258,9 +4258,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.9.tgz",
+      "integrity": "sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {
@@ -4676,14 +4676,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4838,7 +4840,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/ui/package.json
+++ b/ui/package.json
@@ -44,7 +44,9 @@
     "zod": "^4.4.3"
   },
   "overrides": {
-    "dompurify": ">=3.4.0",
+    "@babel/core": "7.29.6",
+    "dompurify": "3.4.9",
+    "form-data": "4.0.6",
     "lodash": ">=4.18.0",
     "follow-redirects": ">=1.16.0",
     "brace-expansion": ">=5.0.6"


### PR DESCRIPTION
Fixes open Dependabot alerts for form-data, @babel/core, and DOMPurify by forcing patched UI lockfile versions. Fixes CodeQL stack-trace exposure alerts in CA operations by replacing raw connector exception text with explicit public validation messages at the connector and API boundary. Adds regression coverage for patched dependency versions and error redaction. Local checks: pytest security alert regression + CA security, dependency gates, enterprise stability gates, ruff on touched Python, npm audit, UI typecheck, git diff --check.