### PR TITLE
feat(sdk): cover runtime resources and repair knowledge lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to AgenticOrg are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased] - 2026-08-29
+
+### Added
+- Python and TypeScript SDK `0.4.0` resources for knowledge/OCR, voice, RPA,
+  local bridges, connector diagnostics, workflow cancellation, and the
+  seller/buyer commerce runtime.
+- An idempotent migration that repairs the native `knowledge_documents` index
+  on both legacy and ORM-bootstrap installations.
+
+### Fixed
+- Knowledge deletion now retires native vector chunks as well as RAGFlow and
+  document records, preventing deleted content from remaining searchable.
+- Plural billing callback OpenAPI operations now have unique GET/POST IDs for
+  generated SDK clients.
+- Connector harness and voice integration fixtures no longer emit avoidable
+  async/Pydantic deprecation warnings.
+
 ## [4.0.0] — 2026-04-05
 
 ### Added — Project Apex (22 Features)

--- a/README.md
+++ b/README.md
@@ -171,13 +171,21 @@ See [sdk/README.md](sdk/README.md).
     agenticorg agents list
     agenticorg a2a card
 
-The SDK supports authenticated platform operations exposed by its client. Server features may require a newer deployment than the installed client, so consumers should check package and server release notes.
+SDK `0.4.0` covers agents, workflows, connector diagnostics, knowledge/OCR,
+voice, RPA, local bridges, and the seller-commerce runtime. External-action
+methods such as outbound calls, RPA runs, connector sync, and bridge routing
+remain explicit calls and still require tenant authorization. Server features
+may require a newer deployment than the installed client, so consumers should
+check package and server release notes.
 
 ### TypeScript SDK
 
 See [sdk-ts/README.md](sdk-ts/README.md).
 
     npm install agenticorg-sdk
+
+The TypeScript `0.4.0` resource surface mirrors the Python runtime coverage,
+including knowledge/OCR, voice, RPA, bridges, and commerce preparation APIs.
 
 ### MCP server
 

