### PR TITLE
fix: repair missing feedback table during migration

### DIFF
--- a/migrations/versions/v6_z8_shadow_hitl_learning.py
+++ b/migrations/versions/v6_z8_shadow_hitl_learning.py
@@ -17,6 +17,33 @@ def upgrade() -> None:
     # The migration wrapper bootstraps legacy databases with current ORM
     # metadata before stamping the baseline. Keep every schema operation
     # idempotent so that path and normal version-to-version upgrades both work.
+    # Some long-lived production databases were stamped past the original
+    # v4 migration without receiving this table. Repair that legacy drift
+    # before adding the shadow-learning columns.
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS agent_feedback (
+            id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            agent_id UUID NOT NULL REFERENCES agents(id),
+            tenant_id UUID NOT NULL REFERENCES tenants(id),
+            run_id VARCHAR(200) NOT NULL,
+            feedback_type VARCHAR(30) NOT NULL,
+            feedback_text TEXT,
+            original_output JSONB,
+            corrected_output JSONB,
+            applied_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_agent_feedback_agent_id "
+        "ON agent_feedback (agent_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_agent_feedback_tenant_id "
+        "ON agent_feedback (tenant_id)"
+    )
     op.execute(
         "ALTER TABLE agents ADD COLUMN IF NOT EXISTS "
         "shadow_model_confidence_current NUMERIC(4, 3)"

--- a/tests/integration/test_alembic_e2e.py
+++ b/tests/integration/test_alembic_e2e.py
@@ -497,6 +497,48 @@ def test_legacy_db_gets_stamped_at_baseline():
     _assert_database_index_health()
 
 
+def test_stamped_legacy_db_repairs_missing_agent_feedback_table():
+    """A stamped production DB may still lack the historical feedback table.
+
+    Reproduce the production v6z7 shape exactly: keep the managed Alembic
+    revision but remove ``agent_feedback`` before upgrading to head.
+    """
+    _reset_schema()
+    _run_migrate_wrapper()
+    command.downgrade(_alembic_cfg(), "v6z7_readiness_security")
+
+    engine = create_engine(_SYNC_URL)
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE agent_feedback"))
+    engine.dispose()
+
+    result = _run_migrate_wrapper()
+    assert result.returncode == 0
+    assert "alembic_version present" in result.stderr
+    assert "agent_feedback" in _table_names()
+
+    engine = create_engine(_SYNC_URL)
+    with engine.connect() as conn:
+        columns = {column["name"] for column in inspect(conn).get_columns("agent_feedback")}
+        version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+    engine.dispose()
+
+    assert {
+        "id",
+        "tenant_id",
+        "agent_id",
+        "run_id",
+        "feedback_type",
+        "source",
+        "source_event_id",
+        "context",
+        "learning_weight",
+        "created_at",
+    } <= columns
+    assert version == _current_head()
+    _assert_database_index_health()
+
+
 def test_already_managed_db_is_noop():
     """A DB that already has alembic_version must take the ``upgrade
     head`` branch, complete cleanly, and exit 0."""


### PR DESCRIPTION
## What changed

- Repair legacy databases that are Alembic-stamped but missing `agent_feedback` before applying the v6z8 shadow-learning changes.
- Recreate the canonical base columns, foreign keys, and legacy indexes idempotently.
- Add a PostgreSQL integration regression that reproduces the production `v6z7` stamped/missing-table shape and upgrades it to head.

## Root cause

The production database reports revision `v6z7_readiness_security`, but its legacy schema never received the historical `agent_feedback` table. Migration v6z8 assumed the table existed and failed on its first `ALTER TABLE`, blocking application startup and production rollout.

## Impact

The repair is a no-op for canonical databases where `agent_feedback` already exists. For drifted databases, it creates the missing base table before the existing idempotent v6z8 column/index/RLS operations. The subsequent v6z9 indexes continue to build concurrently.

## Validation

- `python -m ruff check migrations/versions/v6_z8_shadow_hitl_learning.py tests/integration/test_alembic_e2e.py`
- `python -m pytest tests/unit/test_shadow_hitl_feedback_learning.py -q` (4 passed)
- Added real PostgreSQL migration regression to the CI integration suite
- Confirmed production remains healthy on the prior API/UI revisions after the blocked rollout