### PR TITLE
Harden local runtime under stress and record performance evidence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,4 +67,7 @@ USER agenticorg
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health/liveness', timeout=4).read()"
-CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1", "--timeout-graceful-shutdown", "20"]
+# Uvicorn defaults to one worker and honors WEB_CONCURRENCY when operators
+# deliberately allocate enough CPU and DB connections for more. Do not
+# hard-code the worker count in the image.
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000", "--timeout-graceful-shutdown", "20"]

--- a/api/main.py
+++ b/api/main.py
@@ -125,8 +125,10 @@ async def lifespan(app: FastAPI):
         pass  # Expected to fail - we only care about the JWKS fetch side effect
 
     yield
+    from api.v1.health import close_health_resources
     from core.database import close_db
 
+    await close_health_resources()
     await close_db()
 
 

--- a/api/v1/auth.py
+++ b/api/v1/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import re
@@ -214,7 +215,12 @@ async def signup(body: SignupRequest, request: Request, response: Response):
 
     # Send welcome email (non-blocking)
     try:
-        send_welcome_email(body.admin_email, body.org_name, body.admin_name)
+        await asyncio.to_thread(
+            send_welcome_email,
+            body.admin_email,
+            body.org_name,
+            body.admin_name,
+        )
     # enterprise-gate: broad-except-ok reason=welcome-email-sidecar-failure-does-not-affect-auth-token
     except Exception:
         logger.exception("Welcome email failed but signup succeeded")
@@ -599,7 +605,7 @@ async def forgot_password(body: ForgotPasswordRequest, request: Request):
         app_url = os.getenv("AGENTICORG_APP_URL", "https://app.agenticorg.ai")
         reset_link = f"{app_url}/reset-password?code={code}"
         try:
-            send_password_reset_email(user.email, reset_link)
+            await asyncio.to_thread(send_password_reset_email, user.email, reset_link)
         # enterprise-gate: broad-except-ok reason=password-reset-email-failure-keeps-enumeration-safe-response
         except Exception:
             logger.exception("Password reset email failed for user")

--- a/api/v1/demo.py
+++ b/api/v1/demo.py
@@ -1,6 +1,7 @@
 """Demo request endpoint — stores in DB, creates lead, triggers sales agent, emails notification."""
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid as _uuid
 from html import escape
@@ -182,12 +183,12 @@ async def submit_demo_request(body: DemoRequest):
     internal_notification_sent = False
     requester_confirmation_sent = False
     try:
-        internal_notification_sent = _send_email_notification(body)
+        internal_notification_sent = await asyncio.to_thread(_send_email_notification, body)
     # enterprise-gate: broad-except-ok reason=demo-internal-email-sidecar-records-false-flag
     except Exception:
         logger.exception("Email send failed but request was saved")
     try:
-        requester_confirmation_sent = _send_trial_confirmation(body)
+        requester_confirmation_sent = await asyncio.to_thread(_send_trial_confirmation, body)
     # enterprise-gate: broad-except-ok reason=demo-confirmation-email-sidecar-records-false-flag
     except Exception:
         logger.exception("Requester confirmation email failed but request was saved")

--- a/api/v1/health.py
+++ b/api/v1/health.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import time
 from datetime import UTC, datetime, timedelta
 
 import redis.asyncio as aioredis
@@ -14,7 +15,7 @@ from sqlalchemy import text
 from api.deps import require_scope
 from api.route_metadata import route_meta
 from connectors.registry import ConnectorRegistry
-from core.config import settings
+from core.config import redis_socket_timeout_kwargs, settings
 from core.database import async_session_factory
 
 logger = structlog.get_logger()
@@ -45,6 +46,89 @@ def _deployed_commit() -> str:
 
 # Timeout for individual connector health checks (seconds)
 _CONNECTOR_HC_TIMEOUT = 5.0
+_DEPENDENCY_HC_TIMEOUT = 3.0
+_DEPENDENCY_HC_CACHE_TTL_SECONDS = 1.0
+_health_redis_client: aioredis.Redis | None = None
+_health_dependency_cache: tuple[float, dict[str, str]] | None = None
+_health_dependency_lock: asyncio.Lock | None = None
+
+
+def _get_health_redis_client() -> aioredis.Redis:
+    """Reuse one bounded Redis pool instead of creating a client per probe."""
+    global _health_redis_client
+    if _health_redis_client is None:
+        _health_redis_client = aioredis.from_url(
+            settings.redis_url,
+            decode_responses=True,
+            max_connections=max(10, settings.db_pool_size + settings.db_max_overflow),
+            **redis_socket_timeout_kwargs(),
+        )
+    return _health_redis_client
+
+
+async def close_health_resources() -> None:
+    """Close the shared health-check pool during application shutdown."""
+    global _health_dependency_cache, _health_dependency_lock, _health_redis_client
+    client, _health_redis_client = _health_redis_client, None
+    _health_dependency_cache = None
+    _health_dependency_lock = None
+    if client is not None:
+        await client.aclose()
+
+
+async def _db_health_status() -> str:
+    try:
+        async with async_session_factory() as session:
+            await asyncio.wait_for(
+                session.execute(text("SELECT 1")),
+                timeout=_DEPENDENCY_HC_TIMEOUT,
+            )
+        return "healthy"
+    # enterprise-gate: broad-except-ok reason=readiness-db-probe-fails-closed-unhealthy
+    except Exception as exc:
+        return f"unhealthy: {type(exc).__name__}"
+
+
+async def _redis_health_status() -> str:
+    try:
+        await asyncio.wait_for(
+            _get_health_redis_client().ping(),
+            timeout=_DEPENDENCY_HC_TIMEOUT,
+        )
+        return "healthy"
+    # enterprise-gate: broad-except-ok reason=readiness-redis-probe-fails-closed-unhealthy
+    except Exception as exc:
+        return f"unhealthy: {type(exc).__name__}"
+
+
+async def _critical_dependency_checks() -> dict[str, str]:
+    """Return coalesced DB/Redis health without amplifying probe bursts."""
+    global _health_dependency_cache, _health_dependency_lock
+    now = time.monotonic()
+    if (
+        _health_dependency_cache is not None
+        and now - _health_dependency_cache[0] <= _DEPENDENCY_HC_CACHE_TTL_SECONDS
+    ):
+        return dict(_health_dependency_cache[1])
+
+    if _health_dependency_lock is None:
+        _health_dependency_lock = asyncio.Lock()
+
+    async with _health_dependency_lock:
+        now = time.monotonic()
+        if (
+            _health_dependency_cache is not None
+            and now - _health_dependency_cache[0] <= _DEPENDENCY_HC_CACHE_TTL_SECONDS
+        ):
+            return dict(_health_dependency_cache[1])
+
+        db_status, redis_status = await asyncio.gather(
+            _db_health_status(),
+            _redis_health_status(),
+        )
+        checks = {"db": db_status, "redis": redis_status}
+        _health_dependency_cache = (time.monotonic(), checks)
+        return dict(checks)
 
 
 async def _check_connector(connector_name: str) -> dict:
@@ -82,24 +166,7 @@ async def health_readiness():
     K8s readiness probes should point here so external outages don't
     flap pods.
     """
-    checks: dict[str, str] = {"db": "unknown", "redis": "unknown"}
-
-    try:
-        async with async_session_factory() as session:
-            await session.execute(text("SELECT 1"))
-        checks["db"] = "healthy"
-    # enterprise-gate: broad-except-ok reason=readiness-db-probe-fails-closed-unhealthy
-    except Exception as e:
-        checks["db"] = f"unhealthy: {type(e).__name__}"
-
-    try:
-        r = aioredis.from_url(settings.redis_url, decode_responses=True)
-        await r.ping()
-        await r.close()
-        checks["redis"] = "healthy"
-    # enterprise-gate: broad-except-ok reason=readiness-redis-probe-fails-closed-unhealthy
-    except Exception as e:
-        checks["redis"] = f"unhealthy: {type(e).__name__}"
+    checks = await _critical_dependency_checks()
 
     core_healthy = checks["db"] == "healthy" and checks["redis"] == "healthy"
     return {
@@ -313,24 +380,8 @@ async def diagnostics():
 
     Not used by K8s probes. Called by the SRE dashboard.
     """
-    checks: dict[str, str | dict] = {"db": "unknown", "redis": "unknown"}
-
-    try:
-        async with async_session_factory() as session:
-            await session.execute(text("SELECT 1"))
-        checks["db"] = "healthy"
-    # enterprise-gate: broad-except-ok reason=diagnostics-db-probe-fails-closed-unhealthy
-    except Exception as e:
-        checks["db"] = f"unhealthy: {type(e).__name__}"
-
-    try:
-        r = aioredis.from_url(settings.redis_url, decode_responses=True)
-        await r.ping()
-        await r.close()
-        checks["redis"] = "healthy"
-    # enterprise-gate: broad-except-ok reason=diagnostics-redis-probe-fails-closed-unhealthy
-    except Exception as e:
-        checks["redis"] = f"unhealthy: {type(e).__name__}"
+    dependency_checks = await _critical_dependency_checks()
+    checks: dict[str, str | dict] = dict(dependency_checks)
 
     connector_names = ConnectorRegistry.all_names()
     connector_checks: dict[str, dict] = {}

--- a/api/v1/health.py
+++ b/api/v1/health.py
@@ -12,11 +12,11 @@ import structlog
 from fastapi import APIRouter
 from sqlalchemy import text
 
+import core.database as database
 from api.deps import require_scope
 from api.route_metadata import route_meta
 from connectors.registry import ConnectorRegistry
 from core.config import redis_socket_timeout_kwargs, settings
-from core.database import async_session_factory
 
 logger = structlog.get_logger()
 
@@ -78,7 +78,7 @@ async def close_health_resources() -> None:
 
 async def _db_health_status() -> str:
     try:
