### PR TITLE
Fix local Docker E2E credentials and stale regressions

### DIFF
--- a/scripts/local_e2e.sh
+++ b/scripts/local_e2e.sh
@@ -58,12 +58,25 @@ LOCAL_UI_MODE="${LOCAL_UI_MODE:-preview}"
 API_URL="http://localhost:${LOCAL_API_PORT}"
 SPEC_ARGS=("$@")
 
-# Demo creds match core/seed_ca_demo.py DEMO_USER_EMAIL / DEMO_USER_PASSWORD.
-# The CA-firms seeder is what runs in our bootstrap step below. It creates
-# this primary demo partner plus the documented CxO role accounts used by
-# the wider regression suite.
-DEMO_EMAIL="demo@cafirm.agenticorg.ai"
-DEMO_PASSWORD="demo123!"
+# Local-only demo credentials consumed by core/seed_ca_demo.py and the
+# Playwright role-authorization regressions. Every password satisfies the
+# seeder's minimum length and can be overridden by the caller.
+DEMO_EMAIL="${AGENTICORG_DEMO_USER_EMAIL:-demo@cafirm.agenticorg.ai}"
+DEMO_PASSWORD="${AGENTICORG_DEMO_USER_PASSWORD:-local-e2e-demo-123!}"
+export AGENTICORG_DEMO_USER_EMAIL="${DEMO_EMAIL}"
+export AGENTICORG_DEMO_USER_PASSWORD="${DEMO_PASSWORD}"
+export AGENTICORG_DEMO_CEO_EMAIL="${AGENTICORG_DEMO_CEO_EMAIL:-ceo@agenticorg.local}"
+export AGENTICORG_DEMO_CEO_PASSWORD="${AGENTICORG_DEMO_CEO_PASSWORD:-local-e2e-ceo-123!}"
+export AGENTICORG_DEMO_CFO_EMAIL="${AGENTICORG_DEMO_CFO_EMAIL:-cfo@agenticorg.local}"
+export AGENTICORG_DEMO_CFO_PASSWORD="${AGENTICORG_DEMO_CFO_PASSWORD:-local-e2e-cfo-123!}"
+export AGENTICORG_DEMO_CHRO_EMAIL="${AGENTICORG_DEMO_CHRO_EMAIL:-chro@agenticorg.local}"
+export AGENTICORG_DEMO_CHRO_PASSWORD="${AGENTICORG_DEMO_CHRO_PASSWORD:-local-e2e-chro-123!}"
+export AGENTICORG_DEMO_CMO_EMAIL="${AGENTICORG_DEMO_CMO_EMAIL:-cmo@agenticorg.local}"
+export AGENTICORG_DEMO_CMO_PASSWORD="${AGENTICORG_DEMO_CMO_PASSWORD:-local-e2e-cmo-123!}"
+export AGENTICORG_DEMO_COO_EMAIL="${AGENTICORG_DEMO_COO_EMAIL:-coo@agenticorg.local}"
+export AGENTICORG_DEMO_COO_PASSWORD="${AGENTICORG_DEMO_COO_PASSWORD:-local-e2e-coo-123!}"
+export AGENTICORG_DEMO_AUDITOR_EMAIL="${AGENTICORG_DEMO_AUDITOR_EMAIL:-auditor@agenticorg.local}"
+export AGENTICORG_DEMO_AUDITOR_PASSWORD="${AGENTICORG_DEMO_AUDITOR_PASSWORD:-local-e2e-auditor-123!}"
 
 RED='\033[0;31m'
 GRN='\033[0;32m'
@@ -496,6 +509,36 @@ log "Running Playwright (BASE_URL=${UI_URL}, workers=${LOCAL_E2E_WORKERS}${SPEC_
   E2E_TOKEN="${TOKEN}" \
   MARKETING_URL="${UI_URL}" \
   npx playwright test "${PLAYWRIGHT_ARGS[@]}"
