### PR TITLE
Expose direct AgenticOrg CLI install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ FastAPI Backend
     ├── RouteLLM → Smart model routing → 3-tier cost optimization
     ├── Presidio → Pre-LLM PII redaction → Aadhaar/PAN/GSTIN scrubbing
     ├── Composio → 1000+ tool marketplace → OAuth bridge
-    ├── MCP Server → native tools exposed to Claude/Cursor/ChatGPT (see /api/v1/product-facts.tool_count)
+    ├── MCP Server → governed agent + seller tools for Claude/Cursor/ChatGPT/VS Code
     ├── API Key Manager → ao_sk_ keys → SDK/CLI/MCP auth
     ├── SOP Parser → Upload SOPs → Deploy as agents
     └── Sales Agent → Gmail API → Email Sequences
@@ -481,6 +481,12 @@ Base URL: `https://app.agenticorg.ai/api/v1`
 
 ## SDKs, CLI & MCP Server
 
+`pip install agenticorg` is the canonical Python install path for both the
+SDK and the direct `agenticorg` CLI. Use the CLI from shell-capable assistants
+and developer environments such as Claude Code, Codex, Gemini CLI, VS Code
+tasks/terminals, CI jobs, and customer runbooks. Use the MCP server when the
+client supports Model Context Protocol and should call AgenticOrg as tools.
+
 ### Python SDK
 
 ```bash
@@ -530,7 +536,7 @@ const agents = await client.agents.list();
 
 ### MCP Server
 
-Any MCP-compatible client (Claude Desktop, Cursor, ChatGPT) can use AgenticOrg agents and tools:
+Any MCP-compatible client (Claude Desktop, Cursor, ChatGPT, VS Code MCP clients) can use AgenticOrg agents and tools:
 
 ```bash
 AGENTICORG_API_KEY=ao_sk_... npx agenticorg-mcp-server
@@ -560,9 +566,14 @@ agenticorg agents run commerce_sales_agent --action buyer_discovery_preview --in
 agenticorg agents generate "Create a contract intelligence agent using Confluence and Jira"
 agenticorg knowledge search "vendor renewal policy" --top-k 3
 agenticorg workflows generate "Review vendor renewal risk using KB and Jira"
-agenticorg sop parse "When invoice > 5L, require CFO approval"
+agenticorg workflows run wf-123 --input '{"vendor_id":"V-100"}'
+agenticorg sop parse --text "When invoice > 5L, require CFO approval"
+agenticorg a2a card
 agenticorg mcp tools
 ```
+
+The same root package also installs `agenticorg-bridge` for the on-prem Tally
+bridge used by CA-firm deployments.
 
 See `sdk/README.md` and `mcp-server/README.md` for full documentation.
 
@@ -588,9 +599,14 @@ AgenticOrg implements Google's A2A protocol for cross-platform agent discovery a
 - `POST /a2a/tasks` — execute tasks via A2A protocol (JWT or Grantex auth)
 
 ### MCP (Model Context Protocol)
-Full MCP server exposing the live connector tools to any MCP-compatible client (see /api/v1/product-facts.tool_count):
+MCP server exposing governed AgenticOrg agent tools, platform discovery, and
+read-only seller OACP artifact tools to compatible clients:
 - `GET /mcp/tools` — list all available MCP tools (no auth required)
-- `POST /mcp/call` — call any MCP tool (JWT or Grantex auth)
+- `POST /mcp/call` — call an AgenticOrg MCP tool (JWT or Grantex auth)
+
+Direct connector tools are not exposed as MCP tools. Use `run_agent` or
+`agenticorg_<agent_type>` tools so connector access remains inside the
+AgenticOrg runtime, scope checks, approval gates, and audit trail.
 
 ### Grantex Authorization & Scope Enforcement
 OAuth2-based authorization with manifest-based scope enforcement (Grantex SDK v0.3.3+):

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2228,10 +2228,10 @@ GET  /api/v1/workflows/runs/{run_id}
 Starts a workflow run and then polls the run record, including step status,
 inputs, outputs, confidence, and errors.
 
-### SDK launch contract
+### SDK, CLI, and MCP launch contract
 
-The Python SDK, TypeScript SDK, and MCP server are expected to cover this
-end-to-end path:
+The Python SDK, TypeScript SDK, direct `agenticorg` CLI, and MCP server are
+expected to cover this end-to-end path:
 
 1. Discover launchable agents through `GET /api/v1/a2a/agent-card`,
    `GET /api/v1/a2a/agents`, and `GET /api/v1/mcp/tools`.
@@ -2239,6 +2239,19 @@ end-to-end path:
    buyer/seller discovery.
 3. List connectors, search knowledge, generate an agent, generate a workflow,
    create the workflow, run it, and poll the run status.
+
+The direct CLI is installed by `pip install agenticorg`:
+
+```bash
+agenticorg agents run commerce_sales_agent \
+  --action buyer_discovery_preview \
+  --input '{"merchant_id":"merchant_demo"}'
+```
+
+Use it from shell-capable assistants and environments such as Claude Code,
+Codex, Gemini CLI, VS Code terminals/tasks, CI jobs, and runbooks. Use
+`npx agenticorg-mcp-server` when the client should discover AgenticOrg through
+MCP tools.
 
 ### Knowledge search — native pgvector fallback
 

--- a/docs/api/agent-run-contract.md
+++ b/docs/api/agent-run-contract.md
@@ -67,8 +67,9 @@ Both endpoints MUST produce the canonical shape:
 
 Tests: `tests/regression/test_agent_run_contract.py` asserts every field is present (with correct null-ness) on both endpoints.
 
-## SDKs
+## SDKs And CLI
 
 - **Python** (`sdk/agenticorg/client.py`): `run()` returns `AgentRunResult` dataclass. Raw response is normalized in `_to_agent_run_result()`; both endpoint shapes (canonical + legacy-shaped) produce identical `AgentRunResult`.
 - **TypeScript** (`sdk-ts/src/index.ts`): `AgentRunResult` interface matches this doc. Runtime helper `toAgentRunResult()` normalizes.
+- **CLI** (`sdk/agenticorg/cli.py`): `agenticorg agents run ...` uses the same Python SDK client and returns the same normalized JSON. The root package and SDK package both expose the `agenticorg` console script.
 - **In-product snippet** (`ui/src/pages/Integrations.tsx`): the example on the Integrations page mirrors the SDK signature. Drift is caught by `ui/e2e/sdk-examples.spec.ts`.

--- a/docs/enterprise-evaluation/03-developer-integration.md
+++ b/docs/enterprise-evaluation/03-developer-integration.md
@@ -2,8 +2,8 @@
 
 **Persona:** platform engineer integrating AgenticOrg into an existing
 product or an MCP-capable client (Claude Desktop, Cursor, ChatGPT)
-**Goal:** run an agent from Python/TS code and from an MCP client,
-and rely on the same canonical contract across both paths
+**Goal:** run an agent from Python/TS code, the direct CLI, and an MCP
+client, and rely on the same canonical contract across all paths
 **Playwright:** `ui/e2e/sdk-examples.spec.ts`
 **Regression:** `tests/regression/test_agent_run_contract.py`
 
@@ -43,6 +43,26 @@ const result = await client.agents.run({
 // Same canonical shape — see sdk-ts/src/index.ts::AgentRunResult
 ```
 
