### PR TITLE
Harden agentic egress and credential retargeting

### DIFF
--- a/api/v1/billing.py
+++ b/api/v1/billing.py
@@ -675,14 +675,33 @@ async def create_portal(
     idempotency="read-only-provider-order-status",
     audit_event="billing.order_status.read",
 )
-async def check_order_status(body: OrderStatusRequest) -> dict[str, Any]:
+async def check_order_status(
+    body: OrderStatusRequest,
+    tenant_id: str = Depends(get_current_tenant),
+) -> dict[str, Any]:
     """Check the status of a Plural payment order."""
     import asyncio
 
-    from core.billing.pinelabs_client import get_order_status
+    from core.billing.pinelabs_client import get_order_status, lookup_order_details_by_order_id
 
     try:
-        return await asyncio.to_thread(get_order_status, body.order_id)
+        order_details = await asyncio.to_thread(lookup_order_details_by_order_id, body.order_id)
+        if not order_details or order_details.get("tenant_id") != tenant_id:
+            raise HTTPException(status_code=404, detail="Billing order not found")
+        provider_status = await asyncio.to_thread(get_order_status, body.order_id)
+        if str(provider_status.get("order_id") or body.order_id) != body.order_id:
+            raise HTTPException(status_code=502, detail="Plural returned a mismatched order_id")
+        expected_ref = str(order_details.get("merchant_order_reference") or "")
+        provider_ref = str(provider_status.get("merchant_order_reference") or "")
+        if expected_ref and provider_ref and expected_ref != provider_ref:
+            raise HTTPException(status_code=502, detail="Plural returned a mismatched merchant reference")
+        return {
+            **provider_status,
+            "tenant_id": tenant_id,
+            "plan": order_details.get("plan", ""),
+        }
+    except HTTPException:
+        raise
     # enterprise-gate: broad-except-ok reason=plural-status-provider-error-mapped-to-502-no-success
     except Exception as exc:
         logger.exception("plural_status_error", order_id=body.order_id)

--- a/api/v1/commerce_runtime.py
+++ b/api/v1/commerce_runtime.py
@@ -57,6 +57,11 @@ from core.models.commerce_c6z_runtime import (
     C6ZSellerOnboardingPacketRow,
 )
 from core.models.connector_config import ConnectorConfig
