### PR TITLE
Expose OACP buyer surface bridge matrix

### DIFF
--- a/api/v1/commerce_runtime.py
+++ b/api/v1/commerce_runtime.py
@@ -27,6 +27,7 @@ from core.commerce.c6z_runtime_vertical import (
     ShopifyCredentials,
     answer_product_question_from_cache,
     build_bridge_contract_response,
+    build_buyer_surface_bridge_matrix,
     build_cache_record_from_grantex_artifact,
     build_grantex_authority_request_payload,
     build_seller_onboarding_packet,
@@ -633,6 +634,19 @@ async def get_openapi_bridge_schema() -> dict[str, Any]:
 )
 async def get_commerce_a2a_agent_card() -> dict[str, Any]:
     return _commerce_a2a_agent_card()
+
+
+@router.get("/bridges/surfaces")
+@route_meta(
+    auth_required=True,
+    tenant_required=True,
+    scope="commerce.runtime.bridges.surfaces.read",
+    rate_limit="standard",
+    idempotency="read-only",
+    audit_event="commerce.runtime.bridge.surfaces",
+)
+async def get_buyer_surface_bridge_matrix() -> dict[str, Any]:
+    return build_buyer_surface_bridge_matrix()
 
 
 @router.post("/bridges/whatsapp/webhook")

--- a/core/commerce/c6z_runtime_vertical.py
+++ b/core/commerce/c6z_runtime_vertical.py
@@ -82,6 +82,75 @@ C6Z_CAPABILITY_STATUSES: tuple[str, ...] = (
     "blocked_missing_credentials",
     "blocked_provider_error",
 )
