### PR TITLE
fix: remove pip from production runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,15 @@ RUN useradd -m agenticorg
 WORKDIR /app
 COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
+# The runtime does not install packages. Validate the copied environment, then
+# remove pip and its vendored SBOM: Trivy otherwise treats build-only entries
+# in pip/_vendor/bom.cdx.json as installed runtime dependencies. Remove the
+# paths explicitly because copying site-packages over the runtime base can
+# overlay two pip versions that a normal uninstall does not fully clean up.
+RUN python -m pip check \
+    && rm -rf /usr/local/lib/python3.14/site-packages/pip \
+        /usr/local/lib/python3.14/site-packages/pip-*.dist-info \
+        /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.14
 COPY . .
 USER agenticorg
 EXPOSE 8000

--- a/tests/regression/test_security_audit_20260613_dependency_gates.py
+++ b/tests/regression/test_security_audit_20260613_dependency_gates.py
@@ -101,3 +101,12 @@ def test_runtime_image_does_not_install_curl_for_healthcheck() -> None:
     runtime_stage = dockerfile.split("FROM python:3.14-slim@sha256:", 2)[2]
     assert " curl " not in runtime_stage
     assert "urllib.request.urlopen" in runtime_stage
+
+
+def test_runtime_image_validates_dependencies_and_removes_pip() -> None:
+    dockerfile = (REPO / "Dockerfile").read_text(encoding="utf-8")
+    runtime_stage = dockerfile.split("FROM python:3.14-slim@sha256:", 2)[2]
+    assert "python -m pip check" in runtime_stage
+    assert "/site-packages/pip " in runtime_stage
+    assert "/site-packages/pip-*.dist-info" in runtime_stage
+    assert "/usr/local/bin/pip3.14" in runtime_stage


### PR DESCRIPTION
## Summary
- validate the copied production dependency environment with `pip check`
- remove pip's runtime module, metadata, and entry points after the build
- prevent Trivy from treating build-only entries in pip's vendored CycloneDX SBOM as installed runtime dependencies
- add a regression gate for the runtime hardening

## Verification
- focused regression suite: 10 passed
- Ruff: passed
- clean no-cache production image build: passed
- runtime imports and spaCy model load: passed
- pip absent and setuptools 84.0.0 active: verified
- Trivy 0.70.0 HIGH/CRITICAL `--ignore-unfixed --exit-code 1`: passed with zero findings

The local foreground boot progressed through application import and server startup, then stopped only because the disposable test container had no PostgreSQL service configured.