### PR TITLE
Fix Celery async event-loop reuse in production worker

### DIFF
--- a/core/tasks/async_runner.py
+++ b/core/tasks/async_runner.py
@@ -1,0 +1,48 @@
+"""Fork-safe async bridge for synchronous Celery task entry points.
+
+Celery's prefork workers execute task bodies synchronously while the database
+and several task implementations are asynchronous. Creating a new event loop
+with :func:`asyncio.run` for every task is unsafe with SQLAlchemy's pooled
+asyncpg engine: pooled connections stay bound to the loop that created them
+and fail when a later task tries to use them from a new loop.
+
+Keep one event loop per worker process instead. The PID guard prevents reuse
+of a parent-process loop after ``fork()``, and the lock serializes eager or
+threaded calls as well as normal prefork task execution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+from collections.abc import Awaitable
+
+_runner_lock = threading.RLock()
+_runner_loop: asyncio.AbstractEventLoop | None = None
+_runner_pid: int | None = None
+
+
+def _loop_for_current_process() -> asyncio.AbstractEventLoop:
+    global _runner_loop, _runner_pid
+
+    pid = os.getpid()
+    if _runner_loop is None or _runner_loop.is_closed() or _runner_pid != pid:
+        # Never reuse an event loop inherited from another PID. Replacing the
+        # child-local reference is sufficient; parent resources are untouched.
+        _runner_loop = asyncio.new_event_loop()
+        _runner_pid = pid
+    return _runner_loop
+
+
+def run_async[T](awaitable: Awaitable[T]) -> T:
+    """Run an awaitable on the persistent loop for this worker process."""
+
+    with _runner_lock:
+        loop = _loop_for_current_process()
+        if loop.is_running():
+            raise RuntimeError(
+                "run_async cannot be called from inside the Celery async runner loop"
+            )
+        asyncio.set_event_loop(loop)
+        return loop.run_until_complete(awaitable)

--- a/core/tasks/budget_tasks.py
+++ b/core/tasks/budget_tasks.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
-
 import structlog
 
+from core.tasks.async_runner import run_async
 from core.tasks.celery_app import app
 
 logger = structlog.get_logger()
@@ -19,4 +18,4 @@ def run_budget_evaluator() -> dict:
     """
     from core.billing.budget_evaluator import evaluate_budget_alerts
 
-    return asyncio.run(evaluate_budget_alerts())
+    return run_async(evaluate_budget_alerts())

--- a/core/tasks/health_snapshot.py
+++ b/core/tasks/health_snapshot.py
@@ -17,7 +17,6 @@ live_snapshot``) rather than silently producing a stale chart.
 
 from __future__ import annotations
 
-import asyncio
 import os
 import uuid as _uuid
 from datetime import UTC, datetime, timedelta
@@ -28,6 +27,7 @@ from sqlalchemy import text
 
 from core.config import settings
 from core.database import async_session_factory
+from core.tasks.async_runner import run_async
 from core.tasks.celery_app import app
 
 logger = structlog.get_logger()
@@ -131,7 +131,7 @@ def record_health_snapshot() -> dict:
     Scheduled every 5 minutes by Celery Beat (see celery_app.beat_schedule).
     """
     try:
-        result = asyncio.run(_record_snapshot_async())
+        result = run_async(_record_snapshot_async())
         logger.info(
             "health_snapshot_recorded",
             status=result["status"],

--- a/core/tasks/invoice_tasks.py
+++ b/core/tasks/invoice_tasks.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
-
 import structlog
 
+from core.tasks.async_runner import run_async
 from core.tasks.celery_app import app
 
 logger = structlog.get_logger()
@@ -19,4 +18,4 @@ def generate_monthly_invoices() -> dict:
     """
     from core.billing.invoice_generator import generate_invoices_for_period
 
-    return asyncio.run(generate_invoices_for_period())
+    return run_async(generate_invoices_for_period())

--- a/core/tasks/report_tasks.py
+++ b/core/tasks/report_tasks.py
@@ -333,14 +333,11 @@ def deliver_report(
             },
         ]
 
-        # delivery.deliver is async — run via event loop.
-        import asyncio
+        # delivery.deliver is async; reuse the worker process event loop so
+        # pooled async clients stay bound to one loop across tasks.
+        from core.tasks.async_runner import run_async
 
