### PR TITLE
fix: validate Twilio webhooks with official SDK

### DIFF
--- a/core/voice/runtime.py
+++ b/core/voice/runtime.py
@@ -2,30 +2,25 @@
 
 from __future__ import annotations
 
-import base64
-import hashlib
-import hmac
 import xml.etree.ElementTree as ET
 from typing import Any
 
 import httpx
+from twilio.request_validator import RequestValidator
 
 TERMINAL_CALL_STATUSES = frozenset({"completed", "busy", "failed", "no_answer", "cancelled"})
 
 
 def build_twilio_signature(*, url: str, params: dict[str, str], auth_token: str) -> str:
-    """Build the HMAC-SHA1 signature required by Twilio's webhook protocol."""
-    canonical = url + "".join(f"{key}{params[key]}" for key in sorted(params))
-    digest = hmac.new(auth_token.encode("utf-8"), canonical.encode("utf-8"), hashlib.sha1).digest()
-    return base64.b64encode(digest).decode("ascii")
+    """Build the signature required by Twilio's webhook protocol."""
+    return RequestValidator(auth_token).compute_signature(url, params)
 
 
 def verify_twilio_signature(*, url: str, params: dict[str, str], signature: str, auth_token: str) -> bool:
-    """Verify Twilio's HMAC-SHA1 webhook signature without an SDK dependency."""
+    """Verify a Twilio webhook with the provider-maintained validator."""
     if not signature or not auth_token or not url.startswith("https://"):
         return False
-    expected = build_twilio_signature(url=url, params=params, auth_token=auth_token)
-    return hmac.compare_digest(expected, signature.strip())
+    return RequestValidator(auth_token).validate(url, params, signature.strip())
 
 
 def build_conversation_twiml(*, action_url: str, prompt: str, language: str = "en-IN") -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ dependencies = [
     "PyJWT[crypto]>=2.13.0",
     "passlib[bcrypt]>=1.7.4",
     "httpx>=0.28.0",
+    # Twilio webhook signatures are protocol-defined HMAC-SHA1. Delegate
+    # canonicalisation and constant-time validation to the maintained SDK.
+    "twilio>=9.11.0",
     # Billing checkout is a production request path. Keep the Stripe SDK in
     # base deps so Docker's `pip install .[v4]` image can create Checkout
     # Sessions when STRIPE_SECRET_KEY and price IDs are configured.

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,6 +51,9 @@ grantex==0.4.1
 # ─── HTTP Client & DNS ───────────────────────────────────────────────────────
 httpx==0.28.1
 dnspython==2.8.0
+# Twilio webhook signatures are protocol-defined HMAC-SHA1. Delegate
+# canonicalisation and validation to the maintained SDK.
+twilio==9.11.0
 # Billing checkout SDK. Required in the production API image whenever
 # STRIPE_SECRET_KEY and Stripe price IDs are configured.
 stripe==15.6.0

--- a/tests/regression/test_claude_mistakes.py
+++ b/tests/regression/test_claude_mistakes.py
@@ -366,6 +366,7 @@ def test_self_visible_to_pytest() -> None:
             "pytest",
             "--collect-only",
             "-q",
+            "--no-cov",
             str(Path(__file__).relative_to(REPO).as_posix()),
         ],
         cwd=REPO,

--- a/tests/regression/test_release_acceptance.py
+++ b/tests/regression/test_release_acceptance.py
@@ -272,6 +272,7 @@ def test_check_registry_is_complete() -> None:
 @pytest.mark.parametrize(
     "key", ["skips", "coverage", "qa_matrix", "crypto", "tsc", "npm_build", "vitest", "playwright", "artefacts"]
 )
+@pytest.mark.timeout(180)
 def test_each_check_returns_a_checkresult(key) -> None:
     """Smoke: every check function returns a CheckResult, never
     raises uncaught. Some legitimately fail in the test env (no

--- a/tests/unit/test_voice_runtime_20260826.py
+++ b/tests/unit/test_voice_runtime_20260826.py
@@ -36,6 +36,14 @@ def test_twilio_webhook_signature_verification() -> None:
     )
 
 
+def test_twilio_signature_validation_fails_closed_for_missing_inputs() -> None:
+    url = "https://api.agenticorg.ai/api/v1/voice/webhooks/twilio/t/a/incoming"
+    params = {"CallSid": "CA123"}
+
+    assert not verify_twilio_signature(url=url, params=params, signature="", auth_token="token")
+    assert not verify_twilio_signature(url=url, params=params, signature="signature", auth_token="")
+
+
 def test_twilio_webhooks_reach_signature_boundary_without_jwt() -> None:
     from auth.grantex_middleware import GrantexAuthMiddleware
     from auth.middleware import AuthMiddleware


### PR DESCRIPTION
## Summary
- replace custom Twilio HMAC-SHA1 code with the official Twilio `RequestValidator`
- retain fail-closed checks for missing credentials/signatures and non-HTTPS webhook URLs
- add deterministic signature and missing-input coverage
- make nested regression collection independent of outer coverage and align the release-acceptance timeout with its documented helper budget

## Security
Closes CodeQL alert #114 (`py/weak-sensitive-data-hashing`). Twilio webhook signatures require HMAC-SHA1 by protocol; delegating canonicalization and comparison to the maintained official SDK avoids custom weak-hash handling without breaking valid webhook verification.

## Local validation
- Full local Docker E2E on the aggregate release candidate: 702 passed, 9 intentionally skipped
- Python integration/regression: 1,386 passed, 107 skipped, 5 xfailed
- Python unit/connector/security/regression: 5,933 passed, 8 skipped, 5 xfailed; coverage 74.39%
- Rebased focused suite: 43 passed
- Ruff and mypy: passed
- UI lint/typecheck/tests/build: passed; 182 tests
- npm audit and pip-audit: no known vulnerabilities