### PR TITLE
perf(db): align indexes with production queries

### DIFF
--- a/core/models/abm.py
+++ b/core/models/abm.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from decimal import Decimal
 
-from sqlalchemy import ForeignKey, Numeric, String
+from sqlalchemy import ForeignKey, Index, Numeric, String, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -14,6 +14,26 @@ from core.models.base import BaseModel, TenantMixin, TimestampMixin
 
 class ABMAccount(BaseModel, TenantMixin, TimestampMixin):
     __tablename__ = "abm_accounts"
+    __table_args__ = (
+        Index("ix_abm_accounts_tenant_intent", "tenant_id", text("intent_score DESC")),
+        Index(
+            "ix_abm_accounts_tenant_tier_intent",
+            "tenant_id",
+            "tier",
+            text("intent_score DESC"),
+        ),
+        Index(
+            "ix_abm_accounts_tenant_industry_intent",
+            "tenant_id",
+            text("lower(industry)"),
+            text("intent_score DESC"),
+        ),
+        Index(
+            "ix_abm_accounts_tenant_domain_lower",
+            "tenant_id",
+            text("lower(domain)"),
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name: Mapped[str] = mapped_column(String(200), nullable=False)

--- a/core/models/agent.py
+++ b/core/models/agent.py
@@ -31,8 +31,26 @@ class Agent(BaseModel):
     __tablename__ = "agents"
     __table_args__ = (
         UniqueConstraint("tenant_id", "agent_type", "employee_name", "version"),
-        Index("idx_agents_tenant_domain", "tenant_id", "domain"),
         Index("idx_agents_routing", "tenant_id", "agent_type", "status"),
+        Index("ix_agents_tenant_created", "tenant_id", text("created_at DESC")),
+        Index(
+            "ix_agents_tenant_status_created",
+            "tenant_id",
+            "status",
+            text("created_at DESC"),
+        ),
+        Index(
+            "ix_agents_tenant_domain_created",
+            "tenant_id",
+            "domain",
+            text("created_at DESC"),
+        ),
+        Index(
+            "ix_agents_tenant_company_created",
+            "tenant_id",
+            "company_id",
+            text("created_at DESC"),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -144,7 +162,10 @@ class Agent(BaseModel):
 
 class AgentVersion(BaseModel):
     __tablename__ = "agent_versions"
-    __table_args__ = (UniqueConstraint("agent_id", "version"),)
+    __table_args__ = (
+        UniqueConstraint("agent_id", "version"),
+        Index("ix_agent_versions_agent_created", "agent_id", text("created_at DESC")),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[uuid.UUID] = mapped_column(
@@ -174,6 +195,14 @@ class AgentVersion(BaseModel):
 
 class AgentLifecycleEvent(BaseModel):
     __tablename__ = "agent_lifecycle_events"
+    __table_args__ = (
+        Index(
+            "ix_agent_lifecycle_agent_status_created",
+            "agent_id",
+            "to_status",
+            text("created_at DESC"),
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[uuid.UUID] = mapped_column(
@@ -201,7 +230,10 @@ class AgentLifecycleEvent(BaseModel):
 
 class AgentTeam(BaseModel):
     __tablename__ = "agent_teams"
-    __table_args__ = (UniqueConstraint("tenant_id", "name"),)
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "name"),
+        Index("ix_agent_teams_tenant_created", "tenant_id", text("created_at DESC")),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[uuid.UUID] = mapped_column(

--- a/core/models/api_key.py
+++ b/core/models/api_key.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import TIMESTAMP, ForeignKey, String, Text, func
+from sqlalchemy import TIMESTAMP, ForeignKey, Index, String, Text, func, text
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -14,6 +14,14 @@ from core.models.base import BaseModel
 
 class APIKey(BaseModel):
     __tablename__ = "api_keys"
+    __table_args__ = (
+        Index(
+            "ix_api_keys_active_prefix",
+            "prefix",
+            postgresql_where=text("status = 'active'"),
+        ),
+        Index("ix_api_keys_tenant_created", "tenant_id", text("created_at DESC")),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)

--- a/core/models/audit.py
+++ b/core/models/audit.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import TIMESTAMP, String, Text, func
+from sqlalchemy import TIMESTAMP, Index, String, Text, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -14,6 +14,36 @@ from core.models.base import BaseModel
 
 class AuditLog(BaseModel):
     __tablename__ = "audit_log"
+    __table_args__ = (
+        Index("ix_audit_log_tenant_created", "tenant_id", text("created_at DESC")),
+        Index(
+            "ix_audit_log_tenant_agent_created",
+            "tenant_id",
+            "agent_id",
+            text("created_at DESC"),
+        ),
+        Index(
+            "ix_audit_log_tenant_company_created",
+            "tenant_id",
+            "company_id",
+            text("created_at DESC"),
+        ),
+        Index("ix_audit_log_tenant_actor", "tenant_id", "actor_id"),
+        Index(
+            "ix_audit_log_tool_outcome_created",
+            "tenant_id",
+            "outcome",
+            text("created_at DESC"),
+            postgresql_where=text("resource_type = 'tool_call'"),
+        ),
+        Index(
+            "ix_audit_log_tool_connector_created",
+            "tenant_id",
+            text("(details->>'connector')"),
+            text("created_at DESC"),
+            postgresql_where=text("resource_type = 'tool_call'"),
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)

--- a/core/models/commerce_c6z_runtime.py
+++ b/core/models/commerce_c6z_runtime.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import JSON, TIMESTAMP, Boolean, Index, Integer, String, Text, func
+from sqlalchemy import JSON, TIMESTAMP, Boolean, Index, Integer, String, Text, func, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -26,6 +26,13 @@ class C6ZSellerOnboardingPacketRow(BaseModel):
         Index("ix_c6z_onboarding_merchant_id", "merchant_id"),
         Index("ix_c6z_onboarding_seller_agent_id", "seller_agent_id"),
         Index("ix_c6z_onboarding_status", "status"),
+        Index(
+            "ix_c6z_onboarding_scope_created",
+            "tenant_id",
+            "merchant_id",
+            "seller_agent_id",
+            text("created_at DESC"),
+        ),
     )
 
     packet_id: Mapped[str] = mapped_column(String(180), primary_key=True)
@@ -67,6 +74,13 @@ class C6ZConnectorEvidenceRow(BaseModel):
         Index("ix_c6z_connector_evidence_packet_id", "packet_id"),
         Index("ix_c6z_connector_evidence_synced_at", "synced_at"),
         Index("ix_c6z_connector_evidence_source_ref", "source_evidence_ref"),
+        Index(
+            "ix_c6z_connector_evidence_scope_synced",
+            "tenant_id",
+            "merchant_id",
+            "seller_agent_id",
+            text("synced_at DESC"),
+        ),
     )
 
     evidence_id: Mapped[str] = mapped_column(String(180), primary_key=True)
@@ -108,6 +122,13 @@ class C6ZProviderCapabilityEvidenceRow(BaseModel):
         Index("ix_c6z_capability_provider", "provider"),
         Index("ix_c6z_capability_result_status", "result_status"),
         Index("ix_c6z_capability_expires_at", "expires_at"),
+        Index(
+            "ix_c6z_capability_scope_checked",
+            "tenant_id",
+            "merchant_id",
+            "seller_agent_id",
+            text("checked_at DESC"),
+        ),
     )
 
     evidence_id: Mapped[str] = mapped_column(String(180), primary_key=True)
@@ -145,6 +166,13 @@ class C6ZMerchantCommerceConfigRow(BaseModel):
         Index("ix_c6z_merchant_config_seller_agent_id", "seller_agent_id"),
         Index("ix_c6z_merchant_config_status", "status"),
         Index("uq_c6z_merchant_config_scope", "tenant_id", "merchant_id", "seller_agent_id", unique=True),
+        Index(
+            "ix_c6z_merchant_config_scope_created",
+            "tenant_id",
+            "merchant_id",
+            "seller_agent_id",
+            text("created_at DESC"),
+        ),
     )
 
     config_id: Mapped[str] = mapped_column(String(180), primary_key=True)

--- a/core/models/company.py
+++ b/core/models/company.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     Boolean,
     Date,
     ForeignKey,
+    Index,
     String,
     Text,
     UniqueConstraint,
@@ -33,6 +34,8 @@ class Company(BaseModel):
     __tablename__ = "companies"
     __table_args__ = (
         UniqueConstraint("tenant_id", "gstin", name="uq_company_tenant_gstin"),
+        Index("ix_companies_tenant_name", "tenant_id", "name"),
+        Index("ix_companies_tenant_active_name", "tenant_id", "is_active", "name"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(

--- a/core/models/compliance_deadline.py
+++ b/core/models/compliance_deadline.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     Boolean,
     Date,
     ForeignKey,
+    Index,
     String,
     UniqueConstraint,
     func,
@@ -33,6 +34,12 @@ class ComplianceDeadline(BaseModel):
             "deadline_type",
             "filing_period",
             name="uq_deadline_company_type_period",
+        ),
+        Index(
+            "ix_compliance_deadlines_scope_due",
+            "tenant_id",
+            "company_id",
+            "due_date",
         ),
     )
 

--- a/core/models/connector.py
+++ b/core/models/connector.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import TIMESTAMP, ForeignKey, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy import TIMESTAMP, ForeignKey, Index, Integer, String, Text, UniqueConstraint, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -14,7 +14,15 @@ from core.models.base import BaseModel
 
 class Connector(BaseModel):
     __tablename__ = "connectors"
-    __table_args__ = (UniqueConstraint("tenant_id", "name"),)
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "name"),
+        Index(
+            "ix_connectors_tenant_category_live",
+            "tenant_id",
+            "category",
+            postgresql_where=text("COALESCE(status, 'active') <> 'deleted'"),
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[uuid.UUID] = mapped_column(

--- a/core/models/connector_config.py
+++ b/core/models/connector_config.py
@@ -41,6 +41,7 @@ class ConnectorConfig(BaseModel):
         Index("ix_connector_configs_tenant", "tenant_id"),
         Index("ix_connector_configs_tenant_company", "tenant_id", "company_id"),
         Index("ix_connector_configs_status", "tenant_id", "status"),
+        Index("ix_connector_configs_company_id", "company_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(

--- a/core/models/document.py
+++ b/core/models/document.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import date, datetime
 
-from sqlalchemy import TIMESTAMP, BigInteger, Date, ForeignKey, String, func
+from sqlalchemy import TIMESTAMP, BigInteger, Date, ForeignKey, Index, String, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -14,6 +14,20 @@ from core.models.base import BaseModel
 
 class Document(BaseModel):
     __tablename__ = "documents"
+    __table_args__ = (
+        Index(
+            "ix_documents_tenant_filename_live",
+            "tenant_id",
+            "filename",
+            postgresql_where=text("status <> 'deleted'"),
+        ),
+        Index(
+            "ix_documents_tenant_created_live",
+            "tenant_id",
+            text("created_at DESC"),
+            postgresql_where=text("status <> 'deleted'"),
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[uuid.UUID] = mapped_column(

--- a/core/models/feed.py
+++ b/core/models/feed.py
@@ -16,7 +16,6 @@ class FeedEvent(BaseModel):
     __tablename__ = "feed_events"
     __table_args__ = (
         UniqueConstraint("tenant_id", "sequence", name="uq_feed_events_tenant_sequence"),
-        Index("ix_feed_events_tenant_sequence", "tenant_id", "sequence"),
         Index("ix_feed_events_tenant_created", "tenant_id", "created_at"),
     )
 

--- a/core/models/feedback.py
+++ b/core/models/feedback.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime
 from decimal import Decimal
 
-from sqlalchemy import TIMESTAMP, ForeignKey, Numeric, String, Text, UniqueConstraint, func
+from sqlalchemy import TIMESTAMP, ForeignKey, Index, Numeric, String, Text, UniqueConstraint, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -20,6 +20,12 @@ class AgentFeedback(BaseModel):
             "tenant_id",
             "source_event_id",
             name="uq_agent_feedback_tenant_source_event",
+        ),
+        Index(
+            "ix_agent_feedback_agent_tenant_created",
+            "agent_id",
+            "tenant_id",
+            text("created_at DESC"),
         ),
     )
 

--- a/core/models/filing_approval.py
+++ b/core/models/filing_approval.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     TIMESTAMP,
     Boolean,
     ForeignKey,
+    Index,
     String,
     Text,
     func,
@@ -27,6 +28,14 @@ from core.models.base import BaseModel
 
 class FilingApproval(BaseModel):
     __tablename__ = "filing_approvals"
+    __table_args__ = (
+        Index(
+            "ix_filing_approvals_scope_created",
+            "tenant_id",
+            "company_id",
+            text("created_at DESC"),
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4

--- a/core/models/gstn_upload.py
+++ b/core/models/gstn_upload.py
@@ -14,8 +14,10 @@ from sqlalchemy import (
     TIMESTAMP,
     BigInteger,
     ForeignKey,
+    Index,
     String,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -25,6 +27,14 @@ from core.models.base import BaseModel
 
 class GSTNUpload(BaseModel):
     __tablename__ = "gstn_uploads"
+    __table_args__ = (
+        Index(
+            "ix_gstn_uploads_scope_created",
+            "tenant_id",
+            "company_id",
+            text("created_at DESC"),
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4

--- a/core/models/hitl.py
+++ b/core/models/hitl.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import TIMESTAMP, ForeignKey, String, Text, func
+from sqlalchemy import TIMESTAMP, ForeignKey, Index, String, Text, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -14,6 +14,14 @@ from core.models.base import BaseModel
 
 class HITLQueue(BaseModel):
     __tablename__ = "hitl_queue"
+    __table_args__ = (
+        Index(
+            "ix_hitl_queue_tenant_status_created",
+            "tenant_id",
+            "status",
+            text("created_at DESC"),
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[uuid.UUID] = mapped_column(

--- a/core/models/lead_pipeline.py
+++ b/core/models/lead_pipeline.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     String,
     Text,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -25,8 +26,20 @@ from core.models.base import BaseModel
 class LeadPipeline(BaseModel):
     __tablename__ = "lead_pipeline"
     __table_args__ = (
-        Index("idx_lead_pipeline_tenant", "tenant_id", "stage"),
         Index("idx_lead_pipeline_email", "email"),
+        Index(
+            "ix_lead_pipeline_tenant_score_created",
+            "tenant_id",
+            text("score DESC"),
+            text("created_at DESC"),
+        ),
+        Index(
+            "ix_lead_pipeline_tenant_stage_score_created",
+            "tenant_id",
+            "stage",
+            text("score DESC"),
+            text("created_at DESC"),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -85,6 +98,12 @@ class EmailSequence(BaseModel):
     __tablename__ = "email_sequences"
     __table_args__ = (
         Index("idx_email_sequences_lead", "lead_id", "sequence_name", "step_number"),
+        Index(
+            "ix_email_sequences_tenant_status_sent",
+            "tenant_id",
+            "status",
+            "sent_at",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/core/models/schema_registry.py
+++ b/core/models/schema_registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import TIMESTAMP, Boolean, ForeignKey, String, Text, UniqueConstraint, func
+from sqlalchemy import TIMESTAMP, Boolean, ForeignKey, Index, String, Text, UniqueConstraint, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -14,7 +14,10 @@ from core.models.base import BaseModel
 
 class SchemaRegistry(BaseModel):
     __tablename__ = "schema_registry"
-    __table_args__ = (UniqueConstraint("tenant_id", "name", "version"),)
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "name", "version"),
+        Index("ix_schema_registry_tenant_created", "tenant_id", text("created_at DESC")),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)

--- a/core/models/workflow.py
+++ b/core/models/workflow.py
@@ -28,7 +28,26 @@ from core.models.base import BaseModel
 
 class WorkflowDefinition(BaseModel):
     __tablename__ = "workflow_definitions"
-    __table_args__ = (UniqueConstraint("tenant_id", "name", "version"),)
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "name", "version"),
+        Index(
+            "ix_workflow_definitions_tenant_created",
+            "tenant_id",
+            text("created_at DESC"),
+        ),
+        Index(
+            "ix_workflow_definitions_tenant_domain_created",
+            "tenant_id",
+            "domain",
+            text("created_at DESC"),
+        ),
+        Index(
+            "ix_workflow_definitions_tenant_company_created",
+            "tenant_id",
+            "company_id",
+            text("created_at DESC"),
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[uuid.UUID] = mapped_column(
@@ -60,8 +79,19 @@ class WorkflowDefinition(BaseModel):
 class WorkflowRun(BaseModel):
     __tablename__ = "workflow_runs"
     __table_args__ = (
-        Index("idx_wf_runs_tenant_status", "tenant_id", "status"),
         Index("idx_wf_runs_created", "created_at"),
+        Index(
+            "ix_workflow_runs_definition_tenant_created",
+            "workflow_def_id",
+            "tenant_id",
+            text("created_at DESC"),
+        ),
+        Index(
+            "ix_workflow_runs_tenant_status_created",
+            "tenant_id",
+            "status",
+            text("created_at DESC"),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/migrations/versions/v6_z9_query_performance_indexes.py
+++ b/migrations/versions/v6_z9_query_performance_indexes.py
@@ -1,0 +1,319 @@
+# ruff: noqa: S608
+"""Align PostgreSQL indexes with production query shapes.
+
+Revision ID: v6z9_query_performance
+Revises: v6z8_shadow_hitl
+Create Date: 2026-08-09
+
+The earlier FK coverage migration protects referential-integrity operations,
+but a leading FK column alone does not cover tenant-scoped pagination,
+ordering, queue reads, or substring search.  This migration adds the
+composite/partial indexes used by those hot paths and removes exact duplicate
+indexes left by the legacy SQL + ORM bootstrap combination.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v6z9_query_performance"
+down_revision = "v6z8_shadow_hitl"
+branch_labels = None
+depends_on = None
+
+
+_BTREE_INDEXES: tuple[tuple[str, str], ...] = (
+    # Append-only audit history: tenant pagination plus the optional filters
+    # exposed by /audit and /audit/enforcement.
+    (
+        "ix_audit_log_tenant_created",
+        "ON audit_log (tenant_id, created_at DESC)",
+    ),
+    (
+        "ix_audit_log_tenant_agent_created",
+        "ON audit_log (tenant_id, agent_id, created_at DESC)",
+    ),
+    (
+        "ix_audit_log_tenant_company_created",
+        "ON audit_log (tenant_id, company_id, created_at DESC)",
+    ),
+    (
+        "ix_audit_log_tenant_actor",
+        "ON audit_log (tenant_id, actor_id)",
+    ),
+    (
+        "ix_audit_log_tool_outcome_created",
+        "ON audit_log (tenant_id, outcome, created_at DESC) "
+        "WHERE resource_type = 'tool_call'",
+    ),
+    (
+        "ix_audit_log_tool_connector_created",
+        "ON audit_log (tenant_id, (details->>'connector'), created_at DESC) "
+        "WHERE resource_type = 'tool_call'",
+    ),
+    # Approval queue reads always scope by tenant/status and return newest
+    # first.  The same prefix accelerates the KPI pending-approval join.
+    (
+        "ix_hitl_queue_tenant_status_created",
+        "ON hitl_queue (tenant_id, status, created_at DESC)",
+    ),
+    # Recent feedback drives shadow learning.  Leading agent_id also closes
+    # the FK coverage gap introduced after v6z4.
+    (
+        "ix_agent_feedback_agent_tenant_created",
+        "ON agent_feedback (agent_id, tenant_id, created_at DESC)",
+    ),
+    # API-key authentication must never scan all tenants' key hashes.
+    (
+        "ix_api_keys_active_prefix",
+        "ON api_keys (prefix) WHERE status = 'active'",
+    ),
+    (
+        "ix_api_keys_tenant_created",
+        "ON api_keys (tenant_id, created_at DESC)",
+    ),
+    (
+        "ix_agent_lifecycle_agent_status_created",
+        "ON agent_lifecycle_events (agent_id, to_status, created_at DESC)",
+    ),
+    (
+        "ix_agent_versions_agent_created",
+        "ON agent_versions (agent_id, created_at DESC)",
+    ),
+    (
+        "ix_documents_tenant_filename_live",
+        "ON documents (tenant_id, filename) WHERE status <> 'deleted'",
+    ),
+    (
+        "ix_documents_tenant_created_live",
+        "ON documents (tenant_id, created_at DESC) WHERE status <> 'deleted'",
+    ),
+    (
+        "ix_workflow_runs_definition_tenant_created",
+        "ON workflow_runs (workflow_def_id, tenant_id, created_at DESC)",
+    ),
+    (
+        "ix_workflow_runs_tenant_status_created",
+        "ON workflow_runs (tenant_id, status, created_at DESC)",
+    ),
+    (
+        "ix_companies_tenant_name",
+        "ON companies (tenant_id, name)",
+    ),
+    (
+        "ix_companies_tenant_active_name",
+        "ON companies (tenant_id, is_active, name)",
+    ),
+    # Agent/workflow registries are paginated newest-first and optionally
+    # narrowed by the same dimensions used by RBAC and company scope.
+    (
+        "ix_agents_tenant_created",
+        "ON agents (tenant_id, created_at DESC)",
+    ),
+    (
+        "ix_agents_tenant_status_created",
+        "ON agents (tenant_id, status, created_at DESC)",
+    ),
+    (
+        "ix_agents_tenant_domain_created",
+        "ON agents (tenant_id, domain, created_at DESC)",
+    ),
+    (
+        "ix_agents_tenant_company_created",
+        "ON agents (tenant_id, company_id, created_at DESC)",
+    ),
+    (
+        "ix_agent_teams_tenant_created",
+        "ON agent_teams (tenant_id, created_at DESC)",
+    ),
+    (
+        "ix_workflow_definitions_tenant_created",
+        "ON workflow_definitions (tenant_id, created_at DESC)",
+    ),
+    (
+        "ix_workflow_definitions_tenant_domain_created",
+        "ON workflow_definitions (tenant_id, domain, created_at DESC)",
+    ),
+    (
+        "ix_workflow_definitions_tenant_company_created",
+        "ON workflow_definitions (tenant_id, company_id, created_at DESC)",
+    ),
+    (
+        "ix_schema_registry_tenant_created",
+        "ON schema_registry (tenant_id, created_at DESC)",
+    ),
+    # ABM and sales dashboards combine filtering, scoring and recency.
+    (
+        "ix_abm_accounts_tenant_intent",
+        "ON abm_accounts (tenant_id, intent_score DESC)",
+    ),
+    (
+        "ix_abm_accounts_tenant_tier_intent",
+        "ON abm_accounts (tenant_id, tier, intent_score DESC)",
+    ),
+    (
+        "ix_abm_accounts_tenant_industry_intent",
+        "ON abm_accounts (tenant_id, lower(industry), intent_score DESC)",
+    ),
+    (
+        "ix_abm_accounts_tenant_domain_lower",
+        "ON abm_accounts (tenant_id, lower(domain))",
+    ),
+    (
+        "ix_lead_pipeline_tenant_score_created",
+        "ON lead_pipeline (tenant_id, score DESC, created_at DESC)",
+    ),
+    (
+        "ix_lead_pipeline_tenant_stage_score_created",
+        "ON lead_pipeline (tenant_id, stage, score DESC, created_at DESC)",
+    ),
+    (
+        "ix_email_sequences_tenant_status_sent",
+        "ON email_sequences (tenant_id, status, sent_at)",
+    ),
+    # Company operations pages scope by tenant+company and then sort.
+    (
+        "ix_filing_approvals_scope_created",
+        "ON filing_approvals (tenant_id, company_id, created_at DESC)",
+    ),
+    (
+        "ix_gstn_uploads_scope_created",
+        "ON gstn_uploads (tenant_id, company_id, created_at DESC)",
+    ),
+    (
+        "ix_compliance_deadlines_scope_due",
+        "ON compliance_deadlines (tenant_id, company_id, due_date)",
+    ),
+    # Commerce runtime reads are merchant-scoped and time ordered.  The old
+    # schema had one index per column, which required bitmap scans + sorts.
+    (
+        "ix_c6z_onboarding_scope_created",
+        "ON commerce_c6z_seller_onboarding_packets "
+        "(tenant_id, merchant_id, seller_agent_id, created_at DESC)",
+    ),
+    (
+        "ix_c6z_connector_evidence_scope_synced",
+        "ON commerce_c6z_connector_evidence_records "
+        "(tenant_id, merchant_id, seller_agent_id, synced_at DESC)",
+    ),
+    (
+        "ix_c6z_capability_scope_checked",
+        "ON commerce_c6z_provider_capability_evidence "
+        "(tenant_id, merchant_id, seller_agent_id, checked_at DESC)",
+    ),
+    (
+        "ix_c6z_merchant_config_scope_created",
+        "ON commerce_c6z_merchant_configs "
+        "(tenant_id, merchant_id, seller_agent_id, created_at DESC)",
+    ),
+    (
+        "ix_connectors_tenant_category_live",
+        "ON connectors (tenant_id, category) "
+        "WHERE COALESCE(status, 'active') <> 'deleted'",
+    ),
+    # ConnectorConfig's common lookup is already covered by its partial
+    # unique indexes.  This leading company index is specifically for the FK.
+    (
+        "ix_connector_configs_company_id",
+        "ON connector_configs (company_id)",
+    ),
+)
+
+
+_TRIGRAM_INDEXES: tuple[tuple[str, str], ...] = (
+    (
+        "ix_audit_log_event_type_trgm",
+        "ON audit_log USING gin (event_type gin_trgm_ops)",
+    ),
+    (
+        "ix_companies_name_trgm",
+        "ON companies USING gin (name gin_trgm_ops)",
+    ),
+    (
+        "ix_companies_gstin_trgm",
+        "ON companies USING gin (gstin gin_trgm_ops)",
+    ),
+    (
+        "ix_companies_industry_trgm",
+        "ON companies USING gin (industry gin_trgm_ops)",
+    ),
+)
+
+
+_REDUNDANT_INDEXES: tuple[str, ...] = (
+    "ix_a2a_tasks_task_id",
+    "ix_a2a_tasks_tenant_id",
+    "ix_bridge_registry_tenant_id",
+    "ix_ca_subscriptions_tenant_id",
+    "ix_feed_events_tenant_sequence",
+    "ix_report_schedules_tenant_id",
+    "idx_agents_tenant_domain",
+    "idx_lead_pipeline_tenant",
+    # Superseded by the same prefix plus created_at ordering above.
+    "idx_wf_runs_tenant_status",
+)
+
+
+def _drop_duplicate_connector_config_fk() -> None:
+    """Remove only a structurally duplicate auto-named company FK.
+
+    Fresh bootstrap creates the FK from ORM metadata before v6z6 adds its
+    canonical named constraint.  Existing upgraded databases normally have
+    only the canonical constraint, so the guarded repair is a no-op there.
+    """
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM pg_constraint automatic
+                JOIN pg_constraint canonical
+                  ON canonical.conrelid = automatic.conrelid
+                 AND canonical.contype = 'f'
+                 AND canonical.conkey = automatic.conkey
+                 AND canonical.confrelid = automatic.confrelid
+                 AND canonical.confkey = automatic.confkey
+                 AND canonical.conname = 'fk_connector_configs_company_id'
+                WHERE automatic.conrelid = 'connector_configs'::regclass
+                  AND automatic.contype = 'f'
+                  AND automatic.conname = 'connector_configs_company_id_fkey'
+            ) THEN
+                ALTER TABLE connector_configs
+                DROP CONSTRAINT connector_configs_company_id_fkey;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def upgrade() -> None:
+    # Required for the two user-facing substring searches.  GIN trigram
+    # indexes are the only practical PostgreSQL index for leading-wildcard
+    # ILIKE predicates.
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+
+    # Large audit/queue tables must remain writable while indexes build.
+    # Dropping the new name first also repairs a not-valid index left by an
+    # interrupted CREATE INDEX CONCURRENTLY before Alembic retries the revision.
+    with op.get_context().autocommit_block():
+        for index_name, definition in (*_BTREE_INDEXES, *_TRIGRAM_INDEXES):
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}")
+            op.execute(f"CREATE INDEX CONCURRENTLY {index_name} {definition}")
+
+        for index_name in _REDUNDANT_INDEXES:
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}")
+
+    _drop_duplicate_connector_config_fk()
+
+
+def downgrade() -> None:
+    # Restore only indexes that predated this revision.  The duplicate FK is
+    # intentionally not recreated: duplicate constraints are never useful.
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_wf_runs_tenant_status "
+            "ON workflow_runs (tenant_id, status)"
+        )
+        for index_name, _ in reversed((*_TRIGRAM_INDEXES, *_BTREE_INDEXES)):
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}")

--- a/scripts/alembic_migrate.py
+++ b/scripts/alembic_migrate.py
@@ -98,9 +98,22 @@ def _assert_required_runtime_tables(engine) -> None:
         )
 
 
+def _assert_database_index_health() -> None:
+    """Reject a rollout when the effective PostgreSQL catalog is unhealthy."""
+    from scripts.check_database_indexes import audit_database  # noqa: PLC0415
+
+    failures = audit_database(settings.db_url)
+    if failures:
+        raise RuntimeError(
+            "Database index verification failed after Alembic upgrade:\n\n"
+            + "\n\n".join(failures)
+        )
+
+
 def _upgrade_head_and_verify(cfg: Config, engine, complete_message: str) -> None:
     command.upgrade(cfg, "head")
     _assert_required_runtime_tables(engine)
+    _assert_database_index_health()
     logger.info(complete_message)
 
 

--- a/scripts/check_database_indexes.py
+++ b/scripts/check_database_indexes.py
@@ -1,0 +1,249 @@
+"""Fail fast on PostgreSQL index correctness and query-index regressions.
+
+Usage::
+
+    python scripts/check_database_indexes.py
+
+The command reads ``AGENTICORG_DB_URL``.  It checks the effective database
+catalog rather than ORM declarations, so it catches migration/bootstrap drift,
+invalid indexes, unindexed foreign keys, and exact duplicate index structures.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Sequence
+
+from sqlalchemy import create_engine, text
+
+
+REQUIRED_QUERY_INDEXES = {
+    "ix_abm_accounts_tenant_domain_lower",
+    "ix_abm_accounts_tenant_industry_intent",
+    "ix_abm_accounts_tenant_intent",
+    "ix_abm_accounts_tenant_tier_intent",
+    "ix_agent_feedback_agent_tenant_created",
+    "ix_agent_lifecycle_agent_status_created",
+    "ix_agent_teams_tenant_created",
+    "ix_agent_versions_agent_created",
+    "ix_agents_tenant_company_created",
+    "ix_agents_tenant_created",
+    "ix_agents_tenant_domain_created",
+    "ix_agents_tenant_status_created",
+    "ix_api_keys_active_prefix",
+    "ix_api_keys_tenant_created",
+    "ix_audit_log_event_type_trgm",
+    "ix_audit_log_tenant_actor",
+    "ix_audit_log_tenant_agent_created",
+    "ix_audit_log_tenant_company_created",
+    "ix_audit_log_tenant_created",
+    "ix_audit_log_tool_connector_created",
+    "ix_audit_log_tool_outcome_created",
+    "ix_companies_gstin_trgm",
+    "ix_companies_industry_trgm",
+    "ix_companies_name_trgm",
+    "ix_companies_tenant_active_name",
+    "ix_companies_tenant_name",
+    "ix_compliance_deadlines_scope_due",
+    "ix_connector_configs_company_id",
+    "ix_connectors_tenant_category_live",
+    "ix_c6z_capability_scope_checked",
+    "ix_c6z_connector_evidence_scope_synced",
+    "ix_c6z_merchant_config_scope_created",
+    "ix_c6z_onboarding_scope_created",
+    "ix_documents_tenant_created_live",
+    "ix_documents_tenant_filename_live",
+    "ix_email_sequences_tenant_status_sent",
+    "ix_filing_approvals_scope_created",
+    "ix_gstn_uploads_scope_created",
+    "ix_hitl_queue_tenant_status_created",
+    "ix_lead_pipeline_tenant_score_created",
+    "ix_lead_pipeline_tenant_stage_score_created",
+    "ix_schema_registry_tenant_created",
+    "ix_workflow_definitions_tenant_company_created",
+    "ix_workflow_definitions_tenant_created",
+    "ix_workflow_definitions_tenant_domain_created",
+    "ix_workflow_runs_definition_tenant_created",
+    "ix_workflow_runs_tenant_status_created",
+}
+
+
+_MISSING_FK_SQL = text(
+    """
+    SELECT child.relname AS table_name,
+           constraint_row.conname AS constraint_name,
+           attribute_row.attname AS column_name
+    FROM pg_constraint constraint_row
+    JOIN pg_class child ON child.oid = constraint_row.conrelid
+    JOIN pg_namespace namespace_row ON namespace_row.oid = child.relnamespace
+    JOIN LATERAL unnest(constraint_row.conkey) WITH ORDINALITY key_column(attnum, position)
+      ON key_column.position = 1
+    JOIN pg_attribute attribute_row
+      ON attribute_row.attrelid = child.oid
+     AND attribute_row.attnum = key_column.attnum
+    WHERE namespace_row.nspname = current_schema()
+      AND constraint_row.contype = 'f'
+      AND NOT EXISTS (
+          SELECT 1
+          FROM pg_index index_row
+          WHERE index_row.indrelid = child.oid
+            AND index_row.indisvalid
+            AND index_row.indisready
+            AND index_row.indkey[0] = key_column.attnum
+      )
+    ORDER BY child.relname, constraint_row.conname
+    """
+)
+
+
+_DUPLICATE_INDEX_SQL = text(
+    """
+    WITH indexes AS (
+        SELECT index_row.indexrelid,
+               index_row.indrelid,
+               table_row.relname AS table_name,
+               index_class.relname AS index_name,
+               index_row.indisunique,
+               index_row.indisprimary,
+               index_row.indkey::text AS key_attnums,
+               index_row.indclass::text AS opclasses,
+               index_row.indcollation::text AS collations,
+               index_row.indoption::text AS options,
+               pg_get_expr(index_row.indexprs, index_row.indrelid) AS expressions,
+               pg_get_expr(index_row.indpred, index_row.indrelid) AS predicate,
+               access_method.amname
+        FROM pg_index index_row
+        JOIN pg_class table_row ON table_row.oid = index_row.indrelid
+        JOIN pg_namespace namespace_row ON namespace_row.oid = table_row.relnamespace
+        JOIN pg_class index_class ON index_class.oid = index_row.indexrelid
+        JOIN pg_am access_method ON access_method.oid = index_class.relam
+        WHERE namespace_row.nspname = current_schema()
+          AND index_row.indisvalid
+          AND index_row.indisready
+    )
+    SELECT left_index.table_name,
+           left_index.index_name,
+           right_index.index_name
+    FROM indexes left_index
+    JOIN indexes right_index
+      ON left_index.indrelid = right_index.indrelid
+     AND left_index.indexrelid < right_index.indexrelid
+     AND left_index.key_attnums = right_index.key_attnums
+     AND left_index.opclasses = right_index.opclasses
+     AND left_index.collations = right_index.collations
+     AND left_index.options = right_index.options
+     AND COALESCE(left_index.expressions, '') = COALESCE(right_index.expressions, '')
+     AND COALESCE(left_index.predicate, '') = COALESCE(right_index.predicate, '')
+     AND left_index.amname = right_index.amname
+    ORDER BY left_index.table_name, left_index.index_name
+    """
+)
+
+
+_DUPLICATE_FK_SQL = text(
+    """
+    SELECT child.relname, left_fk.conname, right_fk.conname
+    FROM pg_constraint left_fk
+    JOIN pg_constraint right_fk
+      ON left_fk.conrelid = right_fk.conrelid
+     AND left_fk.oid < right_fk.oid
+     AND left_fk.contype = 'f'
+     AND right_fk.contype = 'f'
+     AND left_fk.conkey = right_fk.conkey
+     AND left_fk.confrelid = right_fk.confrelid
+     AND left_fk.confkey = right_fk.confkey
+    JOIN pg_class child ON child.oid = left_fk.conrelid
+    JOIN pg_namespace namespace_row ON namespace_row.oid = child.relnamespace
+    WHERE namespace_row.nspname = current_schema()
+    ORDER BY child.relname, left_fk.conname
+    """
+)
+
+
+def _sync_url(url: str) -> str:
+    return url.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def _format_rows(rows: Sequence[object]) -> str:
+    return "\n".join(
+        f"  - {row if isinstance(row, str) else tuple(row)}" for row in rows
+    )
+
+
+def audit_database(database_url: str) -> list[str]:
+    """Return human-readable catalog failures for ``database_url``."""
+    engine = create_engine(_sync_url(database_url), pool_pre_ping=True)
+    failures: list[str] = []
+    try:
+        with engine.connect() as connection:
+            missing_fk = connection.execute(_MISSING_FK_SQL).all()
+            duplicate_indexes = connection.execute(_DUPLICATE_INDEX_SQL).all()
+            duplicate_fks = connection.execute(_DUPLICATE_FK_SQL).all()
+            invalid_indexes = connection.execute(
+                text(
+                    """
+                    SELECT table_row.relname, index_row.relname
+                    FROM pg_index catalog_row
+                    JOIN pg_class table_row ON table_row.oid = catalog_row.indrelid
+                    JOIN pg_class index_row ON index_row.oid = catalog_row.indexrelid
+                    JOIN pg_namespace namespace_row ON namespace_row.oid = table_row.relnamespace
+                    WHERE namespace_row.nspname = current_schema()
+                      AND (NOT catalog_row.indisvalid OR NOT catalog_row.indisready)
+                    ORDER BY table_row.relname, index_row.relname
+                    """
+                )
+            ).all()
+            present = set(
+                connection.execute(
+                    text(
+                        """
+                        SELECT index_class.relname
+                        FROM pg_index index_row
+                        JOIN pg_class index_class ON index_class.oid = index_row.indexrelid
+                        JOIN pg_class table_row ON table_row.oid = index_row.indrelid
+                        JOIN pg_namespace namespace_row ON namespace_row.oid = table_row.relnamespace
+                        WHERE namespace_row.nspname = current_schema()
+                          AND index_row.indisvalid
+                          AND index_row.indisready
+                        """
+                    )
+                ).scalars()
+            )
+    finally:
+        engine.dispose()
+
+    if missing_fk:
+        failures.append("foreign keys without a leading index:\n" + _format_rows(missing_fk))
+    if duplicate_indexes:
+        failures.append("structurally duplicate indexes:\n" + _format_rows(duplicate_indexes))
+    if duplicate_fks:
+        failures.append("structurally duplicate foreign keys:\n" + _format_rows(duplicate_fks))
+    if invalid_indexes:
+        failures.append("invalid or not-ready indexes:\n" + _format_rows(invalid_indexes))
+    missing_required = sorted(REQUIRED_QUERY_INDEXES - present)
+    if missing_required:
+        failures.append("missing required query indexes:\n" + _format_rows(missing_required))
+    return failures
+
+
+def main() -> int:
+    database_url = os.getenv("AGENTICORG_DB_URL")
+    if not database_url:
+        print("AGENTICORG_DB_URL is required", file=sys.stderr)
+        return 2
+
+    failures = audit_database(database_url)
+    if failures:
+        print("DATABASE INDEX AUDIT FAILED\n\n" + "\n\n".join(failures), file=sys.stderr)
+        return 1
+
+    print(
+        "DATABASE INDEX AUDIT PASSED: all foreign keys are covered, "
+        "all query-contract indexes are valid, and no exact duplicates remain."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_alembic_e2e.py
+++ b/tests/integration/test_alembic_e2e.py
@@ -21,6 +21,7 @@ without Docker). CI ``integration-tests`` always has Postgres.
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -112,6 +113,118 @@ def _run_migrate_wrapper() -> subprocess.CompletedProcess[str]:
         env=env,
         check=True,
     )
+
+
+def _assert_database_index_health() -> None:
+    env = os.environ.copy()
+    env["AGENTICORG_DB_URL"] = _DB_URL
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "scripts/check_database_indexes.py"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "DATABASE INDEX AUDIT PASSED" in result.stdout
+
+
+def _assert_hot_query_plans() -> None:
+    """Prove each critical query shape can use its intended index.
+
+    Empty/CI databases naturally prefer sequential scans.  Disabling them for
+    these EXPLAIN-only probes checks index eligibility without inserting test
+    data or mutating planner statistics.
+    """
+    tenant_id = "00000000-0000-0000-0000-000000000001"
+    agent_id = "00000000-0000-0000-0000-000000000002"
+    workflow_id = "00000000-0000-0000-0000-000000000003"
+    company_id = "00000000-0000-0000-0000-000000000004"
+    probes = {
+        "ix_audit_log_tenant_created": (
+            "SELECT * FROM audit_log WHERE tenant_id = :tenant_id "
+            "ORDER BY created_at DESC LIMIT 20"
+        ),
+        "ix_audit_log_event_type_trgm": (
+            "SELECT count(*) FROM audit_log WHERE event_type ILIKE '%invoice%'"
+        ),
+        "ix_hitl_queue_tenant_status_created": (
+            "SELECT * FROM hitl_queue WHERE tenant_id = :tenant_id "
+            "AND status = 'pending' ORDER BY created_at DESC LIMIT 20"
+        ),
+        "ix_agent_feedback_agent_tenant_created": (
+            "SELECT * FROM agent_feedback WHERE agent_id = :agent_id "
+            "AND tenant_id = :tenant_id ORDER BY created_at DESC LIMIT 50"
+        ),
+        "ix_api_keys_active_prefix": (
+            "SELECT * FROM api_keys WHERE prefix = 'ao_sk_probe' AND status = 'active'"
+        ),
+        "ix_agent_lifecycle_agent_status_created": (
+            "SELECT * FROM agent_lifecycle_events WHERE agent_id = :agent_id "
+            "AND to_status = 'paused' ORDER BY created_at DESC LIMIT 1"
+        ),
+        "ix_agent_versions_agent_created": (
+            "SELECT * FROM agent_versions WHERE agent_id = :agent_id "
+            "ORDER BY created_at DESC LIMIT 1"
+        ),
+        "ix_agents_tenant_created": (
+            "SELECT * FROM agents WHERE tenant_id = :tenant_id "
+            "ORDER BY created_at DESC LIMIT 20"
+        ),
+        "ix_workflow_definitions_tenant_created": (
+            "SELECT * FROM workflow_definitions WHERE tenant_id = :tenant_id "
+            "ORDER BY created_at DESC LIMIT 20"
+        ),
+        "ix_schema_registry_tenant_created": (
+            "SELECT * FROM schema_registry WHERE tenant_id = :tenant_id "
+            "ORDER BY created_at DESC LIMIT 20"
+        ),
+        "ix_lead_pipeline_tenant_stage_score_created": (
+            "SELECT * FROM lead_pipeline WHERE tenant_id = :tenant_id AND stage = 'new' "
+            "ORDER BY score DESC, created_at DESC"
+        ),
+        "ix_filing_approvals_scope_created": (
+            "SELECT * FROM filing_approvals WHERE tenant_id = :tenant_id "
+            "AND company_id = :company_id ORDER BY created_at DESC"
+        ),
+        "ix_c6z_connector_evidence_scope_synced": (
+            "SELECT * FROM commerce_c6z_connector_evidence_records "
+            "WHERE tenant_id = 'tenant' AND merchant_id = 'merchant' "
+            "AND seller_agent_id = 'seller' ORDER BY synced_at DESC"
+        ),
+        "ix_documents_tenant_created_live": (
+            "SELECT * FROM documents WHERE tenant_id = :tenant_id "
+            "AND status <> 'deleted' ORDER BY created_at DESC"
+        ),
+        "ix_workflow_runs_definition_tenant_created": (
+            "SELECT * FROM workflow_runs WHERE workflow_def_id = :workflow_id "
+            "AND tenant_id = :tenant_id ORDER BY created_at DESC LIMIT 20"
+        ),
+        "ix_companies_tenant_name": (
+            "SELECT * FROM companies WHERE tenant_id = :tenant_id ORDER BY name LIMIT 50"
+        ),
+        "ix_connectors_tenant_category_live": (
+            "SELECT * FROM connectors WHERE tenant_id = :tenant_id "
+            "AND category = 'crm' AND COALESCE(status, 'active') <> 'deleted'"
+        ),
+    }
+    engine = create_engine(_SYNC_URL)
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL enable_seqscan = off"))
+        for expected_index, query in probes.items():
+            plan = conn.execute(
+                text(f"EXPLAIN (FORMAT JSON) {query}"),
+                {
+                    "tenant_id": tenant_id,
+                    "agent_id": agent_id,
+                    "workflow_id": workflow_id,
+                    "company_id": company_id,
+                },
+            ).scalar_one()
+            assert expected_index in json.dumps(plan), (
+                f"planner cannot use {expected_index} for: {query}; plan={plan}"
+            )
+    engine.dispose()
 
 
 def _table_names() -> set[str]:
@@ -352,6 +465,8 @@ def test_empty_db_bootstraps_baseline_then_upgrades_to_head():
     assert version == _current_head()
     _assert_readiness_controls()
     _assert_connector_config_controls()
+    _assert_database_index_health()
+    _assert_hot_query_plans()
 
 
 def test_legacy_db_gets_stamped_at_baseline():
@@ -379,6 +494,7 @@ def test_legacy_db_gets_stamped_at_baseline():
     assert version == expected_head
     _assert_readiness_controls()
     _assert_connector_config_controls()
+    _assert_database_index_health()
 
 
 def test_already_managed_db_is_noop():
@@ -395,6 +511,7 @@ def test_already_managed_db_is_noop():
     assert "alembic_version" in _table_names()
     _assert_readiness_controls()
     _assert_connector_config_controls()
+    _assert_database_index_health()
 
 
 def test_readiness_migration_downgrade_upgrade_round_trip():
@@ -425,6 +542,7 @@ def test_readiness_migration_downgrade_upgrade_round_trip():
     command.upgrade(_alembic_cfg(), "head")
     _assert_readiness_controls()
     _assert_connector_config_controls()
+    _assert_database_index_health()
 
 
 def test_connector_config_migration_replaces_legacy_policies_and_round_trips():


### PR DESCRIPTION
## What changed

- add 47 evidence-backed composite, partial, expression, and trigram indexes for production query shapes
- remove 9 structurally redundant indexes and repair the duplicate connector-company foreign key
- build indexes concurrently and self-heal interrupted index builds
- add a post-migration catalog audit for missing FK coverage, invalid indexes, duplicate indexes/FKs, and required query contracts
- add PostgreSQL EXPLAIN plan regression coverage and align SQLAlchemy metadata

## Why

Several high-traffic tenant-scoped list, queue, authentication, audit, feedback, workflow, sales, and commerce queries had only single-column FK indexes. PostgreSQL could still require broad scans or explicit sorts. The effective catalog also contained duplicate indexes and a duplicate FK constraint, increasing write amplification.

## Validation

- full suite: 5,921 passed; two metadata assertions identified, corrected, and rerun successfully
- PostgreSQL migration/RLS/catalog/plan suite: 8 passed
- Ruff: passed
- enterprise stability gates: passed
- consistency sweep: passed
- fresh live migration and final database index audit: passed