+C6Z_BUYER_SURFACE_BRIDGES: tuple[dict[str, Any], ...] = (
+    {
+        "surface": "web",
+        "buyer_surface_label": "AgenticOrg web session",
+        "bridge_kind": "web_session",
+        "primary_endpoint": "/api/v1/commerce/runtime/bridges/web/ask",
+        "fallback_endpoint": "/api/v1/commerce/runtime/buyer-sessions/ask",
+        "required_env_vars": (),
+        "external_approval_required": False,
+    },
+    {
+        "surface": "chatgpt",
+        "buyer_surface_label": "ChatGPT-style agent surface",
+        "bridge_kind": "mcp_or_openapi_action",
+        "primary_endpoint": "agenticorg-mcp-server seller.* tools",
+        "fallback_endpoint": "/api/v1/commerce/runtime/bridges/openapi/ask",
+        "required_env_vars": ("AGENTICORG_API_KEY",),
+        "external_approval_required": True,
+    },
+    {
+        "surface": "claude",
+        "buyer_surface_label": "Claude / Claude Code MCP surface",
+        "bridge_kind": "mcp_stdio_or_remote",
+        "primary_endpoint": "agenticorg-mcp-server seller.* tools",
+        "fallback_endpoint": "/api/v1/commerce/runtime/bridges/openapi/ask",
+        "required_env_vars": ("AGENTICORG_API_KEY",),
+        "external_approval_required": True,
+    },
+    {
+        "surface": "gemini",
+        "buyer_surface_label": "Gemini-style function/A2A surface",
+        "bridge_kind": "openapi_function_or_a2a",
+        "primary_endpoint": "/api/v1/commerce/runtime/bridges/openapi/schema",
+        "fallback_endpoint": "/api/v1/commerce/runtime/bridges/a2a/agent-card",
+        "required_env_vars": ("AGENTICORG_API_KEY",),
+        "external_approval_required": True,
+    },
+    {
+        "surface": "perplexity",
+        "buyer_surface_label": "Perplexity-style answer/action surface",
+        "bridge_kind": "openapi_hosted_answer",
+        "primary_endpoint": "/api/v1/commerce/runtime/bridges/openapi/schema",
+        "fallback_endpoint": "/api/v1/commerce/runtime/bridges/openapi/ask",
+        "required_env_vars": ("AGENTICORG_API_KEY",),
+        "external_approval_required": True,
+    },
+    {
+        "surface": "whatsapp",
+        "buyer_surface_label": "WhatsApp Business Platform",
+        "bridge_kind": "webhook_channel",
+        "primary_endpoint": "/api/v1/commerce/runtime/bridges/whatsapp/webhook",
+        "fallback_endpoint": "/api/v1/commerce/runtime/bridges/web/ask",
+        "required_env_vars": (
+            "WHATSAPP_BUSINESS_ACCESS_TOKEN",
+            "WHATSAPP_BUSINESS_PHONE_NUMBER_ID",
+            "WHATSAPP_WEBHOOK_VERIFY_TOKEN",
+        ),
+        "external_approval_required": True,
+    },
+    {
+        "surface": "telegram",
+        "buyer_surface_label": "Telegram Bot API",
+        "bridge_kind": "webhook_channel",
+        "primary_endpoint": "/api/v1/commerce/runtime/bridges/telegram/webhook",
+        "fallback_endpoint": "/api/v1/commerce/runtime/bridges/web/ask",
+        "required_env_vars": ("TELEGRAM_BOT_TOKEN",),
+        "external_approval_required": True,
+    },
+)
 
 PRIVATE_KEY_MARKERS: tuple[str, ...] = (
     "access_token",
@@ -205,6 +274,63 @@ def resolve_env(required: Sequence[str], env: Mapping[str, str] | None = None) -
     source = os.environ if env is None else env
     missing = tuple(name for name in required if not str(source.get(name, "")).strip())
     return C6ZEnvResolution(required=tuple(required), missing=missing)
+
+
+def build_buyer_surface_bridge_matrix(env: Mapping[str, str] | None = None) -> dict[str, Any]:
+    """Return the concrete first-channel bridge contract for OACP commerce.
+
+    This is runtime metadata for operators and channel clients. It does not
+    create marketplace approvals, publish public discovery, or enable checkout.
+    """
+
+    source = os.environ if env is None else env
+    surfaces: list[dict[str, Any]] = []
+    for item in C6Z_BUYER_SURFACE_BRIDGES:
+        required_env_vars = tuple(str(name) for name in item["required_env_vars"])
+        missing_env_vars = tuple(name for name in required_env_vars if not str(source.get(name, "")).strip())
+        surfaces.append(
+            {
+                "surface": item["surface"],
+                "buyer_surface_label": item["buyer_surface_label"],
+                "bridge_kind": item["bridge_kind"],
+                "primary_endpoint": item["primary_endpoint"],
+                "fallback_endpoint": item["fallback_endpoint"],
+                "status": "bridge_ready" if not missing_env_vars else "blocked_missing_channel_config",
+                "required_env_vars": required_env_vars,
+                "missing_env_vars": missing_env_vars,
+                "external_approval_required": bool(item["external_approval_required"]),
+                "supported_actions": (
+                    "seller_product_question_answering",
+                    "catalog_snapshot_listing",
+                    "source_freshness_labeling",
+                    "prepared_handoff_explanation",
+                ),
+                "unsupported_actions": (
+                    "checkout_execution",
+                    "payment_execution",
+                    "order_creation",
+                    "inventory_hold_execution",
+                    "mandate_creation",
+                    "refund_execution",
+                    "return_execution",
+                    "shipping_execution",
+                    "public_discovery_publication",
+                ),
+                "allowed_to_execute": False,
+                "non_authoritative_for_transaction": True,
+                "no_payment_execution": True,
+                "no_public_discovery_enablement": True,
+            }
+        )
+    return {
+        "status": "surface_bridge_matrix_ready",
+        "surfaces": surfaces,
+        "schema_endpoint": "/api/v1/commerce/runtime/bridges/openapi/schema",
+        "a2a_agent_card_endpoint": "/api/v1/commerce/runtime/bridges/a2a/agent-card",
+        "mcp_package": "agenticorg-mcp-server",
+        "allowed_to_execute": False,
+        "non_authoritative_for_transaction": True,
+    }
 
 
 def resolve_shopify_credentials(env: Mapping[str, str] | None = None) -> ShopifyCredentials:

--- a/docs/commerce-agent-developer-guide.md
+++ b/docs/commerce-agent-developer-guide.md
@@ -219,6 +219,7 @@ The C6Z runtime closure adds these AgenticOrg-owned paths:
 | Artifact cache | `POST /api/v1/commerce/runtime/artifacts/cache` | Validates artifacts before storing cache records. |
 | Buyer answer | `POST /api/v1/commerce/runtime/buyer-sessions/ask` | Answers from cache with source/freshness labels. |
 | Bridge adapters | `/bridges/web`, `/bridges/openapi`, `/bridges/a2a`, `/bridges/whatsapp`, `/bridges/telegram` | One common non-executing bridge contract. |
+| Bridge surface matrix | `GET /api/v1/commerce/runtime/bridges/surfaces` | Lists web, ChatGPT-style, Claude, Gemini-style, Perplexity-style, WhatsApp, and Telegram bridge readiness plus required channel config. |
 | Plural/Pine capability | `POST /api/v1/commerce/runtime/providers/plural-pine/mandate-capability/verify` | Capability metadata only; no mandate or payment execution. |
 
 ## Historical Commerce Alias Requirements

--- a/docs/commerce-agent-overview.md
+++ b/docs/commerce-agent-overview.md
@@ -155,17 +155,19 @@ The operational flow is:
 ## Buyer Agent Launch Surfaces
 
 The buyer agent must be easy to start from the places buyers already chat. The
-current implementation does not yet make every surface launch-ready; this is a
-tracked PRD gap.
+runtime now exposes a concrete surface matrix at
+`GET /api/v1/commerce/runtime/bridges/surfaces`. The matrix names each first
+surface, the bridge kind, the endpoint or MCP package, required channel
+configuration, and whether external platform approval is still required.
 
 | Surface | Intended launch model | Current readiness posture |
 | --- | --- | --- |
-| ChatGPT | MCP seller tools backed by cached OACP artifacts. | MCP tools exist; marketplace/app approval is not claimed. |
-| Claude | MCP seller tools backed by cached OACP artifacts. | MCP tools exist; client approval is not claimed. |
-| Gemini | AgenticOrg OpenAPI/function bridge. | Runtime route/schema exists; native channel approval is not claimed. |
-| Perplexity/OpenAI Actions-style clients | AgenticOrg OpenAPI/function bridge. | Runtime route/schema exists; external marketplace approval is not claimed. |
-| WhatsApp | WhatsApp Business Platform webhook adapter. | Route and config checklist exist; live sending is blocked without credentials. |
-| Telegram | Telegram Bot API webhook adapter. | Route and config checklist exist; live sending is blocked without credentials. |
+| ChatGPT | MCP seller tools with OpenAPI fallback, backed by cached OACP artifacts. | `agenticorg-mcp-server` seller tools and OpenAPI bridge exist; external ChatGPT approval/config is not claimed. |
+| Claude | MCP seller tools backed by cached OACP artifacts. | `agenticorg-mcp-server` seller tools exist; client setup/approval is not claimed. |
+| Gemini | OpenAPI/function bridge with A2A fallback. | Runtime schema and A2A card exist; native Gemini approval/config is not claimed. |
+| Perplexity/OpenAI Actions-style clients | Hosted OpenAPI answer/action bridge. | Runtime schema and ask route exist; external platform approval is not claimed. |
+| WhatsApp | WhatsApp Business Platform webhook adapter. | Runtime route exists; live sending is blocked without configured WhatsApp credentials and app approval. |
+| Telegram | Telegram Bot API webhook adapter. | Runtime route exists; live sending is blocked without configured bot token and webhook setup. |
 | Web/mobile | AgenticOrg-hosted buyer-agent session or embedded merchant widget. | Runtime route exists. |
 
 Every channel must create or resume a buyer-agent session, use OACP artifacts or
@@ -205,7 +207,9 @@ the cross-repo OACP runtime closing these gaps:
 - Refund/return request workflow before any refund execution.
 - Live provider approval, webhook signature verification, reconciliation, and
   rollback readiness.
-- UCP/ACP/schema.org adapter generation from one canonical Grantex model.
+- UCP/ACP/schema.org adapter generation from one canonical Grantex model into
+  non-certifying compatibility payloads; external publication and conformance
+  remain separate approval steps.
 - Order, fulfillment, delivery/pickup, cancellation, support, return, refund,
   settlement, and payout surfaces that agents can read without inventing facts.
 - Product/landing copy that explains "agentic commerce readiness" without

--- a/docs/oacp-end-user-flow.md
+++ b/docs/oacp-end-user-flow.md
@@ -1,8 +1,14 @@
 # OACP End-User Flow
 
-Status: current runtime closure guide, updated 2026-06-18.
+Status: current runtime closure guide, updated 2026-06-19.
 
-OACP in AgenticOrg is a non-executing runtime path for seller and buyer agents.
+OACP in AgenticOrg is the runtime path for seller and buyer agents. The current
+shipping path is live-data capable for read-only Shopify catalog evidence,
+Grantex internal artifact issuance, cached buyer answers, channel bridge
+contracts, and Plural/Pine capability checks. It is not yet a final payment or
+order execution path until the provider, platform, legal, and merchant gates
+listed below are configured and approved.
+
 AgenticOrg creates Seller Commerce Agent onboarding packets, starts read-only
 merchant connector syncs, stores Grantex-issued artifacts in its durable cache,
 answers buyer product questions, and exposes bridge adapters. Grantex remains
@@ -20,7 +26,9 @@ own payment or mandate execution.
    `sync_ready`.
 4. AgenticOrg runs read-only Shopify product sync and stores normalized public
    product snapshots only. `raw_payload_stored=false`.
-5. AgenticOrg sends redacted connector evidence to Grantex.
+5. AgenticOrg sends redacted connector evidence to Grantex through the C6Z
+   authority endpoint. Production should use the dedicated Grantex
+   AgenticOrg-authority service token, tenant-allowlisted on the Grantex side.
 6. Grantex validates the request and issues internal OACP artifacts.
 7. AgenticOrg validates and caches the artifacts for non-binding use until TTL,
    revocation, freshness, scope, risk, or final-commitment rules require
@@ -35,13 +43,52 @@ own payment or mandate execution.
 3. The answer includes source label, freshness label, artifact refs, matched
    product facts, unsupported capabilities, and refusal reason when needed.
 4. If the buyer asks to buy, pay, place an order, hold stock, create a mandate,
-   refund, return, ship, or publish public discovery, AgenticOrg refuses.
+   refund, return, ship, or publish public discovery, AgenticOrg must either:
+   produce a prepared handoff/consent path backed by fresh OACP artifacts and
+   approved provider capability evidence, or refuse. It must not invent payment,
+   order, inventory, delivery, refund, or return state.
+
+## First Buyer Surfaces
+
+AgenticOrg exposes a runtime surface matrix at:
+
+`GET /api/v1/commerce/runtime/bridges/surfaces`
+
+| Buyer surface | Runtime bridge | Current meaning |
+| --- | --- | --- |
+| Web | `/bridges/web/ask` | AgenticOrg-hosted web buyer session for grounded product Q&A. |
+| ChatGPT-style | MCP seller tools, OpenAPI fallback | Uses `agenticorg-mcp-server` seller tools or OpenAPI action bridge; external ChatGPT approval is not implied. |
+| Claude / Claude Code | MCP seller tools | Uses `agenticorg-mcp-server` seller tools; client configuration/approval is outside OACP artifacts. |
+| Gemini-style | OpenAPI/function bridge, A2A fallback | Uses `/bridges/openapi/schema` and `/bridges/a2a/agent-card`. |
+| Perplexity-style | OpenAPI hosted answer/action bridge | Uses `/bridges/openapi/schema` and `/bridges/openapi/ask`. |
+| WhatsApp | `/bridges/whatsapp/webhook` | Requires WhatsApp Business Platform credentials and webhook approval. |
+| Telegram | `/bridges/telegram/webhook` | Requires Telegram bot token and webhook setup. |
 
 ## Launch Boundaries
 
 - Public discovery remains disabled.
 - `allowed_to_execute=false`.
 - No checkout, payment, order, mandate, refund, return, shipment, inventory
-  hold, provider execution, merchant-private mutation, or live rail is enabled.
+  hold, provider execution, merchant-private mutation, or live rail is enabled
+  by the OACP artifact/cache path alone.
 - OACP compatibility adapters are not certification, conformance,
   standardization, public publication, merchant approval, or payment approval.
+
+## Activation Checklist For A Shopify Merchant Pilot
+
+The runtime can move a Shopify merchant only when these are true:
+
+- Shopify Admin API credential has read-only product, variant, media, and
+  inventory access and passes validation through AgenticOrg connector setup.
+- Grantex C6Z authority service token is configured on both sides and
+  `COMMERCE_C6Z_AUTHORITY_SERVICE_TENANTS` allowlists the merchant tenant.
+- Grantex issues all required artifact families, including catalog, price,
+  inventory, public-discovery state, mandate capability, protocol adapter, and
+  authority status.
+- AgenticOrg caches those artifacts and answers from cache with source and
+  freshness labels.
+- Buyer surface credentials and approvals exist for the intended channels.
+- Plural/Pine P3P capability verification succeeds and stores only
+  non-sensitive evidence references.
+- Final payment/order execution remains blocked until the merchant, provider,
+  legal, channel, rollback, and smoke gates are explicitly approved.

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -1977,7 +1977,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-runtime-write",
     "scope": "commerce.runtime.artifacts.cache",
-    "source_line": 500,
+    "source_line": 501,
     "tenant_required": true
   },
   {
@@ -1995,7 +1995,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-runtime-external",
     "scope": "commerce.runtime.grantex.authority_request",
-    "source_line": 461,
+    "source_line": 462,
     "tenant_required": true
   },
   {
@@ -2013,7 +2013,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "commerce.runtime.bridges.a2a.read",
-    "source_line": 634,
+    "source_line": 635,
     "tenant_required": true
   },
   {
@@ -2031,7 +2031,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-buyer-session",
     "scope": "commerce.runtime.bridges.openapi.ask",
-    "source_line": 605,
+    "source_line": 606,
     "tenant_required": true
   },
   {
@@ -2049,7 +2049,25 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "commerce.runtime.bridges.openapi.read",
-    "source_line": 621,
+    "source_line": 622,
+    "tenant_required": true
+  },
+  {
+    "audit_event": "commerce.runtime.bridge.surfaces",
+    "auth_required": true,
+    "function": "get_buyer_surface_bridge_matrix",
+    "idempotency": "read-only",
+    "key": "GET /api/v1/commerce/runtime/bridges/surfaces api/v1/commerce_runtime.py:get_buyer_surface_bridge_matrix",
+    "metadata_present": true,
+    "methods": [
+      "GET"
+    ],
+    "module": "api/v1/commerce_runtime.py",
+    "path": "/api/v1/commerce/runtime/bridges/surfaces",
+    "public_exempt_reason": null,
+    "rate_limit": "standard",
+    "scope": "commerce.runtime.bridges.surfaces.read",
+    "source_line": 648,
     "tenant_required": true
   },
   {
@@ -2067,7 +2085,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-webhook",
     "scope": "commerce.runtime.bridges.telegram.webhook",
-    "source_line": 667,
+    "source_line": 681,
     "tenant_required": true
   },
   {
@@ -2085,7 +2103,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-buyer-session",
     "scope": "commerce.runtime.bridges.web.ask",
-    "source_line": 589,
+    "source_line": 590,
     "tenant_required": true
   },
   {
@@ -2103,7 +2121,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-webhook",
     "scope": "commerce.runtime.bridges.whatsapp.webhook",
-    "source_line": 647,
+    "source_line": 661,
     "tenant_required": true
   },
   {
@@ -2121,7 +2139,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-buyer-session",
     "scope": "commerce.runtime.buyer_sessions.ask",
-    "source_line": 564,
+    "source_line": 565,
     "tenant_required": true
   },
   {
@@ -2139,7 +2157,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "commerce.runtime.products.read",
-    "source_line": 721,
+    "source_line": 735,
     "tenant_required": true
   },
   {
@@ -2157,7 +2175,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-runtime-external",
     "scope": "commerce.runtime.providers.plural_pine.verify",
-    "source_line": 687,
+    "source_line": 701,
     "tenant_required": true
   },
   {
@@ -2175,7 +2193,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-runtime-write",
     "scope": "commerce.runtime.shopify.credentials.write",
-    "source_line": 199,
+    "source_line": 200,
     "tenant_required": true
   },
   {
@@ -2193,7 +2211,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "commerce.runtime.shopify.credentials.read",
-    "source_line": 306,
+    "source_line": 307,
     "tenant_required": true
   },
   {
@@ -2211,7 +2229,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-runtime-write",
     "scope": "commerce.runtime.seller_agents.write",
-    "source_line": 145,
+    "source_line": 146,
     "tenant_required": true
   },
   {
@@ -2229,7 +2247,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "commerce.runtime.seller_agents.read",
-    "source_line": 179,
+    "source_line": 180,
     "tenant_required": true
   },
   {
@@ -2247,7 +2265,7 @@
     "public_exempt_reason": null,
     "rate_limit": "connector-bulk",
     "scope": "commerce.runtime.shopify.sync",
-    "source_line": 348,
+    "source_line": 349,
     "tenant_required": true
   },
   {
@@ -2265,7 +2283,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-webhook",
     "scope": "commerce.runtime.shopify.webhook",
-    "source_line": 416,
+    "source_line": 417,
     "tenant_required": true
   },
   {

--- a/tests/unit/test_oacp_c6z_runtime_vertical.py
+++ b/tests/unit/test_oacp_c6z_runtime_vertical.py
@@ -20,6 +20,7 @@ from core.commerce.c6z_runtime_vertical import (
     C6ZRuntimeValidationError,
     answer_product_question_from_cache,
     build_bridge_contract_response,
+    build_buyer_surface_bridge_matrix,
     build_cache_record_from_grantex_artifact,
     build_grantex_authority_request_payload,
     build_seller_onboarding_packet,
@@ -719,9 +720,42 @@ def test_c6z_buyer_surface_bridge_routes_are_non_executing() -> None:
         "/bridges/openapi/ask",
         "/bridges/openapi/schema",
         "/bridges/a2a/agent-card",
+        "/bridges/surfaces",
         "/bridges/whatsapp/webhook",
         "/bridges/telegram/webhook",
     ):
         assert route in source
     assert '"allowed_to_execute": True' not in source
     assert '"public_discovery_enabled": True' not in source
+
+
+def test_c6z_buyer_surface_bridge_matrix_names_first_launch_surfaces() -> None:
+    matrix = build_buyer_surface_bridge_matrix(
+        env={
+            "AGENTICORG_API_KEY": "fixture-api-key",
+            "WHATSAPP_BUSINESS_ACCESS_TOKEN": "fixture-whatsapp-token",
+            "WHATSAPP_BUSINESS_PHONE_NUMBER_ID": "fixture-phone-id",
+            "WHATSAPP_WEBHOOK_VERIFY_TOKEN": "fixture-verify-token",
+            "TELEGRAM_BOT_TOKEN": "fixture-telegram-token",
+        }
+    )
+
+    surfaces = {item["surface"]: item for item in matrix["surfaces"]}
+    assert set(surfaces) == {"web", "chatgpt", "claude", "gemini", "perplexity", "whatsapp", "telegram"}
+    assert surfaces["chatgpt"]["bridge_kind"] == "mcp_or_openapi_action"
+    assert surfaces["claude"]["primary_endpoint"] == "agenticorg-mcp-server seller.* tools"
+    assert surfaces["gemini"]["fallback_endpoint"] == "/api/v1/commerce/runtime/bridges/a2a/agent-card"
+    assert surfaces["whatsapp"]["status"] == "bridge_ready"
+    assert all(item["allowed_to_execute"] is False for item in surfaces.values())
+    assert all(item["non_authoritative_for_transaction"] is True for item in surfaces.values())
+
+
+def test_c6z_buyer_surface_bridge_matrix_blocks_missing_channel_config() -> None:
+    matrix = build_buyer_surface_bridge_matrix(env={})
+    surfaces = {item["surface"]: item for item in matrix["surfaces"]}
+
+    assert surfaces["web"]["status"] == "bridge_ready"
+    assert surfaces["whatsapp"]["status"] == "blocked_missing_channel_config"
+    assert "WHATSAPP_BUSINESS_ACCESS_TOKEN" in surfaces["whatsapp"]["missing_env_vars"]
+    assert surfaces["telegram"]["status"] == "blocked_missing_channel_config"
+    assert surfaces["chatgpt"]["external_approval_required"] is True


### PR DESCRIPTION
## Summary
- Adds a runtime bridge surface matrix for web, ChatGPT-style, Claude, Gemini-style, Perplexity-style, WhatsApp, and Telegram buyer surfaces.
- Exposes GET /api/v1/commerce/runtime/bridges/surfaces with endpoint/package mapping, required channel config, external approval markers, and non-execution flags.
- Updates OACP end-user flow, overview, and developer documentation so channel readiness is explicit rather than implied by generic OpenAPI/MCP routes.

## Validation
- python -m pytest tests/unit/test_oacp_c6z_runtime_vertical.py --no-cov
- python -m ruff check core/commerce/c6z_runtime_vertical.py api/v1/commerce_runtime.py tests/unit/test_oacp_c6z_runtime_vertical.py
- python -m mypy core/commerce/c6z_runtime_vertical.py api/v1/commerce_runtime.py tests/unit/test_oacp_c6z_runtime_vertical.py
- git diff --check

## Boundaries
No deploy, workflow, migration, public discovery, checkout/payment execution, live provider rail, provider call, merchant private API call, allowlist change, or OACP publication is included.