### PR TITLE
fix security alerts and shadow HITL learning

### DIFF
--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -441,6 +441,13 @@ def _agent_to_dict(agent: Agent) -> dict:
         "shadow_accuracy_current": float(agent.shadow_accuracy_current)
         if agent.shadow_accuracy_current is not None
         else None,
+        "shadow_model_confidence_current": float(agent.shadow_model_confidence_current)
+        if agent.shadow_model_confidence_current is not None
+        else None,
+        "shadow_human_confidence_current": float(agent.shadow_human_confidence_current)
+        if agent.shadow_human_confidence_current is not None
+        else None,
+        "shadow_feedback_count": agent.shadow_feedback_count,
         "cost_controls": agent.cost_controls,
         "scaling": agent.scaling,
         "tags": agent.tags,
@@ -3018,7 +3025,9 @@ async def run_agent(
                 },
                 context={
                     "correlation_id": correlation_id,
+                    "run_id": msg_id,
                     "agent_type": agent_config["agent_type"],
+                    "agent_status": agent_config.get("status"),
                     "confidence": task_confidence,
                     "reasoning_trace": task_trace,
                     "trigger": hitl_trigger,
@@ -3059,9 +3068,17 @@ async def run_agent(
                     sql_text(
                         "UPDATE agents SET "
                         "shadow_sample_count = COALESCE(shadow_sample_count, 0) + 1, "
+                        "shadow_model_confidence_current = ROUND(CAST("
+                        "  (COALESCE(shadow_model_confidence_current, shadow_accuracy_current, 0) "
+                        "   * COALESCE(shadow_sample_count, 0) + :confidence) "
+                        "  / (COALESCE(shadow_sample_count, 0) + 1) AS NUMERIC), 3), "
                         "shadow_accuracy_current = ROUND(CAST("
-                        "  (COALESCE(shadow_accuracy_current, 0) * COALESCE(shadow_sample_count, 0) + :confidence)"
-                        "  / (COALESCE(shadow_sample_count, 0) + 1) AS NUMERIC), 3) "
+                        "  ((COALESCE(shadow_model_confidence_current, shadow_accuracy_current, 0) "
+                        "    * COALESCE(shadow_sample_count, 0)) + :confidence + "
+                        "   (COALESCE(shadow_human_confidence_current, 0) "
+                        "    * COALESCE(shadow_feedback_count, 0) * 3)) / "
+                        "  (COALESCE(shadow_sample_count, 0) + 1 + "
+                        "   COALESCE(shadow_feedback_count, 0) * 3) AS NUMERIC), 3) "
                         "WHERE id = :agent_id AND tenant_id = :tenant_id"
                     ),
                     {"confidence": task_confidence, "agent_id": str(agent_id), "tenant_id": tenant_id},
@@ -3490,6 +3507,9 @@ async def retest_agent(agent_id: UUID, tenant_id: str = Depends(get_current_tena
 
         agent.shadow_sample_count = 0
         agent.shadow_accuracy_current = None
+        agent.shadow_model_confidence_current = None
+        agent.shadow_human_confidence_current = None
+        agent.shadow_feedback_count = 0
 
         event = AgentLifecycleEvent(
             tenant_id=tid,

--- a/api/v1/approvals.py
+++ b/api/v1/approvals.py
@@ -367,6 +367,7 @@ async def decide(
     user_domains: list[str] | None = Depends(get_user_domains),
 ):
     tid = _uuid.UUID(tenant_id)
+    learning_result: dict = {}
 
     # P2.1: capture decision_by from authenticated user (always required)
     user_id_str = user_claims.get("sub") or user_claims.get("agenticorg:user_id") or ""
@@ -578,6 +579,23 @@ async def decide(
             item.status = "decided"
             workflow_run_id = item.workflow_run_id
 
+        # Capture every human action in the same transaction as the approval.
+        # Terminal shadow decisions also recalibrate the promotion confidence.
+        from core.feedback.shadow_learning import capture_hitl_feedback
+
+        learning_result = await capture_hitl_feedback(
+            session,
+            item=item,
+            decision=body.decision or "defer",
+            notes=body.notes or "",
+            actor_id=user_id_str,
+            actor_role=user_role,
+            actor_name=user_name,
+            policy_action=policy_action,
+            policy_state=policy_state if policy is not None else None,
+            delegated_from=delegated_from,
+        )
+
         # Audit log entry — captures who approved/rejected what
         audit = AuditLog(
             tenant_id=tid,
@@ -599,6 +617,7 @@ async def decide(
                 "policy_action": policy_action,
                 "policy_state": policy_state if policy is not None else None,
                 "delegated_from": delegated_from,
+                "feedback_learning": learning_result,
             },
         )
         session.add(audit)
@@ -627,6 +646,15 @@ async def decide(
             str(engine_run_id_hint or "") or None,
         )
 
+    if learning_result.get("ran_in_shadow") and policy_action in {"advance", "reject"}:
+        from core.feedback.analyzer import analyze_and_apply_feedback
+
+        background_tasks.add_task(
+            analyze_and_apply_feedback,
+            str(item.agent_id),
+            tenant_id,
+        )
+
     return {
         "hitl_id": str(hitl_id),
         "decision": body.decision,
@@ -635,4 +663,5 @@ async def decide(
         "decided_at": item.decision_at.isoformat() if item.decision_at else None,
         "policy_action": policy_action,
         "policy_state": policy_state if policy_state else None,
+        "feedback_learning": learning_result,
     }

--- a/core/feedback/analyzer.py
+++ b/core/feedback/analyzer.py
@@ -48,7 +48,12 @@ async def analyze_feedback(
     # Filter to negative / actionable feedback only
     negative = [
         e for e in entries
-        if e.get("feedback_type") in ("thumbs_down", "correction", "hitl_reject")
+        if e.get("feedback_type") in (
+            "thumbs_down",
+            "correction",
+            "hitl_reject",
+            "hitl_override",
+        )
     ]
 
     if len(entries) < MIN_FEEDBACK_FOR_ANALYSIS:
@@ -157,3 +162,70 @@ def format_amendments_for_prompt(amendments: list[str]) -> str:
         return ""
     lines = "\n".join(f"- {a}" for a in amendments)
     return f"IMPORTANT LEARNED RULES:\n{lines}\n\n"
+
+
+async def analyze_and_apply_feedback(
+    agent_id: str,
+    tenant_id: str,
+) -> dict[str, Any]:
+    """Analyze accumulated feedback and apply a learned rule in shadow mode.
+
+    Active agents never self-modify. Shadow agents may receive a deduplicated,
+    bounded learned-rule set, so the next sample evaluates the improvement.
+    """
+    analysis = await analyze_feedback(agent_id, tenant_id)
+    amendment = str(analysis.get("amendment") or "").strip()
+    if not amendment:
+        return {**analysis, "applied": False}
+
+    import uuid
+    from datetime import UTC, datetime
+
+    from sqlalchemy import select
+    from sqlalchemy import text as sql_text
+
+    from core.database import get_tenant_session
+    from core.models.agent import Agent
+
+    tid = uuid.UUID(tenant_id)
+    aid = uuid.UUID(agent_id)
+    async with get_tenant_session(tid) as session:
+        result = await session.execute(
+            select(Agent)
+            .where(Agent.id == aid, Agent.tenant_id == tid)
+            .with_for_update()
+        )
+        agent = result.scalar_one_or_none()
+        if agent is None:
+            return {**analysis, "applied": False, "reason": "Agent not found."}
+        if agent.status != "shadow":
+            return {
+                **analysis,
+                "applied": False,
+                "reason": "Learned rules auto-apply only while the agent is in shadow mode.",
+            }
+
+        amendments = [str(value) for value in (agent.prompt_amendments or [])]
+        if amendment not in amendments:
+            agent.prompt_amendments = [*amendments[-9:], amendment]
+        await session.execute(
+            sql_text(
+                "UPDATE agent_feedback SET applied_at = :applied_at "
+                "WHERE tenant_id = :tenant_id AND agent_id = :agent_id "
+                "AND applied_at IS NULL AND feedback_type IN "
+                "('thumbs_down', 'correction', 'hitl_reject', 'hitl_override')"
+            ),
+            {
+                "applied_at": datetime.now(UTC),
+                "tenant_id": tenant_id,
+                "agent_id": agent_id,
+            },
+        )
+
+    logger.info(
+        "feedback_amendment_applied",
+        agent_id=agent_id,
+        tenant_id=tenant_id,
+        confidence=analysis.get("confidence"),
+    )
+    return {**analysis, "applied": True}

--- a/core/feedback/collector.py
+++ b/core/feedback/collector.py
@@ -7,6 +7,7 @@ in-memory storage.
 
 from __future__ import annotations
 
+import json
 import uuid
 from datetime import UTC, datetime
 from typing import Any
@@ -18,7 +19,15 @@ logger = structlog.get_logger()
 # In-memory fallback when DB is not available
 _in_memory_store: dict[str, list[dict[str, Any]]] = {}
 
-VALID_FEEDBACK_TYPES = {"thumbs_up", "thumbs_down", "correction", "hitl_reject"}
+VALID_FEEDBACK_TYPES = {
+    "thumbs_up",
+    "thumbs_down",
+    "correction",
+    "hitl_approve",
+    "hitl_reject",
+    "hitl_override",
+    "hitl_vote",
+}
 
 
 async def submit_feedback(
@@ -28,6 +37,12 @@ async def submit_feedback(
     text: str = "",
     corrected_output: dict[str, Any] | None = None,
     tenant_id: str = "",
+    original_output: dict[str, Any] | None = None,
+    source: str = "manual",
+    source_event_id: str | None = None,
+    actor_id: str | None = None,
+    decision: str | None = None,
+    context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Submit feedback for an agent run.
 
@@ -56,8 +71,14 @@ async def submit_feedback(
         "run_id": run_id,
         "feedback_type": feedback_type,
         "text": text,
+        "original_output": original_output,
         "corrected_output": corrected_output,
         "tenant_id": tenant_id,
+        "source": source,
+        "source_event_id": source_event_id,
+        "actor_id": actor_id,
+        "decision": decision,
+        "context": context or {},
         "created_at": datetime.now(UTC).isoformat(),
     }
 
@@ -74,17 +95,27 @@ async def submit_feedback(
                 await session.execute(
                     sql_text(
                         "INSERT INTO agent_feedback "
-                        "(id, agent_id, run_id, feedback_type, text, corrected_output, tenant_id, created_at) "
-                        "VALUES (:id, :agent_id, :run_id, :feedback_type, :text, :corrected_output, :tenant_id, NOW())"
+                        "(id, agent_id, run_id, feedback_type, feedback_text, original_output, "
+                        "corrected_output, tenant_id, source, source_event_id, actor_id, decision, "
+                        "context, created_at) VALUES (:id, :agent_id, :run_id, :feedback_type, "
+                        ":feedback_text, CAST(:original_output AS JSONB), "
+                        "CAST(:corrected_output AS JSONB), :tenant_id, :source, :source_event_id, "
+                        ":actor_id, :decision, CAST(:context AS JSONB), NOW()) ON CONFLICT DO NOTHING"
                     ),
                     {
                         "id": feedback_id,
                         "agent_id": agent_id,
                         "run_id": run_id,
                         "feedback_type": feedback_type,
-                        "text": text,
-                        "corrected_output": str(corrected_output) if corrected_output else None,
+                        "feedback_text": text,
+                        "original_output": json.dumps(original_output) if original_output else None,
+                        "corrected_output": json.dumps(corrected_output) if corrected_output else None,
                         "tenant_id": tenant_id,
+                        "source": source,
+                        "source_event_id": source_event_id,
+                        "actor_id": actor_id,
+                        "decision": decision,
+                        "context": json.dumps(context or {}),
                     },
                 )
                 stored_in_db = True
@@ -135,8 +166,9 @@ async def list_feedback(
 
                 result = await session.execute(
                     sql_text(
-                        "SELECT id, agent_id, run_id, feedback_type, text, "
-                        "corrected_output, tenant_id, created_at "
+                        "SELECT id, agent_id, run_id, feedback_type, feedback_text, "
+                        "corrected_output, tenant_id, created_at, original_output, source, "
+                        "source_event_id, actor_id, decision, context "
                         "FROM agent_feedback "
                         "WHERE agent_id = :agent_id AND tenant_id = :tenant_id "
                         "ORDER BY created_at DESC LIMIT :limit OFFSET :offset"
@@ -159,6 +191,12 @@ async def list_feedback(
                         "corrected_output": r[5],
                         "tenant_id": str(r[6]),
                         "created_at": str(r[7]),
+                        "original_output": r[8],
+                        "source": r[9],
+                        "source_event_id": r[10],
+                        "actor_id": r[11],
+                        "decision": r[12],
+                        "context": r[13],
                     }
                     for r in rows
                 ]

--- a/core/feedback/shadow_learning.py
+++ b/core/feedback/shadow_learning.py
@@ -1,0 +1,150 @@
+"""Close the loop between shadow-mode HITL decisions and agent confidence."""
+
+from __future__ import annotations
+
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.models.agent import Agent
+from core.models.feedback import AgentFeedback
+from core.models.hitl import HITLQueue
+
+HUMAN_EVIDENCE_WEIGHT = Decimal("3.00")
+_MILLI = Decimal("0.001")
+
+
+def _q(value: Decimal) -> Decimal:
+    return max(Decimal("0"), min(Decimal("1"), value)).quantize(
+        _MILLI, rounding=ROUND_HALF_UP
+    )
+
+
+def _decision_signal(decision: str, terminal: bool) -> tuple[str, Decimal | None]:
+    normalized = decision.strip().lower()
+    if not terminal:
+        return "hitl_vote", None
+    if normalized in {"approve", "approved", "accept", "accepted"}:
+        return "hitl_approve", Decimal("1")
+    if normalized in {"reject", "rejected", "deny", "denied"}:
+        return "hitl_reject", Decimal("0")
+    if normalized in {"override", "correct", "correction", "edit"}:
+        return "hitl_override", Decimal("0.25")
+    return "hitl_vote", None
+
+
+async def capture_hitl_feedback(
+    session: AsyncSession,
+    *,
+    item: HITLQueue,
+    decision: str,
+    notes: str,
+    actor_id: str,
+    actor_role: str,
+    actor_name: str,
+    policy_action: str,
+    policy_state: dict[str, Any] | None,
+    delegated_from: str | None,
+) -> dict[str, Any]:
+    """Persist one human action and calibrate shadow confidence atomically.
+
+    The approval mutation and feedback insert share the caller's transaction.
+    A row lock serializes concurrent decisions, while ``source_event_id`` makes
+    retries idempotent. Human evidence is deliberately stronger than the
+    model's self-reported confidence, but it never erases the model signal.
+    """
+    action_number = len((policy_state or {}).get("approvals") or []) or 1
+    source_event_id = f"hitl:{item.id}:action:{action_number}"
+    existing = await session.execute(
+        select(AgentFeedback.id).where(
+            AgentFeedback.tenant_id == item.tenant_id,
+            AgentFeedback.source_event_id == source_event_id,
+        )
+    )
+    existing_id = existing.scalar_one_or_none()
+    if existing_id is not None:
+        return {"feedback_id": str(existing_id), "deduplicated": True}
+
+    agent_result = await session.execute(
+        select(Agent)
+        .where(Agent.id == item.agent_id, Agent.tenant_id == item.tenant_id)
+        .with_for_update()
+    )
+    agent = agent_result.scalar_one()
+    terminal = policy_action in {"advance", "reject"}
+    feedback_type, human_signal = _decision_signal(decision, terminal)
+    context = dict(item.context or {})
+    ran_in_shadow = context.get("agent_status") == "shadow" or agent.status == "shadow"
+    before = Decimal(str(agent.shadow_accuracy_current)) if agent.shadow_accuracy_current is not None else None
+    after = before
+
+    if ran_in_shadow and human_signal is not None:
+        model_count = int(agent.shadow_sample_count or 0)
+        model_average = agent.shadow_model_confidence_current
+        if model_average is None:
+            model_average = agent.shadow_accuracy_current
+        model_average_d = Decimal(str(model_average or 0))
+
+        human_count = int(agent.shadow_feedback_count or 0)
+        human_average_d = Decimal(str(agent.shadow_human_confidence_current or 0))
+        new_human_count = human_count + 1
+        new_human_average = _q(
+            ((human_average_d * human_count) + human_signal) / new_human_count
+        )
+
+        model_mass = model_average_d * model_count
+        human_mass = new_human_average * new_human_count * HUMAN_EVIDENCE_WEIGHT
+        denominator = Decimal(model_count) + Decimal(new_human_count) * HUMAN_EVIDENCE_WEIGHT
+        after = _q(
+            (model_mass + human_mass) / denominator if denominator else human_signal
+        )
+
+        agent.shadow_feedback_count = new_human_count
+        agent.shadow_human_confidence_current = new_human_average
+        agent.shadow_accuracy_current = after
+
+    run_id = str(
+        item.workflow_run_id
+        or context.get("run_id")
+        or context.get("correlation_id")
+        or item.id
+    )
+    original_output = item.decision_options.get("context") if item.decision_options else None
+    feedback = AgentFeedback(
+        tenant_id=item.tenant_id,
+        agent_id=item.agent_id,
+        run_id=run_id,
+        feedback_type=feedback_type,
+        feedback_text=notes or f"Human decision: {decision}",
+        original_output=original_output if isinstance(original_output, dict) else None,
+        corrected_output=None,
+        source="hitl",
+        source_event_id=source_event_id,
+        actor_id=actor_id,
+        decision=decision,
+        context={
+            "hitl_id": str(item.id),
+            "trigger_type": item.trigger_type,
+            "ran_in_shadow": ran_in_shadow,
+            "policy_action": policy_action,
+            "policy_state": policy_state,
+            "actor_role": actor_role,
+            "actor_name": actor_name,
+            "delegated_from": delegated_from,
+        },
+        confidence_before=before,
+        confidence_after=after,
+        learning_weight=HUMAN_EVIDENCE_WEIGHT if human_signal is not None else Decimal("0"),
+    )
+    session.add(feedback)
+    await session.flush()
+    return {
+        "feedback_id": str(feedback.id),
+        "feedback_type": feedback_type,
+        "ran_in_shadow": ran_in_shadow,
+        "confidence_before": float(before) if before is not None else None,
+        "confidence_after": float(after) if after is not None else None,
+        "deduplicated": False,
+    }

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -65,6 +65,7 @@ from core.models.delegation import UserDelegation as UserDelegation
 from core.models.document import Document as Document
 from core.models.feature_flag import FeatureFlag as FeatureFlag
 from core.models.feed import FeedEvent as FeedEvent
+from core.models.feedback import AgentFeedback as AgentFeedback
 from core.models.filing_approval import FilingApproval as FilingApproval
 from core.models.governance_config import GovernanceConfig as GovernanceConfig
 from core.models.gstn_credential import GSTNCredential as GSTNCredential

--- a/core/models/agent.py
+++ b/core/models/agent.py
@@ -91,6 +91,13 @@ class Agent(BaseModel):
     )
     shadow_sample_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     shadow_accuracy_current: Mapped[Decimal | None] = mapped_column(Numeric(4, 3), nullable=True)
+    shadow_model_confidence_current: Mapped[Decimal | None] = mapped_column(
+        Numeric(4, 3), nullable=True
+    )
+    shadow_human_confidence_current: Mapped[Decimal | None] = mapped_column(
+        Numeric(4, 3), nullable=True
+    )
+    shadow_feedback_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     cost_controls: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     scaling: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     tags: Mapped[list] = mapped_column(ARRAY(String(50)), nullable=False, default=list)

--- a/core/models/feedback.py
+++ b/core/models/feedback.py
@@ -1,0 +1,51 @@
+"""Durable, tenant-scoped feedback captured from people and HITL gates."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import TIMESTAMP, ForeignKey, Numeric, String, Text, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.models.base import BaseModel
+
+
+class AgentFeedback(BaseModel):
+    __tablename__ = "agent_feedback"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id",
+            "source_event_id",
+            name="uq_agent_feedback_tenant_source_event",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False
+    )
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+    )
+    run_id: Mapped[str] = mapped_column(String(200), nullable=False)
+    feedback_type: Mapped[str] = mapped_column(String(30), nullable=False)
+    feedback_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    original_output: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    corrected_output: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    source: Mapped[str] = mapped_column(String(30), nullable=False, default="manual")
+    source_event_id: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    actor_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    decision: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    context: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    confidence_before: Mapped[Decimal | None] = mapped_column(Numeric(4, 3), nullable=True)
+    confidence_after: Mapped[Decimal | None] = mapped_column(Numeric(4, 3), nullable=True)
+    learning_weight: Mapped[Decimal] = mapped_column(
+        Numeric(5, 2), nullable=False, default=Decimal("1.00")
+    )
+    applied_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/core/pii/redactor.py
+++ b/core/pii/redactor.py
@@ -32,15 +32,11 @@ logger = structlog.get_logger()
 # ---------------------------------------------------------------------------
 try:
     from presidio_analyzer import AnalyzerEngine
-    from presidio_anonymizer import AnonymizerEngine
-    from presidio_anonymizer.entities import OperatorConfig
 
     _PRESIDIO_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _PRESIDIO_AVAILABLE = False
     AnalyzerEngine = None  # type: ignore[assignment,misc]
-    AnonymizerEngine = None  # type: ignore[assignment,misc]
-    OperatorConfig = None  # type: ignore[assignment,misc]
 
 # ---------------------------------------------------------------------------
 # Redaction mode
@@ -195,7 +191,11 @@ class PIIRedactor:
                     }
                 ).create_engine()
                 self._analyzer = AnalyzerEngine(nlp_engine=nlp_engine)
-                self._anonymizer = AnonymizerEngine()
+                # Redaction is performed below with deterministic tokens.
+                # Presidio Anonymizer is deliberately not required: it was
+                # unused here and its cryptography upper bound prevented us
+                # from installing patched cryptography releases.
+                self._anonymizer = None
             except (OSError, SystemExit) as exc:
                 if _strict_runtime():
                     raise RuntimeError(

--- a/core/schemas/api.py
+++ b/core/schemas/api.py
@@ -119,6 +119,9 @@ class AgentResponse(BaseModel):
     confidence_floor: float
     shadow_sample_count: int = 0
     shadow_accuracy_current: float | None = None
+    shadow_model_confidence_current: float | None = None
+    shadow_human_confidence_current: float | None = None
+    shadow_feedback_count: int = 0
     company_id: UUID | None = None
     created_at: datetime
 

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -410,7 +410,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.list",
-    "source_line": 1599,
+    "source_line": 1606,
     "tenant_required": true
   },
   {
@@ -428,7 +428,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 1352,
+    "source_line": 1359,
     "tenant_required": true
   },
   {
@@ -446,7 +446,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.tools.sensitive.read",
-    "source_line": 1306,
+    "source_line": 1313,
     "tenant_required": true
   },
   {
@@ -464,7 +464,7 @@
     "public_exempt_reason": null,
     "rate_limit": "ai-generation",
     "scope": "agents.generate",
-    "source_line": 2038,
+    "source_line": 2045,
     "tenant_required": true
   },
   {
@@ -482,7 +482,7 @@
     "public_exempt_reason": null,
     "rate_limit": "file-upload",
     "scope": "agents.import",
-    "source_line": 1850,
+    "source_line": 1857,
     "tenant_required": true
   },
   {
@@ -500,7 +500,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.org_tree",
-    "source_line": 1715,
+    "source_line": 1722,
     "tenant_required": true
   },
   {
@@ -518,7 +518,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 4121,
+    "source_line": 4141,
     "tenant_required": true
   },
   {
@@ -536,7 +536,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.read",
-    "source_line": 2168,
+    "source_line": 2175,
     "tenant_required": true
   },
   {
@@ -554,7 +554,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 2341,
+    "source_line": 2348,
     "tenant_required": true
   },
   {
@@ -572,7 +572,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 2196,
+    "source_line": 2203,
     "tenant_required": true
   },
   {
@@ -590,7 +590,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.amendments.read",
-    "source_line": 4082,
+    "source_line": 4102,
     "tenant_required": true
   },
   {
@@ -608,7 +608,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.budget.read",
-    "source_line": 3806,
+    "source_line": 3826,
     "tenant_required": true
   },
   {
@@ -626,7 +626,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 3646,
+    "source_line": 3666,
     "tenant_required": true
   },
   {
@@ -644,7 +644,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.delegate",
-    "source_line": 1776,
+    "source_line": 1783,
     "tenant_required": true
   },
   {
@@ -662,7 +662,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.explanation.read",
-    "source_line": 3949,
+    "source_line": 3969,
     "tenant_required": true
   },
   {
@@ -680,7 +680,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.feedback.list",
-    "source_line": 3921,
+    "source_line": 3941,
     "tenant_required": true
   },
   {
@@ -698,7 +698,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-feedback",
     "scope": "agents.feedback.write",
-    "source_line": 3875,
+    "source_line": 3895,
     "tenant_required": true
   },
   {
@@ -716,7 +716,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.feedback.analyze",
-    "source_line": 4058,
+    "source_line": 4078,
     "tenant_required": true
   },
   {
@@ -734,7 +734,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3164,
+    "source_line": 3181,
     "tenant_required": true
   },
   {
@@ -752,7 +752,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3295,
+    "source_line": 3312,
     "tenant_required": true
   },
   {
@@ -770,7 +770,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.prompt_history",
-    "source_line": 3764,
+    "source_line": 3784,
     "tenant_required": true
   },
   {
@@ -788,7 +788,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3210,
+    "source_line": 3227,
     "tenant_required": true
   },
   {
@@ -806,7 +806,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3474,
+    "source_line": 3491,
     "tenant_required": true
   },
   {
@@ -824,7 +824,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3425,
+    "source_line": 3442,
     "tenant_required": true
   },
   {
@@ -842,7 +842,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3529,
+    "source_line": 3549,
     "tenant_required": true
   },
   {
@@ -860,7 +860,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-execution",
     "scope": "agents.execute",
-    "source_line": 2495,
+    "source_line": 2502,
     "tenant_required": true
   },
   {

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -128,22 +128,6 @@
         }
       }
     },
-    "node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/body-parser": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
@@ -478,6 +462,22 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -600,9 +600,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -651,9 +651,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -42,10 +42,10 @@
   },
   "overrides": {
     "@hono/node-server": ">=2.0.5",
-    "hono": ">=4.12.27",
+    "hono": ">=4.12.34",
     "qs": ">=6.15.2",
-    "fast-uri": "3.1.4",
-    "ip-address": ">=10.1.1",
+    "fast-uri": "3.1.5",
+    "ip-address": ">=10.3.1",
     "body-parser": ">=2.3.0"
   }
 }

--- a/migrations/versions/v6_z8_shadow_hitl_learning.py
+++ b/migrations/versions/v6_z8_shadow_hitl_learning.py
@@ -1,0 +1,81 @@
+"""Capture shadow HITL learning and calibrate confidence.
+
+Revision ID: v6z8_shadow_hitl
+Revises: v6z7_readiness_security
+Create Date: 2026-08-09
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+revision = "v6z8_shadow_hitl"
+down_revision = "v6z7_readiness_security"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("agents", sa.Column("shadow_model_confidence_current", sa.Numeric(4, 3)))
+    op.add_column("agents", sa.Column("shadow_human_confidence_current", sa.Numeric(4, 3)))
+    op.add_column(
+        "agents",
+        sa.Column("shadow_feedback_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.execute(
+        "UPDATE agents SET shadow_model_confidence_current = shadow_accuracy_current "
+        "WHERE shadow_accuracy_current IS NOT NULL"
+    )
+
+    op.add_column(
+        "agent_feedback",
+        sa.Column("source", sa.String(30), nullable=False, server_default="manual"),
+    )
+    op.add_column("agent_feedback", sa.Column("source_event_id", sa.String(200)))
+    op.add_column("agent_feedback", sa.Column("actor_id", sa.String(255)))
+    op.add_column("agent_feedback", sa.Column("decision", sa.String(100)))
+    op.add_column(
+        "agent_feedback",
+        sa.Column("context", JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+    )
+    op.add_column("agent_feedback", sa.Column("confidence_before", sa.Numeric(4, 3)))
+    op.add_column("agent_feedback", sa.Column("confidence_after", sa.Numeric(4, 3)))
+    op.add_column(
+        "agent_feedback",
+        sa.Column("learning_weight", sa.Numeric(5, 2), nullable=False, server_default="1.00"),
+    )
+    op.create_unique_constraint(
+        "uq_agent_feedback_tenant_source_event",
+        "agent_feedback",
+        ["tenant_id", "source_event_id"],
+    )
+    op.execute("ALTER TABLE agent_feedback ENABLE ROW LEVEL SECURITY")
+    op.execute("DROP POLICY IF EXISTS agent_feedback_tenant_isolation ON agent_feedback")
+    op.execute("""
+        CREATE POLICY agent_feedback_tenant_isolation ON agent_feedback
+        USING (tenant_id::text = current_setting('agenticorg.tenant_id', true))
+        WITH CHECK (tenant_id::text = current_setting('agenticorg.tenant_id', true))
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS agent_feedback_tenant_isolation ON agent_feedback")
+    op.execute("ALTER TABLE agent_feedback DISABLE ROW LEVEL SECURITY")
+    op.drop_constraint(
+        "uq_agent_feedback_tenant_source_event", "agent_feedback", type_="unique"
+    )
+    for column in (
+        "learning_weight",
+        "confidence_after",
+        "confidence_before",
+        "context",
+        "decision",
+        "actor_id",
+        "source_event_id",
+        "source",
+    ):
+        op.drop_column("agent_feedback", column)
+    op.drop_column("agents", "shadow_feedback_count")
+    op.drop_column("agents", "shadow_human_confidence_current")
+    op.drop_column("agents", "shadow_model_confidence_current")

--- a/migrations/versions/v6_z8_shadow_hitl_learning.py
+++ b/migrations/versions/v6_z8_shadow_hitl_learning.py
@@ -5,9 +5,6 @@ Revises: v6z7_readiness_security
 Create Date: 2026-08-09
 """
 
-import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import JSONB
-
 from alembic import op
 
 revision = "v6z8_shadow_hitl"
@@ -17,40 +14,59 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("agents", sa.Column("shadow_model_confidence_current", sa.Numeric(4, 3)))
-    op.add_column("agents", sa.Column("shadow_human_confidence_current", sa.Numeric(4, 3)))
-    op.add_column(
-        "agents",
-        sa.Column("shadow_feedback_count", sa.Integer(), nullable=False, server_default="0"),
+    # The migration wrapper bootstraps legacy databases with current ORM
+    # metadata before stamping the baseline. Keep every schema operation
+    # idempotent so that path and normal version-to-version upgrades both work.
+    op.execute(
+        "ALTER TABLE agents ADD COLUMN IF NOT EXISTS "
+        "shadow_model_confidence_current NUMERIC(4, 3)"
+    )
+    op.execute(
+        "ALTER TABLE agents ADD COLUMN IF NOT EXISTS "
+        "shadow_human_confidence_current NUMERIC(4, 3)"
+    )
+    op.execute(
+        "ALTER TABLE agents ADD COLUMN IF NOT EXISTS "
+        "shadow_feedback_count INTEGER NOT NULL DEFAULT 0"
     )
     op.execute(
         "UPDATE agents SET shadow_model_confidence_current = shadow_accuracy_current "
         "WHERE shadow_accuracy_current IS NOT NULL"
     )
 
-    op.add_column(
-        "agent_feedback",
-        sa.Column("source", sa.String(30), nullable=False, server_default="manual"),
+    op.execute(
+        "ALTER TABLE agent_feedback ADD COLUMN IF NOT EXISTS "
+        "source VARCHAR(30) NOT NULL DEFAULT 'manual'"
     )
-    op.add_column("agent_feedback", sa.Column("source_event_id", sa.String(200)))
-    op.add_column("agent_feedback", sa.Column("actor_id", sa.String(255)))
-    op.add_column("agent_feedback", sa.Column("decision", sa.String(100)))
-    op.add_column(
-        "agent_feedback",
-        sa.Column("context", JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+    op.execute(
+        "ALTER TABLE agent_feedback ADD COLUMN IF NOT EXISTS source_event_id VARCHAR(200)"
     )
-    op.add_column("agent_feedback", sa.Column("confidence_before", sa.Numeric(4, 3)))
-    op.add_column("agent_feedback", sa.Column("confidence_after", sa.Numeric(4, 3)))
-    op.add_column(
-        "agent_feedback",
-        sa.Column("learning_weight", sa.Numeric(5, 2), nullable=False, server_default="1.00"),
+    op.execute(
+        "ALTER TABLE agent_feedback ADD COLUMN IF NOT EXISTS actor_id VARCHAR(255)"
     )
-    op.create_unique_constraint(
-        "uq_agent_feedback_tenant_source_event",
-        "agent_feedback",
-        ["tenant_id", "source_event_id"],
+    op.execute(
+        "ALTER TABLE agent_feedback ADD COLUMN IF NOT EXISTS decision VARCHAR(100)"
+    )
+    op.execute(
+        "ALTER TABLE agent_feedback ADD COLUMN IF NOT EXISTS "
+        "context JSONB NOT NULL DEFAULT '{}'::jsonb"
+    )
+    op.execute(
+        "ALTER TABLE agent_feedback ADD COLUMN IF NOT EXISTS confidence_before NUMERIC(4, 3)"
+    )
+    op.execute(
+        "ALTER TABLE agent_feedback ADD COLUMN IF NOT EXISTS confidence_after NUMERIC(4, 3)"
+    )
+    op.execute(
+        "ALTER TABLE agent_feedback ADD COLUMN IF NOT EXISTS "
+        "learning_weight NUMERIC(5, 2) NOT NULL DEFAULT 1.00"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_agent_feedback_tenant_source_event "
+        "ON agent_feedback (tenant_id, source_event_id)"
     )
     op.execute("ALTER TABLE agent_feedback ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE agent_feedback FORCE ROW LEVEL SECURITY")
     op.execute("DROP POLICY IF EXISTS agent_feedback_tenant_isolation ON agent_feedback")
     op.execute("""
         CREATE POLICY agent_feedback_tenant_isolation ON agent_feedback
@@ -61,10 +77,13 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.execute("DROP POLICY IF EXISTS agent_feedback_tenant_isolation ON agent_feedback")
+    op.execute("ALTER TABLE agent_feedback NO FORCE ROW LEVEL SECURITY")
     op.execute("ALTER TABLE agent_feedback DISABLE ROW LEVEL SECURITY")
-    op.drop_constraint(
-        "uq_agent_feedback_tenant_source_event", "agent_feedback", type_="unique"
+    op.execute(
+        "ALTER TABLE agent_feedback DROP CONSTRAINT IF EXISTS "
+        "uq_agent_feedback_tenant_source_event"
     )
+    op.execute("DROP INDEX IF EXISTS uq_agent_feedback_tenant_source_event")
     for column in (
         "learning_weight",
         "confidence_after",
@@ -75,7 +94,7 @@ def downgrade() -> None:
         "source_event_id",
         "source",
     ):
-        op.drop_column("agent_feedback", column)
-    op.drop_column("agents", "shadow_feedback_count")
-    op.drop_column("agents", "shadow_human_confidence_current")
-    op.drop_column("agents", "shadow_model_confidence_current")
+        op.execute(f'ALTER TABLE agent_feedback DROP COLUMN IF EXISTS "{column}"')
+    op.execute("ALTER TABLE agents DROP COLUMN IF EXISTS shadow_feedback_count")
+    op.execute("ALTER TABLE agents DROP COLUMN IF EXISTS shadow_human_confidence_current")
+    op.execute("ALTER TABLE agents DROP COLUMN IF EXISTS shadow_model_confidence_current")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
     "redis[hiredis]>=5.2.0",
     "pydantic>=2.13.4",
     "pydantic-settings>=2.14.2",
+    "cryptography>=50.0.0",
     "PyJWT[crypto]>=2.13.0",
     "passlib[bcrypt]>=1.7.4",
     "httpx>=0.28.0",
@@ -129,9 +130,6 @@ v4 = [
     # latest package can install everywhere.
     "presidio-analyzer>=2.2.364,<2.2.365; python_version >= '3.14'",
     "presidio-analyzer>=2.2.362; python_version < '3.14'",
-    # 2.2.363 pins cryptography<47, which conflicts with grantex>=0.3.14
-    # and the security floor for GHSA-537c-gmf6-5ccf.
-    "presidio-anonymizer>=2.2.364,<2.2.365",
 ]
 bge-m3 = [
     # Heavy in-process BGE-M3 loader. This pulls PyTorch, so it stays out
@@ -157,7 +155,6 @@ dev = [
     # test_v490_reqs). Kept out of the default `project.dependencies`
     # so the wheel stays lean for downstream SDK consumers.
     "presidio-analyzer>=2.2.363",
-    "presidio-anonymizer>=2.2.364,<2.2.365",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,10 +84,10 @@ dependencies = [
     "langchain-google-genai>=4.3.1",
     "langchain-anthropic>=1.5.2",
     "langchain-openai>=1.4.0",
-    "langgraph-checkpoint-postgres>=3.1.0",
+    "langgraph-checkpoint-postgres>=3.1.1",
     "grantex>=0.3.14",
     "langsmith>=0.10.11",
-    "pypdf>=6.14.2",
+    "pypdf>=6.15.0",
     # S0-06 multimodal RAG (PR-3 2026-04-24): Word document ingestion.
     # Image OCR (pytesseract) and audio transcription (openai-whisper)
     # ship behind feature flags in a follow-up — they need system-level

--- a/requirements-v4.txt
+++ b/requirements-v4.txt
@@ -28,6 +28,6 @@
 # Python 3.12/3.13 environments.
 presidio-analyzer==2.2.359; python_version >= "3.14"
 presidio-analyzer==2.2.364; python_version < "3.14"
-# presidio-anonymizer 2.2.363 pins cryptography<47.0.0, conflicting with
-# grantex>=0.3.13 and the cryptography>=48.0.1 security floor.
-presidio-anonymizer==2.2.364
+# Redaction uses analyzer spans plus deterministic local tokens. The unused
+# presidio-anonymizer package is intentionally excluded because its strict
+# cryptography upper bound blocks security upgrades.

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ langchain-core==1.5.2
 langchain-google-genai==4.3.1
 langchain-anthropic==1.5.2
 langchain-openai==1.4.0
-langgraph-checkpoint-postgres==3.1.0
+langgraph-checkpoint-postgres==3.1.1
 langsmith==0.10.11
 
 # ─── Google Cloud Platform ───────────────────────────────────────────────────
@@ -84,7 +84,7 @@ opentelemetry-instrumentation-fastapi==0.65b0
 prometheus-client==0.25.0
 
 # ─── Document Processing & Reporting ─────────────────────────────────────────
-pypdf==6.14.2
+pypdf==6.15.0
 # CVE-2026-41066: keep python-docx/transitive XML parsing on patched lxml.
 lxml==6.1.1
 pyyaml==6.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ pydantic-settings==2.14.2
 jsonschema==4.26.0
 
 # ─── Authentication & Security ───────────────────────────────────────────────
+cryptography>=50.0.0
 PyJWT[crypto]==2.13.0
 passlib[bcrypt]==1.7.4
 grantex==0.3.14

--- a/tests/regression/test_security_20260618_alerts.py
+++ b/tests/regression/test_security_20260618_alerts.py
@@ -13,8 +13,8 @@ def test_ui_lockfile_uses_patched_security_alert_versions() -> None:
 
     assert packages["node_modules/form-data"]["version"] == "4.0.6"
     assert packages["node_modules/@babel/core"]["version"] == "7.29.6"
-    assert packages["node_modules/dompurify"]["version"] == "3.4.12"
-    assert packages["node_modules/undici"]["version"] == "7.28.0"
+    assert packages["node_modules/dompurify"]["version"] == "3.4.13"
+    assert packages["node_modules/undici"]["version"] == "7.29.0"
 
 
 @pytest.mark.asyncio

--- a/tests/regression/test_security_audit_20260613_dependency_gates.py
+++ b/tests/regression/test_security_audit_20260613_dependency_gates.py
@@ -65,14 +65,16 @@ def test_requirements_v4_stays_installable_without_unsafe_optional_sdks() -> Non
     for package in ("composio-core", "routellm", "litellm", "torch", "flagembedding"):
         assert f"\n{package}" not in content
     assert 'presidio-analyzer==2.2.359; python_version >= "3.14"' in content
-    assert "presidio-anonymizer==2.2.364" in content
-    assert "presidio-anonymizer==2.2.363" not in content
+    assert "\npresidio-anonymizer" not in content
 
 
-def test_presidio_anonymizer_excludes_cryptography_upper_bound_release() -> None:
+def test_unused_presidio_anonymizer_does_not_block_cryptography_updates() -> None:
     extras = _pyproject()["project"]["optional-dependencies"]
-    assert "presidio-anonymizer>=2.2.364,<2.2.365" in extras["v4"]
-    assert "presidio-anonymizer>=2.2.364,<2.2.365" in extras["dev"]
+    assert "presidio-anonymizer" not in _dependency_names(extras["v4"])
+    assert "presidio-anonymizer" not in _dependency_names(extras["dev"])
+
+    redactor = (REPO / "core" / "pii" / "redactor.py").read_text(encoding="utf-8")
+    assert "from presidio_anonymizer" not in redactor
 
 
 def test_security_workflows_do_not_continue_on_error() -> None:

--- a/tests/unit/test_agents_and_sales.py
+++ b/tests/unit/test_agents_and_sales.py
@@ -69,6 +69,13 @@ def make_mock_agent(**overrides):
     agent.shadow_sample_count = overrides.get("shadow_sample_count", 0)
     agent.shadow_min_samples = overrides.get("shadow_min_samples", 10)
     agent.shadow_accuracy_current = overrides.get("shadow_accuracy_current", None)
+    agent.shadow_model_confidence_current = overrides.get(
+        "shadow_model_confidence_current", None
+    )
+    agent.shadow_human_confidence_current = overrides.get(
+        "shadow_human_confidence_current", None
+    )
+    agent.shadow_feedback_count = overrides.get("shadow_feedback_count", 0)
     agent.shadow_accuracy_floor = overrides.get(
         "shadow_accuracy_floor", Decimal("0.950")
     )
@@ -191,6 +198,8 @@ class TestAgentToDict:
             "parent_agent_id", "shadow_comparison_agent_id",
             "shadow_min_samples", "shadow_accuracy_floor",
             "shadow_sample_count", "shadow_accuracy_current",
+            "shadow_model_confidence_current", "shadow_human_confidence_current",
+            "shadow_feedback_count",
             "cost_controls", "scaling", "tags", "ttl_hours",
             "expires_at", "created_at", "updated_at",
             "employee_name", "avatar_url", "designation",

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -778,13 +778,22 @@ class TestApprovalsEndpoints:
         from core.schemas.api import HITLDecision
 
         item = _make_hitl(status="pending")
-        # decide() now runs 2 queries: HITL item, then Agent.domain.
-        # Side effect handles both.
+        # decide() reads the HITL item and domain, then captures feedback
+        # idempotently and locks the agent row for confidence calibration.
         agent_domain_result = MagicMock()
         agent_domain_result.scalar_one_or_none.return_value = "finance"
+        existing_feedback_result = MagicMock()
+        existing_feedback_result.scalar_one_or_none.return_value = None
+        learning_agent = MagicMock()
+        learning_agent.status = "active"
+        learning_agent.shadow_accuracy_current = None
+        learning_agent_result = MagicMock()
+        learning_agent_result.scalar_one.return_value = learning_agent
         mock_session.execute = AsyncMock(side_effect=[
             _make_result(scalar_one=item),
             agent_domain_result,
+            existing_feedback_result,
+            learning_agent_result,
         ])
 
         body = HITLDecision(decision="approve", notes="Looks good")

--- a/tests/unit/test_pii_redaction.py
+++ b/tests/unit/test_pii_redaction.py
@@ -27,7 +27,6 @@ import pytest
 _PRESIDIO_INSTALLED = False
 try:
     import presidio_analyzer  # noqa: F401
-    import presidio_anonymizer  # noqa: F401
 
     _PRESIDIO_INSTALLED = True
 except ImportError:

--- a/tests/unit/test_shadow_hitl_feedback_learning.py
+++ b/tests/unit/test_shadow_hitl_feedback_learning.py
@@ -127,3 +127,16 @@ def test_collector_uses_the_deployed_feedback_schema() -> None:
     assert "feedback_text" in source
     assert "CAST(:corrected_output AS JSONB)" in source
     assert "(id, agent_id, run_id, feedback_type, text," not in source
+
+
+def test_shadow_learning_migration_supports_legacy_orm_bootstrap() -> None:
+    migration = (
+        __import__("pathlib").Path(__file__).parents[2]
+        / "migrations"
+        / "versions"
+        / "v6_z8_shadow_hitl_learning.py"
+    ).read_text(encoding="utf-8")
+
+    assert migration.count("ADD COLUMN IF NOT EXISTS") == 11
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS" in migration
+    assert "FORCE ROW LEVEL SECURITY" in migration

--- a/tests/unit/test_shadow_hitl_feedback_learning.py
+++ b/tests/unit/test_shadow_hitl_feedback_learning.py
@@ -1,0 +1,129 @@
+"""Regression coverage for the shadow-mode HITL feedback loop."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core.feedback.shadow_learning import capture_hitl_feedback
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self.value = value
+
+    def scalar_one_or_none(self):
+        return self.value
+
+    def scalar_one(self):
+        return self.value
+
+
+def _hitl_item(*, status: str = "shadow") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        tenant_id=uuid.uuid4(),
+        agent_id=uuid.uuid4(),
+        workflow_run_id=None,
+        trigger_type="confidence_below_floor",
+        context={"agent_status": status, "run_id": "run-123"},
+        decision_options={"context": {"invoice_total": 100}},
+    )
+
+
+def _agent(*, status: str = "shadow") -> SimpleNamespace:
+    return SimpleNamespace(
+        status=status,
+        shadow_sample_count=4,
+        shadow_accuracy_current=Decimal("0.700"),
+        shadow_model_confidence_current=Decimal("0.700"),
+        shadow_feedback_count=0,
+        shadow_human_confidence_current=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_shadow_approval_is_captured_and_raises_calibrated_confidence() -> None:
+    item = _hitl_item()
+    agent = _agent()
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=[_ScalarResult(None), _ScalarResult(agent)])
+    captured = []
+
+    def add(row):
+        row.id = uuid.uuid4()
+        captured.append(row)
+
+    session.add.side_effect = add
+    session.flush = AsyncMock()
+
+    result = await capture_hitl_feedback(
+        session,
+        item=item,
+        decision="approve",
+        notes="Correct result",
+        actor_id="reviewer-1",
+        actor_role="admin",
+        actor_name="Reviewer",
+        policy_action="advance",
+        policy_state=None,
+        delegated_from=None,
+    )
+
+    assert result["feedback_type"] == "hitl_approve"
+    assert result["ran_in_shadow"] is True
+    assert result["confidence_after"] > result["confidence_before"]
+    assert agent.shadow_feedback_count == 1
+    assert agent.shadow_human_confidence_current == Decimal("1.000")
+    assert captured[0].source == "hitl"
+    assert captured[0].source_event_id.startswith(f"hitl:{item.id}:")
+
+
+@pytest.mark.asyncio
+async def test_nonterminal_vote_is_captured_without_changing_confidence() -> None:
+    item = _hitl_item()
+    agent = _agent()
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=[_ScalarResult(None), _ScalarResult(agent)])
+    captured = []
+
+    def add(row):
+        row.id = uuid.uuid4()
+        captured.append(row)
+
+    session.add.side_effect = add
+    session.flush = AsyncMock()
+
+    result = await capture_hitl_feedback(
+        session,
+        item=item,
+        decision="approve",
+        notes="First quorum vote",
+        actor_id="reviewer-1",
+        actor_role="manager",
+        actor_name="Reviewer",
+        policy_action="collect",
+        policy_state={"approvals": [{"user_id": "reviewer-1"}]},
+        delegated_from=None,
+    )
+
+    assert result["feedback_type"] == "hitl_vote"
+    assert result["confidence_after"] == result["confidence_before"]
+    assert agent.shadow_feedback_count == 0
+    assert captured[0].learning_weight == Decimal("0")
+
+
+def test_collector_uses_the_deployed_feedback_schema() -> None:
+    source = (
+        __import__("pathlib").Path(__file__).parents[2]
+        / "core"
+        / "feedback"
+        / "collector.py"
+    ).read_text(encoding="utf-8")
+    assert "feedback_text" in source
+    assert "CAST(:corrected_output AS JSONB)" in source
+    assert "(id, agent_id, run_id, feedback_type, text," not in source

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4481,16 +4481,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -4899,9 +4899,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {
@@ -6198,9 +6198,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -7022,9 +7022,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -48,12 +48,12 @@
   },
   "overrides": {
     "@babel/core": "7.29.6",
-    "dompurify": "3.4.12",
+    "dompurify": "3.4.13",
     "form-data": "4.0.6",
     "lodash": ">=4.18.0",
     "follow-redirects": ">=1.16.0",
     "brace-expansion": ">=5.0.7",
-    "undici": "7.28.0"
+    "undici": "7.29.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## What changed

- upgrades every dependency currently named by the open Dependabot alerts across Python, UI, and MCP lockfiles
- fixes the feedback collector's deployed-schema mismatch that caused database writes to fall back to process memory
- captures every HITL vote and terminal decision in the same transaction as the approval
- adds tenant-scoped, idempotent feedback provenance and RLS
- separates model confidence from human confidence and produces a weighted calibrated shadow score
- auto-applies deduplicated learned prompt rules only while an agent remains in shadow mode
- resets the new confidence signals during a shadow retest and exposes them through the agent API

## Root cause

HITL decisions were audited but never routed into the self-improvement feedback store. The manual collector also wrote to a non-existent `text` column instead of `feedback_text`, so durable persistence silently degraded to an in-memory fallback. Shadow accuracy therefore reflected model self-confidence only and could not improve from human evidence.

## Validation

- Python focused suites: 42 passed
- Python broad suite: 4,188 passed / 2 skipped; its two stale-fixture failures were fixed and rerun green
- Ruff: clean on every changed Python file
- UI: 180 tests passed; TypeScript typecheck passed
- MCP server: TypeScript build and smoke test passed
- npm production audits: zero vulnerabilities in UI and MCP
- Alembic: single head `v6z8_shadow_hitl`
- `git diff --check`: clean