+from core.security.egress import (
+    EgressValidationError,
+    build_pinned_async_transport,
+    validate_public_url,
+)
 
 router = APIRouter(
     prefix="/commerce/runtime",
@@ -525,11 +530,14 @@ async def request_grantex_authority_artifacts(
         evidence_row = await session.get(C6ZConnectorEvidenceRow, body.evidence_id)
         if packet_row is None or evidence_row is None:
             raise HTTPException(404, "C6Z packet or connector evidence not found")
+        if packet_row.tenant_id != tenant_id or evidence_row.tenant_id != tenant_id:
+            raise HTTPException(404, "C6Z packet or connector evidence not found")
         packet = _row_to_packet(packet_row)
         evidence = _row_to_evidence(evidence_row)
         payload = build_grantex_authority_request_payload(
             onboarding_packet=packet,
             connector_evidence=evidence,
+            expected_tenant_id=tenant_id,
         )
         env_resolution = resolve_env(GRANTEX_AUTHORITY_ENV_VARS)
         if not env_resolution.ready:
@@ -1281,9 +1289,22 @@ async def _exchange_shopify_oauth_code(body: ShopifyConnectorCredentialRequest) 
     if body.redirect_uri:
         form["redirect_uri"] = body.redirect_uri.strip()
     shop_domain = _normalize_shopify_domain_for_api(body.shop_domain)
-    async with httpx.AsyncClient(timeout=20.0) as client:
+    token_url = f"https://{shop_domain}/admin/oauth/access_token"
+    try:
+        validate_public_url(
+            token_url,
+            allowed_schemes=("https",),
+            allowed_domains=("myshopify.com",),
+            require_dns=True,
+        )
+    except EgressValidationError as exc:
+        raise HTTPException(status_code=400, detail="Shopify OAuth token endpoint is not allowed") from exc
+    async with httpx.AsyncClient(
+        timeout=20.0,
+        transport=build_pinned_async_transport(require_dns=True),
+    ) as client:
         response = await client.post(
-            f"https://{shop_domain}/admin/oauth/access_token",
+            token_url,
             data=form,
             headers={"Accept": "application/json"},
         )
@@ -1424,8 +1445,32 @@ def _shopify_connector_config_name(merchant_id: str) -> str:
 def _normalize_shopify_domain_for_api(value: Any) -> str:
     text = str(value or "").strip().lower()
     text = text.removeprefix("https://").removeprefix("http://").strip("/")
-    if not text or "/" in text or "." not in text:
+    if not text or "/" in text or "." not in text or ":" in text:
         raise HTTPException(status_code=400, detail="Shopify shop_domain must be a host name")
+    labels = text.split(".")
+    if (
+        len(labels) != 3
+        or labels[1:] != ["myshopify", "com"]
+        or not all(labels)
+        or labels[0].startswith("-")
+        or labels[0].endswith("-")
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="Shopify shop_domain must be a public *.myshopify.com host",
+        )
+    try:
+        validate_public_url(
+            f"https://{text}",
+            allowed_schemes=("https",),
+            require_dns=False,
+            allowed_domains=("myshopify.com",),
+        )
+    except EgressValidationError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Shopify shop_domain must be a public *.myshopify.com host",
+        ) from exc
     return text
 
 

--- a/api/v1/connectors.py
+++ b/api/v1/connectors.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import ipaddress
 import json
 import logging
-import socket
 import uuid as _uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -23,6 +21,7 @@ from core.database import get_tenant_session
 from core.marketing.connector_contracts import evaluate_hubspot_crm_read_contract
 from core.models.connector import Connector
 from core.schemas.api import ConnectorCreate, ConnectorUpdate
+from core.security.egress import EgressValidationError, validate_public_url
 
 _log = logging.getLogger(__name__)
 
@@ -34,6 +33,32 @@ _CMO_SECRET_KEY_MARKERS = (
     "credential",
     "api_key",
     "authorization",
+)
+_CONNECTOR_RETARGET_KEYS = (
+    "api_base_url",
+    "base_url",
+    "bridge_url",
+    "domain",
+    "host",
+    "instance",
+    "org",
+    "site",
+    "subdomain",
+)
+_CONNECTOR_CREDENTIAL_ROTATION_KEYS = (
+    "access_token",
+    "api_key",
+    "api_token",
+    "app_password",
+    "auth_token",
+    "bot_token",
+    "bridge_token",
+    "client_secret",
+    "password",
+    "refresh_token",
+    "secret",
+    "secret_key",
+    "token",
 )
 _CMO_PLACEHOLDER_MARKERS = (
     "REAL_",
@@ -151,6 +176,16 @@ _ZOHO_TOKEN_URLS = {
     "au": "https://accounts.zoho.com.au/oauth/v2/token",
     "jp": "https://accounts.zoho.jp/oauth/v2/token",
 }
+_CONNECTOR_CANONICAL_TOKEN_URLS = {
+    "ga4": "https://oauth2.googleapis.com/token",
+    "gmail": "https://oauth2.googleapis.com/token",
+    "google_ads": "https://oauth2.googleapis.com/token",
+    "google_calendar": "https://oauth2.googleapis.com/token",
+    "youtube": "https://oauth2.googleapis.com/token",
+    "hubspot": "https://api.hubapi.com/oauth/v1/token",
+    "quickbooks": "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer",
+    "banking_aa": "https://aa.finvu.in/api/v1/oauth2/token",
+}
 _ZOHO_REGION_HOSTS = {
     "in": ("zohoapis.in", "books.zoho.in", "accounts.zoho.in"),
     "eu": ("zohoapis.eu", "accounts.zoho.eu"),
@@ -240,6 +275,24 @@ def _clean_auth_config(auth_config: dict[str, Any] | None) -> dict[str, Any]:
             cleaned[str(key)] = stripped
         else:
             cleaned[str(key)] = value
+    return cleaned
+
+
+def _canonical_connector_token_url(name: str, auth_config: dict[str, Any] | None) -> str | None:
+    connector_name = str(name or "").strip().lower().replace("-", "_")
+    if connector_name == "zoho_books":
+        return _ZOHO_TOKEN_URLS[_infer_zoho_region(None, auth_config or {})]
+    return _CONNECTOR_CANONICAL_TOKEN_URLS.get(connector_name)
+
+
+def _canonicalize_connector_secret_urls(name: str, auth_config: dict[str, Any]) -> dict[str, Any]:
+    cleaned = dict(auth_config)
+    cleaned.pop("token_url", None)
+    cleaned.pop("base_url", None)
+    cleaned.pop("api_base_url", None)
+    canonical_token_url = _canonical_connector_token_url(name, cleaned)
+    if canonical_token_url and cleaned:
+        cleaned["token_url"] = canonical_token_url
     return cleaned
 
 
@@ -576,62 +629,31 @@ async def _connector_config_credentials(
 
 
 def _assert_public_base_url(base_url: str) -> None:
-    """Reject connector base_urls that resolve to private/reserved ranges.
+    """Reject connector base_urls that can become server-side SSRF targets.
 
     SECURITY_AUDIT-2026-04-19 MEDIUM-12: admins could previously set any
     base_url on a connector, turning connector test/health flows into an
     SSRF primitive against the cluster's internal network (including
     169.254.169.254 cloud metadata).
 
-    Unresolvable hosts are allowed through (DNS may be environment-
-    specific — CI cannot prove a production host is bad); only explicit
-    resolution to a private/reserved range is blocked.
+    Runtime connector requests repeat this check before attaching
+    credentials so stale DNS and rebinding are blocked in strict runtimes.
     """
     if not base_url:
         return
-    parsed = urlparse(base_url)
-    if parsed.scheme not in ("http", "https"):
-        raise HTTPException(400, f"Connector base_url must be http(s): got '{parsed.scheme}'")
-    host = parsed.hostname or ""
-    if not host:
-        raise HTTPException(400, "Connector base_url is missing a host")
-
-    # Reject bare IPs in private/reserved ranges without needing DNS.
     try:
-        literal_ip: ipaddress._BaseAddress | None = ipaddress.ip_address(host)
-    except ValueError:
-        literal_ip = None
-    candidates: list[str] = []
-    if literal_ip is not None:
-        candidates.append(str(literal_ip))
-    else:
-        try:
-            infos = socket.getaddrinfo(host, None)
-            candidates = [info[4][0] for info in infos]
-        except socket.gaierror:
-            # Unresolvable — httpx will error on the real call. Don't
-            # block registration purely on a transient DNS miss.
-            return
-    for addr in candidates:
-        try:
-            ip = ipaddress.ip_address(addr)
-        except ValueError:
-            continue
-        if (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_multicast
-            or ip.is_reserved
-            or ip.is_unspecified
-        ):
-            raise HTTPException(
-                403,
-                f"Connector base_url '{host}' resolves to a blocked "
-                f"address ({ip}). Private, loopback, link-local, "
-                "multicast, reserved, and unspecified ranges are not "
-                "allowed.",
-            )
+        validate_public_url(base_url, allowed_schemes=("https",), require_dns=True)
+    except EgressValidationError as exc:
+        if exc.reason == "scheme":
+            parsed = urlparse(base_url)
+            raise HTTPException(400, f"Connector base_url must be https: got '{parsed.scheme}'") from exc
+        if exc.reason == "missing_host":
+            raise HTTPException(400, "Connector base_url is missing a host") from exc
+        raise HTTPException(
+            403,
+            "Connector base_url must be a public HTTPS host. Private, loopback, link-local, multicast, "
+            "reserved, unspecified, and direct-IP destinations are not allowed.",
+        ) from exc
 
 router = APIRouter(dependencies=[require_tenant_admin])
 
@@ -977,6 +999,8 @@ async def register_connector(
             "connector_registration_validated",
             extra={"connector": "zoho_books"},
         )
+    else:
+        secret_fields = _canonicalize_connector_secret_urls(body.name, secret_fields)
 
     async with get_tenant_session(tid) as session:
         connector = Connector(
@@ -1438,10 +1462,35 @@ async def update_connector(
         # (new wins on collision), re-encrypt. Callers that genuinely
         # want to replace all creds still can — they just have to send
         # every key they intend to keep.
-        new_secrets = body.model_dump(exclude_none=True).get("auth_config")
+        raw_new_secrets = body.model_dump(exclude_none=True).get("auth_config")
+        new_secrets = (
+            _canonicalize_connector_secret_urls(
+                connector.name,
+                _clean_auth_config(raw_new_secrets),
+            )
+            if raw_new_secrets
+            else None
+        )
         credential_surface_changed = bool(new_secrets) or any(
             field in updates for field in ("base_url", "auth_type")
         )
+        raw_secret_keys = (
+            {str(key).strip().lower() for key in raw_new_secrets or {}}
+            if isinstance(raw_new_secrets, dict)
+            else set()
+        )
+        retarget_requested = "base_url" in updates or bool(
+            raw_secret_keys.intersection(_CONNECTOR_RETARGET_KEYS)
+        )
+        new_secret_keys = {str(key).strip().lower() for key in new_secrets or {}}
+        credential_rotated = bool(
+            new_secret_keys.intersection(_CONNECTOR_CREDENTIAL_ROTATION_KEYS)
+        )
+        if retarget_requested and not credential_rotated:
+            raise HTTPException(
+                status_code=400,
+                detail="Changing connector endpoint/host requires rotating credentials in the same request",
+            )
         if new_secrets:
             from core.crypto import encrypt_for_tenant
             from core.crypto.tenant_secrets import decrypt_for_tenant
@@ -1455,8 +1504,10 @@ async def update_connector(
             )
             cc = cc_result.scalar_one_or_none()
 
+            # Endpoint/host changes are a credential boundary. Do not carry
+            # old encrypted provider credentials to a new destination.
             merged_secrets: dict = {}
-            if cc and cc.credentials_encrypted:
+            if not retarget_requested and cc and cc.credentials_encrypted:
                 enc = cc.credentials_encrypted.get("_encrypted") if isinstance(cc.credentials_encrypted, dict) else None
                 if isinstance(enc, str) and enc:
                     # Codex PR #305 review (P1): if the stored blob

--- a/api/v1/oauth_connector.py
+++ b/api/v1/oauth_connector.py
@@ -575,7 +575,7 @@ async def _upsert_oauth_connector(
     # Region-aware API base — Zoho .in / .com / .eu etc.
     region_urls = spec.urls_for({**user_fields, **extra_config})
     fallback_base = region_urls.get("api_base_url") or defaults["base_url"]
-    base_url = payload.get("base_url") or fallback_base
+    base_url = fallback_base
     _assert_public_base_url(base_url or "")
 
     credentials: dict[str, Any] = {

--- a/api/v1/sso.py
+++ b/api/v1/sso.py
@@ -248,7 +248,7 @@ async def sso_callback(
     # Redirect to UI with token in fragment (so it never hits server logs)
     ui_base = settings.ui_base_url if hasattr(settings, "ui_base_url") else ""
     target = return_to or "/"
-    if not target.startswith("/"):
+    if not target.startswith("/") or target.startswith("//"):
         target = "/"
     return RedirectResponse(
         f"{ui_base}{target}#token={token}",
@@ -328,6 +328,14 @@ async def upsert_config(
     tenant_id: str = Depends(get_current_tenant),
 ) -> SSOConfigOut:
     tid = uuid.UUID(tenant_id)
+    if body.provider_type == "oidc":
+        try:
+            OIDCProvider(body.provider_key, body.config)
+        except (KeyError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="OIDC config must use an HTTPS public issuer and required OIDC fields",
+            ) from exc
     async with get_tenant_session(tid) as session:
         result = await session.execute(
             select(SSOConfig).where(

--- a/api/v1/tenant_ai_credentials.py
+++ b/api/v1/tenant_ai_credentials.py
@@ -32,6 +32,7 @@ from core.models.tenant_ai_credential import (
     STATUS_ALLOWLIST,
     TenantAICredential,
 )
+from core.security.egress import EgressValidationError, validate_public_url
 
 logger = structlog.get_logger(__name__)
 
@@ -39,6 +40,17 @@ router = APIRouter(
     prefix="/tenant-ai-credentials",
     tags=["Tenant AI Credentials"],
     dependencies=[require_tenant_admin],
+)
+
+_PROVIDER_CONFIG_SECRET_MARKERS = (
+    "api_key",
+    "authorization",
+    "bearer",
+    "client_secret",
+    "credential",
+    "password",
+    "secret",
+    "token",
 )
 
 
@@ -192,6 +204,7 @@ async def create_credential(
     from core.crypto.tenant_secrets import encrypt_for_tenant
 
     tid = _uuid.UUID(tenant_id)
+    provider_config = _validate_provider_config(body.provider, body.provider_config)
     prefix, suffix = mask_token(body.api_key)
     ciphertext = await encrypt_for_tenant(body.api_key, tid)
 
@@ -205,7 +218,7 @@ async def create_credential(
         display_prefix=prefix,
         display_suffix=suffix,
         label=body.label,
-        provider_config=body.provider_config,
+        provider_config=provider_config,
     )
     async with get_tenant_session(tid) as session:
         session.add(row)
@@ -317,7 +330,15 @@ async def update_credential(
         if body.label is not None:
             row.label = body.label
         if body.provider_config is not None:
-            row.provider_config = body.provider_config
+            next_provider_config = _validate_provider_config(row.provider, body.provider_config)
+            current_base_url = str((row.provider_config or {}).get("base_url") or "")
+            next_base_url = str((next_provider_config or {}).get("base_url") or "")
+            if current_base_url != next_base_url and body.api_key is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Changing provider_config.base_url requires rotating api_key in the same request",
+                )
+            row.provider_config = next_provider_config
         if body.status is not None:
             row.status = body.status
 
@@ -491,3 +512,53 @@ def _audit(
         )
     except (RuntimeError, TypeError, ValueError) as exc:
         logger.debug("audit_emit_failed", error=str(exc))
+
+
+def _validate_provider_config(provider: str, config: dict[str, Any] | None) -> dict[str, Any] | None:
+    if config is None:
+        return None
+    sanitized = dict(config)
+    for key in sanitized:
+        normalized = str(key).lower().replace("-", "_")
+        if any(marker in normalized for marker in _PROVIDER_CONFIG_SECRET_MARKERS):
+            raise HTTPException(
+                status_code=400,
+                detail="provider_config must not contain secrets or credential material",
+            )
+
+    base_url = str(sanitized.get("base_url") or "").strip()
+    if provider == "openai":
+        if base_url and base_url.rstrip("/") != "https://api.openai.com":
+            raise HTTPException(
+                status_code=400,
+                detail="OpenAI credentials may only use https://api.openai.com as provider_config.base_url",
+            )
+        if base_url:
+            sanitized["base_url"] = "https://api.openai.com"
+        return sanitized or None
+
+    if provider in {"openai_compatible", "azure_openai"}:
+        if not base_url:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{provider} requires provider_config.base_url",
+            )
+        try:
+            validated = validate_public_url(base_url, allowed_schemes=("https",), require_dns=True)
+        except EgressValidationError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{provider} provider_config.base_url must be an HTTPS public endpoint",
+            ) from exc
+        sanitized["base_url"] = _normalized_provider_base_url(base_url, validated.scheme)
+    return sanitized or None
+
+
+def _normalized_provider_base_url(base_url: str, scheme: str) -> str:
+    from urllib.parse import urlparse
+
+    parsed = urlparse(base_url)
+    host = (parsed.hostname or "").rstrip(".").lower()
+    port = f":{parsed.port}" if parsed.port else ""
+    path = parsed.path.rstrip("/")
+    return f"{scheme}://{host}{port}{path}"

--- a/auth/sso/oidc.py
+++ b/auth/sso/oidc.py
@@ -24,12 +24,18 @@ import secrets
 import time
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 import structlog
 from authlib.jose import JsonWebKey, jwt
 
 from core.http_retry import retry_http_async
+from core.security.egress import (
+    EgressValidationError,
+    build_pinned_async_transport,
+    validate_public_url,
+)
 
 logger = structlog.get_logger()
 
@@ -57,7 +63,8 @@ class OIDCProvider:
 
     def __init__(self, provider_key: str, config: dict[str, Any]) -> None:
         self.provider_key = provider_key
-        self.issuer = config["issuer"].rstrip("/")
+        self.issuer = self._validate_issuer(config["issuer"])
+        self._issuer_host = urlparse(self.issuer).hostname or ""
         self.client_id = config["client_id"]
         self.client_secret = config.get("client_secret", "")
         self.redirect_uri = config["redirect_uri"]
@@ -71,10 +78,15 @@ class OIDCProvider:
         if self._discovery is not None:
             return self._discovery
         url = f"{self.issuer}/.well-known/openid-configuration"
-        async with httpx.AsyncClient(timeout=10) as client:
+        self._validate_provider_endpoint(url, "discovery_url")
+        async with httpx.AsyncClient(
+            timeout=10,
+            transport=build_pinned_async_transport(require_dns=True),
+        ) as client:
             resp = await client.get(url)
             resp.raise_for_status()
             self._discovery = resp.json()
+        self._validate_discovery_document(self._discovery)
         return self._discovery
 
     @retry_http_async(max_attempts=3)
@@ -83,7 +95,11 @@ class OIDCProvider:
         if self._jwks is not None and time.time() - self._jwks_fetched_at < 600:
             return self._jwks
         disc = await self._discover()
-        async with httpx.AsyncClient(timeout=10) as client:
+        self._validate_provider_endpoint(str(disc["jwks_uri"]), "jwks_uri")
+        async with httpx.AsyncClient(
+            timeout=10,
+            transport=build_pinned_async_transport(require_dns=True),
+        ) as client:
             resp = await client.get(disc["jwks_uri"])
             resp.raise_for_status()
             self._jwks = resp.json()
@@ -99,6 +115,7 @@ class OIDCProvider:
         # await .prepare() first.
         disc = self._discovery or {}
         base = disc.get("authorization_endpoint") or f"{self.issuer}/authorize"
+        self._validate_provider_endpoint(str(base), "authorization_endpoint", require_dns=False)
         import urllib.parse
 
         params = {
@@ -125,8 +142,12 @@ class OIDCProvider:
         """Exchange the authorization code for tokens + verify ID token."""
         disc = await self._discover()
         token_endpoint = disc["token_endpoint"]
+        self._validate_provider_endpoint(str(token_endpoint), "token_endpoint")
 
-        async with httpx.AsyncClient(timeout=15) as client:
+        async with httpx.AsyncClient(
+            timeout=15,
+            transport=build_pinned_async_transport(require_dns=True),
+        ) as client:
             resp = await client.post(
                 token_endpoint,
                 data={
@@ -175,6 +196,39 @@ class OIDCProvider:
             raise ValueError("OIDC nonce mismatch — possible replay attack")
 
         return dict(claims)
+
+    def _validate_issuer(self, issuer: str) -> str:
+        value = str(issuer or "").strip().rstrip("/")
+        try:
+            validate_public_url(value, allowed_schemes=("https",), require_dns=False)
+        except EgressValidationError as exc:
+            raise ValueError("OIDC issuer must be an HTTPS public URL") from exc
+        return value
+
+    def _validate_provider_endpoint(
+        self,
+        url: str,
+        field: str,
+        *,
+        require_dns: bool | None = None,
+    ) -> str:
+        try:
+            validate_public_url(
+                str(url or "").strip(),
+                allowed_schemes=("https",),
+                require_dns=require_dns,
+                allowed_hosts=(self._issuer_host,),
+            )
+        except EgressValidationError as exc:
+            raise ValueError(f"OIDC {field} must stay on the configured issuer host") from exc
+        return str(url)
+
+    def _validate_discovery_document(self, discovery: dict[str, Any]) -> None:
+        discovered_issuer = str(discovery.get("issuer") or "").rstrip("/")
+        if discovered_issuer != self.issuer:
+            raise ValueError("OIDC discovery issuer mismatch")
+        for field in ("authorization_endpoint", "token_endpoint", "jwks_uri"):
+            self._validate_provider_endpoint(str(discovery.get(field) or ""), field, require_dns=False)
 
 
 # ── PKCE helpers ──────────────────────────────────────────────────

--- a/connectors/comms/gmail.py
+++ b/connectors/comms/gmail.py
@@ -20,6 +20,11 @@ class GmailConnector(BaseConnector):
     base_url = "https://gmail.googleapis.com/gmail/v1"
     rate_limit_rpm = 250
 
+    def __init__(self, config: dict[str, Any] | None = None):
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
+
     def _register_tools(self):
         self._tool_registry["send_email"] = self.send_email
         self._tool_registry["read_inbox"] = self.read_inbox

--- a/connectors/comms/google_calendar.py
+++ b/connectors/comms/google_calendar.py
@@ -20,6 +20,11 @@ class GoogleCalendarConnector(BaseConnector):
     base_url = "https://www.googleapis.com/calendar/v3"
     rate_limit_rpm = 100
 
+    def __init__(self, config: dict[str, Any] | None = None):
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
+
     def _register_tools(self):
         self._tool_registry["create_event"] = self.create_event
         self._tool_registry["list_events"] = self.list_events

--- a/connectors/comms/slack.py
+++ b/connectors/comms/slack.py
@@ -18,6 +18,11 @@ class SlackConnector(BaseConnector):
     base_url = "https://slack.com/api"
     rate_limit_rpm = 100
 
+    def __init__(self, config: dict[str, Any] | None = None):
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
+
     def _register_tools(self):
         self._tool_registry["send_message"] = self.send_message
         self._tool_registry["create_channel"] = self.create_channel

--- a/connectors/comms/twilio.py
+++ b/connectors/comms/twilio.py
@@ -19,7 +19,9 @@ class TwilioConnector(BaseConnector):
     rate_limit_rpm = 100
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
         self._account_sid = self.config.get("account_sid", "")
 
     def _register_tools(self):

--- a/connectors/comms/whatsapp.py
+++ b/connectors/comms/whatsapp.py
@@ -19,7 +19,9 @@ class WhatsappConnector(BaseConnector):
     rate_limit_rpm = 100
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
         self._phone_number_id = self.config.get("phone_number_id", "")
 
     def _register_tools(self):

--- a/connectors/comms/youtube.py
+++ b/connectors/comms/youtube.py
@@ -20,6 +20,11 @@ class YouTubeConnector(BaseConnector):
     base_url = "https://www.googleapis.com/youtube/v3"
     rate_limit_rpm = 200
 
+    def __init__(self, config: dict[str, Any] | None = None):
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
+
     def _register_tools(self):
         self._tool_registry["list_videos"] = self.list_videos
         self._tool_registry["get_video_stats"] = self.get_video_stats

--- a/connectors/finance/aa_consent.py
+++ b/connectors/finance/aa_consent.py
@@ -24,6 +24,7 @@ from connectors.finance.aa_consent_types import (
     ConsentStatus,
     FIDataSession,
 )
+from core.security.egress import EgressValidationError, validate_public_url
 
 logger = structlog.get_logger()
 
@@ -39,7 +40,17 @@ class AAConsentManager:
         callback_url: str = "",
         fiu_id: str = "",
     ):
-        self.base_url = base_url.rstrip("/")
+        cleaned_base_url = base_url.rstrip("/")
+        try:
+            validate_public_url(
+                cleaned_base_url,
+                allowed_schemes=("https",),
+                allowed_hosts=("aa.finvu.in",),
+                require_dns=False,
+            )
+        except EgressValidationError as exc:
+            raise ValueError("AA consent base_url must be the official Finvu HTTPS API host") from exc
+        self.base_url = cleaned_base_url
         self.client_id = client_id
         self.client_secret = client_secret
         self.callback_url = callback_url

--- a/connectors/finance/netsuite.py
+++ b/connectors/finance/netsuite.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import httpx
@@ -10,6 +11,8 @@ import structlog
 from connectors.framework.base_connector import BaseConnector
 
 logger = structlog.get_logger()
+
+_NETSUITE_ACCOUNT_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
 
 
 class NetsuiteConnector(BaseConnector):
@@ -30,11 +33,15 @@ class NetsuiteConnector(BaseConnector):
     rate_limit_rpm = 200
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
         self._account_id: str = self.config.get("account_id", "")
         if not self.base_url and self._account_id:
             # NetSuite REST API base: account ID with underscores replacing dots
             safe_id = self._account_id.lower().replace(".", "_")
+            if not _NETSUITE_ACCOUNT_RE.fullmatch(safe_id):
+                raise ValueError("NetSuite account_id must be a provider account label")
             self.base_url = (
                 f"https://{safe_id}.suitetalk.api.netsuite.com"
                 f"/services/rest/record/v1"
@@ -81,13 +88,7 @@ class NetsuiteConnector(BaseConnector):
                 raise
             logger.info("netsuite_401_retry", tool=tool_name)
             await self._authenticate()
-            if self._client:
-                await self._client.aclose()
-            self._client = httpx.AsyncClient(
-                base_url=self.base_url,
-                timeout=self.timeout_ms / 1000,
-                headers=self._auth_headers,
-            )
+            await self._rebuild_http_client()
             return await super().execute_tool(tool_name, params)
 
     # ── Health check ───────────────────────────────────────────────────

--- a/connectors/finance/oracle_fusion.py
+++ b/connectors/finance/oracle_fusion.py
@@ -8,6 +8,7 @@ from typing import Any
 import structlog
 
 from connectors.framework.base_connector import BaseConnector
+from connectors.framework.url_security import require_dns_label
 
 logger = structlog.get_logger()
 
@@ -23,14 +24,15 @@ class OracleFusionConnector(BaseConnector):
     rate_limit_rpm = 500
 
     def __init__(self, config: dict[str, Any] | None = None):
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
         # Build instance-specific base_url before super().__init__ reads it
-        if config and "instance" in config and "base_url" not in config:
-            instance = config["instance"]
-            config = dict(config)
-            config["base_url"] = (
+        if safe_config.get("instance"):
+            instance = require_dns_label(safe_config["instance"], "Oracle Fusion instance")
+            safe_config["base_url"] = (
                 f"https://{instance}.oraclecloud.com/fscmRestApi/resources/{_API_VERSION}"
             )
-        super().__init__(config)
+        super().__init__(safe_config)
 
     def _register_tools(self):
         self._tool_registry["post_journal_entry"] = self.post_journal_entry

--- a/connectors/finance/quickbooks.py
+++ b/connectors/finance/quickbooks.py
@@ -22,7 +22,9 @@ class QuickbooksConnector(BaseConnector):
     rate_limit_rpm = 500
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
         self._realm_id: str = self.config.get("realm_id", "")
 
     def _register_tools(self):
@@ -169,13 +171,7 @@ class QuickbooksConnector(BaseConnector):
                 raise
             logger.info("quickbooks_401_retry", tool=tool_name)
             await self._authenticate()
-            if self._client:
-                await self._client.aclose()
-            self._client = httpx.AsyncClient(
-                base_url=self.base_url,
-                timeout=self.timeout_ms / 1000,
-                headers=self._auth_headers,
-            )
+            await self._rebuild_http_client()
             return await super().execute_tool(tool_name, params)
 
     def _company_path(self, suffix: str) -> str:

--- a/connectors/finance/sap.py
+++ b/connectors/finance/sap.py
@@ -91,13 +91,7 @@ class SapConnector(BaseConnector):
                 raise
             logger.info("sap_401_retry", tool=tool_name)
             await self._authenticate()
-            if self._client:
-                await self._client.aclose()
-            self._client = httpx.AsyncClient(
-                base_url=self.base_url,
-                timeout=self.timeout_ms / 1000,
-                headers=self._auth_headers,
-            )
+            await self._rebuild_http_client()
             return await super().execute_tool(tool_name, params)
 
     async def health_check(self) -> dict[str, Any]:

--- a/connectors/finance/tally.py
+++ b/connectors/finance/tally.py
@@ -24,6 +24,11 @@ from defusedxml.ElementTree import ParseError as XMLParseError
 from defusedxml.ElementTree import fromstring as xml_fromstring
 
 from connectors.framework.base_connector import BaseConnector
+from core.security.egress import (
+    EgressValidationError,
+    build_pinned_async_transport,
+    validate_public_url,
+)
 
 logger = structlog.get_logger()
 
@@ -236,7 +241,7 @@ class TallyConnector(BaseConnector):
     """Tally connector with optional bridge routing for remote instances.
 
     Config options:
-        bridge_url:   Cloud bridge endpoint (e.g. http://localhost:8000/api/v1/bridge/route/tally).
+        bridge_url:   Public HTTPS cloud bridge endpoint.
                       When set, XML requests are tunneled through the bridge to the
                       CA's local Tally instead of hitting localhost directly.
         bridge_id:    Bridge identifier (required when bridge_url is set).
@@ -251,10 +256,16 @@ class TallyConnector(BaseConnector):
 
     def __init__(self, config: dict[str, Any] | None = None):
         super().__init__(config)
-        self._bridge_url = self.config.get("bridge_url", "")
+        self._bridge_url = str(self.config.get("bridge_url", "") or "").strip()
         self._bridge_id = self.config.get("bridge_id", "")
         self._bridge_token = self.config.get("bridge_token", "")
         self._use_bridge = bool(self._bridge_url and self._bridge_id)
+
+    async def connect(self) -> None:
+        if self._use_bridge:
+            await self._authenticate()
+            return
+        await super().connect()
 
     def _register_tools(self):
         self._tool_registry["post_voucher"] = self.post_voucher
@@ -344,6 +355,19 @@ class TallyConnector(BaseConnector):
         import httpx
 
         request_id = str(uuid.uuid4())
+        try:
+            validate_public_url(
+                self._bridge_url,
+                allowed_schemes=("https",),
+                require_dns=True,
+            )
+        except EgressValidationError as exc:
+            raise TallyBridgeError(
+                "Tally bridge_url must be a public HTTPS endpoint.",
+                detail=str(exc),
+                request_id=request_id,
+                error_category="unsafe_bridge_url",
+            ) from exc
         payload = {
             "request_id": request_id,
             "bridge_id": self._bridge_id,
@@ -359,7 +383,10 @@ class TallyConnector(BaseConnector):
         )
 
         try:
-            async with httpx.AsyncClient(timeout=30) as client:
+            async with httpx.AsyncClient(
+                timeout=30,
+                transport=build_pinned_async_transport(require_dns=True),
+            ) as client:
                 resp = await client.post(
                     self._bridge_url,
                     json=payload,

--- a/connectors/finance/zoho_books.py
+++ b/connectors/finance/zoho_books.py
@@ -378,13 +378,7 @@ class ZohoBooksConnector(BaseConnector):
                 raise self._runtime_error_from_http_status(exc) from exc
             logger.info("zoho_books_401_retry", tool=tool_name)
             await self._authenticate()
-            if self._client:
-                await self._client.aclose()
-            self._client = httpx.AsyncClient(
-                base_url=self.base_url,
-                timeout=self.timeout_ms / 1000,
-                headers=self._auth_headers,
-            )
+            await self._rebuild_http_client()
             try:
                 return await super().execute_tool(tool_name, params)
             except httpx.HTTPStatusError as retry_exc:

--- a/connectors/framework/base_connector.py
+++ b/connectors/framework/base_connector.py
@@ -10,6 +10,12 @@ import httpx
 import structlog
 from defusedxml.ElementTree import fromstring as xml_fromstring
 
+from core.security.egress import (
+    EgressValidationError,
+    build_pinned_async_transport,
+    validate_public_url,
+)
+
 logger = structlog.get_logger()
 
 # Lazy-loaded Secret Manager client (one per process)
@@ -30,6 +36,23 @@ def _get_sm_client():
 _GCP_SECRET_RE = re.compile(
     r"^gcp://projects/(?P<project>[^/]+)/secrets/(?P<secret>[^/]+)/versions/(?P<version>[^/]+)$"
 )
+
+
+class _GuardedAsyncClient(httpx.AsyncClient):
+    """httpx client that validates the final request URL before network egress."""
+
+    def __init__(self, *args: Any, connector_name: str, require_dns: bool, **kwargs: Any) -> None:
+        self._connector_name = connector_name
+        self._require_dns = require_dns
+        super().__init__(*args, **kwargs)
+
+    async def send(self, request: httpx.Request, *args: Any, **kwargs: Any) -> httpx.Response:
+        _validate_connector_egress_url(
+            str(request.url),
+            connector_name=self._connector_name,
+            require_dns=self._require_dns,
+        )
+        return await super().send(request, *args, **kwargs)
 
 
 class BaseConnector(abc.ABC):
@@ -93,26 +116,8 @@ class BaseConnector(abc.ABC):
                 "connector_skip_auth_no_credentials",
                 connector=self.name,
             )
-
-        # Foundation #7 PR-D: hermetic-CI seam. When the env flag
-        # is set, route every connector HTTP call through the
-        # fake-connectors MockTransport so PR CI never touches a
-        # real third-party API. See docs/hermetic_test_doubles.md.
-        from core.test_doubles import fake_connectors  # noqa: PLC0415 — lazy keeps prod cold-path lean
-
-        transport = (
-            fake_connectors.build_transport()
-            if fake_connectors.is_active()
-            else None
-        )
-
         # Create client with whatever auth headers were set (may be empty)
-        self._client = httpx.AsyncClient(
-            base_url=self.base_url,
-            timeout=self.timeout_ms / 1000,
-            headers=self._auth_headers,
-            transport=transport,
-        )
+        self._client = self._build_http_client()
 
     async def disconnect(self) -> None:
         if self._client:
@@ -267,9 +272,38 @@ class BaseConnector(abc.ABC):
         """Perform authentication. Must set self._auth_headers.
         Use self._get_secret(key) to retrieve credentials — never hardcode tokens."""
 
+    def _connector_transport_and_dns(self) -> tuple[Any, bool]:
+        # Foundation #7 PR-D: hermetic-CI seam. When the env flag
+        # is set, route every connector HTTP call through the
+        # fake-connectors MockTransport so PR CI never touches a
+        # real third-party API. See docs/hermetic_test_doubles.md.
+        from core.test_doubles import fake_connectors  # noqa: PLC0415 - lazy keeps prod cold-path lean
+
+        if fake_connectors.is_active():
+            return fake_connectors.build_transport(), False
+        return build_pinned_async_transport(require_dns=True), True
+
+    def _build_http_client(self) -> httpx.AsyncClient:
+        transport, require_dns = self._connector_transport_and_dns()
+        self._validate_connector_egress_url(self.base_url or "", require_dns=require_dns)
+        return _GuardedAsyncClient(
+            base_url=self.base_url,
+            timeout=self.timeout_ms / 1000,
+            headers=self._auth_headers,
+            transport=transport,
+            connector_name=self.name,
+            require_dns=require_dns,
+        )
+
+    async def _rebuild_http_client(self) -> None:
+        if self._client:
+            await self._client.aclose()
+        self._client = self._build_http_client()
+
     async def _get(self, path: str, params: dict | None = None) -> dict[str, Any]:
         if not self._client:
             raise RuntimeError("Connector not connected")
+        self._validate_request_url("GET", path)
         resp = await self._client.get(path, params=params)
         resp.raise_for_status()
         return resp.json()
@@ -277,6 +311,7 @@ class BaseConnector(abc.ABC):
     async def _post(self, path: str, data: dict | None = None) -> dict[str, Any]:
         if not self._client:
             raise RuntimeError("Connector not connected")
+        self._validate_request_url("POST", path)
         resp = await self._client.post(path, json=data)
         resp.raise_for_status()
         return resp.json()
@@ -288,6 +323,7 @@ class BaseConnector(abc.ABC):
         """
         if not self._client:
             raise RuntimeError("Connector not connected")
+        self._validate_request_url("POST", path)
         resp = await self._client.post(path, data=data)
         resp.raise_for_status()
         return resp.json()
@@ -301,6 +337,7 @@ class BaseConnector(abc.ABC):
             raise RuntimeError("Connector not connected")
         params = params or {}
         params.setdefault("$format", "json")
+        self._validate_request_url("GET", path)
         resp = await self._client.get(path, params=params)
         resp.raise_for_status()
         body = resp.json()
@@ -319,6 +356,7 @@ class BaseConnector(abc.ABC):
         """
         if not self._client:
             raise RuntimeError("Connector not connected")
+        self._validate_request_url("POST", "")
         resp = await self._client.post(
             "",
             content=xml_body.encode("utf-8"),
@@ -330,6 +368,7 @@ class BaseConnector(abc.ABC):
     async def _put(self, path: str, data: dict | None = None) -> dict[str, Any]:
         if not self._client:
             raise RuntimeError("Connector not connected")
+        self._validate_request_url("PUT", path)
         resp = await self._client.put(path, json=data)
         resp.raise_for_status()
         return resp.json()
@@ -337,6 +376,7 @@ class BaseConnector(abc.ABC):
     async def _patch(self, path: str, data: dict | None = None) -> dict[str, Any]:
         if not self._client:
             raise RuntimeError("Connector not connected")
+        self._validate_request_url("PATCH", path)
         resp = await self._client.patch(path, json=data)
         resp.raise_for_status()
         return resp.json()
@@ -344,6 +384,33 @@ class BaseConnector(abc.ABC):
     async def _delete(self, path: str) -> dict[str, Any]:
         if not self._client:
             raise RuntimeError("Connector not connected")
+        self._validate_request_url("DELETE", path)
         resp = await self._client.delete(path)
         resp.raise_for_status()
         return resp.json()
+
+    def _validate_request_url(self, method: str, path: str) -> None:
+        if not self._client:
+            raise RuntimeError("Connector not connected")
+        if not isinstance(self._client, httpx.AsyncClient):
+            return
+        request = self._client.build_request(method, path)
+        _, require_dns = self._connector_transport_and_dns()
+        self._validate_connector_egress_url(str(request.url), require_dns=require_dns)
+
+    def _validate_connector_egress_url(self, url: str, *, require_dns: bool = True) -> None:
+        _validate_connector_egress_url(url, connector_name=self.name, require_dns=require_dns)
+
+
+def _validate_connector_egress_url(url: str, *, connector_name: str, require_dns: bool) -> None:
+    if not url:
+        return
+    try:
+        validate_public_url(url, allowed_schemes=("https",), require_dns=require_dns)
+    except EgressValidationError as exc:
+        logger.warning(
+            "connector_egress_blocked",
+            connector=connector_name,
+            reason=exc.reason,
+        )
+        raise ValueError("Connector egress URL must be a public http(s) endpoint") from exc

--- a/connectors/hr/docusign.py
+++ b/connectors/hr/docusign.py
@@ -20,7 +20,9 @@ class DocuSignConnector(BaseConnector):
     rate_limit_rpm = 100
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
         self._account_id = self.config.get("account_id", "")
 
     def _register_tools(self):

--- a/connectors/hr/okta.py
+++ b/connectors/hr/okta.py
@@ -7,8 +7,10 @@ group management, access logging, and MFA operations.
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlparse
 
 from connectors.framework.base_connector import BaseConnector
+from connectors.framework.url_security import require_dns_label
 
 
 class OktaConnector(BaseConnector):
@@ -17,6 +19,21 @@ class OktaConnector(BaseConnector):
     auth_type = "scim_oauth2"
     base_url = "https://org.okta.com/api/v1"
     rate_limit_rpm = 300
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        safe_config = dict(config or {})
+        raw_base_url = str(safe_config.pop("base_url", "") or "")
+        org = safe_config.get("org") or safe_config.get("domain")
+        if not org and raw_base_url:
+            parsed = urlparse(raw_base_url)
+            host = (parsed.hostname or "").rstrip(".").lower()
+            if host.endswith(".okta.com"):
+                org = host.removesuffix(".okta.com")
+        if org:
+            safe_org = require_dns_label(org, "Okta org")
+            safe_config["org"] = safe_org
+            self.base_url = f"https://{safe_org}.okta.com/api/v1"
+        super().__init__(safe_config)
 
     def _register_tools(self):
         self._tool_registry["provision_user"] = self.provision_user

--- a/connectors/marketing/ga4.py
+++ b/connectors/marketing/ga4.py
@@ -25,7 +25,9 @@ class GA4Connector(BaseConnector):
     )
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
         self._property_id = self.config.get("property_id", "")
 
     def _register_tools(self):

--- a/connectors/marketing/google_ads.py
+++ b/connectors/marketing/google_ads.py
@@ -23,7 +23,9 @@ class GoogleAdsConnector(BaseConnector):
     rate_limit_rpm = 200
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
         self._customer_id = self._normalize_customer_id(
             self.config.get("customer_id", "")
         )

--- a/connectors/marketing/hubspot.py
+++ b/connectors/marketing/hubspot.py
@@ -105,6 +105,11 @@ class HubspotConnector(BaseConnector):
         "get_campaign_analytics",
     ]
 
+    def __init__(self, config: dict[str, Any] | None = None):
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
+
     def _register_tools(self):
         # Contacts
         self._tool_registry["list_contacts"] = self.list_contacts
@@ -203,13 +208,7 @@ class HubspotConnector(BaseConnector):
             logger.info("hubspot_401_retry", tool=tool_name)
             await self._authenticate()
             # Re-create client with fresh headers
-            if self._client:
-                await self._client.aclose()
-            self._client = httpx.AsyncClient(
-                base_url=self.base_url,
-                timeout=self.timeout_ms / 1000,
-                headers=self._auth_headers,
-            )
+            await self._rebuild_http_client()
             return await super().execute_tool(tool_name, params)
 
     def _properties_param(self, value: Any, default: str) -> str:

--- a/connectors/marketing/linkedin_ads.py
+++ b/connectors/marketing/linkedin_ads.py
@@ -22,7 +22,9 @@ class LinkedinAdsConnector(BaseConnector):
     rate_limit_rpm = 100
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
         self._ad_account_id = self.config.get("ad_account_id", "")
 
     def _register_tools(self):

--- a/connectors/marketing/mailchimp.py
+++ b/connectors/marketing/mailchimp.py
@@ -9,6 +9,7 @@ import httpx
 import structlog
 
 from connectors.framework.base_connector import BaseConnector
+from connectors.framework.url_security import require_dns_label
 
 logger = structlog.get_logger()
 
@@ -31,7 +32,9 @@ class MailchimpConnector(BaseConnector):
     rate_limit_rpm = 100
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
         self._api_key: str = self.config.get("api_key", "")
         if not self.base_url:
             dc = self.config.get("dc", "")
@@ -39,6 +42,7 @@ class MailchimpConnector(BaseConnector):
                 # Extract data center from API key suffix (e.g. "abc123-us21" -> "us21")
                 dc = self._api_key.rsplit("-", 1)[-1]
             if dc:
+                dc = require_dns_label(dc, "Mailchimp data center")
                 self.base_url = f"https://{dc}.api.mailchimp.com/3.0"
 
     # ── Tool registration ──────────────────────────────────────────────
@@ -85,13 +89,7 @@ class MailchimpConnector(BaseConnector):
                 raise
             logger.info("mailchimp_401_retry", tool=tool_name)
             await self._authenticate()
-            if self._client:
-                await self._client.aclose()
-            self._client = httpx.AsyncClient(
-                base_url=self.base_url,
-                timeout=self.timeout_ms / 1000,
-                headers=self._auth_headers,
-            )
+            await self._rebuild_http_client()
             return await super().execute_tool(tool_name, params)
 
     # ── Health check ───────────────────────────────────────────────────

--- a/connectors/marketing/meta_ads.py
+++ b/connectors/marketing/meta_ads.py
@@ -19,7 +19,9 @@ class MetaAdsConnector(BaseConnector):
     rate_limit_rpm = 200
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
         self._ad_account_id = self.config.get("ad_account_id", "")
 
     def _register_tools(self):

--- a/connectors/marketing/moengage.py
+++ b/connectors/marketing/moengage.py
@@ -11,6 +11,7 @@ import base64
 from typing import Any
 
 from connectors.framework.base_connector import BaseConnector
+from connectors.framework.url_security import require_dns_label
 
 
 class MoEngageConnector(BaseConnector):
@@ -21,11 +22,12 @@ class MoEngageConnector(BaseConnector):
     rate_limit_rpm = 200
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
         # MoEngage datacenter: api-01, api-02, api-03, etc.
-        datacenter = self.config.get("datacenter", "01")
-        if "base_url" not in self.config:
-            self.base_url = f"https://api-{datacenter}.moengage.com/v1"
+        datacenter = require_dns_label(self.config.get("datacenter", "01"), "MoEngage datacenter")
+        self.base_url = f"https://api-{datacenter}.moengage.com/v1"
 
     def _register_tools(self):
         self._tool_registry["create_campaign"] = self.create_campaign

--- a/connectors/marketing/salesforce.py
+++ b/connectors/marketing/salesforce.py
@@ -54,7 +54,9 @@ class SalesforceConnector(BaseConnector):
     ]
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
         self._instance_url = ""
 
     def _register_tools(self):

--- a/connectors/marketing/wordpress.py
+++ b/connectors/marketing/wordpress.py
@@ -4,13 +4,31 @@ from __future__ import annotations
 
 import base64
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 import structlog
 
 from connectors.framework.base_connector import BaseConnector
+from core.security.egress import EgressValidationError, validate_public_url
 
 logger = structlog.get_logger()
+
+
+def _wordpress_api_base_url(site: Any) -> str:
+    text = str(site or "").strip().rstrip("/")
+    if not text:
+        return ""
+    candidate = text if "://" in text else f"https://{text}"
+    parsed = urlparse(candidate)
+    host = (parsed.hostname or "").rstrip(".").lower()
+    port = f":{parsed.port}" if parsed.port else ""
+    origin = f"{parsed.scheme.lower()}://{host}{port}"
+    try:
+        validate_public_url(origin, allowed_schemes=("https",), require_dns=False)
+    except EgressValidationError as exc:
+        raise ValueError("WordPress site must be a public HTTPS host") from exc
+    return f"{origin}/wp-json/wp/v2"
 
 
 class WordpressConnector(BaseConnector):
@@ -32,14 +50,14 @@ class WordpressConnector(BaseConnector):
     rate_limit_rpm = 100
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        safe_config = dict(config or {})
+        raw_base_url = safe_config.pop("base_url", "")
+        if not safe_config.get("site") and raw_base_url:
+            safe_config["site"] = raw_base_url
+        super().__init__(safe_config)
         site = self.config.get("site", "")
         if not self.base_url and site:
-            # Strip protocol if present, then build canonical URL
-            clean_site = site.rstrip("/")
-            if not clean_site.startswith("http"):
-                clean_site = f"https://{clean_site}"
-            self.base_url = f"{clean_site}/wp-json/wp/v2"
+            self.base_url = _wordpress_api_base_url(site)
 
     # ── Tool registration ──────────────────────────────────────────────
 
@@ -94,13 +112,7 @@ class WordpressConnector(BaseConnector):
                 raise
             logger.info("wordpress_401_retry", tool=tool_name)
             await self._authenticate()
-            if self._client:
-                await self._client.aclose()
-            self._client = httpx.AsyncClient(
-                base_url=self.base_url,
-                timeout=self.timeout_ms / 1000,
-                headers=self._auth_headers,
-            )
+            await self._rebuild_http_client()
             return await super().execute_tool(tool_name, params)
 
     # ── Health check ───────────────────────────────────────────────────

--- a/connectors/ops/jira.py
+++ b/connectors/ops/jira.py
@@ -6,6 +6,7 @@ import base64
 from typing import Any
 
 from connectors.framework.base_connector import BaseConnector
+from connectors.framework.url_security import require_dns_label
 
 
 class JiraConnector(BaseConnector):
@@ -16,10 +17,14 @@ class JiraConnector(BaseConnector):
     rate_limit_rpm = 300
 
     def __init__(self, config: dict[str, Any] | None = None):
-        super().__init__(config)
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
         # Allow tenant-specific Jira domain
-        domain = (config or {}).get("domain", "")
+        domain = self.config.get("domain", "")
         if domain:
+            domain = require_dns_label(domain, "Jira domain")
+            self.config["domain"] = domain
             self.base_url = f"https://{domain}.atlassian.net"
 
     def _register_tools(self):

--- a/connectors/ops/pagerduty.py
+++ b/connectors/ops/pagerduty.py
@@ -18,6 +18,11 @@ class PagerdutyConnector(BaseConnector):
     base_url = "https://api.pagerduty.com"
     rate_limit_rpm = 100
 
+    def __init__(self, config: dict[str, Any] | None = None):
+        safe_config = dict(config or {})
+        safe_config.pop("base_url", None)
+        super().__init__(safe_config)
+
     def _register_tools(self):
         self._tool_registry["create_incident"] = self.create_incident
         self._tool_registry["acknowledge_incident"] = self.acknowledge_incident

--- a/connectors/ops/zendesk.py
+++ b/connectors/ops/zendesk.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 import base64
 from typing import Any
+from urllib.parse import urlparse
 
 from connectors.framework.base_connector import BaseConnector
+from connectors.framework.url_security import require_dns_label
 
 
 class ZendeskConnector(BaseConnector):
@@ -18,6 +20,21 @@ class ZendeskConnector(BaseConnector):
     auth_type = "api_token"
     base_url = "https://org.zendesk.com/api/v2"
     rate_limit_rpm = 200
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        safe_config = dict(config or {})
+        raw_base_url = str(safe_config.pop("base_url", "") or "")
+        subdomain = safe_config.get("subdomain") or safe_config.get("domain")
+        if not subdomain and raw_base_url:
+            parsed = urlparse(raw_base_url)
+            host = (parsed.hostname or "").rstrip(".").lower()
+            if host.endswith(".zendesk.com"):
+                subdomain = host.removesuffix(".zendesk.com")
+        if subdomain:
+            safe_subdomain = require_dns_label(subdomain, "Zendesk subdomain")
+            safe_config["subdomain"] = safe_subdomain
+            self.base_url = f"https://{safe_subdomain}.zendesk.com/api/v2"
+        super().__init__(safe_config)
 
     def _register_tools(self):
         self._tool_registry["create_ticket"] = self.create_ticket

--- a/core/ai_providers/health.py
+++ b/core/ai_providers/health.py
@@ -18,6 +18,11 @@ import httpx
 import structlog
 
 from core.ai_providers.resolver import ProviderNotConfigured, get_provider_credential
+from core.security.egress import (
+    EgressValidationError,
+    build_pinned_async_transport,
+    validate_public_url,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -26,8 +31,11 @@ _PROBE_TIMEOUT_S = 10.0
 
 async def _probe_openai(credential: str, base_url: str | None = None) -> dict[str, Any]:
     """OpenAI + OpenAI-compatible: GET /v1/models (lists available models)."""
-    url = f"{(base_url or 'https://api.openai.com').rstrip('/')}/v1/models"
-    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_S) as client:
+    url = _openai_models_url(base_url)
+    async with httpx.AsyncClient(
+        timeout=_PROBE_TIMEOUT_S,
+        transport=build_pinned_async_transport(require_dns=True),
+    ) as client:
         start = time.time()
         resp = await client.get(url, headers={"Authorization": f"Bearer {credential}"})
         latency_ms = int((time.time() - start) * 1000)
@@ -44,7 +52,10 @@ async def _probe_openai(credential: str, base_url: str | None = None) -> dict[st
 async def _probe_anthropic(credential: str) -> dict[str, Any]:
     """Anthropic: HEAD /v1/messages fails cheap on bad key (401)."""
     url = "https://api.anthropic.com/v1/messages"
-    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_S) as client:
+    async with httpx.AsyncClient(
+        timeout=_PROBE_TIMEOUT_S,
+        transport=build_pinned_async_transport(require_dns=True),
+    ) as client:
         start = time.time()
         # POST with an empty body — Anthropic returns 400 for missing
         # required fields when auth is valid, 401 when auth is bad.
@@ -74,7 +85,10 @@ async def _probe_anthropic(credential: str) -> dict[str, Any]:
 async def _probe_gemini(credential: str) -> dict[str, Any]:
     """Gemini: GET /v1beta/models?key=..."""
     url = "https://generativelanguage.googleapis.com/v1beta/models"
-    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_S) as client:
+    async with httpx.AsyncClient(
+        timeout=_PROBE_TIMEOUT_S,
+        transport=build_pinned_async_transport(require_dns=True),
+    ) as client:
         start = time.time()
         resp = await client.get(url, params={"key": credential})
         latency_ms = int((time.time() - start) * 1000)
@@ -91,7 +105,10 @@ async def _probe_gemini(credential: str) -> dict[str, Any]:
 async def _probe_voyage(credential: str) -> dict[str, Any]:
     """Voyage embedding: a minimal embed call against the cheapest model."""
     url = "https://api.voyageai.com/v1/embeddings"
-    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_S) as client:
+    async with httpx.AsyncClient(
+        timeout=_PROBE_TIMEOUT_S,
+        transport=build_pinned_async_transport(require_dns=True),
+    ) as client:
         start = time.time()
         resp = await client.post(
             url,
@@ -112,7 +129,10 @@ async def _probe_voyage(credential: str) -> dict[str, Any]:
 async def _probe_cohere(credential: str) -> dict[str, Any]:
     """Cohere: GET /v1/models."""
     url = "https://api.cohere.ai/v1/models"
-    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_S) as client:
+    async with httpx.AsyncClient(
+        timeout=_PROBE_TIMEOUT_S,
+        transport=build_pinned_async_transport(require_dns=True),
+    ) as client:
         start = time.time()
         resp = await client.get(url, headers={"Authorization": f"Bearer {credential}"})
         latency_ms = int((time.time() - start) * 1000)