--- a/api/v1/billing.py
+++ b/api/v1/billing.py
@@ -446,7 +446,8 @@ async def subscribe_india(
 # ── Plural Callback (Redirect Return) ───────────────────────────────
 
 
-@router.api_route("/callback", methods=["GET", "POST"])
+@router.get("/callback", operation_id="plural_callback_get")
+@router.post("/callback", operation_id="plural_callback_post")
 @route_meta(
     auth_required=False,
     tenant_required=True,

--- a/api/v1/knowledge.py
+++ b/api/v1/knowledge.py
@@ -354,7 +354,7 @@ async def _db_chunk_count(tenant_id: str) -> int:
                 await session.execute(
                     _sqtext(
                         "SELECT COUNT(*) FROM knowledge_documents "  # nosec B608 — `ecol` is a module-level constant name, not user input
-                        f"WHERE tenant_id = :tid AND {ecol} IS NOT NULL"
+                        f"WHERE tenant_id = :tid AND status = 'ready' AND {ecol} IS NOT NULL"
                     ),
                     {"tid": str(tid)},
                 )
@@ -968,18 +968,20 @@ async def list_documents(
 )
 async def delete_document(doc_id: str, tenant_id: str = Depends(get_current_tenant)):
     """Delete a document from the knowledge base."""
+    ragflow_deleted = False
     if _ragflow_available():
         try:
-            deleted = await _ragflow_delete(tenant_id, doc_id)
-            if deleted:
-                return {"ok": True, "document_id": doc_id, "status": "deleted"}
+            ragflow_deleted = await _ragflow_delete(tenant_id, doc_id)
         except _RAGFLOW_ERRORS as exc:
             logger.warning("ragflow_delete_failed", error=str(exc))
 
-    # Fallback: mark as deleted in DB
+    # Always retire both the document record and any native fallback chunks.
+    # RAGFlow and Postgres are independent indexes, so success in one must not
+    # leave the other searchable.
     try:
         from uuid import UUID as _UUID
 
+        from sqlalchemy import text as _sqtext
         from sqlalchemy import update
         from sqlalchemy.exc import SQLAlchemyError
 
@@ -992,7 +994,14 @@ async def delete_document(doc_id: str, tenant_id: str = Depends(get_current_tena
             result = await session.execute(
                 update(Document).where(Document.id == document_uuid, Document.tenant_id == tid).values(status="deleted")
             )
-            if result.rowcount == 0:
+            await session.execute(
+                _sqtext(
+                    "UPDATE knowledge_documents SET status = 'deleted' "
+                    "WHERE tenant_id = :tid AND source_object_id = :doc_id"
+                ),
+                {"tid": str(tid), "doc_id": str(document_uuid)},
+            )
+            if result.rowcount == 0 and not ragflow_deleted:
                 raise HTTPException(
                     status_code=404,
                     detail={"error": "document_not_found", "document_id": doc_id},
@@ -1051,7 +1060,7 @@ async def _native_semantic_search(
                         "SELECT title, content, "  # nosec B608 — `col` is a module-level constant name, not user input
                         f"1 - ({col} <=> CAST(:q AS vector)) AS score "
                         "FROM knowledge_documents "
-                        f"WHERE tenant_id = :tid AND {col} IS NOT NULL "
+                        f"WHERE tenant_id = :tid AND status = 'ready' AND {col} IS NOT NULL "
                         f"ORDER BY {col} <=> CAST(:q AS vector) "
                         "LIMIT :k"
                     ),
@@ -1078,7 +1087,7 @@ async def _native_semantic_search(
                 await session.execute(
                     _sqtext(
                         "SELECT title, content FROM knowledge_documents "
-                        "WHERE tenant_id = :tid AND "
+                        "WHERE tenant_id = :tid AND status = 'ready' AND "
                         "(title ILIKE :like OR content ILIKE :like) "
                         "LIMIT :k"
                     ),

--- a/docs/release-sdks.md
+++ b/docs/release-sdks.md
@@ -6,14 +6,14 @@ credentials, should not live in CI without a release-gating flow).
 
 ## Current release targets
 
-- Python SDK + CLI: `agenticorg==0.3.0` on PyPI. The root
+- Python SDK + CLI release target: `agenticorg==0.4.0`. The root
   AgenticOrg package also includes `sdk/agenticorg` and exposes the
   direct `agenticorg` CLI so `pip install agenticorg` works for shell
   users, Claude Code, Codex, Gemini CLI, VS Code tasks, CI, and runbooks.
   PyPI `agenticorg` remains the lightweight SDK+CLI artifact built from
   `sdk/`; do not upload the root/full-platform wheel to PyPI under the same
   package name.
-- TypeScript SDK: `agenticorg-sdk@0.3.0` on npm. The scoped package
+- TypeScript SDK release target: `agenticorg-sdk@0.4.0`. The scoped package
   `@agenticorg/sdk` is not currently published.
 - MCP server npm package: `agenticorg-mcp-server@4.0.5`.
 - MCP registry server: `io.github.mishrasanjeev/agenticorg@4.0.5`.
@@ -146,8 +146,9 @@ sweep fails if any drifts.
 - Patch bump for bugfix-only changes.
 
 SDK versions track the server's wire contract, not the app version.
-A main app at `4.8.0` is fine with SDKs at `0.3.0` — what matters is
-that the SDK can parse what the server emits.
+Release `0.4.0` adds the current knowledge/OCR, voice, RPA, local bridge,
+and commerce runtime resources without changing the existing agent APIs.
+What matters is that the SDK can parse what the deployed server emits.
 
 ## Drift guard
 

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -1192,10 +1192,27 @@
     "auth_required": false,
     "function": "plural_callback",
     "idempotency": "gateway-order-status-verification",
-    "key": "GET,POST /api/v1/billing/callback api/v1/billing.py:plural_callback",
+    "key": "GET /api/v1/billing/callback api/v1/billing.py:plural_callback",
     "metadata_present": true,
     "methods": [
-      "GET",
+      "GET"
+    ],
+    "module": "api/v1/billing.py",
+    "path": "/api/v1/billing/callback",
+    "public_exempt_reason": "gateway-redirect-server-side-verification",
+    "rate_limit": "gateway-callback",
+    "scope": "public:billing.callback.plural",
+    "source_line": 460,
+    "tenant_required": true
+  },
+  {
+    "audit_event": "billing.callback.plural",
+    "auth_required": false,
+    "function": "plural_callback",
+    "idempotency": "gateway-order-status-verification",
+    "key": "POST /api/v1/billing/callback api/v1/billing.py:plural_callback",
+    "metadata_present": true,
+    "methods": [
       "POST"
     ],
     "module": "api/v1/billing.py",
@@ -1203,7 +1220,7 @@
     "public_exempt_reason": "gateway-redirect-server-side-verification",
     "rate_limit": "gateway-callback",
     "scope": "public:billing.callback.plural",
-    "source_line": 459,
+    "source_line": 460,
     "tenant_required": true
   },
   {
@@ -1221,7 +1238,7 @@
     "public_exempt_reason": "stripe-hosted-checkout-server-side-verification",
     "rate_limit": "gateway-callback",
     "scope": "public:billing.callback.stripe",
-    "source_line": 573,
+    "source_line": 574,
     "tenant_required": true
   },
   {
@@ -1239,7 +1256,7 @@
     "public_exempt_reason": null,
     "rate_limit": "billing-mutating",
     "scope": "billing.subscription.cancel",
-    "source_line": 729,
+    "source_line": 730,
     "tenant_required": true
   },
   {
@@ -1329,7 +1346,7 @@
     "public_exempt_reason": null,
     "rate_limit": "billing-status",
     "scope": "billing.order_status.read",
-    "source_line": 677,
+    "source_line": 678,
     "tenant_required": true
   },
   {
@@ -1365,7 +1382,7 @@
     "public_exempt_reason": null,
     "rate_limit": "billing-mutating",
     "scope": "billing.portal.create",
-    "source_line": 640,
+    "source_line": 641,
     "tenant_required": true
   },
   {
@@ -1455,7 +1472,7 @@
     "public_exempt_reason": "plural-hmac-signature-required",
     "rate_limit": "gateway-webhook",
     "scope": "public:billing.webhook.plural",
-    "source_line": 828,
+    "source_line": 829,
     "tenant_required": true
   },
   {
@@ -1473,7 +1490,7 @@
     "public_exempt_reason": "stripe-signature-required",
     "rate_limit": "gateway-webhook",
     "scope": "public:billing.webhook.stripe",
-    "source_line": 796,
+    "source_line": 797,
     "tenant_required": true
   },
   {
@@ -4155,7 +4172,7 @@
     "public_exempt_reason": "deployment-smoke-test-no-tenant-data",
     "rate_limit": "healthcheck",
     "scope": "knowledge.health.public",
-    "source_line": 1246,
+    "source_line": 1255,
     "tenant_required": false
   },
   {
@@ -4173,7 +4190,7 @@
     "public_exempt_reason": null,
     "rate_limit": "knowledge-search",
     "scope": "knowledge.sensitive.search",
-    "source_line": 1188,
+    "source_line": 1197,
     "tenant_required": true
   },
   {
@@ -4191,7 +4208,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "knowledge.sensitive.stats",
-    "source_line": 1359,
+    "source_line": 1368,
     "tenant_required": true
   },
   {

--- a/migrations/versions/v6_z13_knowledge_documents_repair.py
+++ b/migrations/versions/v6_z13_knowledge_documents_repair.py
@@ -1,0 +1,139 @@
+"""Repair the durable native knowledge-document index table.
+
+Revision ID: v6z13_knowledge_docs
+Revises: v6z12_voice_runtime
+Create Date: 2026-08-29
+
+Legacy-baseline installations can stamp past ``v400_apex`` after ORM
+``create_all``. ``knowledge_documents`` is not an ORM table, so that path left
+it absent. Older installations that did run ``v400_apex`` have the original
+file-metadata shape, while native RAG ingestion now writes title/content and
+embedding provenance. This migration reconciles both states idempotently.
+"""
+
+from alembic import op
+
+revision = "v6z13_knowledge_docs"
+down_revision = "v6z12_voice_runtime"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS knowledge_documents (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+            title VARCHAR(500) NOT NULL,
+            content TEXT NOT NULL,
+            category VARCHAR(100),
+            source VARCHAR(500),
+            file_type VARCHAR(50) DEFAULT 'text',
+            mime_type VARCHAR(128),
+            embedding_model VARCHAR(128),
+            embedding_dimensions INTEGER,
+            token_count INTEGER DEFAULT 0,
+            source_object_id VARCHAR(128),
+            source_object_type VARCHAR(32),
+            status VARCHAR(30) NOT NULL DEFAULT 'ready',
+            embedding vector(384),
+            embedding_bge_m3 vector(1024),
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE knowledge_documents
+            ADD COLUMN IF NOT EXISTS title VARCHAR(500),
+            ADD COLUMN IF NOT EXISTS content TEXT,
+            ADD COLUMN IF NOT EXISTS category VARCHAR(100),
+            ADD COLUMN IF NOT EXISTS source VARCHAR(500),
+            ADD COLUMN IF NOT EXISTS file_type VARCHAR(50) DEFAULT 'text',
+            ADD COLUMN IF NOT EXISTS mime_type VARCHAR(128),
+            ADD COLUMN IF NOT EXISTS embedding_model VARCHAR(128),
+            ADD COLUMN IF NOT EXISTS embedding_dimensions INTEGER,
+            ADD COLUMN IF NOT EXISTS token_count INTEGER DEFAULT 0,
+            ADD COLUMN IF NOT EXISTS source_object_id VARCHAR(128),
+            ADD COLUMN IF NOT EXISTS source_object_type VARCHAR(32),
+            ADD COLUMN IF NOT EXISTS embedding vector(384),
+            ADD COLUMN IF NOT EXISTS embedding_bge_m3 vector(1024)
+        """
+    )
+    op.execute(
+        """
+        UPDATE knowledge_documents
+        SET title = COALESCE(
+                NULLIF(title, ''),
+                NULLIF(to_jsonb(knowledge_documents)->>'filename', ''),
+                'Untitled'
+            ),
+            content = COALESCE(content, '')
+        WHERE title IS NULL OR content IS NULL
+        """
+    )
+    op.execute("ALTER TABLE knowledge_documents ALTER COLUMN title SET NOT NULL")
+    op.execute("ALTER TABLE knowledge_documents ALTER COLUMN content SET NOT NULL")
+
+    # The original v400 shape required file-metadata columns that native RAG
+    # rows do not populate. Preserve the columns for compatibility but remove
+    # only those obsolete NOT NULL constraints when present.
+    op.execute(
+        """
+        DO $$
+        DECLARE legacy_column TEXT;
+        BEGIN
+            FOREACH legacy_column IN ARRAY ARRAY['filename', 'content_type', 'file_size_bytes']
+            LOOP
+                IF EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_schema = current_schema()
+                      AND table_name = 'knowledge_documents'
+                      AND column_name = legacy_column
+                      AND is_nullable = 'NO'
+                ) THEN
+                    EXECUTE format(
+                        'ALTER TABLE knowledge_documents ALTER COLUMN %I DROP NOT NULL',
+                        legacy_column
+                    );
+                END IF;
+            END LOOP;
+        END$$
+        """
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS ix_knowledge_documents_tenant_id ON knowledge_documents (tenant_id)")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_knowledge_documents_tenant_source_type "
+        "ON knowledge_documents (tenant_id, source_object_type)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_knowledge_documents_tenant_source_object "
+        "ON knowledge_documents (tenant_id, source_object_id)"
+    )
+    op.execute("ALTER TABLE knowledge_documents ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_policies
+                WHERE schemaname = current_schema()
+                  AND tablename = 'knowledge_documents'
+                  AND policyname = 'knowledge_documents_tenant_isolation'
+            ) THEN
+                CREATE POLICY knowledge_documents_tenant_isolation
+                    ON knowledge_documents
+                    USING (tenant_id::text = current_setting('agenticorg.tenant_id', true))
+                    WITH CHECK (tenant_id::text = current_setting('agenticorg.tenant_id', true));
+            END IF;
+        END$$
+        """
+    )
+
+
+def downgrade() -> None:
+    # Preserve indexed customer knowledge. The repair is intentionally
+    # forward-only because the pre-repair states are both data-loss hazards.
+    pass

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -1,5 +1,22 @@
 # agenticorg-sdk changelog
 
+## 0.4.0 - 2026-08-29
+
+Runtime surface release.
+
+### Added
+- Knowledge/OCR upload and lifecycle, voice, RPA, local bridges, and the
+  seller/buyer commerce runtime as first-class client resources.
+- Connector health/test and workflow-run cancellation helpers.
+- Multipart upload support that preserves authorization without forcing an
+  invalid JSON content type.
+
+### Fixed
+- SDK coverage now follows the production runtime rather than stopping at the
+  June 2026 agent/workflow subset.
+- Generated OpenAPI clients no longer encounter a duplicate Plural callback
+  operation ID.
+
 ## 0.3.0 - 2026-06-14
 
 Commerce, A2A/MCP, workflow, and knowledge release.

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -97,7 +97,30 @@ new AgenticOrg();
 | `client.a2a` | `agentCard()`, `agents()` |
 | `client.mcp` | `tools()`, `call(name, args?)` |
 | `client.workflows` | `templates()`, `list()`, `generate(description)`, `create(opts)`, `get(id)`, `run(id, opts?)`, `getRun(id)` |
-| `client.knowledge` | `search(query, { topK })` |
+| `client.knowledge` | `search()`, `supportedTypes()`, `upload()`, `documents()`, `delete()`, `health()`, `stats()` |
+| `client.voice` | `status()`, `saveConfig()`, `testConnection()`, `runtimeHealth()`, `calls()`, `placeOutboundCall()` |
+| `client.rpa` | `scripts()`, `history()`, `run()` |
+| `client.bridges` | `register()`, `list()`, `status()`, `route()`, `deregister()` |
+| `client.commerce` | seller onboarding, Shopify sync, artifact cache, buyer ask, protocol adapters, mandate evidence, purchase/POS preparation |
+
+```typescript
+const types = await client.knowledge.supportedTypes();
+const document = await client.knowledge.upload(
+  new Blob([scannedDocumentBytes]),
+  "scanned-invoice.pdf",
+);
+const products = await client.commerce.products("merchant-123");
+const answer = await client.commerce.ask({
+  merchant_id: "merchant-123",
+  question: "Which variants are fresh and in stock?",
+});
+const voiceRuntime = await client.voice.runtimeHealth("agent-uuid");
+```
+
+`placeOutboundCall`, `rpa.run`, `bridges.route`, Shopify sync, and provider
+verification are intentionally explicit because they may contact external
+systems or incur charges. Purchase/POS helpers prepare handoffs; provider and
+POS systems remain transaction authorities.
 
 ## License
 

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenticorg-sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenticorg-sdk",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agenticorg-sdk",
-  "version": "0.3.0",
-  "description": "TypeScript SDK for AgenticOrg - run agents, generate agents/workflows, use KB, A2A, and MCP",
+  "version": "0.4.0",
+  "description": "TypeScript SDK for AgenticOrg agents, knowledge/OCR, voice, RPA, bridges, and commerce runtime",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -187,6 +187,33 @@ class HttpClient {
     if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${await resp.text()}`);
     return resp.json();
   }
+
+  async delete(path: string): Promise<unknown> {
+    const resp = await fetch(new URL(path, this.baseUrl).toString(), {
+      method: "DELETE",
+      headers: this.headers,
+      signal: AbortSignal.timeout(this.timeout),
+    });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${await resp.text()}`);
+    return resp.json();
+  }
+
+  async upload(path: string, form: FormData, params?: Record<string, string>): Promise<unknown> {
+    const headers = { ...this.headers };
+    delete headers["Content-Type"];
+    const url = new URL(path, this.baseUrl);
+    if (params) {
+      Object.entries(params).forEach(([key, value]) => url.searchParams.set(key, value));
+    }
+    const resp = await fetch(url.toString(), {
+      method: "POST",
+      headers,
+      body: form,
+      signal: AbortSignal.timeout(this.timeout),
+    });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${await resp.text()}`);
+    return resp.json();
+  }
 }
 
 class AgentsResource {
@@ -252,6 +279,14 @@ class ConnectorsResource {
 
   async get(connectorId: string): Promise<Record<string, unknown>> {
     return (await this.http.get(`/api/v1/connectors/${connectorId}`)) as Record<string, unknown>;
+  }
+
+  async health(connectorId: string): Promise<Record<string, unknown>> {
+    return (await this.http.get(`/api/v1/connectors/${connectorId}/health`)) as Record<string, unknown>;
+  }
+
+  async test(connectorId: string): Promise<Record<string, unknown>> {
+    return (await this.http.post(`/api/v1/connectors/${connectorId}/test`)) as Record<string, unknown>;
   }
 }
 
@@ -352,6 +387,10 @@ class WorkflowsResource {
   async getRun(runId: string): Promise<Record<string, unknown>> {
     return (await this.http.get(`/api/v1/workflows/runs/${runId}`)) as Record<string, unknown>;
   }
+
+  async cancelRun(runId: string): Promise<Record<string, unknown>> {
+    return (await this.http.post(`/api/v1/workflows/runs/${runId}/cancel`)) as Record<string, unknown>;
+  }
 }
 
 class KnowledgeResource {
@@ -364,6 +403,239 @@ class KnowledgeResource {
     })) as any;
     return data.results ?? data;
   }
+
+  async supportedTypes(): Promise<Record<string, unknown>> {
+    return (await this.http.get("/api/v1/knowledge/supported-types")) as Record<string, unknown>;
+  }
+
+  async upload(
+    file: Blob,
+    filename: string,
+    options: { duplicatePolicy?: "reject" | "replace" | "allow_duplicate" } = {},
+  ): Promise<Record<string, unknown>> {
+    const form = new FormData();
+    form.append("file", file, filename);
+    const policy = options.duplicatePolicy ?? "reject";
+    return (await this.http.upload("/api/v1/knowledge/upload", form, {
+      replace: String(policy === "replace"),
+      allow_duplicate: String(policy === "allow_duplicate"),
+    })) as Record<string, unknown>;
+  }
+
+  async documents(options: { page?: number; perPage?: number } = {}): Promise<Record<string, unknown>> {
+    return (await this.http.get("/api/v1/knowledge/documents", {
+      page: String(options.page ?? 1),
+      per_page: String(options.perPage ?? 20),
+    })) as Record<string, unknown>;
+  }
+
+  async delete(documentId: string): Promise<Record<string, unknown>> {
+    return (await this.http.delete(`/api/v1/knowledge/documents/${documentId}`)) as Record<string, unknown>;
+  }
+
+  async health(): Promise<Record<string, unknown>> {
+    return (await this.http.get("/api/v1/knowledge/health")) as Record<string, unknown>;
+  }
+
+  async stats(): Promise<Record<string, unknown>> {
+    return (await this.http.get("/api/v1/knowledge/stats")) as Record<string, unknown>;
+  }
+}
+
+class VoiceResource {
+  constructor(private http: HttpClient) {}
+
+  async status(agentId?: string): Promise<Record<string, unknown>> {
+    return (await this.http.get(
+      "/api/v1/voice/status",
+      agentId ? { agent_id: agentId } : undefined,
+    )) as Record<string, unknown>;
+  }
+
+  async saveConfig(config: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return (await this.http.post("/api/v1/voice/config", config)) as Record<string, unknown>;
+  }
+
+  async testConnection(provider: string, credentials: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return (await this.http.post("/api/v1/voice/test-connection", {
+      provider,
+      credentials,
+    })) as Record<string, unknown>;
+  }
+
+  async runtimeHealth(agentId: string): Promise<Record<string, unknown>> {
+    return (await this.http.get("/api/v1/voice/runtime/health", {
+      agent_id: agentId,
+    })) as Record<string, unknown>;
+  }
+
+  async calls(agentId: string, limit = 25): Promise<Record<string, unknown>[]> {
+    return (await this.http.get("/api/v1/voice/calls", {
+      agent_id: agentId,
+      limit: String(limit),
+    })) as Record<string, unknown>[];
+  }
+
+  /** Place a real outbound call. This can incur provider charges. */
+  async placeOutboundCall(agentId: string, toNumber: string): Promise<Record<string, unknown>> {
+    return (await this.http.post("/api/v1/voice/calls/outbound", {
+      agent_id: agentId,
+      to_number: toNumber,
+    })) as Record<string, unknown>;
+  }
+}
+
+class RPAResource {
+  constructor(private http: HttpClient) {}
+
+  async scripts(): Promise<Record<string, unknown>[]> {
+    return (await this.http.get("/api/v1/rpa/scripts")) as Record<string, unknown>[];
+  }
+
+  async history(limit = 50): Promise<Record<string, unknown>[]> {
+    return (await this.http.get("/api/v1/rpa/history", { limit: String(limit) })) as Record<string, unknown>[];
+  }
+
+  /** Run an RPA script. The selected script may perform external actions. */
+  async run(scriptId: string, params: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    return (await this.http.post(`/api/v1/rpa/scripts/${scriptId}/run`, { params })) as Record<string, unknown>;
+  }
+}
+
+class BridgesResource {
+  constructor(private http: HttpClient) {}
+
+  async list(): Promise<Record<string, unknown>[]> {
+    return (await this.http.get("/api/v1/bridge/list")) as Record<string, unknown>[];
+  }
+
+  async register(data: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return (await this.http.post("/api/v1/bridge/register", data)) as Record<string, unknown>;
+  }
+
+  async status(bridgeId: string): Promise<Record<string, unknown>> {
+    return (await this.http.get(`/api/v1/bridge/${bridgeId}/status`)) as Record<string, unknown>;
+  }
+
+  async deregister(bridgeId: string): Promise<Record<string, unknown>> {
+    return (await this.http.delete(`/api/v1/bridge/${bridgeId}`)) as Record<string, unknown>;
+  }
+
+  async route(connectorType: string, payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return (await this.http.post(`/api/v1/bridge/route/${connectorType}`, payload)) as Record<string, unknown>;
+  }
+}
+
+class CommerceResource {
+  private prefix = "/api/v1/commerce/runtime";
+
+  constructor(private http: HttpClient) {}
+
+  async createOnboardingPacket(data: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return (await this.http.post(`${this.prefix}/seller-agents/onboarding-packets`, data)) as Record<string, unknown>;
+  }
+
+  async onboardingPacket(packetId: string): Promise<Record<string, unknown>> {
+    return (await this.http.get(`${this.prefix}/seller-agents/onboarding-packets/${packetId}`)) as Record<string, unknown>;
+  }
+
+  async configureShopify(data: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return (await this.http.post(`${this.prefix}/seller-agents/connectors/shopify/credentials`, data)) as Record<string, unknown>;
+  }
+
+  async shopifyStatus(merchantId: string): Promise<Record<string, unknown>> {
+    return (await this.http.get(`${this.prefix}/seller-agents/connectors/shopify/status`, {
+      merchant_id: merchantId,
+    })) as Record<string, unknown>;
+  }
+
+  async syncShopify(data: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return (await this.http.post(`${this.prefix}/seller-agents/shopify/sync`, data)) as Record<string, unknown>;
+  }
+
+  async requestGrantexAuthority(data: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return (await this.http.post(`${this.prefix}/authority/grantex/request`, data)) as Record<string, unknown>;
+  }
+
+  async cacheArtifacts(artifacts: Record<string, unknown>[], buyerAgentId?: string): Promise<Record<string, unknown>> {
+    return (await this.http.post(`${this.prefix}/artifacts/cache`, {
+      artifacts,
+      buyer_agent_id: buyerAgentId,
+    })) as Record<string, unknown>;
+  }
+
+  async ask(data: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return (await this.http.post(`${this.prefix}/buyer-sessions/ask`, data)) as Record<string, unknown>;
+  }
+
+  async products(
+    merchantId: string,
+    options: { sellerAgentId?: string; query?: string } = {},
+  ): Promise<Record<string, unknown>> {
+    const params: Record<string, string> = { merchant_id: merchantId };
+    if (options.sellerAgentId) params.seller_agent_id = options.sellerAgentId;
+    if (options.query) params.q = options.query;
+    return (await this.http.get(`${this.prefix}/products`, params)) as Record<string, unknown>;
+  }
+
+  async protocolAdapters(
+    merchantId: string,
+    sellerAgentId: string,
+    buyerAgentId?: string,
+  ): Promise<Record<string, unknown>> {
+    const params: Record<string, string> = {
+      merchant_id: merchantId,
+      seller_agent_id: sellerAgentId,
+    };
+    if (buyerAgentId) params.buyer_agent_id = buyerAgentId;
+    return (await this.http.get(`${this.prefix}/protocol-adapters`, params)) as Record<string, unknown>;
+  }
+
+  async protocolAdapter(
+    surface: string,
+    merchantId: string,
+    sellerAgentId: string,
+    buyerAgentId?: string,
+  ): Promise<Record<string, unknown>> {
+    const params: Record<string, string> = {
+      merchant_id: merchantId,
+      seller_agent_id: sellerAgentId,
+    };
+    if (buyerAgentId) params.buyer_agent_id = buyerAgentId;
+    return (await this.http.get(`${this.prefix}/protocol-adapters/${surface}`, params)) as Record<string, unknown>;
+  }
+
+  async bridgeSurfaces(): Promise<Record<string, unknown>> {
+    return (await this.http.get(`${this.prefix}/bridges/surfaces`)) as Record<string, unknown>;
+  }
+
+  async verifyMandateCapability(data: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return (await this.http.post(
+      `${this.prefix}/providers/plural-pine/mandate-capability/verify`,
+      data,
+    )) as Record<string, unknown>;
+  }
+
+  /** Prepare a non-executing purchase handoff. */
+  async preparePurchase(data: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return (await this.http.post(`${this.prefix}/purchase/prepare`, data)) as Record<string, unknown>;
+  }
+
+  async offlinePosReadiness(): Promise<Record<string, unknown>> {
+    return (await this.http.get(`${this.prefix}/pos/offline/readiness`)) as Record<string, unknown>;
+  }
+
+  async createOfflinePosHandoff(data: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return (await this.http.post(`${this.prefix}/pos/offline/handoffs`, data)) as Record<string, unknown>;
+  }
+
+  async confirmOfflinePosHandoff(data: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return (await this.http.post(`${this.prefix}/pos/offline/confirmations`, data)) as Record<string, unknown>;
+  }
+
+  async simulateOfflinePosConfirmation(data: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return (await this.http.post(`${this.prefix}/pos/offline/simulator/confirm`, data)) as Record<string, unknown>;
+  }
 }
 
 export class AgenticOrg {
@@ -374,6 +646,10 @@ export class AgenticOrg {
   public mcp: MCPResource;
   public workflows: WorkflowsResource;
   public knowledge: KnowledgeResource;
+  public voice: VoiceResource;
+  public rpa: RPAResource;
+  public bridges: BridgesResource;
+  public commerce: CommerceResource;
 
   constructor(config: AgenticOrgConfig = {}) {
     const apiKey = config.apiKey ?? process.env.AGENTICORG_API_KEY ?? "";
@@ -402,5 +678,9 @@ export class AgenticOrg {
     this.mcp = new MCPResource(http);
     this.workflows = new WorkflowsResource(http);
     this.knowledge = new KnowledgeResource(http);
+    this.voice = new VoiceResource(http);
+    this.rpa = new RPAResource(http);
+    this.bridges = new BridgesResource(http);
+    this.commerce = new CommerceResource(http);
   }
 }

--- a/sdk-ts/test/sdk-contract-smoke.mjs
+++ b/sdk-ts/test/sdk-contract-smoke.mjs
@@ -8,7 +8,12 @@ const calls = [];
 
 globalThis.fetch = async (url, init = {}) => {
   const parsed = new URL(url);
-  const body = init.body ? JSON.parse(String(init.body)) : undefined;
+  let body;
+  if (init.body instanceof FormData) {
+    body = Object.fromEntries(init.body.entries());
+  } else if (init.body) {
+    body = JSON.parse(String(init.body));
+  }
   calls.push({
     method: init.method || "GET",
     path: parsed.pathname,
@@ -26,6 +31,8 @@ globalThis.fetch = async (url, init = {}) => {
   if (parsed.pathname === "/api/v1/connectors") {
     return json({ items: [{ id: "registry-confluence", category: "ops" }] });
   }
+  if (parsed.pathname === "/api/v1/connectors/connector_ts_1/health") return json({ status: "healthy" });
+  if (parsed.pathname === "/api/v1/connectors/connector_ts_1/test") return json({ ok: true });
   if (parsed.pathname === "/api/v1/agents/generate") {
     return json({
       suggestions: [
@@ -66,6 +73,52 @@ globalThis.fetch = async (url, init = {}) => {
       results: [{ chunk_text: "KB result", score: 0.91, document_name: "contract-kb.md" }],
     });
   }
+  if (parsed.pathname === "/api/v1/knowledge/supported-types") {
+    return json({ extensions: ["pdf", "png", "docx"], ocr: true });
+  }
+  if (parsed.pathname === "/api/v1/knowledge/upload") {
+    return json({ document_id: "doc_ts_1", filename: body.file.name, status: "processing" }, 201);
+  }
+  if (parsed.pathname === "/api/v1/knowledge/documents/doc_ts_1" && init.method === "DELETE") {
+    return json({ document_id: "doc_ts_1", status: "deleted" });
+  }
+  if (parsed.pathname === "/api/v1/knowledge/documents") {
+    return json({ items: [{ document_id: "doc_ts_1" }], total: 1 });
+  }
+  if (parsed.pathname === "/api/v1/knowledge/health") return json({ effective_mode: "pgvector" });
+  if (parsed.pathname === "/api/v1/knowledge/stats") return json({ total_documents: 1 });
+  if (parsed.pathname === "/api/v1/voice/status") return json({ configured: true, runtime_status: "ready" });
+  if (parsed.pathname === "/api/v1/voice/config") return json({ runtime_status: "ready", credentials: {} });
+  if (parsed.pathname === "/api/v1/voice/test-connection") return json({ ok: true });
+  if (parsed.pathname === "/api/v1/voice/runtime/health") return json({ status: "ready" });
+  if (parsed.pathname === "/api/v1/voice/calls/outbound") return json({ id: "call_ts_1", status: "queued" });
+  if (parsed.pathname === "/api/v1/voice/calls") return json([{ id: "call_ts_1" }]);
+  if (parsed.pathname === "/api/v1/rpa/scripts/builtin-gst-portal/run") return json({ id: "rpa_ts_1", status: "completed" });
+  if (parsed.pathname === "/api/v1/rpa/scripts") return json([{ id: "builtin-gst-portal" }]);
+  if (parsed.pathname === "/api/v1/rpa/history") return json([{ id: "rpa_ts_1" }]);
+  if (parsed.pathname === "/api/v1/bridge/register") return json({ bridge_id: "bridge_ts_1", bridge_token: "masked-test" });
+  if (parsed.pathname === "/api/v1/bridge/bridge_ts_1/status") return json({ bridge_id: "bridge_ts_1", connected: false });
+  if (parsed.pathname === "/api/v1/bridge/bridge_ts_1" && init.method === "DELETE") return json({ bridge_id: "bridge_ts_1", status: "deregistered" });
+  if (parsed.pathname === "/api/v1/bridge/route/tally") return json({ status: "completed" });
+  if (parsed.pathname === "/api/v1/bridge/list") return json([{ bridge_id: "bridge_ts_1" }]);
+  if (parsed.pathname === "/api/v1/commerce/runtime/seller-agents/onboarding-packets") return json({ packet_id: "packet_ts_1" });
+  if (parsed.pathname === "/api/v1/commerce/runtime/seller-agents/onboarding-packets/packet_ts_1") return json({ packet_id: "packet_ts_1" });
+  if (parsed.pathname === "/api/v1/commerce/runtime/seller-agents/connectors/shopify/credentials") return json({ status: "configured" });
+  if (parsed.pathname === "/api/v1/commerce/runtime/seller-agents/connectors/shopify/status") return json({ status: "configured" });
+  if (parsed.pathname === "/api/v1/commerce/runtime/seller-agents/shopify/sync") return json({ status: "read_only_sync_queued" });
+  if (parsed.pathname === "/api/v1/commerce/runtime/authority/grantex/request") return json({ status: "prepared" });
+  if (parsed.pathname === "/api/v1/commerce/runtime/artifacts/cache") return json({ cached: 1 });
+  if (parsed.pathname === "/api/v1/commerce/runtime/buyer-sessions/ask") return json({ status: "answered_from_cache" });
+  if (parsed.pathname === "/api/v1/commerce/runtime/products") return json({ products: [{ id: "product_ts_1" }] });
+  if (parsed.pathname === "/api/v1/commerce/runtime/protocol-adapters") return json({ adapters: ["schema_org"] });
+  if (parsed.pathname === "/api/v1/commerce/runtime/protocol-adapters/schema_org") return json({ surface: "schema_org" });
+  if (parsed.pathname === "/api/v1/commerce/runtime/bridges/surfaces") return json({ surfaces: ["mcp", "a2a"] });
+  if (parsed.pathname === "/api/v1/commerce/runtime/providers/plural-pine/mandate-capability/verify") return json({ capability_verified: true, allowed_to_execute: false });
+  if (parsed.pathname === "/api/v1/commerce/runtime/purchase/prepare") return json({ status: "prepared", allowed_to_execute: false });
+  if (parsed.pathname === "/api/v1/commerce/runtime/pos/offline/readiness") return json({ status: "ready", allowed_to_execute: false });
+  if (parsed.pathname === "/api/v1/commerce/runtime/pos/offline/handoffs") return json({ handoff_id: "handoff_ts_1" });
+  if (parsed.pathname === "/api/v1/commerce/runtime/pos/offline/confirmations") return json({ status: "recorded" });
+  if (parsed.pathname === "/api/v1/commerce/runtime/pos/offline/simulator/confirm") return json({ status: "simulated" });
   if (parsed.pathname === "/api/v1/workflows/templates") {
     return json({ items: [{ id: "tpl-contract-renewal", domain: "ops" }] });
   }
@@ -88,6 +141,9 @@ globalThis.fetch = async (url, init = {}) => {
   if (parsed.pathname === "/api/v1/workflows/runs/run_ts_1") {
     return json({ run_id: "run_ts_1", status: "completed", steps: [{ step_id: "search_kb" }] });
   }
+  if (parsed.pathname === "/api/v1/workflows/runs/run_ts_1/cancel") {
+    return json({ run_id: "run_ts_1", status: "cancel_requested" });
+  }
   return json({ error: `unhandled ${parsed.pathname}` }, 404);
 };
 
@@ -103,6 +159,8 @@ assert.equal(legacy.confidence, 0.8);
 const client = new AgenticOrg({ apiKey: "sdk-ts-test-key", baseUrl: "https://agenticorg.test" });
 
 assert.equal((await client.connectors.list("ops"))[0].id, "registry-confluence");
+assert.equal((await client.connectors.health("connector_ts_1")).status, "healthy");
+assert.equal((await client.connectors.test("connector_ts_1")).ok, true);
 assert.equal((await client.a2a.agentCard()).skills[0].id, "commerce_sales_agent");
 assert.equal((await client.a2a.agents())[0].id, "commerce_sales_agent");
 assert.equal((await client.mcp.tools())[0].name, "agenticorg_commerce_sales_agent");
@@ -121,6 +179,53 @@ assert.equal(commerceRun.tool_calls[0].tool, "grantex_commerce:buyer_discovery_p
 
 assert.equal((await client.mcp.call("agenticorg_commerce_sales_agent", { inputs: {} })).isError, false);
 assert.equal((await client.knowledge.search("renewal policy", { topK: 1 }))[0].document_name, "contract-kb.md");
+assert.equal((await client.knowledge.supportedTypes()).ocr, true);
+const uploaded = await client.knowledge.upload(new Blob(["scanned invoice"]), "invoice.png");
+assert.equal(uploaded.document_id, "doc_ts_1");
+const uploadCall = calls.find((call) => call.path === "/api/v1/knowledge/upload");
+assert.deepEqual(uploadCall.params, { replace: "false", allow_duplicate: "false" });
+assert.equal((await client.knowledge.documents()).total, 1);
+assert.equal((await client.knowledge.health()).effective_mode, "pgvector");
+assert.equal((await client.knowledge.stats()).total_documents, 1);
+assert.equal((await client.knowledge.delete("doc_ts_1")).status, "deleted");
+assert.equal((await client.voice.status()).runtime_status, "ready");
+assert.equal((await client.voice.saveConfig({ provider: "mock" })).runtime_status, "ready");
+assert.equal((await client.voice.testConnection("mock", { token: "synthetic" })).ok, true);
+assert.equal((await client.voice.runtimeHealth("agent_ts_1")).status, "ready");
+assert.equal((await client.voice.calls("agent_ts_1"))[0].id, "call_ts_1");
+assert.equal((await client.voice.placeOutboundCall("agent_ts_1", "+919999999999")).status, "queued");
+assert.equal((await client.rpa.scripts())[0].id, "builtin-gst-portal");
+assert.equal((await client.rpa.history())[0].id, "rpa_ts_1");
+assert.equal((await client.rpa.run("builtin-gst-portal")).status, "completed");
+const bridge = await client.bridges.register({ tenant_id: "tenant_ts_1", connector_type: "tally" });
+assert.equal((await client.bridges.status(bridge.bridge_id)).connected, false);
+assert.equal((await client.bridges.list())[0].bridge_id, "bridge_ts_1");
+assert.equal((await client.bridges.route("tally", { bridge_id: bridge.bridge_id })).status, "completed");
+assert.equal((await client.bridges.deregister(bridge.bridge_id)).status, "deregistered");
+const packet = await client.commerce.createOnboardingPacket({ merchant_id: "merchant_ts_1" });
+assert.equal((await client.commerce.onboardingPacket(packet.packet_id)).packet_id, "packet_ts_1");
+assert.equal((await client.commerce.configureShopify({ merchant_id: "merchant_ts_1" })).status, "configured");
+assert.equal((await client.commerce.shopifyStatus("merchant_ts_1")).status, "configured");
+assert.equal((await client.commerce.syncShopify({ packet_id: "packet_ts_1" })).status, "read_only_sync_queued");
+assert.equal((await client.commerce.requestGrantexAuthority({ packet_id: "packet_ts_1" })).status, "prepared");
+assert.equal((await client.commerce.cacheArtifacts([{ artifact_id: "artifact_ts_1" }])).cached, 1);
+assert.equal((await client.commerce.products("merchant_ts_1")).products[0].id, "product_ts_1");
+assert.equal((await client.commerce.ask({ merchant_id: "merchant_ts_1", question: "What is fresh?" })).status, "answered_from_cache");
+assert.equal(
+  (await client.commerce.protocolAdapters("merchant_ts_1", "seller_ts_1")).adapters[0],
+  "schema_org",
+);
+assert.equal(
+  (await client.commerce.protocolAdapter("schema_org", "merchant_ts_1", "seller_ts_1")).surface,
+  "schema_org",
+);
+assert.equal((await client.commerce.bridgeSurfaces()).surfaces[0], "mcp");
+assert.equal((await client.commerce.verifyMandateCapability({ merchant_id: "merchant_ts_1" })).allowed_to_execute, false);
+assert.equal((await client.commerce.preparePurchase({ merchant_id: "merchant_ts_1" })).allowed_to_execute, false);
+assert.equal((await client.commerce.offlinePosReadiness()).allowed_to_execute, false);
+assert.equal((await client.commerce.createOfflinePosHandoff({ merchant_id: "merchant_ts_1" })).handoff_id, "handoff_ts_1");
+assert.equal((await client.commerce.confirmOfflinePosHandoff({ handoff_id: "handoff_ts_1" })).status, "recorded");
+assert.equal((await client.commerce.simulateOfflinePosConfirmation({ handoff_id: "handoff_ts_1" })).status, "simulated");
 assert.equal((await client.workflows.templates("ops"))[0].id, "tpl-contract-renewal");
 assert.equal(
   (await client.workflows.generate("Search the KB and open a Jira issue.")).workflow.steps[0].agent_type,
@@ -145,6 +250,7 @@ const workflow = await client.workflows.create({
 });
 const run = await client.workflows.run(workflow.workflow_id, { payload: { contract_id: "CTR-1" } });
 assert.equal((await client.workflows.getRun(run.run_id)).status, "completed");
+assert.equal((await client.workflows.cancelRun(run.run_id)).status, "cancel_requested");
 
 assert.equal(new Set(calls.map((call) => call.authorization)).size, 1);
 assert.equal(calls[0].authorization, "Bearer sdk-ts-test-key");

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,27 @@
 # AgenticOrg Python SDK changelog
 
+## 0.4.0 - 2026-08-29
+
+Runtime surface release.
+
+### Added
+- Knowledge/OCR supported-type discovery, multipart upload, document listing,
+  deletion, health, and statistics.
+- Voice configuration/status, runtime health, call history, and explicitly
+  named outbound-call support.
+- RPA catalog, history, and explicit script execution.
+- Local bridge registration, status, routing, and deregistration.
+- Seller onboarding, Shopify sync, Grantex artifact handoff, cached buyer
+  questions, protocol adapters, mandate-capability verification, purchase
+  preparation, and offline POS handoffs through `client.commerce`.
+- Connector health/test and workflow-run cancellation helpers.
+
+### Fixed
+- SDK coverage now follows the production runtime rather than stopping at the
+  June 2026 agent/workflow subset.
+- Generated OpenAPI clients no longer encounter a duplicate Plural callback
+  operation ID.
+
 ## 0.3.0 - 2026-06-14
 
 Commerce, A2A/MCP, workflow, knowledge, and CLI release.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -97,7 +97,33 @@ or external actions.
 | `client.a2a` | `agent_card`, `agents` | Public discovery data can differ from authenticated runtime access. |
 | `client.mcp` | `tools`, `call` | Tool records do not create execution authority. |
 | `client.workflows` | generation, CRUD, run methods | Availability depends on the configured backend. |
-| `client.knowledge` | `search` | Results depend on authorized indexed content. |
+| `client.knowledge` | search, supported types, upload, documents, delete, health, stats | Uploads can invoke OCR and indexing; inspect returned status. |
+| `client.voice` | status, config, provider test, runtime health, calls, outbound call | Outbound calls are explicit and can incur provider charges. |
+| `client.rpa` | scripts, history, run | A selected script can perform external browser actions. |
+| `client.bridges` | register, list, status, route, deregister | Routes only to an authorized registered local bridge. |
+| `client.commerce` | seller onboarding, Shopify sync, artifact/cache, buyer ask, adapters, mandate evidence, purchase/POS preparation | Purchase and POS helpers prepare handoffs; provider/POS systems remain transaction authorities. |
+
+## Runtime examples
+
+```python
+types = client.knowledge.supported_types()
+document = client.knowledge.upload("scanned-invoice.pdf")
+
+products = client.commerce.products(merchant_id="merchant-123")
+answer = client.commerce.ask({
+    "merchant_id": "merchant-123",
+    "question": "Which variants are fresh and in stock?",
+})
+
+voice = client.voice.status()
+# Runtime health and call history are agent-scoped.
+runtime = client.voice.runtime_health("00000000-0000-0000-0000-000000000001")
+rpa_catalog = client.rpa.scripts()
+```
+
+`place_outbound_call`, `rpa.run`, `bridges.route`, Shopify sync, and provider
+verification are intentionally explicit methods. Call them only with reviewed
+tenant authorization and real external-action intent.
 
 Inspect actual responses and errors instead of relying on illustrative output.
 Authorization denials should remain denials; do not automatically broaden

--- a/sdk/agenticorg/__init__.py
+++ b/sdk/agenticorg/__init__.py
@@ -12,4 +12,4 @@ Quickstart:
 from agenticorg.client import AgenticOrg, AgentRunResult
 
 __all__ = ["AgenticOrg", "AgentRunResult"]
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/sdk/agenticorg/client.py
+++ b/sdk/agenticorg/client.py
@@ -104,8 +104,7 @@ class AgenticOrg:
 
         if not self._api_key and not self._grantex_token:
             raise ValueError(
-                "Provide api_key or grantex_token, or set "
-                "AGENTICORG_API_KEY / AGENTICORG_GRANTEX_TOKEN env var."
+                "Provide api_key or grantex_token, or set AGENTICORG_API_KEY / AGENTICORG_GRANTEX_TOKEN env var."
             )
 
         self._http = httpx.Client(
@@ -121,6 +120,10 @@ class AgenticOrg:
         self.mcp = _MCPResource(self._http)
         self.workflows = _WorkflowsResource(self._http)
         self.knowledge = _KnowledgeResource(self._http)
+        self.voice = _VoiceResource(self._http)
+        self.rpa = _RPAResource(self._http)
+        self.bridges = _BridgesResource(self._http)
+        self.commerce = _CommerceResource(self._http)
 
     def _build_headers(self) -> dict[str, str]:
         # Let httpx select the content type for each request. A client-level
@@ -199,10 +202,13 @@ class _AgentsResource:
             resp = self._http.post(f"/api/v1/agents/{agent_id_or_type}/run", json=payload)
         else:
             # Use A2A task endpoint for agent type
-            resp = self._http.post("/api/v1/a2a/tasks", json={
-                "agent_type": agent_id_or_type,
-                **payload,
-            })
+            resp = self._http.post(
+                "/api/v1/a2a/tasks",
+                json={
+                    "agent_type": agent_id_or_type,
+                    **payload,
+                },
+            )
 
         resp.raise_for_status()
         return _to_agent_run_result(resp.json())
@@ -251,6 +257,18 @@ class _ConnectorsResource:
         resp.raise_for_status()
         return resp.json()
 
+    def health(self, connector_id: str) -> dict[str, Any]:
+        """Read the connector's tenant-scoped health state."""
+        resp = self._http.get(f"/api/v1/connectors/{connector_id}/health")
+        resp.raise_for_status()
+        return resp.json()
+
+    def test(self, connector_id: str) -> dict[str, Any]:
+        """Run the backend's explicit connector connection test."""
+        resp = self._http.post(f"/api/v1/connectors/{connector_id}/test")
+        resp.raise_for_status()
+        return resp.json()
+
 
 class _SOPResource:
     def __init__(self, http: httpx.Client):
@@ -263,11 +281,14 @@ class _SOPResource:
         llm_model: str = "",
     ) -> dict[str, Any]:
         """Parse SOP text and return draft agent config."""
-        resp = self._http.post("/api/v1/sop/parse-text", json={
-            "text": text,
-            "domain_hint": domain_hint,
-            "llm_model": llm_model,
-        })
+        resp = self._http.post(
+            "/api/v1/sop/parse-text",
+            json={
+                "text": text,
+                "domain_hint": domain_hint,
+                "llm_model": llm_model,
+            },
+        )
         resp.raise_for_status()
         return resp.json()
 
@@ -322,10 +343,13 @@ class _MCPResource:
 
     def call(self, tool_name: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
         """Call an MCP tool."""
-        resp = self._http.post("/api/v1/mcp/call", json={
-            "name": tool_name,
-            "arguments": arguments or {},
-        })
+        resp = self._http.post(
+            "/api/v1/mcp/call",
+            json={
+                "name": tool_name,
+                "arguments": arguments or {},
+            },
+        )
         resp.raise_for_status()
         return resp.json()
 
@@ -424,6 +448,12 @@ class _WorkflowsResource:
         resp.raise_for_status()
         return resp.json()
 
+    def cancel_run(self, run_id: str) -> dict[str, Any]:
+        """Request cancellation of a workflow run."""
+        resp = self._http.post(f"/api/v1/workflows/runs/{run_id}/cancel")
+        resp.raise_for_status()
+        return resp.json()
+
 
 class _KnowledgeResource:
     def __init__(self, http: httpx.Client):
@@ -438,3 +468,289 @@ class _KnowledgeResource:
         resp.raise_for_status()
         data = resp.json()
         return data.get("results", data) if isinstance(data, dict) else data
+
+    def supported_types(self) -> dict[str, Any]:
+        """Return accepted document, image, audio, video, and OCR formats."""
+        resp = self._http.get("/api/v1/knowledge/supported-types")
+        resp.raise_for_status()
+        return resp.json()
+
+    def upload(self, file_path: str, *, duplicate_policy: str = "reject") -> dict[str, Any]:
+        """Upload a knowledge document using a real multipart request."""
+        if duplicate_policy not in {"reject", "replace", "allow_duplicate"}:
+            raise ValueError("duplicate_policy must be reject, replace, or allow_duplicate")
+        params = {
+            "replace": str(duplicate_policy == "replace").lower(),
+            "allow_duplicate": str(duplicate_policy == "allow_duplicate").lower(),
+        }
+        with open(file_path, "rb") as file_handle:
+            resp = self._http.post(
+                "/api/v1/knowledge/upload",
+                params=params,
+                files={"file": file_handle},
+            )
+        resp.raise_for_status()
+        return resp.json()
+
+    def documents(self, *, page: int = 1, per_page: int = 20) -> dict[str, Any]:
+        """List tenant knowledge documents and extraction state."""
+        resp = self._http.get(
+            "/api/v1/knowledge/documents",
+            params={"page": page, "per_page": per_page},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def delete(self, document_id: str) -> dict[str, Any]:
+        """Delete one tenant knowledge document."""
+        resp = self._http.delete(f"/api/v1/knowledge/documents/{document_id}")
+        resp.raise_for_status()
+        return resp.json()
+
+    def health(self) -> dict[str, Any]:
+        """Read the public retrieval/OCR backend health summary."""
+        resp = self._http.get("/api/v1/knowledge/health")
+        resp.raise_for_status()
+        return resp.json()
+
+    def stats(self) -> dict[str, Any]:
+        """Read tenant knowledge indexing statistics."""
+        resp = self._http.get("/api/v1/knowledge/stats")
+        resp.raise_for_status()
+        return resp.json()
+
+
+class _VoiceResource:
+    def __init__(self, http: httpx.Client):
+        self._http = http
+
+    def status(self, *, agent_id: str | None = None) -> dict[str, Any]:
+        params = {"agent_id": agent_id} if agent_id else None
+        resp = self._http.get("/api/v1/voice/status", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    def save_config(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Store an admin-reviewed voice configuration; secrets are masked on return."""
+        resp = self._http.post("/api/v1/voice/config", json=config)
+        resp.raise_for_status()
+        return resp.json()
+
+    def test_connection(self, provider: str, credentials: dict[str, Any]) -> dict[str, Any]:
+        """Explicitly probe provider credentials without persisting them."""
+        resp = self._http.post(
+            "/api/v1/voice/test-connection",
+            json={"provider": provider, "credentials": credentials},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def runtime_health(self, agent_id: str) -> dict[str, Any]:
+        resp = self._http.get("/api/v1/voice/runtime/health", params={"agent_id": agent_id})
+        resp.raise_for_status()
+        return resp.json()
+
+    def calls(self, agent_id: str, *, limit: int = 25) -> list[dict[str, Any]]:
+        resp = self._http.get(
+            "/api/v1/voice/calls",
+            params={"agent_id": agent_id, "limit": limit},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def place_outbound_call(self, *, agent_id: str, to_number: str) -> dict[str, Any]:
+        """Place a real outbound call. This can incur provider charges."""
+        resp = self._http.post(
+            "/api/v1/voice/calls/outbound",
+            json={"agent_id": agent_id, "to_number": to_number},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+class _RPAResource:
+    def __init__(self, http: httpx.Client):
+        self._http = http
+
+    def scripts(self) -> list[dict[str, Any]]:
+        resp = self._http.get("/api/v1/rpa/scripts")
+        resp.raise_for_status()
+        return resp.json()
+
+    def history(self, *, limit: int = 50) -> list[dict[str, Any]]:
+        resp = self._http.get("/api/v1/rpa/history", params={"limit": limit})
+        resp.raise_for_status()
+        return resp.json()
+
+    def run(self, script_id: str, *, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Run an RPA script. The selected script may perform external actions."""
+        resp = self._http.post(
+            f"/api/v1/rpa/scripts/{script_id}/run",
+            json={"params": params or {}},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+class _BridgesResource:
+    def __init__(self, http: httpx.Client):
+        self._http = http
+
+    def list(self) -> list[dict[str, Any]]:
+        resp = self._http.get("/api/v1/bridge/list")
+        resp.raise_for_status()
+        return resp.json()
+
+    def register(self, data: dict[str, Any]) -> dict[str, Any]:
+        resp = self._http.post("/api/v1/bridge/register", json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+    def status(self, bridge_id: str) -> dict[str, Any]:
+        resp = self._http.get(f"/api/v1/bridge/{bridge_id}/status")
+        resp.raise_for_status()
+        return resp.json()
+
+    def deregister(self, bridge_id: str) -> dict[str, Any]:
+        resp = self._http.delete(f"/api/v1/bridge/{bridge_id}")
+        resp.raise_for_status()
+        return resp.json()
+
+    def route(self, connector_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """Route an explicit request to a registered local bridge."""
+        resp = self._http.post(f"/api/v1/bridge/route/{connector_type}", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+
+class _CommerceResource:
+    _PREFIX = "/api/v1/commerce/runtime"
+
+    def __init__(self, http: httpx.Client):
+        self._http = http
+
+    def create_onboarding_packet(self, data: dict[str, Any]) -> dict[str, Any]:
+        resp = self._http.post(f"{self._PREFIX}/seller-agents/onboarding-packets", json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+    def onboarding_packet(self, packet_id: str) -> dict[str, Any]:
+        resp = self._http.get(f"{self._PREFIX}/seller-agents/onboarding-packets/{packet_id}")
+        resp.raise_for_status()
+        return resp.json()
+
+    def configure_shopify(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Store Shopify credentials through the server's encrypted connector vault."""
+        resp = self._http.post(f"{self._PREFIX}/seller-agents/connectors/shopify/credentials", json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+    def shopify_status(self, merchant_id: str) -> dict[str, Any]:
+        resp = self._http.get(
+            f"{self._PREFIX}/seller-agents/connectors/shopify/status",
+            params={"merchant_id": merchant_id},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def sync_shopify(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Initiate a real read-only Shopify catalog sync."""
+        resp = self._http.post(f"{self._PREFIX}/seller-agents/shopify/sync", json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+    def request_grantex_authority(self, data: dict[str, Any]) -> dict[str, Any]:
+        resp = self._http.post(f"{self._PREFIX}/authority/grantex/request", json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+    def cache_artifacts(self, artifacts: list[dict[str, Any]], *, buyer_agent_id: str | None = None) -> dict[str, Any]:
+        resp = self._http.post(
+            f"{self._PREFIX}/artifacts/cache",
+            json={"artifacts": artifacts, "buyer_agent_id": buyer_agent_id},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def ask(self, data: dict[str, Any]) -> dict[str, Any]:
+        resp = self._http.post(f"{self._PREFIX}/buyer-sessions/ask", json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+    def products(
+        self, *, merchant_id: str, seller_agent_id: str | None = None, query: str | None = None
+    ) -> dict[str, Any]:
+        params = {"merchant_id": merchant_id}
+        if seller_agent_id:
+            params["seller_agent_id"] = seller_agent_id
+        if query:
+            params["q"] = query
+        resp = self._http.get(f"{self._PREFIX}/products", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    def protocol_adapters(
+        self,
+        *,
+        merchant_id: str,
+        seller_agent_id: str,
+        buyer_agent_id: str | None = None,
+    ) -> dict[str, Any]:
+        params = {"merchant_id": merchant_id, "seller_agent_id": seller_agent_id}
+        if buyer_agent_id:
+            params["buyer_agent_id"] = buyer_agent_id
+        resp = self._http.get(f"{self._PREFIX}/protocol-adapters", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    def protocol_adapter(
+        self,
+        surface: str,
+        *,
+        merchant_id: str,
+        seller_agent_id: str,
+        buyer_agent_id: str | None = None,
+    ) -> dict[str, Any]:
+        params = {"merchant_id": merchant_id, "seller_agent_id": seller_agent_id}
+        if buyer_agent_id:
+            params["buyer_agent_id"] = buyer_agent_id
+        resp = self._http.get(f"{self._PREFIX}/protocol-adapters/{surface}", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    def bridge_surfaces(self) -> dict[str, Any]:
+        resp = self._http.get(f"{self._PREFIX}/bridges/surfaces")
+        resp.raise_for_status()
+        return resp.json()
+
+    def verify_mandate_capability(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Verify provider-owned mandate capability without executing payment."""
+        resp = self._http.post(f"{self._PREFIX}/providers/plural-pine/mandate-capability/verify", json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+    def prepare_purchase(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Prepare a non-executing purchase handoff."""
+        resp = self._http.post(f"{self._PREFIX}/purchase/prepare", json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+    def offline_pos_readiness(self) -> dict[str, Any]:
+        resp = self._http.get(f"{self._PREFIX}/pos/offline/readiness")
+        resp.raise_for_status()
+        return resp.json()
+
+    def create_offline_pos_handoff(self, data: dict[str, Any]) -> dict[str, Any]:
+        resp = self._http.post(f"{self._PREFIX}/pos/offline/handoffs", json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+    def confirm_offline_pos_handoff(self, data: dict[str, Any]) -> dict[str, Any]:
+        resp = self._http.post(f"{self._PREFIX}/pos/offline/confirmations", json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+    def simulate_offline_pos_confirmation(self, data: dict[str, Any]) -> dict[str, Any]:
+        resp = self._http.post(f"{self._PREFIX}/pos/offline/simulator/confirm", json=data)
+        resp.raise_for_status()
+        return resp.json()

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agenticorg"
-version = "0.3.0"
-description = "Python SDK for AgenticOrg - run agents, generate agents/workflows, use KB, A2A, and MCP"
+version = "0.4.0"
+description = "Python SDK for AgenticOrg agents, knowledge/OCR, voice, RPA, bridges, and commerce runtime"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"

--- a/tests/connector_harness/test_all_connectors.py
+++ b/tests/connector_harness/test_all_connectors.py
@@ -12,9 +12,7 @@ from tests.connector_harness.conftest import get_all_connector_names, make_conne
 ALL_NAMES = get_all_connector_names()
 VALID_CONNECTOR_CATEGORIES = {"finance", "hr", "comms", "marketing", "ops", "commerce"}
 
-pytestmark = pytest.mark.asyncio
-
-
+@pytest.mark.asyncio
 @pytest.mark.parametrize("connector_name", ALL_NAMES)
 class TestConnectorToolExecution:
     """Test every tool on every connector returns valid JSON."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -168,7 +168,7 @@ def _patch_jwt_validation(monkeypatch: pytest.MonkeyPatch) -> None:
             **{
                 **{
                     field: getattr(auth_jwt_module.settings, field)
-                    for field in auth_jwt_module.settings.model_fields
+                    for field in type(auth_jwt_module.settings).model_fields
                 },
                 "jwt_issuer": "agenticorg-test-issuer",
                 "jwt_public_key_url": "https://test.example.com/.well-known/jwks.json",

--- a/tests/regression/test_knowledge_documents_migration_repair_20260829.py
+++ b/tests/regression/test_knowledge_documents_migration_repair_20260829.py
@@ -1,0 +1,37 @@
+"""Pins the fresh/legacy knowledge index migration repair."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_knowledge_documents_repair_is_idempotent_tenant_safe_and_current_shape() -> None:
+    source = (ROOT / "migrations" / "versions" / "v6_z13_knowledge_documents_repair.py").read_text(encoding="utf-8")
+
+    assert 'revision = "v6z13_knowledge_docs"' in source
+    assert 'down_revision = "v6z12_voice_runtime"' in source
+    assert "CREATE TABLE IF NOT EXISTS knowledge_documents" in source
+    for column in (
+        "title VARCHAR(500)",
+        "content TEXT",
+        "embedding vector(384)",
+        "embedding_bge_m3 vector(1024)",
+        "source_object_id VARCHAR(128)",
+        "source_object_type VARCHAR(32)",
+    ):
+        assert column in source
+    assert "ENABLE ROW LEVEL SECURITY" in source
+    assert "knowledge_documents_tenant_isolation" in source
+    assert "ix_knowledge_documents_tenant_source_object" in source
+    assert "WITH CHECK" in source
+    assert "DROP TABLE" not in source
+
+
+def test_native_knowledge_chunks_follow_document_deletion_lifecycle() -> None:
+    source = (ROOT / "api" / "v1" / "knowledge.py").read_text(encoding="utf-8")
+
+    assert "UPDATE knowledge_documents SET status = 'deleted'" in source
+    assert source.count("status = 'ready'") >= 4
+    assert "if result.rowcount == 0 and not ragflow_deleted" in source

--- a/tests/regression/test_sdk_release_metadata_20260614.py
+++ b/tests/regression/test_sdk_release_metadata_20260614.py
@@ -19,7 +19,7 @@ def test_python_sdk_release_version_matches_cli_package_metadata() -> None:
 
     assert match
     assert pyproject["project"]["name"] == "agenticorg"
-    assert pyproject["project"]["version"] == "0.3.0"
+    assert pyproject["project"]["version"] == "0.4.0"
     assert match.group(1) == pyproject["project"]["version"]
     assert pyproject["project"]["scripts"]["agenticorg"] == "agenticorg.cli:main"
 
@@ -42,7 +42,7 @@ def test_typescript_sdk_release_metadata_uses_published_package_name() -> None:
     source = (ROOT / "sdk-ts" / "src" / "index.ts").read_text(encoding="utf-8")
 
     assert package_json["name"] == "agenticorg-sdk"
-    assert package_json["version"] == "0.3.0"
+    assert package_json["version"] == "0.4.0"
     assert package_lock["version"] == package_json["version"]
     assert package_lock["packages"][""]["version"] == package_json["version"]
     assert 'from "agenticorg-sdk"' in source

--- a/tests/regression/test_sdk_runtime_resources_20260829.py
+++ b/tests/regression/test_sdk_runtime_resources_20260829.py
@@ -1,0 +1,222 @@
+"""Contract coverage for the AgenticOrg 0.4 runtime SDK resources."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+from typing import Any
+
+import httpx
+import pytest
+
+
+def _load_sdk() -> Any:
+    root = pathlib.Path(__file__).resolve().parents[2]
+    path = root / "sdk" / "agenticorg" / "client.py"
+    spec = importlib.util.spec_from_file_location("_repo_runtime_sdk", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_repo_runtime_sdk"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_runtime_sdk_resources_use_canonical_paths_and_preserve_auth(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    sdk = _load_sdk()
+    calls: list[tuple[str, str, str, bytes, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(
+            (
+                request.method,
+                request.url.path,
+                request.headers.get("authorization", ""),
+                request.content,
+                request.url.query.decode(),
+            )
+        )
+        path = request.url.path
+        if path == "/api/v1/connectors/connector_py_1/health":
+            return httpx.Response(200, json={"status": "healthy"})
+        if path == "/api/v1/connectors/connector_py_1/test":
+            return httpx.Response(200, json={"ok": True})
+        if path == "/api/v1/workflows/runs/run_py_1/cancel":
+            return httpx.Response(200, json={"status": "cancel_requested"})
+        if path == "/api/v1/knowledge/supported-types":
+            return httpx.Response(200, json={"ocr": True})
+        if path == "/api/v1/knowledge/upload":
+            return httpx.Response(201, json={"document_id": "doc_py_1"})
+        if path == "/api/v1/knowledge/documents":
+            return httpx.Response(200, json={"items": [{"document_id": "doc_py_1"}], "total": 1})
+        if path == "/api/v1/knowledge/documents/doc_py_1":
+            return httpx.Response(200, json={"status": "deleted"})
+        if path == "/api/v1/knowledge/health":
+            return httpx.Response(200, json={"effective_mode": "pgvector"})
+        if path == "/api/v1/knowledge/stats":
+            return httpx.Response(200, json={"total_documents": 1})
+        if path == "/api/v1/voice/status":
+            return httpx.Response(200, json={"runtime_status": "ready"})
+        if path == "/api/v1/voice/config":
+            return httpx.Response(200, json={"status": "saved"})
+        if path == "/api/v1/voice/test-connection":
+            return httpx.Response(200, json={"ok": True})
+        if path == "/api/v1/voice/runtime/health":
+            return httpx.Response(200, json={"status": "ready"})
+        if path == "/api/v1/voice/calls":
+            return httpx.Response(200, json=[{"id": "call_py_1"}])
+        if path == "/api/v1/voice/calls/outbound":
+            return httpx.Response(200, json={"status": "queued"})
+        if path == "/api/v1/rpa/scripts":
+            return httpx.Response(200, json=[{"id": "builtin-gst-portal"}])
+        if path == "/api/v1/rpa/history":
+            return httpx.Response(200, json=[{"id": "rpa_py_1"}])
+        if path == "/api/v1/rpa/scripts/builtin-gst-portal/run":
+            return httpx.Response(200, json={"status": "completed"})
+        if path == "/api/v1/bridge/register":
+            return httpx.Response(200, json={"bridge_id": "bridge_py_1"})
+        if path == "/api/v1/bridge/bridge_py_1/status":
+            return httpx.Response(200, json={"connected": False})
+        if path == "/api/v1/bridge/bridge_py_1":
+            return httpx.Response(200, json={"status": "deregistered"})
+        if path == "/api/v1/bridge/list":
+            return httpx.Response(200, json=[{"bridge_id": "bridge_py_1"}])
+        if path == "/api/v1/bridge/route/tally":
+            return httpx.Response(200, json={"status": "completed"})
+        if path == "/api/v1/commerce/runtime/seller-agents/onboarding-packets":
+            return httpx.Response(200, json={"packet_id": "packet_py_1"})
+        if path == "/api/v1/commerce/runtime/seller-agents/onboarding-packets/packet_py_1":
+            return httpx.Response(200, json={"packet_id": "packet_py_1"})
+        if path == "/api/v1/commerce/runtime/seller-agents/connectors/shopify/credentials":
+            return httpx.Response(200, json={"status": "configured"})
+        if path == "/api/v1/commerce/runtime/seller-agents/connectors/shopify/status":
+            return httpx.Response(200, json={"status": "configured"})
+        if path == "/api/v1/commerce/runtime/seller-agents/shopify/sync":
+            return httpx.Response(200, json={"status": "read_only_sync_queued"})
+        if path == "/api/v1/commerce/runtime/authority/grantex/request":
+            return httpx.Response(200, json={"status": "prepared"})
+        if path == "/api/v1/commerce/runtime/artifacts/cache":
+            return httpx.Response(200, json={"cached": 1})
+        if path == "/api/v1/commerce/runtime/products":
+            return httpx.Response(200, json={"products": [{"id": "product_py_1"}]})
+        if path == "/api/v1/commerce/runtime/buyer-sessions/ask":
+            return httpx.Response(200, json={"status": "answered_from_cache"})
+        if path == "/api/v1/commerce/runtime/protocol-adapters":
+            return httpx.Response(200, json={"adapters": ["schema_org"]})
+        if path == "/api/v1/commerce/runtime/protocol-adapters/schema_org":
+            return httpx.Response(200, json={"surface": "schema_org"})
+        if path == "/api/v1/commerce/runtime/bridges/surfaces":
+            return httpx.Response(200, json={"surfaces": ["mcp", "a2a"]})
+        if path.endswith("/providers/plural-pine/mandate-capability/verify"):
+            return httpx.Response(200, json={"allowed_to_execute": False})
+        if path == "/api/v1/commerce/runtime/purchase/prepare":
+            return httpx.Response(200, json={"allowed_to_execute": False})
+        if path == "/api/v1/commerce/runtime/pos/offline/readiness":
+            return httpx.Response(200, json={"allowed_to_execute": False})
+        if path == "/api/v1/commerce/runtime/pos/offline/handoffs":
+            return httpx.Response(200, json={"handoff_id": "handoff_py_1"})
+        if path == "/api/v1/commerce/runtime/pos/offline/confirmations":
+            return httpx.Response(200, json={"status": "recorded"})
+        if path == "/api/v1/commerce/runtime/pos/offline/simulator/confirm":
+            return httpx.Response(200, json={"status": "simulated"})
+        return httpx.Response(404, json={"path": path})
+
+    transport = httpx.MockTransport(handler)
+    original_client = sdk.httpx.Client
+
+    def client_factory(*args: Any, **kwargs: Any) -> httpx.Client:
+        kwargs["transport"] = transport
+        return original_client(*args, **kwargs)
+
+    monkeypatch.setattr(sdk.httpx, "Client", client_factory)
+    upload = tmp_path / "scan.png"
+    upload.write_bytes(b"synthetic scanned document")
+
+    with sdk.AgenticOrg(api_key="sdk-runtime-key", base_url="https://agenticorg.test") as client:
+        assert client.connectors.health("connector_py_1")["status"] == "healthy"
+        assert client.connectors.test("connector_py_1")["ok"] is True
+        assert client.workflows.cancel_run("run_py_1")["status"] == "cancel_requested"
+        assert client.knowledge.supported_types()["ocr"] is True
+        assert client.knowledge.upload(str(upload))["document_id"] == "doc_py_1"
+        assert client.knowledge.documents()["total"] == 1
+        assert client.knowledge.health()["effective_mode"] == "pgvector"
+        assert client.knowledge.stats()["total_documents"] == 1
+        assert client.knowledge.delete("doc_py_1")["status"] == "deleted"
+        assert client.voice.status()["runtime_status"] == "ready"
+        assert client.voice.save_config({"provider": "mock"})["status"] == "saved"
+        assert client.voice.test_connection("mock", {"token": "synthetic"})["ok"] is True
+        assert client.voice.runtime_health("agent_py_1")["status"] == "ready"
+        assert client.voice.calls("agent_py_1")[0]["id"] == "call_py_1"
+        assert (
+            client.voice.place_outbound_call(
+                agent_id="00000000-0000-0000-0000-000000000001",
+                to_number="+919999999999",
+            )["status"]
+            == "queued"
+        )
+        assert client.rpa.scripts()[0]["id"] == "builtin-gst-portal"
+        assert client.rpa.history()[0]["id"] == "rpa_py_1"
+        assert client.rpa.run("builtin-gst-portal")["status"] == "completed"
+        bridge = client.bridges.register({"tenant_id": "tenant_py_1", "connector_type": "tally"})
+        assert client.bridges.status(bridge["bridge_id"])["connected"] is False
+        assert client.bridges.list()[0]["bridge_id"] == "bridge_py_1"
+        assert client.bridges.route("tally", {"bridge_id": bridge["bridge_id"]})["status"] == "completed"
+        assert client.bridges.deregister(bridge["bridge_id"])["status"] == "deregistered"
+        packet = client.commerce.create_onboarding_packet({"merchant_id": "merchant_py_1"})
+        assert client.commerce.onboarding_packet(packet["packet_id"])["packet_id"] == "packet_py_1"
+        assert client.commerce.configure_shopify({"merchant_id": "merchant_py_1"})["status"] == "configured"
+        assert client.commerce.shopify_status("merchant_py_1")["status"] == "configured"
+        assert client.commerce.sync_shopify({"packet_id": "packet_py_1"})["status"] == "read_only_sync_queued"
+        assert client.commerce.request_grantex_authority({"packet_id": "packet_py_1"})["status"] == "prepared"
+        assert client.commerce.cache_artifacts([{"artifact_id": "artifact_py_1"}])["cached"] == 1
+        assert client.commerce.products(merchant_id="merchant_py_1")["products"][0]["id"] == "product_py_1"
+        assert (
+            client.commerce.ask({"merchant_id": "merchant_py_1", "question": "What is fresh?"})["status"]
+            == "answered_from_cache"
+        )
+        assert client.commerce.protocol_adapters(
+            merchant_id="merchant_py_1",
+            seller_agent_id="seller_py_1",
+        )["adapters"] == ["schema_org"]
+        assert (
+            client.commerce.protocol_adapter(
+                "schema_org",
+                merchant_id="merchant_py_1",
+                seller_agent_id="seller_py_1",
+            )["surface"]
+            == "schema_org"
+        )
+        assert client.commerce.bridge_surfaces()["surfaces"] == ["mcp", "a2a"]
+        assert (
+            client.commerce.verify_mandate_capability({"merchant_id": "merchant_py_1"})["allowed_to_execute"] is False
+        )
+        assert client.commerce.prepare_purchase({"merchant_id": "merchant_py_1"})["allowed_to_execute"] is False
+        assert client.commerce.offline_pos_readiness()["allowed_to_execute"] is False
+        assert (
+            client.commerce.create_offline_pos_handoff({"merchant_id": "merchant_py_1"})["handoff_id"] == "handoff_py_1"
+        )
+        assert client.commerce.confirm_offline_pos_handoff({"handoff_id": "handoff_py_1"})["status"] == "recorded"
+        assert (
+            client.commerce.simulate_offline_pos_confirmation({"handoff_id": "handoff_py_1"})["status"] == "simulated"
+        )
+
+    assert calls
+    assert {authorization for _, _, authorization, _, _ in calls} == {"Bearer sdk-runtime-key"}
+    upload_call = next(call for call in calls if call[1] == "/api/v1/knowledge/upload")
+    assert upload_call[4] == "replace=false&allow_duplicate=false"
+    assert b'name="file"; filename="scan.png"' in upload_call[3]
+
+
+def test_openapi_operation_ids_are_unique_for_generated_sdks() -> None:
+    from api.main import app
+
+    operation_ids = [
+        operation["operationId"]
+        for path in app.openapi()["paths"].values()
+        for operation in path.values()
+        if isinstance(operation, dict) and "operationId" in operation
+    ]
+    assert len(operation_ids) == len(set(operation_ids))

--- a/tests/unit/test_enterprise_stability_gates.py
+++ b/tests/unit/test_enterprise_stability_gates.py
@@ -587,7 +587,7 @@ def test_auth_billing_connector_target_routes_have_metadata() -> None:
     routes = gates.scan_routes(target_paths, gates.REPO_ROOT)
     findings = gates.route_metadata_findings(routes)
 
-    assert len(routes) == 44
+    assert len(routes) == 45
     assert findings == []
     assert all(route.metadata_present for route in routes)
     assert all(route.scope for route in routes)

--- a/ui/public/llms-full.txt
+++ b/ui/public/llms-full.txt
@@ -177,13 +177,21 @@ See [sdk/README.md](https://github.com/mishrasanjeev/agentic-org/blob/main/sdk/R
     agenticorg agents list
     agenticorg a2a card
 
-The SDK supports authenticated platform operations exposed by its client. Server features may require a newer deployment than the installed client, so consumers should check package and server release notes.
+SDK `0.4.0` covers agents, workflows, connector diagnostics, knowledge/OCR,
+voice, RPA, local bridges, and the seller-commerce runtime. External-action
+methods such as outbound calls, RPA runs, connector sync, and bridge routing
+remain explicit calls and still require tenant authorization. Server features
+may require a newer deployment than the installed client, so consumers should
+check package and server release notes.
 
 ### TypeScript SDK
 
 See [sdk-ts/README.md](https://github.com/mishrasanjeev/agentic-org/blob/main/sdk-ts/README.md).
 
     npm install agenticorg-sdk
+
+The TypeScript `0.4.0` resource surface mirrors the Python runtime coverage,
+including knowledge/OCR, voice, RPA, bridges, and commerce preparation APIs.
 
 ### MCP server
 


### PR DESCRIPTION
## Summary
- update the Python and TypeScript SDKs to 0.4.0 and expose the current connector, knowledge, voice, RPA, bridge, and commerce runtime resources
- repair fresh and legacy `knowledge_documents` installations, and make knowledge deletion retire native search chunks as well as RAGFlow/metadata records
- assign unique billing callback OpenAPI operation IDs and expand SDK/runtime regression coverage
- refresh SDK release documentation and changelogs

## Local validation
- fresh `scripts/local_e2e.sh` Docker run: 701 passed, 9 skipped
- knowledge/OCR: 25 passed
- voice/STT/TTS: 31 passed, 1 skipped
- RPA: 80 passed
- commerce: 182 passed, 1 skipped
- connector/bridge/A2A matrix: 359 passed
- billing/OpenAPI/SDK: 62 passed
- Python SDK regression suite: 8 passed
- TypeScript SDK build and contract smoke: 54 calls passed
- Python wheel and sdist built; wheel installed into an empty venv and exercised against the Docker-backed API
- TypeScript `npm pack --dry-run` passed
- ruff, mypy, auth-service typecheck, migration single-head check, diff hygiene, ASCII, hidden Unicode, and secret scans passed

## Installed SDK runtime flow
The installed Python 0.4.0 wheel exercised local auth, agents, connectors, supported knowledge types, multipart knowledge upload/search/delete, knowledge health/stats, voice status/runtime/history, RPA catalog/history, bridge lifecycle, commerce onboarding/status/products/adapters/bridge surfaces, and offline POS readiness.

No paid voice call, external RPA action, live Shopify/provider/private API request, live Grantex request, or payment execution was performed. Those paths remain covered by mocked/fail-closed tests because no approved external destination or credentials were used.

## Notes
- MCP stays at 4.0.5 because its current commerce tool surface already passes consistency and package checks.
- One pre-existing Authlib deprecation warning remains and should be handled as a separate auth-library migration.