### PR TITLE
[codex] Allow CMO setup flows without admin

### DIFF
--- a/api/v1/connectors.py
+++ b/api/v1/connectors.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
-from api.deps import get_current_tenant, require_tenant_admin
+from api.deps import get_current_tenant, require_scope, require_tenant_admin
 from api.route_metadata import route_meta
 from core.database import get_tenant_session
 from core.marketing.connector_contracts import evaluate_hubspot_crm_read_contract
@@ -655,7 +655,7 @@ def _assert_public_base_url(base_url: str) -> None:
             "reserved, unspecified, and direct-IP destinations are not allowed.",
         ) from exc
 
-router = APIRouter(dependencies=[require_tenant_admin])
+router = APIRouter()
 
 
 def _connector_to_dict(conn: Connector, has_encrypted_credentials: bool | None = None) -> dict:
@@ -697,7 +697,7 @@ def _connector_to_dict(conn: Connector, has_encrypted_credentials: bool | None =
 
 
 # ── GET /connectors/registry ────────────────────────────────────────────────
-@router.get("/connectors/registry")
+@router.get("/connectors/registry", dependencies=[require_scope("connectors.registry.read")])
 @route_meta(
     auth_required=True,
     tenant_required=False,
@@ -757,7 +757,7 @@ async def list_registry_connectors(category: str | None = None):
     return {"items": items, "total": len(items)}
 
 
-@router.get("/connectors/contracts/marketing")
+@router.get("/connectors/contracts/marketing", dependencies=[require_scope("connectors.contracts.read")])
 @route_meta(
     auth_required=True,
     tenant_required=True,
@@ -813,7 +813,7 @@ async def marketing_connector_contracts(
 
 
 # ── GET /tools — Function-level tool names ─────────────────────────────────
-@router.get("/tools")
+@router.get("/tools", dependencies=[require_scope("connectors.tools.read")])
 @route_meta(
     auth_required=True,
     tenant_required=False,
@@ -890,7 +890,7 @@ async def list_tools(
 
 
 # ── GET /connectors ─────────────────────────────────────────────────────────
-@router.get("/connectors")
+@router.get("/connectors", dependencies=[require_scope("connectors.read")])
 @route_meta(
     auth_required=True,
     tenant_required=True,
@@ -959,7 +959,7 @@ async def list_connectors(
 
 
 # ── POST /connectors ────────────────────────────────────────────────────────
-@router.post("/connectors", status_code=201)
+@router.post("/connectors", status_code=201, dependencies=[require_tenant_admin])
 @route_meta(
     auth_required=True,
     tenant_required=True,
@@ -1124,7 +1124,7 @@ async def register_connector(
     return _connector_to_dict(connector, bool(secret_fields))
 
 
-@router.get("/connectors/cmo-vendor-sandbox")
+@router.get("/connectors/cmo-vendor-sandbox", dependencies=[require_scope("connectors.read")])
 @route_meta(
     auth_required=True,
     tenant_required=True,
@@ -1185,11 +1185,14 @@ async def get_cmo_vendor_sandbox_connectors(
     }
 
 
-@router.post("/connectors/cmo-vendor-sandbox")
+@router.post(
+    "/connectors/cmo-vendor-sandbox",
+    dependencies=[require_scope("connectors.cmo_vendor_sandbox.write")],
+)
 @route_meta(
     auth_required=True,
     tenant_required=True,
-    scope="connectors.create",
+    scope="connectors.cmo_vendor_sandbox.write",
     rate_limit="admin-mutating",
     idempotency="tenant-cmo-vendor-sandbox-upsert",
     audit_event="connectors.cmo_vendor_sandbox.upsert",
@@ -1366,7 +1369,7 @@ async def upsert_cmo_vendor_sandbox_connectors(
 
 
 # ── GET /connectors/{conn_id} ────────────────────────────────────────────────
-@router.get("/connectors/{conn_id}")
+@router.get("/connectors/{conn_id}", dependencies=[require_scope("connectors.read")])
 @route_meta(
     auth_required=True,
     tenant_required=True,
@@ -1405,7 +1408,7 @@ async def get_connector(
 
 
 # ── PUT /connectors/{conn_id} ──────────────────────────────────────────────
-@router.put("/connectors/{conn_id}")
+@router.put("/connectors/{conn_id}", dependencies=[require_tenant_admin])
 @route_meta(
     auth_required=True,
     tenant_required=True,
@@ -1647,7 +1650,7 @@ async def update_connector(
 # audit history. Hard delete is intentionally not supported — a
 # deleted connector can be restored via PUT /connectors/{id}
 # (status=active).
-@router.delete("/connectors/{conn_id}", status_code=200)
+@router.delete("/connectors/{conn_id}", status_code=200, dependencies=[require_tenant_admin])
 @route_meta(
     auth_required=True,
     tenant_required=True,
@@ -1680,7 +1683,7 @@ async def delete_connector(
 
 
 # ── GET /connectors/{conn_id}/health ─────────────────────────────────────────
-@router.get("/connectors/{conn_id}/health")
+@router.get("/connectors/{conn_id}/health", dependencies=[require_tenant_admin])
 @route_meta(
     auth_required=True,
     tenant_required=True,
@@ -1735,7 +1738,7 @@ async def connector_health(
     }
 
 
-@router.post("/connectors/{conn_id}/test")
+@router.post("/connectors/{conn_id}/test", dependencies=[require_tenant_admin])
 @route_meta(
     auth_required=True,
     tenant_required=True,

--- a/api/v1/report_schedules.py
+++ b/api/v1/report_schedules.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 
-from api.deps import get_current_tenant, require_tenant_admin
+from api.deps import get_current_tenant, get_current_user, require_scope
 from api.route_metadata import route_meta
 from core.database import get_tenant_session
 from core.models.report_schedule import ReportSchedule
@@ -110,7 +110,35 @@ def _cron_field_ok(token: str, lo: int, hi: int) -> bool:
             return False
     return True
 
-router = APIRouter(dependencies=[require_tenant_admin])
+router = APIRouter()
+
+_REPORT_TYPES_BY_ROLE: dict[str, set[str]] = {
+    "cfo": {"cfo_daily", "aging_report", "pnl_report"},
+    "cmo": {"cmo_weekly", "campaign_report"},
+}
+
+
+def _is_admin_claims(claims: dict[str, Any]) -> bool:
+    scopes = claims.get("grantex:scopes") or []
+    return any(str(scope).startswith("agenticorg:admin") for scope in scopes)
+
+
+def _allowed_report_types(claims: dict[str, Any]) -> set[str] | None:
+    if _is_admin_claims(claims):
+        return None
+    role = str(claims.get("role") or "").strip().lower()
+    return set(_REPORT_TYPES_BY_ROLE.get(role, set()))
+
+
+def _assert_report_type_allowed(report_type: str, claims: dict[str, Any]) -> None:
+    allowed = _allowed_report_types(claims)
+    if allowed is None:
+        return
+    if report_type not in allowed:
+        raise HTTPException(
+            status_code=403,
+            detail="Report type is outside this role's domain",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -376,7 +404,11 @@ def _parse_schedule_id(schedule_id: str) -> _uuid.UUID:
 # Endpoints
 # ---------------------------------------------------------------------------
 
-@router.get("/report-schedules", response_model=list[ReportScheduleResponse])
+@router.get(
+    "/report-schedules",
+    response_model=list[ReportScheduleResponse],
+    dependencies=[require_scope("report_schedules.read")],
+)
 @route_meta(
     auth_required=True,
     tenant_required=True,
@@ -388,6 +420,7 @@ def _parse_schedule_id(schedule_id: str) -> _uuid.UUID:
 async def list_report_schedules(
     company_id: str | None = None,
     tenant_id: str = Depends(get_current_tenant),
+    current_user: dict = Depends(get_current_user),
 ) -> list[ReportScheduleResponse]:
     """List report schedules for the current tenant.
 
@@ -415,6 +448,11 @@ async def list_report_schedules(
     try:
         async with get_tenant_session(tid) as session:
             query = select(ReportSchedule).where(ReportSchedule.tenant_id == tid)
+            allowed_report_types = _allowed_report_types(current_user)
+            if allowed_report_types is not None:
+                if not allowed_report_types:
+                    return []
+                query = query.where(ReportSchedule.report_type.in_(allowed_report_types))
             if company_uuid is not None:
                 # Return the company's own schedules *and* tenant-wide
                 # schedules (company_id IS NULL) so a company user doesn't
@@ -482,6 +520,7 @@ async def list_report_schedules(
     "/report-schedules",
     response_model=ReportScheduleResponse,
     status_code=status.HTTP_201_CREATED,
+    dependencies=[require_scope("report_schedules.write")],
 )
 @route_meta(
     auth_required=True,
@@ -494,6 +533,7 @@ async def list_report_schedules(
 async def create_report_schedule(
     body: ReportScheduleCreate,
     tenant_id: str = Depends(get_current_tenant),
+    current_user: dict = Depends(get_current_user),
 ) -> ReportScheduleResponse:
     """Create a new report schedule.
 
@@ -507,6 +547,7 @@ async def create_report_schedule(
     re-raised so FastAPI keeps its own mapping.
     """
     try:
+        _assert_report_type_allowed(body.report_type, current_user)
         tid = _uuid.UUID(tenant_id)
         schedule_id = _uuid.uuid4()
         channels_data = [ch.model_dump() for ch in body.delivery_channels]
@@ -590,7 +631,11 @@ async def create_report_schedule(
         ) from exc
 
 
-@router.patch("/report-schedules/{schedule_id}", response_model=ReportScheduleResponse)
+@router.patch(
+    "/report-schedules/{schedule_id}",
+    response_model=ReportScheduleResponse,
+    dependencies=[require_scope("report_schedules.write")],
+)
 @route_meta(
     auth_required=True,
     tenant_required=True,
@@ -603,6 +648,7 @@ async def update_report_schedule(
     schedule_id: str,
     body: ReportScheduleUpdate,
     tenant_id: str = Depends(get_current_tenant),
+    current_user: dict = Depends(get_current_user),
 ) -> ReportScheduleResponse:
     """Update an existing report schedule (partial update)."""
     tid = _uuid.UUID(tenant_id)
@@ -618,10 +664,12 @@ async def update_report_schedule(
         row = result.scalar_one_or_none()
         if row is None:
             raise HTTPException(status_code=404, detail="Schedule not found")
+        _assert_report_type_allowed(row.report_type, current_user)
 
         updates = body.model_dump(exclude_unset=True)
 
         if "report_type" in updates:
+            _assert_report_type_allowed(updates["report_type"], current_user)
             row.report_type = updates["report_type"]
             row.name = updates["report_type"]
 
@@ -663,7 +711,12 @@ async def update_report_schedule(
         return _to_response(row)
 
 
-@router.delete("/report-schedules/{schedule_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
+@router.delete(
+    "/report-schedules/{schedule_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_model=None,
+    dependencies=[require_scope("report_schedules.write")],
+)
 @route_meta(
     auth_required=True,
     tenant_required=True,
@@ -675,6 +728,7 @@ async def update_report_schedule(
 async def delete_report_schedule(
     schedule_id: str,
     tenant_id: str = Depends(get_current_tenant),
+    current_user: dict = Depends(get_current_user),
 ) -> None:
     """Delete a report schedule."""
     tid = _uuid.UUID(tenant_id)
@@ -690,10 +744,14 @@ async def delete_report_schedule(
         row = result.scalar_one_or_none()
         if row is None:
             raise HTTPException(status_code=404, detail="Schedule not found")
+        _assert_report_type_allowed(row.report_type, current_user)
         await session.delete(row)
 
 
-@router.post("/report-schedules/{schedule_id}/run-now")
+@router.post(
+    "/report-schedules/{schedule_id}/run-now",
+    dependencies=[require_scope("report_schedules.run")],
+)
 @route_meta(
     auth_required=True,
     tenant_required=True,
@@ -705,6 +763,7 @@ async def delete_report_schedule(
 async def run_report_now(
     schedule_id: str,
     tenant_id: str = Depends(get_current_tenant),
+    current_user: dict = Depends(get_current_user),
 ) -> dict[str, Any]:
     """Trigger immediate generation for a schedule (ignores cron timing)."""
     tid = _uuid.UUID(tenant_id)
@@ -720,6 +779,7 @@ async def run_report_now(
         row = result.scalar_one_or_none()
         if row is None:
             raise HTTPException(status_code=404, detail="Schedule not found")
+        _assert_report_type_allowed(row.report_type, current_user)
 
         config: dict[str, Any] = row.config or {}
 

--- a/core/rbac.py
+++ b/core/rbac.py
@@ -19,12 +19,22 @@ _DOMAIN_ROLE_SCOPES = [
     "approvals:read",
     "approvals:write",
     "audit:read",
+    "connectors.read",
+    "connectors.contracts.read",
+    "connectors.registry.read",
+    "connectors.tools.read",
+    "report_schedules.read",
+    "report_schedules.write",
+    "report_schedules.run",
 ]
 
 ROLE_SCOPES: dict[str, list[str]] = {
     "cfo": _DOMAIN_ROLE_SCOPES,
     "chro": _DOMAIN_ROLE_SCOPES,
-    "cmo": _DOMAIN_ROLE_SCOPES,
+    "cmo": [
+        *_DOMAIN_ROLE_SCOPES,
+        "connectors.cmo_vendor_sandbox.write",
+    ],
     "coo": _DOMAIN_ROLE_SCOPES,
     "admin": ["agenticorg:admin"],
     "auditor": ["audit:read"],

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -3020,8 +3020,8 @@
     "path": "/api/v1/connectors/cmo-vendor-sandbox",
     "public_exempt_reason": null,
     "rate_limit": "admin-mutating",
-    "scope": "connectors.create",
-    "source_line": 1197,
+    "scope": "connectors.cmo_vendor_sandbox.write",
+    "source_line": 1200,
     "tenant_required": true
   },
   {
@@ -3165,7 +3165,7 @@
     "public_exempt_reason": null,
     "rate_limit": "admin-mutating",
     "scope": "connectors.delete",
-    "source_line": 1659,
+    "source_line": 1662,
     "tenant_required": true
   },
   {
@@ -3183,7 +3183,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "connectors.read",
-    "source_line": 1378,
+    "source_line": 1381,
     "tenant_required": true
   },
   {
@@ -3201,7 +3201,7 @@
     "public_exempt_reason": null,
     "rate_limit": "admin-mutating",
     "scope": "connectors.update",
-    "source_line": 1417,
+    "source_line": 1420,
     "tenant_required": true
   },
   {
@@ -3219,7 +3219,7 @@
     "public_exempt_reason": null,
     "rate_limit": "connector-test",
     "scope": "connectors.health.read",
-    "source_line": 1692,
+    "source_line": 1695,
     "tenant_required": true
   },
   {
@@ -3237,7 +3237,7 @@
     "public_exempt_reason": null,
     "rate_limit": "connector-test",
     "scope": "connectors.test",
-    "source_line": 1747,
+    "source_line": 1750,
     "tenant_required": true
   },
   {
@@ -4731,7 +4731,7 @@
     "public_exempt_reason": null,
     "rate_limit": "report-schedule-read",
     "scope": "report_schedules.sensitive.list",
-    "source_line": 388,
+    "source_line": 420,
     "tenant_required": true
   },
   {
@@ -4749,7 +4749,7 @@
     "public_exempt_reason": null,
     "rate_limit": "report-schedule-write",
     "scope": "report_schedules.write",
-    "source_line": 494,
+    "source_line": 533,
     "tenant_required": true
   },
   {
@@ -4767,7 +4767,7 @@
     "public_exempt_reason": null,
     "rate_limit": "report-schedule-write",
     "scope": "report_schedules.write",
-    "source_line": 675,
+    "source_line": 728,
     "tenant_required": true
   },
   {
@@ -4785,7 +4785,7 @@
     "public_exempt_reason": null,
     "rate_limit": "report-schedule-write",
     "scope": "report_schedules.write",
-    "source_line": 602,
+    "source_line": 647,
     "tenant_required": true
   },
   {
@@ -4803,7 +4803,7 @@
     "public_exempt_reason": null,
     "rate_limit": "manual-report-trigger",
     "scope": "report_schedules.external_action.run",
-    "source_line": 705,
+    "source_line": 763,
     "tenant_required": true
   },
   {

--- a/tests/unit/test_cmo_report_schedule_permissions.py
+++ b/tests/unit/test_cmo_report_schedule_permissions.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from api.v1.report_schedules import (
+    _allowed_report_types,
+    _assert_report_type_allowed,
+)
+
+
+def test_cmo_report_schedule_types_are_domain_limited() -> None:
+    claims = {
+        "role": "cmo",
+        "grantex:scopes": ["report_schedules.read", "report_schedules.write"],
+    }
+
+    assert _allowed_report_types(claims) == {"cmo_weekly", "campaign_report"}
+    _assert_report_type_allowed("cmo_weekly", claims)
+    _assert_report_type_allowed("campaign_report", claims)
+    with pytest.raises(HTTPException) as exc:
+        _assert_report_type_allowed("cfo_daily", claims)
+    assert exc.value.status_code == 403
+
+
+def test_admin_report_schedule_types_are_unrestricted() -> None:
+    claims = {"role": "admin", "grantex:scopes": ["agenticorg:admin"]}
+
+    assert _allowed_report_types(claims) is None
+    _assert_report_type_allowed("cfo_daily", claims)
+    _assert_report_type_allowed("cmo_weekly", claims)

--- a/tests/unit/test_remaining_coverage.py
+++ b/tests/unit/test_remaining_coverage.py
@@ -2265,7 +2265,17 @@ class TestRBAC:
         from core.rbac import _DOMAIN_ROLE_SCOPES, ROLE_SCOPES
 
         for role in ["cfo", "chro", "cmo", "coo"]:
-            assert ROLE_SCOPES[role] == _DOMAIN_ROLE_SCOPES
+            assert set(_DOMAIN_ROLE_SCOPES) <= set(ROLE_SCOPES[role])
+
+    def test_cmo_has_cmo_setup_scopes_without_admin(self):
+        from core.rbac import get_scopes_for_role
+
+        scopes = get_scopes_for_role("cmo")
+        assert "connectors.read" in scopes
+        assert "connectors.cmo_vendor_sandbox.write" in scopes
+        assert "report_schedules.read" in scopes
+        assert "report_schedules.write" in scopes
+        assert "agenticorg:admin" not in scopes
 
 
 # =============================================================================


### PR DESCRIPTION
## What changed

- Adds scoped read access for connector inventory/registry/tooling routes so domain roles can load setup screens without tenant admin privileges.
- Grants CMO the dedicated `connectors.cmo_vendor_sandbox.write` scope for the CMO vendor sandbox upsert route.
- Allows domain report schedule access through scoped dependencies while limiting non-admin roles to their own report types.
- Adds CMO report-schedule permission coverage and updates the route inventory metadata.

## Why

A no-fake production CMO flow showed that the CMO dashboard could load KPIs, but the CMO setup path still hit real 403s on `/connectors`, `/report-schedules`, and `/connectors/cmo-vendor-sandbox` because those routers were admin-only.

## Validation

- `python -m ruff check core\rbac.py api\v1\connectors.py api\v1\report_schedules.py tests\unit\test_remaining_coverage.py tests\unit\test_cmo_report_schedule_permissions.py`
- `python -m pytest tests\unit\test_cmo_report_schedule_permissions.py tests\unit\test_remaining_coverage.py::TestRBAC -q` with fake switches disabled
- Full checked-in CMO unit/regression set: `457 passed` with fake switches disabled
- `python scripts\check_enterprise_stability_gates.py` with fake switches disabled

No production fakes were used for the CMO repro; the production post-deploy CMO smoke will be rerun after this lands.