### PR TITLE
Fix multichannel voice email RPA OCR release verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,14 @@ SLACK_BOT_TOKEN=xoxb-...
 SLACK_HITL_CHANNEL=#hitl-approvals
 SENDGRID_API_KEY=SG....
 HITL_NOTIFICATION_EMAIL=ops@yourorg.com
+# SMTP defaults to Gmail implicit TLS. Plain mode is accepted only for a
+# loopback capture service while AGENTICORG_ENV is local/dev/test/ci.
+AGENTICORG_SMTP_HOST=smtp.gmail.com
+AGENTICORG_SMTP_PORT=465
+AGENTICORG_SMTP_SECURITY=ssl                    # ssl | starttls | plain (loopback local/test only)
+AGENTICORG_SMTP_LOGIN=
+AGENTICORG_GMAIL_APP_PASSWORD=
+AGENTICORG_DEMO_SENDER=sanjeev@agenticorg.ai
 
 # Platform
 AGENTICORG_APP_URL=https://app.agenticorg.com        # Base URL for the app (used in payment callbacks, portal return URLs)

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,11 @@ COPY schemas/ schemas/
 COPY migrations/ migrations/
 RUN pip install --upgrade pip && pip install --no-cache-dir ".[v4]"
 
+# Browser RPA executes with Playwright's version-matched Chromium. Download it
+# in the builder and copy the immutable browser bundle into the runtime image.
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
+RUN python -m playwright install chromium
+
 # Presidio (installed via the [v4] extra) uses spaCy for NER-based PII
 # detection. Without a language model the AnalyzerEngine constructor raises
 # OSError and every agent run 500s with "util.py:531 (OSError)". Bake the
@@ -42,6 +47,12 @@ RUN useradd -m agenticorg
 WORKDIR /app
 COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /opt/playwright-browsers /opt/playwright-browsers
