### PR TITLE
Align noindex response headers with route registry

### DIFF
--- a/tests/regression/test_seo_noindex_nginx.py
+++ b/tests/regression/test_seo_noindex_nginx.py
@@ -1,0 +1,105 @@
+"""Regression coverage for registry-driven nginx noindex headers."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+PUBLIC_SITE = ROOT / "ui" / "src" / "content" / "publicSite.json"
+NGINX_CONFIGS = (
+    ROOT / "ui" / "nginx.conf",
+    ROOT / "ui" / "nginx.cloudrun.conf.template",
+)
+
+
+def _noindex_patterns(config: Path) -> list[re.Pattern[str]]:
+    text = config.read_text(encoding="utf-8")
+    map_block = re.search(
+        r"map\s+\$request_uri\s+\$seo_robots_tag\s*\{(.*?)^\}",
+        text,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert map_block, f"{config.name}: $seo_robots_tag map is missing"
+    patterns = [
+        re.compile(pattern)
+        for pattern in re.findall(
+            r'^\s*~(\S+)\s+"noindex,\s*nofollow";\s*$',
+            map_block.group(1),
+            re.MULTILINE,
+        )
+    ]
+    assert patterns, f"{config.name}: no noindex map patterns found"
+    return patterns
+
+
+def _matches(patterns: list[re.Pattern[str]], uri: str) -> bool:
+    return any(pattern.search(uri) for pattern in patterns)
+
+
+def _registered_pages() -> list[dict[str, object]]:
+    return json.loads(PUBLIC_SITE.read_text(encoding="utf-8"))["pages"]
+
+
+@pytest.mark.parametrize("config", NGINX_CONFIGS, ids=lambda path: path.name)
+def test_every_registered_noindex_route_maps_to_response_header(config: Path) -> None:
+    patterns = _noindex_patterns(config)
+    noindex_pages = [page for page in _registered_pages() if page["index"] is False]
+    assert noindex_pages, "public route registry must contain noindex pages"
+
+    for page in noindex_pages:
+        path = str(page["path"])
+        for uri in (path, path + "/", path + "?utm_source=test", path + "/?utm_source=test"):
+            assert _matches(patterns, uri), (
+                f"{config.name}: registered noindex route variant is uncovered: {uri}"
+            )
+
+
+@pytest.mark.parametrize("config", NGINX_CONFIGS, ids=lambda path: path.name)
+def test_campaign_rules_cover_subpaths_without_overmatching_siblings(config: Path) -> None:
+    patterns = _noindex_patterns(config)
+    campaigns = [
+        str(page["path"])
+        for page in _registered_pages()
+        if page["index"] is False and str(page["path"]).startswith("/solutions/")
+    ]
+    assert campaigns == [
+        "/solutions/ai-invoice-processing",
+        "/solutions/automated-bank-reconciliation",
+        "/solutions/payroll-automation",
+    ]
+
+    for path in campaigns:
+        assert _matches(patterns, path + "/confirmation?lead=accepted")
+        assert not _matches(patterns, path + "-guide")
+
+
+@pytest.mark.parametrize("config", NGINX_CONFIGS, ids=lambda path: path.name)
+def test_existing_auth_and_dashboard_match_boundaries_are_preserved(config: Path) -> None:
+    patterns = _noindex_patterns(config)
+    for uri in (
+        "/dashboard",
+        "/dashboard/agents/agent-1",
+        "/dashboard?tab=agents",
+        "/login",
+        "/login/?next=%2Fdashboard",
+        "/sso/callback?code=redacted",
+    ):
+        assert _matches(patterns, uri), f"{config.name}: private URI is uncovered: {uri}"
+
+    assert not _matches(patterns, "/dashboarding")
+    assert not _matches(patterns, "/login/help")
+    assert not _matches(patterns, "/solutions/cfo")
+
+
+@pytest.mark.parametrize("config", NGINX_CONFIGS, ids=lambda path: path.name)
+def test_registered_indexable_routes_do_not_receive_noindex(config: Path) -> None:
+    patterns = _noindex_patterns(config)
+    for page in _registered_pages():
+        if page["index"] is not False:
+            path = str(page["path"])
+            assert not _matches(patterns, path)
+            assert not _matches(patterns, path + "?utm_source=test")

--- a/ui/nginx.cloudrun.conf.template
+++ b/ui/nginx.cloudrun.conf.template
@@ -2,7 +2,7 @@
 # not emitted, so public routes do not receive a redundant X-Robots-Tag.
 map $request_uri $seo_robots_tag {
     default "";
-    ~^/(dashboard(?:/|\?|$)|login/?(?:\?|$)|signup/?(?:\?|$)|forgot-password/?(?:\?|$)|reset-password/?(?:\?|$)|invite/?(?:\?|$)|accept-invite/?(?:\?|$)|onboarding/?(?:\?|$)|sso/callback/?(?:\?|$)) "noindex, nofollow";
+    ~^/(?:(?:dashboard|solutions/(?:ai-invoice-processing|automated-bank-reconciliation|payroll-automation))(?:/|\?|$)|(?:login|signup|forgot-password|reset-password|invite|accept-invite|onboarding|sso/callback)/?(?:\?|$)) "noindex, nofollow";
 }
 server_tokens off;
 add_header_inherit merge;

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -2,7 +2,7 @@
 # not emitted, so public routes do not receive a redundant X-Robots-Tag.
 map $request_uri $seo_robots_tag {
     default "";
-    ~^/(dashboard(?:/|\?|$)|login/?(?:\?|$)|signup/?(?:\?|$)|forgot-password/?(?:\?|$)|reset-password/?(?:\?|$)|invite/?(?:\?|$)|accept-invite/?(?:\?|$)|onboarding/?(?:\?|$)|sso/callback/?(?:\?|$)) "noindex, nofollow";
+    ~^/(?:(?:dashboard|solutions/(?:ai-invoice-processing|automated-bank-reconciliation|payroll-automation))(?:/|\?|$)|(?:login|signup|forgot-password|reset-password|invite|accept-invite|onboarding|sso/callback)/?(?:\?|$)) "noindex, nofollow";
 }
 # =============================================================================
 # AgenticOrg — Production Nginx Configuration

--- a/ui/scripts/verify-seo.mjs
+++ b/ui/scripts/verify-seo.mjs
@@ -56,6 +56,19 @@ function sitemapLocations(xml) {
   );
 }
 
+function noindexMapPatterns(config) {
+  const mapBlock = config.match(
+    /map\s+\$request_uri\s+\$seo_robots_tag\s*\{([\s\S]*?)^\}/m,
+  );
+  if (!mapBlock) return [];
+  return [...mapBlock[1].matchAll(
+    /^\s*~(\S+)\s+"noindex,\s*nofollow";\s*$/gm,
+  )].map((match) => new RegExp(match[1]));
+}
+
+const hasNoindexHeader = (patterns, uri) =>
+  patterns.some((pattern) => pattern.test(uri));
+
 export function verifySeo(root = UI_ROOT) {
   const errors = [];
   const warnings = [];
@@ -308,6 +321,50 @@ export function verifySeo(root = UI_ROOT) {
     }
     if (!config.includes("X-Robots-Tag $seo_robots_tag always")) {
       fail(configName + " is missing private-route X-Robots-Tag");
+    }
+    const noindexPatterns = noindexMapPatterns(config);
+    if (noindexPatterns.length === 0) {
+      fail(configName + " is missing the $seo_robots_tag noindex map rules");
+    } else {
+      const noindexRoutes = routes.filter((route) => route.index === false);
+      for (const route of noindexRoutes) {
+        const variants = [
+          route.path,
+          route.path + "/",
+          route.path + "?source=seo-verifier",
+          route.path + "/?source=seo-verifier",
+        ];
+        for (const uri of variants) {
+          if (!hasNoindexHeader(noindexPatterns, uri)) {
+            fail(configName + " does not map registered noindex URI " + uri);
+          }
+        }
+      }
+      for (const route of routes.filter((candidate) => candidate.index !== false)) {
+        for (const uri of [route.path, route.path + "?source=seo-verifier"]) {
+          if (hasNoindexHeader(noindexPatterns, uri)) {
+            fail(configName + " incorrectly maps indexable URI " + uri + " to noindex");
+          }
+        }
+      }
+      for (const route of noindexRoutes.filter((candidate) =>
+        candidate.path.startsWith("/solutions/")
+      )) {
+        if (!hasNoindexHeader(noindexPatterns, route.path + "/confirmation")) {
+          fail(configName + " does not preserve noindex on campaign subpaths: " + route.path);
+        }
+        if (hasNoindexHeader(noindexPatterns, route.path + "-guide")) {
+          fail(configName + " overmatches campaign siblings: " + route.path);
+        }
+      }
+      for (const uri of ["/dashboard", "/dashboard/agents/agent-1", "/dashboard?tab=agents"]) {
+        if (!hasNoindexHeader(noindexPatterns, uri)) {
+          fail(configName + " does not preserve private dashboard noindex for " + uri);
+        }
+      }
+      if (hasNoindexHeader(noindexPatterns, "/login/help")) {
+        fail(configName + " broadens the exact auth-flow rule to /login/help");
+      }
     }
     for (const alias of ["/contact", "/privacy-policy", "/terms-of-service", "/refund-policy", "/cancellation"]) {
       if (!config.includes("location = " + alias + " {")) {


### PR DESCRIPTION
## Summary

- add the three registered noindex solution campaigns to nginx's `X-Robots-Tag` map
- preserve query/subpath coverage while preventing sibling/indexable overmatch
- make the SEO verifier derive noindex expectations from the route registry
- add regression coverage for all noindex routes and auth/dashboard boundaries

## Production audit finding

The post-deploy audit of all 83 route shells and 72 hydrated public routes found that these three `index:false` routes had correct HTML robots metadata but lacked the matching response header:

- `/solutions/ai-invoice-processing`
- `/solutions/automated-bank-reconciliation`
- `/solutions/payroll-automation`

All other audited SEO/AEO, security, sitemap, LLM discovery, redirect, 404, and commit checks passed.

## Validation

- full `seo:sync`: 83 routes, 72 sitemap URLs, 86 CSP hashes
- SEO generator tests: 10/10
- targeted Python regressions: 26/26; new noindex regression: 8/8
- exact UI Docker build and `nginx -t`
- live local container header checks for campaign routes/query/subpaths, auth/dashboard, and indexable negative controls
- Ruff and `git diff --check`
- ESLint: 0 errors (20 pre-existing warnings)