### PR TITLE
[codex] Harden commerce evidence artifact paths

### DIFF
--- a/core/commerce/staging_evidence.py
+++ b/core/commerce/staging_evidence.py
@@ -7,6 +7,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from core.security.artifact_paths import atomic_write_text_artifact, resolve_repo_artifact_path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPORT_ROOTS = (
+    REPO_ROOT / ".tmp",
+    REPO_ROOT / "docs" / "reports",
+)
 SENSITIVE_KEY_PARTS = (
     "authorization",
     "token",
@@ -37,6 +44,18 @@ def redact_value(value: Any) -> Any:
 def safe_error_code(result: dict[str, Any]) -> str | None:
     code = result.get("error") or result.get("code")
     return str(code) if code else None
+
+
+def _resolve_evidence_report_path(path: str | Path) -> Path:
+    return resolve_repo_artifact_path(
+        path,
+        repo_root=REPO_ROOT,
+        allowed_roots=REPORT_ROOTS,
+        field_name="evidence_report",
+        outside_reason="outside_report_roots",
+        allowed_suffixes=(".md",),
+        direct_child=True,
+    )
 
 
 @dataclass
@@ -106,8 +125,7 @@ class StagingEvidence:
         }
 
     def write_markdown(self, path: str | Path) -> None:
-        report_path = Path(path)
-        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path = _resolve_evidence_report_path(path)
         data = redact_value(self.as_dict())
         rows = [
             "| Case | Status | Tool | HTTP | Latency ms | Error | Blocker |",
@@ -130,35 +148,33 @@ class StagingEvidence:
                 + " |"
             )
 
