### PR TITLE
Fix UI image build for generated LLM documents

### DIFF
--- a/Dockerfile.ui.cloudrun
+++ b/Dockerfile.ui.cloudrun
@@ -7,6 +7,8 @@ COPY ui/package.json ui/package-lock.json* ./
 RUN npm ci --no-audit --no-fund
 ARG CACHE_BUST=1
 COPY ui/ .
+COPY pyproject.toml README.md ../
+COPY core/billing/limits.py ../core/billing/limits.py
 COPY core/agents/ ../core/agents/
 COPY connectors/ ../connectors/
 ARG VITE_GA4_ID=""


### PR DESCRIPTION
## What changed

- Copy `pyproject.toml` and `README.md` into the UI builder's repository-root layout.
- Copy `core/billing/limits.py` alongside the agents and connectors already available to the LLM document generator.

## Root cause

The new `generate-llms.mjs` resolves repository sources from `/` when `ui/` is flattened into `/app` by `Dockerfile.ui.cloudrun`. Main CI's UI image build therefore failed with `ENOENT: /pyproject.toml`, after the API image had already been published.

## Impact

The UI image can now generate `llms.txt`, `llms-full.txt`, route shells, sitemap, and SEO verification during `npm run build`. Builder-only source files do not enter the final nginx stage, which copies only `/app/dist`.

## Validation

- `node ui/scripts/generate-llms.mjs --check`
- `git diff --check`
- `docker build -f Dockerfile.ui.cloudrun -t agenticorg-ui-cloudrun:llms-fix .`
- Runtime image assertions confirm both LLM files exist and builder sources are absent.