### PR TITLE
[codex] Harden outbound auth and DB indexes

### DIFF
--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -1062,8 +1062,8 @@ async def _assert_connectors_ready_for_dispatch(
     try:
         await _assert_connectors_ready_for_activation(session, tenant_id, connector_ids)
     except HTTPException as exc:
-        detail = exc.detail if isinstance(exc.detail, dict) else {}
-        connectors = detail.get("connectors") if isinstance(detail, dict) else None
+        detail: dict[str, Any] = exc.detail if isinstance(exc.detail, dict) else {}
+        connectors = detail.get("connectors")
         raise HTTPException(
             status_code=409,
             detail={

--- a/api/v1/sales.py
+++ b/api/v1/sales.py
@@ -458,7 +458,7 @@ async def _run_sales_agent_on_lead(
             import httpx
 
             from core.config import external_keys
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=10.0) as client:
                 await client.post(
                     "https://slack.com/api/chat.postMessage",
                     headers={"Authorization": f"Bearer {external_keys.slack_bot_token}"},

--- a/auth/grantex.py
+++ b/auth/grantex.py
@@ -8,6 +8,10 @@ from typing import Any
 import httpx
 
 from core.config import external_keys
+from core.http_retry import DEFAULT_HTTP_TIMEOUT_SECONDS, retry_http_async
+from core.security.egress import EgressValidationError, validate_public_url
+
+_TOKEN_TIMEOUT = httpx.Timeout(DEFAULT_HTTP_TIMEOUT_SECONDS)
 
 
 class GrantexClient:
@@ -20,55 +24,78 @@ class GrantexClient:
         self._platform_token: str | None = None
         self._platform_token_exp: float = 0
 
+    def _validated_token_server(self) -> str:
+        if not self.token_server:
+            raise ValueError("Grantex token server is not configured")
+        try:
+            validated = validate_public_url(
+                self.token_server.rstrip("/"),
+                allowed_schemes=("https",),
+                require_dns=False,
+            )
+        except EgressValidationError as exc:
+            raise ValueError("Grantex token server must be a public HTTPS URL") from exc
+        return validated.url.rstrip("/")
+
+    @retry_http_async(max_attempts=3, base_delay=0.25, cap=2.0)
+    async def _post_token(
+        self,
+        *,
+        data: dict[str, str],
+        headers: dict[str, str] | None = None,
+        path: str = "/oauth2/token",
+        expect_json: bool = True,
+    ) -> dict[str, Any]:
+        async with httpx.AsyncClient(timeout=_TOKEN_TIMEOUT) as client:
+            resp = await client.post(
+                f"{self._validated_token_server()}{path}",
+                data=data,
+                headers=headers,
+            )
+            resp.raise_for_status()
+            return resp.json() if expect_json else {}
+
     async def get_platform_token(self) -> str:
         """Obtain platform-level token via client_credentials grant."""
         now = datetime.now(UTC).timestamp()
         if self._platform_token and now < self._platform_token_exp - 60:
             return self._platform_token
 
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                f"{self.token_server}/oauth2/token",
-                data={
-                    "grant_type": "client_credentials",
-                    "client_id": self.client_id,
-                    "client_secret": self.client_secret,
-                    "scope": "agenticorg:orchestrate agenticorg:agents:read",
-                },
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            self._platform_token = data["access_token"]
-            self._platform_token_exp = now + data.get("expires_in", 3600)
-            return self._platform_token
+        data = await self._post_token(
+            data={
+                "grant_type": "client_credentials",
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "scope": "agenticorg:orchestrate agenticorg:agents:read",
+            },
+        )
+        self._platform_token = data["access_token"]
+        self._platform_token_exp = now + data.get("expires_in", 3600)
+        return self._platform_token
 
     async def delegate_agent_token(
         self, agent_id: str, agent_type: str, scopes: list[str], ttl: int = 3600
     ) -> dict[str, Any]:
         """Obtain scoped agent token via delegation grant."""
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                f"{self.token_server}/oauth2/token",
-                data={
-                    "grant_type": "urn:grantex:agent_delegation",
-                    "agent_id": agent_id,
-                    "agent_type": agent_type,
-                    "delegated_scopes": " ".join(scopes),
-                    "ttl": str(ttl),
-                },
-                headers={"Authorization": f"Bearer {await self.get_platform_token()}"},
-            )
-            resp.raise_for_status()
-            return resp.json()
+        return await self._post_token(
+            data={
+                "grant_type": "urn:grantex:agent_delegation",
+                "agent_id": agent_id,
+                "agent_type": agent_type,
+                "delegated_scopes": " ".join(scopes),
+                "ttl": str(ttl),
+            },
+            headers={"Authorization": f"Bearer {await self.get_platform_token()}"},
+        )
 
     async def revoke_token(self, token: str) -> None:
         """Revoke a specific token."""
-        async with httpx.AsyncClient() as client:
-            await client.post(
-                f"{self.token_server}/oauth2/revoke",
-                data={"token": token},
-                headers={"Authorization": f"Bearer {await self.get_platform_token()}"},
-            )
+        await self._post_token(
+            data={"token": token},
+            headers={"Authorization": f"Bearer {await self.get_platform_token()}"},
+            path="/oauth2/revoke",
+            expect_json=False,
+        )
 
 
 grantex_client = GrantexClient()

--- a/auth/jwt.py
+++ b/auth/jwt.py
@@ -13,12 +13,15 @@ import redis.asyncio as aioredis
 from jwt import PyJWK, PyJWTError
 
 from core.config import is_strict_runtime_env, settings
+from core.http_retry import DEFAULT_HTTP_TIMEOUT_SECONDS, retry_http_async
+from core.security.egress import EgressValidationError, validate_public_url
 
 logger = logging.getLogger(__name__)
 
 _jwks_cache: dict[str, Any] = {}  # enterprise-gate: process-local-ok reason=ttl-cache-of-remote-public-jwks
 _jwks_cache_time: float = 0
 JWKS_CACHE_TTL = 3600
+JWKS_TIMEOUT = httpx.Timeout(DEFAULT_HTTP_TIMEOUT_SECONDS)
 
 # ---------------------------------------------------------------------------
 # Token blacklist — Redis-backed
@@ -249,14 +252,23 @@ def validate_local_token(token: str) -> dict:
 # ---------------------------------------------------------------------------
 
 
+@retry_http_async(max_attempts=3, base_delay=0.25, cap=2.0)
 async def _fetch_jwks() -> dict[str, Any]:
     global _jwks_cache, _jwks_cache_time
     if _jwks_cache and (time.time() - _jwks_cache_time) < JWKS_CACHE_TTL:
         return _jwks_cache
     if not settings.jwt_public_key_url:
         raise ValueError("JWKS URL not configured (AGENTICORG_JWT_PUBLIC_KEY_URL is empty)")
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(settings.jwt_public_key_url)
+    try:
+        jwks_url = validate_public_url(
+            settings.jwt_public_key_url,
+            allowed_schemes=("https",),
+            require_dns=False,
+        ).url
+    except EgressValidationError as exc:
+        raise ValueError("JWKS URL must be a public HTTPS URL") from exc
+    async with httpx.AsyncClient(timeout=JWKS_TIMEOUT) as client:
+        resp = await client.get(jwks_url)
         resp.raise_for_status()
         _jwks_cache = resp.json()
         _jwks_cache_time = time.time()

--- a/auth/opa.py
+++ b/auth/opa.py
@@ -16,7 +16,7 @@ class OPAClient:
     async def evaluate(self, policy_path: str, input_data: dict[str, Any]) -> bool:
         """Evaluate a policy and return allow/deny."""
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=5.0) as client:
                 resp = await client.post(
                     f"{self.opa_url}/v1/data/{policy_path}",
                     json={"input": input_data},

--- a/connectors/comms/gmail.py
+++ b/connectors/comms/gmail.py
@@ -39,7 +39,7 @@ class GmailConnector(BaseConnector):
 
         if refresh_token and client_id and client_secret:
             # Exchange refresh token for access token
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=self.timeout_ms / 1000) as client:
                 resp = await client.post(
                     GOOGLE_OAUTH_TOKEN_URL,
                     data={

--- a/connectors/comms/google_calendar.py
+++ b/connectors/comms/google_calendar.py
@@ -37,7 +37,7 @@ class GoogleCalendarConnector(BaseConnector):
         client_secret = self._get_secret("client_secret")
         refresh_token = self._get_secret("refresh_token")
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=self.timeout_ms / 1000) as client:
             resp = await client.post(
                 "https://oauth2.googleapis.com/token",
                 data={

--- a/connectors/comms/youtube.py
+++ b/connectors/comms/youtube.py
@@ -47,7 +47,7 @@ class YouTubeConnector(BaseConnector):
 
         if refresh_token and client_id and client_secret:
             # Exchange refresh token for a fresh access token
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=self.timeout_ms / 1000) as client:
                 resp = await client.post(
                     GOOGLE_OAUTH_TOKEN_URL,
                     data={

--- a/connectors/finance/aa_consent.py
+++ b/connectors/finance/aa_consent.py
@@ -24,9 +24,11 @@ from connectors.finance.aa_consent_types import (
     ConsentStatus,
     FIDataSession,
 )
+from core.http_retry import DEFAULT_HTTP_TIMEOUT_SECONDS, retry_http_async
 from core.security.egress import EgressValidationError, validate_public_url
 
 logger = structlog.get_logger()
+_AA_TIMEOUT = httpx.Timeout(DEFAULT_HTTP_TIMEOUT_SECONDS)
 
 
 class AAConsentManager:
@@ -61,12 +63,13 @@ class AAConsentManager:
         self._sessions: dict[str, dict[str, Any]] = {}
         self._token: str = ""
 
+    @retry_http_async(max_attempts=3, base_delay=0.25, cap=2.0)
     async def _get_token(self) -> str:
         """Obtain AA API access token via client credentials."""
         if self._token:
             return self._token
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=_AA_TIMEOUT) as client:
             resp = await client.post(
                 f"{self.base_url}/oauth2/token",
                 data={
@@ -133,7 +136,7 @@ class AAConsentManager:
             },
         }
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=_AA_TIMEOUT) as client:
             resp = await client.post(
                 f"{self.base_url}/Consent",
                 json=payload,
@@ -206,7 +209,7 @@ class AAConsentManager:
         """Fetch the signed consent artifact from Finvu."""
         await self._get_token()
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=_AA_TIMEOUT) as client:
             resp = await client.get(
                 f"{self.base_url}/Consent/{consent_id}",
                 headers=self._auth_headers(),
@@ -252,7 +255,7 @@ class AAConsentManager:
             "Consent": {"id": consent_id},
         }
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=_AA_TIMEOUT) as client:
             resp = await client.post(
                 f"{self.base_url}/FI/request",
                 json=payload,
@@ -278,7 +281,7 @@ class AAConsentManager:
         """Fetch financial data using an active FI session."""
         await self._get_token()
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=_AA_TIMEOUT) as client:
             resp = await client.get(
                 f"{self.base_url}/FI/fetch/{session_id}",
                 headers=self._auth_headers(),
@@ -293,7 +296,7 @@ class AAConsentManager:
         """Revoke a previously granted consent."""
         await self._get_token()
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=_AA_TIMEOUT) as client:
             resp = await client.post(
                 f"{self.base_url}/Consent/revoke/{consent_id}",
                 headers=self._auth_headers(),

--- a/connectors/finance/banking_aa.py
+++ b/connectors/finance/banking_aa.py
@@ -60,7 +60,7 @@ class BankingAaConnector(BaseConnector):
     async def _authenticate(self):
         client_id = self._get_secret("client_id")
         client_secret = self._get_secret("client_secret")
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=self.timeout_ms / 1000) as client:
             resp = await client.post(
                 FINVU_TOKEN_URL,
                 data={

--- a/connectors/finance/gstn.py
+++ b/connectors/finance/gstn.py
@@ -185,7 +185,7 @@ class GstnConnector(BaseConnector):
                 "gspappsecret/client_secret credentials."
             )
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=self.timeout_ms / 1000) as client:
             resp = await client.post(
                 f"{self._provider_base_url}/authenticate?grant_type=token",
                 json={},

--- a/connectors/finance/quickbooks.py
+++ b/connectors/finance/quickbooks.py
@@ -72,7 +72,7 @@ class QuickbooksConnector(BaseConnector):
         when the token response also lacks it (rare).
         """
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=self.timeout_ms / 1000) as client:
                 resp = await client.post(
                     _QBO_TOKEN_URL,
                     data={

--- a/connectors/finance/tally.py
+++ b/connectors/finance/tally.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import uuid
 from typing import Any
+from urllib.parse import urlparse
 
 # stdlib ElementTree is used only to construct outbound XML envelopes.
 # All untrusted Tally responses are parsed through defusedxml below.
@@ -31,6 +32,28 @@ from core.security.egress import (
 )
 
 logger = structlog.get_logger()
+
+_DIRECT_TALLY_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def _is_direct_local_tally_url(url: str) -> bool:
+    """Allow only Tally's native local XML endpoint in direct mode."""
+    parsed = urlparse(str(url or "").strip())
+    try:
+        port = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.scheme.lower() == "http"
+        and (parsed.hostname or "").lower() in _DIRECT_TALLY_HOSTS
+        and (port or 80) == 9000
+        and parsed.path in ("", "/")
+        and not parsed.params
+        and not parsed.query
+        and not parsed.fragment
+        and not parsed.username
+        and not parsed.password
+    )
 
 
 # UR-Bug-6 (Uday/Ramesh 2026-04-21): Tally errors used to surface as a
@@ -266,6 +289,14 @@ class TallyConnector(BaseConnector):
             await self._authenticate()
             return
         await super().connect()
+
+    def _validate_connector_egress_url(self, url: str, *, require_dns: bool = True) -> None:
+        # Tally's native desktop endpoint is intentionally local-only. Keep this
+        # exception exact so tenant-controlled base_url values cannot retarget
+        # the connector to arbitrary private services or alternate paths.
+        if not self._use_bridge and _is_direct_local_tally_url(url):
+            return
+        super()._validate_connector_egress_url(url, require_dns=require_dns)
 
     def _register_tools(self):
         self._tool_registry["post_voucher"] = self.post_voucher

--- a/connectors/finance/zoho_books.py
+++ b/connectors/finance/zoho_books.py
@@ -231,7 +231,7 @@ class ZohoBooksConnector(BaseConnector):
         """Exchange refresh_token for a fresh access_token via Zoho OAuth2."""
         token_url = _ZOHO_TOKEN_URLS.get(str(self.config.get("region") or "us"), _ZOHO_TOKEN_URL)
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=self.timeout_ms / 1000) as client:
                 resp = await client.post(
                     token_url,
                     data={

--- a/connectors/framework/auth_adapters.py
+++ b/connectors/framework/auth_adapters.py
@@ -9,7 +9,11 @@ from pathlib import Path
 import httpx
 import structlog
 
+from core.http_retry import DEFAULT_HTTP_TIMEOUT_SECONDS, retry_http_async
+from core.security.egress import EgressValidationError, validate_public_url
+
 logger = structlog.get_logger()
+_OAUTH_TIMEOUT = httpx.Timeout(DEFAULT_HTTP_TIMEOUT_SECONDS)
 
 
 class OAuth2Adapter:
@@ -27,10 +31,21 @@ class OAuth2Adapter:
             await self.refresh()
         return {"Authorization": f"Bearer {self._token}"}
 
-    async def refresh(self) -> None:
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
+    def _validated_token_url(self) -> str:
+        try:
+            return validate_public_url(
                 self.token_url,
+                allowed_schemes=("https",),
+                require_dns=False,
+            ).url
+        except EgressValidationError as exc:
+            raise ValueError("OAuth token_url must be a public HTTPS URL") from exc
+
+    @retry_http_async(max_attempts=3, base_delay=0.25, cap=2.0)
+    async def refresh(self) -> None:
+        async with httpx.AsyncClient(timeout=_OAUTH_TIMEOUT) as client:
+            resp = await client.post(
+                self._validated_token_url(),
                 data={
                     "grant_type": "client_credentials",
                     "client_id": self.client_id,

--- a/connectors/framework/base_connector.py
+++ b/connectors/framework/base_connector.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import abc
 import re
+from collections.abc import Callable
 from typing import Any
 
 import httpx
@@ -41,17 +42,29 @@ _GCP_SECRET_RE = re.compile(
 class _GuardedAsyncClient(httpx.AsyncClient):
     """httpx client that validates the final request URL before network egress."""
 
-    def __init__(self, *args: Any, connector_name: str, require_dns: bool, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *args: Any,
+        connector_name: str,
+        require_dns: bool,
+        egress_validator: Callable[[str], None] | None = None,
+        **kwargs: Any,
+    ) -> None:
         self._connector_name = connector_name
         self._require_dns = require_dns
+        self._egress_validator = egress_validator
         super().__init__(*args, **kwargs)
 
     async def send(self, request: httpx.Request, *args: Any, **kwargs: Any) -> httpx.Response:
-        _validate_connector_egress_url(
-            str(request.url),
-            connector_name=self._connector_name,
-            require_dns=self._require_dns,
-        )
+        url = str(request.url)
+        if self._egress_validator is not None:
+            self._egress_validator(url)
+        else:
+            _validate_connector_egress_url(
+                url,
+                connector_name=self._connector_name,
+                require_dns=self._require_dns,
+            )
         return await super().send(request, *args, **kwargs)
 
 
@@ -293,6 +306,10 @@ class BaseConnector(abc.ABC):
             transport=transport,
             connector_name=self.name,
             require_dns=require_dns,
+            egress_validator=lambda url: self._validate_connector_egress_url(
+                url,
+                require_dns=require_dns,
+            ),
         )
 
     async def _rebuild_http_client(self) -> None:

--- a/connectors/hr/linkedin_talent.py
+++ b/connectors/hr/linkedin_talent.py
@@ -34,7 +34,7 @@ class LinkedinTalentConnector(BaseConnector):
         client_secret = self._get_secret("client_secret")
         refresh_token = self._get_secret("refresh_token")
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=self.timeout_ms / 1000) as client:
             resp = await client.post(
                 "https://www.linkedin.com/oauth/v2/accessToken",
                 data={

--- a/connectors/hr/zoom.py
+++ b/connectors/hr/zoom.py
@@ -33,7 +33,7 @@ class ZoomConnector(BaseConnector):
         client_secret = self._get_secret("client_secret")
         account_id = self._get_secret("account_id")
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=self.timeout_ms / 1000) as client:
             resp = await client.post(
                 "https://zoom.us/oauth/token",
                 params={"grant_type": "account_credentials", "account_id": account_id},

--- a/connectors/marketing/brandwatch.py
+++ b/connectors/marketing/brandwatch.py
@@ -39,7 +39,7 @@ class BrandwatchConnector(BaseConnector):
         username = self._get_secret("username")
         password = self._get_secret("password")
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=self.timeout_ms / 1000) as client:
             resp = await client.post(
                 f"{BRANDWATCH_API_BASE_URL}/oauth/token",
                 data={

--- a/connectors/marketing/ga4.py
+++ b/connectors/marketing/ga4.py
@@ -43,7 +43,7 @@ class GA4Connector(BaseConnector):
         client_secret = self._get_secret("client_secret")
         refresh_token = self._get_secret("refresh_token")
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=self.timeout_ms / 1000) as client:
             resp = await client.post(
                 "https://oauth2.googleapis.com/token",
                 data={

--- a/connectors/marketing/google_ads.py
+++ b/connectors/marketing/google_ads.py
@@ -179,7 +179,7 @@ class GoogleAdsConnector(BaseConnector):
         client_secret = self._get_secret("client_secret")
         refresh_token = self._get_secret("refresh_token")
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=self.timeout_ms / 1000) as client:
             resp = await client.post(
                 "https://oauth2.googleapis.com/token",
                 data={

--- a/connectors/marketing/hubspot.py
+++ b/connectors/marketing/hubspot.py
@@ -178,7 +178,7 @@ class HubspotConnector(BaseConnector):
     ) -> str | None:
         """Exchange refresh_token for a fresh access_token."""
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=self.timeout_ms / 1000) as client:
                 resp = await client.post(
                     "https://api.hubapi.com/oauth/v1/token",
                     data={

--- a/connectors/marketing/linkedin_ads.py
+++ b/connectors/marketing/linkedin_ads.py
@@ -38,7 +38,7 @@ class LinkedinAdsConnector(BaseConnector):
         client_secret = self._get_secret("client_secret")
         refresh_token = self._get_secret("refresh_token")
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=self.timeout_ms / 1000) as client:
             resp = await client.post(
                 "https://www.linkedin.com/oauth/v2/accessToken",
                 data={

--- a/connectors/marketing/salesforce.py
+++ b/connectors/marketing/salesforce.py
@@ -118,7 +118,7 @@ class SalesforceConnector(BaseConnector):
         else:
             data["grant_type"] = "client_credentials"
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=self.timeout_ms / 1000) as client:
             resp = await client.post(login_url, data=data)
             resp.raise_for_status()
             body = resp.json()

--- a/core/http_retry.py
+++ b/core/http_retry.py
@@ -32,6 +32,8 @@ logger = structlog.get_logger()
 
 T = TypeVar("T")
 
+DEFAULT_HTTP_TIMEOUT_SECONDS = 10.0
+
 # Retry on network errors, timeouts, and these HTTP status codes
 RETRYABLE_STATUS_CODES = {408, 425, 429, 500, 502, 503, 504}
 

--- a/migrations/versions/v6_z4_fk_index_coverage.py
+++ b/migrations/versions/v6_z4_fk_index_coverage.py
@@ -1,0 +1,130 @@
+# ruff: noqa: S608
+"""Backfill missing leading-column indexes for foreign keys.
+
+Revision ID: v6z4_fk_index_coverage
+Revises: v6z3_merchant_config_selfsvc
+Create Date: 2026-06-25
+
+The production schema has accumulated some FK columns without a leading
+index. Each index below is created only when no valid existing index already
+starts with the FK column, avoiding duplicate indexes from older migrations
+that used different names.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v6z4_fk_index_coverage"
+down_revision = "v6z3_merchant_config_selfsvc"
+branch_labels = None
+depends_on = None
+
+
+_FK_INDEXES: tuple[tuple[str, str, str], ...] = (
+    ("ix_fk_departments_company_id", "departments", "company_id"),
+    ("ix_fk_departments_parent_id", "departments", "parent_id"),
+    ("ix_fk_departments_manager_user_id", "departments", "manager_user_id"),
+    ("ix_fk_users_department_id", "users", "department_id"),
+    ("ix_fk_abm_campaigns_account_id", "abm_campaigns", "account_id"),
+    ("ix_fk_api_keys_tenant_id", "api_keys", "tenant_id"),
+    ("ix_fk_api_keys_user_id", "api_keys", "user_id"),
+    ("ix_fk_documents_tenant_id", "documents", "tenant_id"),
+    ("ix_fk_governance_config_updated_by", "governance_config", "updated_by"),
+    ("ix_fk_prompt_templates_created_by", "prompt_templates", "created_by"),
+    ("ix_fk_schema_registry_created_by", "schema_registry", "created_by"),
+    ("ix_fk_user_delegations_delegator_id", "user_delegations", "delegator_id"),
+    ("ix_fk_user_delegations_delegate_id", "user_delegations", "delegate_id"),
+    ("ix_fk_agent_task_results_company_id", "agent_task_results", "company_id"),
+    ("ix_fk_ca_client_invoices_service_plan_id", "ca_client_invoices", "service_plan_id"),
+    ("ix_fk_cost_centers_company_id", "cost_centers", "company_id"),
+    ("ix_fk_cost_centers_department_id", "cost_centers", "department_id"),
+    ("ix_fk_kpi_cache_company_id", "kpi_cache", "company_id"),
+    ("ix_fk_prompt_template_edit_history_template_id", "prompt_template_edit_history", "template_id"),
+    ("ix_fk_prompt_template_edit_history_edited_by", "prompt_template_edit_history", "edited_by"),
+    ("ix_fk_rpa_schedules_company_id", "rpa_schedules", "company_id"),
+    ("ix_fk_workflow_definitions_company_id", "workflow_definitions", "company_id"),
+    ("ix_fk_workflow_definitions_created_by", "workflow_definitions", "created_by"),
+    ("ix_fk_agents_company_id", "agents", "company_id"),
+    ("ix_fk_agents_parent_agent_id", "agents", "parent_agent_id"),
+    ("ix_fk_agents_shadow_comparison_agent_id", "agents", "shadow_comparison_agent_id"),
+    ("ix_fk_agents_cost_center_id", "agents", "cost_center_id"),
+    ("ix_fk_budget_alerts_company_id", "budget_alerts", "company_id"),
+    ("ix_fk_budget_alerts_cost_center_id", "budget_alerts", "cost_center_id"),
+    ("ix_fk_workflow_runs_company_id", "workflow_runs", "company_id"),
+    ("ix_fk_workflow_runs_workflow_def_id", "workflow_runs", "workflow_def_id"),
+    ("ix_fk_agent_cost_ledger_agent_id", "agent_cost_ledger", "agent_id"),
+    ("ix_fk_agent_lifecycle_events_tenant_id", "agent_lifecycle_events", "tenant_id"),
+    ("ix_fk_agent_lifecycle_events_agent_id", "agent_lifecycle_events", "agent_id"),
+    ("ix_fk_agent_lifecycle_events_triggered_by_user", "agent_lifecycle_events", "triggered_by_user"),
+    ("ix_fk_agent_team_members_agent_id", "agent_team_members", "agent_id"),
+    ("ix_fk_agent_versions_tenant_id", "agent_versions", "tenant_id"),
+    ("ix_fk_agent_versions_created_by", "agent_versions", "created_by"),
+    ("ix_fk_hitl_queue_tenant_id", "hitl_queue", "tenant_id"),
+    ("ix_fk_hitl_queue_agent_id", "hitl_queue", "agent_id"),
+    ("ix_fk_hitl_queue_decision_by", "hitl_queue", "decision_by"),
+    ("ix_fk_lead_pipeline_assigned_agent_id", "lead_pipeline", "assigned_agent_id"),
+    ("ix_fk_prompt_edit_history_agent_id", "prompt_edit_history", "agent_id"),
+    ("ix_fk_prompt_edit_history_edited_by", "prompt_edit_history", "edited_by"),
+    ("ix_fk_shadow_comparisons_tenant_id", "shadow_comparisons", "tenant_id"),
+    ("ix_fk_shadow_comparisons_shadow_agent_id", "shadow_comparisons", "shadow_agent_id"),
+    ("ix_fk_shadow_comparisons_reference_agent_id", "shadow_comparisons", "reference_agent_id"),
+    ("ix_fk_step_executions_tenant_id", "step_executions", "tenant_id"),
+    ("ix_fk_step_executions_agent_id", "step_executions", "agent_id"),
+    ("ix_fk_tool_calls_agent_id", "tool_calls", "agent_id"),
+    ("ix_fk_workflow_event_waits_workflow_run_id", "workflow_event_waits", "workflow_run_id"),
+    ("ix_fk_email_sequences_tenant_id", "email_sequences", "tenant_id"),
+)
+
+
+def _create_fk_index_if_missing(index_name: str, table_name: str, column_name: str) -> None:
+    sql = f"""
+        DO $$
+        BEGIN
+            IF to_regclass('{table_name}') IS NOT NULL
+               AND EXISTS (
+                    SELECT 1
+                    FROM pg_class t
+                    JOIN pg_namespace n ON n.oid = t.relnamespace
+                    JOIN pg_attribute a
+                      ON a.attrelid = t.oid
+                     AND a.attname = '{column_name}'
+                     AND a.attisdropped IS FALSE
+                    WHERE n.nspname = current_schema()
+                      AND t.relname = '{table_name}'
+               )
+               AND NOT EXISTS (
+                    SELECT 1
+                    FROM pg_index i
+                    JOIN pg_class t ON t.oid = i.indrelid
+                    JOIN pg_namespace n ON n.oid = t.relnamespace
+                    JOIN pg_attribute a
+                      ON a.attrelid = t.oid
+                     AND a.attname = '{column_name}'
+                     AND a.attisdropped IS FALSE
+                    WHERE n.nspname = current_schema()
+                      AND t.relname = '{table_name}'
+                      AND i.indisvalid
+                      AND i.indisready
+                      AND i.indkey[0] = a.attnum
+               ) THEN
+                EXECUTE format(
+                    'CREATE INDEX %I ON %I (%I)',
+                    '{index_name}',
+                    '{table_name}',
+                    '{column_name}'
+                );
+            END IF;
+        END $$;
+    """
+    op.execute(sql)
+
+
+def upgrade() -> None:
+    for index_name, table_name, column_name in _FK_INDEXES:
+        _create_fk_index_if_missing(index_name, table_name, column_name)
+
+
+def downgrade() -> None:
+    for index_name, _, _ in reversed(_FK_INDEXES):
+        op.execute(f"DROP INDEX IF EXISTS {index_name};")

--- a/tests/e2e/test_cxo_flows.py
+++ b/tests/e2e/test_cxo_flows.py
@@ -28,6 +28,7 @@ def app():
     import asyncio
 
     from sqlalchemy import text as _sql_text
+    from sqlalchemy.exc import SQLAlchemyError
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
     from sqlalchemy.pool import NullPool
 
@@ -72,7 +73,15 @@ def app():
                 },
             )
 
-    asyncio.run(_setup())
+    try:
+        asyncio.run(_setup())
+    except (OSError, SQLAlchemyError) as exc:
+        try:
+            asyncio.run(test_engine.dispose())
+        finally:
+            _db.engine = original_engine
+            _db.async_session_factory = original_factory
+        pytest.skip(f"CXO e2e tests require a reachable database: {exc}")
     asyncio.run(test_engine.dispose())
 
     @asynccontextmanager

--- a/tests/regression/test_codeql_connector_ssrf_hardening.py
+++ b/tests/regression/test_codeql_connector_ssrf_hardening.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 
@@ -39,6 +41,46 @@ def _client_factory(client: _RecordingAsyncClient):
         return client
 
     return _factory
+
+
+def test_direct_external_async_clients_have_explicit_timeouts() -> None:
+    repo = Path(__file__).resolve().parents[2]
+    offenders: list[str] = []
+    for root in ("auth", "connectors", "api"):
+        for path in (repo / root).rglob("*.py"):
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            if "httpx.AsyncClient() as client" in text or "AsyncClient() as client" in text:
+                offenders.append(str(path.relative_to(repo)))
+
+    assert offenders == []
+
+
+def test_grantex_token_server_rejects_unsafe_urls() -> None:
+    from auth.grantex import GrantexClient
+
+    client = GrantexClient()
+    client.token_server = "http://auth.example"
+    with pytest.raises(ValueError, match="public HTTPS"):
+        client._validated_token_server()
+
+    client.token_server = "https://169.254.169.254"
+    with pytest.raises(ValueError, match="public HTTPS"):
+        client._validated_token_server()
+
+    client.token_server = "https://auth.example/"
+    assert client._validated_token_server() == "https://auth.example"
+
+
+@pytest.mark.asyncio
+async def test_jwks_fetch_rejects_unsafe_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    import auth.jwt as jwt_module
+
+    monkeypatch.setattr(jwt_module.settings, "jwt_public_key_url", "http://example.com/jwks")
+    jwt_module._jwks_cache = {}
+    jwt_module._jwks_cache_time = 0
+
+    with pytest.raises(ValueError, match="public HTTPS"):
+        await jwt_module._fetch_jwks()
 
 
 @pytest.mark.asyncio

--- a/tests/regression/test_uday_02jun2026_ca_marketing_bugs.py
+++ b/tests/regression/test_uday_02jun2026_ca_marketing_bugs.py
@@ -192,7 +192,7 @@ async def test_gstn_auth_uses_api_key_alias_with_api_secret(monkeypatch) -> None
     from connectors.finance.gstn import GstnConnector
 
     recording = _GSTNAuthClient()
-    monkeypatch.setattr(gstn_module.httpx, "AsyncClient", lambda: recording)
+    monkeypatch.setattr(gstn_module.httpx, "AsyncClient", lambda **_kwargs: recording)
     connector = GstnConnector(
         {
             "api_key": "asp-id",
@@ -220,7 +220,7 @@ async def test_gstn_auth_uses_client_credentials_as_gsp_headers(monkeypatch) -> 
     from connectors.finance.gstn import GstnConnector
 
     recording = _GSTNAuthClient()
-    monkeypatch.setattr(gstn_module.httpx, "AsyncClient", lambda: recording)
+    monkeypatch.setattr(gstn_module.httpx, "AsyncClient", lambda **_kwargs: recording)
     connector = GstnConnector(
         {
             "client_id": "gstn-client",

--- a/tests/unit/test_negative_cases.py
+++ b/tests/unit/test_negative_cases.py
@@ -80,7 +80,7 @@ class TestAuthLogin:
             assert exc.value.status_code == 401
 
     @pytest.mark.asyncio
-    async def test_login_rate_limit(self):
+    async def test_login_rate_limit(self, monkeypatch):
         from api.v1 import auth as auth_mod
         from api.v1.auth import LoginRequest, login
 
@@ -88,6 +88,7 @@ class TestAuthLogin:
         request = MagicMock()
         request.client.host = ip
         response = MagicMock()
+        monkeypatch.setattr(auth_mod, "_get_throttle_redis", AsyncMock(return_value=None))
 
         # Fill rate limit bucket
         auth_mod._login_attempts[ip] = [time.time()] * 5

--- a/tests/unit/test_tally_connector_health_and_errors.py
+++ b/tests/unit/test_tally_connector_health_and_errors.py
@@ -193,6 +193,31 @@ class TestTallyHealthCheckBridge:
 class TestTallyHealthCheckDirect:
     """Health check without a bridge — hits Tally directly over XML."""
 
+    def test_direct_mode_allows_only_exact_local_tally_endpoint(self) -> None:
+        connector = TallyConnector({})
+
+        connector._validate_connector_egress_url("http://localhost:9000")
+        connector._validate_connector_egress_url("http://127.0.0.1:9000/")
+        connector._validate_connector_egress_url("http://[::1]:9000/")
+
+        for unsafe_url in (
+            "http://localhost:9001",
+            "http://localhost:9000/admin",
+            "http://127.0.0.1:9000/?next=http://169.254.169.254",
+            "https://localhost:9000",
+        ):
+            with pytest.raises(ValueError, match="Connector egress URL"):
+                connector._validate_connector_egress_url(unsafe_url)
+
+    @pytest.mark.asyncio
+    async def test_direct_connect_can_build_local_tally_client(self) -> None:
+        connector = TallyConnector({"api_key": "test-key"})
+        await connector.connect()
+        try:
+            assert connector._client is not None
+        finally:
+            await connector.disconnect()
+
     @pytest.mark.asyncio
     async def test_direct_healthy_when_xml_parses(self) -> None:
         connector = TallyConnector({})

--- a/ui/src/__tests__/CompanyDetail.test.tsx
+++ b/ui/src/__tests__/CompanyDetail.test.tsx
@@ -7,6 +7,7 @@ const mockPost = vi.fn();
 const mockPatch = vi.fn();
 const mockPut = vi.fn();
 const mockDelete = vi.fn();
+const mockAgentsListAll = vi.fn();
 
 vi.mock("../lib/api", () => ({
   default: {
@@ -19,6 +20,9 @@ vi.mock("../lib/api", () => ({
       request: { use: vi.fn() },
       response: { use: vi.fn() },
     },
+  },
+  agentsApi: {
+    listAll: (...args: unknown[]) => mockAgentsListAll(...args),
   },
   extractApiError: () => "request failed",
 }));
@@ -154,11 +158,11 @@ describe("CompanyDetail", () => {
       if (url === `/companies/${COMPANY_ID}/gstn-uploads`) return Promise.resolve({ data: uploadsResponse });
       if (url === `/companies/${COMPANY_ID}/roles`) return Promise.resolve({ data: rolesResponse });
       if (url === `/companies/${COMPANY_ID}/credentials`) return Promise.resolve({ data: credentialsResponse });
-      if (url === "/agents") return Promise.resolve({ data: agentsResponse });
       if (url === "/workflows") return Promise.resolve({ data: workflowsResponse });
       if (url === "/audit") return Promise.resolve({ data: auditResponse });
       throw new Error(`Unexpected GET ${url} ${JSON.stringify(config?.params || {})}`);
     });
+    mockAgentsListAll.mockResolvedValue(agentsResponse.items);
   });
 
   it("renders the audit log tab and shows real audit events", async () => {
@@ -192,9 +196,8 @@ describe("CompanyDetail", () => {
     renderPage();
 
     await waitFor(() => {
-      expect(mockGet).toHaveBeenCalledWith(
-        "/agents",
-        expect.objectContaining({ params: expect.objectContaining({ company_id: COMPANY_ID }) }),
+      expect(mockAgentsListAll).toHaveBeenCalledWith(
+        expect.objectContaining({ domain: "finance", company_id: COMPANY_ID }),
       );
     });
 

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -251,6 +251,8 @@
     "action": "Action",
     "noWrites": "No write capability",
     "missingScopes": "Missing",
+    "missingReadScopes": "Missing read scopes",
+    "missingWriteScopes": "Missing write scopes",
     "mockProof": "Mock/test proof is not production proof.",
     "idempotencyReady": "Idempotency ready",
     "idempotencyMissing": "No idempotency proof",

--- a/ui/src/locales/hi.json
+++ b/ui/src/locales/hi.json
@@ -251,6 +251,8 @@
     "action": "Action",
     "noWrites": "No write capability",
     "missingScopes": "Missing",
+    "missingReadScopes": "Missing read scopes",
+    "missingWriteScopes": "Missing write scopes",
     "mockProof": "Mock/test proof production proof नहीं है।",
     "idempotencyReady": "Idempotency ready",
     "idempotencyMissing": "No idempotency proof",


### PR DESCRIPTION
## What changed

- Added bounded timeouts, public-HTTPS validation, and retry wrappers for outbound auth/JWKS/OAuth/token paths.
- Added explicit timeouts to remaining direct connector/API HTTP clients.
- Kept connector egress send-time validation extensible while preserving the guard, and added a narrow direct-local Tally exception for `http://localhost:9000` root only.
- Added an Alembic migration that backfills FK-leading indexes only when no valid existing leading-column index already covers the FK.
- Fixed deterministic test harness issues around Redis-backed login rate-limit tests, GSTN auth mocks, and DB-dependent CXO e2e skips.
- Updated UI contract tests/locales for the current CompanyDetail agent API usage.

## Why

The hardening sweep found unbounded outbound HTTP calls in security-sensitive auth and connector paths, plus missing FK-leading indexes in ORM metadata. The retry changes are limited to token/JWKS/auth acquisition paths where retrying is safe; write-style consent and business operations only gained bounded timeouts to avoid duplicate side effects.

## Validation

- `python -m ruff check .`
- `python -m mypy --ignore-missing-imports api auth bridge connectors core workflows scaling observability audit scripts sdk tests`
- `python -m bandit -r core api auth connectors workflows -ll`
- `python -m pip_audit --desc --timeout 60 .`
- `python scripts/check_enterprise_stability_gates.py`
- `python scripts/check_migration_required.py`
- `python -m pytest tests\unit -q --no-cov --basetemp=C:\tmp\agenticorg-pytest-unit-hardening --cache-clear -o cache_dir=C:\tmp\agenticorg-pytest-cache-unit-hardening`
- `python -m pytest tests\regression -q --no-cov --basetemp=C:\tmp\agenticorg-pytest-regression-hardening --cache-clear -o cache_dir=C:\tmp\agenticorg-pytest-cache-regression-hardening`
- `python -m pytest tests\security tests\connector_harness -q --no-cov --basetemp=C:\tmp\agenticorg-pytest-sec-conn-hardening --cache-clear -o cache_dir=C:\tmp\agenticorg-pytest-cache-sec-conn-hardening`
- `python -m pytest tests\e2e tests\evals tests\integration tests\synthetic_data -q --no-cov --basetemp=C:\tmp\agenticorg-pytest-remaining-hardening --cache-clear -o cache_dir=C:\tmp\agenticorg-pytest-cache-remaining-hardening`
- `python -m pytest tests\regression\test_release_acceptance.py tests\regression\test_migration_helpers.py tests\regression\test_check_encrypted_migration_uses_helpers.py tests\integration\test_alembic_e2e.py -q --no-cov --basetemp=C:\tmp\agenticorg-pytest-migration-hardening --cache-clear -o cache_dir=C:\tmp\agenticorg-pytest-cache-migration-hardening`
- DB index audit: `52` metadata FK-index gaps found, `52` covered by `v6z4_fk_index_coverage`, `0` left uncovered.
- `npm --prefix ui audit --audit-level=moderate`
- `npm --prefix mcp-server audit --audit-level=moderate`
- `npm --prefix sdk-ts audit --audit-level=moderate`
- `npm --prefix ui test`
- `npm --prefix ui run lint` (0 errors, existing hook warnings only)
- `npm --prefix ui run typecheck`
- `npm --prefix ui run build`
- `npm --prefix mcp-server test`
- `npm --prefix sdk-ts test`
