### PR TITLE
Fix shadow learning to graduate routine HITL safely

### DIFF
--- a/api/v1/agents.py
+++ b/api/v1/agents.py
@@ -411,7 +411,7 @@ _MIN_PRODUCTION_SHADOW_ACCURACY = Decimal("0.600")
 
 def _agent_to_dict(agent: Agent) -> dict:
     """Convert an Agent ORM instance to a JSON-serialisable dict."""
-    return {
+    payload = {
         "id": str(agent.id),
         "company_id": str(agent.company_id) if getattr(agent, "company_id", None) else None,
         "name": agent.name,
@@ -438,6 +438,7 @@ def _agent_to_dict(agent: Agent) -> dict:
         "shadow_min_samples": agent.shadow_min_samples,
         "shadow_accuracy_floor": float(agent.shadow_accuracy_floor),
         "shadow_sample_count": agent.shadow_sample_count,
+        "shadow_scored_sample_count": agent.shadow_scored_sample_count,
         "shadow_accuracy_current": float(agent.shadow_accuracy_current)
         if agent.shadow_accuracy_current is not None
         else None,
@@ -477,6 +478,10 @@ def _agent_to_dict(agent: Agent) -> dict:
         # but no Gmail connector linked" before the agent crashes at runtime.
         "connector_ids": getattr(agent, "connector_ids", None) or [],
     }
+    from core.feedback.shadow_learning import learned_review_policy
+
+    payload["review_learning"] = learned_review_policy(agent)
+    return payload
 
 
 def _parse_company_id(company_id: str | None) -> _uuid.UUID | None:
@@ -2530,6 +2535,7 @@ async def run_agent(
             )
 
         agent_config = _agent_to_dict(agent_row)
+        review_learning = agent_config["review_learning"]
         dispatch_connector_ids = _required_connector_ids_for_agent(agent_row)
 
     # 2. Prepare execution config
@@ -2926,8 +2932,12 @@ async def run_agent(
                     "context": payload.get("context", {}),
                 },
                 llm_model=agent_config.get("llm_model", ""),
-                confidence_floor=float(agent_config.get("confidence_floor", 0.88)),
-                hitl_condition=agent_config.get("hitl_condition", ""),
+                confidence_floor=float(review_learning["effective_confidence_floor"]),
+                hitl_condition=(
+                    ""
+                    if review_learning["confidence_condition_suppressed"]
+                    else agent_config.get("hitl_condition", "")
+                ),
                 grant_token=grant_token,
                 connector_config=resolved_connector_config,
                 connector_names=connector_names_for_tools,
@@ -3016,7 +3026,11 @@ async def run_agent(
                 agent_id=agent_id,
                 workflow_run_id=None,
                 title=f"HITL: {agent_config['agent_type']} — {hitl_trigger}",
-                trigger_type="confidence_below_floor",
+                trigger_type=(
+                    "confidence_below_floor"
+                    if str(hitl_trigger).startswith("confidence ")
+                    else "policy_condition"
+                ),
                 priority="high" if task_confidence < 0.7 else "normal",
                 assignee_role=agent_config.get("domain", "admin"),
                 decision_options={
@@ -3068,16 +3082,17 @@ async def run_agent(
                     sql_text(
                         "UPDATE agents SET "
                         "shadow_sample_count = COALESCE(shadow_sample_count, 0) + 1, "
+                        "shadow_scored_sample_count = COALESCE(shadow_scored_sample_count, 0) + 1, "
                         "shadow_model_confidence_current = ROUND(CAST("
                         "  (COALESCE(shadow_model_confidence_current, shadow_accuracy_current, 0) "
-                        "   * COALESCE(shadow_sample_count, 0) + :confidence) "
-                        "  / (COALESCE(shadow_sample_count, 0) + 1) AS NUMERIC), 3), "
+                        "   * COALESCE(shadow_scored_sample_count, 0) + :confidence) "
+                        "  / (COALESCE(shadow_scored_sample_count, 0) + 1) AS NUMERIC), 3), "
                         "shadow_accuracy_current = ROUND(CAST("
                         "  ((COALESCE(shadow_model_confidence_current, shadow_accuracy_current, 0) "
-                        "    * COALESCE(shadow_sample_count, 0)) + :confidence + "
+                        "    * COALESCE(shadow_scored_sample_count, 0)) + :confidence + "
                         "   (COALESCE(shadow_human_confidence_current, 0) "
                         "    * COALESCE(shadow_feedback_count, 0) * 3)) / "
-                        "  (COALESCE(shadow_sample_count, 0) + 1 + "
+                        "  (COALESCE(shadow_scored_sample_count, 0) + 1 + "
                         "   COALESCE(shadow_feedback_count, 0) * 3) AS NUMERIC), 3) "
                         "WHERE id = :agent_id AND tenant_id = :tenant_id"
                     ),
@@ -3159,6 +3174,7 @@ async def run_agent(
         },
         "hitl_trigger": hitl_trigger or None,
         "error": task_error or None,
+        "review_learning": review_learning,
     }
     if incoming_action == "shadow_sample":
         response["shadow_metrics"] = shadow_metrics
@@ -3339,11 +3355,14 @@ async def promote_agent(agent_id: UUID, tenant_id: str = Depends(get_current_ten
         # For shadow->active, validate minimum shadow samples met
         # Skip validation entirely when shadow_min_samples=0 (opt-out)
         if agent.status == "shadow" and agent.shadow_min_samples > 0:
-            if agent.shadow_sample_count < agent.shadow_min_samples:
+            from core.feedback.shadow_learning import scored_shadow_sample_count
+
+            scored_samples = scored_shadow_sample_count(agent)
+            if scored_samples < agent.shadow_min_samples:
                 raise HTTPException(
                     409,
-                    f"Shadow agent has {agent.shadow_sample_count}/{agent.shadow_min_samples} samples; "
-                    f"cannot promote until minimum is met",
+                    f"Shadow agent has {scored_samples}/{agent.shadow_min_samples} scored samples "
+                    f"({agent.shadow_sample_count} total); cannot promote until minimum is met",
                 )
             if agent.shadow_accuracy_current is None:
                 raise HTTPException(
@@ -3506,6 +3525,7 @@ async def retest_agent(agent_id: UUID, tenant_id: str = Depends(get_current_tena
         old_accuracy = float(agent.shadow_accuracy_current) if agent.shadow_accuracy_current is not None else None
 
         agent.shadow_sample_count = 0
+        agent.shadow_scored_sample_count = 0
         agent.shadow_accuracy_current = None
         agent.shadow_model_confidence_current = None
         agent.shadow_human_confidence_current = None

--- a/api/v1/approvals.py
+++ b/api/v1/approvals.py
@@ -370,14 +370,19 @@ async def decide(
     learning_result: dict = {}
 
     # P2.1: capture decision_by from authenticated user (always required)
-    user_id_str = user_claims.get("sub") or user_claims.get("agenticorg:user_id") or ""
+    # Prefer the canonical local user UUID. OIDC ``sub`` is commonly an email
+    # or provider-specific opaque string and cannot populate decision_by's UUID
+    # foreign key, which previously left authenticated decisions unattributed.
+    user_id_str = user_claims.get("agenticorg:user_id") or user_claims.get("sub") or ""
     user_name = user_claims.get("name") or user_claims.get("email") or "unknown"
     if not user_id_str:
         raise HTTPException(401, "Cannot identify user — missing 'sub' claim")
 
     async with get_tenant_session(tid) as session:
         result = await session.execute(
-            select(HITLQueue).where(HITLQueue.id == hitl_id, HITLQueue.tenant_id == tid)
+            select(HITLQueue)
+            .where(HITLQueue.id == hitl_id, HITLQueue.tenant_id == tid)
+            .with_for_update()
         )
         item = result.scalar_one_or_none()
         if not item:
@@ -528,12 +533,24 @@ async def decide(
                 step = step_res.scalar_one_or_none()
 
             if step is not None:
+                duplicate_vote = any(
+                    str(vote.get("user_id") or "") == user_id_str
+                    and int(vote.get("sequence") or current_seq) == int(step.sequence)
+                    for vote in approvals_history
+                    if isinstance(vote, dict)
+                )
+                if duplicate_vote:
+                    raise HTTPException(
+                        409,
+                        "This reviewer has already voted on the current approval step",
+                    )
                 pdec = apply_decision(step, approvals_collected, body.decision or "approve")
                 policy_action = pdec.action
                 approvals_history.append(
                     {
                         "user_id": user_id_str,
                         "decision": body.decision,
+                        "sequence": step.sequence,
                         "at": datetime.now(UTC).isoformat(),
                     }
                 )

--- a/core/feedback/shadow_learning.py
+++ b/core/feedback/shadow_learning.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Any
 
@@ -13,7 +14,13 @@ from core.models.feedback import AgentFeedback
 from core.models.hitl import HITLQueue
 
 HUMAN_EVIDENCE_WEIGHT = Decimal("3.00")
+MIN_HUMAN_REVIEWS_FOR_LEARNED_AUTONOMY = 3
+LEARNED_ROUTINE_CONFIDENCE_FLOOR = Decimal("0.600")
 _MILLI = Decimal("0.001")
+_CONFIDENCE_ONLY_CONDITION = re.compile(
+    r"^\s*confidence\s*(?:<|<=)\s*(?:0(?:\.\d+)?|1(?:\.0+)?)\s*$",
+    re.IGNORECASE,
+)
 
 
 def _q(value: Decimal) -> Decimal:
@@ -33,6 +40,89 @@ def _decision_signal(decision: str, terminal: bool) -> tuple[str, Decimal | None
     if normalized in {"override", "correct", "correction", "edit"}:
         return "hitl_override", Decimal("0.25")
     return "hitl_vote", None
+
+
+def _integer_metric(agent: Any, name: str, fallback: int = 0) -> int:
+    value = getattr(agent, name, None)
+    if isinstance(value, int) and not isinstance(value, bool):
+        return max(value, 0)
+    return max(int(fallback or 0), 0)
+
+
+def scored_shadow_sample_count(agent: Any) -> int:
+    """Return count of samples that actually contributed model confidence.
+
+    The fallback preserves compatibility with rows/mocks created before the
+    dedicated counter existed. Migrated databases backfill the same value.
+    """
+    return _integer_metric(
+        agent,
+        "shadow_scored_sample_count",
+        _integer_metric(agent, "shadow_sample_count"),
+    )
+
+
+def is_confidence_only_condition(condition: str | None) -> bool:
+    """Whether a HITL expression merely duplicates the confidence gate."""
+    return bool(_CONFIDENCE_ONLY_CONDITION.fullmatch(str(condition or "")))
+
+
+def learned_review_policy(agent: Any) -> dict[str, Any]:
+    """Compute the evidence-gated confidence floor for routine review.
+
+    Learning may relax only the generic confidence gate. Explicit amount,
+    policy, workflow, and action-risk approvals remain untouched. A hard 0.60
+    per-run floor also remains in place so an anomalously uncertain run still
+    reaches a human even after the agent has earned routine autonomy.
+    """
+    configured_floor = _q(Decimal(str(getattr(agent, "confidence_floor", 0) or 0)))
+    accuracy_floor = max(
+        _q(Decimal(str(getattr(agent, "shadow_accuracy_floor", 0) or 0))),
+        LEARNED_ROUTINE_CONFIDENCE_FLOOR,
+    )
+    required_samples = _integer_metric(agent, "shadow_min_samples")
+    scored_samples = scored_shadow_sample_count(agent)
+    human_reviews = _integer_metric(agent, "shadow_feedback_count")
+    combined_raw = getattr(agent, "shadow_accuracy_current", None)
+    human_raw = getattr(agent, "shadow_human_confidence_current", None)
+    combined = _q(Decimal(str(combined_raw))) if combined_raw is not None else None
+    human = _q(Decimal(str(human_raw))) if human_raw is not None else None
+    status = str(getattr(agent, "status", "") or "")
+
+    reason = "learned_routine_autonomy_enabled"
+    eligible = True
+    if status not in {"shadow", "active"}:
+        eligible, reason = False, "agent_status_not_learning"
+    elif required_samples <= 0:
+        eligible, reason = False, "shadow_learning_disabled"
+    elif scored_samples < required_samples:
+        eligible, reason = False, "insufficient_scored_samples"
+    elif human_reviews < MIN_HUMAN_REVIEWS_FOR_LEARNED_AUTONOMY:
+        eligible, reason = False, "insufficient_human_reviews"
+    elif combined is None or combined < accuracy_floor:
+        eligible, reason = False, "combined_confidence_below_floor"
+    elif human is None or human < accuracy_floor:
+        eligible, reason = False, "human_confidence_below_floor"
+
+    effective_floor = (
+        LEARNED_ROUTINE_CONFIDENCE_FLOOR if eligible else configured_floor
+    )
+    confidence_condition_suppressed = eligible and is_confidence_only_condition(
+        getattr(agent, "hitl_condition", "")
+    )
+    return {
+        "autonomy_eligible": eligible,
+        "reason": reason,
+        "configured_confidence_floor": float(configured_floor),
+        "effective_confidence_floor": float(effective_floor),
+        "required_scored_samples": required_samples,
+        "scored_samples": scored_samples,
+        "required_human_reviews": MIN_HUMAN_REVIEWS_FOR_LEARNED_AUTONOMY,
+        "human_reviews": human_reviews,
+        "combined_confidence": float(combined) if combined is not None else None,
+        "human_confidence": float(human) if human is not None else None,
+        "confidence_condition_suppressed": confidence_condition_suppressed,
+    }
 
 
 async def capture_hitl_feedback(
@@ -81,7 +171,7 @@ async def capture_hitl_feedback(
     after = before
 
     if ran_in_shadow and human_signal is not None:
-        model_count = int(agent.shadow_sample_count or 0)
+        model_count = scored_shadow_sample_count(agent)
         model_average = agent.shadow_model_confidence_current
         if model_average is None:
             model_average = agent.shadow_accuracy_current

--- a/core/feedback/shadow_learning.py
+++ b/core/feedback/shadow_learning.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from typing import Any
 
 from sqlalchemy import select
@@ -49,6 +49,23 @@ def _integer_metric(agent: Any, name: str, fallback: int = 0) -> int:
     return max(int(fallback or 0), 0)
 
 
+def _decimal_metric(
+    agent: Any,
+    name: str,
+    fallback: Decimal | None = None,
+) -> Decimal | None:
+    value = getattr(agent, name, None)
+    if isinstance(value, bool) or not isinstance(value, (Decimal, int, float, str)):
+        return fallback
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return fallback
+    if not parsed.is_finite():
+        return fallback
+    return _q(parsed)
+
+
 def scored_shadow_sample_count(agent: Any) -> int:
     """Return count of samples that actually contributed model confidence.
 
@@ -75,18 +92,25 @@ def learned_review_policy(agent: Any) -> dict[str, Any]:
     per-run floor also remains in place so an anomalously uncertain run still
     reaches a human even after the agent has earned routine autonomy.
     """
-    configured_floor = _q(Decimal(str(getattr(agent, "confidence_floor", 0) or 0)))
+    configured_floor = _decimal_metric(
+        agent,
+        "confidence_floor",
+        Decimal("0"),
+    ) or Decimal("0")
     accuracy_floor = max(
-        _q(Decimal(str(getattr(agent, "shadow_accuracy_floor", 0) or 0))),
+        _decimal_metric(
+            agent,
+            "shadow_accuracy_floor",
+            Decimal("0"),
+        )
+        or Decimal("0"),
         LEARNED_ROUTINE_CONFIDENCE_FLOOR,
     )
     required_samples = _integer_metric(agent, "shadow_min_samples")
     scored_samples = scored_shadow_sample_count(agent)
     human_reviews = _integer_metric(agent, "shadow_feedback_count")
-    combined_raw = getattr(agent, "shadow_accuracy_current", None)
-    human_raw = getattr(agent, "shadow_human_confidence_current", None)
-    combined = _q(Decimal(str(combined_raw))) if combined_raw is not None else None
-    human = _q(Decimal(str(human_raw))) if human_raw is not None else None
+    combined = _decimal_metric(agent, "shadow_accuracy_current")
+    human = _decimal_metric(agent, "shadow_human_confidence_current")
     status = str(getattr(agent, "status", "") or "")
 
     reason = "learned_routine_autonomy_enabled"

--- a/core/models/agent.py
+++ b/core/models/agent.py
@@ -108,6 +108,13 @@ class Agent(BaseModel):
         Numeric(4, 3), nullable=False, default=Decimal("0.800")
     )
     shadow_sample_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # Total samples and scored samples are deliberately separate. A completed
+    # shadow run can be useful operational evidence while still lacking a
+    # trustworthy confidence signal. Mixing those rows into the model-average
+    # denominator made the next scored run look artificially close to zero.
+    shadow_scored_sample_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0
+    )
     shadow_accuracy_current: Mapped[Decimal | None] = mapped_column(Numeric(4, 3), nullable=True)
     shadow_model_confidence_current: Mapped[Decimal | None] = mapped_column(
         Numeric(4, 3), nullable=True

--- a/core/schemas/api.py
+++ b/core/schemas/api.py
@@ -59,7 +59,7 @@ class AgentCreate(BaseModel):
     output_schema: str | None = None
     initial_status: str = "shadow"
     shadow_comparison_agent: str | None = None
-    shadow_min_samples: int = 20
+    shadow_min_samples: int = 10
     # BUG-012 (Ramesh 2026-04-20): aligned with the ORM default —
     # 0.95 was unrealistic for LLM-driven agents; see
     # core/models/agent.py for the full rationale.
@@ -118,10 +118,12 @@ class AgentResponse(BaseModel):
     version: str
     confidence_floor: float
     shadow_sample_count: int = 0
+    shadow_scored_sample_count: int = 0
     shadow_accuracy_current: float | None = None
     shadow_model_confidence_current: float | None = None
     shadow_human_confidence_current: float | None = None
     shadow_feedback_count: int = 0
+    review_learning: dict[str, Any] = Field(default_factory=dict)
     company_id: UUID | None = None
     created_at: datetime
 

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -410,7 +410,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.list",
-    "source_line": 1606,
+    "source_line": 1611,
     "tenant_required": true
   },
   {
@@ -428,7 +428,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 1359,
+    "source_line": 1364,
     "tenant_required": true
   },
   {
@@ -446,7 +446,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.tools.sensitive.read",
-    "source_line": 1313,
+    "source_line": 1318,
     "tenant_required": true
   },
   {
@@ -464,7 +464,7 @@
     "public_exempt_reason": null,
     "rate_limit": "ai-generation",
     "scope": "agents.generate",
-    "source_line": 2045,
+    "source_line": 2050,
     "tenant_required": true
   },
   {
@@ -482,7 +482,7 @@
     "public_exempt_reason": null,
     "rate_limit": "file-upload",
     "scope": "agents.import",
-    "source_line": 1857,
+    "source_line": 1862,
     "tenant_required": true
   },
   {
@@ -500,7 +500,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.org_tree",
-    "source_line": 1722,
+    "source_line": 1727,
     "tenant_required": true
   },
   {
@@ -518,7 +518,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 4141,
+    "source_line": 4161,
     "tenant_required": true
   },
   {
@@ -536,7 +536,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.read",
-    "source_line": 2175,
+    "source_line": 2180,
     "tenant_required": true
   },
   {
@@ -554,7 +554,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 2348,
+    "source_line": 2353,
     "tenant_required": true
   },
   {
@@ -572,7 +572,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 2203,
+    "source_line": 2208,
     "tenant_required": true
   },
   {
@@ -590,7 +590,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.amendments.read",
-    "source_line": 4102,
+    "source_line": 4122,
     "tenant_required": true
   },
   {
@@ -608,7 +608,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.budget.read",
-    "source_line": 3826,
+    "source_line": 3846,
     "tenant_required": true
   },
   {
@@ -626,7 +626,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.write",
-    "source_line": 3666,
+    "source_line": 3686,
     "tenant_required": true
   },
   {
@@ -644,7 +644,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-write",
     "scope": "agents.delegate",
-    "source_line": 1783,
+    "source_line": 1788,
     "tenant_required": true
   },
   {
@@ -662,7 +662,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.explanation.read",
-    "source_line": 3969,
+    "source_line": 3989,
     "tenant_required": true
   },
   {
@@ -680,7 +680,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.feedback.list",
-    "source_line": 3941,
+    "source_line": 3961,
     "tenant_required": true
   },
   {
@@ -698,7 +698,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-feedback",
     "scope": "agents.feedback.write",
-    "source_line": 3895,
+    "source_line": 3915,
     "tenant_required": true
   },
   {
@@ -716,7 +716,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.feedback.analyze",
-    "source_line": 4078,
+    "source_line": 4098,
     "tenant_required": true
   },
   {
@@ -734,7 +734,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3181,
+    "source_line": 3197,
     "tenant_required": true
   },
   {
@@ -752,7 +752,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3312,
+    "source_line": 3328,
     "tenant_required": true
   },
   {
@@ -770,7 +770,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "agents.sensitive.prompt_history",
-    "source_line": 3784,
+    "source_line": 3804,
     "tenant_required": true
   },
   {
@@ -788,7 +788,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3227,
+    "source_line": 3243,
     "tenant_required": true
   },
   {
@@ -806,7 +806,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3491,
+    "source_line": 3510,
     "tenant_required": true
   },
   {
@@ -824,7 +824,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3442,
+    "source_line": 3461,
     "tenant_required": true
   },
   {
@@ -842,7 +842,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-control",
     "scope": "agents.lifecycle",
-    "source_line": 3549,
+    "source_line": 3569,
     "tenant_required": true
   },
   {
@@ -860,7 +860,7 @@
     "public_exempt_reason": null,
     "rate_limit": "agent-execution",
     "scope": "agents.execute",
-    "source_line": 2502,
+    "source_line": 2507,
     "tenant_required": true
   },
   {

--- a/migrations/002_core.sql
+++ b/migrations/002_core.sql
@@ -49,6 +49,7 @@ CREATE TABLE agents (
   shadow_min_samples INTEGER NOT NULL DEFAULT 10,
   shadow_accuracy_floor NUMERIC(4,3) NOT NULL DEFAULT 0.950,
   shadow_sample_count INTEGER NOT NULL DEFAULT 0,
+  shadow_scored_sample_count INTEGER NOT NULL DEFAULT 0,
   shadow_accuracy_current NUMERIC(4,3),
   cost_controls JSONB NOT NULL DEFAULT '{}',
   scaling JSONB NOT NULL DEFAULT '{"min_replicas":1,"max_replicas":5}',

--- a/migrations/versions/v6_z11_shadow_scored_samples.py
+++ b/migrations/versions/v6_z11_shadow_scored_samples.py
@@ -1,0 +1,34 @@
+"""Separate scored shadow evidence from unscored completed samples.
+
+Revision ID: v6z11_shadow_scored
+Revises: v6z10_legacy_fk_indexes
+Create Date: 2026-08-10
+"""
+
+from alembic import op
+
+revision = "v6z11_shadow_scored"
+down_revision = "v6z10_legacy_fk_indexes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE agents ADD COLUMN IF NOT EXISTS "
+        "shadow_scored_sample_count INTEGER NOT NULL DEFAULT 0"
+    )
+    # Historical model averages were computed using shadow_sample_count. Treat
+    # those samples as scored when a model average exists; rows without a model
+    # signal remain at zero and cannot satisfy the strengthened promotion gate.
+    op.execute(
+        "UPDATE agents SET shadow_scored_sample_count = shadow_sample_count "
+        "WHERE shadow_model_confidence_current IS NOT NULL "
+        "AND shadow_scored_sample_count = 0"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE agents DROP COLUMN IF EXISTS shadow_scored_sample_count"
+    )

--- a/tests/integration/test_shadow_learning_e2e.py
+++ b/tests/integration/test_shadow_learning_e2e.py
@@ -1,0 +1,268 @@
+"""Real-Postgres E2E coverage for shadow learning and adaptive HITL."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from decimal import Decimal
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+
+from core.database import get_tenant_session
+from core.models.agent import Agent
+from core.models.feedback import AgentFeedback
+from core.models.hitl import HITLQueue
+
+
+@pytest.mark.asyncio
+async def test_shadow_feedback_graduates_routine_review_but_keeps_safety_gates(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    make_auth_headers,
+    tenant_id: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.deps import get_user_role
+    from api.main import app
+
+    monkeypatch.setitem(app.dependency_overrides, get_user_role, lambda: "admin")
+
+    create = await client.post(
+        "/api/v1/agents",
+        headers=auth_headers,
+        json={
+            "name": f"shadow-learning-e2e-{uuid.uuid4().hex[:8]}",
+            "agent_type": "shadow_learning_probe",
+            "domain": "platform",
+            "system_prompt_text": "Return a deterministic test result.",
+            "authorized_tools": [],
+            "confidence_floor": 0.88,
+            "shadow_min_samples": 10,
+            "shadow_accuracy_floor": 0.80,
+            "hitl_policy": {
+                "condition": "confidence < 0.88",
+                "assignee_role": "admin",
+                "timeout_hours": 4,
+                "on_timeout": "escalate",
+            },
+        },
+    )
+    assert create.status_code == 201, create.text
+    agent_id = uuid.UUID(create.json()["agent_id"])
+    tid = uuid.UUID(tenant_id)
+
+    # Seed ten genuine model-scored shadow observations. Human evidence starts
+    # empty so the next routine run must still enter HITL.
+    async with get_tenant_session(tid) as session:
+        agent = (
+            await session.execute(
+                select(Agent).where(Agent.id == agent_id, Agent.tenant_id == tid)
+            )
+        ).scalar_one()
+        agent.shadow_sample_count = 10
+        agent.shadow_scored_sample_count = 10
+        agent.shadow_model_confidence_current = Decimal("0.700")
+        agent.shadow_accuracy_current = Decimal("0.700")
+
+    observed_floors: list[float] = []
+    observed_conditions: list[str] = []
+
+    async def deterministic_run(**kwargs):
+        from core.langgraph.agent_graph import _check_hitl_trigger
+
+        confidence = float(kwargs["task_input"]["inputs"].get("test_confidence", 0.7))
+        output = {
+            "answer": "deterministic",
+            "amount": kwargs["task_input"]["inputs"].get("amount", 0),
+        }
+        floor = float(kwargs["confidence_floor"])
+        condition = str(kwargs["hitl_condition"] or "")
+        observed_floors.append(floor)
+        observed_conditions.append(condition)
+        trigger = _check_hitl_trigger(confidence, floor, condition, output)
+        return {
+            "status": "hitl_triggered" if trigger else "completed",
+            "output": output,
+            "confidence": confidence,
+            "reasoning_trace": ["deterministic shadow-learning E2E"],
+            "tool_calls": [],
+            "hitl_trigger": trigger,
+            "error": "",
+            "performance": {
+                "total_latency_ms": 1,
+                "llm_tokens_used": 0,
+                "llm_cost_usd": 0,
+            },
+        }
+
+    import core.langgraph.runner as runner
+
+    monkeypatch.setattr(runner, "run_agent", deterministic_run)
+
+    confidences: list[float] = []
+    for review_number in range(3):
+        run = await client.post(
+            f"/api/v1/agents/{agent_id}/run",
+            headers=auth_headers,
+            json={
+                "action": "process",
+                "inputs": {
+                    "task": f"routine shadow case {review_number}",
+                    "test_confidence": 0.70,
+                },
+            },
+        )
+        assert run.status_code == 200, run.text
+        assert run.json()["status"] == "hitl_triggered"
+        assert run.json()["review_learning"]["autonomy_eligible"] is False
+
+        pending = await client.get(
+            "/api/v1/approvals",
+            headers=auth_headers,
+            params={"status": "pending", "per_page": 100},
+        )
+        assert pending.status_code == 200, pending.text
+        matching = [
+            item
+            for item in pending.json()["items"]
+            if item["agent_id"] == str(agent_id)
+        ]
+        assert len(matching) == 1
+        assert matching[0]["trigger_type"] == "confidence_below_floor"
+
+        decision = await client.post(
+            f"/api/v1/approvals/{matching[0]['id']}/decide",
+            headers=auth_headers,
+            json={"decision": "approve", "notes": "Correct routine result"},
+        )
+        assert decision.status_code == 200, decision.text
+
+        detail = await client.get(f"/api/v1/agents/{agent_id}", headers=auth_headers)
+        assert detail.status_code == 200, detail.text
+        confidences.append(float(detail.json()["shadow_accuracy_current"]))
+        assert detail.json()["review_learning"]["autonomy_eligible"] is (
+            review_number == 2
+        )
+
+    assert confidences == sorted(confidences)
+    assert confidences[-1] >= 0.80
+
+    # The fourth identical routine case is autonomous: learned evidence lowers
+    # only the generic confidence gate from 0.88 to the hard 0.60 backstop.
+    autonomous = await client.post(
+        f"/api/v1/agents/{agent_id}/run",
+        headers=auth_headers,
+        json={
+            "action": "process",
+            "inputs": {"task": "routine autonomous case", "test_confidence": 0.70},
+        },
+    )
+    assert autonomous.status_code == 200, autonomous.text
+    autonomous_body = autonomous.json()
+    assert autonomous_body["status"] == "completed"
+    assert autonomous_body["hitl_trigger"] is None
+    assert autonomous_body["review_learning"]["autonomy_eligible"] is True
+    assert autonomous_body["review_learning"]["effective_confidence_floor"] == 0.6
+    assert autonomous_body["review_learning"]["confidence_condition_suppressed"] is True
+    assert observed_floors[-1] == 0.6
+    assert observed_conditions[-1] == ""
+
+    # An anomalously low-confidence run still gets human review.
+    low_confidence = await client.post(
+        f"/api/v1/agents/{agent_id}/run",
+        headers=auth_headers,
+        json={
+            "action": "process",
+            "inputs": {"task": "uncertain edge case", "test_confidence": 0.40},
+        },
+    )
+    assert low_confidence.status_code == 200, low_confidence.text
+    assert low_confidence.json()["status"] == "hitl_triggered"
+    assert low_confidence.json()["hitl_trigger"].startswith("confidence ")
+
+    pending = await client.get(
+        "/api/v1/approvals",
+        headers=auth_headers,
+        params={"status": "pending", "per_page": 100},
+    )
+    low_item = next(
+        item
+        for item in pending.json()["items"]
+        if item["agent_id"] == str(agent_id)
+        and item["trigger_type"] == "confidence_below_floor"
+    )
+
+    # Tenant scope is enforced before decision mutation or feedback capture.
+    cross_tenant = await client.post(
+        f"/api/v1/approvals/{low_item['id']}/decide",
+        headers=make_auth_headers(tenant_id=str(uuid.uuid4())),
+        json={"decision": "approve", "notes": "cross-tenant attempt"},
+    )
+    assert cross_tenant.status_code == 404
+
+    # Two simultaneous retries serialize on the queue row: one succeeds and
+    # one receives an intentional conflict, with exactly one feedback record.
+    concurrent = await asyncio.gather(
+        *[
+            client.post(
+                f"/api/v1/approvals/{low_item['id']}/decide",
+                headers=auth_headers,
+                json={"decision": "approve", "notes": "concurrent retry"},
+            )
+            for _ in range(2)
+        ]
+    )
+    assert sorted(response.status_code for response in concurrent) == [200, 409]
+    async with get_tenant_session(tid) as session:
+        feedback_rows = (
+            await session.execute(
+                select(func.count(AgentFeedback.id)).where(
+                    AgentFeedback.tenant_id == tid,
+                    AgentFeedback.source_event_id == f"hitl:{low_item['id']}:action:1",
+                )
+            )
+        ).scalar_one()
+        assert feedback_rows == 1
+
+    # Explicit business-policy conditions are never suppressed by learning.
+    async with get_tenant_session(tid) as session:
+        agent = (
+            await session.execute(
+                select(Agent).where(Agent.id == agent_id, Agent.tenant_id == tid)
+            )
+        ).scalar_one()
+        agent.hitl_condition = "amount > 500000"
+
+    policy_run = await client.post(
+        f"/api/v1/agents/{agent_id}/run",
+        headers=auth_headers,
+        json={
+            "action": "process",
+            "inputs": {
+                "task": "large amount policy case",
+                "test_confidence": 0.95,
+                "amount": 750000,
+            },
+        },
+    )
+    assert policy_run.status_code == 200, policy_run.text
+    assert policy_run.json()["status"] == "hitl_triggered"
+    assert "condition matched" in policy_run.json()["hitl_trigger"]
+    assert observed_conditions[-1] == "amount > 500000"
+
+    async with get_tenant_session(tid) as session:
+        policy_item = (
+            await session.execute(
+                select(HITLQueue)
+                .where(
+                    HITLQueue.tenant_id == tid,
+                    HITLQueue.agent_id == agent_id,
+                    HITLQueue.context["trigger"].astext.like("condition matched:%"),
+                )
+                .order_by(HITLQueue.created_at.desc())
+                .limit(1)
+            )
+        ).scalar_one()
+        assert policy_item.trigger_type == "policy_condition"

--- a/tests/unit/test_agents_and_sales.py
+++ b/tests/unit/test_agents_and_sales.py
@@ -67,6 +67,9 @@ def make_mock_agent(**overrides):
     agent.version = overrides.get("version", "1.0.0")
     agent.confidence_floor = overrides.get("confidence_floor", Decimal("0.880"))
     agent.shadow_sample_count = overrides.get("shadow_sample_count", 0)
+    agent.shadow_scored_sample_count = overrides.get(
+        "shadow_scored_sample_count", agent.shadow_sample_count
+    )
     agent.shadow_min_samples = overrides.get("shadow_min_samples", 10)
     agent.shadow_accuracy_current = overrides.get("shadow_accuracy_current", None)
     agent.shadow_model_confidence_current = overrides.get(
@@ -197,7 +200,7 @@ class TestAgentToDict:
             "retry_backoff", "authorized_tools", "output_schema",
             "parent_agent_id", "shadow_comparison_agent_id",
             "shadow_min_samples", "shadow_accuracy_floor",
-            "shadow_sample_count", "shadow_accuracy_current",
+            "shadow_sample_count", "shadow_scored_sample_count", "shadow_accuracy_current",
             "shadow_model_confidence_current", "shadow_human_confidence_current",
             "shadow_feedback_count",
             "cost_controls", "scaling", "tags", "ttl_hours",
@@ -206,6 +209,7 @@ class TestAgentToDict:
             "specialization", "routing_filter", "is_builtin",
             "system_prompt_text", "reporting_to", "org_level",
             "prompt_amendments", "config",
+            "review_learning",
             # v4.6.0: added so the UI can show GA/BETA badges and
             # cost-center attribution.
             "maturity", "cost_center_id",

--- a/tests/unit/test_langgraph_runtime.py
+++ b/tests/unit/test_langgraph_runtime.py
@@ -253,6 +253,17 @@ class TestAgentGraph:
         trigger = _check_hitl_trigger(0.95, 0.88, "amount > 500000", {"amount": 1000000})
         assert "condition matched" in trigger
 
+    def test_explicit_condition_survives_learned_confidence_floor(self):
+        from core.langgraph.agent_graph import _check_hitl_trigger
+
+        trigger = _check_hitl_trigger(
+            0.95,
+            0.60,
+            "amount > 500000",
+            {"amount": 1000000},
+        )
+        assert "condition matched" in trigger
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Runner

--- a/tests/unit/test_module_4_agent_fleet.py
+++ b/tests/unit/test_module_4_agent_fleet.py
@@ -241,13 +241,12 @@ def test_tc_agt_009_promote_map_only_shadow_to_active() -> None:
 
 def test_tc_agt_009_promote_validates_min_samples() -> None:
     """Foundation #8 false-green prevention: promote MUST refuse
-    with 409 when shadow_sample_count < shadow_min_samples.
-    Without this, an agent with 0 samples could go straight
+    with 409 when scored shadow evidence is below shadow_min_samples.
+    Without this, unscored runs could send an agent straight
     to active."""
     src = (REPO / "api" / "v1" / "agents.py").read_text(encoding="utf-8")
-    assert (
-        "if agent.shadow_sample_count < agent.shadow_min_samples:" in src
-    )
+    assert "if scored_samples < agent.shadow_min_samples:" in src
+    assert "scored_shadow_sample_count(agent)" in src
     assert "cannot promote until minimum is met" in src
 
 

--- a/tests/unit/test_shadow_confidence_noise_floor.py
+++ b/tests/unit/test_shadow_confidence_noise_floor.py
@@ -68,6 +68,25 @@ def test_mixed_window_is_not_dragged_by_zero_confidence_samples() -> None:
     assert new_avg == pytest.approx(0.80, abs=0.001)
 
 
+def test_unscored_samples_do_not_dilute_the_next_model_average() -> None:
+    """Ten operational samples with only one trustworthy score stay at 0.8.
+
+    The old SQL divided by total sample count and produced 0.08 here.
+    """
+    total_samples = 10
+    scored_samples = 0
+    old_model_average = Decimal("0")
+    incoming = Decimal("0.800")
+
+    corrected = (
+        (old_model_average * scored_samples) + incoming
+    ) / (scored_samples + 1)
+    buggy = ((old_model_average * total_samples) + incoming) / (total_samples + 1)
+
+    assert corrected == Decimal("0.800")
+    assert buggy < Decimal("0.100")
+
+
 class TestShadowFloorDefault:
     def test_orm_default_is_080_not_095(self) -> None:
         """BUG-012: default floor was 0.95 which was unreachable for
@@ -90,3 +109,8 @@ class TestShadowFloorDefault:
             AgentCreate.model_fields["shadow_accuracy_floor"].default
             == 0.80
         )
+
+    def test_sample_target_default_matches_orm(self) -> None:
+        from core.schemas.api import AgentCreate
+
+        assert AgentCreate.model_fields["shadow_min_samples"].default == 10

--- a/tests/unit/test_shadow_hitl_feedback_learning.py
+++ b/tests/unit/test_shadow_hitl_feedback_learning.py
@@ -233,6 +233,21 @@ def test_only_simple_confidence_conditions_can_be_suppressed() -> None:
     assert is_confidence_only_condition("") is False
 
 
+def test_non_numeric_or_non_finite_metrics_fail_closed() -> None:
+    for invalid in (object(), "not-a-number", float("nan"), Decimal("Infinity")):
+        agent = _agent()
+        agent.shadow_sample_count = 10
+        agent.shadow_scored_sample_count = 10
+        agent.shadow_feedback_count = 3
+        agent.shadow_accuracy_current = invalid
+        agent.shadow_human_confidence_current = Decimal("1.000")
+
+        policy = learned_review_policy(agent)
+
+        assert policy["autonomy_eligible"] is False
+        assert policy["reason"] == "combined_confidence_below_floor"
+
+
 def test_collector_uses_the_deployed_feedback_schema() -> None:
     source = (
         __import__("pathlib").Path(__file__).parents[2]

--- a/tests/unit/test_shadow_hitl_feedback_learning.py
+++ b/tests/unit/test_shadow_hitl_feedback_learning.py
@@ -9,7 +9,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from core.feedback.shadow_learning import capture_hitl_feedback
+from core.feedback.shadow_learning import (
+    MIN_HUMAN_REVIEWS_FOR_LEARNED_AUTONOMY,
+    capture_hitl_feedback,
+    is_confidence_only_condition,
+    learned_review_policy,
+)
 
 
 class _ScalarResult:
@@ -38,7 +43,12 @@ def _hitl_item(*, status: str = "shadow") -> SimpleNamespace:
 def _agent(*, status: str = "shadow") -> SimpleNamespace:
     return SimpleNamespace(
         status=status,
+        confidence_floor=Decimal("0.880"),
+        hitl_condition="confidence < 0.88",
+        shadow_min_samples=10,
+        shadow_accuracy_floor=Decimal("0.800"),
         shadow_sample_count=4,
+        shadow_scored_sample_count=4,
         shadow_accuracy_current=Decimal("0.700"),
         shadow_model_confidence_current=Decimal("0.700"),
         shadow_feedback_count=0,
@@ -115,6 +125,112 @@ async def test_nonterminal_vote_is_captured_without_changing_confidence() -> Non
     assert result["confidence_after"] == result["confidence_before"]
     assert agent.shadow_feedback_count == 0
     assert captured[0].learning_weight == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_approved_shadow_feedback_progressively_unlocks_routine_autonomy() -> None:
+    agent = _agent()
+    agent.shadow_sample_count = 10
+    agent.shadow_scored_sample_count = 10
+    observed = []
+
+    for review_number in range(1, MIN_HUMAN_REVIEWS_FOR_LEARNED_AUTONOMY + 1):
+        item = _hitl_item()
+        session = MagicMock()
+        session.execute = AsyncMock(side_effect=[_ScalarResult(None), _ScalarResult(agent)])
+        session.add.side_effect = lambda row: setattr(row, "id", uuid.uuid4())
+        session.flush = AsyncMock()
+
+        result = await capture_hitl_feedback(
+            session,
+            item=item,
+            decision="approve",
+            notes=f"Accepted review {review_number}",
+            actor_id=f"reviewer-{review_number}",
+            actor_role="admin",
+            actor_name="Reviewer",
+            policy_action="advance",
+            policy_state=None,
+            delegated_from=None,
+        )
+        observed.append(result["confidence_after"])
+
+    assert observed == sorted(observed)
+    assert observed[0] == pytest.approx(0.769)
+    assert observed[-1] == pytest.approx(0.842)
+
+    policy = learned_review_policy(agent)
+    assert policy["autonomy_eligible"] is True
+    assert policy["effective_confidence_floor"] == 0.6
+    assert policy["confidence_condition_suppressed"] is True
+
+
+def test_learning_never_suppresses_explicit_policy_conditions() -> None:
+    agent = _agent()
+    agent.shadow_sample_count = 10
+    agent.shadow_scored_sample_count = 10
+    agent.shadow_feedback_count = 3
+    agent.shadow_accuracy_current = Decimal("0.900")
+    agent.shadow_human_confidence_current = Decimal("1.000")
+    agent.hitl_condition = "amount > 500000"
+
+    policy = learned_review_policy(agent)
+
+    assert policy["autonomy_eligible"] is True
+    assert policy["confidence_condition_suppressed"] is False
+
+
+def test_learned_autonomy_enforces_hard_floor_for_permissive_legacy_config() -> None:
+    agent = _agent()
+    agent.confidence_floor = Decimal("0.400")
+    agent.shadow_sample_count = 10
+    agent.shadow_scored_sample_count = 10
+    agent.shadow_feedback_count = 3
+    agent.shadow_accuracy_current = Decimal("0.900")
+    agent.shadow_human_confidence_current = Decimal("1.000")
+
+    policy = learned_review_policy(agent)
+
+    assert policy["autonomy_eligible"] is True
+    assert policy["effective_confidence_floor"] == 0.6
+
+
+@pytest.mark.parametrize(
+    "mutation,reason",
+    [
+        ({"shadow_scored_sample_count": 9}, "insufficient_scored_samples"),
+        ({"shadow_feedback_count": 2}, "insufficient_human_reviews"),
+        ({"shadow_accuracy_current": Decimal("0.799")}, "combined_confidence_below_floor"),
+        ({"shadow_human_confidence_current": Decimal("0.799")}, "human_confidence_below_floor"),
+        ({"status": "paused"}, "agent_status_not_learning"),
+    ],
+)
+def test_learned_autonomy_fails_closed_when_any_evidence_gate_regresses(
+    mutation: dict,
+    reason: str,
+) -> None:
+    agent = _agent()
+    agent.shadow_sample_count = 10
+    agent.shadow_scored_sample_count = 10
+    agent.shadow_feedback_count = 3
+    agent.shadow_accuracy_current = Decimal("0.900")
+    agent.shadow_human_confidence_current = Decimal("1.000")
+    for field, value in mutation.items():
+        setattr(agent, field, value)
+
+    policy = learned_review_policy(agent)
+
+    assert policy["autonomy_eligible"] is False
+    assert policy["reason"] == reason
+    assert policy["effective_confidence_floor"] == 0.88
+
+
+def test_only_simple_confidence_conditions_can_be_suppressed() -> None:
+    assert is_confidence_only_condition("confidence < 0.88") is True
+    assert is_confidence_only_condition(" confidence <= 1.0 ") is True
+    assert is_confidence_only_condition("amount < 100") is False
+    assert is_confidence_only_condition("confidence < 0.8 or amount < 100") is False
+    assert is_confidence_only_condition("") is False
 
 
 def test_collector_uses_the_deployed_feedback_schema() -> None:


### PR DESCRIPTION
## What changed

- learn an agent's confidence calibration from terminal human approval/rejection feedback in shadow mode
- separate scored confidence evidence from unscored operational samples so averages and promotion gates cannot be diluted
- graduate routine confidence-only reviews after 10 scored samples, 3 human reviews, and both combined/human confidence meet the configured evidence floor
- retain a hard 0.60 per-run anomaly floor and preserve explicit business-policy/action-risk approvals
- serialize approval decisions, reject duplicate reviewers on a policy step, preserve tenant isolation, and record the canonical local reviewer UUID
- expose review-learning eligibility and evidence through agent/run API responses
- add migration/backfill plus full real Postgres/Redis E2E coverage

## Root cause

Human decisions already updated shadow confidence, but runtime HITL continued using the original static confidence threshold forever. The historical model average also used all completed samples as its denominator, including samples without trustworthy confidence, which could collapse the next valid score.

## Impact

Routine runs can stop requiring a human only after sufficient scored and reviewed evidence. Low-confidence anomalies and explicit policy conditions still fail closed to HITL. Manual shadow-to-active promotion remains governed separately.

## Validation

- 360 affected-area unit/API tests passed
- 67 focused safety regression tests passed after final hard-floor tightening
- 44 real Postgres/Redis API and E2E tests passed
- 10 destructive disposable-database migration, downgrade/upgrade, index, trigger, and RLS tests passed
- Ruff passed on all changed Python files
- Mypy passed across 1,005 source files
- clean database upgraded to `v6z11_shadow_scored`