-)
+) &
+PLAYWRIGHT_PID=$!
+
+# A dead preview/API process otherwise turns one infrastructure failure into
+# hundreds of misleading browser-test failures. Abort after three consecutive
+# failed health probes and retain the service logs for diagnosis.
+health_failures=0
+while kill -0 "$PLAYWRIGHT_PID" 2>/dev/null; do
+  if curl -fsS "${UI_URL}" >/dev/null 2>&1 && curl -fsS "${API_URL}/api/v1/health" >/dev/null 2>&1; then
+    health_failures=0
+  else
+    health_failures=$((health_failures + 1))
+    if (( health_failures >= 3 )); then
+      fail "UI/API became unavailable during Playwright. Aborting the invalid run."
+      tail -n 30 "${UI_LOG}" || true
+      tail -n 30 "${API_LOG}" || true
+      stop_pid "$PLAYWRIGHT_PID" "Playwright"
+      wait "$PLAYWRIGHT_PID" 2>/dev/null || true
+      exit 7
+    fi
+  fi
+  sleep 5
+done
+
+set +e
+wait "$PLAYWRIGHT_PID"
+PLAYWRIGHT_STATUS=$?
+set -e
+if (( PLAYWRIGHT_STATUS != 0 )); then
+  exit "$PLAYWRIGHT_STATUS"
+fi
 
 ok "Playwright run finished"

--- a/ui/e2e/aishwarya-18june2026.spec.ts
+++ b/ui/e2e/aishwarya-18june2026.spec.ts
@@ -1,6 +1,9 @@
 import { expect, Page, test } from "@playwright/test";