+### Direct CLI
+
+Install the Python package once and use the direct CLI from any
+shell-capable assistant or developer environment, including Claude
+Code, Codex, Gemini CLI, VS Code terminals/tasks, CI jobs, and
+runbooks.
+
+```bash
+pip install agenticorg
+export AGENTICORG_API_KEY=ao_sk_...
+
+agenticorg agents list
+agenticorg agents run cfo_kpi_monitor --input '{"company_id":"demo-corp"}'
+agenticorg a2a card
+agenticorg mcp tools
+```
+
+The root/full-platform package and the SDK package must both expose the
+same `agenticorg` console script.
+
 ### MCP client (Claude Desktop / Cursor / ChatGPT)
 
 Register AgenticOrg as an MCP server (`npx agenticorg-mcp-server` with
@@ -58,7 +78,7 @@ MCP client surfaces a useful error.
 
 - SDK examples compile and execute against the live API with no
   schema mismatch.
-- Python + TS + MCP all return the same canonical field set.
+- Python + TS + CLI + MCP all return the same canonical field set.
 - Legacy aliases (`task_id`, `result.output`, `result.confidence`) are
   accepted as inputs but deprecated in returns — through v5.0.
 

--- a/docs/release-sdks.md
+++ b/docs/release-sdks.md
@@ -6,7 +6,13 @@ credentials, should not live in CI without a release-gating flow).
 
 ## Current release targets
 
-- Python SDK + CLI: `agenticorg==0.3.0` on PyPI.
+- Python SDK + CLI: `agenticorg==0.3.0` on PyPI. The root
+  AgenticOrg package also includes `sdk/agenticorg` and exposes the
+  direct `agenticorg` CLI so `pip install agenticorg` works for shell
+  users, Claude Code, Codex, Gemini CLI, VS Code tasks, CI, and runbooks.
+  PyPI `agenticorg` remains the lightweight SDK+CLI artifact built from
+  `sdk/`; do not upload the root/full-platform wheel to PyPI under the same
+  package name.
 - TypeScript SDK: `agenticorg-sdk@0.3.0` on npm. The scoped package
   `@agenticorg/sdk` is not currently published.
 - MCP server npm package: `agenticorg-mcp-server@4.0.5`.
@@ -15,6 +21,10 @@ credentials, should not live in CI without a release-gating flow).
 ## Python SDK (PyPI)
 
 **Prereqs:** `pip install build twine`. PyPI token in `~/.pypirc`.
+
+The SDK source lives under `sdk/agenticorg`. It is also included in
+the root wheel so local/full-platform installs expose the same direct
+CLI entrypoint as the SDK package.
 
 ```bash
 cd sdk
@@ -30,11 +40,42 @@ twine upload dist/*
 pip install --upgrade agenticorg
 python -c "import agenticorg; print(agenticorg.__version__)"
 # expect the version from sdk/agenticorg/__init__.py
+agenticorg --help
 ```
 
 The `__version__` in `sdk/agenticorg/__init__.py` must match
 `version` in `sdk/pyproject.toml`. CHANGELOG.md under `sdk/` is the
 release-notes source; keep the top entry dated.
+
+## Root package CLI check (local/container/internal only)
+
+The root/full-platform wheel is allowed for local, container, and internal
+installs so full-platform checkouts expose the same `agenticorg` CLI as the
+published SDK. It is **not** the PyPI release artifact while the SDK package
+also owns the `agenticorg` distribution name.
+
+Before cutting a root/full-platform wheel for internal use, verify both console
+scripts land from the root package metadata:
+
+```bash
+python -m build
+python -m pip install --force-reinstall --no-deps dist/agenticorg-*.whl
+agenticorg --help
+agenticorg-bridge --help
+```
+
+Do not run `twine upload` from the repository root. Public PyPI publishes for
+the `agenticorg` package must come from `sdk/` unless a release owner first
+changes the package-name and version policy.
+
+`pyproject.toml` must include `sdk/agenticorg` in
+`tool.hatch.build.targets.wheel.packages` and expose:
+
+```toml
+[project.scripts]
+agenticorg = "agenticorg.cli:main"
+agenticorg-bridge = "bridge.cli:main"
+```
 
 ## TypeScript SDK (npm)
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -15,6 +15,21 @@ Or run directly with npx:
 AGENTICORG_API_KEY=your-key npx agenticorg-mcp-server
 ```
 
+For shell-capable tools such as Claude Code, Codex, Gemini CLI, VS Code
+terminals/tasks, CI jobs, and runbooks, the direct Python CLI is also
+available:
+
+```bash
+pip install agenticorg
+AGENTICORG_API_KEY=your-key agenticorg agents run commerce_sales_agent \
+  --action buyer_discovery_preview \
+  --input '{"merchant_id":"merchant_demo"}'
+```
+
+Use this MCP server when the client should discover and call AgenticOrg
+through MCP tools. Use the direct CLI when the client can run shell
+commands.
+
 ## Configure in ChatGPT / Claude Desktop / Cursor
 
 Add to your MCP client configuration:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,28 @@ build-backend = "hatchling.build"
 # `pip install agenticorg` gave CA-firm sites the server code with no
 # way to install the bridge client. `bridge` now ships in the wheel
 # and the `agenticorg-bridge` console script works after pip install.
-packages = ["core", "api", "auth", "bridge", "connectors", "workflows", "scaling", "observability", "audit", "schemas"]
+#
+# CLI-2026-06-25: include the Python SDK package in the root wheel too.
+# This makes `pip install agenticorg` land the direct `agenticorg` CLI
+# for Claude Code, Codex, Gemini CLI, VS Code tasks, CI, and shell users,
+# without requiring callers to know about the monorepo's sdk/ subpackage.
+# Publishing policy: PyPI `agenticorg` remains the lightweight SDK+CLI
+# artifact built from sdk/. This root/full-platform wheel is for local,
+# container, and internal installs unless a release owner explicitly changes
+# the package-name/version policy.
+packages = [
+    "core",
+    "api",
+    "auth",
+    "bridge",
+    "connectors",
+    "workflows",
+    "scaling",
+    "observability",
+    "audit",
+    "schemas",
+    "sdk/agenticorg",
+]
 
 [project]
 name = "agenticorg"
@@ -138,6 +159,9 @@ dev = [
 ]
 
 [project.scripts]
+# Direct CLI for launching agents, workflows, A2A discovery, MCP discovery,
+# SOP parsing, and knowledge search from any shell-capable assistant/client.
+agenticorg = "agenticorg.cli:main"
 # UR-Bug-5: CA-firm sites run `agenticorg-bridge` on the client machine
 # to tunnel Tally XML calls to the cloud. Exposing the console script
 # here so `pip install agenticorg` lands a working entrypoint.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -93,6 +93,11 @@ print(matches[0]["document_name"], run["run_id"])
 
 ## Quickstart (CLI)
 
+The same `pip install agenticorg` package installs the Python SDK and the
+direct `agenticorg` CLI. The CLI is intended for shell-capable assistants and
+developer environments such as Claude Code, Codex, Gemini CLI, VS Code
+terminals/tasks, CI jobs, and runbooks.
+
 ```bash
 # Set your API key
 export AGENTICORG_API_KEY=your-key