-        loop = asyncio.new_event_loop()
-        try:
-            loop.run_until_complete(deliver(report_path, delivery_cfg))
-        finally:
-            loop.close()
+        run_async(deliver(report_path, delivery_cfg))
 
         log.info(
             "report_delivery_complete",

--- a/core/tasks/rpa_tasks.py
+++ b/core/tasks/rpa_tasks.py
@@ -15,11 +15,9 @@ Design notes
 ============
 
 - **Synchronous body inside a sync Celery task.** Celery tasks are
-  sync by default; the existing report / workflow tasks already call
-  async coroutines via ``asyncio.run`` and we follow the same pattern
-  here. The tradeoff is higher worker CPU usage during the event-loop
-  setup, but scheduling cadence is O(minutes), not O(requests), so
-  it's fine.
+  sync by default, so async work runs on the worker process's persistent
+  event loop. Reusing that loop is required by the pooled async database
+  engine.
 - **Quality gate runs BEFORE embedding.** Embedding rejected chunks
   would waste compute and pollute retrieval; the registry spec says
   4.8+/5 is the target, and we refuse to publish anything below 4.5
@@ -32,7 +30,6 @@ Design notes
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import logging
 import uuid as _uuid
@@ -43,19 +40,10 @@ from typing import Any
 
 from sqlalchemy import select, text
 
+from core.tasks.async_runner import run_async as _run_async
 from core.tasks.celery_app import app
 
 logger = logging.getLogger(__name__)
-
-
-def _run_async(coro):
-    """Run ``coro`` to completion from a sync Celery task body."""
-    try:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        return loop.run_until_complete(coro)
-    finally:
-        loop.close()
 
 
 # ---------------------------------------------------------------------------

--- a/core/tasks/token_refresh.py
+++ b/core/tasks/token_refresh.py
@@ -13,13 +13,13 @@ execution time and the user can manually re-authenticate.
 
 from __future__ import annotations
 
-import asyncio
 import json
 from datetime import UTC, datetime, timedelta
 
 import httpx
 import structlog
 
+from core.tasks.async_runner import run_async
 from core.tasks.celery_app import app
 
 logger = structlog.get_logger()
@@ -66,7 +66,7 @@ def _canonical_refresh_token_url(connector_name: str, creds: dict) -> str | None
 @app.task(name="core.tasks.token_refresh.refresh_expiring_tokens")
 def refresh_expiring_tokens() -> dict:
     """Celery-compatible sync entry point."""
-    return asyncio.run(_refresh_all())
+    return run_async(_refresh_all())
 
 
 async def _refresh_all() -> dict:

--- a/core/tasks/workflow_tasks.py
+++ b/core/tasks/workflow_tasks.py
@@ -8,11 +8,11 @@ keys as authoritative.
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 import structlog
 
+from core.tasks.async_runner import run_async
 from core.tasks.celery_app import app
 from workflows.event_waits import WorkflowEventWaitStore
 from workflows.state_store import WorkflowStateStore
@@ -128,7 +128,7 @@ async def _resume_workflow_wait_async(run_id: str, step_id: str) -> dict:
 def resume_workflow_wait(run_id: str, step_id: str) -> dict:
     """Resume a workflow paused at a wait_delay or wait_for_event step."""
     try:
-        result = asyncio.run(_resume_workflow_wait_async(run_id, step_id))
+        result = run_async(_resume_workflow_wait_async(run_id, step_id))
         if result.get("status") in {"resumed", "noop"}:
             _best_effort_clean_event_wait_keys(run_id, step_id)
         return result
@@ -209,7 +209,7 @@ async def _timeout_workflow_event_async(run_id: str, step_id: str) -> dict:
 def timeout_workflow_event(run_id: str, step_id: str) -> dict:
     """Mark an event wait as timed_out and let the engine continue later."""
     try:
-        result = asyncio.run(_timeout_workflow_event_async(run_id, step_id))
+        result = run_async(_timeout_workflow_event_async(run_id, step_id))
         if result.get("status") in {"timed_out", "already_completed", "noop"}:
             _best_effort_clean_event_wait_keys(run_id, step_id)
         return result

--- a/tests/regression/test_celery_async_runner.py
+++ b/tests/regression/test_celery_async_runner.py
@@ -1,0 +1,64 @@
+"""Regression coverage for Celery's sync-to-async runtime bridge."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from core.tasks.async_runner import run_async
+
+
+class _LoopBoundResource:
+    """Model the loop affinity enforced by asyncpg pooled connections."""
+
+    def __init__(self) -> None:
+        self.loop: asyncio.AbstractEventLoop | None = None
+
+    async def use(self) -> asyncio.AbstractEventLoop:
+        running = asyncio.get_running_loop()
+        if self.loop is None:
+            self.loop = running
+        elif self.loop is not running:
+            raise RuntimeError("Future attached to a different loop")
+        return running
+
+
+def test_run_async_reuses_one_loop_for_successive_celery_tasks() -> None:
+    resource = _LoopBoundResource()
+
+    first = run_async(resource.use())
+    second = run_async(resource.use())
+
+    assert first is second
+    assert not first.is_closed()
+
+
+def test_run_async_propagates_failure_and_keeps_loop_usable() -> None:
+    async def fail() -> None:
+        raise ValueError("task failed")
+
+    async def recover() -> str:
+        return "ok"
+
+    with pytest.raises(ValueError, match="task failed"):
+        run_async(fail())
+
+    assert run_async(recover()) == "ok"
+
+
+def test_celery_task_modules_do_not_create_per_invocation_event_loops() -> None:
+    task_dir = Path(__file__).resolve().parents[2] / "core" / "tasks"
+    offenders: list[str] = []
+    for path in task_dir.glob("*.py"):
+        if path.name == "async_runner.py":
+            continue
+        source = path.read_text(encoding="utf-8")
+        if "asyncio.run(" in source or "asyncio.new_event_loop(" in source:
+            offenders.append(path.name)
+
+    assert offenders == [], (
+        "Celery task entry points must use core.tasks.async_runner.run_async; "
+        f"per-task loops break pooled async resources: {offenders}"
+    )

--- a/ui/e2e/landing.spec.ts
+++ b/ui/e2e/landing.spec.ts
@@ -87,9 +87,9 @@ test.describe("Landing Page — Sections", () => {
 
   test("How It Works — 3 steps render", async ({ page }) => {
     const steps = [
-      "Register agent roles",
-      "Configure system access",
-      "Validate and promote",
+      "Create or pick your agents",
+      "Connect your systems",
+      "Agents work, you approve",
     ];
     for (const step of steps) {
       await expect(page.getByText(step).first()).toBeVisible({ timeout: 10000 });

--- a/ui/e2e/production-full.spec.ts
+++ b/ui/e2e/production-full.spec.ts
@@ -63,7 +63,7 @@ test.describe("Public Pages", () => {
     await page.goto(MARKETING, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle").catch(() => {});
     await expect(
-      page.getByRole("link", { name: /Start Free|Get Started|Try Free/i }).first()
+      page.getByRole("link", { name: /Review Plans/i }).first()
     ).toBeVisible({ timeout: 15000 });
   });
 
@@ -85,35 +85,24 @@ test.describe("Public Pages", () => {
     expect(count).toBeGreaterThanOrEqual(4);
   });
 
-  test("Blog post: ca-firm loads", async ({ page }) => {
-    await page.goto(`${MARKETING}/blog/ca-firm`, { waitUntil: "domcontentloaded" });
-    await page.waitForLoadState("networkidle").catch(() => {});
-    const body = await page.textContent("body");
-    expect(body?.length).toBeGreaterThan(300);
-  });
+  const representativePosts = [
+    "ai-agents-for-ca-firms-gst-tds-automation",
+    "automated-bank-reconciliation",
+    "virtual-employee-vs-rpa",
+    "hitl-governance-enterprise-ai",
+  ];
 
-  test("Blog post: month-end-close loads", async ({ page }) => {
-    await page.goto(`${MARKETING}/blog/month-end-close`, {
-      waitUntil: "domcontentloaded",
+  for (const slug of representativePosts) {
+    test(`Blog post: ${slug} loads`, async ({ page }) => {
+      await page.goto(`${MARKETING}/blog/${slug}`, { waitUntil: "domcontentloaded" });
+      await page.waitForLoadState("networkidle").catch(() => {});
+      await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible({
+        timeout: 15000,
+      });
+      const body = await page.textContent("body");
+      expect(body?.length).toBeGreaterThan(300);
     });
-    await page.waitForLoadState("networkidle").catch(() => {});
-    const body = await page.textContent("body");
-    expect(body?.length).toBeGreaterThan(200);
-  });
-
-  test("Blog post: honest-roi loads", async ({ page }) => {
-    await page.goto(`${MARKETING}/blog/honest-roi`, { waitUntil: "domcontentloaded" });
-    await page.waitForLoadState("networkidle").catch(() => {});
-    const body = await page.textContent("body");
-    expect(body?.length).toBeGreaterThan(200);
-  });
-
-  test("Blog post: it-cfo-story loads", async ({ page }) => {
-    await page.goto(`${MARKETING}/blog/it-cfo-story`, { waitUntil: "domcontentloaded" });
-    await page.waitForLoadState("networkidle").catch(() => {});
-    const body = await page.textContent("body");
-    expect(body?.length).toBeGreaterThan(200);
-  });
+  }
 
   test("Resources page loads", async ({ page }) => {
     await page.goto(`${MARKETING}/resources`, { waitUntil: "domcontentloaded" });
@@ -385,7 +374,7 @@ test.describe("Responsive -- Mobile (375px)", () => {
     await page.goto(MARKETING, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle").catch(() => {});
     await expect(
-      page.getByText("Your Back Office Runs Itself").first()
+      page.getByRole("heading", { name: /Enterprise Work,\s*Governed by Design\./i }).first()
     ).toBeVisible({ timeout: 15000 });
   });
 });


### PR DESCRIPTION
## Summary
- keep one fork-safe asyncio event loop per Celery worker process
- route all synchronous Celery-to-async bridges through the shared runner
- add regression coverage for asyncpg-style loop affinity
- align production E2E assertions with the deployed landing copy and current canonical blog routes

## Production incident
The worker repeatedly failed `run_budget_evaluator` with `Future attached to a different loop`, and the following health snapshot recorded a false DB-unhealthy result. The global pooled asyncpg engine was surviving while each task used a fresh `asyncio.run()` loop.

## Validation
- 94 focused worker/runtime/budget/RPA/report/workflow tests passed
- Ruff clean; mypy clean across 996 files; Bandit medium/high clean; enterprise gate clean (358 routes)
- UI lint/typecheck, 180 Vitest tests, production build, 78 SEO route shells and 67-page sitemap passed
- all 7 previously failing production Playwright cases passed
- full local suite: 5,925 passed, 151 skipped, 5 xfailed; only 2 Alembic integration cases require the PostgreSQL service supplied by CI