+import { E2E_TOKEN, requireAuth, setSessionToken } from "./helpers/auth";
 
 async function installCommonRoutes(page: Page) {
+  requireAuth();
+  await setSessionToken(page, E2E_TOKEN);
   await page.route("**/api/v1/auth/me", async (route) => {
     await route.fulfill({
       json: {

--- a/ui/e2e/ca-firms.spec.ts
+++ b/ui/e2e/ca-firms.spec.ts
@@ -91,7 +91,7 @@ test.describe("CA Firms Solution Page", () => {
 
     // CTA buttons
     await expect(
-      page.getByRole("button", { name: /Request Evaluation/i }).first()
+      page.getByRole("button", { name: /Request CA Pack Evaluation/i }).first()
     ).toBeVisible({ timeout: 10000 });
 
     await expect(
@@ -120,8 +120,9 @@ test.describe("CA Firms Solution Page", () => {
       page.getByText("CA Pack Evaluation").first()
     ).toBeVisible({ timeout: 10000 });
 
+    await page.getByRole("button", { name: /Request CA Pack Evaluation/i }).first().click();
     await expect(
-      page.getByText(/Commercial terms and plan limits are confirmed/)
+      page.getByText(/current plan limits, provider configuration, and signed terms/)
     ).toBeVisible({ timeout: 10000 });
 
     const body = (await page.locator("body").textContent()) || "";
@@ -470,46 +471,20 @@ test.describe("Landing Page -- CA Firms Section", () => {
 // ==========================================================================
 
 test.describe("CA Demo Login Flow", () => {
-  test("demo login page shows CA Partner option", async ({ page }) => {
+  test("login page does not expose demo role controls", async ({ page }) => {
     await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle").catch(() => {});
 
-    // Look for "Try the demo instead" or a demo section toggle
-    const demoToggle = page.getByText(/Try the demo|Demo|demo/i).first();
-    if (await demoToggle.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await demoToggle.click();
-    }
-
-    // Verify "CA Partner" demo button exists
-    const caPartnerBtn = page.getByText(/CA Partner|CA Firm|Chartered Accountant/i).first();
-    const visible = await caPartnerBtn.isVisible({ timeout: 5000 }).catch(() => false);
-    // The login page should mention CA somewhere (either in demo buttons or text)
-    const body = (await page.locator("body").textContent()) || "";
-    expect(visible || body.includes("CA") || body.includes("demo")).toBeTruthy();
+    await expect(page.getByText(/Try the demo instead/i)).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /CA Partner/i })).toHaveCount(0);
   });
 
-  test("CA demo credentials auto-fill on click", async ({ page }) => {
+  test("login credentials are never prefilled", async ({ page }) => {
     await page.goto(`${APP}/login`, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle").catch(() => {});
 
-    // Expand demo section if collapsed
-    const demoToggle = page.getByText(/Try the demo|Demo|demo/i).first();
-    if (await demoToggle.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await demoToggle.click();
-    }
-
-    // Click CA Partner button if visible
-    const caPartnerBtn = page.getByText(/CA Partner/i).first();
-    if (await caPartnerBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await caPartnerBtn.click();
-
-      // Verify email field is filled with demo CA email
-      const emailInput = page.locator('input[type="email"], input[name="email"], input[placeholder*="email"]').first();
-      if (await emailInput.isVisible({ timeout: 3000 }).catch(() => false)) {
-        const emailValue = await emailInput.inputValue();
-        expect(emailValue).toBe("demo@cafirm.agenticorg.ai");
-      }
-    }
+    await expect(page.locator('input[type="email"]').first()).toHaveValue("");
+    await expect(page.locator('input[type="password"]').first()).toHaveValue("");
   });
 });
 

--- a/ui/e2e/dashboard-403.spec.ts
+++ b/ui/e2e/dashboard-403.spec.ts
@@ -13,13 +13,13 @@
  *     user what was blocked and why.
  */
 import { expect, test } from "@playwright/test";
-import { setSessionToken } from "./helpers/auth";
+import { DEMO_ROLE_CREDENTIALS, setSessionToken } from "./helpers/auth";
 
 const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 const canAuth = !!E2E_TOKEN;
 const ROLE_CREDS: Record<string, { email: string; password: string }> = {
-  cfo: { email: "cfo@agenticorg.local", password: "cfo123!" },
+  cfo: DEMO_ROLE_CREDENTIALS.cfo,
 };
 
 function requireAuth(): void {

--- a/ui/e2e/helpers/auth.ts
+++ b/ui/e2e/helpers/auth.ts
@@ -20,6 +20,38 @@ export const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
 export const E2E_TOKEN = process.env.E2E_TOKEN || "";
 export const canAuth = !!E2E_TOKEN;
 
+export const DEMO_USER_CREDENTIALS = {
+  email: process.env.AGENTICORG_DEMO_USER_EMAIL || "demo@cafirm.agenticorg.ai",
+  password: process.env.AGENTICORG_DEMO_USER_PASSWORD || "local-e2e-demo-123!",
+} as const;
+
+export const DEMO_ROLE_CREDENTIALS = {
+  ceo: {
+    email: process.env.AGENTICORG_DEMO_CEO_EMAIL || "ceo@agenticorg.local",
+    password: process.env.AGENTICORG_DEMO_CEO_PASSWORD || "local-e2e-ceo-123!",
+  },
+  cfo: {
+    email: process.env.AGENTICORG_DEMO_CFO_EMAIL || "cfo@agenticorg.local",
+    password: process.env.AGENTICORG_DEMO_CFO_PASSWORD || "local-e2e-cfo-123!",
+  },
+  chro: {
+    email: process.env.AGENTICORG_DEMO_CHRO_EMAIL || "chro@agenticorg.local",
+    password: process.env.AGENTICORG_DEMO_CHRO_PASSWORD || "local-e2e-chro-123!",
+  },
+  cmo: {
+    email: process.env.AGENTICORG_DEMO_CMO_EMAIL || "cmo@agenticorg.local",
+    password: process.env.AGENTICORG_DEMO_CMO_PASSWORD || "local-e2e-cmo-123!",
+  },
+  coo: {
+    email: process.env.AGENTICORG_DEMO_COO_EMAIL || "coo@agenticorg.local",
+    password: process.env.AGENTICORG_DEMO_COO_PASSWORD || "local-e2e-coo-123!",
+  },
+  auditor: {
+    email: process.env.AGENTICORG_DEMO_AUDITOR_EMAIL || "auditor@agenticorg.local",
+    password: process.env.AGENTICORG_DEMO_AUDITOR_PASSWORD || "local-e2e-auditor-123!",
+  },
+} as const;
+
 /**
  * Assert that the suite has authentication available. Throws if not.
  *

--- a/ui/e2e/negative-cases.spec.ts
+++ b/ui/e2e/negative-cases.spec.ts
@@ -47,13 +47,7 @@ test.describe("AUTH: Login errors", () => {
 
     // Should show error, NOT navigate to dashboard
     expect(page.url()).toContain("/login");
-    const bodyText = await page.textContent("body");
-    const hasError =
-      bodyText?.includes("Invalid") ||
-      bodyText?.includes("failed") ||
-      bodyText?.includes("error") ||
-      bodyText?.includes("incorrect");
-    expect(hasError).toBeTruthy();
+    await expect(page.getByText(/invalid email or password/i)).toBeVisible();
   });
 
   test("Empty form submission is prevented", async ({ page, baseURL }) => {

--- a/ui/e2e/qa-bugs-8apr2026.spec.ts
+++ b/ui/e2e/qa-bugs-8apr2026.spec.ts
@@ -10,7 +10,11 @@
  * NO page.route() mocking -- all responses are real.
  */
 import { test, expect, Page } from "@playwright/test";
-import { setSessionToken } from "./helpers/auth";
+import {
+  DEMO_ROLE_CREDENTIALS,
+  DEMO_USER_CREDENTIALS,
+  setSessionToken,
+} from "./helpers/auth";
 
 const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
@@ -706,13 +710,11 @@ test.describe("Proactive Regression - Similar Issues", () => {
   test("all 7 demo accounts return valid JWT", async ({ request }) => {
     test.setTimeout(120_000); // 7 accounts × up to 3 retries × up to 10s
     const accounts = [
-      { email: "demo@cafirm.agenticorg.ai", pw: "demo123!" },
-      { email: "ceo@agenticorg.local", pw: "ceo123!" },
-      { email: "cfo@agenticorg.local", pw: "cfo123!" },
-      { email: "cmo@agenticorg.local", pw: "cmo123!" },
-      { email: "coo@agenticorg.local", pw: "coo123!" },
-      { email: "chro@agenticorg.local", pw: "chro123!" },
-      { email: "auditor@agenticorg.local", pw: "audit123!" },
+      { email: DEMO_USER_CREDENTIALS.email, pw: DEMO_USER_CREDENTIALS.password },
+      ...Object.values(DEMO_ROLE_CREDENTIALS).map(({ email, password }) => ({
+        email,
+        pw: password,
+      })),
     ];
     for (const [i, a] of accounts.entries()) {
       if (i > 0) await new Promise((r) => setTimeout(r, 1500));

--- a/ui/e2e/qa-cafirms-may03.spec.ts
+++ b/ui/e2e/qa-cafirms-may03.spec.ts
@@ -153,7 +153,7 @@ test.describe("CA Firms May 03 reopen fixes", () => {
     await expect(main).not.toContainText("No CA pack agents are provisioned");
   });
 
-  test("GST auto-file is locked until GSTN credentials exist", async ({ page }) => {
+  test("GST auto-file stays disabled until verified GSTN credentials exist", async ({ page }) => {
     await mockApi(page);
     await page.goto(`${APP}/dashboard/companies/${COMPANY_ID}`, {
       waitUntil: "domcontentloaded",
@@ -162,7 +162,9 @@ test.describe("CA Firms May 03 reopen fixes", () => {
     await page.getByRole("button", { name: "Settings" }).click();
 
     const main = page.locator("main");
-    await expect(main).toContainText("GST auto-file is locked");
+    await expect(main).toContainText(
+      "GST auto-file cannot be enabled until an active GSTN portal credential is saved and verified below.",
+    );
     await expect(page.getByLabel("Enable GST auto-file")).toBeDisabled();
     await expect(main).toContainText("No GSTN credentials stored for this company");
   });

--- a/ui/e2e/qa-module-2-auth.spec.ts
+++ b/ui/e2e/qa-module-2-auth.spec.ts
@@ -19,19 +19,12 @@
  * All other TCs use the demo accounts seeded by the platform.
  */
 import { expect, test } from "@playwright/test";
-import { clearSession, setSessionToken } from "./helpers/auth";
+import { DEMO_ROLE_CREDENTIALS, clearSession, setSessionToken } from "./helpers/auth";
 
 const APP = process.env.BASE_URL || "https://app.agenticorg.ai";
 const E2E_TOKEN = process.env.E2E_TOKEN || "";
 
-const DEMO = {
-  ceo:     { email: "ceo@agenticorg.local",     password: "ceo123!"   },
-  cfo:     { email: "cfo@agenticorg.local",     password: "cfo123!"   },
-  chro:    { email: "chro@agenticorg.local",    password: "chro123!"  },
-  cmo:     { email: "cmo@agenticorg.local",     password: "cmo123!"   },
-  coo:     { email: "coo@agenticorg.local",     password: "coo123!"   },
-  auditor: { email: "auditor@agenticorg.local", password: "audit123!" },
-} as const;
+const DEMO = DEMO_ROLE_CREDENTIALS;
 
 // ---------------------------------------------------------------------------
 // TC-AUTH-001: Login with demo CEO credentials

--- a/ui/e2e/qa-module-9-connectors.spec.ts
+++ b/ui/e2e/qa-module-9-connectors.spec.ts
@@ -10,7 +10,7 @@
  *
  *   curl -X POST https://app.agenticorg.ai/api/v1/auth/login \
  *     -H "Content-Type: application/json" \
- *     -d '{"email":"ceo@agenticorg.local","password":"ceo123!"}' \
+ *     -d "{\"email\":\"${AGENTICORG_DEMO_CEO_EMAIL}\",\"password\":\"${AGENTICORG_DEMO_CEO_PASSWORD}\"}" \
  *     | jq -r .access_token
  *
  * TC-CONN-004 (register) is gated behind QA_ALLOW_PROD_WRITES=1

--- a/ui/e2e/qa-ramesh-aishwarya-may04.spec.ts
+++ b/ui/e2e/qa-ramesh-aishwarya-may04.spec.ts
@@ -125,7 +125,7 @@ test("CA firms evaluation request posts firm metadata and reports confirmation e
   });
 
   await page.goto("/solutions/ca-firms");
-  await page.getByRole("button", { name: /request evaluation/i }).first().click();
+  await page.getByRole("button", { name: /request ca pack evaluation/i }).first().click();
   await page.getByRole("textbox", { name: /^Name \*/ }).fill("Aishwarya");
   await page.getByLabel(/Work Email/).fill("aishwarya@agenticorg.ai");
   await page.getByLabel(/Firm Name/).fill("Aishwarya CA LLP");

--- a/ui/e2e/session5-bugs.spec.ts
+++ b/ui/e2e/session5-bugs.spec.ts
@@ -72,7 +72,7 @@ test.describe("Voice Setup regression", () => {
     await expect(nextBtn).toBeDisabled();
   });
 
-  test("TC-011 Google TTS shows an API key field on selection", async ({ page }) => {
+  test("TC-011 Azure TTS shows a protected API key field on selection", async ({ page }) => {
     // Walk to Step 4.
     await page.locator("button").filter({ hasText: "Twilio" }).first().click();
     await page.getByRole("button", { name: "Next" }).click();
@@ -82,10 +82,11 @@ test.describe("Voice Setup regression", () => {
     await page.locator('input[type="tel"]').fill("+919876543210");
     await page.getByRole("button", { name: "Next" }).click();
 
-    // Google TTS radio → API key field must appear.
-    await page.locator("text=Google TTS (cloud)").first().click();
+    // Azure cloud TTS requires a tenant-provided secret; the provider-managed
+    // production option remains available without exposing a tenant key.
+    await page.getByText("Azure Speech TTS (cloud)", { exact: true }).click();
     await expect(
-      page.getByPlaceholder("Enter Google Cloud API key"),
+      page.getByPlaceholder("Enter Azure Speech API key"),
     ).toBeVisible({ timeout: 5000 });
   });
 

--- a/ui/e2e/v4-features.spec.ts
+++ b/ui/e2e/v4-features.spec.ts
@@ -371,14 +371,15 @@ test.describe("v4 — Billing", () => {
 //  Landing Page — v4 Updates
 // ═══════════════════════════════════════════════════════════════════════════
 
-test.describe("v4 — Landing Page Updates", () => {
-  test("landing_shows_v4_banner", async ({ page }) => {
+test.describe("Landing Page Product Signals", () => {
+  test("landing_shows_current_governed_oacp_banner", async ({ page }) => {
     await page.goto(MARKETING, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle").catch(() => {});
 
-    const body = (await page.textContent("body")) || "";
-    const hasV4 = /v4\.0\.0|project apex|1000\+/i.test(body);
-    expect(hasV4).toBeTruthy();
+    await expect(page.getByTestId("landing-version-badge")).toContainText(
+      "Governed agents with OACP trust boundaries",
+    );
+    await expect(page.getByText("Open Agentic Commerce Protocol", { exact: true }).first()).toBeVisible();
   });
 
   test("landing_shows_updated_stats", async ({ page, request }) => {


### PR DESCRIPTION
## Summary
- align local Docker E2E demo credentials with current password policy and centralize role credentials
- detect API/UI liveness loss during Playwright runs
- update stale UI regression expectations and authenticated test setup
- replace a flaky login error body snapshot with a retrying visible assertion

## Validation
- full Docker-backed Playwright: 700 passed, 9 policy-skipped; one flaky assertion identified and fixed
- focused Docker-backed negative cases after fix: 19 passed
- focused Docker-backed CA firms: 58 passed
- remaining repaired specs: 104 passed, 3 policy-skipped
- UI unit tests: 181 passed
- UI lint: 0 errors (20 existing warnings)
- UI typecheck and production build/SEO verification: passed
- backend focused regressions: 51 passed
- git diff --check and bash syntax: passed