--- a/tests/regression/test_sdk_release_metadata_20260614.py
+++ b/tests/regression/test_sdk_release_metadata_20260614.py
@@ -24,6 +24,18 @@ def test_python_sdk_release_version_matches_cli_package_metadata() -> None:
     assert pyproject["project"]["scripts"]["agenticorg"] == "agenticorg.cli:main"
 
 
+def test_root_package_exposes_direct_cli_and_sdk_package() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    release_docs = (ROOT / "docs" / "release-sdks.md").read_text(encoding="utf-8")
+
+    assert pyproject["project"]["name"] == "agenticorg"
+    assert pyproject["project"]["scripts"]["agenticorg"] == "agenticorg.cli:main"
+    assert pyproject["project"]["scripts"]["agenticorg-bridge"] == "bridge.cli:main"
+    assert "sdk/agenticorg" in pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"]
+    assert "do not upload the root/full-platform wheel to PyPI" in release_docs
+    assert "Do not run `twine upload` from the repository root" in release_docs
+
+
 def test_typescript_sdk_release_metadata_uses_published_package_name() -> None:
     package_json = _read_json("sdk-ts/package.json")
     package_lock = _read_json("sdk-ts/package-lock.json")

--- a/ui/public/llms-full.txt
+++ b/ui/public/llms-full.txt
@@ -1,6 +1,6 @@
 # AgenticOrg — Complete Product Documentation for LLMs
 
-> AgenticOrg is an enterprise AI virtual employee platform. Create custom AI agents with names, personas, and tailored instructions — or deploy 26 pre-built agents across 6 domains: Finance, HR, Marketing, Operations, Back Office, and Communications. Each agent automates domain-specific tasks with human-in-the-loop (HITL) governance, connecting to 54 enterprise systems (339 tools). Built for Indian enterprise with native GSTN, EPFO, and Darwinbox connectors.
+> AgenticOrg is an enterprise AI virtual employee platform. Create custom AI agents with names, personas, and tailored instructions — or deploy 29 pre-built agents across 6 domains: Finance, HR, Marketing, Operations, Back Office, and Communications. Each agent automates domain-specific tasks with human-in-the-loop (HITL) governance, connecting to 56 enterprise systems (430 tools). Built for Indian enterprise with native GSTN, EPFO, and Darwinbox connectors.
 
 ## Product Overview
 
@@ -10,6 +10,7 @@ Website: https://agenticorg.ai
 Playground (try live): https://agenticorg.ai/playground
 Pricing: https://agenticorg.ai/pricing
 Evaluation Matrix: https://agenticorg.ai/evals
+Open Agentic Commerce Protocol: https://agenticorg.ai/open-agentic-commerce-protocol
 GitHub: https://github.com/mishrasanjeev/agentic-org
 
 ---
@@ -21,7 +22,7 @@ GitHub: https://github.com/mishrasanjeev/agentic-org
 2. Orchestration (Nexus orchestrator, DAG workflows, parallel execution)
 3. Agent Runtime (LLM reasoning via Gemini 2.5 Flash, tool calling, confidence scoring)
 4. HITL Governance (approval queues, role-based escalation, timeout policies)
-5. Connector Hub (54 pre-built connectors with circuit breakers)
+5. Connector Hub (56 pre-built connectors with circuit breakers)
 6. Schema Registry (validated data schemas)
 7. Observability (Prometheus metrics, OpenTelemetry traces, structured logging)
 8. Infrastructure (GKE Autopilot, Cloud SQL PostgreSQL, Redis)
@@ -35,7 +36,7 @@ AgenticOrg treats AI agents as virtual employees — named personas that admins 
 ### Agent Creator (No-Code Wizard)
 5-step wizard available to admin/CEO users:
 1. **Persona**: Employee name, designation, avatar, domain
-2. **Role**: Agent type (pick from 26 built-in or create custom), specialization, routing filters
+2. **Role**: Agent type (pick from 29 built-in or create custom), specialization, routing filters
 3. **Prompt**: Select from production-tested prompt templates or write custom instructions, fill in template variables
 4. **Behavior**: Confidence floor, HITL conditions, LLM model, max retries
 5. **Review**: Summary and deploy as Shadow
@@ -51,7 +52,7 @@ Each agent can have monthly cost caps. Before every execution, the system checks
 
 ---
 
-## All 26 Agents — Detailed
+## All 29 Agents — Detailed
 
 ### Finance Domain (6 agents, CFO oversight)
 
@@ -105,15 +106,23 @@ Each agent can have monthly cost caps. Before every execution, the system checks
 - Domain: HR
 - Confidence floor: 88%
 
-### Marketing Domain (5 agents, CMO oversight)
+### Marketing Domain (8 agents, CMO oversight)
+
+#### Abm (abm)
+- Domain: Marketing
+- Confidence floor: 80%
 
 #### Brand Monitor (brand_monitor)
 - Domain: Marketing
-- Confidence floor: 85%
+- Confidence floor: 80%
 
 #### Campaign Pilot (campaign_pilot)
 - Domain: Marketing
 - Confidence floor: 85%
+
+#### Competitive Intel (competitive_intel)
+- Domain: Marketing
+- Confidence floor: 80%
 
 #### Content Factory (content_factory)
 - Domain: Marketing
@@ -121,11 +130,15 @@ Each agent can have monthly cost caps. Before every execution, the system checks
 
 #### Crm Intelligence (crm_intelligence)
 - Domain: Marketing
-- Confidence floor: 88%
+- Confidence floor: 80%
 
 #### Seo Strategist (seo_strategist)
 - Domain: Marketing
-- Confidence floor: 90%
+- Confidence floor: 80%
+
+#### Social Media (social_media)
+- Domain: Marketing
+- Confidence floor: 80%
 
 ### Operations Domain (6 agents, COO oversight)
 
@@ -169,21 +182,23 @@ Each agent can have monthly cost caps. Before every execution, the system checks
 
 ---
 
-## 54 Enterprise Connectors (339 total tools)
+## 56 Enterprise Connectors (430 total tools)
 
-### Finance (12 connectors)
+### Finance (14 connectors)
 - Banking Aa: 5 tools (aa_oauth2)
-- Gstn: 8 tools (gsp_dsc)
+- Gstn: 9 tools (gsp_dsc)
 - Gstn Sandbox: 0 tools (api_key)
-- Income Tax India: 7 tools (dsc)
+- Income Tax India: 13 tools (dsc)
 - Netsuite: 8 tools (token)
 - Oracle Fusion: 10 tools (basic)
 - Pinelabs Plural: 6 tools (oauth2)
