### PR TITLE
deps: update FlagEmbedding requirement to 1.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ v4 = [
 bge-m3 = [
     # Heavy in-process BGE-M3 loader. This pulls PyTorch, so it stays out
     # of the production API image; production should use AGENTICORG_TEI_URL.
-    "FlagEmbedding>=1.4.0",
+    "FlagEmbedding>=1.4.1",
 ]
 dev = [
     "pytest>=8.4.2",

--- a/tests/regression/test_security_audit_20260613_dependency_gates.py
+++ b/tests/regression/test_security_audit_20260613_dependency_gates.py
@@ -56,8 +56,8 @@ def test_vulnerable_jwt_stack_is_not_in_production_dependencies() -> None:
 
 def test_bge_m3_loader_is_explicit_extra_only() -> None:
     extras = _pyproject()["project"]["optional-dependencies"]
-    assert "FlagEmbedding>=1.4.0" in extras["bge-m3"]
-    assert "FlagEmbedding>=1.4.0" not in extras["v4"]
+    assert "flagembedding" in _dependency_names(extras["bge-m3"])
+    assert "flagembedding" not in _dependency_names(extras["v4"])
 
 
 def test_requirements_v4_stays_installable_without_unsafe_optional_sdks() -> None:


### PR DESCRIPTION
Replaces #1171 after its repaired Dependabot branch stopped emitting synchronize checks. Updates the optional bge-m3 extra to FlagEmbedding 1.4.1 and makes the placement regression gate version-neutral. No production base or v4 dependency change.