+# Install only the OS libraries required by the bundled Chromium. Playwright's
+# installer owns this compatibility list for the pinned Python package.
+RUN python -m playwright install-deps chromium \
+    && rm -rf /var/lib/apt/lists/*
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
 # The runtime does not install packages. Validate the copied environment, then
 # remove pip and its vendored SBOM: Trivy otherwise treats build-only entries
 # in pip/_vendor/bom.cdx.json as installed runtime dependencies. Remove the

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ buyer channel, payment rail, merchant system, or POS path is usable only when
 the target tenant has the required credentials, scopes, configuration, and
 provider approval.
 
+Voice, email, OCR, and browser RPA can be exercised together before release
+with the Docker-backed [local multichannel simulation](docs/local-multichannel-simulation.md).
+It uses fresh PostgreSQL, local Mailpit delivery, real Tesseract, and optional
+real Playwright Chromium while keeping paid calls and production mutations off.
+
 ## What is in this repository
 
 | Area | Current implementation |
@@ -338,6 +343,7 @@ To refresh the tracked sitemap and llms copies plus route JSON-LD CSP hashes:
 - [API reference](docs/api-reference.md)
 - [Deployment](docs/deployment.md)
 - [Knowledge ingestion and OCR](docs/knowledge-ingestion.md)
+- [Local voice, email, RPA, and OCR simulation](docs/local-multichannel-simulation.md)
 - [Voice runtime](docs/voice-runtime.md)
 - [RPA runtime](docs/rpa-runtime.md)
 - [OACP runtime documentation](docs/oacp/README.md)

--- a/core/email.py
+++ b/core/email.py
@@ -1,10 +1,13 @@
-"""Email utility — Gmail SMTP for notifications with domain validation."""
+"""Email utility with domain validation and fail-closed SMTP transport."""
 import logging
 import os
 import smtplib
+import ssl
 from email.mime.text import MIMEText
 
 import dns.resolver
+
+from core.config import is_relaxed_env
 
 logger = logging.getLogger(__name__)
 
@@ -49,10 +52,12 @@ def validate_email_domain(email: str) -> tuple[bool, str]:
 
 
 def send_email(to: str, subject: str, html: str) -> bool:
-    """Send HTML email via Gmail SMTP. Validates domain before sending.
+    """Send HTML email through the configured SMTP transport.
 
-    Uses AGENTICORG_SMTP_LOGIN for SMTP authentication (Gmail account)
-    and AGENTICORG_DEMO_SENDER for the display From address.
+    Gmail over implicit TLS remains the default. Passwordless plaintext SMTP is
+    accepted only for a loopback capture service in an explicitly relaxed
+    environment, which lets the real delivery path be tested with Mailpit
+    without weakening production transport requirements.
     """
     # Validate email domain BEFORE the fake-mail seam so tests
     # asserting "invalid domain → no send" stay accurate even when
@@ -74,10 +79,31 @@ def send_email(to: str, subject: str, html: str) -> bool:
         logger.info("[fake_mail] captured email to=%s subject=%r", to, subject)
         return True
 
+    host = os.getenv("AGENTICORG_SMTP_HOST", "smtp.gmail.com").strip()
+    security = os.getenv("AGENTICORG_SMTP_SECURITY", "ssl").strip().lower()
+    try:
+        port = int(os.getenv("AGENTICORG_SMTP_PORT", "465"))
+    except ValueError:
+        logger.warning("Invalid AGENTICORG_SMTP_PORT; refusing email delivery")
+        return False
+    if not host or not 1 <= port <= 65535:
+        logger.warning("Invalid SMTP host or port; refusing email delivery")
+        return False
+    if security not in {"ssl", "starttls", "plain"}:
+        logger.warning("Unsupported SMTP security mode; refusing email delivery")
+        return False
+
+    runtime_env = os.getenv("AGENTICORG_ENV", "development")
+    loopback_capture = host.lower() in {"localhost", "127.0.0.1", "::1"}
+    local_plain_capture = security == "plain" and loopback_capture and is_relaxed_env(runtime_env)
+    if security == "plain" and not local_plain_capture:
+        logger.warning("Plain SMTP is restricted to loopback local/test capture services")
+        return False
+
     password = os.getenv("AGENTICORG_GMAIL_APP_PASSWORD", "")
     smtp_login = os.getenv("AGENTICORG_SMTP_LOGIN", os.getenv("AGENTICORG_DEMO_SENDER", ""))
     display_sender = os.getenv("AGENTICORG_DEMO_SENDER", "sanjeev@agenticorg.ai")
-    if not password or not smtp_login:
+    if not local_plain_capture and (not password or not smtp_login):
         logger.warning("AGENTICORG_GMAIL_APP_PASSWORD or SMTP_LOGIN not set - skipping email")
         return False
     msg = MIMEText(html, "html")
@@ -86,10 +112,21 @@ def send_email(to: str, subject: str, html: str) -> bool:
     msg["Reply-To"] = display_sender
     msg["To"] = to
     try:
-        with smtplib.SMTP_SSL("smtp.gmail.com", 465) as smtp:
-            smtp.login(smtp_login, password)
+        tls_context = ssl.create_default_context()
+        connection = (
+            smtplib.SMTP_SSL(host, port, timeout=15, context=tls_context)
+            if security == "ssl"
+            else smtplib.SMTP(host, port, timeout=15)
+        )
+        with connection as smtp:
+            if security == "starttls":
+                smtp.ehlo()
+                smtp.starttls(context=tls_context)
+                smtp.ehlo()
+            if smtp_login and password:
+                smtp.login(smtp_login, password)
             smtp.send_message(msg)
-        logger.info("Email sent to %s from %s (via %s)", to, display_sender, smtp_login)
+        logger.info("Email sent to %s from %s via SMTP host %s", to, display_sender, host)
         return True
     # enterprise-gate: broad-except-ok reason=smtp-send-failure-returns-false-no-delivery-success
     except Exception:

--- a/core/rpa/executor.py
+++ b/core/rpa/executor.py
@@ -4,7 +4,8 @@ Each script is a Python module in ``rpa/scripts/`` that exposes an
 ``async def run(page, params) -> dict`` function.
 
 All Playwright imports are guarded so the module can be imported without
-``playwright`` installed.  Install with ``pip install agenticorg[v4]``.
+``playwright`` installed. Install with ``pip install agenticorg[v4]`` and run
+``playwright install chromium`` outside the production container image.
 """
 
 from __future__ import annotations

--- a/docker-compose.simulation.yml
+++ b/docker-compose.simulation.yml
@@ -1,0 +1,11 @@
+services:
+  mailpit:
+    image: axllent/mailpit:v1.27.8@sha256:6abc8e633df15eaf785cfcf38bae48e66f64beecdc03121e249d0f9ec15f0707
+    ports:
+      - "1025"
+      - "8025"
+    healthcheck:
+      test: ["CMD", "/mailpit", "readyz"]
+      interval: 2s
+      timeout: 2s
+      retries: 20

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ Service health comes from
 | Upload documents and scans | [Knowledge ingestion and OCR](knowledge-ingestion.md) |
 | Configure voice agents | [Voice runtime](voice-runtime.md) |
 | Run browser automation | [RPA runtime](rpa-runtime.md) |
+| Simulate voice, email, OCR, and RPA locally | [Local multichannel simulation](local-multichannel-simulation.md) |
 | Integrate through APIs | [API reference](api-reference.md), generated OpenAPI, [Python SDK](../sdk/README.md), [TypeScript SDK](../sdk-ts/README.md) |
 | Connect an MCP client | [MCP server](../mcp-server/README.md) |
 | Implement agentic commerce | [OACP documentation](oacp/README.md) |

--- a/docs/knowledge-ingestion.md
+++ b/docs/knowledge-ingestion.md
@@ -69,3 +69,8 @@ Production validation should use an approved smoke tenant and a synthetic,
 non-sensitive document. A successful supported-types response proves the
 capability matrix is deployed; it does not by itself prove extraction quality
 for every language, layout, handwriting style, or damaged scan.
+
+Run the [local multichannel simulation](local-multichannel-simulation.md) for a
+real synthetic-image OCR proof alongside voice, email, and RPA checks. Its JSON
+evidence records extraction method, confidence, and page count without storing
+a customer document.

--- a/docs/local-multichannel-simulation.md
+++ b/docs/local-multichannel-simulation.md
@@ -1,0 +1,114 @@
+# Local voice, email, RPA, and OCR simulation
+
+This runbook validates the four runtime paths with real local components before
+a production release. It produces evidence under
+`codex-pytest-artifacts/multichannel/` and removes its Docker containers and
+volumes when it finishes.
+
+## What the simulation proves
+
+```mermaid
+flowchart LR
+    Runner[Local simulation runner]
+    Runner --> PG[(Fresh PostgreSQL)]
+    Runner --> Voice[Signed voice webhook lifecycle]
+    Voice --> PG
+    Voice --> TwiML[STT text intake and TwiML TTS output]
+    Runner --> SMTP[AgenticOrg email path]
+    SMTP --> Mailpit[Local Mailpit SMTP capture]
+    Runner --> OCR[Synthetic scanned invoice]
+    OCR --> Tesseract[Real Tesseract extraction]
+    Runner -. approved opt-in .-> Browser[Real Playwright Chromium]
+    Browser --> TestSite[Operator-approved public test portal]
+```
+
+| Flow | Real components exercised | Deliberately not exercised |
+| --- | --- | --- |
+| Voice | Signed Twilio-shaped inbound and status webhooks, speech transcript input, agent turn, escaped TwiML TTS response, encrypted transcript storage, masked history, tenant isolation | Twilio network, PSTN delivery, microphone/audio quality, paid call |
+| Email | Production `send_email` code, SMTP protocol, MIME message, local Mailpit receipt and inspection | External mailbox delivery, spam placement, provider reputation |
+| OCR | Real Tesseract binary, image preprocessing, confidence and page provenance | Every language, handwriting, damaged scans, every scanner model |
+| RPA | Real Python Playwright, bundled Chromium, egress guard, login form, extraction, screenshots | A merchant production account unless its owner separately approves a canary |
+
+The simulation must not be presented as proof of a provider last mile. A real
+phone canary, external email inbox, merchant portal, or damaged multilingual
+document still requires an approved destination and non-sensitive test data.
+
+## Prerequisites
+
+- Python environment with `.[v4,dev]` installed.
+- Docker Desktop with Compose.
+- Tesseract on the host for the OCR leg.
+- Chromium installed for optional RPA:
+
+```bash
+python -m playwright install chromium
+```
+
+The production Docker image installs Playwright and its version-matched
+Chromium automatically.
+
+## Run the safe local suite
+
+```bash
+python scripts/local_multichannel_simulation.py
+```
+
+This starts fresh PostgreSQL and a digest-pinned Mailpit container on random
+host ports. The default email recipient is an address at an MX-valid domain,
+but the message never leaves Mailpit.
+
+Expected result:
+
+- `voice.status = passed`
+- `email.status = passed`
+- `ocr.status = passed`
+- `rpa.status = skipped` unless the explicit RPA option is used
+- `production_mutation = false`
+- `paid_phone_call = false`
+
+## Add a real Playwright test-portal leg
+
+Use only a portal whose owner permits automation and only credentials created
+for testing. Keep them in the process environment, never in source or command
+history shared with others.
+
+```bash
+export AGENTICORG_SIM_RPA_URL='https://approved-test.example/login'
+export AGENTICORG_SIM_RPA_USERNAME='test-user'
+export AGENTICORG_SIM_RPA_PASSWORD='test-password'
+export AGENTICORG_SIM_RPA_WAIT_FOR='#post-login-marker'
+export AGENTICORG_SIM_RPA_EXTRACT_SELECTOR='#safe-result'
+python scripts/local_multichannel_simulation.py --with-public-rpa
+```
+
+The RPA route guard continues to reject loopback, private, link-local, metadata,
+IP-literal, and DNS-rebinding targets. Do not weaken the guard to test a local
+HTML server; use an approved publicly reachable test environment.
+
+## Production canary inputs
+
+Simulation covers nearly all deterministic application behavior. To finish the
+provider last mile, an operator supplies:
+
+| Canary | Minimum approved input | Cost or side effect |
+| --- | --- | --- |
+| Phone | One test phone number, calling window, Twilio tenant/agent config, and permission to incur a call charge | Paid call and stored provider call metadata |
+| Email | One controlled inbox and permission to send a uniquely tagged message | External delivery and mailbox retention |
+| RPA | Non-production portal account, approved domain, permitted actions, and expected success marker | External login and possible test-system mutation |
+| OCR | Synthetic or cleared scan corpus with expected ground truth | Document upload and temporary evidence storage |
+
+Never place a phone call or run a write-capable RPA action against a real account
+without explicit approval for that destination and action.
+
+## SMTP safety
+
+Production defaults remain `smtp.gmail.com:465` with implicit TLS and required
+credentials. `AGENTICORG_SMTP_SECURITY=plain` is accepted only when all of the
+following are true:
+
+1. `AGENTICORG_ENV` is `local`, `dev`, `development`, `test`, or `ci`.
+2. `AGENTICORG_SMTP_HOST` is `localhost`, `127.0.0.1`, or `::1`.
+3. The caller still passes normal recipient-domain validation.
+
+Unknown modes, invalid ports, plaintext remote hosts, and plaintext strict
+environments fail closed before opening a connection.

--- a/docs/rpa-runtime.md
+++ b/docs/rpa-runtime.md
@@ -69,3 +69,15 @@ current SDK version.
 
 See [current product status](PRODUCT_STATUS.md), generated OpenAPI, and the
 security guidance in [SECURITY.md](../SECURITY.md).
+
+## Local browser proof
+
+The production image includes the Python Playwright driver, its
+version-matched Chromium bundle, and required OS libraries. Local source
+environments install `.[v4]` and then run `python -m playwright install
+chromium` once.
+
+The [local multichannel simulation](local-multichannel-simulation.md) can run a
+real browser login/extraction against an operator-approved public test portal.
+This opt-in proof preserves the normal egress guard and captures bounded
+screenshots. It is not permission to automate a merchant production account.

--- a/docs/voice-runtime.md
+++ b/docs/voice-runtime.md
@@ -71,3 +71,9 @@ Deployment is complete only after migrations run, API and UI health checks pass,
 the runtime-health endpoint reports `ready`, a signed inbound test call completes,
 an outbound test call completes, and call history shows the real provider status.
 Never use an unsigned webhook or synthetic call row as production evidence.
+
+Before a provider canary, run the [local multichannel simulation](local-multichannel-simulation.md).
+It executes the signed webhook lifecycle, STT text intake, TwiML TTS response,
+encrypted persistence, masking, and tenant isolation against fresh PostgreSQL.
+It intentionally does not place a paid call; PSTN/audio quality still needs one
+explicitly approved test number and calling window.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ packages = [
     "auth",
     "bridge",
     "connectors",
+    "rpa",
     "workflows",
     "scaling",
     "observability",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,9 @@ v4 = [
     # latest package can install everywhere.
     "presidio-analyzer>=2.2.364,<2.2.365; python_version >= '3.14'",
     "presidio-analyzer>=2.2.362; python_version < '3.14'",
+    # Browser RPA is a shipped runtime. Keep the Python driver in the
+    # production extra; Dockerfile installs the matching Chromium binary.
+    "playwright>=1.62.0,<2",
 ]
 bge-m3 = [
     # Heavy in-process BGE-M3 loader. This pulls PyTorch, so it stays out

--- a/requirements-v4.txt
+++ b/requirements-v4.txt
@@ -28,6 +28,9 @@
 # Python 3.12/3.13 environments.
 presidio-analyzer==2.2.359; python_version >= "3.14"
 presidio-analyzer==2.2.364; python_version < "3.14"
+# Browser RPA runtime. Dockerfile installs the matching Chromium browser and
+# OS dependencies; local operators must also run `playwright install chromium`.
+playwright==1.62.0
 # Redaction uses analyzer spans plus deterministic local tokens. The unused
 # presidio-anonymizer package is intentionally excluded because its strict
 # cryptography upper bound blocks security upgrades.

--- a/scripts/local_multichannel_simulation.py
+++ b/scripts/local_multichannel_simulation.py
@@ -184,8 +184,8 @@ def main() -> int:
         "paid_phone_call": False,
         "flows": {},
     }
-    _run(_compose("up", "-d", "--wait", "postgres", "mailpit"))
     try:
+        _run(_compose("up", "-d", "--wait", "postgres", "mailpit"))
         db_port = _mapped_port("postgres", 5432)
         smtp_port = _mapped_port("mailpit", 1025)
         mailpit_api_port = _mapped_port("mailpit", 8025)
@@ -228,7 +228,12 @@ def main() -> int:
         report_path = evidence_dir / "simulation-report.json"
         report_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
         print(json.dumps(report, indent=2, sort_keys=True))
-        _run(_compose("down", "--volumes", "--remove-orphans"))
+        try:
+            _run(_compose("down", "--volumes", "--remove-orphans"))
+        except Exception as cleanup_exc:  # enterprise-gate: broad-except-ok reason=preserve-primary-simulation-result
+            print(f"Simulation cleanup failed: {cleanup_exc}", file=sys.stderr)
+            if return_code == 0:
+                return_code = 1
     return return_code
 
 

--- a/scripts/local_multichannel_simulation.py
+++ b/scripts/local_multichannel_simulation.py
@@ -1,0 +1,236 @@
+"""Run real local voice, email, OCR, and optional public-demo RPA simulations.
+
+This script never calls a telephony provider. The voice leg exercises signed
+webhooks, STT text intake, TwiML TTS output, encrypted persistence, and tenant
+isolation against fresh PostgreSQL. Email is delivered to local Mailpit. OCR
+uses the installed Tesseract binary. RPA is opt-in because it navigates an
+operator-approved public test site.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import io
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+from PIL import Image, ImageDraw, ImageFont
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+COMPOSE_PROJECT = "agenticorg_multichannel_sim"
+COMPOSE_FILES = (
+    ROOT / "docker-compose.yml",
+    ROOT / "docker-compose.local-e2e.yml",
+    ROOT / "docker-compose.simulation.yml",
+)
+
+
+def _run(command: list[str], *, env: dict[str, str] | None = None) -> str:
+    completed = subprocess.run(  # noqa: S603 - argv is assembled only from fixed local runner commands
+        command,
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode:
+        detail = (completed.stdout + "\n" + completed.stderr).strip()
+        raise RuntimeError(f"Command failed ({completed.returncode}): {' '.join(command)}\n{detail}")
+    return completed.stdout.strip()
+
+
+def _compose(*args: str) -> list[str]:
+    command = ["docker", "compose", "--project-name", COMPOSE_PROJECT]
+    for path in COMPOSE_FILES:
+        command.extend(["-f", str(path)])
+    command.extend(args)
+    return command
+
+
+def _mapped_port(service: str, container_port: int) -> int:
+    output = _run(_compose("port", service, str(container_port)))
+    return int(output.rsplit(":", 1)[1])
+
+
+def _mailpit_message(api_port: int, subject: str) -> dict[str, Any]:
+    response = httpx.get(f"http://127.0.0.1:{api_port}/api/v1/messages", timeout=10)
+    response.raise_for_status()
+    payload = response.json()
+    messages = payload.get("messages", [])
+    message = next((item for item in messages if item.get("Subject") == subject), None)
+    if not message:
+        raise RuntimeError(f"Mailpit did not capture subject {subject!r}")
+    return message
+
+
+def _simulate_email(smtp_port: int, api_port: int, recipient: str) -> dict[str, Any]:
+    from core.email import send_email
+
+    subject = f"AgenticOrg local simulation {int(time.time())}"
+    previous = os.environ.copy()
+    os.environ.update(
+        {
+            "AGENTICORG_ENV": "local",
+            "AGENTICORG_SMTP_HOST": "127.0.0.1",
+            "AGENTICORG_SMTP_PORT": str(smtp_port),
+            "AGENTICORG_SMTP_SECURITY": "plain",
+            "AGENTICORG_SMTP_LOGIN": "",
+            "AGENTICORG_GMAIL_APP_PASSWORD": "",
+            "AGENTICORG_TEST_FAKE_MAIL": "",
+            "AGENTICORG_DEMO_SENDER": "simulation@agenticorg.ai",
+        }
+    )
+    try:
+        if not send_email(recipient, subject, "<h1>AgenticOrg local delivery verified</h1>"):
+            raise RuntimeError("send_email returned false during local Mailpit delivery")
+    finally:
+        os.environ.clear()
+        os.environ.update(previous)
+    captured = _mailpit_message(api_port, subject)
+    return {
+        "status": "passed",
+        "transport": "local_mailpit_smtp",
+        "subject": subject,
+        "captured_message_id": captured.get("ID"),
+    }
+
+
+def _simulate_ocr(evidence_dir: Path) -> dict[str, Any]:
+    from core.rag.extractors import extract
+
+    phrase = "AGENTICORG INVOICE 2026 TOTAL INR 1250"
+    image = Image.new("RGB", (2200, 700), "white")
+    try:
+        font = ImageFont.truetype("DejaVuSans.ttf", 70)
+    except OSError:
+        font = ImageFont.load_default()
+    ImageDraw.Draw(image).text((100, 280), phrase, fill="black", font=font)
+    stream = io.BytesIO()
+    image.save(stream, format="PNG")
+    source = evidence_dir / "synthetic-invoice.png"
+    source.write_bytes(stream.getvalue())
+
+    result = extract(stream.getvalue(), "image/png", source.name)
+    normalized = result.full_text().upper()
+    for token in ("AGENTICORG", "INVOICE", "2026", "1250"):
+        if token not in normalized:
+            raise RuntimeError(f"OCR output omitted required token {token!r}: {normalized!r}")
+    return {
+        "status": "passed",
+        "method": result.extraction_method,
+        "mean_confidence": result.extra.get("ocr_mean_confidence"),
+        "page_count": result.extra.get("page_count"),
+        "source": str(source),
+    }
+
+
+async def _simulate_rpa(evidence_dir: Path) -> dict[str, Any]:
+    from core.rpa.executor import execute_rpa_script
+
+    required = {
+        "portal_url": "AGENTICORG_SIM_RPA_URL",
+        "username": "AGENTICORG_SIM_RPA_USERNAME",
+        "password": "AGENTICORG_SIM_RPA_PASSWORD",
+        "wait_for": "AGENTICORG_SIM_RPA_WAIT_FOR",
+        "extract_selector": "AGENTICORG_SIM_RPA_EXTRACT_SELECTOR",
+    }
+    params = {name: os.getenv(env_name, "") for name, env_name in required.items()}
+    missing = [env_name for name, env_name in required.items() if not params[name]]
+    if missing:
+        raise RuntimeError("Public RPA simulation requires environment variables: " + ", ".join(missing))
+    params["action"] = "extract"
+    result = await execute_rpa_script(
+        "generic_portal",
+        params,
+        timeout_s=75,
+        screenshot_dir=str(evidence_dir / "rpa-screenshots"),
+    )
+    if not result.get("success") or not result.get("data", {}).get("logged_in"):
+        raise RuntimeError(f"RPA simulation failed: {result.get('error') or result.get('data', {}).get('error')}")
+    data = result["data"]
+    return {
+        "status": "passed",
+        "elapsed_ms": result.get("elapsed_ms"),
+        "page_title": data.get("page_title"),
+        "current_url": data.get("current_url"),
+        "extracted_text": data.get("extracted_text"),
+        "screenshot_count": len(result.get("screenshots", [])),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--with-public-rpa", action="store_true", help="Run approved public-site RPA inputs from env")
+    parser.add_argument("--recipient", default="simulation@orchestrum.in", help="Address captured by local Mailpit")
+    parser.add_argument("--evidence-dir", type=Path, default=ROOT / "codex-pytest-artifacts" / "multichannel")
+    args = parser.parse_args()
+
+    evidence_dir = args.evidence_dir.resolve()
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    report: dict[str, Any] = {
+        "started_at": datetime.now(UTC).isoformat(),
+        "production_mutation": False,
+        "paid_phone_call": False,
+        "flows": {},
+    }
+    _run(_compose("up", "-d", "--wait", "postgres", "mailpit"))
+    try:
+        db_port = _mapped_port("postgres", 5432)
+        smtp_port = _mapped_port("mailpit", 1025)
+        mailpit_api_port = _mapped_port("mailpit", 8025)
+        voice_env = os.environ.copy()
+        voice_env["AGENTICORG_DB_URL"] = (
+            f"postgresql+asyncpg://agenticorg:agenticorg_dev@127.0.0.1:{db_port}/agenticorg"
+        )
+        _run(
+            [sys.executable, "-m", "pytest", "tests/integration/test_voice_runtime_e2e.py", "--no-cov", "-q"],
+            env=voice_env,
+        )
+        report["flows"]["voice"] = {
+            "status": "passed",
+            "coverage": [
+                "signed inbound webhook",
+                "speech transcript intake",
+                "TwiML text-to-speech response",
+                "signed status callback",
+                "encrypted transcript persistence",
+                "masked history",
+                "tenant isolation",
+            ],
+            "provider_last_mile": "not_called",
+        }
+        report["flows"]["email"] = _simulate_email(smtp_port, mailpit_api_port, args.recipient)
+        report["flows"]["ocr"] = _simulate_ocr(evidence_dir)
+        report["flows"]["rpa"] = (
+            asyncio.run(_simulate_rpa(evidence_dir))
+            if args.with_public_rpa
+            else {"status": "skipped", "reason": "pass --with-public-rpa and approved test-site env inputs"}
+        )
+        report["status"] = "passed"
+        return_code = 0
+    except Exception as exc:  # enterprise-gate: broad-except-ok reason=simulation-report-must-record-failure
+        report["status"] = "failed"
+        report["error"] = str(exc)
+        return_code = 1
+    finally:
+        report["finished_at"] = datetime.now(UTC).isoformat()
+        report_path = evidence_dir / "simulation-report.json"
+        report_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+        print(json.dumps(report, indent=2, sort_keys=True))
+        _run(_compose("down", "--volumes", "--remove-orphans"))
+    return return_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/regression/test_multichannel_simulation_runtime.py
+++ b/tests/regression/test_multichannel_simulation_runtime.py
@@ -1,0 +1,142 @@
+"""Regression coverage for the local voice/email/RPA/OCR simulation contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _smtp_env(**overrides: str) -> dict[str, str]:
+    values = {
+        "AGENTICORG_ENV": "development",
+        "AGENTICORG_SMTP_HOST": "smtp.gmail.com",
+        "AGENTICORG_SMTP_PORT": "465",
+        "AGENTICORG_SMTP_SECURITY": "ssl",
+        "AGENTICORG_SMTP_LOGIN": "sender@real.invalid",
+        "AGENTICORG_GMAIL_APP_PASSWORD": "synthetic-password",
+        "AGENTICORG_TEST_FAKE_MAIL": "",
+    }
+    values.update(overrides)
+    return values
+
+
+def test_local_loopback_mail_capture_uses_real_smtp_without_authentication() -> None:
+    from core.email import send_email
+
+    smtp = MagicMock()
+    context = MagicMock()
+    context.__enter__.return_value = smtp
+    context.__exit__.return_value = False
+    with (
+        patch.dict(
+            "os.environ",
+            _smtp_env(
+                AGENTICORG_SMTP_HOST="127.0.0.1",
+                AGENTICORG_SMTP_PORT="1025",
+                AGENTICORG_SMTP_SECURITY="plain",
+                AGENTICORG_SMTP_LOGIN="",
+                AGENTICORG_GMAIL_APP_PASSWORD="",
+            ),
+            clear=False,
+        ),
+        patch("core.email.validate_email_domain", return_value=(True, "OK")),
+        patch("core.email.smtplib.SMTP", return_value=context) as smtp_class,
+    ):
+        assert send_email("recipient@real.invalid", "Simulation", "<p>captured</p>") is True
+
+    smtp_class.assert_called_once_with("127.0.0.1", 1025, timeout=15)
+    smtp.login.assert_not_called()
+    smtp.send_message.assert_called_once()
+
+
+@pytest.mark.parametrize("runtime_env", ["production", "staging", "preview", "unknown"])
+def test_plain_smtp_is_rejected_outside_relaxed_loopback(runtime_env: str) -> None:
+    from core.email import send_email
+
+    with (
+        patch.dict(
+            "os.environ",
+            _smtp_env(
+                AGENTICORG_ENV=runtime_env,
+                AGENTICORG_SMTP_HOST="127.0.0.1",
+                AGENTICORG_SMTP_SECURITY="plain",
+            ),
+            clear=False,
+        ),
+        patch("core.email.validate_email_domain", return_value=(True, "OK")),
+        patch("core.email.smtplib.SMTP") as smtp_class,
+    ):
+        assert send_email("recipient@real.invalid", "Blocked", "<p>blocked</p>") is False
+
+    smtp_class.assert_not_called()
+
+
+def test_plain_smtp_is_rejected_for_remote_host_even_in_local_environment() -> None:
+    from core.email import send_email
+
+    with (
+        patch.dict(
+            "os.environ",
+            _smtp_env(
+                AGENTICORG_ENV="local",
+                AGENTICORG_SMTP_HOST="smtp.remote.invalid",
+                AGENTICORG_SMTP_SECURITY="plain",
+            ),
+            clear=False,
+        ),
+        patch("core.email.validate_email_domain", return_value=(True, "OK")),
+        patch("core.email.smtplib.SMTP") as smtp_class,
+    ):
+        assert send_email("recipient@real.invalid", "Blocked", "<p>blocked</p>") is False
+
+    smtp_class.assert_not_called()
+
+
+def test_starttls_transport_authenticates_before_delivery() -> None:
+    from core.email import send_email
+
+    smtp = MagicMock()
+    context = MagicMock()
+    context.__enter__.return_value = smtp
+    context.__exit__.return_value = False
+    with (
+        patch.dict(
+            "os.environ",
+            _smtp_env(
+                AGENTICORG_SMTP_HOST="smtp.provider.invalid",
+                AGENTICORG_SMTP_PORT="587",
+                AGENTICORG_SMTP_SECURITY="starttls",
+            ),
+            clear=False,
+        ),
+        patch("core.email.validate_email_domain", return_value=(True, "OK")),
+        patch("core.email.smtplib.SMTP", return_value=context),
+    ):
+        assert send_email("recipient@real.invalid", "TLS", "<p>encrypted</p>") is True
+
+    assert smtp.ehlo.call_count == 2
+    smtp.starttls.assert_called_once()
+    smtp.login.assert_called_once_with("sender@real.invalid", "synthetic-password")
+    smtp.send_message.assert_called_once()
+
+
+def test_production_image_packages_playwright_and_chromium() -> None:
+    pyproject = (REPO / "pyproject.toml").read_text(encoding="utf-8")
+    dockerfile = (REPO / "Dockerfile").read_text(encoding="utf-8")
+
+    assert '"playwright>=1.62.0,<2"' in pyproject
+    assert "python -m playwright install chromium" in dockerfile
+    assert "python -m playwright install-deps chromium" in dockerfile
+    assert "PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers" in dockerfile
+
+
+def test_mailpit_simulation_image_is_digest_pinned() -> None:
+    compose = (REPO / "docker-compose.simulation.yml").read_text(encoding="utf-8")
+
+    assert "axllent/mailpit:v1.27.8@sha256:" in compose
+    assert '"1025"' in compose
+    assert '"8025"' in compose

--- a/tests/regression/test_multichannel_simulation_runtime.py
+++ b/tests/regression/test_multichannel_simulation_runtime.py
@@ -129,9 +129,18 @@ def test_production_image_packages_playwright_and_chromium() -> None:
     dockerfile = (REPO / "Dockerfile").read_text(encoding="utf-8")
 
     assert '"playwright>=1.62.0,<2"' in pyproject
+    assert '"rpa",' in pyproject
     assert "python -m playwright install chromium" in dockerfile
     assert "python -m playwright install-deps chromium" in dockerfile
     assert "PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers" in dockerfile
+
+
+def test_simulation_guards_partial_compose_startup_with_cleanup() -> None:
+    script = (REPO / "scripts/local_multichannel_simulation.py").read_text(encoding="utf-8")
+
+    try_position = script.index("    try:\n        _run(_compose(\"up\"")
+    cleanup_position = script.index('_run(_compose("down", "--volumes", "--remove-orphans"))')
+    assert try_position < cleanup_position
 
 
 def test_mailpit_simulation_image_is_digest_pinned() -> None:

--- a/ui/public/llms-full.txt
+++ b/ui/public/llms-full.txt
@@ -46,6 +46,11 @@ buyer channel, payment rail, merchant system, or POS path is usable only when
 the target tenant has the required credentials, scopes, configuration, and
 provider approval.
 
+Voice, email, OCR, and browser RPA can be exercised together before release
+with the Docker-backed [local multichannel simulation](https://github.com/mishrasanjeev/agentic-org/blob/main/docs/local-multichannel-simulation.md).
+It uses fresh PostgreSQL, local Mailpit delivery, real Tesseract, and optional
+real Playwright Chromium while keeping paid calls and production mutations off.
+
 ## What is in this repository
 
 | Area | Current implementation |
@@ -344,6 +349,7 @@ To refresh the tracked sitemap and llms copies plus route JSON-LD CSP hashes:
 - [API reference](https://github.com/mishrasanjeev/agentic-org/blob/main/docs/api-reference.md)
 - [Deployment](https://github.com/mishrasanjeev/agentic-org/blob/main/docs/deployment.md)
 - [Knowledge ingestion and OCR](https://github.com/mishrasanjeev/agentic-org/blob/main/docs/knowledge-ingestion.md)
+- [Local voice, email, RPA, and OCR simulation](https://github.com/mishrasanjeev/agentic-org/blob/main/docs/local-multichannel-simulation.md)
 - [Voice runtime](https://github.com/mishrasanjeev/agentic-org/blob/main/docs/voice-runtime.md)
 - [RPA runtime](https://github.com/mishrasanjeev/agentic-org/blob/main/docs/rpa-runtime.md)
 - [OACP runtime documentation](https://github.com/mishrasanjeev/agentic-org/blob/main/docs/oacp/README.md)


### PR DESCRIPTION
## Summary
- add Docker-backed local voice, email, OCR, and optional real RPA simulation
- make SMTP transport configurable while restricting plaintext to loopback local/test capture
- ship Playwright and version-matched Chromium in the production image
- update README and operator runbooks

## Local evidence
- unified voice/email/OCR/RPA simulation passed
- signed voice lifecycle passed against fresh PostgreSQL
- Mailpit SMTP capture passed
- real Tesseract image OCR passed at 94.5 mean confidence
- real Playwright public test-portal login/extraction passed with three screenshots
- production Docker image built; Chromium and image-only PDF OCR passed inside it
- 261 focused regression tests passed; ruff and mypy passed

No paid call, production mutation, secret disclosure, or production deployment occurred during implementation.