+- Professional Tax: 5 tools (state_portal)
 - Quickbooks: 6 tools (oauth2)
 - Sap: 7 tools (odata_oauth2)
 - Stripe: 8 tools (api_key)
 - Tally: 6 tools (tdl_xml)
-- Zoho Books: 7 tools (oauth2)
+- Traces: 4 tools (deductor_portal)
+- Zoho Books: 35 tools (oauth2)
 
 ### HR (8 connectors)
 - Darwinbox: 10 tools (api_key_oauth2)
@@ -203,13 +218,13 @@ Each agent can have monthly cost caps. Before every execution, the system checks
 - G2: 4 tools (api_key)
 - Ga4: 6 tools (oauth2)
 - Google Ads: 5 tools (oauth2)
-- Hubspot: 13 tools (oauth2)
+- Hubspot: 32 tools (oauth2)
 - Linkedin Ads: 4 tools (oauth2)
 - Mailchimp: 10 tools (basic)
 - Meta Ads: 5 tools (oauth2)
 - Mixpanel: 5 tools (basic)
 - Moengage: 6 tools (basic)
-- Salesforce: 6 tools (oauth2)
+- Salesforce: 24 tools (oauth2)
 - Trustradius: 4 tools (api_key)
 - Wordpress: 7 tools (basic)
 
@@ -223,7 +238,7 @@ Each agent can have monthly cost caps. Before every execution, the system checks
 - Zendesk: 8 tools (api_token)
 
 ### Communications & Cloud (11 connectors)
-- Github: 9 tools (pat_oauth2)
+- Github: 19 tools (pat_oauth2)
 - Gmail: 4 tools (oauth2)
 - Google Calendar: 5 tools (oauth2)
 - Langsmith: 5 tools (api_key)
@@ -280,7 +295,7 @@ Shadow agents have configurable limits: minimum sample count (default 100), accu
 
 ## MCP Registry
 
-AgenticOrg is listed in the official MCP Registry (mcpregistry.com) under the name `agenticorg-mcp-server`. Any MCP-compatible client — ChatGPT, Claude Desktop, Cursor, Windsurf, VS Code — can discover and connect to AgenticOrg agents and tools automatically. The MCP server exposes 10 tools and 339 connector tools via stdio transport.
+AgenticOrg is listed in the official MCP Registry (mcpregistry.com) under the name `agenticorg-mcp-server`. Any MCP-compatible client — ChatGPT, Claude Desktop, Cursor, Windsurf, VS Code — can discover and connect to AgenticOrg agents and governed tools. The MCP server exposes agent-management, A2A discovery, platform MCP discovery, and read-only seller OACP artifact tools via stdio transport. Direct connector tools are not exposed; agents invoke approved connector workflows through the AgenticOrg runtime.
 
 ---
 
@@ -362,6 +377,13 @@ AgenticOrg is listed in the official MCP Registry (mcpregistry.com) under the na
 
 ## Blog
 
