### PR TITLE
chore: ignore generated output artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ docs/*.xlsx
 *.key
 secrets/
 
+# Generated media artifacts
+/output/
+
 # Demo videos and recordings
 video/
 scripts/slack_demo.py


### PR DESCRIPTION
## What changed

- Ignore the repository-root `output/` directory.
- Keep generated videos, audio, frames, and other rendered media out of Git status and future commits.

## Why

Local media-generation runs currently leave a large untracked artifact tree. These files are build outputs rather than source and should remain local.

## Impact

Existing local artifacts are not deleted. They are simply ignored by Git.

## Validation

- `git diff --check`
- `git check-ignore` against representative CFO and OACP rendered videos
- Confirmed the PR contains only `.gitignore`