-        report_path.write_text(
-            "\n".join(
-                [
-                    "# Commerce Sales Agent Real-Staging Evidence",
-                    "",
-                    f"- Run mode: `{self.run_mode}`",
-                    f"- Grantex host: `{self.grantex_host}`",
-                    f"- Auth source env name: `{self.auth_source_env_name}`",
-                    f"- Fixture env path: `{self.fixture_env_path or ''}`",
-                    f"- Fixture env variable names recorded: {len(self.fixture_env_var_names)}",
-                    f"- Fixture synthetic IDs recorded: {bool(self.fixture_synthetic_ids)}",
-                    f"- Fixture sensitive value hashes recorded: {bool(self.fixture_value_hashes)}",
-                    "- Secret values recorded: false",
-                    "- Raw passports/JWTs recorded: false",
-                    "- Request correlation values recorded: false",
-                    "- Provider material recorded: false",
-                    "- Raw request/response bodies recorded: false",
-                    "",
-                    "## Case Results",
-                    "",
-                    *rows,
-                    "",
-                    "## Redacted Summary",
-                    "",
-                    "```json",
-                    json.dumps(data, indent=2, sort_keys=True),
-                    "```",
-                    "",
-                ]
-            ),
-            encoding="utf-8",
+        content = "\n".join(
+            [
+                "# Commerce Sales Agent Real-Staging Evidence",
+                "",
+                f"- Run mode: `{self.run_mode}`",
+                f"- Grantex host: `{self.grantex_host}`",
+                f"- Auth source env name: `{self.auth_source_env_name}`",
+                f"- Fixture env path: `{self.fixture_env_path or ''}`",
+                f"- Fixture env variable names recorded: {len(self.fixture_env_var_names)}",
+                f"- Fixture synthetic IDs recorded: {bool(self.fixture_synthetic_ids)}",
+                f"- Fixture sensitive value hashes recorded: {bool(self.fixture_value_hashes)}",
+                "- Secret values recorded: false",
+                "- Raw passports/JWTs recorded: false",
+                "- Request correlation values recorded: false",
+                "- Provider material recorded: false",
+                "- Raw request/response bodies recorded: false",
+                "",
+                "## Case Results",
+                "",
+                *rows,
+                "",
+                "## Redacted Summary",
+                "",
+                "```json",
+                json.dumps(data, indent=2, sort_keys=True),
+                "```",
+                "",
+            ]
         )
+        atomic_write_text_artifact(report_path, content, encoding="utf-8", repo_root=REPO_ROOT)

--- a/core/commerce/staging_runtime.py
+++ b/core/commerce/staging_runtime.py
@@ -8,8 +8,15 @@ from hashlib import sha256
 from pathlib import Path
 from urllib.parse import urlparse
 
+from core.security.artifact_paths import ArtifactPathError, resolve_repo_artifact_path
+
 APPROVED_STAGING_ORIGIN = "https://api-staging.grantex.dev"
 REPO_ROOT = Path(__file__).resolve().parents[2]
+TMP_ROOT = REPO_ROOT / ".tmp"
+REPORT_ROOTS = (
+    TMP_ROOT,
+    REPO_ROOT / "docs" / "reports",
+)
 REFUSED_PRODUCTION_ORIGINS = frozenset(
     {
         "https://api.grantex.dev",
@@ -219,21 +226,32 @@ def _decode_fixture_value(value: str) -> str:
 
 
 def _resolve_fixture_path(path: str) -> Path:
-    candidate = (REPO_ROOT / path).resolve()
-    tmp_root = (REPO_ROOT / ".tmp").resolve()
     try:
-        candidate.relative_to(tmp_root)
-    except ValueError as exc:
-        raise RealStagingConfigError(
-            "fixture_env_outside_tmp",
-            "Commerce real-staging fixture env files must be read from .tmp/ only.",
-        ) from exc
-    if candidate == tmp_root:
-        raise RealStagingConfigError(
-            "fixture_env_outside_tmp",
-            "Commerce real-staging fixture env must be a file under .tmp/.",
+        return resolve_repo_artifact_path(
+            path,
+            repo_root=REPO_ROOT,
+            allowed_roots=(TMP_ROOT,),
+            field_name="fixture_env",
+            outside_reason="outside_tmp",
+            direct_child=False,
         )
-    return candidate
+    except ArtifactPathError as exc:
+        raise RealStagingConfigError(exc.code, exc.message) from exc
+
+
+def _resolve_evidence_report_path(path: str | Path) -> Path:
+    try:
+        return resolve_repo_artifact_path(
+            path,
+            repo_root=REPO_ROOT,
+            allowed_roots=REPORT_ROOTS,
+            field_name="evidence_report",
+            outside_reason="outside_report_roots",
+            allowed_suffixes=(".md",),
+            direct_child=True,
+        )
+    except ArtifactPathError as exc:
+        raise RealStagingConfigError(exc.code, exc.message) from exc
 
 
 def _load_fixture_env(path: str | None) -> CommerceFixtureConfig:
@@ -359,6 +377,6 @@ def validate_real_staging_config(
         auth_env_name=auth_env_name,
         auth_value=_resolve_auth_value(merged_env, auth_env_name),
         auth_config_key=AUTH_CONFIG_KEYS[auth_env_name],
-        evidence_report=evidence_report,
+        evidence_report=str(_resolve_evidence_report_path(evidence_report)) if evidence_report else None,
         fixture=fixture,
     )

--- a/core/security/artifact_paths.py
+++ b/core/security/artifact_paths.py
@@ -1,0 +1,192 @@
+"""Path gates for operator-supplied local artifact reads and writes."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+
+
+class ArtifactPathError(ValueError):
+    """Raised when an artifact path escapes its intended workspace."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def _norm(path: Path) -> str:
+    return os.path.normcase(str(path))
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    return _norm(left) == _norm(right)
+
+
+def _under_or_same(path: Path, root: Path) -> bool:
+    path_text = _norm(path)
+    root_text = _norm(root)
+    return path_text == root_text or path_text.startswith(root_text + os.sep)
+
+
+def _is_reparse_point(path: Path) -> bool:
+    try:
+        if path.is_symlink():
+            return True
+        is_junction = getattr(path, "is_junction", None)
+        return bool(is_junction and is_junction())
+    except OSError:
+        return True
+
+
+def _has_reparse_component(path: Path, *, repo_root: Path) -> bool:
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current /= part
+        if not _under_or_same(current, repo_root):
+            continue
+        if current.exists() and _is_reparse_point(current):
+            return True
+    return False
+
+
+def _reject_drive_relative_or_rooted(path: Path, *, field_name: str) -> None:
+    if path.drive and not path.is_absolute():
+        raise ArtifactPathError(
+            f"{field_name}_path_unanchored",
+            f"{field_name} must not use a drive-relative path.",
+        )
+    if path.root and not path.is_absolute():
+        raise ArtifactPathError(
+            f"{field_name}_path_unanchored",
+            f"{field_name} must not use a rooted path without a drive.",
+        )
+
+
+def _safe_allowed_root(root: Path, *, repo_root: Path, field_name: str) -> Path:
+    root_path = root if root.is_absolute() else repo_root / root
+    resolved_root = root_path.resolve()
+    if not _under_or_same(resolved_root, repo_root):
+        raise ArtifactPathError(
+            f"{field_name}_root_outside_repo",
+            f"{field_name} allowed root resolves outside the repository.",
+        )
+    if _has_reparse_component(root_path, repo_root=repo_root):
+        raise ArtifactPathError(
+            f"{field_name}_root_reparse_point",
+            f"{field_name} allowed root must not contain a symlink or junction.",
+        )
+    return resolved_root
+
+
+def resolve_repo_artifact_path(
+    path: str | Path,
+    *,
+    repo_root: Path,
+    allowed_roots: Sequence[Path],
+    field_name: str,
+    outside_reason: str,
+    allowed_suffixes: Sequence[str] | None = None,
+    direct_child: bool = True,
+) -> Path:
+    """Resolve a local artifact path under explicit repository-owned roots."""
+
+    raw_path = str(path or "").strip()
+    if not raw_path:
+        raise ArtifactPathError(f"{field_name}_path_missing", f"{field_name} path is required.")
+
+    repo = repo_root.resolve()
+    candidate = Path(raw_path)
+    _reject_drive_relative_or_rooted(candidate, field_name=field_name)
+    if not candidate.is_absolute():
+        candidate = repo / candidate
+
+    try:
+        resolved = candidate.resolve()
+    except (OSError, ValueError) as exc:
+        raise ArtifactPathError(
+            f"{field_name}_path_unresolvable",
+            f"{field_name} path could not be resolved.",
+        ) from exc
+
+    if _has_reparse_component(candidate, repo_root=repo):
+        raise ArtifactPathError(
+            f"{field_name}_path_reparse_point",
+            f"{field_name} path must not contain a symlink or junction.",
+        )
+
+    if allowed_suffixes is not None:
+        suffixes = {suffix.lower() for suffix in allowed_suffixes}
+        if resolved.suffix.lower() not in suffixes:
+            raise ArtifactPathError(
+                f"{field_name}_path_extension_refused",
+                f"{field_name} must use one of these suffixes: {sorted(suffixes)}.",
+            )
+
+    safe_roots = tuple(
+        _safe_allowed_root(root, repo_root=repo, field_name=field_name)
+        for root in allowed_roots
+    )
+    for root in safe_roots:
+        if direct_child:
+            if _same_path(resolved.parent, root):
+                return resolved
+        elif _under_or_same(resolved, root) and not _same_path(resolved, root):
+            return resolved
+
+    raise ArtifactPathError(
+        f"{field_name}_{outside_reason}",
+        f"{field_name} must stay under an allowed repository artifact root.",
+    )
+
+
+def _reject_unsafe_write_target(target: Path, *, repo_root: Path | None = None) -> None:
+    if repo_root is not None and _has_reparse_component(target.parent, repo_root=repo_root.resolve()):
+        raise ArtifactPathError(
+            "artifact_parent_reparse_point",
+            "Artifact parent must not contain a symlink or junction.",
+        )
+    if _is_reparse_point(target):
+        raise ArtifactPathError(
+            "artifact_target_reparse_point",
+            "Artifact target must not be a symlink or junction.",
+        )
+
+
+def atomic_write_text_artifact(
+    path: str | Path,
+    content: str,
+    *,
+    encoding: str = "utf-8",
+    repo_root: Path | None = None,
+) -> None:
+    """Write text through a temp file in the already-validated target directory."""
+
+    target = Path(path)
+    _reject_unsafe_write_target(target, repo_root=repo_root)
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    _reject_unsafe_write_target(target, repo_root=repo_root)
+    temp_name = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding=encoding,
+            dir=target.parent,
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temp_name = handle.name
+            handle.write(content)
+        _reject_unsafe_write_target(target, repo_root=repo_root)
+        os.replace(temp_name, target)
+        temp_name = ""
+    finally:
+        if temp_name:
+            try:
+                Path(temp_name).unlink(missing_ok=True)
+            except OSError:
+                pass

--- a/demos/commerce_sales_agent_demo.py
+++ b/demos/commerce_sales_agent_demo.py
@@ -749,8 +749,8 @@ async def run_real_staging_demo(
         )
 
         evidence.no_provider_call_confirmation = _no_provider_calls(tool_sequence)
-        if evidence_report:
-            evidence.write_markdown(evidence_report)
+        if config.evidence_report:
+            evidence.write_markdown(config.evidence_report)
 
         return {
             "title": "AgenticOrg Commerce Sales Agent Real-Staging Demo",
@@ -769,7 +769,7 @@ async def run_real_staging_demo(
                 "fixture_env_path": fixture.env_path,
                 "fixture_env_var_names": fixture.variable_names,
                 "fixture_synthetic_ids": fixture.synthetic_ids,
-                "evidence_report": evidence_report,
+                "evidence_report": config.evidence_report,
             },
         }
     finally:

--- a/scripts/commerce_agent_hosted_smoke.py
+++ b/scripts/commerce_agent_hosted_smoke.py
@@ -20,6 +20,16 @@ from urllib.parse import urlparse
 
 import httpx
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core.security.artifact_paths import (  # noqa: E402
+    ArtifactPathError,
+    atomic_write_text_artifact,
+    resolve_repo_artifact_path,
+)
+
 EXPECTED_CONSENT_EXCHANGE_BLOCKER = "preexported_checkout_passport_without_granted_consent_fixture"
 
 AUTH_SOURCE_ENV_NAMES = (
@@ -92,6 +102,11 @@ DEFAULT_PUBLIC_ENV_NAMES = (
     "COMMERCE_LIVE_MODE_ENABLED",
     "PLURAL_LIVE_ENABLED",
     "PLURAL_ENV",
+)
+TMP_ROOT = REPO_ROOT / ".tmp"
+REPORT_ROOTS = (
+    TMP_ROOT,
+    REPO_ROOT / "docs" / "reports",
 )
 
 
@@ -215,16 +230,32 @@ def _decode_env_value(raw_value: str) -> str:
 
 
 def _resolve_tmp_fixture_path(path: str) -> Path:
-    repo_root = Path(__file__).resolve().parents[1]
-    candidate = (repo_root / path).resolve()
-    tmp_root = (repo_root / ".tmp").resolve()
     try:
-        candidate.relative_to(tmp_root)
-    except ValueError as exc:
-        raise HostedSmokeConfigError("fixture_env_outside_tmp", "Fixture env files must stay under .tmp/.") from exc
-    if candidate == tmp_root:
-        raise HostedSmokeConfigError("fixture_env_outside_tmp", "Fixture env must be a file under .tmp/.")
-    return candidate
+        return resolve_repo_artifact_path(
+            path,
+            repo_root=REPO_ROOT,
+            allowed_roots=(TMP_ROOT,),
+            field_name="fixture_env",
+            outside_reason="outside_tmp",
+            direct_child=False,
+        )
+    except ArtifactPathError as exc:
+        raise HostedSmokeConfigError(exc.code, exc.message) from exc
+
+
+def _resolve_report_path(path: str | Path, *, field_name: str) -> Path:
+    try:
+        return resolve_repo_artifact_path(
+            path,
+            repo_root=REPO_ROOT,
+            allowed_roots=REPORT_ROOTS,
+            field_name=field_name,
+            outside_reason="outside_report_roots",
+            allowed_suffixes=(".md",),
+            direct_child=True,
+        )
+    except ArtifactPathError as exc:
+        raise HostedSmokeConfigError(exc.code, exc.message) from exc
 
 
 def _summarize_fixture_env(path: str, *, auth_source_env_name: str) -> FixtureSummary:
@@ -266,7 +297,7 @@ def _summarize_fixture_env(path: str, *, auth_source_env_name: str) -> FixtureSu
             hashes.append({"name": name, "sha256_12": sha256(value.encode("utf-8")).hexdigest()[:12]})
 
     synthetic_ids = {name: values[name] for name in sorted(SYNTHETIC_ID_ENV_NAMES) if values.get(name)}
-    relative_path = fixture_path.relative_to(Path(__file__).resolve().parents[1]).as_posix()
+    relative_path = fixture_path.relative_to(REPO_ROOT).as_posix()
     return FixtureSummary(
         env_path=relative_path,
         variable_names=tuple(sorted(values)),
@@ -322,6 +353,17 @@ def validate_config(args: argparse.Namespace, *, environ: dict[str, str] | None 
     smoke_binding_names = tuple(
         _validate_smoke_name(name, field_name="protected binding") for name in args.smoke_binding_name
     )
+    evidence_report = (
+        str(_resolve_report_path(args.evidence_report, field_name="evidence_report"))
+        if args.evidence_report
+        else None
+    )
+    real_staging_evidence_report = (
+        str(_resolve_report_path(args.real_staging_evidence_report, field_name="real_staging_evidence_report"))
+        if args.real_staging_evidence_report
+        else None
+    )
+
     return HostedSmokeConfig(
         agenticorg_base_url=agenticorg_origin,
         grantex_base_url=grantex_origin,
@@ -337,8 +379,8 @@ def validate_config(args: argparse.Namespace, *, environ: dict[str, str] | None 
         commit_sha=args.commit_sha,
         image_tag=args.image_tag,
         cleanup_by=args.cleanup_by,
-        evidence_report=args.evidence_report,
-        real_staging_evidence_report=args.real_staging_evidence_report,
+        evidence_report=evidence_report,
+        real_staging_evidence_report=real_staging_evidence_report,
         fixture=fixture,
     )
 
@@ -543,8 +585,7 @@ def evidence_as_dict(config: HostedSmokeConfig, cases: list[SmokeCase], *, dry_r
 
 
 def write_evidence_report(config: HostedSmokeConfig, cases: list[SmokeCase], *, dry_run: bool, path: str | Path) -> None:
-    report_path = Path(path)
-    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path = _resolve_report_path(path, field_name="evidence_report")
     rows = [
         "| Case | Status | HTTP | Latency ms | Error | Blocker |",
         "| --- | --- | --- | --- | --- | --- |",
@@ -565,38 +606,39 @@ def write_evidence_report(config: HostedSmokeConfig, cases: list[SmokeCase], *, 
             + " |"
         )
     data = evidence_as_dict(config, cases, dry_run=dry_run)
-    report_path.write_text(
-        "\n".join(
-            [
-                "# AgenticOrg C3 Hosted Commerce Smoke Evidence",
-                "",
-                f"- Run mode: `{data['run_mode']}`",
-                f"- AgenticOrg host: `{data['agenticorg_host']}`",
-                f"- Grantex host: `{data['grantex_host']}`",
-                f"- Auth source env name: `{config.auth_source_env_name}`",
-                f"- Fixture source: `{data['fixture']['source'] or ''}`",
-                f"- Fixture binding name: `{config.fixture.fixture_binding_name or ''}`",
-                "- Secret values recorded: false",
-                "- Raw passports/JWTs recorded: false",
-                "- Idempotency values recorded: false",
-                "- Provider material recorded: false",
-                "- Raw request/response bodies recorded: false",
-                "- DB/Redis URLs recorded: false",
-                "",
-                "## Case Results",
-                "",
-                *rows,
-                "",
-                "## Redacted Summary",
-                "",
-                "```json",
-                json.dumps(data, indent=2, sort_keys=True),
-                "```",
-                "",
-            ]
-        ),
-        encoding="utf-8",
+    content = "\n".join(
+        [
+            "# AgenticOrg C3 Hosted Commerce Smoke Evidence",
+            "",
+            f"- Run mode: `{data['run_mode']}`",
+            f"- AgenticOrg host: `{data['agenticorg_host']}`",
+            f"- Grantex host: `{data['grantex_host']}`",
+            f"- Auth source env name: `{config.auth_source_env_name}`",
+            f"- Fixture source: `{data['fixture']['source'] or ''}`",
+            f"- Fixture binding name: `{config.fixture.fixture_binding_name or ''}`",
+            "- Secret values recorded: false",
+            "- Raw passports/JWTs recorded: false",
+            "- Idempotency values recorded: false",
+            "- Provider material recorded: false",
+            "- Raw request/response bodies recorded: false",
+            "- DB/Redis URLs recorded: false",
+            "",
+            "## Case Results",
+            "",
+            *rows,
+            "",
+            "## Redacted Summary",
+            "",
+            "```json",
+            json.dumps(data, indent=2, sort_keys=True),
+            "```",
+            "",
+        ]
     )
+    try:
+        atomic_write_text_artifact(report_path, content, encoding="utf-8", repo_root=REPO_ROOT)
+    except ArtifactPathError as exc:
+        raise HostedSmokeConfigError(exc.code, exc.message) from exc
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tests/regression/test_commerce_agent_hosted_smoke_runner.py
+++ b/tests/regression/test_commerce_agent_hosted_smoke_runner.py
@@ -182,6 +182,103 @@ def test_fixture_sources_are_not_ambiguous() -> None:
     assert excinfo.value.code == "fixture_source_ambiguous"
 
 
+def test_evidence_report_path_is_anchored_to_repo_when_cwd_differs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    config = _validate("--evidence-report", "docs/reports/commerce-agent-hosted-smoke-evidence.md")
+
+    expected = (
+        Path(runner.__file__).resolve().parents[1]
+        / "docs"
+        / "reports"
+        / "commerce-agent-hosted-smoke-evidence.md"
+    ).resolve()
+    assert config.evidence_report == str(expected)
+
+
+@pytest.mark.parametrize(
+    ("flag", "value", "code"),
+    [
+        ("--evidence-report", "../evidence.md", "evidence_report_outside_report_roots"),
+        ("--evidence-report", "docs/reports/nested/evidence.md", "evidence_report_outside_report_roots"),
+        ("--evidence-report", "docs/reports/evidence.json", "evidence_report_path_extension_refused"),
+        (
+            "--real-staging-evidence-report",
+            "../real-staging.md",
+            "real_staging_evidence_report_outside_report_roots",
+        ),
+    ],
+)
+def test_report_paths_reject_escapes_subdirs_and_non_markdown(flag: str, value: str, code: str) -> None:
+    with pytest.raises(runner.HostedSmokeConfigError) as excinfo:
+        _validate(flag, value)
+
+    assert excinfo.value.code == code
+
+
+def test_absolute_report_path_outside_repo_is_rejected(tmp_path: Path) -> None:
+    outside = tmp_path / "evidence.md"
+
+    with pytest.raises(runner.HostedSmokeConfigError) as excinfo:
+        _validate("--evidence-report", str(outside))
+
+    assert excinfo.value.code == "evidence_report_outside_report_roots"
+
+
+def test_report_allowed_root_must_stay_inside_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+    outside_repo = Path(runner.__file__).resolve().parents[2]
+    monkeypatch.setattr(runner, "REPORT_ROOTS", (outside_repo,))
+
+    with pytest.raises(runner.HostedSmokeConfigError) as excinfo:
+        _validate("--evidence-report", "docs/reports/commerce-agent-hosted-smoke-evidence.md")
+
+    assert excinfo.value.code == "evidence_report_root_outside_repo"
+
+
+def test_fixture_allowed_root_must_stay_inside_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+    outside_repo = Path(runner.__file__).resolve().parents[2]
+    monkeypatch.setattr(runner, "TMP_ROOT", outside_repo)
+
+    with pytest.raises(runner.HostedSmokeConfigError) as excinfo:
+        _validate("--fixture-env", ".tmp/commerce-agent-c3-hosted-smoke.env")
+
+    assert excinfo.value.code == "fixture_env_root_outside_repo"
+
+
+def test_write_evidence_report_rechecks_output_path(tmp_path: Path) -> None:
+    config = _validate()
+
+    with pytest.raises(runner.HostedSmokeConfigError) as excinfo:
+        runner.write_evidence_report(config, [], dry_run=False, path=tmp_path / "outside.md")
+
+    assert excinfo.value.code == "evidence_report_outside_report_roots"
+
+
+def test_write_evidence_report_rejects_existing_symlink_target(tmp_path: Path) -> None:
+    config = _validate()
+    target = Path(".tmp/commerce-agent-c3-hosted-smoke-symlink.md")
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside", encoding="utf-8")
+    target.parent.mkdir(exist_ok=True)
+    target.unlink(missing_ok=True)
+    try:
+        target.symlink_to(outside)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    try:
+        with pytest.raises(runner.HostedSmokeConfigError) as excinfo:
+            runner.write_evidence_report(config, [], dry_run=False, path=target)
+    finally:
+        target.unlink(missing_ok=True)
+
+    assert excinfo.value.code in {"evidence_report_path_reparse_point", "artifact_target_reparse_point"}
+
+
 def test_hosted_checks_validate_health_mcp_and_a2a_discovery() -> None:
     config = _validate()
 

--- a/tests/regression/test_commerce_sales_agent_real_staging_mode.py
+++ b/tests/regression/test_commerce_sales_agent_real_staging_mode.py
@@ -6,8 +6,9 @@ from typing import Any
 
 import pytest
 
-from core.commerce.staging_evidence import redact_value
+from core.commerce.staging_evidence import StagingEvidence, redact_value
 from core.commerce.staging_runtime import RealStagingConfigError, validate_real_staging_config
+from core.security.artifact_paths import ArtifactPathError
 from demos import commerce_sales_agent_demo
 
 
@@ -287,6 +288,63 @@ def test_real_staging_refuses_fixture_env_outside_tmp() -> None:
     assert excinfo.value.code == "fixture_env_outside_tmp"
 
 
+def test_real_staging_evidence_report_path_is_anchored_to_repo_when_cwd_differs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    config = validate_real_staging_config(
+        grantex_base_url="https://api-staging.grantex.dev",
+        evidence_report="docs/reports/commerce-agent-real-staging-evidence.md",
+        environ=_env(GRANTEX_AGENT_ASSERTION="present-but-not-printed"),
+    )
+
+    expected = (
+        Path(commerce_sales_agent_demo.__file__).resolve().parents[1]
+        / "docs"
+        / "reports"
+        / "commerce-agent-real-staging-evidence.md"
+    ).resolve()
+    assert config.evidence_report == str(expected)
+
+
+@pytest.mark.parametrize(
+    ("value", "code"),
+    [
+        ("../evidence.md", "evidence_report_outside_report_roots"),
+        ("docs/reports/nested/evidence.md", "evidence_report_outside_report_roots"),
+        ("docs/reports/evidence.json", "evidence_report_path_extension_refused"),
+    ],
+)
+def test_real_staging_evidence_report_rejects_escapes_subdirs_and_non_markdown(
+    value: str,
+    code: str,
+) -> None:
+    with pytest.raises(RealStagingConfigError) as excinfo:
+        validate_real_staging_config(
+            grantex_base_url="https://api-staging.grantex.dev",
+            evidence_report=value,
+            environ=_env(GRANTEX_AGENT_ASSERTION="present-but-not-printed"),
+        )
+
+    assert excinfo.value.code == code
+
+
+def test_real_staging_evidence_writer_rechecks_output_path(tmp_path: Path) -> None:
+    evidence = StagingEvidence(
+        run_mode="real_staging",
+        grantex_host="api-staging.grantex.dev",
+        auth_source_env_name="GRANTEX_AGENT_ASSERTION",
+    )
+
+    with pytest.raises(ArtifactPathError) as excinfo:
+        evidence.write_markdown(tmp_path / "outside.md")
+
+    assert excinfo.value.code == "evidence_report_outside_report_roots"
+
+
 def test_real_staging_fixture_preserves_exactly_one_auth_source_rule() -> None:
     smoke_url = "https://grantex-auth-smoke-example-uc.a.run.app"
     fixture = _write_tmp_fixture(
@@ -375,6 +433,7 @@ async def test_real_staging_skips_inventory_when_browse_passport_fixture_missing
 
     assert not any(name == "inventory_check" for name, _params in connector.calls)
     assert "grantex_commerce:inventory_check" not in result["audit_summary"]["tool_sequence"]
+    assert result["audit_summary"]["evidence_report"] == str(report.resolve())
     assert "| inventory_check | skipped |  |  |  |  | requires browse passport fixture |" in report_text
 
 


### PR DESCRIPTION
## Summary
- Add a shared repository artifact path gate for operator-supplied local reads/writes.
- Anchor commerce staging and hosted-smoke evidence paths to repo-owned roots with markdown-only direct-child reports.
- Add regressions for cwd-independent path anchoring, path escapes, unsafe roots, and symlink targets.

## Validation
- python -m pytest --basetemp C:\tmp\agentic-vvah-pr-pytest tests/regression/test_commerce_agent_hosted_smoke_runner.py tests/regression/test_commerce_sales_agent_real_staging_mode.py tests/regression/test_vvah_security_hardening.py
- Result: 61 passed, 1 skipped.