+- [Merchant Self-Service Config for OACP Commerce](https://agenticorg.ai/blog/merchant-self-service-oacp-commerce-config)
+- [How a Shopify Merchant Goes Live with a Seller Commerce Agent](https://agenticorg.ai/blog/shopify-merchant-seller-commerce-agent-oacp)
+- [How ChatGPT, Claude, Gemini, Perplexity, WhatsApp, and Telegram Reach a Seller Agent](https://agenticorg.ai/blog/oacp-buyer-channels-seller-agent)
+- [How OACP Maps Catalog, Price, Inventory, and Policy into Buyer-Safe Artifacts](https://agenticorg.ai/blog/oacp-artifacts-buyer-safe-commerce-facts)
+- [How Pine/Plural and Bank-Owned Payment Handoffs Fit into OACP](https://agenticorg.ai/blog/provider-owned-pine-bank-handoff-oacp)
+- [How Grantex Stays a Trust Authority Without Becoming a Transaction Toll Booth](https://agenticorg.ai/blog/grantex-trust-authority-not-commerce-toll-booth)
+- [Offline POS Bridge: Connecting In-Store Checkout to AI Buyer Agents](https://agenticorg.ai/blog/offline-pos-bridge-agentic-commerce)
 - [How AI Agents Are Transforming CA Firms: GST, TDS, and Bank Reconciliation on Autopilot](https://agenticorg.ai/blog/ai-agents-for-ca-firms-gst-tds-automation)
 - [Why Your Month-End Close Takes 5 Days (And How AI Cuts It to 1.5)](https://agenticorg.ai/blog/why-month-end-close-takes-5-days)
 - [Measuring Real ROI from AI Agents: Our Honest Framework](https://agenticorg.ai/blog/measuring-real-roi-from-ai-agents)
@@ -377,6 +399,13 @@ AgenticOrg is listed in the official MCP Registry (mcpregistry.com) under the na
 
 ## Resources
 
+- [Move Your Shopify Store to Agentic Commerce](https://agenticorg.ai/resources/move-shopify-store-to-agentic-commerce)
+- [How Buyer Agents Shop Safely with OACP](https://agenticorg.ai/resources/buyer-agents-shop-safely-oacp)
+- [Build Against OACP Artifacts and Bridges](https://agenticorg.ai/resources/build-against-oacp-artifacts-bridges)
+- [How OACP Maps to Schema.org, UCP, ACP, AP2, A2A, and MCP](https://agenticorg.ai/resources/oacp-protocol-partner-mappings)
+- [Provider-Owned Mandate and Payment Evidence in OACP](https://agenticorg.ai/resources/provider-owned-mandate-payment-evidence-oacp)
+- [Launch and Rollback Runbook for OACP Commerce](https://agenticorg.ai/resources/oacp-launch-rollback-runbook)
+- [Commerce Sales Agent with Grantex Controls](https://agenticorg.ai/resources/commerce-sales-agent-grantex)
 - [What Are AI Agents for Enterprise?](https://agenticorg.ai/resources/what-are-ai-agents-for-enterprise)
 - [AI Agents vs RPA: Why Enterprises Are Moving Beyond Robotic Process Automation](https://agenticorg.ai/resources/ai-agents-vs-rpa)
 - [AI Agents vs Chatbots: What's the Difference?](https://agenticorg.ai/resources/ai-agents-vs-chatbots)
@@ -411,7 +440,7 @@ AgenticOrg is listed in the official MCP Registry (mcpregistry.com) under the na
 ### Python SDK (PyPI)
 - Install: `pip install agenticorg`
 - Usage: `from agenticorg import AgenticOrg; client = AgenticOrg(api_key="ao_sk_...")`
-- Features: Run agents, parse SOPs, A2A discovery, MCP tool calls, CLI
+- Features: Run agents, parse SOPs, A2A discovery, MCP tool calls, and the direct `agenticorg` CLI from the same install
 - Package: https://pypi.org/project/agenticorg/
 
 ### TypeScript SDK (npm)
@@ -422,9 +451,16 @@ AgenticOrg is listed in the official MCP Registry (mcpregistry.com) under the na
 
 ### MCP Server (npm)
 - Install: `npx agenticorg-mcp-server`
-- Exposes 10 tools: list_agents, run_agent, get_agent_details, create_agent_from_sop, deploy_agent, list_connectors, call_connector_tool, list_mcp_tools, discover_agents_a2a, get_agent_card
-- Works with ChatGPT, Claude Desktop, Cursor, Windsurf, or any MCP client
+- Exposes tools such as list_agents, run_agent, get_agent_details, create_agent_from_sop, deploy_agent, list_connectors, list_mcp_tools, discover_agents_a2a, get_agent_card, and seller.* read-only OACP artifact tools
+- Direct connector tools are not exposed; use run_agent for governed agent workflows
+- Works with ChatGPT, Claude Desktop, Cursor, Windsurf, VS Code MCP clients, or any MCP client
 - Package: https://www.npmjs.com/package/agenticorg-mcp-server
+
+### Direct CLI
+- Install: `pip install agenticorg`
+- Launch agents: `agenticorg agents run commerce_sales_agent --action buyer_discovery_preview --input '{"merchant_id":"merchant_demo"}'`
+- Discover surfaces: `agenticorg agents list`, `agenticorg a2a card`, `agenticorg mcp tools`
+- Fits shell-capable assistants and developer environments: Claude Code, Codex, Gemini CLI, VS Code terminals/tasks, CI jobs, and scripts
 
 ### API Keys
 - Generate from dashboard: Settings > API Keys
@@ -435,7 +471,7 @@ AgenticOrg is listed in the official MCP Registry (mcpregistry.com) under the na
 
 ### Integration Protocols
 - **A2A (Agent-to-Agent)**: Google's protocol for agent discovery. Agent Card at `/api/v1/a2a/agent-card`
-- **MCP (Model Context Protocol)**: Anthropic's protocol. 339 tools exposed via stdio transport. Listed in official MCP Registry
+- **MCP (Model Context Protocol)**: Anthropic's protocol. Agent-management, discovery, and read-only seller OACP artifact tools exposed via stdio transport. Listed in official MCP Registry
 - **Grantex**: Delegated authorization with RS256 grant tokens for cross-tenant agent access
 
 ---
@@ -444,6 +480,7 @@ AgenticOrg is listed in the official MCP Registry (mcpregistry.com) under the na
 
 - Website: https://agenticorg.ai
 - Book a demo: https://agenticorg.ai (click "Book a Demo")
+- Open Agentic Commerce Protocol: https://agenticorg.ai/open-agentic-commerce-protocol
 - Integration Workflow: https://agenticorg.ai/integration-workflow
 - GitHub: https://github.com/mishrasanjeev/agentic-org
 - Python SDK: https://pypi.org/project/agenticorg/

--- a/ui/public/llms.txt
+++ b/ui/public/llms.txt
@@ -1,17 +1,17 @@
 # AgenticOrg — AI Virtual Employees for Enterprise
 
-> AgenticOrg lets you create AI virtual employees or deploy 26 pre-built agents across 6 domains — Finance, HR, Marketing, Operations, Back Office, and Communications — with human-in-the-loop governance on every critical decision.
+> AgenticOrg lets you create AI virtual employees or deploy 29 pre-built agents across 6 domains — Finance, HR, Marketing, Operations, Back Office, and Communications — with human-in-the-loop governance on every critical decision.
 
 ## What is AgenticOrg?
 
-AgenticOrg is an enterprise AI virtual employee platform. Create custom AI agents with names, personas, and tailored instructions through a no-code wizard — or deploy 26 pre-built agents that automate back-office operations across 6 domains: Finance, HR, Marketing, Operations, Back Office, and Communications & Cloud. Each agent connects to 54 enterprise systems (339 tools) and executes domain-specific tasks with human approval on every critical decision.
+AgenticOrg is an enterprise AI virtual employee platform. Create custom AI agents with names, personas, and tailored instructions through a no-code wizard — or deploy 29 pre-built agents that automate back-office operations across 6 domains: Finance, HR, Marketing, Operations, Back Office, and Communications & Cloud. Each agent connects to 56 enterprise systems (430 tools) and executes domain-specific tasks with human approval on every critical decision.
 
 ## Key Features
 
 - **AI Virtual Employees**: Create custom AI agents with employee names, designations, and specializations. Multiple agents can share the same role with smart routing
 - **No-Code Agent Creator**: 5-step wizard to build agents — set persona, pick role, configure prompt from templates, define behavior, and deploy
-- **26 Pre-Built AI Agents**: Ap Processor, Ar Collections, Close Agent, Fpa Agent, Recon Agent, Tax Compliance, Ld Coordinator, Offboarding Agent, Onboarding Agent, Payroll Engine, Performance Coach, Talent Acquisition, Brand Monitor, Campaign Pilot, Content Factory, Crm Intelligence, Seo Strategist, Compliance Guard, Contract Intelligence, It Operations, Support Deflector, Support Triage, Vendor Manager, Facilities Agent, Legal Ops, Risk Sentinel
-- **54 Enterprise Connectors (339 tools)**: Banking Aa (5 tools), Gstn (8 tools), Gstn Sandbox (0 tools), Income Tax India (7 tools), Netsuite (8 tools), Oracle Fusion (10 tools), Pinelabs Plural (6 tools), Quickbooks (6 tools), Sap (7 tools), Stripe (8 tools), Tally (6 tools), Zoho Books (7 tools), Darwinbox (10 tools), Docusign (6 tools), Epfo (6 tools), Greenhouse (8 tools), Keka (6 tools), Linkedin Talent (6 tools), Okta (8 tools), Zoom (6 tools), Ahrefs (5 tools), Bombora (4 tools), Brandwatch (5 tools), Buffer (5 tools), G2 (4 tools), Ga4 (6 tools), Google Ads (5 tools), Hubspot (13 tools), Linkedin Ads (4 tools), Mailchimp (10 tools), Meta Ads (5 tools), Mixpanel (5 tools), Moengage (6 tools), Salesforce (6 tools), Trustradius (4 tools), Wordpress (7 tools), Confluence (6 tools), Jira (11 tools), Mca Portal (4 tools), Pagerduty (6 tools), Sanctions Api (5 tools), Servicenow (6 tools), Zendesk (8 tools), Github (9 tools), Gmail (4 tools), Google Calendar (5 tools), Langsmith (5 tools), S3 (6 tools), Sendgrid (7 tools), Slack (7 tools), Twilio (5 tools), Twitter (6 tools), Whatsapp (5 tools), Youtube (6 tools)
+- **29 Pre-Built AI Agents**: Ap Processor, Ar Collections, Close Agent, Fpa Agent, Recon Agent, Tax Compliance, Ld Coordinator, Offboarding Agent, Onboarding Agent, Payroll Engine, Performance Coach, Talent Acquisition, Abm, Brand Monitor, Campaign Pilot, Competitive Intel, Content Factory, Crm Intelligence, Seo Strategist, Social Media, Compliance Guard, Contract Intelligence, It Operations, Support Deflector, Support Triage, Vendor Manager, Facilities Agent, Legal Ops, Risk Sentinel
+- **56 Enterprise Connectors (430 tools)**: Banking Aa (5 tools), Gstn (9 tools), Gstn Sandbox (0 tools), Income Tax India (13 tools), Netsuite (8 tools), Oracle Fusion (10 tools), Pinelabs Plural (6 tools), Professional Tax (5 tools), Quickbooks (6 tools), Sap (7 tools), Stripe (8 tools), Tally (6 tools), Traces (4 tools), Zoho Books (35 tools), Darwinbox (10 tools), Docusign (6 tools), Epfo (6 tools), Greenhouse (8 tools), Keka (6 tools), Linkedin Talent (6 tools), Okta (8 tools), Zoom (6 tools), Ahrefs (5 tools), Bombora (4 tools), Brandwatch (5 tools), Buffer (5 tools), G2 (4 tools), Ga4 (6 tools), Google Ads (5 tools), Hubspot (32 tools), Linkedin Ads (4 tools), Mailchimp (10 tools), Meta Ads (5 tools), Mixpanel (5 tools), Moengage (6 tools), Salesforce (24 tools), Trustradius (4 tools), Wordpress (7 tools), Confluence (6 tools), Jira (11 tools), Mca Portal (4 tools), Pagerduty (6 tools), Sanctions Api (5 tools), Servicenow (6 tools), Zendesk (8 tools), Github (19 tools), Gmail (4 tools), Google Calendar (5 tools), Langsmith (5 tools), S3 (6 tools), Sendgrid (7 tools), Slack (7 tools), Twilio (5 tools), Twitter (6 tools), Whatsapp (5 tools), Youtube (6 tools)
 - **Agents That Act**: Agents don't just generate text — they call real external APIs via a tool_calls pipeline: LLM reasons → outputs tool calls → Tool Gateway executes → results fed back
 - **Human-in-the-Loop (HITL)**: Every critical decision requires human approval. Prompts are locked after agent promotion — clone to edit
 - **Shadow Mode**: Test agents against real data before promoting to production
@@ -19,7 +19,7 @@ AgenticOrg is an enterprise AI virtual employee platform. Create custom AI agent
 - **Agent Observatory**: Real-time monitoring of agent reasoning traces, tool calls, confidence scores
 - **Per-Agent LLM Selection**: Gemini 2.5 Flash (default), Claude 3.5 Sonnet, or GPT-4o
 - **Shadow Limit Enforcement**: Agents in shadow mode have configurable sample limits, accuracy floors, and 6 quality gates that must all pass before promotion to production
-- **MCP Registry Listed**: AgenticOrg is listed in the official MCP Registry — discoverable by any MCP-compatible client (ChatGPT, Claude Desktop, Cursor, Windsurf)
+- **MCP Registry Listed**: AgenticOrg is listed in the official MCP Registry — discoverable by any MCP-compatible client (ChatGPT, Claude Desktop, Cursor, Windsurf, VS Code MCP clients)
 
 ## Agents by Department
 
@@ -39,12 +39,15 @@ AgenticOrg is an enterprise AI virtual employee platform. Create custom AI agent
 - Performance Coach (confidence: 0.8)
 - Talent Acquisition (confidence: 0.88)
 
-### Marketing (5 agents, CMO oversight)
-- Brand Monitor (confidence: 0.85)
+### Marketing (8 agents, CMO oversight)
+- Abm (confidence: 0.8)
+- Brand Monitor (confidence: 0.8)
 - Campaign Pilot (confidence: 0.85)
+- Competitive Intel (confidence: 0.8)
 - Content Factory (confidence: 0.88)
-- Crm Intelligence (confidence: 0.88)
-- Seo Strategist (confidence: 0.9)
+- Crm Intelligence (confidence: 0.8)
+- Seo Strategist (confidence: 0.8)
+- Social Media (confidence: 0.8)
 
 ### Operations (6 agents, COO oversight)
 - Compliance Guard (confidence: 0.95)
@@ -71,13 +74,13 @@ AgenticOrg is built for Indian enterprise with native connectors for: Banking Aa
 
 ## Developer SDKs & Integration
 
-- **Python SDK**: `pip install agenticorg` — run agents, parse SOPs, A2A/MCP access ([PyPI](https://pypi.org/project/agenticorg/))
+- **Python SDK + CLI**: `pip install agenticorg` — run agents, parse SOPs, A2A/MCP access, and install the direct `agenticorg` CLI ([PyPI](https://pypi.org/project/agenticorg/))
 - **TypeScript SDK**: `npm i agenticorg-sdk` — full TypeScript client library ([npm](https://www.npmjs.com/package/agenticorg-sdk))
-- **MCP Server**: `npx agenticorg-mcp-server` — expose every AgenticOrg agent and native tool to ChatGPT, Claude Desktop, Cursor (live counts: `/api/v1/product-facts`) ([npm](https://www.npmjs.com/package/agenticorg-mcp-server))
-- **CLI**: `agenticorg agents list`, `agenticorg agents run`, `agenticorg sop deploy`
+- **MCP Server**: `npx agenticorg-mcp-server` — expose AgenticOrg agents and read-only seller tools to ChatGPT, Claude Desktop, Cursor, VS Code MCP clients, and other MCP clients ([npm](https://www.npmjs.com/package/agenticorg-mcp-server))
+- **Direct CLI**: `agenticorg agents list`, `agenticorg agents run`, `agenticorg workflows run`, `agenticorg a2a card`, `agenticorg mcp tools`. Works from Claude Code, Codex, Gemini CLI, VS Code terminals/tasks, CI, and shell scripts.
 - **API Keys**: Generate from Settings > API Keys in the dashboard. Keys use `ao_sk_` prefix, bcrypt-hashed, scoped, revocable
 - **A2A Protocol**: Google Agent-to-Agent discovery via Agent Cards at `/api/v1/a2a/agent-card`
-- **MCP Protocol**: Anthropic Model Context Protocol — 10 tools for agent management and connector access
+- **MCP Protocol**: Anthropic Model Context Protocol — agent management, A2A discovery, platform MCP discovery, and read-only seller OACP artifact tools. Direct connector tools are not exposed.
 - **Grantex Authorization**: Delegated auth with scoped grant tokens for third-party agent access
 
 ## Links
@@ -86,8 +89,16 @@ AgenticOrg is built for Indian enterprise with native connectors for: Banking Aa
 - Playground (try live): https://agenticorg.ai/playground
 - Pricing: https://agenticorg.ai/pricing
 - Evaluation Matrix: https://agenticorg.ai/evals
+- Open Agentic Commerce Protocol: https://agenticorg.ai/open-agentic-commerce-protocol
 - Integration Workflow: https://agenticorg.ai/integration-workflow
 - Blog: https://agenticorg.ai/blog
+  - Merchant Self-Service Config for OACP Commerce: https://agenticorg.ai/blog/merchant-self-service-oacp-commerce-config
+  - How a Shopify Merchant Goes Live with a Seller Commerce Agent: https://agenticorg.ai/blog/shopify-merchant-seller-commerce-agent-oacp
+  - How ChatGPT, Claude, Gemini, Perplexity, WhatsApp, and Telegram Reach a Seller Agent: https://agenticorg.ai/blog/oacp-buyer-channels-seller-agent
+  - How OACP Maps Catalog, Price, Inventory, and Policy into Buyer-Safe Artifacts: https://agenticorg.ai/blog/oacp-artifacts-buyer-safe-commerce-facts
+  - How Pine/Plural and Bank-Owned Payment Handoffs Fit into OACP: https://agenticorg.ai/blog/provider-owned-pine-bank-handoff-oacp
+  - How Grantex Stays a Trust Authority Without Becoming a Transaction Toll Booth: https://agenticorg.ai/blog/grantex-trust-authority-not-commerce-toll-booth
+  - Offline POS Bridge: Connecting In-Store Checkout to AI Buyer Agents: https://agenticorg.ai/blog/offline-pos-bridge-agentic-commerce
   - How AI Agents Are Transforming CA Firms: GST, TDS, and Bank Reconciliation on Autopilot: https://agenticorg.ai/blog/ai-agents-for-ca-firms-gst-tds-automation
   - Why Your Month-End Close Takes 5 Days (And How AI Cuts It to 1.5): https://agenticorg.ai/blog/why-month-end-close-takes-5-days
   - Measuring Real ROI from AI Agents: Our Honest Framework: https://agenticorg.ai/blog/measuring-real-roi-from-ai-agents
@@ -101,6 +112,13 @@ AgenticOrg is built for Indian enterprise with native connectors for: Banking Aa
   - No-Code AI Agent Builder: Create Custom Virtual Employees in 5 Minutes: https://agenticorg.ai/blog/no-code-ai-agent-builder
   - Email-Triggered Workflows: Automate Finance Operations from Your Inbox: https://agenticorg.ai/blog/email-triggered-workflows
 - Resources: https://agenticorg.ai/resources
+  - Move Your Shopify Store to Agentic Commerce: https://agenticorg.ai/resources/move-shopify-store-to-agentic-commerce
+  - How Buyer Agents Shop Safely with OACP: https://agenticorg.ai/resources/buyer-agents-shop-safely-oacp
+  - Build Against OACP Artifacts and Bridges: https://agenticorg.ai/resources/build-against-oacp-artifacts-bridges
+  - How OACP Maps to Schema.org, UCP, ACP, AP2, A2A, and MCP: https://agenticorg.ai/resources/oacp-protocol-partner-mappings
+  - Provider-Owned Mandate and Payment Evidence in OACP: https://agenticorg.ai/resources/provider-owned-mandate-payment-evidence-oacp
+  - Launch and Rollback Runbook for OACP Commerce: https://agenticorg.ai/resources/oacp-launch-rollback-runbook
+  - Commerce Sales Agent with Grantex Controls: https://agenticorg.ai/resources/commerce-sales-agent-grantex
   - What Are AI Agents for Enterprise?: https://agenticorg.ai/resources/what-are-ai-agents-for-enterprise
   - AI Agents vs RPA: Why Enterprises Are Moving Beyond Robotic Process Automation: https://agenticorg.ai/resources/ai-agents-vs-rpa
   - AI Agents vs Chatbots: What's the Difference?: https://agenticorg.ai/resources/ai-agents-vs-chatbots

--- a/ui/scripts/generate-llms.mjs
+++ b/ui/scripts/generate-llms.mjs
@@ -236,7 +236,7 @@ AgenticOrg is an enterprise AI virtual employee platform. Create custom AI agent
 - **Agent Observatory**: Real-time monitoring of agent reasoning traces, tool calls, confidence scores
 - **Per-Agent LLM Selection**: Gemini 2.5 Flash (default), Claude 3.5 Sonnet, or GPT-4o
 - **Shadow Limit Enforcement**: Agents in shadow mode have configurable sample limits, accuracy floors, and 6 quality gates that must all pass before promotion to production
-- **MCP Registry Listed**: AgenticOrg is listed in the official MCP Registry — discoverable by any MCP-compatible client (ChatGPT, Claude Desktop, Cursor, Windsurf)
+- **MCP Registry Listed**: AgenticOrg is listed in the official MCP Registry — discoverable by any MCP-compatible client (ChatGPT, Claude Desktop, Cursor, Windsurf, VS Code MCP clients)
 
 ## Agents by Department
 
@@ -257,13 +257,13 @@ ${pricingLines}
 
 ## Developer SDKs & Integration
 
-- **Python SDK**: \`pip install agenticorg\` — run agents, parse SOPs, A2A/MCP access ([PyPI](https://pypi.org/project/agenticorg/))
+- **Python SDK + CLI**: \`pip install agenticorg\` — run agents, parse SOPs, A2A/MCP access, and install the direct \`agenticorg\` CLI ([PyPI](https://pypi.org/project/agenticorg/))
 - **TypeScript SDK**: \`npm i agenticorg-sdk\` — full TypeScript client library ([npm](https://www.npmjs.com/package/agenticorg-sdk))
-- **MCP Server**: \`npx agenticorg-mcp-server\` — expose every AgenticOrg agent and native tool to ChatGPT, Claude Desktop, Cursor (live counts: \`/api/v1/product-facts\`) ([npm](https://www.npmjs.com/package/agenticorg-mcp-server))
-- **CLI**: \`agenticorg agents list\`, \`agenticorg agents run\`, \`agenticorg sop deploy\`
+- **MCP Server**: \`npx agenticorg-mcp-server\` — expose AgenticOrg agents and read-only seller tools to ChatGPT, Claude Desktop, Cursor, VS Code MCP clients, and other MCP clients ([npm](https://www.npmjs.com/package/agenticorg-mcp-server))
+- **Direct CLI**: \`agenticorg agents list\`, \`agenticorg agents run\`, \`agenticorg workflows run\`, \`agenticorg a2a card\`, \`agenticorg mcp tools\`. Works from Claude Code, Codex, Gemini CLI, VS Code terminals/tasks, CI, and shell scripts.
 - **API Keys**: Generate from Settings > API Keys in the dashboard. Keys use \`ao_sk_\` prefix, bcrypt-hashed, scoped, revocable
 - **A2A Protocol**: Google Agent-to-Agent discovery via Agent Cards at \`/api/v1/a2a/agent-card\`
-- **MCP Protocol**: Anthropic Model Context Protocol — 10 tools for agent management and connector access
+- **MCP Protocol**: Anthropic Model Context Protocol — agent management, A2A discovery, platform MCP discovery, and read-only seller OACP artifact tools. Direct connector tools are not exposed.
 - **Grantex Authorization**: Delegated auth with scoped grant tokens for third-party agent access
 
 ## Links
@@ -433,7 +433,7 @@ Shadow agents have configurable limits: minimum sample count (default 100), accu
 
 ## MCP Registry
 
-AgenticOrg is listed in the official MCP Registry (mcpregistry.com) under the name \`agenticorg-mcp-server\`. Any MCP-compatible client — ChatGPT, Claude Desktop, Cursor, Windsurf, VS Code — can discover and connect to AgenticOrg agents and tools automatically. The MCP server exposes 10 tools and ${totalTools} connector tools via stdio transport.
+AgenticOrg is listed in the official MCP Registry (mcpregistry.com) under the name \`agenticorg-mcp-server\`. Any MCP-compatible client — ChatGPT, Claude Desktop, Cursor, Windsurf, VS Code — can discover and connect to AgenticOrg agents and governed tools. The MCP server exposes agent-management, A2A discovery, platform MCP discovery, and read-only seller OACP artifact tools via stdio transport. Direct connector tools are not exposed; agents invoke approved connector workflows through the AgenticOrg runtime.
 
 ---
 
@@ -501,7 +501,7 @@ ${resources.map((r) => `- [${r.title}](${SITE}/resources/${r.slug})`).join("\n")
 ### Python SDK (PyPI)
 - Install: \`pip install agenticorg\`
 - Usage: \`from agenticorg import AgenticOrg; client = AgenticOrg(api_key="ao_sk_...")\`
-- Features: Run agents, parse SOPs, A2A discovery, MCP tool calls, CLI
+- Features: Run agents, parse SOPs, A2A discovery, MCP tool calls, and the direct \`agenticorg\` CLI from the same install
 - Package: https://pypi.org/project/agenticorg/
 
 ### TypeScript SDK (npm)
@@ -512,9 +512,16 @@ ${resources.map((r) => `- [${r.title}](${SITE}/resources/${r.slug})`).join("\n")
 
 ### MCP Server (npm)
 - Install: \`npx agenticorg-mcp-server\`
-- Exposes 10 tools: list_agents, run_agent, get_agent_details, create_agent_from_sop, deploy_agent, list_connectors, call_connector_tool, list_mcp_tools, discover_agents_a2a, get_agent_card
-- Works with ChatGPT, Claude Desktop, Cursor, Windsurf, or any MCP client
+- Exposes tools such as list_agents, run_agent, get_agent_details, create_agent_from_sop, deploy_agent, list_connectors, list_mcp_tools, discover_agents_a2a, get_agent_card, and seller.* read-only OACP artifact tools
+- Direct connector tools are not exposed; use run_agent for governed agent workflows
+- Works with ChatGPT, Claude Desktop, Cursor, Windsurf, VS Code MCP clients, or any MCP client
 - Package: https://www.npmjs.com/package/agenticorg-mcp-server
+
+### Direct CLI
+- Install: \`pip install agenticorg\`
+- Launch agents: \`agenticorg agents run commerce_sales_agent --action buyer_discovery_preview --input '{"merchant_id":"merchant_demo"}'\`
+- Discover surfaces: \`agenticorg agents list\`, \`agenticorg a2a card\`, \`agenticorg mcp tools\`
+- Fits shell-capable assistants and developer environments: Claude Code, Codex, Gemini CLI, VS Code terminals/tasks, CI jobs, and scripts
 
 ### API Keys
 - Generate from dashboard: Settings > API Keys
@@ -525,7 +532,7 @@ ${resources.map((r) => `- [${r.title}](${SITE}/resources/${r.slug})`).join("\n")
 
 ### Integration Protocols
 - **A2A (Agent-to-Agent)**: Google's protocol for agent discovery. Agent Card at \`/api/v1/a2a/agent-card\`
-- **MCP (Model Context Protocol)**: Anthropic's protocol. ${totalTools} tools exposed via stdio transport. Listed in official MCP Registry
+- **MCP (Model Context Protocol)**: Anthropic's protocol. Agent-management, discovery, and read-only seller OACP artifact tools exposed via stdio transport. Listed in official MCP Registry
 - **Grantex**: Delegated authorization with RS256 grant tokens for cross-tenant agent access
 
 ---

--- a/ui/src/pages/Integrations.tsx
+++ b/ui/src/pages/Integrations.tsx
@@ -130,10 +130,12 @@ const run = await client.workflows.run(workflow.id, {
               </div>
             </CardHeader>
             <CardContent className="space-y-3">
-              <pre className="bg-muted rounded p-3 text-sm font-mono whitespace-pre-wrap">{`export AGENTICORG_API_KEY=your-key
+              <pre className="bg-muted rounded p-3 text-sm font-mono whitespace-pre-wrap">{`pip install agenticorg
+export AGENTICORG_API_KEY=your-key
 
 agenticorg agents list --domain finance
 agenticorg agents run ap_processor --input '{"invoice_id": "INV-001"}'
+agenticorg workflows run wf-123 --input '{"vendor_id":"V-100"}'
 agenticorg sop parse --file invoice_sop.pdf --domain finance
 agenticorg a2a card
 agenticorg mcp tools`}</pre>

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -1569,7 +1569,7 @@ $ agenticorg sop deploy \\
                   <svg className="w-6 h-6 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" /></svg>
                 </div>
                 <h3 className="font-bold text-white mb-2">MCP (Model Context Protocol)</h3>
-                <p className="text-sm text-slate-400">Anthropic's MCP. Expose {toolsText} tools to ChatGPT, Claude Desktop, Cursor, Windsurf, or any MCP client.</p>
+                <p className="text-sm text-slate-400">Anthropic's MCP. Expose governed AgenticOrg agents and read-only seller tools to ChatGPT, Claude Desktop, Cursor, Windsurf, VS Code MCP clients, or any MCP client.</p>
               </div>
               <div className="bg-slate-800/50 border border-slate-700 rounded-xl p-6 text-center">
                 <div className="w-12 h-12 rounded-full bg-emerald-500/20 flex items-center justify-center mx-auto mb-4">


### PR DESCRIPTION
## Summary
- include the Python SDK package in the root/full-platform wheel so local/container/internal installs expose the direct \\genticorg\\ CLI alongside \\genticorg-bridge\\
- document the canonical publish policy: PyPI \\genticorg\\ stays the lightweight SDK+CLI artifact from \\sdk/\\, while the root wheel is not uploaded to PyPI
- refresh README, SDK/MCP/API docs, UI snippets, landing copy, and generated llms.txt / llms-full.txt for CLI/MCP launch guidance
- add release metadata regression coverage for the root CLI and publish-policy guard

## Verification
- \\python -m pytest tests/regression/test_agent_run_contract.py tests/regression/test_sdk_release_metadata_20260614.py tests/regression/test_sdk_e2e_launch_and_workflows_20260613.py -q --no-cov\\
- \\
pm --prefix mcp-server test\\
- \\
pm --prefix sdk-ts test\\
- \\
pm --prefix ui run typecheck\\
- \\
pm --prefix ui run build\\
- root wheel build/inspection confirmed \\genticorg\\ and \\genticorg-bridge\\ entry points