### PR TITLE
fix: prevent eval scorecard error disclosure

### DIFF
--- a/api/v1/evals.py
+++ b/api/v1/evals.py
@@ -11,12 +11,15 @@ measured benchmark output. Real scorecards are flagged
 from __future__ import annotations
 
 import json
+import logging
 from datetime import UTC, datetime
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Response
 
 from api.route_metadata import route_meta
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -96,10 +99,11 @@ def _load_scorecard() -> tuple[dict, str]:
             scorecard = json.load(f)
         scorecard["data_quality"] = "measured"
         return scorecard, "measured"
-    except (OSError, json.JSONDecodeError) as exc:
-        # If the on-disk file is corrupt, still don't blank the page.
+    except (OSError, json.JSONDecodeError):
+        # If the on-disk file is corrupt, still don't blank the page. Keep
+        # exception details in server logs because this endpoint is public.
+        logger.exception("Failed to load evaluation scorecard; serving demo baseline")
         baseline = dict(_DEFAULT_SCORECARD)
-        baseline["_load_error"] = str(exc)
         baseline["served_at"] = datetime.now(UTC).isoformat()
         baseline["data_quality"] = "demo"
         return baseline, "demo"

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -3705,7 +3705,7 @@
     "public_exempt_reason": "public-product-scorecard-data-quality-labeled",
     "rate_limit": "public-evals-read",
     "scope": "public:evals.scorecard.read",
-    "source_line": 132,
+    "source_line": 136,
     "tenant_required": false
   },
   {
@@ -3723,7 +3723,7 @@
     "public_exempt_reason": "public-product-scorecard-data-quality-labeled",
     "rate_limit": "public-evals-read",
     "scope": "public:evals.agent_scorecard.read",
-    "source_line": 155,
+    "source_line": 159,
     "tenant_required": false
   },
   {

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -2396,6 +2396,32 @@ class TestLoadScorecard:
         assert result["data_quality"] == "demo"
         assert quality == "demo"
 
+    def test_load_scorecard_does_not_expose_exception_details(self, tmp_path):
+        """A corrupt scorecard must not leak filesystem or secret details."""
+        from api.v1.evals import _load_scorecard
+
+        scorecard_file = tmp_path / "scorecard.json"
+        scorecard_file.write_text("{}")
+        sensitive_details = (
+            "Authorization: Bearer secret-token at /srv/app/evals/scorecard.json"
+        )
+
+        with (
+            patch("api.v1.evals._SCORECARD_PATH", scorecard_file),
+            patch("api.v1.evals.json.load", side_effect=OSError(sensitive_details)),
+            patch("api.v1.evals.logger.exception") as log_exception,
+        ):
+            result, quality = _load_scorecard()
+
+        assert result["_is_baseline"] is True
+        assert result["data_quality"] == "demo"
+        assert quality == "demo"
+        assert "_load_error" not in result
+        assert sensitive_details not in json.dumps(result)
+        log_exception.assert_called_once_with(
+            "Failed to load evaluation scorecard; serving demo baseline"
+        )
+
     def test_load_scorecard_reads_latest(self, tmp_path):
         from api.v1.evals import _load_scorecard
 


### PR DESCRIPTION
## What changed

- stop returning scorecard load exception text from the public `GET /api/v1/evals` response
- log scorecard load failures server-side with a fixed client-safe message
- add a regression test that injects bearer-token and filesystem-path details into an `OSError` and proves they are absent from the serialized response

## Why

GitHub CodeQL alert #103 (`py/stack-trace-exposure`, CWE-209/CWE-497) identified that `str(exc)` was copied into the public scorecard response as `_load_error`. That could expose runtime paths, parser details, or secret-bearing exception text to unauthenticated callers.

The existing baseline contract remains unchanged: callers still receive `_is_baseline=true`, `data_quality=demo`, and `served_at` when the scorecard cannot be loaded.

## Validation

- `python -m pytest -q tests/unit/test_api_endpoints.py::TestLoadScorecard` — 4 passed
- `python -m ruff check api/v1/evals.py tests/unit/test_api_endpoints.py` — passed
- `git diff --check` — passed

Fixes code-scanning alert #103.