### PR TITLE
[codex] Exclude generated pytest caches from mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,6 +234,10 @@ check_untyped_defs = true
 allow_redefinition = true
 warn_return_any = false
 disable_error_code = ["union-attr", "attr-defined", "assignment", "arg-type", "return-value", "type-var", "import-untyped", "misc"]
+exclude = [
+    '(^|[\\/])(codex-pytest-basetemp|codex-pytest-cache|codex-pytest-temp|codex-pytest-artifacts)([\\/]|$)',
+    '(^|[\\/])(\.mypy_cache|\.ruff_cache)([\\/]|$)',
+]
 
 [[tool.mypy.overrides]]
 module = ["scripts.*", "tests.*"]


### PR DESCRIPTION
## Summary
- Add mypy excludes for generated pytest/cache directories under the repo workspace.
- Keeps mypy . stable after local pytest runs without excluding product source files.

## Validation
- python -m mypy --ignore-missing-imports .
- python -m ruff check .

## Deployment
- Merging this changes Python project metadata/config; production deploy will be run against the merge SHA after CI/build passes.