### PR TITLE
Add mandatory frontend CI validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,6 +94,32 @@ jobs:
       - run: ruff check .
       - run: mypy --ignore-missing-imports .
 
+  frontend-validation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+      - name: Install locked frontend dependencies
+        run: npm ci --no-audit --no-fund
+      - name: Lint frontend
+        run: npm run lint
+      - name: Type-check frontend
+        run: npm run typecheck
+      - name: Test frontend
+        run: npm test
+      - name: Build production frontend
+        run: npm run build
+
   unit-tests:
     needs: lint
     runs-on: ubuntu-latest
@@ -212,7 +238,7 @@ jobs:
           pip-audit --desc --timeout 60 -r requirements-v4.txt
 
   release-acceptance:
-    needs: [classify-changes, unit-tests, integration-tests, security-scan]
+    needs: [classify-changes, unit-tests, integration-tests, security-scan, frontend-validation]
     if: |
       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) &&
       needs.classify-changes.outputs.docs_only != 'true'
@@ -252,7 +278,7 @@ jobs:
           retention-days: 30
 
   build:
-    needs: [classify-changes, unit-tests, integration-tests, security-scan, release-acceptance]
+    needs: [classify-changes, unit-tests, integration-tests, security-scan, frontend-validation, release-acceptance]
     if: |
       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) &&
       needs.classify-changes.outputs.docs_only != 'true'

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -4,7 +4,7 @@
 FROM node:26-slim@sha256:a1d9d671994fc2d26e297ac56b4b1522a8bc7fa71c43b14cd1b1fe6c5116f7dc AS builder
 WORKDIR /app
 COPY ui/package.json ui/package-lock.json* ./
-RUN npm install --legacy-peer-deps
+RUN npm ci --no-audit --no-fund
 ARG CACHE_BUST=1
 COPY ui/ .
 # Copy backend source for llms.txt/sitemap generators (they parse agents + connectors)

--- a/Dockerfile.ui.cloudrun
+++ b/Dockerfile.ui.cloudrun
@@ -4,7 +4,7 @@
 FROM node:26-slim@sha256:a1d9d671994fc2d26e297ac56b4b1522a8bc7fa71c43b14cd1b1fe6c5116f7dc AS builder
 WORKDIR /app
 COPY ui/package.json ui/package-lock.json* ./
-RUN npm install --legacy-peer-deps
+RUN npm ci --no-audit --no-fund
 ARG CACHE_BUST=1
 COPY ui/ .
 COPY core/agents/ ../core/agents/


### PR DESCRIPTION
## What changed

- add a mandatory `frontend-validation` job to the existing CI workflow
- run locked install, ESLint, TypeScript typecheck, Vitest, and the production UI build on pull requests
- make release acceptance and image publication depend on the frontend gate
- replace legacy-peer dependency installation with deterministic `npm ci` in both UI Dockerfiles

## Why

PR #960 appeared green even though TypeScript 7 could not resolve or lint with the supported TypeScript-ESLint toolchain. PR CI previously exercised only the Python path, while frontend validation and image builds were skipped on pull requests.

## Impact

Frontend dependency incompatibilities and broken production UI builds now fail before merge. Production image builds use the committed lockfile and no longer bypass peer-dependency constraints.

## Validation

- YAML parse
- `npm ci --no-audit --no-fund`
- `npm run lint` (0 errors)
- `npm run typecheck`
- `npm test` (163 passed)
- `npm run build`
- targeted workflow/security regressions (119 passed, 1 skipped)
- Cloud Run UI builder Docker build with the new `npm ci` path