### PR TITLE
fix: repair legacy foreign key indexes

### DIFF
--- a/migrations/versions/v6_z10_legacy_fk_indexes.py
+++ b/migrations/versions/v6_z10_legacy_fk_indexes.py
@@ -1,0 +1,64 @@
+# ruff: noqa: S608
+"""Repair leading foreign-key indexes missing from legacy databases.
+
+Revision ID: v6z10_legacy_fk_indexes
+Revises: v6z9_query_performance
+Create Date: 2026-08-09
+
+Some production databases were stamped past historical CA-firm migrations
+without receiving the single-column indexes emitted by current ORM metadata.
+The post-migration catalog audit correctly rejects those schemas. Build the
+missing indexes concurrently so the repair does not block writes to live
+tables.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "v6z10_legacy_fk_indexes"
+down_revision = "v6z9_query_performance"
+branch_labels = None
+depends_on = None
+
+
+_INDEXES: tuple[tuple[str, str, str], ...] = (
+    ("ix_ca_client_invoices_company_id", "ca_client_invoices", "company_id"),
+    ("ix_ca_client_payments_company_id", "ca_client_payments", "company_id"),
+    ("ix_ca_client_payments_invoice_id", "ca_client_payments", "invoice_id"),
+    ("ix_client_portal_documents_company_id", "client_portal_documents", "company_id"),
+    ("ix_client_portal_invites_company_id", "client_portal_invites", "company_id"),
+    ("ix_filing_approvals_company_id", "filing_approvals", "company_id"),
+    ("ix_gstn_credentials_tenant_id", "gstn_credentials", "tenant_id"),
+    ("ix_gstn_uploads_company_id", "gstn_uploads", "company_id"),
+    (
+        "ix_professional_tax_registrations_company_id",
+        "professional_tax_registrations",
+        "company_id",
+    ),
+    (
+        "ix_professional_tax_returns_company_id",
+        "professional_tax_returns",
+        "company_id",
+    ),
+    (
+        "ix_professional_tax_returns_registration_id",
+        "professional_tax_returns",
+        "registration_id",
+    ),
+)
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        for index_name, table_name, column_name in _INDEXES:
+            op.execute(
+                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {index_name} "
+                f"ON {table_name} ({column_name})"
+            )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        for index_name, _, _ in reversed(_INDEXES):
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}")

--- a/tests/integration/test_alembic_e2e.py
+++ b/tests/integration/test_alembic_e2e.py
@@ -53,6 +53,19 @@ _READINESS_TRIGGERS = {
     "capability_promotion_chain",
     "capability_promotion_events_immutable",
 }
+_LEGACY_FK_INDEXES = {
+    "ix_ca_client_invoices_company_id",
+    "ix_ca_client_payments_company_id",
+    "ix_ca_client_payments_invoice_id",
+    "ix_client_portal_documents_company_id",
+    "ix_client_portal_invites_company_id",
+    "ix_filing_approvals_company_id",
+    "ix_gstn_credentials_tenant_id",
+    "ix_gstn_uploads_company_id",
+    "ix_professional_tax_registrations_company_id",
+    "ix_professional_tax_returns_company_id",
+    "ix_professional_tax_returns_registration_id",
+}
 
 
 def _pg_available() -> bool:
@@ -535,6 +548,47 @@ def test_stamped_legacy_db_repairs_missing_agent_feedback_table():
         "learning_weight",
         "created_at",
     } <= columns
+    assert version == _current_head()
+    _assert_database_index_health()
+
+
+def test_v6z10_repairs_legacy_foreign_key_index_drift():
+    """Upgrade a v6z9 catalog missing ORM-created foreign-key indexes."""
+    _reset_schema()
+    _run_migrate_wrapper()
+    command.downgrade(_alembic_cfg(), "v6z9_query_performance")
+
+    engine = create_engine(_SYNC_URL)
+    with engine.connect() as conn:
+        indexes_before = set(
+            conn.execute(
+                text(
+                    "SELECT indexname FROM pg_indexes "
+                    "WHERE schemaname = current_schema()"
+                )
+            ).scalars()
+        )
+    engine.dispose()
+    assert not (_LEGACY_FK_INDEXES & indexes_before)
+
+    result = _run_migrate_wrapper()
+    assert result.returncode == 0
+    assert "alembic_version present" in result.stderr
+
+    engine = create_engine(_SYNC_URL)
+    with engine.connect() as conn:
+        indexes_after = set(
+            conn.execute(
+                text(
+                    "SELECT indexname FROM pg_indexes "
+                    "WHERE schemaname = current_schema()"
+                )
+            ).scalars()
+        )
+        version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+    engine.dispose()
+
+    assert _LEGACY_FK_INDEXES <= indexes_after
     assert version == _current_head()
     _assert_database_index_health()
 


### PR DESCRIPTION
## What changed

- Add forward migration `v6z10_legacy_fk_indexes` after the already-applied v6z9 revision.
- Build the 11 leading foreign-key indexes missing from the production legacy catalog using `CREATE INDEX CONCURRENTLY IF NOT EXISTS`.
- Add a PostgreSQL regression that downgrades to v6z9, verifies the repair indexes are absent, upgrades to head, and requires the catalog audit to pass.

## Root cause

The repaired v6z8 migration completed in production and v6z9 ran, but the migration job's post-upgrade catalog audit found 11 unindexed foreign keys on legacy CA/client-portal tables. Current ORM bootstraps create those indexes automatically, so the existing CI scenarios did not reproduce a stamped production catalog that lacked them.

## Impact

The migration is idempotent and builds indexes concurrently to keep live tables writable. Fresh/canonical databases retain their existing indexes; drifted databases receive only the missing leading indexes.

## Validation

- `python -m ruff check migrations/versions/v6_z10_legacy_fk_indexes.py tests/integration/test_alembic_e2e.py`
- `python -m alembic heads` -> `v6z10_legacy_fk_indexes (head)`
- `python -m pytest tests/unit/test_shadow_hitl_feedback_learning.py -q` -> 4 passed
- Added real PostgreSQL upgrade/audit regression to CI integration tests
- Production remains healthy on the prior API/UI revisions; failed release revisions have 0% traffic