### PR TITLE
[codex] Fix Aishwarya 23Jun workflow and connector regressions

### DIFF
--- a/api/v1/approvals.py
+++ b/api/v1/approvals.py
@@ -183,6 +183,7 @@ async def _resume_workflow_bg(
     tenant_id: _uuid.UUID,
     workflow_run_id: _uuid.UUID,
     decision: dict,
+    engine_run_id_hint: str | None = None,
 ) -> None:
     """Resume a workflow after HITL decision and sync remaining results to DB."""
     from api.v1.workflows import (
@@ -204,7 +205,7 @@ async def _resume_workflow_bg(
         ).scalar_one_or_none()
         if not db_run:
             return
-        engine_run_id = (db_run.context or {}).get("_engine_run_id")
+        engine_run_id = engine_run_id_hint or (db_run.context or {}).get("_engine_run_id")
         wf_def = (
             await session.execute(
                 select(WorkflowDefinition).where(
@@ -215,6 +216,25 @@ async def _resume_workflow_bg(
         definition = wf_def.definition if wf_def else None
 
     if not engine_run_id or not definition:
+        _log.error(
+            "workflow_resume_missing_engine_context",
+            run_id=str(workflow_run_id),
+            has_engine_run_id=bool(engine_run_id),
+            has_definition=bool(definition),
+        )
+        async with get_tenant_session(tenant_id) as session:
+            db_run = (
+                await session.execute(
+                    select(WorkflowRun).where(WorkflowRun.id == workflow_run_id)
+                )
+            ).scalar_one_or_none()
+            if db_run is not None:
+                db_run.status = "failed"
+                db_run.error = {
+                    "message": "Resume failed: workflow engine context is missing.",
+                    "code": "workflow_resume_context_missing",
+                }
+                db_run.completed_at = datetime.now(UTC)
         return
 
     state_store = WorkflowStateStore()
@@ -229,6 +249,19 @@ async def _resume_workflow_bg(
 
         state = await state_store.load(engine_run_id)
         if not state:
+            async with get_tenant_session(tenant_id) as session:
+                db_run = (
+                    await session.execute(
+                        select(WorkflowRun).where(WorkflowRun.id == workflow_run_id)
+                    )
+                ).scalar_one_or_none()
+                if db_run is not None:
+                    db_run.status = "failed"
+                    db_run.error = {
+                        "message": "Resume failed: workflow engine state is missing.",
+                        "code": "workflow_resume_state_missing",
+                    }
+                    db_run.completed_at = datetime.now(UTC)
             return
 
         steps_def = {s["id"]: s for s in definition.get("steps", [])}
@@ -453,6 +486,15 @@ async def decide(
         )
 
         ctx = dict(item.context or {})
+        if item.workflow_run_id is None and ctx.get("workflow_run_id"):
+            try:
+                item.workflow_run_id = _uuid.UUID(str(ctx["workflow_run_id"]))
+            except (TypeError, ValueError):
+                _log.warning(
+                    "hitl_context_workflow_run_id_invalid",
+                    hitl_id=str(hitl_id),
+                    workflow_run_id=ctx.get("workflow_run_id"),
+                )
         policy_state = dict(ctx.get("policy_state") or {})
         policy_action = "advance"  # default — the legacy single-step path
 
@@ -572,11 +614,17 @@ async def decide(
 
     # Resume workflow execution in background
     if workflow_run_id:
+        engine_run_id_hint = (
+            ctx.get("_engine_run_id")
+            or ctx.get("engine_run_id")
+            or ctx.get("workflow_engine_run_id")
+        )
         background_tasks.add_task(
             _resume_workflow_bg,
             tid,
             workflow_run_id,
             {"decision": body.decision, "notes": body.notes},
+            str(engine_run_id_hint or "") or None,
         )
 
     return {

--- a/api/v1/workflows.py
+++ b/api/v1/workflows.py
@@ -429,6 +429,67 @@ async def get_workflow(
     return _wf_to_dict(wf)
 
 
+@router.get("/workflows/{wf_id}/runs", response_model=PaginatedResponse)
+@route_meta(
+    auth_required=True,
+    tenant_required=True,
+    scope="workflows.runs.sensitive.list",
+    rate_limit="standard",
+    idempotency="read-only",
+    audit_event="workflows.runs.list",
+)
+async def list_workflow_runs(
+    wf_id: UUID,
+    page: int = 1,
+    per_page: int = 5,
+    tenant_id: str = Depends(get_current_tenant),
+):
+    """List recent runs for a workflow definition."""
+
+    if page < 1:
+        raise HTTPException(422, "page must be >= 1")
+    per_page = min(max(per_page, 1), 50)
+    tid = _uuid.UUID(tenant_id)
+    async with get_tenant_session(tid) as session:
+        workflow_exists = (
+            await session.execute(
+                select(WorkflowDefinition.id).where(
+                    WorkflowDefinition.id == wf_id,
+                    WorkflowDefinition.tenant_id == tid,
+                )
+            )
+        ).scalar_one_or_none()
+        if workflow_exists is None:
+            raise HTTPException(404, "Workflow not found")
+
+        filters = (
+            WorkflowRun.workflow_def_id == wf_id,
+            WorkflowRun.tenant_id == tid,
+        )
+        total = (
+            await session.execute(
+                select(func.count()).select_from(WorkflowRun).where(*filters)
+            )
+        ).scalar() or 0
+        result = await session.execute(
+            select(WorkflowRun)
+            .where(*filters)
+            .order_by(WorkflowRun.created_at.desc())
+            .offset((page - 1) * per_page)
+            .limit(per_page)
+        )
+        runs = result.scalars().all()
+
+    pages = max(1, (total + per_page - 1) // per_page)
+    return PaginatedResponse(
+        items=[_run_to_dict(run, include_steps=False) for run in runs],
+        total=total,
+        page=page,
+        per_page=per_page,
+        pages=pages,
+    )
+
+
 # ── POST /workflows ─────────────────────────────────────────────────────────
 @router.post("/workflows", status_code=201)
 @route_meta(

--- a/connectors/comms/sendgrid.py
+++ b/connectors/comms/sendgrid.py
@@ -17,28 +17,48 @@ _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 _DATE_ASSIGNMENT_RE = re.compile(
     r"(?i)\b(?P<key>start[_\s-]?date|end[_\s-]?date|aggregated[_\s-]?by)\s*[:=]\s*(?P<value>[A-Za-z0-9_-]+)"
 )
+PARAM_WRAPPER_KEYS = (
+    "kwargs",
+    "params",
+    "parameters",
+    "arguments",
+    "args",
+    "input",
+    "tool_input",
+    "toolInput",
+    "payload",
+    "data",
+)
+TEXT_PARAM_KEYS = ("query", "prompt", "text", "message", "instruction", "instructions")
 
 
 def _flatten_stats_params(params: dict[str, Any]) -> dict[str, Any]:
-    flattened = dict(params or {})
-    for wrapper_key in ("kwargs", "params", "arguments", "input"):
-        nested = flattened.get(wrapper_key)
-        if isinstance(nested, dict):
-            flattened.update(nested)
-        elif isinstance(nested, str) and nested.strip():
-            text = nested.strip()
-            try:
-                parsed = json.loads(text)
-            except ValueError:
-                parsed = None
-            if isinstance(parsed, dict):
-                flattened.update(parsed)
-            else:
-                flattened.update(_parse_stats_text(text))
-    for text_key in ("query", "prompt", "text"):
-        text_value = flattened.get(text_key)
-        if isinstance(text_value, str):
-            flattened.update(_parse_stats_text(text_value))
+    flattened: dict[str, Any] = {}
+
+    def merge_payload(payload: dict[str, Any]) -> None:
+        for key, value in payload.items():
+            if key not in flattened or flattened[key] in (None, ""):
+                flattened[key] = value
+        for wrapper_key in PARAM_WRAPPER_KEYS:
+            nested = payload.get(wrapper_key)
+            if isinstance(nested, dict):
+                merge_payload(nested)
+            elif isinstance(nested, str) and nested.strip():
+                text = nested.strip()
+                try:
+                    parsed = json.loads(text)
+                except ValueError:
+                    parsed = None
+                if isinstance(parsed, dict):
+                    merge_payload(parsed)
+                else:
+                    flattened.update(_parse_stats_text(text))
+        for text_key in TEXT_PARAM_KEYS:
+            text_value = payload.get(text_key)
+            if isinstance(text_value, str):
+                flattened.update(_parse_stats_text(text_value))
+
+    merge_payload(dict(params or {}))
     return flattened
 
 

--- a/connectors/marketing/google_ads.py
+++ b/connectors/marketing/google_ads.py
@@ -8,11 +8,143 @@ searchStream endpoint rather than individual REST paths per resource.
 
 from __future__ import annotations
 
+import json
+import re
+from datetime import date
 from typing import Any
 
 import httpx
 
 from connectors.framework.base_connector import BaseConnector
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_ARG_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(?P<key>start[_\s-]?date|end[_\s-]?date|campaign[_\s-]?id|limit)\s*[:=]\s*(?P<value>[A-Za-z0-9_-]+)"
+)
+PARAM_WRAPPER_KEYS = (
+    "kwargs",
+    "params",
+    "parameters",
+    "arguments",
+    "args",
+    "input",
+    "tool_input",
+    "toolInput",
+    "payload",
+    "data",
+)
+TEXT_PARAM_KEYS = ("query", "prompt", "text", "message", "instruction", "instructions")
+
+
+def _parse_tool_text(text: str) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for match in _ARG_ASSIGNMENT_RE.finditer(text):
+        key = match.group("key").lower().replace(" ", "_").replace("-", "_")
+        parsed[key] = match.group("value")
+    return parsed
+
+
+def _flatten_tool_params(params: dict[str, Any]) -> dict[str, Any]:
+    flattened: dict[str, Any] = {}
+
+    def merge_payload(payload: dict[str, Any]) -> None:
+        for key, value in payload.items():
+            if key not in flattened or flattened[key] in (None, ""):
+                flattened[key] = value
+        for wrapper_key in PARAM_WRAPPER_KEYS:
+            nested = payload.get(wrapper_key)
+            if isinstance(nested, dict):
+                merge_payload(nested)
+            elif isinstance(nested, str) and nested.strip():
+                text = nested.strip()
+                try:
+                    parsed = json.loads(text)
+                except ValueError:
+                    parsed = None
+                if isinstance(parsed, dict):
+                    merge_payload(parsed)
+                else:
+                    flattened.update(_parse_tool_text(text))
+        for text_key in TEXT_PARAM_KEYS:
+            text_value = payload.get(text_key)
+            if isinstance(text_value, str):
+                flattened.update(_parse_tool_text(text_value))
+
+    merge_payload(dict(params or {}))
+    return flattened
+
+
+def _first_value(params: dict[str, Any], *names: str) -> Any:
+    for name in names:
+        value = params.get(name)
+        if value not in (None, ""):
+            return value
+    return ""
+
+
+def _normalize_date(value: Any) -> str:
+    text = str(value or "").strip()
+    if not _DATE_RE.match(text):
+        return ""
+    try:
+        date.fromisoformat(text)
+    except ValueError:
+        return ""
+    return text
+
+
+def _date_range_or_error(params: dict[str, Any], *, tool: str) -> tuple[str, str, dict[str, Any] | None]:
+    start_raw = _first_value(params, "start_date", "startDate", "date_from", "from_date", "from")
+    end_raw = _first_value(params, "end_date", "endDate", "date_to", "to_date", "to")
+    start = _normalize_date(start_raw)
+    end = _normalize_date(end_raw)
+    missing = [
+        name
+        for name, raw in (("start_date", start_raw), ("end_date", end_raw))
+        if raw in (None, "")
+    ]
+    invalid = [
+        name
+        for name, raw, normalized in (
+            ("start_date", start_raw, start),
+            ("end_date", end_raw, end),
+        )
+        if raw not in (None, "") and not normalized
+    ]
+    if not missing and not invalid and date.fromisoformat(start) > date.fromisoformat(end):
+        invalid.append("date_range")
+    if missing or invalid:
+        return "", "", {
+            "error": "validation_failed",
+            "tool": tool,
+            "message": "start_date and end_date are required in YYYY-MM-DD format.",
+            "expected_format": "YYYY-MM-DD",
+            "missing_parameters": missing,
+            "invalid_parameters": invalid,
+        }
+    return start, end, None
+
+
+def _campaign_filter_or_error(params: dict[str, Any], *, tool: str) -> tuple[str, dict[str, Any] | None]:
+    campaign_id = str(_first_value(params, "campaign_id", "campaignId", "campaign") or "").strip()
+    if not campaign_id:
+        return "", None
+    if not campaign_id.isdigit():
+        return "", {
+            "error": "validation_failed",
+            "tool": tool,
+            "message": "campaign_id must be a numeric Google Ads campaign id.",
+            "invalid_parameters": ["campaign_id"],
+        }
+    return f" AND campaign.id = {campaign_id}", None
+
+
+def _safe_limit(value: Any, default: int, maximum: int) -> int:
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(1, min(limit, maximum))
 
 
 class GoogleAdsConnector(BaseConnector):
@@ -141,13 +273,21 @@ class GoogleAdsConnector(BaseConnector):
 
         Params: start_date (YYYY-MM-DD), end_date, campaign_id (optional).
         """
-        start = params.get("start_date", "")
-        end = params.get("end_date", "")
-        cid_filter = ""
-        if params.get("campaign_id"):
-            cid_filter = f" AND campaign.id = {params['campaign_id']}"
+        params = _flatten_tool_params(params)
+        start, end, validation_error = _date_range_or_error(
+            params,
+            tool="get_campaign_performance",
+        )
+        if validation_error:
+            return validation_error
+        cid_filter, campaign_error = _campaign_filter_or_error(
+            params,
+            tool="get_campaign_performance",
+        )
+        if campaign_error:
+            return campaign_error
         query = (
-            "SELECT campaign.id, campaign.name, "
+            "SELECT campaign.id, campaign.name, segments.date, "
             "metrics.impressions, metrics.clicks, metrics.cost_micros, "
             "metrics.conversions, metrics.cost_per_conversion "
             f"FROM campaign WHERE segments.date BETWEEN '{start}' AND '{end}'"  # noqa: S608  # nosec B608
@@ -182,14 +322,22 @@ class GoogleAdsConnector(BaseConnector):
 
         Params: start_date, end_date, campaign_id (optional), limit (100).
         """
-        start = params.get("start_date", "")
-        end = params.get("end_date", "")
-        limit = params.get("limit", 100)
-        cid_filter = ""
-        if params.get("campaign_id"):
-            cid_filter = f" AND campaign.id = {params['campaign_id']}"
+        params = _flatten_tool_params(params)
+        start, end, validation_error = _date_range_or_error(
+            params,
+            tool="get_search_terms",
+        )
+        if validation_error:
+            return validation_error
+        cid_filter, campaign_error = _campaign_filter_or_error(
+            params,
+            tool="get_search_terms",
+        )
+        if campaign_error:
+            return campaign_error
+        limit = _safe_limit(params.get("limit"), 100, 1000)
         query = (
-            "SELECT search_term_view.search_term, "
+            "SELECT search_term_view.search_term, segments.date, "
             "metrics.impressions, metrics.clicks, metrics.cost_micros, "
             "metrics.conversions "
             f"FROM search_term_view WHERE segments.date BETWEEN '{start}' AND '{end}'"  # noqa: S608  # nosec B608

--- a/core/marketing/connector_contracts.py
+++ b/core/marketing/connector_contracts.py
@@ -72,6 +72,25 @@ HUBSPOT_CRM_READ_SCOPES = (
 )
 HUBSPOT_OPTIONAL_SCOPES = ("automation",)
 HUBSPOT_CRM_READ_TOOLS = ("list_contacts", "search_contacts", "list_deals")
+SCOPE_PAYLOAD_KEYS = (
+    "granted_scopes",
+    "validated_scopes",
+    "configured_scopes",
+    "available_scopes",
+    "oauth_scopes",
+    "scope_list",
+    "scopes",
+    "scope",
+)
+NESTED_SCOPE_PAYLOAD_KEYS = (
+    "auth",
+    "oauth",
+    "health",
+    "health_check",
+    "health_result",
+    "connection_test",
+    "metadata",
+)
 
 
 @dataclass(frozen=True)
@@ -1064,15 +1083,29 @@ def _tuple_from_payload(
 
 
 def _scopes_from_contract_or_config(contract: dict[str, Any], config: dict[str, Any]) -> list[str]:
-    value = (
-        contract.get("granted_scopes")
-        or contract.get("validated_scopes")
-        or config.get("granted_scopes")
-        or config.get("validated_scopes")
-        or config.get("scopes")
-        or config.get("scope")
-    )
-    return [str(item) for item in _list_from_value(value) if str(item).strip()]
+    scopes: list[str] = []
+    seen: set[str] = set()
+    for source in _scope_payload_sources(contract, config):
+        for key in SCOPE_PAYLOAD_KEYS:
+            for item in _list_from_value(source.get(key)):
+                text = str(item).strip()
+                if text and text not in seen:
+                    scopes.append(text)
+                    seen.add(text)
+    return scopes
+
+
+def _scope_payload_sources(*payloads: dict[str, Any]) -> list[dict[str, Any]]:
+    sources: list[dict[str, Any]] = []
+    stack = [payload for payload in payloads if isinstance(payload, dict)]
+    while stack:
+        payload = stack.pop(0)
+        sources.append(payload)
+        for key in NESTED_SCOPE_PAYLOAD_KEYS:
+            nested = payload.get(key)
+            if isinstance(nested, dict):
+                stack.append(nested)
+    return sources
 
 
 def _missing_scopes(required: tuple[str, ...], granted: list[str]) -> list[str]:
@@ -1109,14 +1142,8 @@ def evaluate_hubspot_crm_read_contract(
     tools = {_tool_name_from_value(tool) for tool in (tool_functions or [])}
     tools.discard("")
     missing_tools = tuple(tool for tool in HUBSPOT_CRM_READ_TOOLS if tool not in tools)
-    scopes = _normalise_scopes(
-        (credentials or {}).get("scope"),
-        (credentials or {}).get("scopes"),
-        (config or {}).get("scope"),
-        (config or {}).get("scopes"),
-        (config or {}).get("granted_scopes"),
-        (config or {}).get("validated_scopes"),
-    )
+    scope_payload = {**(credentials or {}), **(config or {})}
+    scopes = _scopes_from_contract_or_config({}, scope_payload)
     missing_required_scopes = tuple(scope for scope in HUBSPOT_CRM_READ_SCOPES if scope not in scopes)
     missing_optional = tuple(scope for scope in HUBSPOT_OPTIONAL_SCOPES if scope not in scopes)
     active = _normalize_key(connector_status) == "active"
@@ -1248,7 +1275,6 @@ def _hubspot_private_app_read_scope_gap_is_non_blocking(
             contract.get("blocking_reason"),
             contract.get("last_error"),
             config.get("last_error"),
-            setup_row.get("detail"),
         )
     ).lower()
     if _contains_any(explicit_blocker_text, AUTH_EXPIRED_MARKERS) or _contains_any(
@@ -1266,8 +1292,7 @@ def _hubspot_private_app_read_scope_gap_is_non_blocking(
     if health_values.isdisjoint({"healthy", "ok", "ready", "valid"}):
         return False
 
-    read_scope_evidence = set(granted_scopes).intersection(set(HUBSPOT_CRM_READ_SCOPES))
-    if read_scope_evidence:
+    if _hubspot_crm_read_tool_payload_present(contract, config):
         return _hubspot_crm_read_tools_registered(contract, config)
     return True
 
@@ -1290,12 +1315,35 @@ def _hubspot_crm_read_tools_registered(
     return all(tool in tools for tool in HUBSPOT_CRM_READ_TOOLS)
 
 
+def _hubspot_crm_read_tool_payload_present(
+    contract: dict[str, Any],
+    config: dict[str, Any],
+) -> bool:
+    for key in (
+        "tool_functions",
+        "registered_tools",
+        "available_tools",
+        "tools",
+        "crm_read_tools",
+    ):
+        if _list_from_value(contract.get(key)) or _list_from_value(config.get(key)):
+            return True
+    return False
+
+
 def _tool_name_from_value(tool: Any) -> str:
     if isinstance(tool, dict):
         nested = tool.get("function")
         nested_name = nested.get("name") if isinstance(nested, dict) else None
-        return str(tool.get("name") or nested_name or "").strip()
-    return str(getattr(tool, "name", tool) or "").strip()
+        raw = tool.get("name") or nested_name or ""
+    else:
+        raw = getattr(tool, "name", tool)
+    text = str(raw or "").strip()
+    if ":" in text:
+        text = text.rsplit(":", 1)[1]
+    if "." in text:
+        text = text.rsplit(".", 1)[1]
+    return _normalize_key(text)
 
 
 def _list_from_value(value: Any) -> list[Any]:

--- a/core/marketing/connector_setup.py
+++ b/core/marketing/connector_setup.py
@@ -29,6 +29,25 @@ HUBSPOT_PRIVATE_APP_SCOPE_GAPS = {
     "crm.objects.deals.read",
     "automation",
 }
+SCOPE_PAYLOAD_KEYS = (
+    "granted_scopes",
+    "validated_scopes",
+    "configured_scopes",
+    "available_scopes",
+    "oauth_scopes",
+    "scope_list",
+    "scopes",
+    "scope",
+)
+NESTED_SCOPE_PAYLOAD_KEYS = (
+    "auth",
+    "oauth",
+    "health",
+    "health_check",
+    "health_result",
+    "connection_test",
+    "metadata",
+)
 
 
 @dataclass(frozen=True)
@@ -487,17 +506,32 @@ def _account_id_from_config(config: dict[str, Any]) -> str | None:
 
 
 def _scopes_from_config(config: dict[str, Any]) -> list[str]:
-    raw = (
-        config.get("granted_scopes")
-        or config.get("validated_scopes")
-        or config.get("scopes")
-        or config.get("scope")
-    )
-    if isinstance(raw, str):
-        return [part for part in raw.replace(",", " ").split() if part]
-    if isinstance(raw, (list, tuple, set)):
-        return [str(part) for part in raw if str(part).strip()]
-    return []
+    scopes: list[str] = []
+    seen: set[str] = set()
+    for source in _scope_payload_sources(config):
+        for key in SCOPE_PAYLOAD_KEYS:
+            raw = source.get(key)
+            values = raw.replace(",", " ").split() if isinstance(raw, str) else raw
+            if isinstance(values, (list, tuple, set)):
+                for part in values:
+                    text = str(part).strip()
+                    if text and text not in seen:
+                        scopes.append(text)
+                        seen.add(text)
+    return scopes
+
+
+def _scope_payload_sources(config: dict[str, Any]) -> list[dict[str, Any]]:
+    sources: list[dict[str, Any]] = []
+    stack = [config] if isinstance(config, dict) else []
+    while stack:
+        payload = stack.pop(0)
+        sources.append(payload)
+        for key in NESTED_SCOPE_PAYLOAD_KEYS:
+            nested = payload.get(key)
+            if isinstance(nested, dict):
+                stack.append(nested)
+    return sources
 
 
 def _missing_scopes(required: tuple[str, ...], granted: list[str]) -> list[str]:

--- a/docs/aishwarya_23june2026_bugfix_learnings.md
+++ b/docs/aishwarya_23june2026_bugfix_learnings.md
@@ -1,0 +1,30 @@
+# Aishwarya 23 June 2026 Bugfix Learnings
+
+## Why These Cases Reopened
+
+The reopened cases were valid. The earlier fixes were too narrow because they patched one observed payload shape or one UI route instead of auditing the full contract between connectors, workflows, approvals, and run visibility.
+
+- HubSpot readiness trusted only a small set of scope field names. Tester evidence used configured scopes plus registered CRM tools, but the contract path did not normalize all equivalent scope payloads.
+- SendGrid accepted direct date arguments but not the wrappers and prompt text that agent/tool callers actually send.
+- Google Ads passed malformed or incomplete date arguments through to the vendor, producing an opaque HTTP 400 instead of an actionable local validation error.
+- Workflow contact retrieval used a generic CRM agent action (`process`) for a deterministic HubSpot connector operation, so standalone connector success did not prove workflow success.
+- HITL approval could return success while resume silently stopped when workflow-run linkage, engine-run-id, or engine state was missing.
+- The workflow details page showed definition metadata but not the latest execution progress, so an approved run looked stuck even when run state existed elsewhere.
+
+## Permanent Rules
+
+- Normalize families of payload names at boundaries. Scope and tool parameters must handle direct keys, nested health/auth metadata, JSON wrappers, and prompt text where those are valid caller shapes.
+- Healthy connector auth is not enough proof for HubSpot CRM read readiness when tool evidence is present. Missing read scopes can be waived only when the CRM read tools are registered, while legacy private-app rows without any tool registry payload keep the established healthy-read fallback.
+- Connector tools inside workflows must be routed deterministically through the connector adapter. Do not let known connector retrieval aliases fall through to generic LLM agent actions.
+- Resume paths must never return silently after an approval. If resume cannot continue, mark the DB workflow run failed with a structured error code.
+- Vendor connectors should validate required parameters before network calls and identify missing or invalid fields in the response.
+- Workflow list/detail pages must expose recent run status and progress, and must poll paused live states that can advance externally.
+
+## Regression Pins Added
+
+- HubSpot configured-scope and registered-tool normalization across setup, contracts, and the legacy CRM read evaluator.
+- SendGrid `get_stats` JSON wrapper, nested parameter, and prompt-text date parsing.
+- Google Ads `get_campaign_performance` local validation and GAQL generation with explicit `segments.date`.
+- Workflow `retrieve_hubspot_contacts` alias execution through the HubSpot `list_contacts` connector tool.
+- HITL resume failure modes for missing engine context and missing engine state.
+- Playwright coverage for CMO HubSpot read/write readiness and workflow detail latest-run progress polling.

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -950,7 +950,7 @@
     "public_exempt_reason": null,
     "rate_limit": "approval-decision",
     "scope": "approvals.decide",
-    "source_line": 327,
+    "source_line": 360,
     "tenant_required": true
   },
   {
@@ -5847,7 +5847,7 @@
     "public_exempt_reason": null,
     "rate_limit": "workflow-write",
     "scope": "workflows.write",
-    "source_line": 442,
+    "source_line": 503,
     "tenant_required": true
   },
   {
@@ -5883,7 +5883,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "workflows.runs.sensitive.read",
-    "source_line": 790,
+    "source_line": 851,
     "tenant_required": true
   },
   {
@@ -5901,7 +5901,7 @@
     "public_exempt_reason": null,
     "rate_limit": "workflow-control",
     "scope": "workflows.runs.cancel",
-    "source_line": 880,
+    "source_line": 941,
     "tenant_required": true
   },
   {
@@ -5919,7 +5919,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "workflows.runs.sensitive.replan-history",
-    "source_line": 836,
+    "source_line": 897,
     "tenant_required": true
   },
   {
@@ -5955,7 +5955,7 @@
     "public_exempt_reason": null,
     "rate_limit": "workflow-write",
     "scope": "workflows.write",
-    "source_line": 504,
+    "source_line": 565,
     "tenant_required": true
   },
   {
@@ -5991,7 +5991,7 @@
     "public_exempt_reason": null,
     "rate_limit": "workflow-write",
     "scope": "workflows.write",
-    "source_line": 983,
+    "source_line": 1044,
     "tenant_required": true
   },
   {
@@ -6009,7 +6009,25 @@
     "public_exempt_reason": null,
     "rate_limit": "workflow-execution",
     "scope": "workflows.run",
-    "source_line": 692,
+    "source_line": 753,
+    "tenant_required": true
+  },
+  {
+    "audit_event": "workflows.runs.list",
+    "auth_required": true,
+    "function": "list_workflow_runs",
+    "idempotency": "read-only",
+    "key": "GET /api/v1/workflows/{wf_id}/runs api/v1/workflows.py:list_workflow_runs",
+    "metadata_present": true,
+    "methods": [
+      "GET"
+    ],
+    "module": "api/v1/workflows.py",
+    "path": "/api/v1/workflows/{wf_id}/runs",
+    "public_exempt_reason": null,
+    "rate_limit": "standard",
+    "scope": "workflows.runs.sensitive.list",
+    "source_line": 441,
     "tenant_required": true
   },
   {

--- a/tests/regression/test_aishwarya_23jun2026_reopens.py
+++ b/tests/regression/test_aishwarya_23jun2026_reopens.py
@@ -9,7 +9,6 @@ from uuid import uuid4
 
 import pytest
 
-
 NOW = datetime(2026, 6, 23, 12, 0, tzinfo=UTC)
 
 

--- a/tests/regression/test_aishwarya_23jun2026_reopens.py
+++ b/tests/regression/test_aishwarya_23jun2026_reopens.py
@@ -1,0 +1,339 @@
+"""Aishwarya 23 June 2026 workbook regression pins."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+
+NOW = datetime(2026, 6, 23, 12, 0, tzinfo=UTC)
+
+
+def _connector_config(name: str, config: dict) -> SimpleNamespace:
+    return SimpleNamespace(
+        connector_name=name,
+        display_name=None,
+        auth_type="oauth2",
+        credentials_encrypted={"_encrypted": "enc"},
+        config=config,
+        status="active",
+        last_health_check=NOW,
+        health_status="healthy",
+        last_sync_at=NOW - timedelta(hours=1),
+        sync_error=None,
+    )
+
+
+def _hubspot_scopes() -> list[str]:
+    return [
+        "crm.objects.contacts.read",
+        "crm.objects.deals.read",
+        "crm.objects.companies.read",
+        "crm.objects.owners.read",
+        "automation",
+    ]
+
+
+def _hubspot_tools() -> list[object]:
+    return [
+        "hubspot.list_contacts",
+        {"name": "hubspot.search_contacts"},
+        {"function": {"name": "hubspot:list_deals"}},
+        "hubspot.validate_crm_access",
+    ]
+
+
+def test_hubspot_contract_uses_configured_scopes_and_registered_tools() -> None:
+    from core.marketing.connector_contracts import build_marketing_connector_contracts
+    from core.marketing.connector_setup import build_marketing_connector_setup
+
+    config = _connector_config(
+        "hubspot",
+        {
+            "account_id": "sandbox-portal",
+            "health": {"scopes": _hubspot_scopes()},
+            "registered_tools": _hubspot_tools(),
+            "marketing_connector_contract": {
+                "status": "healthy",
+                "registered_tools": _hubspot_tools(),
+                "retry_budget": {"max_attempts": 1, "idempotency_supported": True},
+            },
+        },
+    )
+
+    setup = build_marketing_connector_setup([config], now=NOW)
+    setup_row = next(row for row in setup if row["key"] == "hubspot")
+    contracts = build_marketing_connector_contracts(setup, [config], now=NOW)
+    contract = next(row for row in contracts if row["connector_key"] == "hubspot")
+
+    assert setup_row["health_status"] == "healthy"
+    assert setup_row["missing_scopes"] == []
+    assert contract["read_status"] == "ready"
+    assert contract["write_status"] == "ready"
+    assert contract["missing_read_scopes"] == []
+    assert contract["missing_write_scopes"] == []
+    assert contract["granted_scopes"] == _hubspot_scopes()
+
+
+def test_legacy_hubspot_read_contract_accepts_configured_scope_payloads() -> None:
+    from core.marketing.connector_contracts import evaluate_hubspot_crm_read_contract
+
+    contract = evaluate_hubspot_crm_read_contract(
+        connector_status="active",
+        health_status="healthy",
+        tool_functions=_hubspot_tools(),
+        config={"configured_scopes": _hubspot_scopes()},
+    )
+
+    assert contract.status == "ready"
+    assert contract.missing_scopes == ()
+    assert contract.missing_tools == ()
+
+
+class _StatsResponse:
+    status_code = 200
+    headers: dict[str, str] = {}
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> list[dict]:
+        return [{"date": "2026-06-18", "stats": [{"metrics": {"delivered": 8}}]}]
+
+
+class _StatsClient:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def get(self, path: str, params: dict):
+        self.calls.append({"path": path, "params": dict(params)})
+        return _StatsResponse()
+
+
+@pytest.mark.asyncio
+async def test_sendgrid_get_stats_accepts_json_tool_input_wrapper() -> None:
+    from connectors.comms.sendgrid import SendgridConnector
+
+    connector = SendgridConnector({"api_key": "SG.test"})
+    client = _StatsClient()
+    connector._client = client
+
+    result = await connector.get_stats(
+        tool_input=(
+            '{"parameters":{"start_date":"2026-06-18",'
+            '"end_date":"2026-06-19","aggregated_by":"day"}}'
+        )
+    )
+
+    assert result["stats"][0]["metrics"]["delivered"] == 8
+    assert client.calls == [
+        {
+            "path": "/stats",
+            "params": {
+                "start_date": "2026-06-18",
+                "end_date": "2026-06-19",
+                "aggregated_by": "day",
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_google_ads_campaign_performance_validates_dates_before_vendor_call() -> None:
+    from connectors.marketing.google_ads import GoogleAdsConnector
+
+    connector = GoogleAdsConnector({"customer_id": "123-456-7890"})
+    calls: list[str] = []
+
+    async def fake_gaql_search(query: str) -> list[dict]:
+        calls.append(query)
+        return []
+
+    connector._gaql_search = fake_gaql_search
+
+    result = await connector.get_campaign_performance(
+        prompt="Use get_campaign_performance for this healthy Google Ads connector"
+    )
+
+    assert result["error"] == "validation_failed"
+    assert result["missing_parameters"] == ["start_date", "end_date"]
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_google_ads_campaign_performance_accepts_prompt_dates_and_campaign_id() -> None:
+    from connectors.marketing.google_ads import GoogleAdsConnector
+
+    connector = GoogleAdsConnector({"customer_id": "123-456-7890"})
+    captured: dict[str, str] = {}
+
+    async def fake_gaql_search(query: str) -> list[dict]:
+        captured["query"] = query
+        return [{"campaign": {"id": "9876543210", "name": "Brand"}}]
+
+    connector._gaql_search = fake_gaql_search
+
+    result = await connector.get_campaign_performance(
+        prompt=(
+            "Use get_campaign_performance with start_date=2026-06-18 "
+            "end_date=2026-06-19 campaign_id=9876543210"
+        )
+    )
+
+    assert result["date_range"] == {"start": "2026-06-18", "end": "2026-06-19"}
+    assert "segments.date BETWEEN '2026-06-18' AND '2026-06-19'" in captured["query"]
+    assert "campaign.id = 9876543210" in captured["query"]
+    assert "segments.date" in captured["query"]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_hubspot_contacts_workflow_alias_executes_connector_tool(monkeypatch) -> None:
+    from core.langgraph import tool_adapter
+    from workflows.step_types import execute_step
+
+    captured: dict[str, object] = {}
+
+    async def fake_execute_connector_tool(connector, tool, params, config):
+        captured.update(
+            {
+                "connector": connector,
+                "tool": tool,
+                "params": params,
+                "config": config,
+            }
+        )
+        return {"contacts": [{"id": "1", "email": "qa@example.com"}]}
+
+    monkeypatch.setattr(tool_adapter, "_execute_connector_tool", fake_execute_connector_tool)
+
+    result = await execute_step(
+        {
+            "id": "retrieve_hubspot_contacts",
+            "type": "agent",
+            "agent": "crm_intelligence",
+            "action": "process",
+            "inputs": {"limit": 5},
+            "connector_config": {"access_token": "pat-test"},
+        },
+        {"tenant_id": "22222222-2222-2222-2222-222222222222"},
+    )
+
+    assert result["status"] == "completed"
+    assert captured == {
+        "connector": "hubspot",
+        "tool": "list_contacts",
+        "params": {"limit": 5},
+        "config": {"access_token": "pat-test"},
+    }
+
+
+class _FakeScalarResult:
+    def __init__(self, value):
+        self.value = value
+
+    def scalar_one_or_none(self):
+        return self.value
+
+    def scalar_one(self):
+        return self.value
+
+
+def _install_fake_tenant_sessions(monkeypatch, values: list[object]):
+    from api.v1 import approvals
+
+    class FakeSession:
+        async def execute(self, _query):
+            if not values:
+                raise AssertionError("Unexpected query")
+            return _FakeScalarResult(values.pop(0))
+
+    @asynccontextmanager
+    async def fake_get_tenant_session(_tenant_id):
+        yield FakeSession()
+
+    monkeypatch.setattr(approvals, "get_tenant_session", fake_get_tenant_session)
+
+
+@pytest.mark.asyncio
+async def test_approval_resume_missing_engine_context_marks_run_failed(monkeypatch) -> None:
+    from api.v1.approvals import _resume_workflow_bg
+
+    tenant_id = uuid4()
+    workflow_run_id = uuid4()
+    run = SimpleNamespace(
+        id=workflow_run_id,
+        workflow_def_id=uuid4(),
+        context={},
+        status="waiting_hitl",
+        error=None,
+        completed_at=None,
+    )
+    workflow_def = SimpleNamespace(definition={"steps": [{"id": "approval"}]})
+    _install_fake_tenant_sessions(monkeypatch, [run, workflow_def, run])
+
+    await _resume_workflow_bg(tenant_id, workflow_run_id, {"decision": "approve"})
+
+    assert run.status == "failed"
+    assert run.error["code"] == "workflow_resume_context_missing"
+    assert run.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_approval_resume_missing_engine_state_marks_run_failed(monkeypatch) -> None:
+    from api.v1.approvals import _resume_workflow_bg
+    from workflows import engine as engine_module
+    from workflows import state_store as state_store_module
+
+    tenant_id = uuid4()
+    workflow_run_id = uuid4()
+    run = SimpleNamespace(
+        id=workflow_run_id,
+        workflow_def_id=uuid4(),
+        context={"_engine_run_id": "wfr_resume_missing_state"},
+        status="waiting_hitl",
+        error=None,
+        completed_at=None,
+    )
+    workflow_def = SimpleNamespace(definition={"steps": [{"id": "approval"}]})
+    _install_fake_tenant_sessions(monkeypatch, [run, workflow_def, run])
+
+    class FakeStateStore:
+        async def init(self):
+            return None
+
+        async def load(self, _run_id):
+            return None
+
+        async def close(self):
+            return None
+
+    class FakeEngine:
+        def __init__(self, _state_store):
+            pass
+
+        async def resume_from_hitl(self, run_id, decision):
+            assert run_id == "wfr_resume_missing_state"
+            assert decision == {"decision": "approve"}
+            return {"status": "completed"}
+
+    monkeypatch.setattr(state_store_module, "WorkflowStateStore", FakeStateStore)
+    monkeypatch.setattr(engine_module, "WorkflowEngine", FakeEngine)
+
+    await _resume_workflow_bg(tenant_id, workflow_run_id, {"decision": "approve"})
+
+    assert run.status == "failed"
+    assert run.error["code"] == "workflow_resume_state_missing"
+    assert run.completed_at is not None
+
+
+def test_approval_decide_passes_engine_run_id_hint_variants() -> None:
+    from pathlib import Path
+
+    src = Path("api/v1/approvals.py").read_text(encoding="utf-8")
+    assert 'ctx.get("_engine_run_id")' in src
+    assert 'ctx.get("engine_run_id")' in src
+    assert 'ctx.get("workflow_engine_run_id")' in src

--- a/tests/unit/test_enterprise_stability_gates.py
+++ b/tests/unit/test_enterprise_stability_gates.py
@@ -651,7 +651,7 @@ def test_core_execution_target_routes_have_metadata() -> None:
     routes = gates.scan_routes(target_paths, gates.REPO_ROOT)
     findings = gates.route_metadata_findings(routes)
 
-    assert len(routes) == 76
+    assert len(routes) == 77
     assert findings == []
     assert all(route.metadata_present for route in routes)
     assert all(route.scope for route in routes)
@@ -702,6 +702,7 @@ def test_core_execution_sensitive_routes_are_marked_in_scope() -> None:
         ("GET", "/api/v1/agents/{agent_id}/budget"),
         ("GET", "/api/v1/companies/{company_id}/credentials"),
         ("POST", "/api/v1/knowledge/search"),
+        ("GET", "/api/v1/workflows/{wf_id}/runs"),
         ("GET", "/api/v1/workflows/runs/{run_id}"),
     }
     assert sensitive_routes <= set(by_method_path)

--- a/ui/e2e/aishwarya-23june2026.spec.ts
+++ b/ui/e2e/aishwarya-23june2026.spec.ts
@@ -1,0 +1,213 @@
+import { expect, Page, test } from "@playwright/test";
+import { setSessionToken } from "./helpers/auth";
+
+async function installCommonRoutes(page: Page) {
+  await setSessionToken(
+    page,
+    process.env.E2E_TOKEN || "aishwarya-23jun2026-session",
+  );
+
+  await page.route("**/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      json: {
+        email: "qa@example.com",
+        name: "QA",
+        role: "admin",
+        domain: "all",
+        tenant_id: "tenant-1",
+        onboarding_complete: true,
+      },
+    });
+  });
+  await page.route("**/api/v1/product-facts", async (route) => {
+    await route.fulfill({
+      json: { version: "test", connector_count: 10, agent_count: 1, tool_count: 20 },
+    });
+  });
+  await page.route("**/api/v1/companies**", async (route) => {
+    await route.fulfill({ json: { items: [], total: 0, page: 1, per_page: 20, pages: 1 } });
+  });
+}
+
+function cmoPayload() {
+  const scopes = [
+    "crm.objects.contacts.read",
+    "crm.objects.deals.read",
+    "crm.objects.companies.read",
+    "crm.objects.owners.read",
+    "automation",
+  ];
+  return {
+    demo: false,
+    company_id: "comp-1",
+    agent_count: 1,
+    total_tasks_30d: 10,
+    success_rate: 90,
+    hitl_interventions: 0,
+    total_cost_usd: 1.5,
+    domain_breakdown: [
+      { domain: "marketing", total: 10, completed: 9, failed: 1, avg_confidence: 0.9 },
+    ],
+    connector_contracts: [
+      {
+        connector_key: "hubspot",
+        name: "HubSpot",
+        category: "CRM",
+        configured_status: "configured",
+        vendor_id: null,
+        account_id: "portal-123",
+        workspace_id: null,
+        read_capabilities: ["contacts.read", "deals.read", "lists.read"],
+        write_capabilities: ["workflow.enroll"],
+        required_read_scopes: ["crm.objects.contacts.read", "crm.objects.deals.read"],
+        required_write_scopes: ["automation"],
+        granted_scopes: scopes,
+        missing_read_scopes: [],
+        missing_write_scopes: [],
+        read_scope_evidence: ["HubSpot CRM read tools registered"],
+        auth_status: "valid",
+        health_status: "healthy",
+        contract_state: "healthy",
+        read_status: "ready",
+        write_status: "ready",
+        read_ready: true,
+        write_ready: true,
+        production_ready: true,
+        mock_or_test_double: false,
+        last_sync_at: "2026-06-23T00:00:00Z",
+        source_objects: [],
+        data_freshness: {
+          status: "fresh",
+          ttl_seconds: 86400,
+          last_sync_at: "2026-06-23T00:00:00Z",
+        },
+        retry_budget: {
+          max_attempts: 1,
+          attempts_used: 0,
+          remaining_attempts: 1,
+          reset_at: null,
+          next_retry_at: null,
+          idempotency_key: null,
+          idempotency_supported: true,
+        },
+        degraded_mode_reason: null,
+        idempotency_key_supported: true,
+        external_write_confirmation_status: "none",
+        external_write_confirmations: [],
+        next_action_cta: "none",
+      },
+    ],
+    connector_contract_summary: {
+      total: 1,
+      configured: 1,
+      read_ready: 1,
+      write_ready: 1,
+      blocked: 0,
+      degraded: 0,
+      missing_write_scope: 0,
+      write_unconfirmed: 0,
+      write_confirmed: 0,
+      mock_or_test_double: 0,
+      readiness: "ready",
+    },
+  };
+}
+
+function workflowPayload() {
+  return {
+    id: "wf-23",
+    name: "HubSpot approval workflow",
+    version: "1.0",
+    description: "Fetch HubSpot contacts after approval",
+    domain: "marketing",
+    trigger_type: "manual",
+    trigger_config: {},
+    is_active: true,
+    created_at: "2026-06-23T00:00:00Z",
+    definition: {
+      steps: [
+        { id: "approval", type: "human_in_loop" },
+        { id: "retrieve_hubspot_contacts", type: "agent", agent: "crm_intelligence" },
+        { id: "notify_owner", type: "notify" },
+      ],
+    },
+  };
+}
+
+test.describe("Aishwarya 23 June 2026 workbook regressions", () => {
+  test("CMO connector contracts render healthy HubSpot as read and write ready", async ({
+    page,
+    baseURL,
+  }) => {
+    await installCommonRoutes(page);
+    await page.route("**/api/v1/kpis/cmo**", async (route) => {
+      await route.fulfill({ json: cmoPayload() });
+    });
+
+    await page.goto(`${baseURL}/dashboard/cmo`, { waitUntil: "domcontentloaded" });
+
+    const hubspotRow = page.locator("tr", { hasText: "HubSpot" }).first();
+    await expect(hubspotRow.locator("td").nth(1)).toContainText("Healthy");
+    await expect(hubspotRow.locator("td").nth(2)).toContainText("Ready");
+    await expect(hubspotRow.locator("td").nth(3)).toContainText("Ready");
+    await expect(hubspotRow).not.toContainText("Missing Scope");
+    await expect(hubspotRow).not.toContainText("crm.objects.contacts.read");
+    await expect(hubspotRow).not.toContainText("crm.objects.deals.read");
+    await expect(hubspotRow).not.toContainText("automation");
+  });
+
+  test("workflow detail page shows and polls latest run execution progress", async ({
+    page,
+    baseURL,
+  }) => {
+    await installCommonRoutes(page);
+    await page.route("**/api/v1/workflows/wf-23", async (route) => {
+      await route.fulfill({ json: workflowPayload() });
+    });
+
+    let runCalls = 0;
+    await page.route("**/api/v1/workflows/wf-23/runs**", async (route) => {
+      runCalls += 1;
+      await route.fulfill({
+        json: {
+          items: [
+            runCalls < 3
+              ? {
+                  run_id: "run-23",
+                  workflow_def_id: "wf-23",
+                  status: "waiting_hitl",
+                  steps_total: 3,
+                  steps_completed: 1,
+                  started_at: "2026-06-23T00:00:00Z",
+                }
+              : {
+                  run_id: "run-23",
+                  workflow_def_id: "wf-23",
+                  status: "completed",
+                  steps_total: 3,
+                  steps_completed: 3,
+                  started_at: "2026-06-23T00:00:00Z",
+                  completed_at: "2026-06-23T00:01:00Z",
+                },
+          ],
+          total: 1,
+          page: 1,
+          per_page: 5,
+          pages: 1,
+        },
+      });
+    });
+
+    await page.goto(`${baseURL}/dashboard/workflows/wf-23`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page.locator("main")).toContainText("Latest Run");
+    await expect(page.locator("main")).toContainText("waiting_hitl");
+    await expect(page.locator("main")).toContainText("1/3");
+    await expect(page.getByRole("button", { name: "View Run" })).toBeVisible();
+    await expect.poll(() => runCalls, { timeout: 10000 }).toBeGreaterThan(1);
+    await expect(page.locator("main")).toContainText("completed");
+    await expect(page.locator("main")).toContainText("3/3");
+  });
+});

--- a/ui/src/pages/WorkflowDetail.tsx
+++ b/ui/src/pages/WorkflowDetail.tsx
@@ -1,21 +1,117 @@
-import { useState, useEffect } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import api from "@/lib/api";
+
+const LIVE_RUN_STATUSES = new Set(["running", "waiting_hitl", "waiting_delay", "waiting_event"]);
+
+interface WorkflowRunSummary {
+  id?: string;
+  run_id?: string;
+  workflow_def_id: string;
+  status: string;
+  steps_total?: number | null;
+  steps_completed?: number | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+}
+
+function runIdFor(run: WorkflowRunSummary): string {
+  return run.run_id || run.id || "";
+}
 
 export default function WorkflowDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [workflow, setWorkflow] = useState<any>(null);
+  const [runs, setRuns] = useState<WorkflowRunSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const [runsLoading, setRunsLoading] = useState(false);
+  const [triggerInFlight, setTriggerInFlight] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [runsError, setRunsError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!id) return;
-    api.get(`/workflows/${id}`)
-      .then(({ data }) => setWorkflow(data))
-      .catch(() => setError("Workflow not found"))
-      .finally(() => setLoading(false));
+    fetchWorkflow();
+    fetchRuns();
   }, [id]);
+
+  const latestRun = runs[0] || null;
+
+  useEffect(() => {
+    if (!id || !latestRun || !LIVE_RUN_STATUSES.has(latestRun.status)) return;
+    const interval = setInterval(() => fetchRuns({ showLoading: false }), 3000);
+    return () => clearInterval(interval);
+  }, [id, latestRun?.status, latestRun ? runIdFor(latestRun) : ""]);
+
+  async function fetchWorkflow() {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await api.get(`/workflows/${id}`);
+      setWorkflow(data);
+    } catch (e: any) {
+      const detail = e?.response?.data?.detail || e?.message;
+      setError(detail ? `Workflow not found: ${detail}` : "Workflow not found");
+      setWorkflow(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function fetchRuns(options: { showLoading?: boolean } = {}) {
+    if (!id) return;
+    if (options.showLoading !== false) setRunsLoading(true);
+    setRunsError(null);
+    try {
+      const { data } = await api.get(`/workflows/${id}/runs`, {
+        params: { per_page: 5 },
+      });
+      setRuns(Array.isArray(data?.items) ? data.items : []);
+    } catch (e: any) {
+      setRuns([]);
+      setRunsError(e?.response?.data?.detail || "Failed to load recent workflow runs");
+    } finally {
+      setRunsLoading(false);
+    }
+  }
+
+  async function triggerRun() {
+    if (!id) return;
+    setTriggerInFlight(true);
+    setRunsError(null);
+    try {
+      const { data } = await api.post(`/workflows/${id}/run`, {});
+      if (data?.run_id) {
+        navigate(`/dashboard/workflows/${id}/runs/${data.run_id}`);
+      } else {
+        await fetchRuns({ showLoading: false });
+      }
+    } catch (e: any) {
+      setRunsError(e?.response?.data?.detail || "Failed to trigger workflow run");
+    } finally {
+      setTriggerInFlight(false);
+    }
+  }
+
+  const steps = workflow?.definition?.steps || [];
+  const statusVariant: Record<string, string> = {
+    running: "warning",
+    waiting_hitl: "secondary",
+    waiting_delay: "secondary",
+    waiting_event: "secondary",
+    completed: "success",
+    failed: "destructive",
+    cancelled: "outline",
+  };
+  const latestProgress = useMemo(() => {
+    const total = Number(latestRun?.steps_total || 0);
+    const completed = Number(latestRun?.steps_completed || 0);
+    return total > 0 ? Math.round((completed / total) * 100) : 0;
+  }, [latestRun]);
 
   if (loading) return <p className="text-muted-foreground">Loading...</p>;
   if (error || !workflow) {
@@ -23,37 +119,41 @@ export default function WorkflowDetail() {
       <div className="space-y-4">
         <h2 className="text-2xl font-bold">Workflow Not Found</h2>
         <p className="text-muted-foreground">{error || "The requested workflow does not exist."}</p>
-        <button onClick={() => navigate("/dashboard/workflows")} className="text-primary hover:underline text-sm">
+        <Button variant="ghost" onClick={() => navigate("/dashboard/workflows")} className="px-0">
           Back to Workflows
-        </button>
+        </Button>
       </div>
     );
   }
 
-  const steps = workflow.definition?.steps || [];
-
   return (
     <div className="space-y-6">
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
           <h2 className="text-2xl font-bold">{workflow.name}</h2>
           <p className="text-muted-foreground text-sm mt-1">{workflow.description}</p>
         </div>
-        <div className="flex gap-2">
-          <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${workflow.is_active ? "bg-green-100 text-green-800" : "bg-gray-100 text-gray-800"}`}>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant={workflow.is_active ? ("success" as any) : "secondary"}>
             {workflow.is_active ? "Active" : "Inactive"}
-          </span>
-          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-            v{workflow.version}
-          </span>
+          </Badge>
+          <Badge variant="outline">v{workflow.version}</Badge>
+          <Button size="sm" onClick={triggerRun} disabled={triggerInFlight || !workflow.is_active}>
+            {triggerInFlight ? "Starting..." : "Run Now"}
+          </Button>
         </div>
       </div>
 
-      {/* Info Grid */}
+      {runsError && (
+        <div className="rounded-lg bg-red-50 text-red-800 border border-red-200 px-4 py-3 text-sm">
+          {runsError}
+        </div>
+      )}
+
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className="border rounded-lg p-4">
           <p className="text-xs text-muted-foreground">Domain</p>
-          <p className="text-sm font-medium mt-1 capitalize">{workflow.domain || "—"}</p>
+          <p className="text-sm font-medium mt-1 capitalize">{workflow.domain || "-"}</p>
         </div>
         <div className="border rounded-lg p-4">
           <p className="text-xs text-muted-foreground">Trigger</p>
@@ -69,7 +169,56 @@ export default function WorkflowDetail() {
         </div>
       </div>
 
-      {/* Steps */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Latest Run</CardTitle>
+          <Button variant="outline" size="sm" onClick={() => fetchRuns()} disabled={runsLoading}>
+            Refresh
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {runsLoading && runs.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Loading recent runs...</p>
+          ) : latestRun ? (
+            <div className="space-y-4">
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <Badge variant={(statusVariant[latestRun.status] || "default") as any}>
+                      {latestRun.status}
+                    </Badge>
+                    <span className="font-mono text-xs text-muted-foreground">{runIdFor(latestRun)}</span>
+                  </div>
+                  <p className="text-sm text-muted-foreground mt-2">
+                    Started {latestRun.started_at ? new Date(latestRun.started_at).toLocaleString() : "not recorded"}
+                  </p>
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => navigate(`/dashboard/workflows/${id}/runs/${runIdFor(latestRun)}`)}
+                >
+                  View Run
+                </Button>
+              </div>
+              <div>
+                <div className="flex justify-between text-sm">
+                  <span>Execution progress</span>
+                  <span>
+                    {latestRun.steps_completed ?? 0}/{latestRun.steps_total ?? 0}
+                  </span>
+                </div>
+                <div className="w-full bg-muted rounded-full h-2 mt-2">
+                  <div className="bg-primary rounded-full h-2 transition-all" style={{ width: `${latestProgress}%` }} />
+                </div>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No workflow runs yet.</p>
+          )}
+        </CardContent>
+      </Card>
+
       {steps.length > 0 && (
         <div className="border rounded-lg p-6">
           <h3 className="text-lg font-semibold mb-4">Workflow Steps</h3>
@@ -82,21 +231,21 @@ export default function WorkflowDetail() {
                 <div className="flex-1 border rounded-lg p-3">
                   <p className="font-medium text-sm">{step.id}</p>
                   <p className="text-xs text-muted-foreground">
-                    {step.type === "hitl" ? "Human-in-the-Loop approval" : `Agent: ${step.agent}`}
+                    {step.type === "hitl" || step.type === "human_in_loop"
+                      ? "Human-in-the-loop approval"
+                      : `Agent: ${step.agent || step.agent_type || "-"}`}
                   </p>
                 </div>
-                {i < steps.length - 1 && (
-                  <div className="text-muted-foreground text-lg">→</div>
-                )}
+                {i < steps.length - 1 && <div className="text-muted-foreground text-lg">-&gt;</div>}
               </div>
             ))}
           </div>
         </div>
       )}
 
-      <button onClick={() => navigate("/dashboard/workflows")} className="text-sm text-muted-foreground hover:text-foreground">
-        ← Back to Workflows
-      </button>
+      <Button variant="ghost" onClick={() => navigate("/dashboard/workflows")} className="px-0 text-muted-foreground">
+        Back to Workflows
+      </Button>
     </div>
   );
 }

--- a/workflows/step_types.py
+++ b/workflows/step_types.py
@@ -62,9 +62,13 @@ CONNECTOR_TOOL_ALIASES: dict[str, tuple[str, str]] = {
     "fetch_hubspot_contacts": ("hubspot", "list_contacts"),
     "get_hubspot_contacts": ("hubspot", "list_contacts"),
     "list_hubspot_contacts": ("hubspot", "list_contacts"),
+    "retrieve_hubspot_contacts": ("hubspot", "list_contacts"),
+    "hubspot_contact_retrieval": ("hubspot", "list_contacts"),
     "fetch_hubspot_deals": ("hubspot", "list_deals"),
     "get_hubspot_deals": ("hubspot", "list_deals"),
     "list_hubspot_deals": ("hubspot", "list_deals"),
+    "retrieve_hubspot_deals": ("hubspot", "list_deals"),
+    "hubspot_deal_retrieval": ("hubspot", "list_deals"),
 }
 
 


### PR DESCRIPTION
## Summary
- harden HubSpot readiness scope/tool evidence handling across CMO contract/setup paths
- normalize SendGrid and Google Ads agent/tool payload parsing with strict local validation
- repair HITL workflow resume failure handling and add latest-run polling on workflow detail
- add reopened-case regression tests, Playwright coverage, and permanent bug-fix learnings

## Validation
- python -m pytest tests\\regression\\test_aishwarya_23jun2026_reopens.py
- npm --prefix ui run typecheck
- earlier full retest before commit: 25 backend tests passed, broader connector regression passed, Playwright aishwarya-23june2026 passed

## Notes
- Source workbook credentials/tokens were not committed or copied into repo artifacts.