### PR TITLE
[codex] Fix Aishwarya 19 Jun workflow and connector reopens

### DIFF
--- a/api/v1/approvals.py
+++ b/api/v1/approvals.py
@@ -185,7 +185,13 @@ async def _resume_workflow_bg(
     decision: dict,
 ) -> None:
     """Resume a workflow after HITL decision and sync remaining results to DB."""
-    from core.models.workflow import StepExecution, WorkflowDefinition, WorkflowRun
+    from api.v1.workflows import (
+        TERMINAL_WORKFLOW_STATUSES,
+        _run_steps_completed,
+        _run_steps_total,
+        _upsert_step_execution,
+    )
+    from core.models.workflow import WorkflowDefinition, WorkflowRun
     from workflows.engine import WorkflowEngine
     from workflows.state_store import WorkflowStateStore
 
@@ -217,7 +223,9 @@ async def _resume_workflow_bg(
 
     try:
         # Resume executes all remaining steps (or pauses at next HITL)
-        await engine.resume_from_hitl(engine_run_id, decision)
+        resume_result = await engine.resume_from_hitl(engine_run_id, decision)
+        if isinstance(resume_result, dict) and resume_result.get("error"):
+            raise RuntimeError(str(resume_result["error"]))
 
         state = await state_store.load(engine_run_id)
         if not state:
@@ -226,15 +234,6 @@ async def _resume_workflow_bg(
         steps_def = {s["id"]: s for s in definition.get("steps", [])}
 
         async with get_tenant_session(tenant_id) as session:
-            existing = (
-                await session.execute(
-                    select(StepExecution.step_id).where(
-                        StepExecution.workflow_run_id == workflow_run_id
-                    )
-                )
-            ).scalars().all()
-            synced_steps = set(existing)
-
             db_run = (
                 await session.execute(
                     select(WorkflowRun).where(WorkflowRun.id == workflow_run_id)
@@ -242,55 +241,55 @@ async def _resume_workflow_bg(
             ).scalar_one()
 
             for step_id, step_result in state.get("step_results", {}).items():
-                if step_id in synced_steps:
-                    # Update existing step if status changed (e.g. waiting_hitl → completed)
-                    existing_step = (
-                        await session.execute(
-                            select(StepExecution).where(
-                                StepExecution.workflow_run_id == workflow_run_id,
-                                StepExecution.step_id == step_id,
+                step_def = steps_def.get(step_id, {})
+                step_row, created = await _upsert_step_execution(
+                    session,
+                    tenant_id=tenant_id,
+                    workflow_run_id=workflow_run_id,
+                    step_id=step_id,
+                    step_result=step_result,
+                    step_def=step_def,
+                )
+
+                if created and step_row.status == "waiting_hitl":
+                    timeout_h = step_def.get("timeout_hours", 4)
+                    hitl_agent_id = step_row.agent_id
+                    if not hitl_agent_id:
+                        hitl_agent_id = (
+                            await session.execute(
+                                select(Agent.id).where(Agent.tenant_id == tenant_id).limit(1)
+                            )
+                        ).scalar_one_or_none()
+                    if hitl_agent_id:
+                        session.add(
+                            HITLQueue(
+                                tenant_id=tenant_id,
+                                workflow_run_id=workflow_run_id,
+                                agent_id=hitl_agent_id,
+                                title=f"Approval required: {step_def.get('title', step_id)}",
+                                trigger_type="workflow_step",
+                                priority=step_def.get("priority", "normal"),
+                                assignee_role=step_result.get(
+                                    "assignee_role",
+                                    step_def.get("assignee_role", "admin"),
+                                ),
+                                decision_options=step_def.get(
+                                    "decision_options",
+                                    {"options": ["approve", "reject"]},
+                                ),
+                                context={
+                                    "workflow_run_id": str(workflow_run_id),
+                                    "step_id": step_id,
+                                    "engine_run_id": engine_run_id,
+                                },
+                                expires_at=datetime.now(UTC) + timedelta(hours=timeout_h),
                             )
                         )
-                    ).scalar_one_or_none()
-                    if existing_step and existing_step.status != step_result.get("status"):
-                        existing_step.status = step_result.get("status", "completed")
-                        existing_step.output = step_result.get("output")
-                        existing_step.completed_at = datetime.now(UTC)
-                    continue
 
-                step_def = steps_def.get(step_id, {})
-                agent_id = None
-                raw_agent = step_def.get("agent_id")
-                if raw_agent:
-                    try:
-                        agent_id = _uuid.UUID(str(raw_agent))
-                    except (ValueError, TypeError):
-                        pass
-
-                session.add(
-                    StepExecution(
-                        tenant_id=tenant_id,
-                        workflow_run_id=workflow_run_id,
-                        step_id=step_id,
-                        step_type=step_def.get("type", "agent"),
-                        agent_id=agent_id,
-                        status=step_result.get("status", "completed"),
-                        output=step_result.get("output"),
-                        confidence=step_result.get("confidence"),
-                        error=(
-                            {"message": step_result["error"]}
-                            if step_result.get("error")
-                            else None
-                        ),
-                        started_at=datetime.now(UTC),
-                        completed_at=datetime.now(UTC),
-                    )
-                )
-                synced_steps.add(step_id)
-
-            db_run.steps_completed = len(synced_steps)
+            db_run.steps_completed = _run_steps_completed(state)
+            db_run.steps_total = _run_steps_total(state, db_run.steps_total)
             db_run.status = state.get("status", "running")
-            if state.get("status") in ("completed", "failed", "timed_out"):
+            if state.get("status") in TERMINAL_WORKFLOW_STATUSES:
                 db_run.completed_at = datetime.now(UTC)
             if state.get("status") == "completed":
                 db_run.result = state.get("step_results")

--- a/api/v1/approvals.py
+++ b/api/v1/approvals.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid as _uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 import structlog

--- a/api/v1/workflows.py
+++ b/api/v1/workflows.py
@@ -21,6 +21,8 @@ from core.schemas.api import PaginatedResponse, WorkflowCreate, WorkflowRunTrigg
 
 router = APIRouter()
 _log = structlog.get_logger()
+PAUSED_WORKFLOW_STATUSES = {"waiting_hitl", "waiting_delay", "waiting_event"}
+TERMINAL_WORKFLOW_STATUSES = {"completed", "failed", "timed_out", "cancelled"}
 
 
 # ── NL-to-Workflow schemas ──────────────────────────────────────────────────
@@ -56,7 +58,58 @@ def _wf_to_dict(wf: WorkflowDefinition) -> dict:
     }
 
 
+def _step_error_payload(error: object) -> dict | None:
+    if not error:
+        return None
+    if isinstance(error, dict):
+        return error
+    return {"message": str(error)}
+
+
+def _step_error_message(error: object) -> str | None:
+    payload = _step_error_payload(error)
+    if not payload:
+        return None
+    message = payload.get("message") or payload.get("error")
+    if message:
+        return str(message)
+    code = payload.get("code")
+    return str(code) if code else None
+
+
+def _step_error_code(error: object) -> str | None:
+    payload = _step_error_payload(error)
+    if not payload:
+        return None
+    code = payload.get("code") or payload.get("error")
+    return str(code) if code else None
+
+
+def _step_result_error(step_result: dict) -> dict | None:
+    error = step_result.get("error")
+    if not error:
+        return None
+    if isinstance(error, dict):
+        return error
+    return {"message": str(error)}
+
+
+def _run_steps_completed(state: dict) -> int:
+    raw = state.get("steps_completed")
+    if isinstance(raw, int):
+        return raw
+    return len(state.get("step_results", {}))
+
+
+def _run_steps_total(state: dict, fallback: int | None) -> int | None:
+    raw = state.get("steps_total")
+    if isinstance(raw, int):
+        return raw
+    return fallback
+
+
 def _step_to_dict(step: StepExecution) -> dict:
+    error_payload = _step_error_payload(step.error)
     return {
         "id": str(step.id),
         "step_id": step.step_id,
@@ -66,7 +119,10 @@ def _step_to_dict(step: StepExecution) -> dict:
         "input": step.input,
         "output": step.output,
         "confidence": float(step.confidence) if step.confidence is not None else None,
-        "error": step.error,
+        "error": error_payload,
+        "error_message": _step_error_message(error_payload),
+        "error_code": _step_error_code(error_payload),
+        "error_details": error_payload.get("details") if isinstance(error_payload, dict) else None,
         "retry_count": step.retry_count,
         "latency_ms": step.latency_ms,
         "started_at": step.started_at.isoformat() if step.started_at else None,
@@ -106,6 +162,77 @@ def _parse_company_id(company_id: str | None) -> _uuid.UUID | None:
         return _uuid.UUID(company_id)
     except (ValueError, TypeError) as exc:
         raise HTTPException(400, "Invalid company_id format") from exc
+
+
+def _step_agent_id(step_def: dict) -> _uuid.UUID | None:
+    raw_agent = step_def.get("agent_id")
+    if not raw_agent:
+        return None
+    try:
+        return _uuid.UUID(str(raw_agent))
+    except (ValueError, TypeError):
+        return None
+
+
+def _step_completed_at(step_status: str, existing: datetime | None) -> datetime | None:
+    if step_status != "waiting_hitl" and step_status not in {
+        "pending",
+        "running",
+        "waiting_delay",
+        "waiting_event",
+    }:
+        return existing or datetime.now(UTC)
+    if step_status in PAUSED_WORKFLOW_STATUSES or step_status in {"pending", "running"}:
+        return None
+    return existing
+
+
+async def _upsert_step_execution(
+    session,
+    *,
+    tenant_id: _uuid.UUID,
+    workflow_run_id: _uuid.UUID,
+    step_id: str,
+    step_result: dict,
+    step_def: dict,
+) -> tuple[StepExecution, bool]:
+    """Persist the latest engine result for a workflow step."""
+    result = await session.execute(
+        select(StepExecution).where(
+            StepExecution.workflow_run_id == workflow_run_id,
+            StepExecution.step_id == step_id,
+        )
+    )
+    row = result.scalar_one_or_none()
+    created = row is None
+    now = datetime.now(UTC)
+    step_status = str(step_result.get("status") or "completed")
+
+    if row is None:
+        row = StepExecution(
+            tenant_id=tenant_id,
+            workflow_run_id=workflow_run_id,
+            step_id=step_id,
+            step_type=step_def.get("type", "agent"),
+            started_at=now,
+        )
+        session.add(row)
+
+    row.step_type = step_def.get("type", row.step_type or "agent")
+    row.agent_id = _step_agent_id(step_def)
+    row.status = step_status
+    row.input = step_result.get("input") or step_def.get("inputs") or step_def.get("params")
+    row.output = step_result.get("output")
+    row.confidence = step_result.get("confidence")
+    row.error = _step_result_error(step_result)
+    row.completed_at = (
+        _step_completed_at(step_status, row.completed_at)
+        if step_status != "waiting_hitl"
+        else None
+    )
+    if row.started_at is None:
+        row.started_at = now
+    return row, created
 
 
 # ── POST /workflows/generate ─────────────────────────────────────────────────
@@ -431,7 +558,6 @@ async def _execute_workflow_bg(
             db_run.context = {**(db_run.context or {}), "_engine_run_id": engine_run_id}
 
         steps_def = {s["id"]: s for s in definition.get("steps", [])}
-        synced_steps: set[str] = set()
 
         while True:
             await engine.execute_next(engine_run_id)
@@ -449,48 +575,21 @@ async def _execute_workflow_bg(
                 ).scalar_one()
 
                 for step_id, step_result in state.get("step_results", {}).items():
-                    if step_id in synced_steps:
-                        continue
-
                     step_def = steps_def.get(step_id, {})
-                    agent_id = None
-                    raw_agent = step_def.get("agent_id")
-                    if raw_agent:
-                        try:
-                            agent_id = _uuid.UUID(str(raw_agent))
-                        except (ValueError, TypeError):
-                            agent_id = None
-
-                    step_status = step_result.get("status", "completed")
-                    session.add(
-                        StepExecution(
-                            tenant_id=tenant_id,
-                            workflow_run_id=run_id,
-                            step_id=step_id,
-                            step_type=step_def.get("type", "agent"),
-                            agent_id=agent_id,
-                            status=step_status,
-                            output=step_result.get("output"),
-                            confidence=step_result.get("confidence"),
-                            error=(
-                                {"message": step_result["error"]}
-                                if step_result.get("error")
-                                else None
-                            ),
-                            started_at=datetime.now(UTC),
-                            completed_at=(
-                                datetime.now(UTC)
-                                if step_status != "waiting_hitl"
-                                else None
-                            ),
-                        )
+                    step_row, created = await _upsert_step_execution(
+                        session,
+                        tenant_id=tenant_id,
+                        workflow_run_id=run_id,
+                        step_id=step_id,
+                        step_result=step_result,
+                        step_def=step_def,
                     )
-                    synced_steps.add(step_id)
+                    step_status = step_row.status
 
                     # Create HITLQueue entry for approval steps
-                    if step_status == "waiting_hitl":
+                    if created and step_status == "waiting_hitl":
                         timeout_h = step_def.get("timeout_hours", 4)
-                        hitl_agent_id = agent_id
+                        hitl_agent_id = step_row.agent_id
                         if not hitl_agent_id:
                             hitl_agent_id = (
                                 await session.execute(
@@ -526,20 +625,15 @@ async def _execute_workflow_bg(
                                 )
                             )
 
-                db_run.steps_completed = len(synced_steps)
+                db_run.steps_completed = _run_steps_completed(state)
+                db_run.steps_total = _run_steps_total(state, db_run.steps_total)
                 db_run.status = state.get("status", "running")
-                if state.get("status") in ("completed", "failed", "timed_out"):
+                if state.get("status") in TERMINAL_WORKFLOW_STATUSES:
                     db_run.completed_at = datetime.now(UTC)
                 if state.get("status") == "completed":
                     db_run.result = state.get("step_results")
 
-            if state.get("status") in (
-                "completed",
-                "failed",
-                "waiting_hitl",
-                "timed_out",
-                "cancelled",
-            ):
+            if state.get("status") in TERMINAL_WORKFLOW_STATUSES | PAUSED_WORKFLOW_STATUSES:
                 break
 
     # enterprise-gate: broad-except-ok reason=background-workflow-boundary-marks-db-run-failed

--- a/connectors/comms/sendgrid.py
+++ b/connectors/comms/sendgrid.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import re
+from datetime import date
 from typing import Any
 
 import structlog
@@ -9,6 +12,61 @@ import structlog
 from connectors.framework.base_connector import BaseConnector
 
 logger = structlog.get_logger()
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_DATE_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(?P<key>start[_\s-]?date|end[_\s-]?date|aggregated[_\s-]?by)\s*[:=]\s*(?P<value>[A-Za-z0-9_-]+)"
+)
+
+
+def _flatten_stats_params(params: dict[str, Any]) -> dict[str, Any]:
+    flattened = dict(params or {})
+    for wrapper_key in ("kwargs", "params", "arguments", "input"):
+        nested = flattened.get(wrapper_key)
+        if isinstance(nested, dict):
+            flattened.update(nested)
+        elif isinstance(nested, str) and nested.strip():
+            text = nested.strip()
+            try:
+                parsed = json.loads(text)
+            except ValueError:
+                parsed = None
+            if isinstance(parsed, dict):
+                flattened.update(parsed)
+            else:
+                flattened.update(_parse_stats_text(text))
+    for text_key in ("query", "prompt", "text"):
+        text_value = flattened.get(text_key)
+        if isinstance(text_value, str):
+            flattened.update(_parse_stats_text(text_value))
+    return flattened
+
+
+def _parse_stats_text(text: str) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for match in _DATE_ASSIGNMENT_RE.finditer(text):
+        key = match.group("key").lower().replace(" ", "_").replace("-", "_")
+        parsed[key] = match.group("value")
+    return parsed
+
+
+def _first_value(params: dict[str, Any], *names: str) -> Any:
+    for name in names:
+        value = params.get(name)
+        if value not in (None, ""):
+            return value
+    return ""
+
+
+def _normalize_date(value: Any) -> str:
+    text = str(value or "").strip()
+    if not _DATE_RE.match(text):
+        return ""
+    try:
+        date.fromisoformat(text)
+    except ValueError:
+        return ""
+    return text
 
 
 class SendgridConnector(BaseConnector):
@@ -162,13 +220,27 @@ class SendgridConnector(BaseConnector):
             end_date: End date (YYYY-MM-DD, defaults to today)
             aggregated_by: Aggregation period — "day", "week", or "month"
         """
-        start_date = params.get("start_date", "")
+        params = _flatten_stats_params(params)
+        start_date = _normalize_date(
+            _first_value(params, "start_date", "startDate", "date_from", "from_date", "from")
+        )
         if not start_date:
-            return {"error": "start_date is required"}
+            return {
+                "error": "start_date is required and should be a YYYY-MM-DD formatted date",
+                "expected_format": "YYYY-MM-DD",
+            }
 
         query_params: dict[str, Any] = {"start_date": start_date}
-        if params.get("end_date"):
-            query_params["end_date"] = params["end_date"]
+        if _first_value(params, "end_date", "endDate", "date_to", "to_date", "to"):
+            end_date = _normalize_date(
+                _first_value(params, "end_date", "endDate", "date_to", "to_date", "to")
+            )
+            if not end_date:
+                return {
+                    "error": "end_date should be a YYYY-MM-DD formatted date",
+                    "expected_format": "YYYY-MM-DD",
+                }
+            query_params["end_date"] = end_date
         if params.get("aggregated_by"):
             query_params["aggregated_by"] = params["aggregated_by"]
 

--- a/core/marketing/connector_contracts.py
+++ b/core/marketing/connector_contracts.py
@@ -650,7 +650,23 @@ def _contract_state(
         return "connector_disabled"
     if auth_status == "expired" or _contains_any(status_text, AUTH_EXPIRED_MARKERS):
         return "auth_expired"
-    if missing_read_scopes or _contains_any(status_text, MISSING_SCOPE_MARKERS):
+    explicit_scope_failure = _contains_any(
+        " ".join(
+            str(part or "")
+            for part in (
+                contract.get("degraded_mode_reason"),
+                contract.get("blocking_reason"),
+                contract.get("last_error"),
+                setup_row.get("detail"),
+            )
+        ).lower(),
+        MISSING_SCOPE_MARKERS,
+    )
+    if missing_read_scopes or explicit_scope_failure:
+        return "missing_scope"
+    if raw in {"missing_scope", "insufficient_scope"} and missing_write_scopes:
+        return "healthy"
+    if raw in {"missing_scope", "insufficient_scope"}:
         return "missing_scope"
     if _contains_any(status_text, RATE_LIMIT_MARKERS):
         return "rate_limited"
@@ -668,9 +684,9 @@ def _contract_state(
         return "stale_data"
     if raw in CONTRACT_STATES:
         return raw
-    if missing_write_scopes:
-        return "missing_scope"
     if raw in {"healthy", "ok", "ready"}:
+        return "healthy"
+    if missing_write_scopes:
         return "healthy"
     return "degraded"
 
@@ -1250,10 +1266,28 @@ def _hubspot_private_app_read_scope_gap_is_non_blocking(
     if health_values.isdisjoint({"healthy", "ok", "ready", "valid"}):
         return False
 
-    # If a scope payload exists and proves some read scopes are actually
-    # missing, keep the stricter blocker. The override is only for private-app
-    # or legacy configs with no persisted read-scope evidence at all.
-    return not set(granted_scopes).intersection(set(HUBSPOT_CRM_READ_SCOPES))
+    read_scope_evidence = set(granted_scopes).intersection(set(HUBSPOT_CRM_READ_SCOPES))
+    if read_scope_evidence:
+        return _hubspot_crm_read_tools_registered(contract, config)
+    return True
+
+
+def _hubspot_crm_read_tools_registered(
+    contract: dict[str, Any],
+    config: dict[str, Any],
+) -> bool:
+    tools: set[str] = set()
+    for key in (
+        "tool_functions",
+        "registered_tools",
+        "available_tools",
+        "tools",
+        "crm_read_tools",
+    ):
+        tools.update(_tool_name_from_value(tool) for tool in _list_from_value(contract.get(key)))
+        tools.update(_tool_name_from_value(tool) for tool in _list_from_value(config.get(key)))
+    tools.discard("")
+    return all(tool in tools for tool in HUBSPOT_CRM_READ_TOOLS)
 
 
 def _tool_name_from_value(tool: Any) -> str:

--- a/core/marketing/connector_setup.py
+++ b/core/marketing/connector_setup.py
@@ -24,6 +24,11 @@ INSUFFICIENT_SCOPE_MARKERS = ("insufficient_scope", "missing_scope", "forbidden"
 MALFORMED_PAYLOAD_MARKERS = ("malformed_payload", "malformed payload", "invalid_payload", "schema_error")
 QUOTA_EXHAUSTED_MARKERS = ("quota_exhausted", "quota exhausted", "quota", "limit exhausted")
 CONNECTOR_DISABLED_MARKERS = ("connector_disabled", "connector disabled", "disabled", "inactive")
+HUBSPOT_PRIVATE_APP_SCOPE_GAPS = {
+    "crm.objects.contacts.read",
+    "crm.objects.deals.read",
+    "automation",
+}
 
 
 @dataclass(frozen=True)
@@ -236,6 +241,7 @@ def _build_row(
     missing_scopes = _missing_scopes(requirement.required_scopes, granted_scopes)
     contract_payload = _contract_payload(config_payload)
     contract_state = _contract_state_from_payload(contract_payload, last_sync_at, now)
+    non_blocking_scope_gaps: list[str] = []
 
     if status in UNCONFIGURED_STATUSES or not has_credentials:
         return _missing_row(requirement)
@@ -256,6 +262,18 @@ def _build_row(
         or _contains_any(status_text, INSUFFICIENT_SCOPE_MARKERS)
     ) and not missing_scopes:
         missing_scopes = list(requirement.required_scopes)
+
+    if _hubspot_private_app_scope_gap_is_non_blocking(
+        requirement=requirement,
+        missing_scopes=missing_scopes,
+        status=status,
+        health_status_raw=health_status_raw,
+        status_text=status_text,
+        contract_payload=contract_payload,
+        contract_state=contract_state,
+    ):
+        non_blocking_scope_gaps = list(missing_scopes)
+        missing_scopes = []
 
     if contract_state == "missing_scope" or _contains_any(status_text, INSUFFICIENT_SCOPE_MARKERS) or missing_scopes:
         health_status = "insufficient_scope"
@@ -331,6 +349,7 @@ def _build_row(
         "data_coverage_status": data_coverage_status,
         "cta_state": cta_state,
         "missing_scopes": missing_scopes,
+        "non_blocking_scope_gaps": non_blocking_scope_gaps,
         "granted_scopes": granted_scopes,
         "detail": detail,
     }
@@ -351,6 +370,7 @@ def _missing_row(requirement: MarketingConnectorRequirement) -> dict[str, Any]:
         "data_coverage_status": "missing",
         "cta_state": "setup",
         "missing_scopes": list(requirement.required_scopes),
+        "non_blocking_scope_gaps": [],
         "granted_scopes": [],
         "detail": "Connector is missing; configure it before treating CMO data as production-ready.",
     }
@@ -485,6 +505,40 @@ def _missing_scopes(required: tuple[str, ...], granted: list[str]) -> list[str]:
         return []
     granted_set = set(granted)
     return [scope for scope in required if scope not in granted_set]
+
+
+def _hubspot_private_app_scope_gap_is_non_blocking(
+    *,
+    requirement: MarketingConnectorRequirement,
+    missing_scopes: list[str],
+    status: str,
+    health_status_raw: str,
+    status_text: str,
+    contract_payload: dict[str, Any],
+    contract_state: str,
+) -> bool:
+    """Treat healthy HubSpot CRM access as setup proof despite scope text gaps."""
+
+    if requirement.key != "hubspot" or not missing_scopes:
+        return False
+    if not set(missing_scopes).issubset(HUBSPOT_PRIVATE_APP_SCOPE_GAPS):
+        return False
+    if status not in CONFIGURED_STATUSES and status:
+        return False
+    if health_status_raw not in HEALTHY_STATUSES:
+        return False
+    explicit_scope_failure = " ".join(
+        str(part or "")
+        for part in (
+            status_text,
+            contract_payload.get("degraded_mode_reason"),
+            contract_payload.get("blocking_reason"),
+            contract_payload.get("last_error"),
+        )
+    ).lower()
+    if contract_state == "missing_scope" or _contains_any(explicit_scope_failure, INSUFFICIENT_SCOPE_MARKERS):
+        return False
+    return True
 
 
 def _contains_any(value: str, markers: tuple[str, ...]) -> bool:

--- a/docs/aishwarya_19june2026_bugfix_learnings.md
+++ b/docs/aishwarya_19june2026_bugfix_learnings.md
@@ -1,0 +1,30 @@
+# Aishwarya 19 June 2026 Bugfix Learnings
+
+## What Reopened
+
+The reopened cases had one common cause: earlier fixes stopped at the visible symptom and did not audit sibling runtime paths.
+
+- HubSpot scope handling mixed read readiness and write permission gaps into one "missing scope" state. A healthy CRM read connection could still look blocked because optional/write scopes were projected into the contract badge.
+- SendGrid stats accepted only the most direct `start_date` shape. Workflow/tool callers can wrap arguments under `kwargs`, `params`, `arguments`, or free-text prompts.
+- Workflow HubSpot contact fetch worked as a standalone connector call but not as a workflow step because the workflow engine routed it through generic LLM agent execution.
+- HITL resume updated only some existing step fields and only when status changed. Output, errors, counters, and later HITL pauses could stay stale.
+- The workflow run page stopped polling in `waiting_hitl`, so a browser opened before approval could miss the resumed run entirely.
+- Failed steps exposed only a status badge; structured provider errors were persisted but not rendered for operators.
+
+## Permanent Rules
+
+- Read and write readiness must remain separate in backend state, API payloads, and UI tables.
+- Connector tools used by workflows need deterministic workflow step execution; do not rely on an LLM agent path for direct connector calls.
+- Resume paths must share persistence logic with first-run paths. Do not duplicate insert-only step sync code.
+- UI polling must continue for paused non-terminal workflow states that can transition externally.
+- Error payloads must be structured and displayed as code, message, and details. Never collapse provider failures into a bare "Failed" badge.
+- Regression tests must include wrapped/tool-caller input shapes, not only hand-written direct function calls.
+
+## Regression Pins Added
+
+- HubSpot healthy private-app partial scope handling in CMO setup and connector contracts.
+- SendGrid `get_stats` wrapped arguments, prompt text parsing, and invalid-date fail-fast behavior.
+- Workflow `fetch_hubspot_contacts` alias execution through the connector tool adapter.
+- Structured connector-tool failure propagation.
+- Workflow parser support for `connector_tool`.
+- Playwright coverage for CMO contract read/write separation, HITL run polling, and failed step detail rendering.

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -950,7 +950,7 @@
     "public_exempt_reason": null,
     "rate_limit": "approval-decision",
     "scope": "approvals.decide",
-    "source_line": 328,
+    "source_line": 327,
     "tenant_required": true
   },
   {
@@ -5685,7 +5685,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "workflows.sensitive.list",
-    "source_line": 229,
+    "source_line": 356,
     "tenant_required": true
   },
   {
@@ -5703,7 +5703,7 @@
     "public_exempt_reason": null,
     "rate_limit": "workflow-write",
     "scope": "workflows.write",
-    "source_line": 315,
+    "source_line": 442,
     "tenant_required": true
   },
   {
@@ -5721,7 +5721,7 @@
     "public_exempt_reason": null,
     "rate_limit": "ai-generation",
     "scope": "workflows.generate",
-    "source_line": 121,
+    "source_line": 248,
     "tenant_required": true
   },
   {
@@ -5739,7 +5739,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "workflows.runs.sensitive.read",
-    "source_line": 696,
+    "source_line": 790,
     "tenant_required": true
   },
   {
@@ -5757,7 +5757,7 @@
     "public_exempt_reason": null,
     "rate_limit": "workflow-control",
     "scope": "workflows.runs.cancel",
-    "source_line": 786,
+    "source_line": 880,
     "tenant_required": true
   },
   {
@@ -5775,7 +5775,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "workflows.runs.sensitive.replan-history",
-    "source_line": 742,
+    "source_line": 836,
     "tenant_required": true
   },
   {
@@ -5793,7 +5793,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "workflows.templates.read",
-    "source_line": 204,
+    "source_line": 331,
     "tenant_required": false
   },
   {
@@ -5811,7 +5811,7 @@
     "public_exempt_reason": null,
     "rate_limit": "workflow-write",
     "scope": "workflows.write",
-    "source_line": 377,
+    "source_line": 504,
     "tenant_required": true
   },
   {
@@ -5829,7 +5829,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "workflows.sensitive.read",
-    "source_line": 288,
+    "source_line": 415,
     "tenant_required": true
   },
   {
@@ -5847,7 +5847,7 @@
     "public_exempt_reason": null,
     "rate_limit": "workflow-write",
     "scope": "workflows.write",
-    "source_line": 889,
+    "source_line": 983,
     "tenant_required": true
   },
   {
@@ -5865,7 +5865,7 @@
     "public_exempt_reason": null,
     "rate_limit": "workflow-execution",
     "scope": "workflows.run",
-    "source_line": 598,
+    "source_line": 692,
     "tenant_required": true
   },
   {

--- a/tests/regression/test_aishwarya_19jun2026_reopens.py
+++ b/tests/regression/test_aishwarya_19jun2026_reopens.py
@@ -1,0 +1,83 @@
+"""Aishwarya 19 June 2026 reopened bug regression pins."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class _StatsResponse:
+    status_code = 200
+    headers: dict[str, str] = {}
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> list[dict]:
+        return [
+            {
+                "date": "2026-06-18",
+                "stats": [{"metrics": {"requests": 7, "delivered": 6}}],
+            }
+        ]
+
+
+class _StatsClient:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def get(self, path: str, params: dict):
+        self.calls.append({"path": path, "params": dict(params)})
+        return _StatsResponse()
+
+
+@pytest.mark.asyncio
+async def test_sendgrid_get_stats_accepts_wrapped_valid_date_range() -> None:
+    from connectors.comms.sendgrid import SendgridConnector
+
+    connector = SendgridConnector({"api_key": "SG.test"})
+    client = _StatsClient()
+    connector._client = client
+
+    result = await connector.get_stats(
+        kwargs={"start_date": "2026-06-18", "end_date": "2026-06-19"}
+    )
+
+    assert result["stats"][0]["metrics"]["delivered"] == 6
+    assert client.calls == [
+        {
+            "path": "/stats",
+            "params": {"start_date": "2026-06-18", "end_date": "2026-06-19"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sendgrid_get_stats_accepts_prompt_text_date_range() -> None:
+    from connectors.comms.sendgrid import SendgridConnector
+
+    connector = SendgridConnector({"api_key": "SG.test"})
+    client = _StatsClient()
+    connector._client = client
+
+    await connector.get_stats(
+        query="Fetch stats for start_date=2026-06-18 and end_date=2026-06-19"
+    )
+
+    assert client.calls[0]["params"] == {
+        "start_date": "2026-06-18",
+        "end_date": "2026-06-19",
+    }
+
+
+@pytest.mark.asyncio
+async def test_sendgrid_get_stats_rejects_invalid_dates_before_vendor_call() -> None:
+    from connectors.comms.sendgrid import SendgridConnector
+
+    connector = SendgridConnector({"api_key": "SG.test"})
+    client = _StatsClient()
+    connector._client = client
+
+    result = await connector.get_stats(start_date="2026-06-31")
+
+    assert "YYYY-MM-DD" in result["error"]
+    assert client.calls == []

--- a/tests/unit/test_cmo_marketing_connector_contracts.py
+++ b/tests/unit/test_cmo_marketing_connector_contracts.py
@@ -196,6 +196,10 @@ def _contract_row(rows: list[dict], connector_key: str) -> dict:
     return next(row for row in rows if row["connector_key"] == connector_key)
 
 
+def _setup_row(rows: list[dict], connector_key: str) -> dict:
+    return next(row for row in rows if row["key"] == connector_key)
+
+
 def _workflow_config() -> dict:
     return {
         "mode": "shadow",
@@ -257,6 +261,41 @@ def test_hubspot_private_app_without_persisted_scopes_is_read_ready() -> None:
     ]
 
 
+def test_hubspot_healthy_private_app_partial_scopes_do_not_poison_setup() -> None:
+    configs = _base_configs()
+    configs[0].config["granted_scopes"] = ["crm.objects.contacts.read"]
+
+    setup = build_marketing_connector_setup(configs, now=NOW)
+    hubspot = _setup_row(setup, "hubspot")
+
+    assert hubspot["health_status"] == "healthy"
+    assert hubspot["cta_state"] == "none"
+    assert hubspot["missing_scopes"] == []
+    assert hubspot["non_blocking_scope_gaps"] == [
+        "crm.objects.deals.read",
+        "automation",
+    ]
+
+
+def test_hubspot_healthy_private_app_partial_scopes_with_tools_is_read_ready() -> None:
+    configs = _base_configs()
+    configs[0].config["granted_scopes"] = ["crm.objects.contacts.read"]
+    configs[0].config["tool_functions"] = [
+        "list_contacts",
+        "search_contacts",
+        "list_deals",
+    ]
+
+    hubspot = _contract_row(_contracts(configs), "hubspot")
+
+    assert hubspot["contract_state"] == "healthy"
+    assert hubspot["read_ready"] is True
+    assert hubspot["read_status"] == "ready"
+    assert hubspot["missing_read_scopes"] == []
+    assert hubspot["missing_write_scopes"] == ["automation"]
+    assert hubspot["write_status"] == "missing_scope"
+
+
 def test_missing_write_scope_blocks_write_workflow_readiness() -> None:
     configs = _base_configs()
     configs[1].config["marketing_connector_contract"] = _contract(
@@ -286,6 +325,7 @@ def test_missing_write_scope_state_does_not_block_read_contract() -> None:
 
     assert google_ads["read_ready"] is True
     assert google_ads["read_status"] == "ready"
+    assert google_ads["contract_state"] == "healthy"
     assert google_ads["write_ready"] is False
     assert google_ads["write_status"] == "missing_scope"
     assert google_ads["missing_read_scopes"] == []

--- a/tests/unit/test_module_7_workflows.py
+++ b/tests/unit/test_module_7_workflows.py
@@ -251,11 +251,11 @@ def test_tc_wf_005_waiting_hitl_step_keeps_completed_at_null() -> None:
     here would make the step look done in dashboards (and
     silently fail to wait for approval)."""
     src = (REPO / "api" / "v1" / "workflows.py").read_text(encoding="utf-8")
-    # The conditional `if step_status != "waiting_hitl" else None`
-    # is the contract.
+    # The shared persistence helper keeps waiting HITL rows visibly open.
     assert 'step_status != "waiting_hitl"' in src
-    # Before that line we set completed_at conditionally.
-    assert "completed_at=(" in src and "else None" in src
+    assert "row.completed_at = (" in src
+    assert "_step_completed_at(step_status, row.completed_at)" in src
+    assert "else None" in src
 
 
 def test_tc_wf_005_hitl_step_creates_queue_entry_with_documented_title() -> None:
@@ -264,7 +264,7 @@ def test_tc_wf_005_hitl_step_creates_queue_entry_with_documented_title() -> None
     waiting" — and the trigger_type='workflow_step' so HITL
     handlers know to resume the workflow on approval."""
     src = (REPO / "api" / "v1" / "workflows.py").read_text(encoding="utf-8")
-    assert 'if step_status == "waiting_hitl":' in src
+    assert 'if created and step_status == "waiting_hitl":' in src
     assert 'trigger_type="workflow_step"' in src
     assert 'title=f"Approval required: {step_def.get(\'title\', step_id)}"' in src
 
@@ -275,7 +275,9 @@ def test_tc_wf_005_hitl_step_assignee_role_resolved_with_fallback() -> None:
     so an under-specified workflow still routes the approval
     to someone."""
     src = (REPO / "api" / "v1" / "workflows.py").read_text(encoding="utf-8")
-    hitl_section = src.split('if step_status == "waiting_hitl":', 1)[1][:1500]
+    hitl_section = src.split('if created and step_status == "waiting_hitl":', 1)[1][
+        :1500
+    ]
     assert 'step_result.get(' in hitl_section
     assert '"assignee_role"' in hitl_section
     assert 'step_def.get("assignee_role", "admin")' in hitl_section
@@ -285,7 +287,9 @@ def test_tc_wf_005_hitl_step_priority_pulled_from_step_def_with_default() -> Non
     """Step priority defaults to 'normal' if the step doesn't
     set it — high/urgent must be opt-in."""
     src = (REPO / "api" / "v1" / "workflows.py").read_text(encoding="utf-8")
-    hitl_section = src.split('if step_status == "waiting_hitl":', 1)[1][:1500]
+    hitl_section = src.split('if created and step_status == "waiting_hitl":', 1)[1][
+        :1500
+    ]
     assert 'priority=step_def.get("priority", "normal")' in hitl_section
 
 
@@ -294,5 +298,7 @@ def test_tc_wf_005_hitl_timeout_default_is_four_hours() -> None:
     default so a refactor can't silently make approvals
     stale-forever (they'd silently block workflows)."""
     src = (REPO / "api" / "v1" / "workflows.py").read_text(encoding="utf-8")
-    hitl_section = src.split('if step_status == "waiting_hitl":', 1)[1][:1500]
+    hitl_section = src.split('if created and step_status == "waiting_hitl":', 1)[1][
+        :1500
+    ]
     assert 'timeout_h = step_def.get("timeout_hours", 4)' in hitl_section

--- a/tests/unit/test_workflow_no_false_success.py
+++ b/tests/unit/test_workflow_no_false_success.py
@@ -211,3 +211,96 @@ async def test_no_false_success_failed_step_fails_workflow_in_engine(monkeypatch
         result["step_results"]["notify_step"]["error"]["code"]
         == "notify_side_effect_not_configured"
     )
+
+
+@pytest.mark.asyncio
+async def test_connector_tool_alias_executes_hubspot_contacts_in_workflow(monkeypatch):
+    from core.langgraph import tool_adapter
+    from workflows.step_types import execute_step
+
+    captured: dict[str, object] = {}
+
+    async def fake_execute_connector_tool(connector, tool, params, config):
+        captured.update(
+            {
+                "connector": connector,
+                "tool": tool,
+                "params": params,
+                "config": config,
+            }
+        )
+        return {"contacts": [{"id": "1", "email": "qa@example.com"}]}
+
+    monkeypatch.setattr(tool_adapter, "_execute_connector_tool", fake_execute_connector_tool)
+
+    result = await execute_step(
+        {
+            "id": "fetch_hubspot_contacts",
+            "type": "agent",
+            "inputs": {"limit": 5},
+            "connector_config": {"access_token": "pat-test"},
+        },
+        {"tenant_id": "22222222-2222-2222-2222-222222222222"},
+    )
+
+    assert result["status"] == "completed"
+    assert result["output"]["contacts"][0]["email"] == "qa@example.com"
+    assert captured == {
+        "connector": "hubspot",
+        "tool": "list_contacts",
+        "params": {"limit": 5},
+        "config": {"access_token": "pat-test"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_connector_tool_failure_returns_structured_step_error(monkeypatch):
+    from core.langgraph import tool_adapter
+    from workflows.step_types import execute_step
+
+    async def fake_execute_connector_tool(*_args, **_kwargs):
+        return {
+            "error": "insufficient_scope",
+            "message": "HubSpot returned 403 insufficient scope",
+            "http_status": 403,
+        }
+
+    monkeypatch.setattr(tool_adapter, "_execute_connector_tool", fake_execute_connector_tool)
+
+    result = await execute_step(
+        {
+            "id": "fetch_hubspot_contacts",
+            "type": "agent",
+            "inputs": {"limit": 5},
+            "connector_config": {"access_token": "pat-test"},
+        },
+        {"tenant_id": "22222222-2222-2222-2222-222222222222"},
+    )
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "connector_tool_execution_failed"
+    assert result["error"]["message"] == "HubSpot returned 403 insufficient scope"
+    assert result["error"]["details"]["connector"] == "hubspot"
+    assert result["error"]["details"]["tool"] == "list_contacts"
+    assert result["error"]["details"]["http_status"] == 403
+
+
+def test_connector_tool_step_type_is_valid_workflow_parser_input() -> None:
+    from workflows.parser import WorkflowParser
+
+    parsed = WorkflowParser().parse(
+        {
+            "name": "HubSpot contact fetch",
+            "steps": [
+                {
+                    "id": "fetch_contacts",
+                    "type": "connector_tool",
+                    "connector": "hubspot",
+                    "tool": "list_contacts",
+                    "inputs": {"limit": 10},
+                }
+            ],
+        }
+    )
+
+    assert parsed["steps"][0]["type"] == "connector_tool"

--- a/ui/e2e/aishwarya-19june2026.spec.ts
+++ b/ui/e2e/aishwarya-19june2026.spec.ts
@@ -1,0 +1,227 @@
+import { expect, Page, test } from "@playwright/test";
+
+async function installCommonRoutes(page: Page) {
+  await page.route("**/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      json: {
+        email: "qa@example.com",
+        name: "QA",
+        role: "admin",
+        domain: "all",
+        tenant_id: "tenant-1",
+        onboarding_complete: true,
+      },
+    });
+  });
+  await page.route("**/api/v1/product-facts", async (route) => {
+    await route.fulfill({
+      json: { version: "test", connector_count: 10, agent_count: 1, tool_count: 20 },
+    });
+  });
+  await page.route("**/api/v1/companies**", async (route) => {
+    await route.fulfill({ json: { items: [], total: 0, page: 1, per_page: 20, pages: 1 } });
+  });
+}
+
+function cmoPayload() {
+  return {
+    demo: false,
+    company_id: "comp-1",
+    agent_count: 1,
+    total_tasks_30d: 10,
+    success_rate: 90,
+    hitl_interventions: 0,
+    total_cost_usd: 1.5,
+    domain_breakdown: [
+      { domain: "marketing", total: 10, completed: 9, failed: 1, avg_confidence: 0.9 },
+    ],
+    connector_contracts: [
+      {
+        connector_key: "hubspot",
+        name: "HubSpot",
+        category: "CRM",
+        configured_status: "configured",
+        vendor_id: null,
+        account_id: "portal-123",
+        workspace_id: null,
+        read_capabilities: ["contacts.read", "deals.read", "lists.read"],
+        write_capabilities: ["workflow.enroll"],
+        required_read_scopes: ["crm.objects.contacts.read", "crm.objects.deals.read"],
+        required_write_scopes: ["automation"],
+        granted_scopes: ["crm.objects.contacts.read"],
+        missing_read_scopes: [],
+        missing_write_scopes: ["automation"],
+        read_scope_evidence: [
+          "Healthy HubSpot connector state proves CRM read capability even without a persisted OAuth scope string.",
+        ],
+        auth_status: "valid",
+        health_status: "healthy",
+        contract_state: "healthy",
+        read_status: "ready",
+        write_status: "missing_scope",
+        read_ready: true,
+        write_ready: false,
+        production_ready: true,
+        mock_or_test_double: false,
+        last_sync_at: "2026-06-19T00:00:00Z",
+        source_objects: [],
+        data_freshness: {
+          status: "fresh",
+          ttl_seconds: 86400,
+          last_sync_at: "2026-06-19T00:00:00Z",
+        },
+        retry_budget: {
+          max_attempts: 0,
+          attempts_used: 0,
+          remaining_attempts: 0,
+          reset_at: null,
+          next_retry_at: null,
+          idempotency_key: null,
+          idempotency_supported: false,
+        },
+        degraded_mode_reason: null,
+        idempotency_key_supported: false,
+        external_write_confirmation_status: "none",
+        external_write_confirmations: [],
+        next_action_cta: "add_scope",
+      },
+    ],
+    connector_contract_summary: {
+      total: 1,
+      configured: 1,
+      read_ready: 1,
+      write_ready: 0,
+      blocked: 0,
+      degraded: 0,
+      missing_write_scope: 1,
+      write_unconfirmed: 0,
+      write_confirmed: 0,
+      mock_or_test_double: 0,
+      readiness: "ready",
+    },
+  };
+}
+
+test.describe("Aishwarya 19 June 2026 reopened regressions", () => {
+  test("CMO connector contracts keep HubSpot read ready while write scope is missing", async ({
+    page,
+    baseURL,
+  }) => {
+    await installCommonRoutes(page);
+    await page.route("**/api/v1/kpis/cmo**", async (route) => {
+      await route.fulfill({ json: cmoPayload() });
+    });
+
+    await page.goto(`${baseURL}/dashboard/cmo`, { waitUntil: "domcontentloaded" });
+
+    const hubspotRow = page.locator("tr", { hasText: "HubSpot" }).first();
+    await expect(hubspotRow.locator("td").nth(1)).toContainText("Healthy");
+    await expect(hubspotRow.locator("td").nth(2)).toContainText("Ready");
+    await expect(hubspotRow.locator("td").nth(3)).toContainText("Missing Scope");
+    await expect(hubspotRow.locator("td").nth(3)).toContainText("Missing write scopes: automation");
+    await expect(hubspotRow.locator("td").nth(3)).not.toContainText("crm.objects.contacts.read");
+    await expect(hubspotRow.locator("td").nth(3)).not.toContainText("crm.objects.deals.read");
+  });
+
+  test("workflow run keeps polling while waiting for HITL and shows resumed progress", async ({
+    page,
+    baseURL,
+  }) => {
+    await installCommonRoutes(page);
+    let calls = 0;
+    await page.route("**/api/v1/workflows/runs/run-hitl", async (route) => {
+      calls += 1;
+      await route.fulfill({
+        json:
+          calls <= 2
+            ? {
+                run_id: "run-hitl",
+                workflow_def_id: "wf-1",
+                status: "waiting_hitl",
+                steps_total: 2,
+                steps_completed: 1,
+                started_at: "2026-06-19T00:00:00Z",
+                steps: [
+                  {
+                    step_id: "approval",
+                    step_type: "human_in_loop",
+                    status: "waiting_hitl",
+                  },
+                ],
+              }
+            : {
+                run_id: "run-hitl",
+                workflow_def_id: "wf-1",
+                status: "completed",
+                steps_total: 2,
+                steps_completed: 2,
+                started_at: "2026-06-19T00:00:00Z",
+                completed_at: "2026-06-19T00:01:00Z",
+                steps: [
+                  {
+                    step_id: "approval",
+                    step_type: "human_in_loop",
+                    status: "completed",
+                  },
+                  {
+                    step_id: "fetch_hubspot_contacts",
+                    step_type: "connector_tool",
+                    status: "completed",
+                  },
+                ],
+              },
+      });
+    });
+
+    await page.goto(`${baseURL}/dashboard/workflows/wf-1/runs/run-hitl`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page.locator("main")).toContainText("waiting_hitl");
+    await expect.poll(() => calls, { timeout: 5000 }).toBeGreaterThan(2);
+    await expect(page.locator("main")).toContainText("completed");
+    await expect(page.locator("main")).toContainText("2/2");
+    await expect(page.locator("main")).toContainText("fetch_hubspot_contacts");
+  });
+
+  test("workflow run renders structured failed step details", async ({ page, baseURL }) => {
+    await installCommonRoutes(page);
+    await page.route("**/api/v1/workflows/runs/run-failed", async (route) => {
+      await route.fulfill({
+        json: {
+          run_id: "run-failed",
+          workflow_def_id: "wf-1",
+          status: "failed",
+          steps_total: 1,
+          steps_completed: 1,
+          started_at: "2026-06-19T00:00:00Z",
+          completed_at: "2026-06-19T00:01:00Z",
+          steps: [
+            {
+              step_id: "fetch_hubspot_contacts",
+              step_type: "connector_tool",
+              status: "failed",
+              error: {
+                code: "connector_tool_execution_failed",
+                message: "HubSpot returned 403 insufficient scope",
+                details: { connector: "hubspot", tool: "list_contacts", http_status: 403 },
+              },
+              error_code: "connector_tool_execution_failed",
+              error_message: "HubSpot returned 403 insufficient scope",
+            },
+          ],
+        },
+      });
+    });
+
+    await page.goto(`${baseURL}/dashboard/workflows/wf-1/runs/run-failed`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    const error = page.getByTestId("step-error-fetch_hubspot_contacts");
+    await expect(error).toContainText("connector_tool_execution_failed");
+    await expect(error).toContainText("HubSpot returned 403 insufficient scope");
+    await expect(error).toContainText("list_contacts");
+    await expect(error).not.toContainText("[object Object]");
+  });
+});

--- a/ui/src/pages/CMODashboard.tsx
+++ b/ui/src/pages/CMODashboard.tsx
@@ -1732,7 +1732,6 @@ export default function CMODashboard() {
                     const writeCapabilities = row.write_capabilities.length > 0
                       ? row.write_capabilities.join(", ")
                       : t("cmoConnectorContracts.noWrites", "No write capability");
-                    const missingScopes = [...row.missing_read_scopes, ...row.missing_write_scopes];
                     return (
                       <tr key={row.connector_key} className="border-b align-top last:border-0">
                         <td className="py-2 pr-4">
@@ -1768,6 +1767,11 @@ export default function CMODashboard() {
                               {row.read_scope_evidence.join(" ")}
                             </div>
                           )}
+                          {row.missing_read_scopes.length > 0 && (
+                            <div className="mt-1 max-w-[260px] text-xs text-amber-700">
+                              {t("cmoConnectorContracts.missingReadScopes", "Missing read scopes")}: {row.missing_read_scopes.join(", ")}
+                            </div>
+                          )}
                         </td>
                         <td className="py-2 pr-4">
                           <Badge variant={contractStatusVariant(row.write_status)}>
@@ -1776,9 +1780,9 @@ export default function CMODashboard() {
                           <div className="mt-1 max-w-[260px] text-xs text-muted-foreground">
                             {writeCapabilities}
                           </div>
-                          {missingScopes.length > 0 && (
+                          {row.missing_write_scopes.length > 0 && (
                             <div className="mt-1 max-w-[260px] text-xs text-muted-foreground">
-                              {t("cmoConnectorContracts.missingScopes", "Missing")}: {missingScopes.join(", ")}
+                              {t("cmoConnectorContracts.missingWriteScopes", "Missing write scopes")}: {row.missing_write_scopes.join(", ")}
                             </div>
                           )}
                         </td>

--- a/ui/src/pages/WorkflowRun.tsx
+++ b/ui/src/pages/WorkflowRun.tsx
@@ -5,6 +5,20 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import api from "@/lib/api";
 
+const LIVE_RUN_STATUSES = new Set(["running", "waiting_hitl", "waiting_delay", "waiting_event"]);
+
+type StepErrorPayload =
+  | string
+  | {
+      message?: unknown;
+      error?: unknown;
+      code?: unknown;
+      details?: unknown;
+      [key: string]: unknown;
+    }
+  | null
+  | undefined;
+
 interface StepExecution {
   step_id: string;
   step_type: string;
@@ -12,7 +26,10 @@ interface StepExecution {
   agent_id?: string;
   confidence?: number;
   latency_ms?: number;
-  error?: string;
+  error?: StepErrorPayload;
+  error_message?: string | null;
+  error_code?: string | null;
+  error_details?: unknown;
   replanned?: boolean;
 }
 
@@ -27,6 +44,54 @@ interface RunDetail {
   steps: StepExecution[];
 }
 
+function stringifyErrorDetail(value: unknown): string | null {
+  if (value == null || value === "") return null;
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export function formatStepError(step: StepExecution): {
+  code?: string;
+  message: string;
+  details?: string;
+} | null {
+  const raw = step.error;
+  const details = stringifyErrorDetail(step.error_details);
+
+  if (typeof raw === "string") {
+    return {
+      code: step.error_code || undefined,
+      message: step.error_message || raw,
+      details: details || undefined,
+    };
+  }
+
+  if (raw && typeof raw === "object") {
+    const message = raw.message || raw.error || step.error_message;
+    const code = raw.code || step.error_code || raw.error;
+    const rawDetails = raw.details ?? step.error_details;
+    return {
+      code: code ? String(code) : undefined,
+      message: message ? String(message) : "Step failed without a message.",
+      details: stringifyErrorDetail(rawDetails) || details || undefined,
+    };
+  }
+
+  if (step.error_message || step.error_code) {
+    return {
+      code: step.error_code || undefined,
+      message: step.error_message || "Step failed without a message.",
+      details: details || undefined,
+    };
+  }
+
+  return null;
+}
+
 export default function WorkflowRun() {
   const { runId } = useParams();
   const [run, setRun] = useState<RunDetail | null>(null);
@@ -35,18 +100,18 @@ export default function WorkflowRun() {
   const [cancelInFlight, setCancelInFlight] = useState(false);
 
   useEffect(() => {
-    if (runId) fetchRun();
+    if (runId) fetchRun({ showLoading: true });
   }, [runId]);
 
-  // Auto-refresh while workflow is running
+  // Auto-refresh while workflow is active or paused for an external event.
   useEffect(() => {
-    if (!run || run.status !== "running") return;
-    const interval = setInterval(fetchRun, 3000);
+    if (!run || !LIVE_RUN_STATUSES.has(run.status)) return;
+    const interval = setInterval(() => fetchRun({ showLoading: false }), 3000);
     return () => clearInterval(interval);
   }, [run?.status]);
 
-  async function fetchRun() {
-    setLoading(true);
+  async function fetchRun(options: { showLoading?: boolean } = {}) {
+    if (options.showLoading !== false) setLoading(true);
     setError(null);
     try {
       const { data } = await api.get(`/workflows/runs/${runId}`);
@@ -74,7 +139,7 @@ export default function WorkflowRun() {
       await api.post(`/workflows/runs/${runId}/cancel`);
       // Re-fetch immediately so the UI reflects the new status without
       // waiting for the next auto-refresh tick.
-      await fetchRun();
+      await fetchRun({ showLoading: false });
     } catch (e: any) {
       const status = e?.response?.status;
       const detail = e?.response?.data?.detail || e?.response?.data?.message;
@@ -111,7 +176,7 @@ export default function WorkflowRun() {
         >
           <span className="font-medium text-destructive shrink-0">Error:</span>
           <span className="flex-1">{error || "Run not found."}</span>
-          <Button size="sm" variant="outline" onClick={fetchRun}>
+          <Button size="sm" variant="outline" onClick={() => fetchRun({ showLoading: true })}>
             Retry
           </Button>
         </div>
@@ -140,7 +205,7 @@ export default function WorkflowRun() {
               {cancelInFlight ? "Cancelling…" : "Cancel"}
             </Button>
           )}
-          <Button variant="outline" size="sm" onClick={fetchRun}>Refresh</Button>
+          <Button variant="outline" size="sm" onClick={() => fetchRun({ showLoading: true })}>Refresh</Button>
         </div>
       </div>
 
@@ -177,25 +242,52 @@ export default function WorkflowRun() {
         <CardContent>
           {run.steps && run.steps.length > 0 ? (
             <div className="space-y-3">
-              {run.steps.map((step, i) => (
-                <div key={step.step_id} className="flex items-center justify-between border rounded p-3">
-                  <div className="flex items-center gap-3">
-                    <span className="text-sm font-mono text-muted-foreground w-6">{i + 1}</span>
-                    <div>
-                      <p className="text-sm font-medium">{step.step_id}</p>
-                      <p className="text-xs text-muted-foreground">{step.step_type}{step.agent_id ? ` | ${step.agent_id}` : ""}</p>
+              {run.steps.map((step, i) => {
+                const stepError = formatStepError(step);
+                return (
+                  <div key={step.step_id} className="border rounded p-3 space-y-3">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <span className="text-sm font-mono text-muted-foreground w-6">{i + 1}</span>
+                        <div>
+                          <p className="text-sm font-medium">{step.step_id}</p>
+                          <p className="text-xs text-muted-foreground">{step.step_type}{step.agent_id ? ` | ${step.agent_id}` : ""}</p>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-3">
+                        {step.confidence != null && <span className="text-xs text-muted-foreground">{(step.confidence * 100).toFixed(0)}%</span>}
+                        {step.latency_ms != null && <span className="text-xs text-muted-foreground">{step.latency_ms}ms</span>}
+                        {(step.replanned || step.status === "replanned") && (
+                          <Badge variant="outline" className="bg-orange-100 text-orange-800 border-orange-300" data-testid="replanned-badge">Replanned</Badge>
+                        )}
+                        <Badge variant={(stepStatusColor[step.status] || "default") as any}>{step.status}</Badge>
+                      </div>
                     </div>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    {step.confidence != null && <span className="text-xs text-muted-foreground">{(step.confidence * 100).toFixed(0)}%</span>}
-                    {step.latency_ms != null && <span className="text-xs text-muted-foreground">{step.latency_ms}ms</span>}
-                    {(step.replanned || step.status === "replanned") && (
-                      <Badge variant="outline" className="bg-orange-100 text-orange-800 border-orange-300" data-testid="replanned-badge">Replanned</Badge>
+                    {stepError && (
+                      <div
+                        role="alert"
+                        data-testid={`step-error-${step.step_id}`}
+                        className="rounded border border-destructive/40 bg-destructive/5 p-3 text-sm"
+                      >
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium text-destructive">Error</span>
+                          {stepError.code && (
+                            <Badge variant="outline" className="font-mono">
+                              {stepError.code}
+                            </Badge>
+                          )}
+                        </div>
+                        <p className="mt-1 text-foreground">{stepError.message}</p>
+                        {stepError.details && (
+                          <pre className="mt-2 max-h-36 overflow-auto whitespace-pre-wrap rounded bg-muted p-2 text-xs text-muted-foreground">
+                            {stepError.details}
+                          </pre>
+                        )}
+                      </div>
                     )}
-                    <Badge variant={(stepStatusColor[step.status] || "default") as any}>{step.status}</Badge>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           ) : (
             <p className="text-sm text-muted-foreground">No step execution data available.</p>

--- a/workflows/parser.py
+++ b/workflows/parser.py
@@ -15,6 +15,7 @@ class WorkflowParser:
         "parallel",
         "loop",
         "transform",
+        "connector_tool",
         "notify",
         "sub_workflow",
         "wait",

--- a/workflows/step_results.py
+++ b/workflows/step_results.py
@@ -94,6 +94,43 @@ class NotifySideEffectNotConfiguredError(WorkflowStepError):
         )
 
 
+class ConnectorToolConfigError(WorkflowStepError):
+    def __init__(self, *, step_id: str, connector: str | None, tool: str | None) -> None:
+        super().__init__(
+            "connector_tool_config_missing",
+            "Connector tool step is missing connector or tool configuration.",
+            {"step_id": step_id, "connector": connector, "tool": tool},
+        )
+
+
+class ConnectorToolExecutionError(WorkflowStepError):
+    def __init__(
+        self,
+        *,
+        step_id: str,
+        connector: str,
+        tool: str,
+        result: dict[str, Any],
+    ) -> None:
+        message = str(
+            result.get("message")
+            or result.get("error")
+            or f"{connector}.{tool} failed."
+        )
+        super().__init__(
+            "connector_tool_execution_failed",
+            message,
+            {
+                "step_id": step_id,
+                "connector": connector,
+                "tool": tool,
+                "provider_error": result.get("error"),
+                "http_status": result.get("http_status"),
+                "error_class": result.get("error_class"),
+            },
+        )
+
+
 class ExternalWriteConfirmationMissingError(WorkflowStepError):
     def __init__(
         self,

--- a/workflows/step_types.py
+++ b/workflows/step_types.py
@@ -18,6 +18,8 @@ from workflows.parallel_executor import execute_parallel
 from workflows.step_results import (
     ALLOWED_STEP_STATUSES,
     AgentExecutionError,
+    ConnectorToolConfigError,
+    ConnectorToolExecutionError,
     ExternalWriteConfirmationMissingError,
     MissingAgentConfigError,
     MissingLLMProviderConfigError,
@@ -56,6 +58,14 @@ MARKETING_WRITE_ACTION_HINTS = (
     "start_nurture",
     "update_crm",
 )
+CONNECTOR_TOOL_ALIASES: dict[str, tuple[str, str]] = {
+    "fetch_hubspot_contacts": ("hubspot", "list_contacts"),
+    "get_hubspot_contacts": ("hubspot", "list_contacts"),
+    "list_hubspot_contacts": ("hubspot", "list_contacts"),
+    "fetch_hubspot_deals": ("hubspot", "list_deals"),
+    "get_hubspot_deals": ("hubspot", "list_deals"),
+    "list_hubspot_deals": ("hubspot", "list_deals"),
+}
 
 
 def _env_flag(name: str) -> bool:
@@ -165,6 +175,45 @@ async def _load_workflow_agent_config(agent_id: str, tenant_id: str) -> dict[str
     }
 
 
+async def _load_workflow_connector_config(connector_name: str, tenant_id: str) -> dict[str, Any]:
+    if not connector_name or not tenant_id:
+        return {}
+    try:
+        tenant_uuid = uuid.UUID(str(tenant_id))
+    except (TypeError, ValueError):
+        return {}
+
+    import json as _json
+
+    from sqlalchemy import select
+
+    from core.database import get_tenant_session
+    from core.models.connector_config import ConnectorConfig
+
+    async with get_tenant_session(tenant_uuid) as session:
+        result = await session.execute(
+            select(ConnectorConfig).where(
+                ConnectorConfig.tenant_id == tenant_uuid,
+                ConnectorConfig.connector_name == connector_name,
+            )
+        )
+        row = result.scalar_one_or_none()
+    if row is None:
+        return {}
+
+    config = dict(row.config or {})
+    creds = row.credentials_encrypted or {}
+    if isinstance(creds, str):
+        creds = _json.loads(creds)
+    if isinstance(creds, dict) and "_encrypted" in creds:
+        from core.crypto import decrypt_for_tenant
+
+        creds = _json.loads(decrypt_for_tenant(creds["_encrypted"]))
+    if isinstance(creds, dict):
+        config.update(creds)
+    return config
+
+
 def _normalize_key(value: Any) -> str:
     return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
 
@@ -227,6 +276,51 @@ def _connector_key(step: dict, output: dict[str, Any]) -> str | None:
         or output.get("connector")
     )
     return str(value).strip().lower() if value else None
+
+
+def _connector_tool_ref_from_step(
+    step: dict,
+    *,
+    allow_action_tool: bool = True,
+) -> tuple[str | None, str | None]:
+    connector = step.get("connector") or step.get("connector_key")
+    tool = step.get("tool") or step.get("tool_name")
+    action = step.get("action")
+    agent = step.get("agent") or step.get("agent_type")
+    step_id = step.get("id")
+
+    for value in (tool, action, agent, step_id):
+        normalized = _normalize_key(value)
+        if normalized in CONNECTOR_TOOL_ALIASES:
+            return CONNECTOR_TOOL_ALIASES[normalized]
+
+    for value in (tool, action):
+        if isinstance(value, str) and ":" in value and not value.startswith("tool:"):
+            maybe_connector, maybe_tool = value.split(":", 1)
+            return _normalize_key(maybe_connector), maybe_tool.strip()
+
+    if connector and tool:
+        return _normalize_key(connector), str(tool).strip()
+    if allow_action_tool and connector and action:
+        return _normalize_key(connector), str(action).strip()
+    return None, None
+
+
+def _connector_step_inputs(step: dict, state: dict) -> dict[str, Any]:
+    raw = step.get("params", step.get("arguments", step.get("inputs", {})))
+    if not isinstance(raw, dict):
+        return {}
+    inputs = dict(raw)
+    context = state.get("context") if isinstance(state.get("context"), dict) else {}
+    trigger = state.get("trigger_payload") if isinstance(state.get("trigger_payload"), dict) else {}
+    for key, value in list(inputs.items()):
+        if isinstance(value, str) and value.startswith("$"):
+            lookup = value[1:]
+            if lookup in context:
+                inputs[key] = context[lookup]
+            elif lookup in trigger:
+                inputs[key] = trigger[lookup]
+    return inputs
 
 
 def _connector_contracts_from_state(state: dict) -> list[dict[str, Any]]:
@@ -313,6 +407,13 @@ def _external_write_failure(
 
 async def execute_step(step: dict, state: dict) -> dict[str, Any]:
     step_type = step.get("type", "agent")
+    if step_type == "agent" and any(key in step for key in ("tool", "tool_name")):
+        return await _execute_connector_tool_step(step, state)
+    if step_type == "agent" and _connector_tool_ref_from_step(
+        step,
+        allow_action_tool=False,
+    ) != (None, None):
+        return await _execute_connector_tool_step(step, state)
     handlers = {
         "agent": _execute_agent,
         "condition": _execute_condition,
@@ -320,6 +421,7 @@ async def execute_step(step: dict, state: dict) -> dict[str, Any]:
         "parallel": _execute_parallel,
         "loop": _execute_loop,
         "transform": _execute_transform,
+        "connector_tool": _execute_connector_tool_step,
         "notify": _execute_notify,
         "sub_workflow": _execute_sub_workflow,
         "wait": _execute_wait,
@@ -334,6 +436,56 @@ async def _execute_collaboration(step: dict, state: dict) -> dict[str, Any]:
     from workflows.collaboration import execute_collaboration_step
 
     return await execute_collaboration_step(step, state)
+
+
+async def _execute_connector_tool_step(step: dict, state: dict) -> dict[str, Any]:
+    connector, tool = _connector_tool_ref_from_step(step)
+    if not connector or not tool:
+        return failure_result(
+            step_id=str(step.get("id", "")),
+            step_type="connector_tool",
+            failure=ConnectorToolConfigError(
+                step_id=str(step.get("id", "")),
+                connector=connector,
+                tool=tool,
+            ),
+        )
+
+    config = step.get("connector_config")
+    if not isinstance(config, dict):
+        state_config = _state_lookup(state, "connector_config", f"{connector}_connector_config")
+        config = state_config if isinstance(state_config, dict) else {}
+    if not config:
+        config = await _load_workflow_connector_config(connector, str(state.get("tenant_id") or ""))
+
+    from core.langgraph.tool_adapter import _execute_connector_tool
+
+    result = await _execute_connector_tool(
+        connector,
+        tool,
+        _connector_step_inputs(step, state),
+        config,
+    )
+    if isinstance(result, dict) and result.get("error"):
+        return failure_result(
+            step_id=str(step.get("id", "")),
+            step_type="connector_tool",
+            failure=ConnectorToolExecutionError(
+                step_id=str(step.get("id", "")),
+                connector=connector,
+                tool=tool,
+                result=result,
+            ),
+            output=result,
+        )
+    return {
+        "step_id": step["id"],
+        "type": "connector_tool",
+        "status": "completed",
+        "output": result,
+        "connector": connector,
+        "tool": tool,
+    }
 
 
 async def _execute_agent(step: dict, state: dict) -> dict[str, Any]:

--- a/workflows/step_types.py
+++ b/workflows/step_types.py
@@ -311,8 +311,10 @@ def _connector_step_inputs(step: dict, state: dict) -> dict[str, Any]:
     if not isinstance(raw, dict):
         return {}
     inputs = dict(raw)
-    context = state.get("context") if isinstance(state.get("context"), dict) else {}
-    trigger = state.get("trigger_payload") if isinstance(state.get("trigger_payload"), dict) else {}
+    context_raw = state.get("context")
+    context: dict[Any, Any] = context_raw if isinstance(context_raw, dict) else {}
+    trigger_raw = state.get("trigger_payload")
+    trigger: dict[Any, Any] = trigger_raw if isinstance(trigger_raw, dict) else {}
     for key, value in list(inputs.items()):
         if isinstance(value, str) and value.startswith("$"):
             lookup = value[1:]


### PR DESCRIPTION
## Summary

Fixes the Aishwarya 19 Jun 2026 reopened connector/workflow bugs across backend, UI, and regression coverage.

- Separates HubSpot CRM read readiness from optional/write scope gaps in CMO setup and connector contracts.
- Normalizes SendGrid `get_stats` arguments from direct, wrapped, alias, JSON, and prompt-text shapes.
- Adds deterministic workflow connector-tool execution for HubSpot contact/deal fetch aliases.
- Reworks workflow step persistence so initial execution and HITL resume share the same step upsert path.
- Keeps workflow run details polling through externally resumable paused states and renders structured step errors.
- Adds reopening analysis in `docs/aishwarya_19june2026_bugfix_learnings.md`.

## Root Cause

The reopened cases were caused by fixes that stopped at one visible layer:

- read/write scope state was collapsed into one missing-scope bucket;
- direct connector calls were tested, but workflow execution used a different path;
- HITL resume duplicated step sync logic and lost output/error/progress updates;
- the UI stopped polling in `waiting_hitl` and hid provider error details.

## Validation

- `python -m py_compile api/v1/workflows.py api/v1/approvals.py connectors/comms/sendgrid.py core/marketing/connector_contracts.py core/marketing/connector_setup.py workflows/parser.py workflows/step_results.py workflows/step_types.py`
- `python -m pytest tests/unit/test_cmo_marketing_connector_contracts.py tests/regression/test_aishwarya_19jun2026_reopens.py tests/unit/test_workflow_no_false_success.py`
- `npm --prefix ui test -- WorkflowRun CMODashboard`
- `npm --prefix ui run typecheck`
- `BASE_URL=http://127.0.0.1:4177 npm --prefix ui run test:e2e -- aishwarya-19june2026.spec.ts`

## Artifact

Bug-fix summary workbook generated locally:

`C:\Users\mishr\Downloads\AgenticOrg_Aishwarya19Jun2026_BugFixSummary.xlsx`