-        async with async_session_factory() as session:
+        async with database.async_session_factory() as session:
             await asyncio.wait_for(
                 session.execute(text("SELECT 1")),
                 timeout=_DEPENDENCY_HC_TIMEOUT,
@@ -223,7 +223,7 @@ async def _fetch_history(hours: int) -> list[dict]:
     snapshot in those cases.
     """
     try:
-        async with async_session_factory() as session:
+        async with database.async_session_factory() as session:
             result = await session.execute(
                 text(
                     "SELECT recorded_at, status, checks, version, commit "

--- a/api/v1/knowledge.py
+++ b/api/v1/knowledge.py
@@ -20,6 +20,8 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from api.deps import get_current_tenant
 from api.route_metadata import route_meta
+from core.config import settings
+from core.runtime_capacity import AsyncCapacityGate, CapacityLimitError
 
 logger = structlog.get_logger()
 
@@ -51,6 +53,12 @@ _NATIVE_VECTOR_ERRORS = (
 ) + ((_httpx.HTTPError,) if _httpx else ())
 _DB_READ_ERRORS = (SQLAlchemyError, RuntimeError, TypeError, ValueError)
 _DB_WRITE_ERRORS = (SQLAlchemyError, RuntimeError, TypeError, ValueError)
+
+_DOCUMENT_EXTRACTION_CAPACITY = AsyncCapacityGate(
+    "document extraction",
+    limit=settings.document_extraction_max_concurrency,
+    queue_timeout_seconds=settings.document_extraction_queue_timeout_seconds,
+)
 
 
 def _now_iso() -> str:
@@ -587,12 +595,24 @@ async def upload_document(
     try:
         content = upload_path.read_bytes()
         try:
-            extracted_content = await asyncio.to_thread(
-                extract,
-                content,
-                mime_type=(file.content_type or ""),
-                filename=filename,
-            )
+            try:
+                async with _DOCUMENT_EXTRACTION_CAPACITY.slot():
+                    extracted_content = await asyncio.to_thread(
+                        extract,
+                        content,
+                        mime_type=(file.content_type or ""),
+                        filename=filename,
+                    )
+            except CapacityLimitError as exc:
+                raise HTTPException(
+                    status_code=503,
+                    detail={
+                        "error": "document_extraction_capacity_exhausted",
+                        "message": str(exc),
+                        "retryable": True,
+                    },
+                    headers={"Retry-After": str(max(1, int(exc.timeout_seconds)))},
+                ) from exc
         except UnsupportedMimeType as exc:
             raise HTTPException(
                 status_code=415,

--- a/api/v1/knowledge.py
+++ b/api/v1/knowledge.py
@@ -7,7 +7,6 @@ with basic keyword search (no vector embeddings).
 
 from __future__ import annotations
 
-import asyncio
 import os
 import uuid
 from datetime import UTC, datetime
@@ -596,13 +595,12 @@ async def upload_document(
         content = upload_path.read_bytes()
         try:
             try:
-                async with _DOCUMENT_EXTRACTION_CAPACITY.slot():
-                    extracted_content = await asyncio.to_thread(
-                        extract,
-                        content,
-                        mime_type=(file.content_type or ""),
-                        filename=filename,
-                    )
+                extracted_content = await _DOCUMENT_EXTRACTION_CAPACITY.run_blocking(
+                    extract,
+                    content,
+                    mime_type=(file.content_type or ""),
+                    filename=filename,
+                )
             except CapacityLimitError as exc:
                 raise HTTPException(
                     status_code=503,

--- a/api/v1/org.py
+++ b/api/v1/org.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import re
@@ -222,7 +223,14 @@ async def invite_member(body: InviteRequest, request: Request):
     invite_link = f"{app_url}/accept-invite?code={code}"
 
     try:
-        send_invite_email(body.email, tenant.name, inviter_email, body.role, invite_link)
+        await asyncio.to_thread(
+            send_invite_email,
+            body.email,
+            tenant.name,
+            inviter_email,
+            body.role,
+            invite_link,
+        )
     # enterprise-gate: broad-except-ok reason=invite-email-sidecar-failure-keeps-user-created
     except Exception:
         logger.exception("Invite email failed but user was created")

--- a/api/v1/rpa.py
+++ b/api/v1/rpa.py
@@ -152,6 +152,8 @@ class RPAExecutionOut(BaseModel):
     elapsed_ms: int = 0
     success: bool = False
     error: str | None = None
+    error_class: str | None = None
+    retryable: bool = False
 
 
 # ── Endpoints ────────���───────────────────────────────────────────────
@@ -306,6 +308,8 @@ async def run_script(
         execution.success = result.get("success", False)
         execution.elapsed_ms = result.get("elapsed_ms", 0)
         execution.error = result.get("error")
+        execution.error_class = result.get("error_class")
+        execution.retryable = result.get("retryable", False)
         execution.completed_at = datetime.now(UTC).isoformat()
 
     # enterprise-gate: broad-except-ok reason=rpa-execution-failure-records-failed-result

--- a/api/v1/sales.py
+++ b/api/v1/sales.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import csv
 import io
 import uuid as _uuid
@@ -428,13 +429,15 @@ async def _run_sales_agent_on_lead(
                 session.add(email_record)
                 try:
                     from core.email import send_email
-                    send_email(
-                        to=email_data["to"],
-                        subject=email_data.get("subject", "AgenticOrg"),
-                        html=email_data.get("body_html", ""),
+                    sent = await asyncio.to_thread(
+                        send_email,
+                        email_data["to"],
+                        email_data.get("subject", "AgenticOrg"),
+                        email_data.get("body_html", ""),
                     )
-                    email_record.status = "sent"
-                    email_record.sent_at = datetime.now(UTC)
+                    if sent:
+                        email_record.status = "sent"
+                        email_record.sent_at = datetime.now(UTC)
                 # enterprise-gate: broad-except-ok reason=sales-email-sidecar-failure-leaves-email-pending
                 except Exception as e:
                     logger.warning("sales_email_failed", lead_id=lead_id, error=str(e))

--- a/core/billing/budget_evaluator.py
+++ b/core/billing/budget_evaluator.py
@@ -15,6 +15,7 @@ can be set as a comma-separated list.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
@@ -102,10 +103,11 @@ async def _send_notification(
                     f"<h2>{subject}</h2>"
                     f"<p>{body}</p>"
                 )
-                send_email(
-                    to="sanjeev@agenticorg.ai",
-                    subject=subject,
-                    html=html_body,
+                await asyncio.to_thread(
+                    send_email,
+                    "sanjeev@agenticorg.ai",
+                    subject,
+                    html_body,
                 )
             elif channel == "slack":
                 import os

--- a/core/config.py
+++ b/core/config.py
@@ -135,6 +135,13 @@ class Settings(BaseSettings):
     default_confidence_floor: float = 0.88
     max_agent_retries: int = 3
 
+    # Resource-intensive local runtimes. These per-worker caps prevent one API
+    # process from spawning unbounded Tesseract and Chromium processes.
+    document_extraction_max_concurrency: int = Field(default=2, ge=1, le=32)
+    document_extraction_queue_timeout_seconds: float = Field(default=30.0, ge=0.1, le=300.0)
+    rpa_max_concurrency: int = Field(default=2, ge=1, le=16)
+    rpa_queue_timeout_seconds: float = Field(default=5.0, ge=0.1, le=120.0)
+
     # SEC-012: every environment except local / dev / test is treated
     # as strict. Staging is internet-accessible, used for demos, pilots,
     # and enterprise security review — weak staging secrets become real

--- a/core/crypto/tenant_secrets.py
+++ b/core/crypto/tenant_secrets.py
@@ -24,6 +24,7 @@ import structlog
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 
+import core.database as database
 from core.crypto.credential_vault import (
     decrypt_credential as _legacy_decrypt,
 )
@@ -31,7 +32,6 @@ from core.crypto.credential_vault import (
     encrypt_credential as _legacy_encrypt,
 )
 from core.crypto.envelope import decrypt_from_string, encrypt_to_string
-from core.database import async_session_factory
 from core.models.tenant import Tenant
 
 logger = structlog.get_logger()
@@ -48,7 +48,7 @@ async def _resolve_kek(tenant_id: uuid.UUID) -> str:
       3. Empty string → caller falls back to legacy Fernet
     """
     try:
-        async with async_session_factory() as session:
+        async with database.async_session_factory() as session:
             result = await session.execute(
                 select(Tenant.byok_kek_resource).where(Tenant.id == tenant_id)
             )

--- a/core/rpa/executor.py
+++ b/core/rpa/executor.py
@@ -20,6 +20,9 @@ from typing import Any
 
 import structlog
 
+from core.config import settings
+from core.runtime_capacity import AsyncCapacityGate, CapacityLimitError
+
 logger = structlog.get_logger()
 
 # ---------------------------------------------------------------------------
@@ -41,6 +44,12 @@ _SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "rpa" / "scripts"
 # Default execution timeout (seconds)
 DEFAULT_TIMEOUT_S = 60
 MAX_NAVIGATION_SCREENSHOTS = 10
+
+_RPA_CAPACITY = AsyncCapacityGate(
+    "RPA browser execution",
+    limit=settings.rpa_max_concurrency,
+    queue_timeout_seconds=settings.rpa_queue_timeout_seconds,
+)
 
 
 async def _capture_screenshot(
@@ -77,7 +86,7 @@ def _result_error(result_data: Any) -> str:
     return str(error) if error else ""
 
 
-async def execute_rpa_script(
+async def _execute_rpa_script(
     script_name: str,
     params: dict[str, Any],
     timeout_s: int = DEFAULT_TIMEOUT_S,
@@ -251,3 +260,36 @@ async def execute_rpa_script(
         if browser is not None:
             with contextlib.suppress(Exception):
                 await browser.close()
+
+
+async def execute_rpa_script(
+    script_name: str,
+    params: dict[str, Any],
+    timeout_s: int = DEFAULT_TIMEOUT_S,
+    screenshot_dir: str | None = None,
+) -> dict[str, Any]:
+    """Execute one browser job within the per-container capacity budget."""
+    try:
+        async with _RPA_CAPACITY.slot():
+            return await _execute_rpa_script(
+                script_name=script_name,
+                params=params,
+                timeout_s=timeout_s,
+                screenshot_dir=screenshot_dir,
+            )
+    except CapacityLimitError as exc:
+        logger.warning(
+            "rpa_capacity_exhausted",
+            limit=_RPA_CAPACITY.limit,
+            waiting=_RPA_CAPACITY.snapshot.waiting,
+            queue_timeout_seconds=exc.timeout_seconds,
+        )
+        return {
+            "success": False,
+            "data": None,
+            "screenshots": [],
+            "elapsed_ms": 0,
+            "error": str(exc),
+            "error_class": "rpa_capacity_exhausted",
+            "retryable": True,
+        }

--- a/core/rpa/executor.py
+++ b/core/rpa/executor.py
@@ -270,13 +270,14 @@ async def execute_rpa_script(
 ) -> dict[str, Any]:
     """Execute one browser job within the per-container capacity budget."""
     try:
-        async with _RPA_CAPACITY.slot():
-            return await _execute_rpa_script(
+        return await _RPA_CAPACITY.run(
+            lambda: _execute_rpa_script(
                 script_name=script_name,
                 params=params,
                 timeout_s=timeout_s,
                 screenshot_dir=screenshot_dir,
             )
+        )
     except CapacityLimitError as exc:
         logger.warning(
             "rpa_capacity_exhausted",

--- a/core/runtime_capacity.py
+++ b/core/runtime_capacity.py
@@ -1,0 +1,71 @@
+"""Bounded admission control for resource-intensive local runtimes."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+
+class CapacityLimitError(RuntimeError):
+    """Raised when work cannot enter a bounded runtime before its deadline."""
+
+    def __init__(self, workload: str, timeout_seconds: float) -> None:
+        super().__init__(f"{workload} capacity is busy; retry after queued work completes")
+        self.workload = workload
+        self.timeout_seconds = timeout_seconds
+
+
+@dataclass(frozen=True)
+class CapacitySnapshot:
+    """Point-in-time state used by tests and operational diagnostics."""
+
+    limit: int
+    active: int
+    waiting: int
+
+
+class AsyncCapacityGate:
+    """Limit concurrent expensive jobs and bound their queue wait."""
+
+    def __init__(self, workload: str, *, limit: int, queue_timeout_seconds: float) -> None:
+        if limit < 1:
+            raise ValueError("capacity limit must be at least one")
+        if queue_timeout_seconds <= 0:
+            raise ValueError("queue timeout must be positive")
+        self.workload = workload
+        self.limit = limit
+        self.queue_timeout_seconds = queue_timeout_seconds
+        self._semaphore = asyncio.Semaphore(limit)
+        self._active = 0
+        self._waiting = 0
+
+    @property
+    def snapshot(self) -> CapacitySnapshot:
+        return CapacitySnapshot(limit=self.limit, active=self._active, waiting=self._waiting)
+
+    @asynccontextmanager
+    async def slot(self) -> AsyncIterator[None]:
+        """Acquire one execution slot or fail without starting the workload."""
+        self._waiting += 1
+        try:
+            try:
+                await asyncio.wait_for(
+                    self._semaphore.acquire(),
+                    timeout=self.queue_timeout_seconds,
+                )
+            except TimeoutError as exc:
+                raise CapacityLimitError(
+                    self.workload,
+                    self.queue_timeout_seconds,
+                ) from exc
+        finally:
+            self._waiting -= 1
+
+        self._active += 1
+        try:
+            yield
+        finally:
+            self._active -= 1
+            self._semaphore.release()

--- a/core/runtime_capacity.py
+++ b/core/runtime_capacity.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
+from typing import Any, TypeVar
+
+_T = TypeVar("_T")
 
 
 class CapacityLimitError(RuntimeError):
@@ -40,14 +43,13 @@ class AsyncCapacityGate:
         self._semaphore = asyncio.Semaphore(limit)
         self._active = 0
         self._waiting = 0
+        self._draining_tasks: set[asyncio.Task[None]] = set()
 
     @property
     def snapshot(self) -> CapacitySnapshot:
         return CapacitySnapshot(limit=self.limit, active=self._active, waiting=self._waiting)
 
-    @asynccontextmanager
-    async def slot(self) -> AsyncIterator[None]:
-        """Acquire one execution slot or fail without starting the workload."""
+    async def _acquire(self) -> None:
         self._waiting += 1
         try:
             try:
@@ -62,10 +64,56 @@ class AsyncCapacityGate:
                 ) from exc
         finally:
             self._waiting -= 1
-
         self._active += 1
+
+    def _release(self) -> None:
+        self._active -= 1
+        self._semaphore.release()
+
+    @asynccontextmanager
+    async def slot(self) -> AsyncIterator[None]:
+        """Acquire one execution slot or fail without starting the workload."""
+        await self._acquire()
         try:
             yield
         finally:
-            self._active -= 1
-            self._semaphore.release()
+            self._release()
+
+    async def run(self, operation: Callable[[], Awaitable[_T]]) -> _T:
+        """Run one async operation under this production capacity gate."""
+        async with self.slot():
+            return await operation()
+
+    async def _release_when_done(self, task: asyncio.Task[Any]) -> None:
+        with suppress(BaseException):
+            await task
+        self._release()
+
+    async def run_blocking(
+        self,
+        operation: Callable[..., _T],
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> _T:
+        """Run blocking work without releasing capacity on request cancellation.
+
+        Cancelling ``asyncio.to_thread`` only cancels the awaiter, not the worker
+        thread. When a caller disconnects, keep the permit until that underlying
+        thread exits so replacement requests cannot oversubscribe the process.
+        """
+        await self._acquire()
+        task = asyncio.create_task(asyncio.to_thread(operation, *args, **kwargs))
+        release_here = True
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            if not task.done():
+                release_here = False
+                draining = asyncio.create_task(self._release_when_done(task))
+                self._draining_tasks.add(draining)
+                draining.add_done_callback(self._draining_tasks.discard)
+            raise
+        finally:
+            if release_here:
+                self._release()

--- a/core/tasks/rpa_tasks.py
+++ b/core/tasks/rpa_tasks.py
@@ -46,6 +46,17 @@ from core.tasks.celery_app import app
 logger = logging.getLogger(__name__)
 
 
+class RetryableRPAExecutionError(RuntimeError):
+    """Transient RPA admission failure that must be retried by Celery."""
+
+
+def _raise_for_retryable_execution_failure(raw_result: dict[str, Any]) -> None:
+    if raw_result.get("success", False) or raw_result.get("retryable") is not True:
+        return
+    detail = str(raw_result.get("error") or "retryable RPA execution failure")[:200]
+    raise RetryableRPAExecutionError(detail)
+
+
 def _script_payload(raw_result: dict[str, Any], *, http_only: bool) -> dict[str, Any]:
     """Normalize direct HTTP and Playwright executor result shapes."""
     if http_only:
@@ -124,6 +135,7 @@ async def _execute_schedule(tenant_id: str, schedule_id: str) -> dict[str, Any]:
         await _record_failure(tid, sid, f"script_error: {type(exc).__name__}", 0, 0, None)
         return {"ok": False, "error": str(exc)}
 
+    _raise_for_retryable_execution_failure(raw_result)
     if not raw_result.get("success", False):
         detail = str(raw_result.get("error") or "script reported failure")[:200]
         await _record_failure(tid, sid, detail, 0, 0, None)

--- a/docker-compose.performance.yml
+++ b/docker-compose.performance.yml
@@ -1,0 +1,26 @@
+# Production-like local performance override. Use with docker-compose.yml,
+# docker-compose.local-e2e.yml, and docker-compose.simulation.yml.
+services:
+  api:
+    image: ${AGENTICORG_PERF_IMAGE:-agenticorg-performance:local}
+    ports: !override
+      - "8000"
+    volumes: !override []
+    environment:
+      AGENTICORG_ENV: development
+      AGENTICORG_DB_URL: postgresql+asyncpg://agenticorg:agenticorg_dev@postgres:5432/agenticorg
+      AGENTICORG_REDIS_URL: redis://redis:6379/0
+      AGENTICORG_STORAGE_BUCKET: agenticorg-docs-dev
+      AGENTICORG_STORAGE_ENDPOINT: http://minio:9000
+      AGENTICORG_SECRET_KEY: agenticorg-dev-only-do-not-use-in-production
+      AGENTICORG_PII_MASKING: "true"
+      AGENTICORG_LOG_LEVEL: WARNING
+      AGENTICORG_DB_POOL_SIZE: ${AGENTICORG_PERF_DB_POOL_SIZE:-5}
+      AGENTICORG_DB_MAX_OVERFLOW: ${AGENTICORG_PERF_DB_MAX_OVERFLOW:-5}
+      AGENTICORG_DOCUMENT_EXTRACTION_MAX_CONCURRENCY: ${AGENTICORG_PERF_OCR_CONCURRENCY:-2}
+      AGENTICORG_DOCUMENT_EXTRACTION_QUEUE_TIMEOUT_SECONDS: "30"
+      AGENTICORG_RPA_MAX_CONCURRENCY: ${AGENTICORG_PERF_RPA_CONCURRENCY:-2}
+      AGENTICORG_RPA_QUEUE_TIMEOUT_SECONDS: "5"
+    command: >-
+      uvicorn api.main:app --host 0.0.0.0 --port 8000
+      --timeout-graceful-shutdown 20

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -78,6 +78,7 @@ synthetic local content and performs no external action:
 
 ```powershell
 docker run --rm --network none `
+  -e PYTHONPATH=/work `
   --mount "type=bind,source=$PWD,target=/work,readonly" `
   -w /work agenticorg-performance:local `
   python tests/load/local_docker_resource_stress.py

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,88 +1,108 @@
-# Performance Baselines
+# Performance and Load Testing
 
-This document captures the performance numbers customers can expect
-from AgenticOrg. All measurements are from the production deployment
-at `app.agenticorg.ai` running on GKE with the resource allocation
-documented in `docs/SCALING.md`.
+AgenticOrg performance claims must come from a reproducible result. This page
+defines the supported local Docker checks and the boundary between measured
+evidence and production capacity planning.
 
-## How we measure
+## Current evidence
 
-- **Source of truth**: Grafana dashboards backed by Prometheus.
-- **Load generator**: Python E2E smoke tests run every hour from a
-  dedicated worker in the same GCP region. End-to-end measurements
-  include TLS handshake and service-side processing.
-- **Window**: percentiles are computed over a trailing 24-hour
-  window.
+The latest checked-in workstation run is:
 
-Raw numbers live in the dashboard at `/d/perf-baseline` (Grafana).
+- [Local Docker stress and performance report](reports/agenticorg-local-docker-stress-performance-2026-09-01.md)
 
-## API latency (public endpoints)
+That report measures one Docker Desktop host. It is useful for regression and
+resource-safety decisions, but it is not a Cloud Run SLA or a claim about
+tenant, LLM, telephony, payment-provider, or third-party connector capacity.
 
-| Endpoint                                    | p50   | p95   | p99    |
-|---------------------------------------------|-------|-------|--------|
-| `GET  /api/v1/health`                       |  8 ms |  20 ms|  40 ms |
-| `GET  /api/v1/agents`                       | 35 ms | 90 ms | 140 ms |
-| `POST /api/v1/agents/{id}/run` (LLM path)   | 1.8 s | 6.0 s | 12 s   |
-| `POST /api/v1/workflows/{id}/trigger`       | 60 ms | 180 ms| 320 ms |
-| `POST /api/v1/approvals/{id}/decide`        | 45 ms | 140 ms| 260 ms |
-| `GET  /api/v1/kpis/{domain}`                | 120 ms| 350 ms| 600 ms |
-| `POST /api/v1/billing/subscribe/india`      | 300 ms| 900 ms| 1.5 s  |
+## Runtime protections
 
-The LLM path dominates the tail — 95% of latency > 1 s is time spent
-waiting on Anthropic/Gemini. The non-LLM p99 target is 500 ms across
-all endpoints.
+AgenticOrg applies bounded admission control to the two most expensive local
+runtime paths:
 
-## Throughput
+| Workload | Default concurrency per worker | Queue deadline | Saturation behavior |
+|---|---:|---:|---|
+| Document extraction and OCR | 2 | 30 seconds | HTTP 503 with a retryable capacity error |
+| Browser RPA | 2 | 5 seconds | Structured retryable failure; the browser is not launched |
 
-- **Sustained**: 120 req/s per API pod (p95 < 200 ms).
-- **Burst**: 400 req/s per pod for up to 30 seconds before HPA kicks in.
-- **At 20 pods**: ~2400 req/s sustained.
+Tune these only after measuring the target container CPU and memory:
 
-## Workflow execution
-
-| Scenario                              | p50   | p95    |
-|---------------------------------------|-------|--------|
-| Sequential workflow, 5 steps, no LLM  | 1.2 s | 2.8 s  |
-| Sequential workflow, 5 steps, 1 LLM   | 4.8 s | 12 s   |
-| Parallel workflow, 10 branches        | 6.2 s | 14 s   |
-| Workflow with HITL (excluding wait)   | 250 ms| 700 ms |
-
-Max workflow duration is capped at 30 minutes. Workflows exceeding
-this are auto-cancelled and the caller sees a `workflow_timeout`
-error.
-
-## Database
-
-- p95 query latency: 3 ms (read), 12 ms (write).
-- Connection pool size: 20 per API pod, 30 per worker.
-- Vacuum runs automatically; long running queries are killed after 60 s.
-
-## Known cliffs
-
-1. **> 1000 rows in a single KPI response**: pagination recommended;
-   the response body becomes the bottleneck.
-2. **Workflow with > 100 parallel steps**: the LangGraph checkpointer
-   serializes on a single DB row for the run state. Keep fan-out below
-   100 or split into sub-workflows.
-3. **Search over > 1M documents in the knowledge base**: RAGFlow is
-   tuned for 500K docs. Above that, shard the index.
-
-## Load test methodology
-
-Run locally with:
-```
-cd tests/load
-python locustfile.py --users 500 --spawn-rate 20 --host https://app.agenticorg.ai
+```text
+AGENTICORG_DOCUMENT_EXTRACTION_MAX_CONCURRENCY
+AGENTICORG_DOCUMENT_EXTRACTION_QUEUE_TIMEOUT_SECONDS
+AGENTICORG_RPA_MAX_CONCURRENCY
+AGENTICORG_RPA_QUEUE_TIMEOUT_SECONDS
 ```
 
-Load tests run weekly on a staging cluster; results are attached to
-the Monday release review.
+Readiness checks reuse a bounded Redis pool, probe DB and Redis concurrently,
+and coalesce concurrent probes into a one-second cache. Liveness remains a
+dependency-free process check.
 
-## History
+The Docker image defaults to one Uvicorn worker. Operators may set
+`WEB_CONCURRENCY` when the service has enough CPU and its total DB connection
+budget has been calculated. Capacity gates are process-local, so effective
+container concurrency is `WEB_CONCURRENCY` multiplied by each configured
+limit. More workers are not automatically faster for a CPU-saturated OCR/RPA
+container.
 
-| Version | Date       | p95 /agents/run | Notes                       |
-|---------|------------|-----------------|------------------------------|
-| v3.0.0  | 2026-01-10 | 9.2 s           | Baseline                    |
-| v4.0.0  | 2026-02-14 | 7.1 s           | Prompt caching              |
-| v4.3.0  | 2026-03-08 | 6.5 s           | Gemini fallback for simple  |
-| v4.6.0  | 2026-04-11 | 6.0 s           | Current                     |
+## Reproduce locally
+
+Build and start a production-style API with isolated dependencies:
+
+```powershell
+docker build -t agenticorg-performance:local .
+$env:AGENTICORG_PERF_IMAGE = "agenticorg-performance:local"
+docker compose -p agenticorg_perf `
+  -f docker-compose.yml `
+  -f docker-compose.local-e2e.yml `
+  -f docker-compose.simulation.yml `
+  -f docker-compose.performance.yml `
+  up -d --wait postgres redis minio mailpit api
+docker compose -p agenticorg_perf `
+  -f docker-compose.yml `
+  -f docker-compose.local-e2e.yml `
+  -f docker-compose.simulation.yml `
+  -f docker-compose.performance.yml `
+  port api 8000
+```
+
+Run the HTTP harness against the mapped API port:
+
+```powershell
+python tests/load/local_docker_http.py `
+  --base-url http://127.0.0.1:<mapped-port> `
+  --output codex-pytest-artifacts/local-docker-http.json
+```
+
+Run real OCR and Chromium stress inside the built container. The workload uses
+synthetic local content and performs no external action:
+
+```powershell
+docker run --rm --network none `
+  --mount "type=bind,source=$PWD,target=/work,readonly" `
+  -w /work agenticorg-performance:local `
+  python tests/load/local_docker_resource_stress.py
+```
+
+Remove the isolated stack when finished:
+
+```powershell
+docker compose -p agenticorg_perf `
+  -f docker-compose.yml `
+  -f docker-compose.local-e2e.yml `
+  -f docker-compose.simulation.yml `
+  -f docker-compose.performance.yml `
+  down --volumes --remove-orphans
+```
+
+## Production release gate
+
+Before raising production concurrency or instance limits, run a staging soak
+with production-equivalent Cloud Run CPU, memory, DB pool, Redis tier, and
+autoscaling settings. Include authenticated API mixes, tenant isolation,
+large-document OCR, browser RPA, websocket/voice control traffic, and failure
+injection. Record p50/p95/p99, error rate, queue wait, CPU, memory, DB pool
+wait, Redis latency, and external-provider latency.
+
+Do not load-test paid telephony, payment rails, merchant systems, or other
+third-party services without written approval, dedicated test credentials,
+spend caps, and provider-safe test destinations.

--- a/docs/reports/agenticorg-local-docker-stress-performance-2026-09-01.md
+++ b/docs/reports/agenticorg-local-docker-stress-performance-2026-09-01.md
@@ -52,7 +52,9 @@ reported a configured limit of two and a measured maximum of two active jobs.
 
 Focused regression validation after these review fixes passed 59 tests,
 including capacity cancellation, RPA API/scheduler propagation, health,
-history durability, RPA execution, and voice/RPA handling.
+history durability, RPA execution, and voice/RPA handling. The expanded
+affected-area pack passed 190 tests after updating legacy health-cache and
+extraction source-pin tests for the new runtime contract.
 
 ## Exact-commit reproducibility rerun
 

--- a/docs/reports/agenticorg-local-docker-stress-performance-2026-09-01.md
+++ b/docs/reports/agenticorg-local-docker-stress-performance-2026-09-01.md
@@ -1,0 +1,193 @@
+# AgenticOrg Local Docker Stress and Performance Report
+
+Date: 2026-09-01
+
+Scope: local workstation Docker only
+
+Base commit: `2af012775be7ce3269c76340a93691eb59db1640`
+
+Branch: `codex/stress-performance-20260901`
+
+## Executive result
+
+The production API image, fresh migrations, dependency services, HTTP probes,
+real Tesseract OCR, real Playwright Chromium, local SMTP capture, and the
+signed voice runtime were exercised on Docker Desktop. The implementation now
+bounds OCR and browser concurrency, sheds work with retryable errors rather
+than spawning processes without limit, removes blocking SMTP/DNS work from the
+async event loop, and coalesces readiness dependency probes.
+
+The final Docker-network HTTP run completed 9,500 requests with zero client or
+HTTP errors. The resource stress completed 12 OCR jobs and 8 Chromium jobs with
+all jobs successful and a maximum of two expensive jobs active at once.
+
+This is regression evidence from one workstation. It is not a production SLA,
+Cloud Run capacity claim, or proof of external LLM, telephony, payment, or
+merchant-system capacity.
+
+## Test host and isolation
+
+- Docker Desktop allocation: 16 CPUs and 31.08 GiB memory.
+- AgenticOrg used an isolated Compose project with PostgreSQL, Redis, MinIO,
+  Mailpit, and a production Dockerfile API image.
+- Application migrations ran against fresh dedicated databases.
+- HTTP was measured both through the Windows mapped port and on the Docker
+  network. The Docker-network result is the final regression gate.
+- Other unrelated Docker stacks were active on the shared workstation during
+  parts of the run. Host-port tail latency was therefore noisy and is recorded
+  as diagnostic evidence, not a capacity ceiling.
+- No production endpoint, paid phone number, payment rail, merchant system, or
+  external write target was used.
+
+## Baseline findings
+
+### HTTP before hardening
+
+The initial one-worker production image had no HTTP errors in the baseline,
+but burst tail latency was high:
+
+| Phase | Requests / concurrency | Throughput | p50 | p95 | p99 | Errors |
+|---|---:|---:|---:|---:|---:|---:|
+| Liveness steady | 3,000 / 50 | 199.01 rps | 144.84 ms | 796.45 ms | 1,295.61 ms | 0 |
+| DB/Redis readiness | 1,500 / 50 | 164.17 rps | 268.17 ms | 539.40 ms | 706.44 ms | 0 |
+| Liveness burst | 5,000 / 150 | 281.80 rps | 278.22 ms | 1,603.28 ms | 4,678.10 ms | 0 |
+
+Readiness created a Redis client for every request and performed DB and Redis
+checks serially. Concurrent probes could amplify load on both dependencies.
+
+### Unbounded expensive work
+
+| Workload | Jobs | Elapsed | Sampled peak CPU | Sampled peak memory | Peak PIDs |
+|---|---:|---:|---:|---:|---:|
+| OCR, unbounded | 12 | 7.99 s | 1,853.73% | about 702 MiB | 72 |
+| Chromium, unbounded | 8 | 0.927 s | 746.22% | about 601.4 MiB | 552 |
+
+The short elapsed time hid unsafe resource fan-out. Multiple simultaneous OCR
+uploads or RPA jobs could exhaust a smaller Cloud Run container.
+
+### Dependency headroom
+
+The isolated dependency services were not the first bottleneck:
+
+- PostgreSQL `pgbench`, scale 10, 20 clients, 4 threads, 15 seconds:
+  49,858 transactions, zero failures, 6.000 ms average latency, 3,320.35 TPS.
+- Redis, 100,000 requests, 50 clients: PING 109,289.62 rps, SET 80,775.45
+  rps, GET 63,856.96 rps; p50 was 0.215-0.327 ms.
+
+These numbers describe the local containers only and do not project managed
+database or network performance.
+
+## Fixes implemented
+
+1. Added reusable async admission control with bounded concurrency and queue
+   deadlines.
+2. Applied the gate to document extraction/OCR. Saturation returns HTTP 503,
+   a stable `document_extraction_capacity_exhausted` code, `retryable: true`,
+   and `Retry-After` without starting another extraction.
+3. Applied the gate to browser RPA. Saturation returns a structured retryable
+   `rpa_capacity_exhausted` result without launching Chromium.
+4. Added environment-validated OCR and RPA capacity settings. Defaults are two
+   active jobs per API worker process; one worker is the image default.
+5. Reused a bounded Redis pool for health checks, added dependency timeouts,
+   ran DB and Redis probes concurrently, and coalesced concurrent readiness
+   probes into a one-second cache.
+6. Closed shared health resources during application shutdown.
+7. Moved synchronous email delivery and recipient-domain validation off the
+   FastAPI event loop for signup, password reset, invitation, demo, sales, and
+   budget-notification paths.
+8. Corrected sales email state so a transport refusal is not marked `sent`.
+9. Removed the hard-coded single worker flag from the Docker image. One worker
+   remains the default, while an explicitly sized deployment can use
+   `WEB_CONCURRENCY`.
+10. Added a production-style performance Compose override and reproducible
+    HTTP/resource stress harnesses.
+11. Replaced stale, unverified GKE/Grafana capacity statements with measured
+    local evidence and an explicit production staging gate.
+
+## Final stress result
+
+### HTTP through the Docker network
+
+| Phase | Requests / concurrency | Throughput | p50 | p95 | p99 | Errors |
+|---|---:|---:|---:|---:|---:|---:|
+| Liveness steady | 3,000 / 50 | 128.77 rps | 241.33 ms | 1,189.14 ms | 1,806.43 ms | 0 |
+| Coalesced readiness | 1,500 / 50 | 198.77 rps | 163.59 ms | 713.18 ms | 1,203.52 ms | 0 |
+| Liveness burst | 5,000 / 150 | 220.28 rps | 400.02 ms | 2,154.47 ms | 3,809.16 ms | 0 |
+
+The run passed the local readiness p95 threshold of 1,000 ms. Overall HTTP
+throughput was lower than the earlier quiet-host baseline because unrelated
+containers were active during the final run. The safety conclusion is based on
+zero errors and bounded resources, not a claim that this noisy run is faster in
+every percentile.
+
+A simultaneous repeat through Docker Desktop's Windows host-port forwarding
+did not pass: 2 of 5,000 burst requests ended in client-side
+`RemoteProtocolError`, and readiness p95 was 1,739.13 ms. At that point the
+workstation was also running unrelated application/model test stacks. The same
+API and workload passed on the Docker network with zero errors. This isolates
+the observed failure to the contended host/port-forwarding path but does not
+erase it; a quiet-host repeat remains a release-engineering follow-up.
+
+### Bounded OCR and Chromium
+
+| Workload | Jobs | Limit / max active | Elapsed | Result |
+|---|---:|---:|---:|---|
+| Tesseract OCR | 12 | 2 / 2 | 70.281 s | 12 passed |
+| Playwright Chromium | 8 | 2 / 2 | 5.617 s | 8 passed |
+
+Across the bounded run, sampled peak memory was about 305.1 MiB and peak PIDs
+were 170. During the OCR phase, sampled memory stayed at or below about 171.6
+MiB and PIDs at or below 28. Compared with unbounded execution, this reduced
+sampled OCR memory by about 75% and browser peak PIDs by about 69%.
+
+Queueing intentionally increases completion time. With the API defaults, work
+that cannot enter within its deadline is rejected for retry instead of waiting
+indefinitely or exhausting the container.
+
+## End-to-end verification
+
+| Check | Result |
+|---|---|
+| Production Docker image build and dependency check | Passed |
+| Fresh migration from empty PostgreSQL database to head | Passed |
+| API liveness and DB/Redis readiness | Passed |
+| Tenant signup, JWT issuance, and authenticated agent listing | Passed |
+| HTTP stress, 9,500 requests | Passed, zero errors |
+| Runtime/voice/RPA/OCR regression pack | 36 passed |
+| Auth, email, demo, and negative-case unit pack | 177 passed |
+| Signed voice runtime with durable PostgreSQL state | 1 passed |
+| Real synthetic-image Tesseract OCR | Passed |
+| Real synthetic-page Playwright Chromium | Passed |
+| Local email through Mailpit SMTP capture | Passed |
+| Compose configuration rendering | Passed |
+| Ruff and focused type/regression checks | Passed |
+
+The voice integration used signed synthetic events and local persistence. No
+paid call was placed. Email was captured by Mailpit and never left the
+workstation. Browser RPA used `page.set_content` with synthetic HTML and no
+external navigation.
+
+## Remaining limits and next production gate
+
+- Run a dedicated, quiet-host repeat before using workstation numbers as a
+  long-term regression baseline.
+- Run a production-equivalent staging soak with the actual Cloud Run CPU,
+  memory, instance concurrency, autoscaling limits, Cloud SQL pool budget, and
+  Redis tier.
+- Add authenticated mixed-route load with realistic tenant cardinality and
+  payload sizes. The public health test does not represent the whole API.
+- Measure long scanned PDFs and multilingual OCR separately; the current
+  resource test uses one-page synthetic PNGs.
+- Measure websocket audio streaming and STT/TTS providers with approved test
+  credentials and spend caps. The local run proves control/persistence paths,
+  not external provider throughput.
+- Exercise real RPA targets only in an approved sandbox with deterministic
+  test accounts. Browser resource safety is proven here; third-party site
+  capacity is not.
+- Add queue-wait and rejection counters to production metrics before changing
+  the default OCR/RPA limits.
+
+## Reproduction commands
+
+The supported commands are maintained in [Performance and Load
+Testing](../PERFORMANCE.md) and [the load-test README](../../tests/load/README.md).

--- a/docs/reports/agenticorg-local-docker-stress-performance-2026-09-01.md
+++ b/docs/reports/agenticorg-local-docker-stress-performance-2026-09-01.md
@@ -56,6 +56,24 @@ history durability, RPA execution, and voice/RPA handling. The expanded
 affected-area pack passed 190 tests after updating legacy health-cache and
 extraction source-pin tests for the new runtime contract.
 
+## PR CI lifecycle hardening
+
+The first full PR integration run exposed two cross-event-loop failures in
+credentialed connector registration. Readiness and tenant secret resolution
+had imported the process database session factory by value. The integration
+harness swaps that factory for a per-loop `NullPool` engine, but the stale
+bindings bypassed the swap and could reuse an asyncpg connection owned by a
+closed loop. Both helpers now resolve the active factory from
+`core.database` when called. Production still uses the same configured
+factory; tests and any controlled runtime factory replacement no longer retain
+stale pooled connections.
+
+The exact CI failure sequence was reproduced against fresh local Docker
+PostgreSQL and Redis: two readiness requests followed by two credentialed
+connector registrations on separate test event loops. All four requests
+passed after the fix. The complete API integration lifecycle plus the signed
+voice runtime then passed 44 tests on the same fresh Docker dependencies.
+
 ## Exact-commit reproducibility rerun
 
 After the fixes were committed, the complete local gate was repeated from a

--- a/docs/reports/agenticorg-local-docker-stress-performance-2026-09-01.md
+++ b/docs/reports/agenticorg-local-docker-stress-performance-2026-09-01.md
@@ -27,6 +27,33 @@ This is regression evidence from one workstation. It is not a production SLA,
 Cloud Run capacity claim, or proof of external LLM, telephony, payment, or
 merchant-system capacity.
 
+## PR review hardening rerun
+
+PR review identified four ways the first evidence pass could be stronger. The
+runtime and harnesses were corrected before merge:
+
+1. Cancelled upload requests retain their extraction permit until the worker
+   thread actually exits; cancellation can no longer oversubscribe OCR.
+2. RPA capacity exhaustion remains retryable in the API response and causes a
+   scheduled Celery run to retry without recording a permanent failure or
+   advancing its schedule.
+3. HTTP stress now rejects an HTTP 200 readiness response when its body says
+   DB or Redis is unhealthy.
+4. OCR and Chromium stress use the production AgenticOrg capacity gates. The
+   harness no longer creates private semaphores that could mask missing runtime
+   protection.
+
+The corrected harnesses were rerun from `agenticorg-stress:optimized` with the
+PR worktree mounted as `PYTHONPATH=/work`. The Docker-network HTTP result was
+9,500 of 9,500 successful responses, zero client/status/readiness-body errors,
+and 337.72 ms readiness p95. The resource result was 12 of 12 OCR jobs in
+12.866 seconds and 8 of 8 Chromium jobs in 2.419 seconds. Both production gates
+reported a configured limit of two and a measured maximum of two active jobs.
+
+Focused regression validation after these review fixes passed 59 tests,
+including capacity cancellation, RPA API/scheduler propagation, health,
+history durability, RPA execution, and voice/RPA handling.
+
 ## Exact-commit reproducibility rerun
 
 After the fixes were committed, the complete local gate was repeated from a

--- a/docs/reports/agenticorg-local-docker-stress-performance-2026-09-01.md
+++ b/docs/reports/agenticorg-local-docker-stress-performance-2026-09-01.md
@@ -8,6 +8,8 @@ Base commit: `2af012775be7ce3269c76340a93691eb59db1640`
 
 Branch: `codex/stress-performance-20260901`
 
+Implementation commit tested: `3fda4cbc747b6b5a96cb4885324065d04c760515`
+
 ## Executive result
 
 The production API image, fresh migrations, dependency services, HTTP probes,
@@ -24,6 +26,78 @@ all jobs successful and a maximum of two expensive jobs active at once.
 This is regression evidence from one workstation. It is not a production SLA,
 Cloud Run capacity claim, or proof of external LLM, telephony, payment, or
 merchant-system capacity.
+
+## Exact-commit reproducibility rerun
+
+After the fixes were committed, the complete local gate was repeated from a
+new production image and a new isolated Compose project. The image was built
+from implementation commit `3fda4cbc747b6b5a96cb4885324065d04c760515`
+and had image ID
+`sha256:5f764daf254180ca1136ad3ba09f289a4086225ce7132dadb8cd6df4e66969cd`.
+PostgreSQL, Redis, MinIO, Mailpit, application data, and the voice-integration
+database were fresh for this rerun.
+
+### Repeated HTTP result
+
+| Phase | Requests / concurrency | Throughput | p50 | p95 | p99 | Max | Errors |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Liveness steady | 3,000 / 50 | 210.67 rps | 146.36 ms | 742.43 ms | 1,189.77 ms | 2,615.19 ms | 0 |
+| Coalesced readiness | 1,500 / 50 | 188.84 rps | 160.57 ms | 773.18 ms | 1,311.33 ms | 2,779.75 ms | 0 |
+| Liveness burst | 5,000 / 150 | 170.51 rps | 517.15 ms | 2,877.65 ms | 4,889.91 ms | 8,148.80 ms | 0 |
+
+All 9,500 responses were HTTP 200. Readiness remained below the 1,000 ms
+local p95 gate. The burst maximum shows substantial tail latency on this
+shared workstation, so the result is a correctness and overload-safety gate,
+not a latency objective.
+
+### Repeated resource result
+
+| Workload | Jobs | Limit / max active | Elapsed | Result |
+|---|---:|---:|---:|---|
+| Tesseract OCR | 12 | 2 / 2 | 72.815 s | 12 passed |
+| Playwright Chromium | 8 | 2 / 2 | 4.508 s | 8 passed |
+
+Sampled peak usage across the repeated resource run was 1,092.84% CPU,
+319.8 MiB memory, and 164 PIDs. The CPU value is Docker's aggregate across
+cores, not utilization of a single core. The gate held at two active jobs and
+the container completed without an OOM or restart.
+
+### Repeated dependency result
+
+- PostgreSQL `pgbench`, scale 10, 20 clients, 4 threads, 15 seconds: 8,232
+  transactions, zero failures, 36.380 ms average latency, and 546.07 TPS.
+- Redis, 100,000 requests per operation with 50 clients: PING inline
+  24,271.85 rps, PING multibulk 15,576.32 rps, SET 13,260.84 rps, and GET
+  28,579.59 rps. Operation p50 was 0.455-1.087 ms.
+
+These repeated dependency numbers are much lower than the quiet first-pass
+baseline because unrelated Docker workloads were active. They are retained
+as honest shared-host evidence. Both services remained correct and returned
+zero benchmark failures; a quiet-host benchmark is still required for a
+stable capacity baseline.
+
+### Repeated end-to-end and regression gate
+
+| Check | Repeated result |
+|---|---|
+| Production image build and `pip check` | Passed |
+| Empty-database ORM bootstrap and Alembic migration to head | Passed twice, including dedicated voice database |
+| HTTP stress | 9,500 passed, zero errors and zero non-200 responses |
+| OCR, RPA, voice, and multichannel focused pack | 36 passed |
+| Auth, email, sales, budget, and security pack | 302 passed; 42 existing test/deprecation warnings |
+| Signed voice runtime with encrypted durable PostgreSQL state | 1 passed |
+| Local Mailpit SMTP transport and capture | Passed; one local-only message captured |
+| Tenant signup, JWT issuance, and authenticated agent listing | Passed; 20 seeded agents returned |
+| Ruff on all changed Python files | Passed |
+| Focused mypy check | Passed with third-party missing imports ignored |
+| Compose rendering and `git diff --check` | Passed |
+| API process stability | Zero restarts, no OOM, no traceback or HTTP 5xx log match |
+
+The email transport used Mailpit on the workstation and did not deliver
+externally. The signed voice test mocked provider transport and did not place
+a paid call. The browser used synthetic in-memory HTML and made no external
+navigation. No new runtime defect reproduced during this exact-commit rerun,
+so no additional code change was made after the performance fixes.
 
 ## Test host and isolation
 

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -338,7 +338,7 @@
     "public_exempt_reason": null,
     "rate_limit": "demo-seed",
     "scope": "demo.seed.control_plane.write",
-    "source_line": 59,
+    "source_line": 60,
     "tenant_required": true
   },
   {
@@ -1004,7 +1004,7 @@
     "public_exempt_reason": "auth-bootstrap-config-no-tenant-data",
     "rate_limit": "public-read",
     "scope": "public:auth.config",
-    "source_line": 768,
+    "source_line": 774,
     "tenant_required": false
   },
   {
@@ -1022,7 +1022,7 @@
     "public_exempt_reason": "password-reset-bootstrap-rate-limited",
     "rate_limit": "auth-password-reset",
     "scope": "public:auth.password_reset.request",
-    "source_line": 566,
+    "source_line": 572,
     "tenant_required": false
   },
   {
@@ -1040,7 +1040,7 @@
     "public_exempt_reason": "google-id-token-verification",
     "rate_limit": "auth-login",
     "scope": "public:auth.google",
-    "source_line": 442,
+    "source_line": 448,
     "tenant_required": false
   },
   {
@@ -1058,7 +1058,7 @@
     "public_exempt_reason": "auth-bootstrap-rate-limited-credentials",
     "rate_limit": "auth-login",
     "scope": "public:auth.login",
-    "source_line": 358,
+    "source_line": 364,
     "tenant_required": false
   },
   {
@@ -1076,7 +1076,7 @@
     "public_exempt_reason": null,
     "rate_limit": "auth-mutating",
     "scope": "auth.session.logout",
-    "source_line": 673,
+    "source_line": 679,
     "tenant_required": true
   },
   {
@@ -1094,7 +1094,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "auth.session.read",
-    "source_line": 699,
+    "source_line": 705,
     "tenant_required": true
   },
   {
@@ -1112,7 +1112,7 @@
     "public_exempt_reason": "one-time-reset-code-validated",
     "rate_limit": "auth-password-reset",
     "scope": "public:auth.password_reset.consume",
-    "source_line": 620,
+    "source_line": 626,
     "tenant_required": false
   },
   {
@@ -1130,7 +1130,7 @@
     "public_exempt_reason": "auth-bootstrap-rate-limited-password-policy",
     "rate_limit": "auth-signup",
     "scope": "public:auth.signup",
-    "source_line": 138,
+    "source_line": 139,
     "tenant_required": false
   },
   {
@@ -3740,7 +3740,7 @@
     "public_exempt_reason": "public-lead-capture-email-and-sales-agent-trigger",
     "rate_limit": "demo-request-public",
     "scope": "public:demo_request.external_input.write",
-    "source_line": 112,
+    "source_line": 113,
     "tenant_required": false
   },
   {
@@ -4028,7 +4028,7 @@
     "public_exempt_reason": "public-readiness-probe-limited-db-redis-status",
     "rate_limit": "infra-health-probe",
     "scope": "public:health.readiness.dependency_status",
-    "source_line": 78,
+    "source_line": 162,
     "tenant_required": false
   },
   {
@@ -4046,7 +4046,7 @@
     "public_exempt_reason": null,
     "rate_limit": "health-sla-read",
     "scope": "health.sla.sensitive.read",
-    "source_line": 196,
+    "source_line": 263,
     "tenant_required": false
   },
   {
@@ -4064,7 +4064,7 @@
     "public_exempt_reason": null,
     "rate_limit": "health-diagnostics-read",
     "scope": "health.diagnostics.admin.sensitive.read",
-    "source_line": 311,
+    "source_line": 378,
     "tenant_required": false
   },
   {
@@ -4082,7 +4082,7 @@
     "public_exempt_reason": "public-liveness-probe-no-dependency-detail",
     "rate_limit": "infra-health-probe",
     "scope": "public:health.liveness",
-    "source_line": 123,
+    "source_line": 190,
     "tenant_required": false
   },
   {
@@ -4100,7 +4100,7 @@
     "public_exempt_reason": null,
     "rate_limit": "health-sla-read",
     "scope": "health.sla.sensitive.read",
-    "source_line": 246,
+    "source_line": 313,
     "tenant_required": false
   },
   {
@@ -4136,7 +4136,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "knowledge.sensitive.documents.list",
-    "source_line": 870,
+    "source_line": 890,
     "tenant_required": true
   },
   {
@@ -4154,7 +4154,7 @@
     "public_exempt_reason": null,
     "rate_limit": "knowledge-write",
     "scope": "knowledge.documents.delete",
-    "source_line": 969,
+    "source_line": 989,
     "tenant_required": true
   },
   {
@@ -4172,7 +4172,7 @@
     "public_exempt_reason": "deployment-smoke-test-no-tenant-data",
     "rate_limit": "healthcheck",
     "scope": "knowledge.health.public",
-    "source_line": 1255,
+    "source_line": 1275,
     "tenant_required": false
   },
   {
@@ -4190,7 +4190,7 @@
     "public_exempt_reason": null,
     "rate_limit": "knowledge-search",
     "scope": "knowledge.sensitive.search",
-    "source_line": 1197,
+    "source_line": 1217,
     "tenant_required": true
   },
   {
@@ -4208,7 +4208,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "knowledge.sensitive.stats",
-    "source_line": 1368,
+    "source_line": 1388,
     "tenant_required": true
   },
   {
@@ -4226,7 +4226,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "knowledge.upload.types.read",
-    "source_line": 497,
+    "source_line": 505,
     "tenant_required": true
   },
   {
@@ -4244,7 +4244,7 @@
     "public_exempt_reason": null,
     "rate_limit": "file-upload",
     "scope": "knowledge.upload",
-    "source_line": 523,
+    "source_line": 531,
     "tenant_required": true
   },
   {
@@ -4424,7 +4424,7 @@
     "public_exempt_reason": "one-time-invite-code-validated",
     "rate_limit": "auth-invite",
     "scope": "public:org.invite.accept",
-    "source_line": 295,
+    "source_line": 303,
     "tenant_required": false
   },
   {
@@ -4496,7 +4496,7 @@
     "public_exempt_reason": null,
     "rate_limit": "admin-mutating",
     "scope": "org.members.invite.admin",
-    "source_line": 165,
+    "source_line": 166,
     "tenant_required": true
   },
   {
@@ -4514,7 +4514,7 @@
     "public_exempt_reason": "one-time-invite-code-preview",
     "rate_limit": "auth-invite",
     "scope": "public:org.invite.preview",
-    "source_line": 248,
+    "source_line": 256,
     "tenant_required": false
   },
   {
@@ -4532,7 +4532,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "org.members.read.admin",
-    "source_line": 131,
+    "source_line": 132,
     "tenant_required": true
   },
   {
@@ -4550,7 +4550,7 @@
     "public_exempt_reason": null,
     "rate_limit": "admin-mutating",
     "scope": "org.members.delete.admin",
-    "source_line": 404,
+    "source_line": 412,
     "tenant_required": true
   },
   {
@@ -4568,7 +4568,7 @@
     "public_exempt_reason": null,
     "rate_limit": "admin-mutating",
     "scope": "org.onboarding.update.admin",
-    "source_line": 367,
+    "source_line": 375,
     "tenant_required": true
   },
   {
@@ -4586,7 +4586,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "org.profile.read.admin",
-    "source_line": 101,
+    "source_line": 102,
     "tenant_required": true
   },
   {
@@ -5432,7 +5432,7 @@
     "public_exempt_reason": null,
     "rate_limit": "bulk-import",
     "scope": "sales.pipeline.sensitive.bulk_import",
-    "source_line": 572,
+    "source_line": 575,
     "tenant_required": true
   },
   {
@@ -5450,7 +5450,7 @@
     "public_exempt_reason": null,
     "rate_limit": "business-metrics-read",
     "scope": "sales.metrics.sensitive.read",
-    "source_line": 492,
+    "source_line": 495,
     "tenant_required": true
   },
   {
@@ -5468,7 +5468,7 @@
     "public_exempt_reason": null,
     "rate_limit": "sales-read",
     "scope": "sales.pipeline.sensitive.list",
-    "source_line": 142,
+    "source_line": 143,
     "tenant_required": true
   },
   {
@@ -5486,7 +5486,7 @@
     "public_exempt_reason": null,
     "rate_limit": "sales-read",
     "scope": "sales.pipeline.sensitive.followups",
-    "source_line": 181,
+    "source_line": 182,
     "tenant_required": true
   },
   {
@@ -5504,7 +5504,7 @@
     "public_exempt_reason": null,
     "rate_limit": "sales-write",
     "scope": "sales.pipeline.sensitive.write",
-    "source_line": 109,
+    "source_line": 110,
     "tenant_required": true
   },
   {
@@ -5522,7 +5522,7 @@
     "public_exempt_reason": null,
     "rate_limit": "sales-agent-trigger",
     "scope": "sales.pipeline.external_action.process",
-    "source_line": 205,
+    "source_line": 206,
     "tenant_required": true
   },
   {
@@ -5540,7 +5540,7 @@
     "public_exempt_reason": null,
     "rate_limit": "sales-read",
     "scope": "sales.pipeline.sensitive.read",
-    "source_line": 244,
+    "source_line": 245,
     "tenant_required": true
   },
   {
@@ -5558,7 +5558,7 @@
     "public_exempt_reason": null,
     "rate_limit": "sales-write",
     "scope": "sales.pipeline.sensitive.write",
-    "source_line": 288,
+    "source_line": 289,
     "tenant_required": true
   },
   {
@@ -5576,7 +5576,7 @@
     "public_exempt_reason": null,
     "rate_limit": "sales-inbox-sync",
     "scope": "sales.pipeline.external_action.process_inbox",
-    "source_line": 924,
+    "source_line": 927,
     "tenant_required": true
   },
   {
@@ -5594,7 +5594,7 @@
     "public_exempt_reason": null,
     "rate_limit": "sales-agent-trigger",
     "scope": "sales.pipeline.external_action.run_followups",
-    "source_line": 730,
+    "source_line": 733,
     "tenant_required": true
   },
   {
@@ -5612,7 +5612,7 @@
     "public_exempt_reason": null,
     "rate_limit": "sales-write",
     "scope": "sales.pipeline.sensitive.seed_demo",
-    "source_line": 846,
+    "source_line": 849,
     "tenant_required": true
   },
   {

--- a/docs/route_inventory.json
+++ b/docs/route_inventory.json
@@ -4136,7 +4136,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "knowledge.sensitive.documents.list",
-    "source_line": 890,
+    "source_line": 888,
     "tenant_required": true
   },
   {
@@ -4154,7 +4154,7 @@
     "public_exempt_reason": null,
     "rate_limit": "knowledge-write",
     "scope": "knowledge.documents.delete",
-    "source_line": 989,
+    "source_line": 987,
     "tenant_required": true
   },
   {
@@ -4172,7 +4172,7 @@
     "public_exempt_reason": "deployment-smoke-test-no-tenant-data",
     "rate_limit": "healthcheck",
     "scope": "knowledge.health.public",
-    "source_line": 1275,
+    "source_line": 1273,
     "tenant_required": false
   },
   {
@@ -4190,7 +4190,7 @@
     "public_exempt_reason": null,
     "rate_limit": "knowledge-search",
     "scope": "knowledge.sensitive.search",
-    "source_line": 1217,
+    "source_line": 1215,
     "tenant_required": true
   },
   {
@@ -4208,7 +4208,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "knowledge.sensitive.stats",
-    "source_line": 1388,
+    "source_line": 1386,
     "tenant_required": true
   },
   {
@@ -4226,7 +4226,7 @@
     "public_exempt_reason": null,
     "rate_limit": "standard",
     "scope": "knowledge.upload.types.read",
-    "source_line": 505,
+    "source_line": 504,
     "tenant_required": true
   },
   {
@@ -4244,7 +4244,7 @@
     "public_exempt_reason": null,
     "rate_limit": "file-upload",
     "scope": "knowledge.upload",
-    "source_line": 531,
+    "source_line": 530,
     "tenant_required": true
   },
   {
@@ -5378,7 +5378,7 @@
     "public_exempt_reason": null,
     "rate_limit": "rpa-read",
     "scope": "rpa.execution.sensitive.history",
-    "source_line": 213,
+    "source_line": 215,
     "tenant_required": true
   },
   {
@@ -5396,7 +5396,7 @@
     "public_exempt_reason": null,
     "rate_limit": "rpa-read",
     "scope": "rpa.catalog.sensitive.list",
-    "source_line": 169,
+    "source_line": 171,
     "tenant_required": true
   },
   {
@@ -5414,7 +5414,7 @@
     "public_exempt_reason": null,
     "rate_limit": "rpa-execution",
     "scope": "rpa.execution.external_action.run",
-    "source_line": 240,
+    "source_line": 242,
     "tenant_required": true
   },
   {

--- a/tests/integration/test_voice_runtime_e2e.py
+++ b/tests/integration/test_voice_runtime_e2e.py
@@ -22,14 +22,8 @@ async def test_signed_voice_runtime_persists_encrypted_tenant_safe_calls(
     tenant_id,
     monkeypatch,
 ) -> None:
-    import core.crypto.tenant_secrets as tenant_secrets
     import core.database as db_mod
     from api.v1 import voice_runtime
-
-    # The shared integration client swaps core.database to a NullPool engine.
-    # This crypto module imports the session factory by value, so point that
-    # binding at the same per-test engine instead of the process-global pool.
-    monkeypatch.setattr(tenant_secrets, "async_session_factory", db_mod.async_session_factory)
 
     agent_id = uuid.uuid4()
     auth_token = "local-twilio-signature-token"

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,6 +1,35 @@
 # Load test harness
 
-This directory holds Locust load tests for the AgenticOrg API.
+This directory holds repeatable local Docker stress tools and the staging-only
+Locust connector test.
+
+## Local Docker runtime tests
+
+`local_docker_http.py` exercises liveness, dependency readiness, and a burst
+phase. It emits JSON and returns non-zero for client errors, non-200 responses,
+or a readiness p95 above the configured limit.
+
+```powershell
+python tests/load/local_docker_http.py `
+  --base-url http://127.0.0.1:<mapped-port> `
+  --output codex-pytest-artifacts/local-docker-http.json
+```
+
+`local_docker_resource_stress.py` runs real Tesseract OCR and Playwright
+Chromium against synthetic local data. It checks that expensive work stays
+inside configured concurrency bounds without contacting an external site.
+
+```powershell
+docker run --rm --network none `
+  --mount "type=bind,source=$PWD,target=/work,readonly" `
+  -w /work agenticorg-performance:local `
+  python tests/load/local_docker_resource_stress.py
+```
+
+See [Performance and Load Testing](../../docs/PERFORMANCE.md) for the complete
+production-style Compose command and interpretation rules.
+
+## Connector rate-limit test
 
 ## Why Locust
 
@@ -14,7 +43,7 @@ This directory holds Locust load tests for the AgenticOrg API.
   in `core.tool_gateway.rate_limiter.RateLimiter` actually clamps at
   the published RPM. Run against a staging API (never production).
 
-## Running locally against a dev API
+### Running locally against a dev API
 
 ```
 pip install locust
@@ -26,7 +55,7 @@ locust -f tests/load/locustfile_connectors.py \
   --headless --csv tests/load/results/local
 ```
 
-## Running in CI
+### Running in CI
 
 Locust is *not* part of the default `pytest` run because it needs a
 live API to talk to. The intended CI flow is:
@@ -41,7 +70,7 @@ live API to talk to. The intended CI flow is:
 This nightly job is not yet wired — it's a P2 item tracked in
 `docs/ENTERPRISE_V4_8_0_SUMMARY.md`.
 
-## Interpreting the output
+### Interpreting the output
 
 | Connector | Published RPM | Expected 429 rate when running at 50% | When running at 110% |
 |-----------|---------------|--------------------------------------|----------------------|

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -7,7 +7,8 @@ Locust connector test.
 
 `local_docker_http.py` exercises liveness, dependency readiness, and a burst
 phase. It emits JSON and returns non-zero for client errors, non-200 responses,
-or a readiness p95 above the configured limit.
+unhealthy DB/Redis state in an HTTP 200 readiness body, or a readiness p95
+above the configured limit.
 
 ```powershell
 python tests/load/local_docker_http.py `
@@ -16,11 +17,13 @@ python tests/load/local_docker_http.py `
 ```
 
 `local_docker_resource_stress.py` runs real Tesseract OCR and Playwright
+through the same production capacity gates used by knowledge ingestion and RPA
 Chromium against synthetic local data. It checks that expensive work stays
 inside configured concurrency bounds without contacting an external site.
 
 ```powershell
 docker run --rm --network none `
+  -e PYTHONPATH=/work `
   --mount "type=bind,source=$PWD,target=/work,readonly" `
   -w /work agenticorg-performance:local `
   python tests/load/local_docker_resource_stress.py

--- a/tests/load/local_docker_http.py
+++ b/tests/load/local_docker_http.py
@@ -38,6 +38,28 @@ def _percentile(values: list[float], percentile: float) -> float:
     return round(ordered[index], 2)
 
 
+def _readiness_body_errors(response: httpx.Response) -> list[str]:
+    """Reject HTTP 200 readiness responses whose dependency body is unhealthy."""
+    try:
+        payload = response.json()
+    except ValueError:
+        return ["readiness_invalid_json"]
+    if not isinstance(payload, dict):
+        return ["readiness_invalid_payload"]
+
+    failures: list[str] = []
+    if payload.get("status") != "healthy":
+        failures.append("readiness_status_unhealthy")
+    checks = payload.get("checks")
+    if not isinstance(checks, dict):
+        failures.append("readiness_checks_missing")
+        return failures
+    for dependency in ("db", "redis"):
+        if checks.get(dependency) != "healthy":
+            failures.append(f"readiness_{dependency}_unhealthy")
+    return failures
+
+
 async def _run_phase(
     client: httpx.AsyncClient,
     *,
@@ -57,6 +79,8 @@ async def _run_phase(
             try:
                 response = await client.get(path)
                 statuses[str(response.status_code)] += 1
+                if path == "/api/v1/health" and response.status_code == 200:
+                    errors.update(_readiness_body_errors(response))
             except Exception as exc:  # enterprise-gate: broad-except-ok reason=load-harness-aggregates-client-errors
                 errors[type(exc).__name__] += 1
             finally:

--- a/tests/load/local_docker_http.py
+++ b/tests/load/local_docker_http.py
@@ -1,0 +1,165 @@
+"""Repeatable HTTP stress harness for a local AgenticOrg Docker container."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import math
+import time
+from collections import Counter
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+
+
+@dataclass(frozen=True)
+class PhaseResult:
+    name: str
+    path: str
+    requests: int
+    concurrency: int
+    elapsed_seconds: float
+    requests_per_second: float
+    p50_ms: float
+    p95_ms: float
+    p99_ms: float
+    max_ms: float
+    statuses: dict[str, int]
+    error_count: int
+    errors: dict[str, int]
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, math.ceil(percentile * len(ordered)) - 1))
+    return round(ordered[index], 2)
+
+
+async def _run_phase(
+    client: httpx.AsyncClient,
+    *,
+    name: str,
+    path: str,
+    requests: int,
+    concurrency: int,
+) -> PhaseResult:
+    semaphore = asyncio.Semaphore(concurrency)
+    latencies: list[float] = []
+    statuses: Counter[str] = Counter()
+    errors: Counter[str] = Counter()
+
+    async def request_once() -> None:
+        async with semaphore:
+            started = time.perf_counter()
+            try:
+                response = await client.get(path)
+                statuses[str(response.status_code)] += 1
+            except Exception as exc:  # enterprise-gate: broad-except-ok reason=load-harness-aggregates-client-errors
+                errors[type(exc).__name__] += 1
+            finally:
+                latencies.append((time.perf_counter() - started) * 1000)
+
+    started = time.perf_counter()
+    await asyncio.gather(*(request_once() for _ in range(requests)))
+    elapsed = time.perf_counter() - started
+    return PhaseResult(
+        name=name,
+        path=path,
+        requests=requests,
+        concurrency=concurrency,
+        elapsed_seconds=round(elapsed, 3),
+        requests_per_second=round(requests / elapsed, 2),
+        p50_ms=_percentile(latencies, 0.50),
+        p95_ms=_percentile(latencies, 0.95),
+        p99_ms=_percentile(latencies, 0.99),
+        max_ms=round(max(latencies), 2),
+        statuses=dict(statuses),
+        error_count=sum(errors.values()),
+        errors=dict(errors),
+    )
+
+
+async def _run(args: argparse.Namespace) -> dict[str, object]:
+    maximum = max(args.steady_concurrency, args.burst_concurrency)
+    limits = httpx.Limits(max_connections=maximum, max_keepalive_connections=maximum)
+    async with httpx.AsyncClient(
+        base_url=args.base_url.rstrip("/"),
+        limits=limits,
+        timeout=httpx.Timeout(args.timeout_seconds),
+    ) as client:
+        phases = [
+            await _run_phase(
+                client,
+                name="liveness_steady",
+                path="/api/v1/health/liveness",
+                requests=args.steady_requests,
+                concurrency=args.steady_concurrency,
+            ),
+            await _run_phase(
+                client,
+                name="dependency_readiness",
+                path="/api/v1/health",
+                requests=args.readiness_requests,
+                concurrency=args.steady_concurrency,
+            ),
+            await _run_phase(
+                client,
+                name="liveness_burst",
+                path="/api/v1/health/liveness",
+                requests=args.burst_requests,
+                concurrency=args.burst_concurrency,
+            ),
+        ]
+
+    failures: list[str] = []
+    for phase in phases:
+        if phase.error_count:
+            failures.append(f"{phase.name}: {phase.error_count} client errors")
+        non_200 = sum(count for status, count in phase.statuses.items() if status != "200")
+        if non_200:
+            failures.append(f"{phase.name}: {non_200} non-200 responses")
+    readiness = next(phase for phase in phases if phase.name == "dependency_readiness")
+    if readiness.p95_ms > args.max_readiness_p95_ms:
+        failures.append(
+            f"dependency_readiness: p95 {readiness.p95_ms}ms exceeds "
+            f"{args.max_readiness_p95_ms}ms"
+        )
+
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "base_url": args.base_url,
+        "workload": "local_docker_http",
+        "phases": [asdict(phase) for phase in phases],
+        "thresholds": {"max_readiness_p95_ms": args.max_readiness_p95_ms},
+        "passed": not failures,
+        "failures": failures,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--steady-requests", type=int, default=3000)
+    parser.add_argument("--readiness-requests", type=int, default=1500)
+    parser.add_argument("--burst-requests", type=int, default=5000)
+    parser.add_argument("--steady-concurrency", type=int, default=50)
+    parser.add_argument("--burst-concurrency", type=int, default=150)
+    parser.add_argument("--timeout-seconds", type=float, default=10.0)
+    parser.add_argument("--max-readiness-p95-ms", type=float, default=750.0)
+    args = parser.parse_args()
+
+    report = asyncio.run(_run(args))
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    return 0 if report["passed"] else 1
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/load/local_docker_resource_stress.py
+++ b/tests/load/local_docker_resource_stress.py
@@ -1,0 +1,157 @@
+"""Stress OCR and browser resources locally without external side effects."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import io
+import json
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+from playwright.async_api import async_playwright
+
+from core.rag.extractors import extract
+from core.runtime_capacity import AsyncCapacityGate
+
+
+@dataclass(frozen=True)
+class ResourceResult:
+    workload: str
+    jobs: int
+    concurrency_limit: int
+    maximum_active: int
+    elapsed_seconds: float
+    successful: int
+    failed: int
+
+
+def _ocr_fixture() -> bytes:
+    image = Image.new("RGB", (1600, 900), "white")
+    draw = ImageDraw.Draw(image)
+    for index in range(12):
+        draw.text(
+            (80, 60 + index * 65),
+            f"AgenticOrg local OCR stress line {index + 1:02d} invoice total 1250.00",
+            fill="black",
+        )
+    stream = io.BytesIO()
+    image.save(stream, format="PNG")
+    return stream.getvalue()
+
+
+async def _run_ocr(jobs: int, concurrency: int) -> ResourceResult:
+    gate = AsyncCapacityGate("OCR stress", limit=concurrency, queue_timeout_seconds=120)
+    fixture = _ocr_fixture()
+    active = 0
+    maximum_active = 0
+
+    async def run_one(index: int) -> bool:
+        nonlocal active, maximum_active
+        async with gate.slot():
+            active += 1
+            maximum_active = max(maximum_active, active)
+            try:
+                result = await asyncio.to_thread(
+                    extract,
+                    fixture,
+                    "image/png",
+                    f"synthetic-stress-{index}.png",
+                )
+                return "AgenticOrg" in result.full_text()
+            finally:
+                active -= 1
+
+    started = time.perf_counter()
+    results = await asyncio.gather(*(run_one(index) for index in range(jobs)))
+    elapsed = time.perf_counter() - started
+    successful = sum(results)
+    return ResourceResult(
+        workload="tesseract_ocr",
+        jobs=jobs,
+        concurrency_limit=concurrency,
+        maximum_active=maximum_active,
+        elapsed_seconds=round(elapsed, 3),
+        successful=successful,
+        failed=jobs - successful,
+    )
+
+
+async def _run_browser(jobs: int, concurrency: int) -> ResourceResult:
+    gate = AsyncCapacityGate("browser stress", limit=concurrency, queue_timeout_seconds=120)
+    active = 0
+    maximum_active = 0
+
+    async with async_playwright() as playwright:
+
+        async def run_one(index: int) -> bool:
+            nonlocal active, maximum_active
+            async with gate.slot():
+                active += 1
+                maximum_active = max(maximum_active, active)
+                browser = await playwright.chromium.launch(headless=True)
+                try:
+                    page = await browser.new_page()
+                    await page.set_content(
+                        f"<main><h1>AgenticOrg RPA stress {index}</h1>"
+                        "<button id='submit'>Submit</button></main>"
+                    )
+                    await page.click("#submit")
+                    screenshot = await page.screenshot()
+                    return len(screenshot) > 100
+                finally:
+                    await browser.close()
+                    active -= 1
+
+        started = time.perf_counter()
+        results = await asyncio.gather(*(run_one(index) for index in range(jobs)))
+        elapsed = time.perf_counter() - started
+
+    successful = sum(results)
+    return ResourceResult(
+        workload="playwright_chromium",
+        jobs=jobs,
+        concurrency_limit=concurrency,
+        maximum_active=maximum_active,
+        elapsed_seconds=round(elapsed, 3),
+        successful=successful,
+        failed=jobs - successful,
+    )
+
+
+async def _run(args: argparse.Namespace) -> dict[str, object]:
+    results = [
+        await _run_ocr(args.ocr_jobs, args.ocr_concurrency),
+        await _run_browser(args.browser_jobs, args.browser_concurrency),
+    ]
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "workload": "local_docker_resource_stress",
+        "passed": all(result.failed == 0 for result in results),
+        "results": [asdict(result) for result in results],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ocr-jobs", type=int, default=12)
+    parser.add_argument("--ocr-concurrency", type=int, default=2)
+    parser.add_argument("--browser-jobs", type=int, default=8)
+    parser.add_argument("--browser-concurrency", type=int, default=2)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    report = asyncio.run(_run(args))
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/load/local_docker_resource_stress.py
+++ b/tests/load/local_docker_resource_stress.py
@@ -6,6 +6,7 @@ import argparse
 import asyncio
 import io
 import json
+import threading
 import time
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
@@ -14,8 +15,9 @@ from pathlib import Path
 from PIL import Image, ImageDraw
 from playwright.async_api import async_playwright
 
+from api.v1.knowledge import _DOCUMENT_EXTRACTION_CAPACITY
 from core.rag.extractors import extract
-from core.runtime_capacity import AsyncCapacityGate
+from core.rpa.executor import _RPA_CAPACITY
 
 
 @dataclass(frozen=True)
@@ -44,26 +46,34 @@ def _ocr_fixture() -> bytes:
 
 
 async def _run_ocr(jobs: int, concurrency: int) -> ResourceResult:
-    gate = AsyncCapacityGate("OCR stress", limit=concurrency, queue_timeout_seconds=120)
+    if concurrency != _DOCUMENT_EXTRACTION_CAPACITY.limit:
+        raise ValueError(
+            "--ocr-concurrency must match "
+            f"AGENTICORG_DOCUMENT_EXTRACTION_MAX_CONCURRENCY={_DOCUMENT_EXTRACTION_CAPACITY.limit}"
+        )
     fixture = _ocr_fixture()
     active = 0
     maximum_active = 0
+    active_lock = threading.Lock()
 
     async def run_one(index: int) -> bool:
-        nonlocal active, maximum_active
-        async with gate.slot():
-            active += 1
-            maximum_active = max(maximum_active, active)
+        def extract_one() -> bool:
+            nonlocal active, maximum_active
+            with active_lock:
+                active += 1
+                maximum_active = max(maximum_active, active)
             try:
-                result = await asyncio.to_thread(
-                    extract,
+                result = extract(
                     fixture,
-                    "image/png",
-                    f"synthetic-stress-{index}.png",
+                    mime_type="image/png",
+                    filename=f"synthetic-stress-{index}.png",
                 )
                 return "AgenticOrg" in result.full_text()
             finally:
-                active -= 1
+                with active_lock:
+                    active -= 1
+
+        return await _DOCUMENT_EXTRACTION_CAPACITY.run_blocking(extract_one)
 
     started = time.perf_counter()
     results = await asyncio.gather(*(run_one(index) for index in range(jobs)))
@@ -81,7 +91,11 @@ async def _run_ocr(jobs: int, concurrency: int) -> ResourceResult:
 
 
 async def _run_browser(jobs: int, concurrency: int) -> ResourceResult:
-    gate = AsyncCapacityGate("browser stress", limit=concurrency, queue_timeout_seconds=120)
+    if concurrency != _RPA_CAPACITY.limit:
+        raise ValueError(
+            "--browser-concurrency must match "
+            f"AGENTICORG_RPA_MAX_CONCURRENCY={_RPA_CAPACITY.limit}"
+        )
     active = 0
     maximum_active = 0
 
@@ -89,22 +103,28 @@ async def _run_browser(jobs: int, concurrency: int) -> ResourceResult:
 
         async def run_one(index: int) -> bool:
             nonlocal active, maximum_active
-            async with gate.slot():
+
+            async def run_browser_job() -> bool:
+                nonlocal active, maximum_active
                 active += 1
                 maximum_active = max(maximum_active, active)
-                browser = await playwright.chromium.launch(headless=True)
                 try:
-                    page = await browser.new_page()
-                    await page.set_content(
-                        f"<main><h1>AgenticOrg RPA stress {index}</h1>"
-                        "<button id='submit'>Submit</button></main>"
-                    )
-                    await page.click("#submit")
-                    screenshot = await page.screenshot()
-                    return len(screenshot) > 100
+                    browser = await playwright.chromium.launch(headless=True)
+                    try:
+                        page = await browser.new_page()
+                        await page.set_content(
+                            f"<main><h1>AgenticOrg RPA stress {index}</h1>"
+                            "<button id='submit'>Submit</button></main>"
+                        )
+                        await page.click("#submit")
+                        screenshot = await page.screenshot()
+                        return len(screenshot) > 100
+                    finally:
+                        await browser.close()
                 finally:
-                    await browser.close()
                     active -= 1
+
+            return await _RPA_CAPACITY.run(run_browser_job)
 
         started = time.perf_counter()
         results = await asyncio.gather(*(run_one(index) for index in range(jobs)))

--- a/tests/regression/test_bugs_march2026.py
+++ b/tests/regression/test_bugs_march2026.py
@@ -727,7 +727,7 @@ class TestIntConn016HealthEndpoint:
         from api.v1.health import diagnostics as health_check
 
         with (
-            patch("api.v1.health.async_session_factory") as mock_sf,
+            patch("api.v1.health.database.async_session_factory") as mock_sf,
             patch("api.v1.health.aioredis") as mock_redis,
             patch("api.v1.health.ConnectorRegistry") as mock_cr,
         ):
@@ -761,7 +761,7 @@ class TestIntConn016HealthEndpoint:
         from api.v1.health import diagnostics as health_check
 
         with (
-            patch("api.v1.health.async_session_factory") as mock_sf,
+            patch("api.v1.health.database.async_session_factory") as mock_sf,
             patch("api.v1.health.aioredis") as mock_redis,
             patch("api.v1.health.ConnectorRegistry") as mock_cr,
             patch("api.v1.health._check_connector") as mock_check,
@@ -789,7 +789,7 @@ class TestIntConn016HealthEndpoint:
         from api.v1.health import diagnostics as health_check
 
         with (
-            patch("api.v1.health.async_session_factory") as mock_sf,
+            patch("api.v1.health.database.async_session_factory") as mock_sf,
             patch("api.v1.health.aioredis") as mock_redis,
             patch("api.v1.health.ConnectorRegistry") as mock_cr,
             patch("api.v1.health._check_connector") as mock_check,

--- a/tests/regression/test_sla_telemetry_persistence.py
+++ b/tests/regression/test_sla_telemetry_persistence.py
@@ -257,7 +257,7 @@ async def test_fetch_history_returns_empty_on_query_error(monkeypatch) -> None:
     def _factory():
         return _BoomSession()
 
-    monkeypatch.setattr(health_module, "async_session_factory", _factory)
+    monkeypatch.setattr(health_module.database, "async_session_factory", _factory)
 
     rows = await health_module._fetch_history(24)
     assert rows == []

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -64,6 +64,14 @@ def _make_result(scalar_one=None, scalars_list=None, scalar_value=None):
 
 class TestHealthEndpoints:
 
+    @pytest.fixture(autouse=True)
+    def _reset_health_runtime_state(self, monkeypatch: pytest.MonkeyPatch):
+        from api.v1 import health
+
+        monkeypatch.setattr(health, "_health_dependency_cache", None)
+        monkeypatch.setattr(health, "_health_dependency_lock", None)
+        monkeypatch.setattr(health, "_health_redis_client", None)
+
     @pytest.mark.asyncio
     async def test_liveness_returns_alive(self):
         from api.v1.health import liveness
@@ -97,6 +105,8 @@ class TestHealthEndpoints:
             mock_aioredis.from_url.return_value = mock_redis
             mock_settings.redis_url = "redis://localhost"
             mock_settings.env = "test"
+            mock_settings.db_pool_size = 5
+            mock_settings.db_max_overflow = 5
             mock_registry.all_names.return_value = []
 
             resp = await health_check()
@@ -122,6 +132,8 @@ class TestHealthEndpoints:
             mock_aioredis.from_url.return_value = mock_redis
             mock_settings.redis_url = "redis://localhost"
             mock_settings.env = "test"
+            mock_settings.db_pool_size = 5
+            mock_settings.db_max_overflow = 5
             mock_registry.all_names.return_value = []
 
             resp = await health_check()
@@ -148,6 +160,8 @@ class TestHealthEndpoints:
             mock_aioredis.from_url.return_value = mock_redis
             mock_settings.redis_url = "redis://localhost"
             mock_settings.env = "test"
+            mock_settings.db_pool_size = 5
+            mock_settings.db_max_overflow = 5
             mock_registry.all_names.return_value = []
 
             resp = await health_check()

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -96,7 +96,7 @@ class TestHealthEndpoints:
         mock_redis.ping = AsyncMock()
         mock_redis.close = AsyncMock()
 
-        with patch("api.v1.health.async_session_factory") as mock_sf, \
+        with patch("api.v1.health.database.async_session_factory") as mock_sf, \
              patch("api.v1.health.aioredis") as mock_aioredis, \
              patch("api.v1.health.settings") as mock_settings, \
              patch("api.v1.health.ConnectorRegistry") as mock_registry:
@@ -123,7 +123,7 @@ class TestHealthEndpoints:
         mock_redis.ping = AsyncMock()
         mock_redis.close = AsyncMock()
 
-        with patch("api.v1.health.async_session_factory") as mock_sf, \
+        with patch("api.v1.health.database.async_session_factory") as mock_sf, \
              patch("api.v1.health.aioredis") as mock_aioredis, \
              patch("api.v1.health.settings") as mock_settings, \
              patch("api.v1.health.ConnectorRegistry") as mock_registry:
@@ -151,7 +151,7 @@ class TestHealthEndpoints:
         mock_redis = AsyncMock()
         mock_redis.ping = AsyncMock(side_effect=ConnectionError("refused"))
 
-        with patch("api.v1.health.async_session_factory") as mock_sf, \
+        with patch("api.v1.health.database.async_session_factory") as mock_sf, \
              patch("api.v1.health.aioredis") as mock_aioredis, \
              patch("api.v1.health.settings") as mock_settings, \
              patch("api.v1.health.ConnectorRegistry") as mock_registry:

--- a/tests/unit/test_envelope_encryption.py
+++ b/tests/unit/test_envelope_encryption.py
@@ -156,7 +156,7 @@ class TestTenantSecretsRouting:
         tagged = _ENVELOPE_PREFIX + envelope_payload
         assert decrypt_for_tenant(tagged) == "new-pw"
 
-    @patch("core.crypto.tenant_secrets.async_session_factory")
+    @patch("core.crypto.tenant_secrets.database.async_session_factory")
     def test_encrypt_for_tenant_falls_back_to_fernet_when_no_kek(
         self, mock_session_factory, monkeypatch
     ):
@@ -188,7 +188,7 @@ class TestTenantSecretsRouting:
         # And it round-trips through fernet_decrypt
         assert fernet_decrypt(result) == "plaintext"
 
-    @patch("core.crypto.tenant_secrets.async_session_factory")
+    @patch("core.crypto.tenant_secrets.database.async_session_factory")
     def test_encrypt_for_tenant_uses_byok_when_set(
         self, mock_session_factory, stub_kms
     ):
@@ -217,7 +217,7 @@ class TestTenantSecretsRouting:
         # Round-trip
         assert decrypt_for_tenant(result) == "byok-secret"
 
-    @patch("core.crypto.tenant_secrets.async_session_factory")
+    @patch("core.crypto.tenant_secrets.database.async_session_factory")
     @patch("core.crypto.tenant_secrets.encrypt_to_string")
     def test_encrypt_for_tenant_configured_kek_failure_does_not_downgrade_to_legacy(
         self, mock_encrypt_to_string, mock_session_factory, monkeypatch

--- a/tests/unit/test_module_19_health_api.py
+++ b/tests/unit/test_module_19_health_api.py
@@ -67,12 +67,24 @@ def test_tc_api_001_liveness_endpoint_is_lightweight() -> None:
 def test_tc_api_002_readiness_checks_db_and_redis() -> None:
     """Readiness must probe BOTH DB and Redis — Cloud Run / K8s
     keys off this to decide whether to send traffic."""
-    src = (REPO / "api" / "v1" / "health.py").read_text(encoding="utf-8")
-    block = src.split('@router.get("/health")', 1)[1].split(
-        '@router.get(', 1
-    )[0]
-    assert "session.execute(text" in block
-    assert "aioredis.from_url" in block
+    import inspect
+
+    from api.v1.health import (
+        _critical_dependency_checks,
+        _db_health_status,
+        _get_health_redis_client,
+        _redis_health_status,
+        health_readiness,
+    )
+
+    block = inspect.getsource(health_readiness)
+    assert "_critical_dependency_checks" in block
+    assert "session.execute(text" in inspect.getsource(_db_health_status)
+    assert "_get_health_redis_client().ping" in inspect.getsource(_redis_health_status)
+    assert "aioredis.from_url" in inspect.getsource(_get_health_redis_client)
+    dependency_block = inspect.getsource(_critical_dependency_checks)
+    assert "_db_health_status" in dependency_block
+    assert "_redis_health_status" in dependency_block
     # Returns the per-check status so dashboards can show which
     # subsystem broke.
     assert '"checks":' in block

--- a/tests/unit/test_runtime_capacity.py
+++ b/tests/unit/test_runtime_capacity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -53,6 +54,35 @@ async def test_capacity_gate_rejects_when_queue_deadline_expires() -> None:
 
 
 @pytest.mark.asyncio
+async def test_blocking_capacity_stays_occupied_after_caller_cancellation() -> None:
+    gate = AsyncCapacityGate("blocking test", limit=1, queue_timeout_seconds=0.01)
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_work() -> None:
+        started.set()
+        assert release.wait(timeout=2)
+
+    task = asyncio.create_task(gate.run_blocking(blocking_work))
+    assert await asyncio.to_thread(started.wait, 1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert gate.snapshot.active == 1
+    with pytest.raises(CapacityLimitError):
+        async with gate.slot():
+            pytest.fail("cancelled thread must retain its production permit")
+
+    release.set()
+    for _ in range(100):
+        if gate.snapshot.active == 0:
+            break
+        await asyncio.sleep(0.01)
+    assert gate.snapshot.active == 0
+
+
+@pytest.mark.asyncio
 async def test_rpa_wrapper_returns_retryable_capacity_error(monkeypatch: pytest.MonkeyPatch) -> None:
     from core.rpa import executor
 
@@ -75,6 +105,61 @@ async def test_rpa_wrapper_returns_retryable_capacity_error(monkeypatch: pytest.
     assert refused["success"] is False
     assert refused["error_class"] == "rpa_capacity_exhausted"
     assert refused["retryable"] is True
+
+
+def test_rpa_api_contract_preserves_retryable_capacity_fields() -> None:
+    from api.v1.rpa import RPAExecutionOut
+
+    result = RPAExecutionOut(
+        id="execution-1",
+        script_key="test",
+        script_name="Test",
+        status="failed",
+        started_at="2026-09-01T00:00:00Z",
+        error_class="rpa_capacity_exhausted",
+        retryable=True,
+    )
+
+    assert result.error_class == "rpa_capacity_exhausted"
+    assert result.retryable is True
+
+
+def test_rpa_scheduler_escalates_retryable_result_without_recording_failure() -> None:
+    from core.tasks.rpa_tasks import (
+        RetryableRPAExecutionError,
+        _raise_for_retryable_execution_failure,
+    )
+
+    with pytest.raises(RetryableRPAExecutionError, match="capacity is busy"):
+        _raise_for_retryable_execution_failure(
+            {
+                "success": False,
+                "error": "RPA browser execution capacity is busy",
+                "error_class": "rpa_capacity_exhausted",
+                "retryable": True,
+            }
+        )
+
+
+def test_http_stress_readiness_validation_rejects_unhealthy_200() -> None:
+    import httpx
+
+    from tests.load.local_docker_http import _readiness_body_errors
+
+    unhealthy = httpx.Response(
+        200,
+        json={"status": "unhealthy", "checks": {"db": "healthy", "redis": "unhealthy: TimeoutError"}},
+    )
+    healthy = httpx.Response(
+        200,
+        json={"status": "healthy", "checks": {"db": "healthy", "redis": "healthy"}},
+    )
+
+    assert _readiness_body_errors(unhealthy) == [
+        "readiness_status_unhealthy",
+        "readiness_redis_unhealthy",
+    ]
+    assert _readiness_body_errors(healthy) == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_runtime_capacity.py
+++ b/tests/unit/test_runtime_capacity.py
@@ -1,0 +1,143 @@
+"""Runtime capacity and local performance regression tests."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core.runtime_capacity import AsyncCapacityGate, CapacityLimitError
+
+
+@pytest.mark.asyncio
+async def test_capacity_gate_never_exceeds_limit() -> None:
+    gate = AsyncCapacityGate("test", limit=2, queue_timeout_seconds=1)
+    active = 0
+    maximum = 0
+
+    async def work() -> None:
+        nonlocal active, maximum
+        async with gate.slot():
+            active += 1
+            maximum = max(maximum, active)
+            await asyncio.sleep(0.02)
+            active -= 1
+
+    await asyncio.gather(*(work() for _ in range(12)))
+
+    assert maximum == 2
+    assert gate.snapshot.active == 0
+    assert gate.snapshot.waiting == 0
+
+
+@pytest.mark.asyncio
+async def test_capacity_gate_rejects_when_queue_deadline_expires() -> None:
+    gate = AsyncCapacityGate("test workload", limit=1, queue_timeout_seconds=0.01)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def hold_slot() -> None:
+        async with gate.slot():
+            entered.set()
+            await release.wait()
+
+    holder = asyncio.create_task(hold_slot())
+    await entered.wait()
+    with pytest.raises(CapacityLimitError, match="test workload capacity is busy"):
+        async with gate.slot():
+            pytest.fail("timed-out work must not start")
+    release.set()
+    await holder
+
+
+@pytest.mark.asyncio
+async def test_rpa_wrapper_returns_retryable_capacity_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from core.rpa import executor
+
+    gate = AsyncCapacityGate("RPA browser execution", limit=1, queue_timeout_seconds=0.01)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_execute(**_kwargs):  # noqa: ANN003, ANN202
+        entered.set()
+        await release.wait()
+        return {"success": True}
+
+    monkeypatch.setattr(executor, "_RPA_CAPACITY", gate)
+    monkeypatch.setattr(executor, "_execute_rpa_script", fake_execute)
+    first = asyncio.create_task(executor.execute_rpa_script("test", {}))
+    await entered.wait()
+    refused = await executor.execute_rpa_script("test", {})
+    release.set()
+    assert await first == {"success": True}
+    assert refused["success"] is False
+    assert refused["error_class"] == "rpa_capacity_exhausted"
+    assert refused["retryable"] is True
+
+
+@pytest.mark.asyncio
+async def test_health_checks_run_dependencies_concurrently(monkeypatch: pytest.MonkeyPatch) -> None:
+    from api.v1 import health
+
+    async def delayed() -> str:
+        await asyncio.sleep(0.04)
+        return "healthy"
+
+    monkeypatch.setattr(health, "_db_health_status", delayed)
+    monkeypatch.setattr(health, "_redis_health_status", delayed)
+    monkeypatch.setattr(health, "_health_dependency_cache", None)
+    monkeypatch.setattr(health, "_health_dependency_lock", None)
+    started = asyncio.get_running_loop().time()
+    result = await health._critical_dependency_checks()
+    elapsed = asyncio.get_running_loop().time() - started
+
+    assert result == {"db": "healthy", "redis": "healthy"}
+    assert elapsed < 0.07
+
+
+@pytest.mark.asyncio
+async def test_health_checks_coalesce_concurrent_probe_bursts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.v1 import health
+
+    async def healthy_probe() -> str:
+        await asyncio.sleep(0)
+        return "healthy"
+
+    db_probe = AsyncMock(side_effect=healthy_probe)
+    redis_probe = AsyncMock(side_effect=healthy_probe)
+    monkeypatch.setattr(health, "_db_health_status", db_probe)
+    monkeypatch.setattr(health, "_redis_health_status", redis_probe)
+    monkeypatch.setattr(health, "_health_dependency_cache", None)
+    monkeypatch.setattr(health, "_health_dependency_lock", None)
+
+    results = await asyncio.gather(*(health._critical_dependency_checks() for _ in range(50)))
+
+    assert results == [{"db": "healthy", "redis": "healthy"}] * 50
+    assert db_probe.await_count == 1
+    assert redis_probe.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_health_redis_client_is_reused(monkeypatch: pytest.MonkeyPatch) -> None:
+    from api.v1 import health
+
+    client = AsyncMock()
+    factory = MagicMock(return_value=client)
+    monkeypatch.setattr(health, "_health_redis_client", None)
+    monkeypatch.setattr(health.aioredis, "from_url", factory)
+
+    assert health._get_health_redis_client() is client
+    assert health._get_health_redis_client() is client
+    assert factory.call_count == 1
+    await health.close_health_resources()
+    client.aclose.assert_awaited_once()
+
+
+def test_docker_image_allows_web_concurrency_tuning() -> None:
+    dockerfile = (Path(__file__).resolve().parents[2] / "Dockerfile").read_text(encoding="utf-8")
+    command = dockerfile.rsplit("CMD", 1)[-1]
+    assert '"--workers", "1"' not in command

--- a/tests/unit/test_signoff_remaining_blockers.py
+++ b/tests/unit/test_signoff_remaining_blockers.py
@@ -95,8 +95,8 @@ class TestKbContentExtractionPersisted:
         src = inspect.getsource(knowledge.upload_document)
         assert "content_text" in src
         assert "extracted_text" in src
-        assert "extracted_content = await asyncio.to_thread" in src
-        assert src.index("extracted_content = await asyncio.to_thread") < src.index(
+        assert "extracted_content = await _DOCUMENT_EXTRACTION_CAPACITY.run_blocking" in src
+        assert src.index("extracted_content = await _DOCUMENT_EXTRACTION_CAPACITY.run_blocking") < src.index(
             "if not allow_duplicate and not replace"
         )
         assert "document_has_no_extractable_text" in src


### PR DESCRIPTION
## Summary
- add bounded OCR and RPA admission control with retryable overload behavior
- coalesce and bound readiness dependency checks
- move blocking SMTP and DNS work off the async API event loop
- add production-style local Docker stress harnesses and capacity configuration
- document two complete local Docker stress/E2E rounds with measured results

## Local Docker verification
- production image build and `pip check`: passed
- fresh ORM bootstrap and Alembic migration to head: passed twice
- HTTP stress: 9,500 requests, zero errors and zero non-200 responses
- OCR: 12/12 passed with max active 2
- Chromium/RPA: 8/8 passed with max active 2
- focused OCR/RPA/voice/multichannel pack: 36 passed
- auth/email/sales/budget/security pack: 302 passed
- signed durable voice integration: passed without a paid call
- local Mailpit SMTP capture: passed without external delivery
- signup/JWT/authenticated agent listing: passed
- Ruff, focused mypy, Compose rendering, and `git diff --check`: passed

## Safety
No production endpoint, external email target, paid telephony call, payment rail, merchant system, or cloud resource was used during the local stress run. The report is workstation regression evidence, not a production SLA.

## Report
`docs/reports/agenticorg-local-docker-stress-performance-2026-09-01.md`