@@ -138,6 +158,26 @@ def _classify_http_error(status_code: int) -> str:
     if 500 <= status_code < 600:
         return f"Provider returned {status_code}: upstream is unhealthy."
     return f"Provider returned unexpected status {status_code}."
+
+
+def _openai_models_url(base_url: str | None) -> str:
+    endpoint = (base_url or "https://api.openai.com").rstrip("/")
+    validated = validate_public_url(f"{endpoint}/v1/models", allowed_schemes=("https",), require_dns=True)
+    return validated.url
+
+
+def _validate_openai_probe_base(provider: str, base_url: str | None) -> str | None:
+    clean = str(base_url or "").strip().rstrip("/")
+    if provider == "openai":
+        if clean and clean != "https://api.openai.com":
+            raise ValueError("OpenAI provider probes may only target api.openai.com")
+        return "https://api.openai.com"
+    if provider in {"openai_compatible", "azure_openai"}:
+        if not clean:
+            raise ValueError(f"{provider} requires provider_config.base_url")
+        validate_public_url(clean, allowed_schemes=("https",), require_dns=True)
+        return clean
+    return clean or None
 
 
 async def probe_provider(
@@ -167,9 +207,9 @@ async def probe_provider(
 
     try:
         if provider == "openai":
-            return await _probe_openai(secret, base_url)
+            return await _probe_openai(secret, _validate_openai_probe_base(provider, base_url))
         if provider == "openai_compatible":
-            return await _probe_openai(secret, base_url)
+            return await _probe_openai(secret, _validate_openai_probe_base(provider, base_url))
         if provider == "azure_openai":
             # Azure shape needs endpoint + deployment; require base_url
             if not base_url:
@@ -180,7 +220,7 @@ async def probe_provider(
                         "(your Azure resource endpoint)."
                     ),
                 }
-            return await _probe_openai(secret, base_url)
+            return await _probe_openai(secret, _validate_openai_probe_base(provider, base_url))
         if provider == "anthropic":
             return await _probe_anthropic(secret)
         if provider == "gemini":
@@ -199,6 +239,10 @@ async def probe_provider(
         }
     except TimeoutError:
         return {"ok": False, "error": f"Probe timed out after {_PROBE_TIMEOUT_S}s."}
+    except EgressValidationError:
+        return {"ok": False, "error": "EgressValidationError"}
+    except ValueError:
+        return {"ok": False, "error": "ValueError"}
     # enterprise-gate: broad-except-ok reason=provider-health-probe-failure-returns-unhealthy-error
     except Exception as exc:
         logger.warning(

--- a/core/billing/pinelabs_client.py
+++ b/core/billing/pinelabs_client.py
@@ -83,6 +83,8 @@ PLAN_AMOUNT_INR: dict[str, int] = {
 # runtimes fail closed if Redis is unavailable.
 # enterprise-gate: process-local-ok reason=relaxed-env-only-plural-order-map-fallback
 _order_map: dict[str, Any] = {}
+# enterprise-gate: process-local-ok reason=relaxed-env-only-plural-order-id-map-fallback
+_order_id_map: dict[str, Any] = {}
 _MAPPING_TTL = 86400  # 24 hours
 
 
@@ -108,24 +110,33 @@ def store_order_mapping(
     import json as _json
 
     entry = {"order_id": order_id, "tenant_id": tenant_id, "plan": plan}
+    order_id_entry = {**entry, "merchant_order_reference": merchant_ref}
 
     redis = _redis_client()
     if redis is None:
         if _strict_order_mapping():
             raise RuntimeError("Plural order mapping requires Redis in strict runtime")
         _order_map[merchant_ref] = entry
+        if order_id:
+            _order_id_map[order_id] = order_id_entry
         return
 
     try:
         redis.setex(f"plural:order:{merchant_ref}", _MAPPING_TTL, _json.dumps(entry))
+        if order_id:
+            redis.setex(f"plural:order-id:{order_id}", _MAPPING_TTL, _json.dumps(order_id_entry))
         if not _strict_order_mapping():
             _order_map[merchant_ref] = entry
+            if order_id:
+                _order_id_map[order_id] = order_id_entry
     # enterprise-gate: broad-except-ok reason=payment-order-mapping-write-fails-closed-in-strict-runtime
     except Exception as exc:
         if _strict_order_mapping():
             raise RuntimeError("Plural order mapping Redis write failed in strict runtime") from exc
         logger.debug("plural_order_mapping_redis_failed")
         _order_map[merchant_ref] = entry
+        if order_id:
+            _order_id_map[order_id] = order_id_entry
 
 
 def lookup_order_id(merchant_ref: str) -> str:
@@ -159,6 +170,35 @@ def lookup_order_details(merchant_ref: str) -> dict[str, str]:
     if _strict_order_mapping():
         return {}
     entry = _order_map.get(merchant_ref, {})
+    return entry if isinstance(entry, dict) else {}
+
+
+def lookup_order_details_by_order_id(order_id: str) -> dict[str, str]:
+    """Look up full order details by Plural order_id."""
+    import json as _json
+
+    redis = _redis_client()
+    if redis is None:
+        if _strict_order_mapping():
+            raise RuntimeError("Plural order mapping lookup requires Redis in strict runtime")
+        entry = _order_id_map.get(order_id, {})
+        return entry if isinstance(entry, dict) else {}
+
+    try:
+        raw = redis.get(f"plural:order-id:{order_id}")
+        if raw:
+            if isinstance(raw, bytes):
+                raw = raw.decode()
+            return _json.loads(raw)
+    # enterprise-gate: broad-except-ok reason=payment-order-id-mapping-read-fails-closed-in-strict-runtime
+    except Exception as exc:
+        if _strict_order_mapping():
+            raise RuntimeError("Plural order-id mapping Redis read failed in strict runtime") from exc
+        logger.debug("plural_order_id_lookup_redis_failed")
+
+    if _strict_order_mapping():
+        return {}
+    entry = _order_id_map.get(order_id, {})
     return entry if isinstance(entry, dict) else {}
 
 

--- a/core/commerce/c6z_runtime_vertical.py
+++ b/core/commerce/c6z_runtime_vertical.py
@@ -28,6 +28,11 @@ from core.commerce.oacp_artifacts import (
     PersistentCacheActionIntent,
     evaluate_oacp_persistent_artifact_cache_record,
 )
+from core.security.egress import (
+    EgressValidationError,
+    build_pinned_async_transport,
+    validate_public_url,
+)
 
 SHOPIFY_ENV_VARS: tuple[str, ...] = (
     "SHOPIFY_SHOP_DOMAIN",
@@ -564,9 +569,20 @@ class ShopifyAdminGraphQLClient:
         if max_pages < 1 or max_pages > 20:
             raise C6ZRuntimeValidationError("max_pages must be between 1 and 20")
 
+        try:
+            validate_public_url(
+                self.graphql_url,
+                allowed_schemes=("https",),
+                allowed_domains=("myshopify.com",),
+                require_dns=self._transport is None,
+            )
+        except EgressValidationError as exc:
+            raise C6ZRuntimeValidationError("unsafe Shopify Admin API endpoint") from exc
+
         products: list[dict[str, Any]] = []
         after_cursor: str | None = None
-        async with httpx.AsyncClient(timeout=self._timeout_seconds, transport=self._transport) as client:
+        transport = self._transport or build_pinned_async_transport(require_dns=True)
+        async with httpx.AsyncClient(timeout=self._timeout_seconds, transport=transport) as client:
             for _ in range(max_pages):
                 payload: dict[str, Any] = {
                     "query": SHOPIFY_PRODUCTS_QUERY,
@@ -835,9 +851,14 @@ def build_grantex_authority_request_payload(
     *,
     onboarding_packet: Mapping[str, Any],
     connector_evidence: Mapping[str, Any],
+    expected_tenant_id: str | None = None,
 ) -> dict[str, Any]:
     validate_seller_onboarding_packet(onboarding_packet)
     validate_connector_evidence(connector_evidence)
+    if expected_tenant_id is not None and str(onboarding_packet["tenant_id"]) != str(
+        expected_tenant_id
+    ):
+        raise C6ZRuntimeValidationError("authenticated tenant scope mismatch")
     if connector_evidence["tenant_id"] != onboarding_packet["tenant_id"]:
         raise C6ZRuntimeValidationError("tenant scope mismatch")
     if connector_evidence["merchant_id"] != onboarding_packet["merchant_id"]:
@@ -922,7 +943,15 @@ async def send_grantex_authority_request(
             "non_authoritative_for_transaction": True,
         }
     base_url = source["GRANTEX_COMMERCE_BASE_URL"].rstrip("/")
-    async with httpx.AsyncClient(timeout=20.0, transport=transport) as client:
+    try:
+        validate_public_url(
+            f"{base_url}/v1/commerce/oacp/c6z/authority-requests",
+            require_dns=transport is None,
+        )
+    except EgressValidationError as exc:
+        raise C6ZRuntimeValidationError("unsafe Grantex authority endpoint") from exc
+    client_transport = transport or build_pinned_async_transport(require_dns=True)
+    async with httpx.AsyncClient(timeout=20.0, transport=client_transport) as client:
         response = await client.post(
             f"{base_url}/v1/commerce/oacp/c6z/authority-requests",
             json=payload,
@@ -1577,12 +1606,23 @@ async def verify_plural_pine_mandate_capability(
     }
     explicit_capability_url = str(source.get("PLURAL_PINE_CAPABILITY_URL", "") or "").strip()
     try:
-        async with httpx.AsyncClient(timeout=20.0, transport=transport) as client:
+        client_transport = transport or build_pinned_async_transport(require_dns=True)
+        async with httpx.AsyncClient(timeout=20.0, transport=client_transport) as client:
             if explicit_capability_url:
+                validate_public_url(
+                    explicit_capability_url,
+                    allowed_schemes=("https",),
+                    require_dns=transport is None,
+                )
                 response = await client.post(explicit_capability_url, json=payload, headers=headers)
                 response.raise_for_status()
                 body = response.json()
             else:
+                validate_public_url(
+                    f"{_plural_pine_base_url(source)}/auth/v1/token",
+                    allowed_schemes=("https",),
+                    require_dns=transport is None,
+                )
                 response = await client.post(
                     f"{_plural_pine_base_url(source)}/auth/v1/token",
                     json={
@@ -1681,11 +1721,29 @@ def contains_private_or_executable_value(value: Any) -> bool:
 
 
 def _normalize_shopify_domain(value: str) -> str:
-    domain = value.strip().replace("https://", "").replace("http://", "").rstrip("/")
+    domain = value.strip().lower().removeprefix("https://").removeprefix("http://").rstrip("/")
     if not domain:
         raise C6ZRuntimeValidationError("Shopify shop domain is required")
-    if "/" in domain or " " in domain:
+    if "/" in domain or " " in domain or ":" in domain:
         raise C6ZRuntimeValidationError("Shopify shop domain must be a host name")
+    labels = domain.split(".")
+    if (
+        len(labels) != 3
+        or labels[1:] != ["myshopify", "com"]
+        or not all(labels)
+        or labels[0].startswith("-")
+        or labels[0].endswith("-")
+    ):
+        raise C6ZRuntimeValidationError("Shopify shop domain must be a public *.myshopify.com host")
+    try:
+        validate_public_url(
+            f"https://{domain}",
+            allowed_schemes=("https",),
+            require_dns=False,
+            allowed_domains=("myshopify.com",),
+        )
+    except EgressValidationError as exc:
+        raise C6ZRuntimeValidationError("Shopify shop domain must be a public *.myshopify.com host") from exc
     return domain
 
 

--- a/core/security/__init__.py
+++ b/core/security/__init__.py
@@ -1,0 +1,2 @@
+"""Shared security helpers."""
+

--- a/core/security/egress.py
+++ b/core/security/egress.py
@@ -1,0 +1,286 @@
+"""Outbound URL validation for tenant-influenced network destinations."""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+from core.config import is_strict_runtime_env
+
+
+class EgressValidationError(ValueError):
+    """Raised when a URL/host is unsafe for server-side egress."""
+
+    def __init__(self, reason: str, detail: str = "") -> None:
+        self.reason = reason
+        self.detail = detail
+        super().__init__(f"{reason}: {detail}" if detail else reason)
+
+
+@dataclass(frozen=True)
+class ValidatedUrl:
+    url: str
+    scheme: str
+    host: str
+
+
+class PinnedDnsAsyncNetworkBackend:
+    """httpcore network backend that connects to a prevalidated DNS answer.
+
+    The normal httpx flow resolves DNS inside the transport after callers have
+    validated a URL. For tenant-influenced destinations, that leaves a DNS
+    rebinding window between validation and connect. This backend resolves and
+    validates once, then passes the vetted IP address to the underlying network
+    backend while httpcore still applies TLS/SNI to the original origin host.
+    """
+
+    def __init__(self, *, require_dns: bool = True, delegate: Any | None = None) -> None:
+        if delegate is None:
+            from httpcore._backends.auto import AutoBackend  # noqa: PLC0415
+
+            delegate = AutoBackend()
+        self._require_dns = require_dns
+        self._delegate = delegate
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: Iterable[Any] | None = None,
+    ) -> Any:
+        targets = resolve_public_hostname_addresses(host, require_dns=self._require_dns)
+        last_exc: Exception | None = None
+        for target in targets:
+            try:
+                return await self._delegate.connect_tcp(
+                    target,
+                    port,
+                    timeout=timeout,
+                    local_address=local_address,
+                    socket_options=socket_options,
+                )
+            # enterprise-gate: broad-except-ok reason=pinned-dns-connect-failure-continues-to-next-public-address
+            except Exception as exc:  # pragma: no cover - exercised by httpcore integration
+                last_exc = exc
+        if last_exc is not None:
+            raise last_exc
+        raise EgressValidationError("unresolvable", host)
+
+    async def connect_unix_socket(
+        self,
+        path: str,
+        timeout: float | None = None,
+        socket_options: Iterable[Any] | None = None,
+    ) -> Any:
+        raise EgressValidationError("unix_socket", "Unix sockets are not allowed for tenant egress")
+
+    async def sleep(self, seconds: float) -> None:
+        return await self._delegate.sleep(seconds)
+
+
+class PinnedDnsAsyncHTTPTransport:
+    """httpx async transport backed by a DNS-pinning httpcore pool."""
+
+    def __init__(self, *, require_dns: bool = True) -> None:
+        import httpcore  # noqa: PLC0415
+        from httpx import AsyncBaseTransport  # noqa: PLC0415
+        from httpx._config import DEFAULT_LIMITS, create_ssl_context  # noqa: PLC0415
+
+        self._base_transport_type = AsyncBaseTransport
+        self._pool = httpcore.AsyncConnectionPool(
+            ssl_context=create_ssl_context(verify=True, cert=None, trust_env=True),
+            max_connections=DEFAULT_LIMITS.max_connections,
+            max_keepalive_connections=DEFAULT_LIMITS.max_keepalive_connections,
+            keepalive_expiry=DEFAULT_LIMITS.keepalive_expiry,
+            http1=True,
+            http2=False,
+            network_backend=PinnedDnsAsyncNetworkBackend(require_dns=require_dns),
+        )
+
+    async def __aenter__(self) -> PinnedDnsAsyncHTTPTransport:
+        await self._pool.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: Any | None = None,
+    ) -> None:
+        from httpx._transports.default import map_httpcore_exceptions  # noqa: PLC0415
+
+        with map_httpcore_exceptions():
+            await self._pool.__aexit__(exc_type, exc_value, traceback)
+
+    async def handle_async_request(self, request: Any) -> Any:
+        import httpcore  # noqa: PLC0415
+        from httpx import Response  # noqa: PLC0415
+        from httpx._transports.default import (  # noqa: PLC0415
+            AsyncResponseStream,
+            map_httpcore_exceptions,
+        )
+        from httpx._types import AsyncByteStream  # noqa: PLC0415
+
+        assert isinstance(request.stream, AsyncByteStream)
+        req = httpcore.Request(
+            method=request.method,
+            url=httpcore.URL(
+                scheme=request.url.raw_scheme,
+                host=request.url.raw_host,
+                port=request.url.port,
+                target=request.url.raw_path,
+            ),
+            headers=request.headers.raw,
+            content=request.stream,
+            extensions=request.extensions,
+        )
+        with map_httpcore_exceptions():
+            resp = await self._pool.handle_async_request(req)
+        return Response(
+            status_code=resp.status,
+            headers=resp.headers,
+            stream=AsyncResponseStream(resp.stream),
+            extensions=resp.extensions,
+        )
+
+    async def aclose(self) -> None:
+        await self._pool.aclose()
+
+
+def egress_dns_validation_required() -> bool:
+    """Return True when DNS-resolved egress checks are required."""
+
+    env = os.getenv("AGENTICORG_ENV") or os.getenv("ENV")
+    if not env:
+        return True
+    return is_strict_runtime_env(env)
+
+
+def host_matches_domain(host: str, domain: str) -> bool:
+    normalized_host = host.rstrip(".").lower()
+    normalized_domain = domain.rstrip(".").lower()
+    return normalized_host == normalized_domain or normalized_host.endswith(f".{normalized_domain}")
+
+
+def validate_public_url(
+    url: str,
+    *,
+    allowed_schemes: Sequence[str] = ("https",),
+    require_dns: bool | None = None,
+    allowed_hosts: Iterable[str] | None = None,
+    allowed_domains: Iterable[str] | None = None,
+) -> ValidatedUrl:
+    """Validate a tenant-influenced outbound URL before using credentials with it."""
+
+    parsed = urlparse(str(url or "").strip())
+    scheme = parsed.scheme.lower()
+    allowed = {item.lower() for item in allowed_schemes}
+    if scheme not in allowed:
+        raise EgressValidationError("scheme", f"expected one of {sorted(allowed)}, got {scheme!r}")
+    if parsed.username or parsed.password:
+        raise EgressValidationError("userinfo", "URLs with embedded credentials are not allowed")
+    host = (parsed.hostname or "").rstrip(".").lower()
+    if not host:
+        raise EgressValidationError("missing_host", "URL is missing a hostname")
+    validate_public_hostname(
+        host,
+        require_dns=egress_dns_validation_required() if require_dns is None else require_dns,
+    )
+
+    if allowed_hosts is not None:
+        host_allowlist = {item.rstrip(".").lower() for item in allowed_hosts}
+        if host not in host_allowlist:
+            raise EgressValidationError("host_not_allowed", f"{host!r} is not in the allowed host set")
+    if allowed_domains is not None:
+        domains = tuple(item.rstrip(".").lower() for item in allowed_domains)
+        if not any(host_matches_domain(host, domain) for domain in domains):
+            raise EgressValidationError("domain_not_allowed", f"{host!r} is not under an allowed domain")
+    return ValidatedUrl(url=url, scheme=scheme, host=host)
+
+
+def validate_public_hostname(hostname: str, *, require_dns: bool | None = None) -> str:
+    """Validate a hostname for public server-side egress."""
+
+    host = str(hostname or "").strip().rstrip(".").lower()
+    if not host:
+        raise EgressValidationError("missing_host", "hostname is required")
+    if host == "localhost" or host.endswith(".localhost") or host.endswith(".local"):
+        raise EgressValidationError("local_host", host)
+    try:
+        ip_literal = ipaddress.ip_address(host)
+    except ValueError:
+        ip_literal = None
+    if ip_literal is not None:
+        raise EgressValidationError("ip_literal", f"direct IP URLs are blocked ({host})")
+    if require_dns is None:
+        require_dns = egress_dns_validation_required()
+    if require_dns:
+        resolve_public_hostname_addresses(host, require_dns=True)
+    return host
+
+
+def resolve_public_hostname_addresses(
+    hostname: str,
+    *,
+    require_dns: bool | None = None,
+) -> tuple[str, ...]:
+    """Return validated public DNS answers for a hostname, or the hostname in non-DNS mode."""
+
+    host = validate_public_hostname(hostname, require_dns=False)
+    if require_dns is None:
+        require_dns = egress_dns_validation_required()
+    if not require_dns:
+        return (host,)
+    addresses = _resolve_host(host)
+    if not addresses:
+        raise EgressValidationError("unresolvable", host)
+    for address in addresses:
+        if _is_blocked_ip(address):
+            raise EgressValidationError("blocked_ip", f"{host} resolved to {address}")
+    return tuple(str(address) for address in addresses)
+
+
+def build_pinned_async_transport(*, require_dns: bool = True) -> Any:
+    """Build an httpx transport that pins DNS to validated public answers."""
+
+    return PinnedDnsAsyncHTTPTransport(require_dns=require_dns)
+
+
+def _resolve_host(hostname: str) -> tuple[ipaddress.IPv4Address | ipaddress.IPv6Address, ...]:
+    try:
+        infos = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+    except (socket.gaierror, OSError):
+        return ()
+
+    addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    for info in infos:
+        ip_text = str(info[4][0])
+        try:
+            address = ipaddress.ip_address(ip_text)
+        except ValueError:
+            continue
+        if address not in addresses:
+            addresses.append(address)
+    return tuple(addresses)
+
+
+def _is_blocked_ip(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    if (
+        address.is_loopback
+        or address.is_private
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+    ):
+        return True
+    if isinstance(address, ipaddress.IPv4Address) and address in ipaddress.IPv4Network("100.64.0.0/10"):
+        return True
+    return False

--- a/core/tasks/token_refresh.py
+++ b/core/tasks/token_refresh.py
@@ -24,6 +24,44 @@ from core.tasks.celery_app import app
 
 logger = structlog.get_logger()
 
+_ZOHO_TOKEN_URLS = {
+    "in": "https://accounts.zoho.in/oauth/v2/token",
+    "us": "https://accounts.zoho.com/oauth/v2/token",
+    "eu": "https://accounts.zoho.eu/oauth/v2/token",
+    "au": "https://accounts.zoho.com.au/oauth/v2/token",
+    "jp": "https://accounts.zoho.jp/oauth/v2/token",
+}
+_CONNECTOR_CANONICAL_TOKEN_URLS = {
+    "ga4": "https://oauth2.googleapis.com/token",
+    "gmail": "https://oauth2.googleapis.com/token",
+    "google_ads": "https://oauth2.googleapis.com/token",
+    "google_calendar": "https://oauth2.googleapis.com/token",
+    "youtube": "https://oauth2.googleapis.com/token",
+    "hubspot": "https://api.hubapi.com/oauth/v1/token",
+    "quickbooks": "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer",
+    "banking_aa": "https://aa.finvu.in/api/v1/oauth2/token",
+}
+
+
+def _canonical_refresh_token_url(connector_name: str, creds: dict) -> str | None:
+    name = str(connector_name or "").strip().lower().replace("-", "_")
+    if name == "zoho_books":
+        region = str(creds.get("region") or "in").strip().lower().replace(".", "")
+        aliases = {
+            "india": "in",
+            "in_dc": "in",
+            "global": "us",
+            "us_dc": "us",
+            "europe": "eu",
+            "eu_dc": "eu",
+            "australia": "au",
+            "au_dc": "au",
+            "japan": "jp",
+            "jp_dc": "jp",
+        }
+        return _ZOHO_TOKEN_URLS.get(aliases.get(region, region), _ZOHO_TOKEN_URLS["in"])
+    return _CONNECTOR_CANONICAL_TOKEN_URLS.get(name)
+
 
 @app.task(name="core.tasks.token_refresh.refresh_expiring_tokens")
 def refresh_expiring_tokens() -> dict:
@@ -69,7 +107,7 @@ async def _refresh_all() -> dict:
                 creds = {**(cc.config or {}), **creds}
 
             refresh_token = creds.get("refresh_token", "")
-            token_url = creds.get("token_url", "")
+            token_url = _canonical_refresh_token_url(cc.connector_name, creds)
             client_id = creds.get("client_id", "")
             client_secret = creds.get("client_secret", "")
             expires_at_str = creds.get("expires_at", "")

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -1239,7 +1239,7 @@
     "public_exempt_reason": null,
     "rate_limit": "billing-mutating",
     "scope": "billing.subscription.cancel",
-    "source_line": 711,
+    "source_line": 730,
     "tenant_required": true
   },
   {
@@ -1455,7 +1455,7 @@
     "public_exempt_reason": "plural-hmac-signature-required",
     "rate_limit": "gateway-webhook",
     "scope": "public:billing.webhook.plural",
-    "source_line": 810,
+    "source_line": 829,
     "tenant_required": true
   },
   {
@@ -1473,7 +1473,7 @@
     "public_exempt_reason": "stripe-signature-required",
     "rate_limit": "gateway-webhook",
     "scope": "public:billing.webhook.stripe",
-    "source_line": 778,
+    "source_line": 797,
     "tenant_required": true
   },
   {
@@ -1977,7 +1977,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-runtime-write",
     "scope": "commerce.runtime.artifacts.cache",
-    "source_line": 558,
+    "source_line": 566,
     "tenant_required": true
   },
   {
@@ -1995,7 +1995,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-runtime-external",
     "scope": "commerce.runtime.grantex.authority_request",
-    "source_line": 519,
+    "source_line": 524,
     "tenant_required": true
   },
   {
@@ -2013,7 +2013,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "commerce.runtime.bridges.a2a.read",
-    "source_line": 692,
+    "source_line": 700,
     "tenant_required": true
   },
   {
@@ -2031,7 +2031,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-buyer-session",
     "scope": "commerce.runtime.bridges.openapi.ask",
-    "source_line": 663,
+    "source_line": 671,
     "tenant_required": true
   },
   {
@@ -2049,7 +2049,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "commerce.runtime.bridges.openapi.read",
-    "source_line": 679,
+    "source_line": 687,
     "tenant_required": true
   },
   {
@@ -2067,7 +2067,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "commerce.runtime.bridges.surfaces.read",
-    "source_line": 705,
+    "source_line": 713,
     "tenant_required": true
   },
   {
@@ -2085,7 +2085,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-webhook",
     "scope": "commerce.runtime.bridges.telegram.webhook",
-    "source_line": 746,
+    "source_line": 754,
     "tenant_required": true
   },
   {
@@ -2103,7 +2103,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-buyer-session",
     "scope": "commerce.runtime.bridges.web.ask",
-    "source_line": 647,
+    "source_line": 655,
     "tenant_required": true
   },
   {
@@ -2121,7 +2121,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-webhook",
     "scope": "commerce.runtime.bridges.whatsapp.webhook",
-    "source_line": 718,
+    "source_line": 726,
     "tenant_required": true
   },
   {
@@ -2139,7 +2139,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-buyer-session",
     "scope": "commerce.runtime.buyer_sessions.ask",
-    "source_line": 622,
+    "source_line": 630,
     "tenant_required": true
   },
   {
@@ -2157,7 +2157,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "commerce.runtime.products.read",
-    "source_line": 911,
+    "source_line": 919,
     "tenant_required": true
   },
   {
@@ -2175,7 +2175,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "commerce.runtime.protocol_adapters.read",
-    "source_line": 806,
+    "source_line": 814,
     "tenant_required": true
   },
   {
@@ -2193,7 +2193,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "commerce.runtime.protocol_adapters.read",
-    "source_line": 837,
+    "source_line": 845,
     "tenant_required": true
   },
   {
@@ -2211,7 +2211,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-runtime-external",
     "scope": "commerce.runtime.providers.plural_pine.verify",
-    "source_line": 772,
+    "source_line": 780,
     "tenant_required": true
   },
   {
@@ -2229,7 +2229,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-runtime-write",
     "scope": "commerce.runtime.purchase.prepare",
-    "source_line": 865,
+    "source_line": 873,
     "tenant_required": true
   },
   {
@@ -2247,7 +2247,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-runtime-write",
     "scope": "commerce.runtime.shopify.credentials.write",
-    "source_line": 222,
+    "source_line": 227,
     "tenant_required": true
   },
   {
@@ -2265,7 +2265,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "commerce.runtime.shopify.credentials.read",
-    "source_line": 329,
+    "source_line": 334,
     "tenant_required": true
   },
   {
@@ -2283,7 +2283,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-runtime-write",
     "scope": "commerce.runtime.seller_agents.write",
-    "source_line": 168,
+    "source_line": 173,
     "tenant_required": true
   },
   {
@@ -2301,7 +2301,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "commerce.runtime.seller_agents.read",
-    "source_line": 202,
+    "source_line": 207,
     "tenant_required": true
   },
   {
@@ -2319,7 +2319,7 @@
     "public_exempt_reason": null,
     "rate_limit": "connector-bulk",
     "scope": "commerce.runtime.shopify.sync",
-    "source_line": 371,
+    "source_line": 376,
     "tenant_required": true
   },
   {
@@ -2337,7 +2337,7 @@
     "public_exempt_reason": null,
     "rate_limit": "commerce-webhook",
     "scope": "commerce.runtime.shopify.webhook",
-    "source_line": 439,
+    "source_line": 444,
     "tenant_required": true
   },
   {
@@ -2967,7 +2967,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "connectors.read",
-    "source_line": 880,
+    "source_line": 902,
     "tenant_required": true
   },
   {
@@ -2985,7 +2985,7 @@
     "public_exempt_reason": null,
     "rate_limit": "admin-mutating",
     "scope": "connectors.create",
-    "source_line": 949,
+    "source_line": 971,
     "tenant_required": true
   },
   {
@@ -3003,7 +3003,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "connectors.read",
-    "source_line": 1112,
+    "source_line": 1136,
     "tenant_required": true
   },
   {
@@ -3021,7 +3021,7 @@
     "public_exempt_reason": null,
     "rate_limit": "admin-mutating",
     "scope": "connectors.create",
-    "source_line": 1173,
+    "source_line": 1197,
     "tenant_required": true
   },
   {
@@ -3039,7 +3039,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "connectors.contracts.read",
-    "source_line": 747,
+    "source_line": 769,
     "tenant_required": true
   },
   {
@@ -3129,7 +3129,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "connectors.registry.read",
-    "source_line": 687,
+    "source_line": 709,
     "tenant_required": false
   },
   {
@@ -3165,7 +3165,7 @@
     "public_exempt_reason": null,
     "rate_limit": "admin-mutating",
     "scope": "connectors.delete",
-    "source_line": 1608,
+    "source_line": 1659,
     "tenant_required": true
   },
   {
@@ -3183,7 +3183,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "connectors.read",
-    "source_line": 1354,
+    "source_line": 1378,
     "tenant_required": true
   },
   {
@@ -3201,7 +3201,7 @@
     "public_exempt_reason": null,
     "rate_limit": "admin-mutating",
     "scope": "connectors.update",
-    "source_line": 1393,
+    "source_line": 1417,
     "tenant_required": true
   },
   {
@@ -3219,7 +3219,7 @@
     "public_exempt_reason": null,
     "rate_limit": "connector-test",
     "scope": "connectors.health.read",
-    "source_line": 1641,
+    "source_line": 1692,
     "tenant_required": true
   },
   {
@@ -3237,7 +3237,7 @@
     "public_exempt_reason": null,
     "rate_limit": "connector-test",
     "scope": "connectors.test",
-    "source_line": 1696,
+    "source_line": 1747,
     "tenant_required": true
   },
   {
@@ -5379,7 +5379,7 @@
     "public_exempt_reason": null,
     "rate_limit": "security-admin-write",
     "scope": "sso.config.write",
-    "source_line": 390,
+    "source_line": 398,
     "tenant_required": true
   },
   {
@@ -5415,7 +5415,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "tenant_ai_credentials.secrets.sensitive.list",
-    "source_line": 161,
+    "source_line": 173,
     "tenant_required": true
   },
   {
@@ -5433,7 +5433,7 @@
     "public_exempt_reason": null,
     "rate_limit": "credential-write",
     "scope": "tenant_ai_credentials.secrets.write",
-    "source_line": 188,
+    "source_line": 200,
     "tenant_required": true
   },
   {
@@ -5451,7 +5451,7 @@
     "public_exempt_reason": null,
     "rate_limit": "credential-write",
     "scope": "tenant_ai_credentials.secrets.write",
-    "source_line": 347,
+    "source_line": 368,
     "tenant_required": true
   },
   {
@@ -5469,7 +5469,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "tenant_ai_credentials.secrets.sensitive.read",
-    "source_line": 248,
+    "source_line": 261,
     "tenant_required": true
   },
   {
@@ -5487,7 +5487,7 @@
     "public_exempt_reason": null,
     "rate_limit": "credential-write",
     "scope": "tenant_ai_credentials.secrets.write",
-    "source_line": 280,
+    "source_line": 293,
     "tenant_required": true
   },
   {
@@ -5505,7 +5505,7 @@
     "public_exempt_reason": null,
     "rate_limit": "external-provider-check",
     "scope": "tenant_ai_credentials.secrets.test",
-    "source_line": 389,
+    "source_line": 410,
     "tenant_required": true
   },
   {
@@ -5577,7 +5577,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "connectors.tools.read",
-    "source_line": 803,
+    "source_line": 825,
     "tenant_required": false
   },
   {

--- a/tests/connector_harness/test_connector_errors.py
+++ b/tests/connector_harness/test_connector_errors.py
@@ -16,10 +16,11 @@ class TestConnectorErrorHandling:
     async def test_http_500_raises(self, mock_server_url):
         """HTTP 500 from external service raises an error."""
         connector = await make_connector("stripe", mock_server_url)
-        # Override base_url to error path
+        transport = httpx.MockTransport(lambda request: httpx.Response(500, request=request))
         connector._client = httpx.AsyncClient(
-            base_url=f"{mock_server_url}/error/500",
+            base_url="https://api.stripe.com",
             timeout=10.0,
+            transport=transport,
         )
         with pytest.raises(httpx.HTTPStatusError):
             await connector.execute_tool("create_payment_intent", {"amount": 1000, "currency": "usd"})
@@ -27,9 +28,11 @@ class TestConnectorErrorHandling:
     async def test_http_429_raises(self, mock_server_url):
         """HTTP 429 rate limit from external service raises an error."""
         connector = await make_connector("hubspot", mock_server_url)
+        transport = httpx.MockTransport(lambda request: httpx.Response(429, request=request))
         connector._client = httpx.AsyncClient(
-            base_url=f"{mock_server_url}/error/429",
+            base_url="https://api.hubapi.com",
             timeout=10.0,
+            transport=transport,
         )
         with pytest.raises(httpx.HTTPStatusError):
             await connector.execute_tool("create_contact", {"email": "test@test.com"})

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -320,10 +320,10 @@ class TestConnectorRegistration:
         return {
             "name": f"oracle-fusion-{uuid.uuid4().hex[:8]}",
             "category": "erp",
-            "base_url": "https://oracle.example.com/api/v1",
+            "base_url": "https://www.oracle.com/api/v1",
             "auth_type": "oauth2",
             "auth_config": {
-                "token_url": "https://oracle.example.com/oauth/token",
+                "token_url": "https://www.oracle.com/oauth/token",
                 "grant_type": "client_credentials",
             },
             "secret_ref": "vault://secrets/oracle-fusion-creds",
@@ -627,7 +627,7 @@ class TestFullPipeline:
             json={
                 "name": "tally-prime-test",
                 "category": "accounting",
-                "base_url": "https://tally.example.com/api",
+                "base_url": "https://tallysolutions.com/api",
                 "auth_type": "api_key",
                 "auth_config": {"header": "X-API-Key"},
                 "secret_ref": "vault://secrets/tally-key",

--- a/tests/regression/test_security_audit_20260419_high.py
+++ b/tests/regression/test_security_audit_20260419_high.py
@@ -183,10 +183,14 @@ def test_medium12_base_url_blocks_private():
 
     with pytest.raises(HTTPException) as excinfo:
         _assert_public_base_url("http://127.0.0.1:8080")
+    assert excinfo.value.status_code == 400
+
+    with pytest.raises(HTTPException) as excinfo:
+        _assert_public_base_url("https://127.0.0.1:8080")
     assert excinfo.value.status_code == 403
 
     with pytest.raises(HTTPException) as excinfo:
-        _assert_public_base_url("http://169.254.169.254/latest/meta-data/")
+        _assert_public_base_url("https://169.254.169.254/latest/meta-data/")
     assert excinfo.value.status_code == 403
 
     with pytest.raises(HTTPException) as excinfo:

--- a/tests/regression/test_vvah_security_hardening.py
+++ b/tests/regression/test_vvah_security_hardening.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+
+def test_shared_egress_guard_blocks_ip_literals_and_private_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    from core.security.egress import EgressValidationError, validate_public_url
+
+    monkeypatch.delenv("AGENTICORG_ENV", raising=False)
+    monkeypatch.delenv("ENV", raising=False)
+    with pytest.raises(EgressValidationError, match="ip_literal"):
+        validate_public_url("https://169.254.169.254/latest/meta-data", allowed_schemes=("https",))
+
+    monkeypatch.setattr(
+        "core.security.egress.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [(None, None, None, "", ("10.0.0.5", 443))],
+    )
+    with pytest.raises(EgressValidationError, match="blocked_ip"):
+        validate_public_url("https://tenant-controlled.example")
+
+
+@pytest.mark.asyncio
+async def test_pinned_dns_backend_connects_to_validated_ip(monkeypatch: pytest.MonkeyPatch) -> None:
+    from core.security.egress import EgressValidationError, PinnedDnsAsyncNetworkBackend
+
+    seen: list[str] = []
+
+    class Delegate:
+        async def connect_tcp(self, host: str, *_args, **_kwargs):
+            seen.append(host)
+            return object()
+
+        async def sleep(self, _seconds: float) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "core.security.egress.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [(None, None, None, "", ("93.184.216.34", 443))],
+    )
+    backend = PinnedDnsAsyncNetworkBackend(require_dns=True, delegate=Delegate())
+
+    await backend.connect_tcp("tenant-controlled.example", 443)
+
+    assert seen == ["93.184.216.34"]
+
+    monkeypatch.setattr(
+        "core.security.egress.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [(None, None, None, "", ("10.0.0.5", 443))],
+    )
+    with pytest.raises(EgressValidationError, match="blocked_ip"):
+        await backend.connect_tcp("tenant-controlled.example", 443)
+
+
+def test_shopify_runtime_rejects_non_shopify_admin_domains() -> None:
+    from api.v1 import commerce_runtime as commerce_runtime_api
+
+    with pytest.raises(HTTPException, match="myshopify"):
+        commerce_runtime_api._normalize_shopify_domain_for_api("https://169.254.169.254")
+
+    with pytest.raises(HTTPException, match="myshopify"):
+        commerce_runtime_api._normalize_shopify_domain_for_api("attacker.example.com")
+
+    with pytest.raises(HTTPException, match="myshopify"):
+        commerce_runtime_api._normalize_shopify_domain_for_api("myshopify.com")
+
+    assert (
+        commerce_runtime_api._normalize_shopify_domain_for_api("Good-Shop.myshopify.com/")
+        == "good-shop.myshopify.com"
+    )
+
+
+@pytest.mark.asyncio
+async def test_shopify_graphql_client_blocks_unsafe_domain_before_network() -> None:
+    from core.commerce.c6z_runtime_vertical import (
+        C6ZRuntimeValidationError,
+        ShopifyAdminGraphQLClient,
+        ShopifyCredentials,
+    )
+
+    client = ShopifyAdminGraphQLClient(
+        ShopifyCredentials(
+            shop_domain="169.254.169.254",
+            admin_access_token="shpat_redacted_fixture",
+            api_version="2026-04",
+        ),
+        transport=httpx.MockTransport(lambda _request: httpx.Response(200, json={})),
+    )
+    with pytest.raises(C6ZRuntimeValidationError, match="unsafe Shopify"):
+        await client.fetch_products(page_size=1, max_pages=1)
+
+
+@pytest.mark.asyncio
+async def test_oidc_discovery_rejects_rewritten_jwks_host() -> None:
+    from auth.sso.oidc import OIDCProvider
+
+    provider = OIDCProvider(
+        provider_key="okta_test",
+        config={
+            "issuer": "https://example.com",
+            "client_id": "client-abc",
+            "client_secret": "shhh",
+            "redirect_uri": "https://app.example.com/api/v1/auth/sso/okta_test/callback",
+            "scopes": ["openid", "profile", "email"],
+        },
+    )
+    discovery_doc = {
+        "issuer": "https://example.com",
+        "authorization_endpoint": "https://example.com/oauth2/v1/authorize",
+        "token_endpoint": "https://example.com/oauth2/v1/token",
+        "jwks_uri": "https://169.254.169.254/latest/meta-data",
+    }
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        client_ctx = mock_client_cls.return_value.__aenter__.return_value
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json = MagicMock(return_value=discovery_doc)
+        client_ctx.get = AsyncMock(return_value=response)
+        with pytest.raises(ValueError, match="jwks_uri"):
+            await provider.prepare()
+
+
+def test_tenant_ai_provider_config_blocks_bearer_exfiltration_targets() -> None:
+    from api.v1 import tenant_ai_credentials as creds_api
+
+    with pytest.raises(HTTPException, match="api.openai.com"):
+        creds_api._validate_provider_config("openai", {"base_url": "https://attacker.example.com"})
+
+    with pytest.raises(HTTPException, match="HTTPS public"):
+        creds_api._validate_provider_config("openai_compatible", {"base_url": "http://127.0.0.1:8000"})
+
+    with pytest.raises(HTTPException, match="must not contain secrets"):
+        creds_api._validate_provider_config(
+            "openai_compatible",
+            {"base_url": "https://example.com", "api_key": "sk-leak"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_base_connector_validates_actual_request_url_before_send() -> None:
+    from connectors.framework.base_connector import BaseConnector, _validate_connector_egress_url
+
+    class StubConnector(BaseConnector):
+        name = "stub"
+        base_url = "https://example.com"
+
+        def _register_tools(self) -> None:
+            return None
+
+        async def _authenticate(self) -> None:
+            return None
+
+    connector = StubConnector()
+    await connector.connect()
+    try:
+        assert connector._client is not None
+        with pytest.raises(ValueError, match="Connector egress URL"):
+            await connector._client.get("http://169.254.169.254/latest/meta-data")
+        with pytest.raises(ValueError, match="Connector egress URL"):
+            await connector._get("http://169.254.169.254/latest/meta-data")
+        with pytest.raises(ValueError, match="Connector egress URL"):
+            _validate_connector_egress_url("http://example.com", connector_name="stub", require_dns=False)
+    finally:
+        await connector.disconnect()
+
+
+def test_connector_retry_paths_do_not_recreate_raw_httpx_clients() -> None:
+    repo = Path(__file__).resolve().parents[2]
+    offenders = []
+    for path in (repo / "connectors").rglob("*.py"):
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if "self._client = httpx.AsyncClient" in text:
+            offenders.append(str(path.relative_to(repo)))
+
+    assert offenders == []
+
+
+def test_provider_specific_host_builders_reject_ssrf_hosts() -> None:
+    from connectors.finance.aa_consent import AAConsentManager
+    from connectors.finance.oracle_fusion import OracleFusionConnector
+    from connectors.marketing.mailchimp import MailchimpConnector
+    from connectors.marketing.moengage import MoEngageConnector
+    from connectors.ops.jira import JiraConnector
+
+    with pytest.raises(ValueError, match="Finvu"):
+        AAConsentManager(base_url="https://169.254.169.254/api/v1")
+    with pytest.raises(ValueError, match="Finvu"):
+        AAConsentManager(base_url="https://attacker.example/api/v1")
+    assert AAConsentManager().base_url == "https://aa.finvu.in/api/v1"
+
+    with pytest.raises(ValueError, match="Oracle Fusion instance"):
+        OracleFusionConnector({"instance": "169.254.169.254"})
+    assert (
+        OracleFusionConnector({"instance": "tenant1"}).base_url
+        == "https://tenant1.oraclecloud.com/fscmRestApi/resources/11.13.18.05"
+    )
+    with pytest.raises(ValueError, match="Mailchimp data center"):
+        MailchimpConnector({"api_key": "fixture", "dc": "us21.evil"})
+    with pytest.raises(ValueError, match="MoEngage datacenter"):
+        MoEngageConnector({"datacenter": "01.evil"})
+    with pytest.raises(ValueError, match="Jira domain"):
+        JiraConnector({"domain": "tenant.atlassian.net.evil"})
+
+
+def test_fixed_provider_connectors_ignore_untrusted_base_url_overrides() -> None:
+    from connectors.comms.gmail import GmailConnector
+    from connectors.comms.google_calendar import GoogleCalendarConnector
+    from connectors.comms.slack import SlackConnector
+    from connectors.comms.twilio import TwilioConnector
+    from connectors.comms.whatsapp import WhatsappConnector
+    from connectors.comms.youtube import YouTubeConnector
+    from connectors.finance.netsuite import NetsuiteConnector
+    from connectors.finance.quickbooks import QuickbooksConnector
+    from connectors.hr.docusign import DocuSignConnector
+    from connectors.hr.okta import OktaConnector
+    from connectors.marketing.ga4 import GA4Connector
+    from connectors.marketing.google_ads import GoogleAdsConnector
+    from connectors.marketing.hubspot import HubspotConnector
+    from connectors.marketing.linkedin_ads import LinkedinAdsConnector
+    from connectors.marketing.mailchimp import MailchimpConnector
+    from connectors.marketing.meta_ads import MetaAdsConnector
+    from connectors.marketing.moengage import MoEngageConnector
+    from connectors.marketing.salesforce import SalesforceConnector
+    from connectors.ops.jira import JiraConnector
+    from connectors.ops.pagerduty import PagerdutyConnector
+    from connectors.ops.zendesk import ZendeskConnector
+
+    attacker = {"base_url": "https://attacker.example"}
+    cases = [
+        (HubspotConnector(attacker), "https://api.hubapi.com"),
+        (GmailConnector(attacker), "https://gmail.googleapis.com/gmail/v1"),
+        (GoogleCalendarConnector(attacker), "https://www.googleapis.com/calendar/v3"),
+        (YouTubeConnector(attacker), "https://www.googleapis.com/youtube/v3"),
+        (QuickbooksConnector(attacker), "https://quickbooks.api.intuit.com/v3"),
+        (SalesforceConnector(attacker), "https://org.my.salesforce.com/services/data/v60.0"),
+        (GA4Connector(attacker), "https://analyticsdata.googleapis.com/v1beta"),
+        (GoogleAdsConnector(attacker), "https://googleads.googleapis.com/v24"),
+        (LinkedinAdsConnector(attacker), "https://api.linkedin.com/rest"),
+        (MetaAdsConnector(attacker), "https://graph.facebook.com/v21.0"),
+        (TwilioConnector(attacker), "https://api.twilio.com/2010-04-01"),
+        (WhatsappConnector(attacker), "https://graph.facebook.com/v21.0"),
+        (SlackConnector(attacker), "https://slack.com/api"),
+        (DocuSignConnector(attacker), "https://na4.docusign.net/restapi/v2.1"),
+        (OktaConnector(attacker), "https://org.okta.com/api/v1"),
+        (OktaConnector({"base_url": "https://tenant1.okta.com/api/v1"}), "https://tenant1.okta.com/api/v1"),
+        (PagerdutyConnector(attacker), "https://api.pagerduty.com"),
+        (ZendeskConnector(attacker), "https://org.zendesk.com/api/v2"),
+        (ZendeskConnector({"base_url": "https://tenant1.zendesk.com/api/v2"}), "https://tenant1.zendesk.com/api/v2"),
+        (MailchimpConnector({**attacker, "api_key": "fixture-us21"}), "https://us21.api.mailchimp.com/3.0"),
+        (MoEngageConnector({**attacker, "datacenter": "02"}), "https://api-02.moengage.com/v1"),
+        (JiraConnector({**attacker, "domain": "tenant1"}), "https://tenant1.atlassian.net"),
+        (
+            NetsuiteConnector({**attacker, "account_id": "TSTDRV.1234.567"}),
+            "https://tstdrv_1234_567.suitetalk.api.netsuite.com/services/rest/record/v1",
+        ),
+    ]
+
+    for connector, expected_base_url in cases:
+        assert connector.base_url == expected_base_url
+
+    with pytest.raises(ValueError, match="NetSuite account_id"):
+        NetsuiteConnector({"account_id": "tenant/evil"})
+
+
+@pytest.mark.asyncio
+async def test_tally_bridge_url_is_guarded_https_egress() -> None:
+    from connectors.finance.tally import TallyBridgeError, TallyConnector
+
+    connector = TallyConnector(
+        {
+            "bridge_url": "http://169.254.169.254/bridge",
+            "bridge_id": "bridge-1",
+            "bridge_token": "secret-token",
+        }
+    )
+
+    with pytest.raises(TallyBridgeError, match="public HTTPS"):
+        await connector._send_via_bridge("<ENVELOPE />")
+
+
+def test_byo_ai_endpoint_changes_require_key_rotation_and_oauth_base_url_is_canonical() -> None:
+    from api.v1 import connectors as connectors_api
+
+    repo = Path(__file__).resolve().parents[2]
+    tenant_ai_src = (repo / "api" / "v1" / "tenant_ai_credentials.py").read_text(encoding="utf-8")
+    oauth_src = (repo / "api" / "v1" / "oauth_connector.py").read_text(encoding="utf-8")
+    sso_src = (repo / "api" / "v1" / "sso.py").read_text(encoding="utf-8")
+    connectors_src = (repo / "api" / "v1" / "connectors.py").read_text(encoding="utf-8")
+
+    assert "Changing provider_config.base_url requires rotating api_key" in tenant_ai_src
+    assert "current_base_url != next_base_url and body.api_key is None" in tenant_ai_src
+    assert "base_url = fallback_base" in oauth_src
+    assert "payload.get(\"base_url\") or fallback_base" not in oauth_src
+    assert 'target.startswith("//")' in sso_src
+    assert "_CONNECTOR_RETARGET_KEYS" in connectors_src
+    assert "Changing connector endpoint/host requires rotating credentials" in connectors_src
+    assert "new_secret_keys.intersection(_CONNECTOR_CREDENTIAL_ROTATION_KEYS)" in connectors_src
+    assert "Endpoint/host changes are a credential boundary" in connectors_src
+    assert "if not retarget_requested and cc and cc.credentials_encrypted" in connectors_src
+    assert "bridge_url" in connectors_api._CONNECTOR_RETARGET_KEYS
+    assert "bridge_token" in connectors_api._CONNECTOR_CREDENTIAL_ROTATION_KEYS
+    assert "build_pinned_async_transport(require_dns=True)" in (
+        repo / "connectors" / "framework" / "base_connector.py"
+    ).read_text(encoding="utf-8")
+    assert "transport=build_pinned_async_transport(require_dns=True)" in (
+        repo / "connectors" / "finance" / "tally.py"
+    ).read_text(encoding="utf-8")
+    assert "username" not in connectors_api._CONNECTOR_CREDENTIAL_ROTATION_KEYS
+    assert not connectors_api._canonicalize_connector_secret_urls(
+        "sendgrid",
+        connectors_api._clean_auth_config({"username": ""}),
+    )
+    assert not connectors_api._canonicalize_connector_secret_urls("hubspot", {})
+
+
+def test_wordpress_site_normalization_does_not_silently_retarget_over_site() -> None:
+    from connectors.marketing.wordpress import WordpressConnector
+
+    connector = WordpressConnector(
+        {
+            "base_url": "https://attacker.example/wp-json/wp/v2",
+            "site": "merchant.example",
+        }
+    )
+    assert connector.base_url == "https://merchant.example/wp-json/wp/v2"
+
+    with pytest.raises(ValueError, match="WordPress site"):
+        WordpressConnector({"site": "http://merchant.example"})
+
+
+def test_connector_refresh_urls_are_canonical_not_user_supplied() -> None:
+    from api.v1 import connectors as connectors_api
+    from core.tasks import token_refresh
+
+    cleaned = connectors_api._canonicalize_connector_secret_urls(
+        "hubspot",
+        {
+            "refresh_token": "refresh-fixture",
+            "client_id": "client",
+            "client_secret": "secret",
+            "token_url": "https://attacker.example/token",
+            "base_url": "https://attacker.example",
+            "api_base_url": "https://attacker.example/api",
+        },
+    )
+    assert cleaned["token_url"] == "https://api.hubapi.com/oauth/v1/token"
+    assert "base_url" not in cleaned
+    assert "api_base_url" not in cleaned
+
+    assert (
+        token_refresh._canonical_refresh_token_url("hubspot", {"token_url": "https://attacker.example/token"})
+        == "https://api.hubapi.com/oauth/v1/token"
+    )
+    assert (
+        token_refresh._canonical_refresh_token_url("zoho_books", {"region": "eu", "token_url": "https://evil.test"})
+        == "https://accounts.zoho.eu/oauth/v2/token"
+    )
+    assert token_refresh._canonical_refresh_token_url("custom_oauth", {"token_url": "https://evil.test"}) is None
+
+
+@pytest.mark.asyncio
+async def test_plural_order_status_is_bound_to_authenticated_tenant(monkeypatch: pytest.MonkeyPatch) -> None:
+    from api.v1 import billing
+    from core.billing import pinelabs_client
+
+    pinelabs_client._order_map.clear()
+    pinelabs_client._order_id_map.clear()
+    monkeypatch.setattr(pinelabs_client.settings, "env", "development")
+    monkeypatch.setattr(pinelabs_client, "_redis_client", lambda: None)
+    pinelabs_client.store_order_mapping("aoabc", "v1-order-tenant-a", "tenant-a", "pro")
+    monkeypatch.setattr(
+        pinelabs_client,
+        "get_order_status",
+        lambda _order_id: {
+            "order_id": "v1-order-tenant-a",
+            "merchant_order_reference": "aoabc",
+            "status": "PROCESSED",
+        },
+    )
+
+    allowed = await billing.check_order_status(
+        billing.OrderStatusRequest(order_id="v1-order-tenant-a"),
+        tenant_id="tenant-a",
+    )
+    assert allowed["status"] == "PROCESSED"
+    assert allowed["tenant_id"] == "tenant-a"
+
+    with pytest.raises(HTTPException) as exc_info:
+        await billing.check_order_status(
+            billing.OrderStatusRequest(order_id="v1-order-tenant-a"),
+            tenant_id="tenant-b",
+        )
+    assert exc_info.value.status_code == 404

--- a/tests/unit/test_oacp_c6z_runtime_vertical.py
+++ b/tests/unit/test_oacp_c6z_runtime_vertical.py
@@ -341,6 +341,24 @@ def test_grantex_authority_payload_matches_issuer_contract() -> None:
     assert payload["connector_evidence"]["no_public_discovery_enablement"] is True
 
 
+def test_grantex_authority_payload_enforces_authenticated_tenant_scope() -> None:
+    packet = _packet()
+    evidence = build_shopify_connector_evidence(
+        packet=packet,
+        products=[_shopify_product()],
+        synced_at=_iso(_now()),
+        source_observed_at=_iso(_now()),
+        currency="INR",
+    )
+
+    with pytest.raises(C6ZRuntimeValidationError, match="authenticated tenant"):
+        build_grantex_authority_request_payload(
+            onboarding_packet=packet,
+            connector_evidence=evidence,
+            expected_tenant_id="22222222-2222-2222-2222-222222222222",
+        )
+
+
 @pytest.mark.asyncio
 async def test_onboarding_packet_read_enforces_tenant_boundary(monkeypatch: pytest.MonkeyPatch) -> None:
     @asynccontextmanager
@@ -356,6 +374,32 @@ async def test_onboarding_packet_read_enforces_tenant_boundary(monkeypatch: pyte
     with pytest.raises(HTTPException) as exc_info:
         await commerce_runtime_api.get_seller_onboarding_packet(
             "packet_1",
+            tenant_id="11111111-1111-1111-1111-111111111111",
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_grantex_authority_request_enforces_tenant_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    @asynccontextmanager
+    async def fake_session(_tenant_id):
+        class FakeSession:
+            async def get(self, _model, _row_id):
+                return SimpleNamespace(tenant_id="22222222-2222-2222-2222-222222222222")
+
+        yield FakeSession()
+
+    monkeypatch.setattr(commerce_runtime_api, "get_tenant_session", fake_session)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await commerce_runtime_api.request_grantex_authority_artifacts(
+            commerce_runtime_api.GrantexAuthorityRequest(
+                packet_id="packet_1",
+                evidence_id="evidence_1",
+            ),
             tenant_id="11111111-1111-1111-1111-111111111111",
         )
 

--- a/tests/unit/test_oidc_provider.py
+++ b/tests/unit/test_oidc_provider.py
@@ -54,7 +54,7 @@ def _make_provider() -> OIDCProvider:
     return OIDCProvider(
         provider_key="okta_test",
         config={
-            "issuer": "https://example.okta.com",
+            "issuer": "https://example.com",
             "client_id": "client-abc",
             "client_secret": "shhh",
             "redirect_uri": "https://app.example.com/api/v1/auth/sso/okta_test/callback",
@@ -69,10 +69,10 @@ class TestOIDCProviderAuthorize:
         provider = _make_provider()
 
         discovery_doc = {
-            "issuer": "https://example.okta.com",
-            "authorization_endpoint": "https://example.okta.com/oauth2/v1/authorize",
-            "token_endpoint": "https://example.okta.com/oauth2/v1/token",
-            "jwks_uri": "https://example.okta.com/oauth2/v1/keys",
+            "issuer": "https://example.com",
+            "authorization_endpoint": "https://example.com/oauth2/v1/authorize",
+            "token_endpoint": "https://example.com/oauth2/v1/token",
+            "jwks_uri": "https://example.com/oauth2/v1/keys",
         }
         jwks_doc = {"keys": []}
 
@@ -94,7 +94,7 @@ class TestOIDCProviderAuthorize:
     async def test_build_authorize_url_includes_pkce_and_state(self):
         provider = _make_provider()
         provider._discovery = {
-            "authorization_endpoint": "https://example.okta.com/oauth2/v1/authorize",
+            "authorization_endpoint": "https://example.com/oauth2/v1/authorize",
         }
         verifier, challenge = new_pkce_pair()
         state = new_state()
@@ -102,7 +102,7 @@ class TestOIDCProviderAuthorize:
 
         url = provider.build_authorize_url(state, nonce, challenge)
 
-        assert url.startswith("https://example.okta.com/oauth2/v1/authorize?")
+        assert url.startswith("https://example.com/oauth2/v1/authorize?")
         assert "client_id=client-abc" in url
         assert "response_type=code" in url
         assert f"state={state}" in url
@@ -128,9 +128,9 @@ class TestOIDCCodeExchange:
     async def test_exchange_code_calls_token_endpoint_and_verifies_id_token(self):
         provider = _make_provider()
         provider._discovery = {
-            "token_endpoint": "https://example.okta.com/oauth2/v1/token",
-            "jwks_uri": "https://example.okta.com/oauth2/v1/keys",
-            "issuer": "https://example.okta.com",
+            "token_endpoint": "https://example.com/oauth2/v1/token",
+            "jwks_uri": "https://example.com/oauth2/v1/keys",
+            "issuer": "https://example.com",
         }
 
         # We replace _verify_id_token entirely so we don't need real
@@ -165,7 +165,7 @@ class TestOIDCCodeExchange:
 
         # Verify the POST body had grant_type=authorization_code
         call = client_ctx.post.await_args
-        assert call.args[0] == "https://example.okta.com/oauth2/v1/token"
+        assert call.args[0] == "https://example.com/oauth2/v1/token"
         body = call.kwargs["data"]
         assert body["grant_type"] == "authorization_code"
         assert body["code"] == "auth-code-xyz"
@@ -175,7 +175,7 @@ class TestOIDCCodeExchange:
     async def test_exchange_code_rejects_missing_id_token(self):
         provider = _make_provider()
         provider._discovery = {
-            "token_endpoint": "https://example.okta.com/oauth2/v1/token",
+            "token_endpoint": "https://example.com/oauth2/v1/token",
         }
         with patch("httpx.AsyncClient") as mock_client_cls:
             client_ctx = mock_client_cls.return_value.__aenter__.return_value

--- a/tests/unit/test_process_local_state_hardening.py
+++ b/tests/unit/test_process_local_state_hardening.py
@@ -42,6 +42,7 @@ def test_pinelabs_order_mapping_fails_closed_in_strict_runtime(monkeypatch) -> N
     from core.billing import pinelabs_client
 
     pinelabs_client._order_map.clear()
+    pinelabs_client._order_id_map.clear()
     monkeypatch.setattr(pinelabs_client.settings, "env", "production")
     monkeypatch.setattr(pinelabs_client, "_redis_client", lambda: None)
 
@@ -57,6 +58,7 @@ def test_pinelabs_order_mapping_relaxed_runtime_uses_memory_fallback(monkeypatch
     from core.billing import pinelabs_client
 
     pinelabs_client._order_map.clear()
+    pinelabs_client._order_id_map.clear()
     monkeypatch.setattr(pinelabs_client.settings, "env", "development")
     monkeypatch.setattr(pinelabs_client, "_redis_client", lambda: None)
 
@@ -67,7 +69,14 @@ def test_pinelabs_order_mapping_relaxed_runtime_uses_memory_fallback(monkeypatch
         "tenant_id": "tenant-2",
         "plan": "enterprise",
     }
+    assert pinelabs_client.lookup_order_details_by_order_id("order-2") == {
+        "merchant_order_reference": "merchant-2",
+        "order_id": "order-2",
+        "tenant_id": "tenant-2",
+        "plan": "enterprise",
+    }
     pinelabs_client._order_map.clear()
+    pinelabs_client._order_id_map.clear()
 
 
 def test_chat_sessions_fail_closed_in_strict_runtime_without_redis(monkeypatch) -> None:

--- a/tests/unit/test_production_components.py
+++ b/tests/unit/test_production_components.py
@@ -145,7 +145,7 @@ class TestTallyConnectorBridgeRouting:
         from connectors.finance.tally import TallyConnector
 
         connector = TallyConnector(config={
-            "bridge_url": "http://cloud/api/v1/bridge/route/tally",
+            "bridge_url": "https://example.com/api/v1/bridge/route/tally",
             "bridge_id": "bridge-123",
             "bridge_token": "token-456",
         })
@@ -169,7 +169,7 @@ class TestTallyConnectorBridgeRouting:
         from connectors.finance.tally import TallyConnector
 
         connector = TallyConnector(config={
-            "bridge_url": "http://cloud/api/v1/bridge/route/tally",
+            "bridge_url": "https://example.com/api/v1/bridge/route/tally",
             "bridge_id": "bridge-123",
             "bridge_token": "token-456",
         })
@@ -191,7 +191,7 @@ class TestTallyConnectorBridgeRouting:
         from connectors.finance.tally import TallyConnector
 
         connector = TallyConnector(config={
-            "bridge_url": "http://cloud/api/v1/bridge/route/tally",
+            "bridge_url": "https://example.com/api/v1/bridge/route/tally",
             "bridge_id": "bridge-123",
             "bridge_token": "token-456",
         })

--- a/tests/unit/test_tally_connector_health_and_errors.py
+++ b/tests/unit/test_tally_connector_health_and_errors.py
@@ -85,7 +85,7 @@ class TestTallyHealthCheckBridge:
         405 every time because Tally only accepts POST. TallyConnector
         must override and send an XML POST instead."""
         connector = TallyConnector({
-            "bridge_url": "http://bridge.test/api",
+            "bridge_url": "https://example.com/api",
             "bridge_id": "bid-1",
             "bridge_token": "tok-1",
         })
@@ -133,7 +133,7 @@ class TestTallyHealthCheckBridge:
     @pytest.mark.asyncio
     async def test_bridge_http_error_surfaces_durable_request_metadata(self) -> None:
         connector = TallyConnector({
-            "bridge_url": "http://bridge.test/api",
+            "bridge_url": "https://example.com/api",
             "bridge_id": "bid-1",
             "bridge_token": "tok-1",
         })


### PR DESCRIPTION
## Summary
- Add shared outbound egress validation and DNS-pinned httpx transport for tenant-influenced destinations.
- Harden connector, OAuth/OIDC, BYO AI provider, Shopify/OACP, Plural/Pine, and Tally bridge egress paths against SSRF, DNS rebinding, and credential exfiltration by retargeting.
- Enforce tenant scope on Grantex authority requests and Pine Labs order-status lookups.
- Add VVAH-style regression coverage for egress, connector retargeting, OIDC, Shopify/OACP, Tally bridge, and billing tenant isolation.

## Validation
- python -m pytest tests\\regression\\test_vvah_security_hardening.py tests\\unit\\test_oacp_c6z_runtime_vertical.py --no-cov -q
- python -m pytest tests\\regression\\test_codeql_connector_ssrf_hardening.py tests\\unit\\test_connector_real_paths.py tests\\regression\\test_celery_runtime_wrappers.py tests\\regression\\test_s009_byo_tokens.py tests\\unit\\test_oacp_c6z_runtime_vertical.py tests\\unit\\test_production_components.py tests\\unit\\test_billing.py tests\\unit\\test_process_local_state_hardening.py tests\\unit\\test_oidc_provider.py tests\\unit\\test_enterprise_stability_gates.py tests\\unit\\test_v490_reqs.py --no-cov -q
- python -m ruff check <changed files>
- python -m mypy --follow-imports=skip <changed source files>
- git diff --check
- codex exec --model gpt-5.5 security rereview: No concrete exploitable findings found.

## Notes
- Visa VVAH was used for harness setup/sizing and threat-model guidance; its scanner backend does not expose Codex CLI directly, so the actual review pass was forced through Codex CLI with model gpt-5.5.